### PR TITLE
Autogenerate tagging-compliant descriptor methods for all archetypes

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1042,7 +1042,6 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
     assert_eq!(kind, &ObjectKind::Archetype);
 
     let display_name = re_case::to_human_case(name);
-    let archetype_name = &obj.fqname;
     let name = format_ident!("{name}");
 
     fn compute_component_descriptors(
@@ -1056,18 +1055,11 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
                 field
                     .try_get_attr::<String>(requirement_attr_value)
                     .map(|_| {
-                        let Some(component_name) = field.typ.fqname() else {
-                            panic!("Archetype field must be an object/union or an array/vector of such")
-                        };
-
-                        let archetype_name = &obj.fqname;
+                        let archetype_name = format_ident!("{}", obj.name);
                         let archetype_field_name = field.snake_case_name();
+                        let fn_name = format_ident!("descriptor_{archetype_field_name}");
 
-                        quote!(ComponentDescriptor {
-                            archetype_name: Some(#archetype_name.into()),
-                            component_name: #component_name.into(),
-                            archetype_field_name: Some(#archetype_field_name.into()),
-                        })
+                        quote!(#archetype_name::#fn_name())
                     })
             })
             .collect_vec();
@@ -1106,15 +1098,35 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
                 }
             }
         })
+        .chain(std::iter::once({
+            let archetype_name = &obj.fqname;
+            let indicator_component_name = format!(
+                "{}Indicator",
+                obj.fqname.replace("archetypes", "components")
+            );
+
+            let doc = "Returns the [`ComponentDescriptor`] for the associated indicator component.";
+
+            quote! {
+                #[doc = #doc]
+                #[inline]
+                pub fn descriptor_indicator() -> ComponentDescriptor {
+                    ComponentDescriptor {
+                        archetype_name: Some(#archetype_name.into()),
+                        component_name: #indicator_component_name.into(),
+                        archetype_field_name: None,
+                    }
+                }
+            }
+        }))
         .collect_vec();
 
+    let archetype_name = format_ident!("{}", obj.name);
     let indicator_name = format!("{}Indicator", obj.name);
 
     let quoted_indicator_name = format_ident!("{indicator_name}");
     let quoted_indicator_doc =
         format!("Indicator component for the [`{name}`] [`::re_types_core::Archetype`]");
-    let indicator_component_name =
-        format!("{}Indicator", fqname.replace("archetypes", "components"));
 
     let (num_required_descriptors, required_descriptors) =
         compute_component_descriptors(obj, ATTR_RERUN_COMPONENT_REQUIRED);
@@ -1126,11 +1138,7 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
     num_recommended_descriptors += 1;
     recommended_descriptors = quote! {
         #recommended_descriptors
-        ComponentDescriptor {
-            archetype_name: Some(#archetype_name.into()),
-            component_name: #indicator_component_name.into(),
-            archetype_field_name: None,
-        },
+        #archetype_name::descriptor_indicator(),
     };
 
     let num_components_docstring = quote_doc_line(&format!(
@@ -1190,21 +1198,14 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
                 quote!{ Some(&self.#field_name as &dyn ComponentBatch) }
             };
 
-            let Some(component_name) = obj_field.typ.fqname() else {
-                panic!("Archetype field must be an object/union or an array/vector of such")
-            };
-            let archetype_name = &obj.fqname;
             let archetype_field_name = obj_field.snake_case_name();
+            let descr_fn_name = format_ident!("descriptor_{archetype_field_name}");
 
             quote! {
                 (#batch).map(|batch| {
                     ::re_types_core::ComponentBatchCowWithDescriptor {
                         batch: batch.into(),
-                        descriptor_override: Some(ComponentDescriptor {
-                            archetype_name: Some(#archetype_name.into()),
-                            archetype_field_name: Some((#archetype_field_name).into()),
-                            component_name: (#component_name).into(),
-                        }),
+                        descriptor_override: Some(Self::#descr_fn_name()),
                     }
                 })
 

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -75,6 +75,18 @@ pub struct AnnotationContext {
     pub context: crate::components::AnnotationContext,
 }
 
+impl AnnotationContext {
+    /// Returns the [`ComponentDescriptor`] for [`Self::context`].
+    #[inline]
+    pub fn descriptor_context() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
+            component_name: "rerun.components.AnnotationContext".into(),
+            archetype_field_name: Some("context".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -85,25 +85,23 @@ impl AnnotationContext {
             archetype_field_name: Some("context".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-            component_name: "rerun.components.AnnotationContext".into(),
-            archetype_field_name: Some("context".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
             component_name: "rerun.components.AnnotationContextIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [AnnotationContext::descriptor_context()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [AnnotationContext::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
@@ -111,16 +109,8 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-                component_name: "rerun.components.AnnotationContext".into(),
-                archetype_field_name: Some("context".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-                component_name: "rerun.components.AnnotationContextIndicator".into(),
-                archetype_field_name: None,
-            },
+            AnnotationContext::descriptor_context(),
+            AnnotationContext::descriptor_indicator(),
         ]
     });
 
@@ -207,11 +197,7 @@ impl ::re_types_core::AsComponents for AnnotationContext {
             (Some(&self.context as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-                        archetype_field_name: Some(("context").into()),
-                        component_name: ("rerun.components.AnnotationContext").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_context()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -167,117 +167,53 @@ impl Arrows2D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.Arrows2DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-            component_name: "rerun.components.Vector2D".into(),
-            archetype_field_name: Some("vectors".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Arrows2D::descriptor_vectors()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("origins".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Arrows2DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Arrows2D::descriptor_origins(),
+            Arrows2D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Arrows2D::descriptor_radii(),
+            Arrows2D::descriptor_colors(),
+            Arrows2D::descriptor_labels(),
+            Arrows2D::descriptor_show_labels(),
+            Arrows2D::descriptor_draw_order(),
+            Arrows2D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Vector2D".into(),
-                archetype_field_name: Some("vectors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("origins".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Arrows2DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Arrows2D::descriptor_vectors(),
+            Arrows2D::descriptor_origins(),
+            Arrows2D::descriptor_indicator(),
+            Arrows2D::descriptor_radii(),
+            Arrows2D::descriptor_colors(),
+            Arrows2D::descriptor_labels(),
+            Arrows2D::descriptor_show_labels(),
+            Arrows2D::descriptor_draw_order(),
+            Arrows2D::descriptor_class_ids(),
         ]
     });
 
@@ -450,11 +386,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
             (Some(&self.vectors as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                        archetype_field_name: Some(("vectors").into()),
-                        component_name: ("rerun.components.Vector2D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_vectors()),
                 }
             }),
             (self
@@ -463,11 +395,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                    archetype_field_name: Some(("origins").into()),
-                    component_name: ("rerun.components.Position2D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_origins()),
             }),
             (self
                 .radii
@@ -475,11 +403,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -487,11 +411,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -499,11 +419,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -511,11 +427,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .draw_order
@@ -523,11 +435,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
             (self
                 .class_ids
@@ -535,11 +443,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -87,6 +87,88 @@ pub struct Arrows2D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl Arrows2D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
+    #[inline]
+    pub fn descriptor_vectors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.Vector2D".into(),
+            archetype_field_name: Some("vectors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
+    #[inline]
+    pub fn descriptor_origins() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.Position2D".into(),
+            archetype_field_name: Some("origins".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -165,107 +165,51 @@ impl Arrows3D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.Arrows3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-            component_name: "rerun.components.Vector3D".into(),
-            archetype_field_name: Some("vectors".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Arrows3D::descriptor_vectors()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Position3D".into(),
-                archetype_field_name: Some("origins".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Arrows3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Arrows3D::descriptor_origins(),
+            Arrows3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Arrows3D::descriptor_radii(),
+            Arrows3D::descriptor_colors(),
+            Arrows3D::descriptor_labels(),
+            Arrows3D::descriptor_show_labels(),
+            Arrows3D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Vector3D".into(),
-                archetype_field_name: Some("vectors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Position3D".into(),
-                archetype_field_name: Some("origins".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Arrows3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Arrows3D::descriptor_vectors(),
+            Arrows3D::descriptor_origins(),
+            Arrows3D::descriptor_indicator(),
+            Arrows3D::descriptor_radii(),
+            Arrows3D::descriptor_colors(),
+            Arrows3D::descriptor_labels(),
+            Arrows3D::descriptor_show_labels(),
+            Arrows3D::descriptor_class_ids(),
         ]
     });
 
@@ -428,11 +372,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
             (Some(&self.vectors as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                        archetype_field_name: Some(("vectors").into()),
-                        component_name: ("rerun.components.Vector3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_vectors()),
                 }
             }),
             (self
@@ -441,11 +381,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                    archetype_field_name: Some(("origins").into()),
-                    component_name: ("rerun.components.Position3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_origins()),
             }),
             (self
                 .radii
@@ -453,11 +389,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -465,11 +397,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -477,11 +405,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -489,11 +413,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .class_ids
@@ -501,11 +421,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -95,6 +95,78 @@ pub struct Arrows3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl Arrows3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
+    #[inline]
+    pub fn descriptor_vectors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.Vector3D".into(),
+            archetype_field_name: Some("vectors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
+    #[inline]
+    pub fn descriptor_origins() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.Position3D".into(),
+            archetype_field_name: Some("origins".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -108,65 +108,39 @@ impl Asset3D {
             archetype_field_name: Some("albedo_factor".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Asset3D".into()),
+            component_name: "rerun.components.Asset3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Asset3D".into()),
-            component_name: "rerun.components.Blob".into(),
-            archetype_field_name: Some("blob".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Asset3D::descriptor_blob()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "rerun.components.MediaType".into(),
-                archetype_field_name: Some("media_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "rerun.components.Asset3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Asset3D::descriptor_media_type(),
+            Asset3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Asset3D".into()),
-            component_name: "rerun.components.AlbedoFactor".into(),
-            archetype_field_name: Some("albedo_factor".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Asset3D::descriptor_albedo_factor()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "rerun.components.Blob".into(),
-                archetype_field_name: Some("blob".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "rerun.components.MediaType".into(),
-                archetype_field_name: Some("media_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "rerun.components.Asset3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "rerun.components.AlbedoFactor".into(),
-                archetype_field_name: Some("albedo_factor".into()),
-            },
+            Asset3D::descriptor_blob(),
+            Asset3D::descriptor_media_type(),
+            Asset3D::descriptor_indicator(),
+            Asset3D::descriptor_albedo_factor(),
         ]
     });
 
@@ -276,11 +250,7 @@ impl ::re_types_core::AsComponents for Asset3D {
             (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                        archetype_field_name: Some(("blob").into()),
-                        component_name: ("rerun.components.Blob").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_blob()),
                 }
             }),
             (self
@@ -289,11 +259,7 @@ impl ::re_types_core::AsComponents for Asset3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                    archetype_field_name: Some(("media_type").into()),
-                    component_name: ("rerun.components.MediaType").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_media_type()),
             }),
             (self
                 .albedo_factor
@@ -301,11 +267,7 @@ impl ::re_types_core::AsComponents for Asset3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                    archetype_field_name: Some(("albedo_factor").into()),
-                    component_name: ("rerun.components.AlbedoFactor").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_albedo_factor()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -78,6 +78,38 @@ pub struct Asset3D {
     pub albedo_factor: Option<crate::components::AlbedoFactor>,
 }
 
+impl Asset3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
+    #[inline]
+    pub fn descriptor_blob() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Asset3D".into()),
+            component_name: "rerun.components.Blob".into(),
+            archetype_field_name: Some("blob".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    #[inline]
+    pub fn descriptor_media_type() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Asset3D".into()),
+            component_name: "rerun.components.MediaType".into(),
+            archetype_field_name: Some("media_type".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
+    #[inline]
+    pub fn descriptor_albedo_factor() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Asset3D".into()),
+            component_name: "rerun.components.AlbedoFactor".into(),
+            archetype_field_name: Some("albedo_factor".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -139,6 +139,28 @@ pub struct AssetVideo {
     pub media_type: Option<crate::components::MediaType>,
 }
 
+impl AssetVideo {
+    /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
+    #[inline]
+    pub fn descriptor_blob() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+            component_name: "rerun.components.Blob".into(),
+            archetype_field_name: Some("blob".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    #[inline]
+    pub fn descriptor_media_type() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+            component_name: "rerun.components.MediaType".into(),
+            archetype_field_name: Some("media_type".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -159,30 +159,26 @@ impl AssetVideo {
             archetype_field_name: Some("media_type".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+            component_name: "rerun.components.AssetVideoIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-            component_name: "rerun.components.Blob".into(),
-            archetype_field_name: Some("blob".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [AssetVideo::descriptor_blob()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: "rerun.components.MediaType".into(),
-                archetype_field_name: Some("media_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: "rerun.components.AssetVideoIndicator".into(),
-                archetype_field_name: None,
-            },
+            AssetVideo::descriptor_media_type(),
+            AssetVideo::descriptor_indicator(),
         ]
     });
 
@@ -192,21 +188,9 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: "rerun.components.Blob".into(),
-                archetype_field_name: Some("blob".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: "rerun.components.MediaType".into(),
-                archetype_field_name: Some("media_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: "rerun.components.AssetVideoIndicator".into(),
-                archetype_field_name: None,
-            },
+            AssetVideo::descriptor_blob(),
+            AssetVideo::descriptor_media_type(),
+            AssetVideo::descriptor_indicator(),
         ]
     });
 
@@ -302,11 +286,7 @@ impl ::re_types_core::AsComponents for AssetVideo {
             (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                        archetype_field_name: Some(("blob").into()),
-                        component_name: ("rerun.components.Blob").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_blob()),
                 }
             }),
             (self
@@ -315,11 +295,7 @@ impl ::re_types_core::AsComponents for AssetVideo {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                    archetype_field_name: Some(("media_type").into()),
-                    component_name: ("rerun.components.MediaType").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_media_type()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -75,53 +75,33 @@ impl BarChart {
             archetype_field_name: Some("color".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.BarChart".into()),
-            component_name: "rerun.components.TensorData".into(),
-            archetype_field_name: Some("values".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.BarChart".into()),
             component_name: "rerun.components.BarChartIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [BarChart::descriptor_values()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [BarChart::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.BarChart".into()),
-            component_name: "rerun.components.Color".into(),
-            archetype_field_name: Some("color".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [BarChart::descriptor_color()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.BarChart".into()),
-                component_name: "rerun.components.TensorData".into(),
-                archetype_field_name: Some("values".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.BarChart".into()),
-                component_name: "rerun.components.BarChartIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.BarChart".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
+            BarChart::descriptor_values(),
+            BarChart::descriptor_indicator(),
+            BarChart::descriptor_color(),
         ]
     });
 
@@ -217,11 +197,7 @@ impl ::re_types_core::AsComponents for BarChart {
             (Some(&self.values as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.BarChart".into()),
-                        archetype_field_name: Some(("values").into()),
-                        component_name: ("rerun.components.TensorData").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_values()),
                 }
             }),
             (self
@@ -230,11 +206,7 @@ impl ::re_types_core::AsComponents for BarChart {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.BarChart".into()),
-                    archetype_field_name: Some(("color").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_color()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -55,6 +55,28 @@ pub struct BarChart {
     pub color: Option<crate::components::Color>,
 }
 
+impl BarChart {
+    /// Returns the [`ComponentDescriptor`] for [`Self::values`].
+    #[inline]
+    pub fn descriptor_values() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.BarChart".into()),
+            component_name: "rerun.components.TensorData".into(),
+            archetype_field_name: Some("values".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    #[inline]
+    pub fn descriptor_color() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.BarChart".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -80,6 +80,88 @@ pub struct Boxes2D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl Boxes2D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
+    #[inline]
+    pub fn descriptor_half_sizes() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.HalfSize2D".into(),
+            archetype_field_name: Some("half_sizes".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
+    #[inline]
+    pub fn descriptor_centers() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.Position2D".into(),
+            archetype_field_name: Some("centers".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -160,117 +160,53 @@ impl Boxes2D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.Boxes2DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-            component_name: "rerun.components.HalfSize2D".into(),
-            archetype_field_name: Some("half_sizes".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Boxes2D::descriptor_half_sizes()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("centers".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Boxes2DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Boxes2D::descriptor_centers(),
+            Boxes2D::descriptor_colors(),
+            Boxes2D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Boxes2D::descriptor_radii(),
+            Boxes2D::descriptor_labels(),
+            Boxes2D::descriptor_show_labels(),
+            Boxes2D::descriptor_draw_order(),
+            Boxes2D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.HalfSize2D".into(),
-                archetype_field_name: Some("half_sizes".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("centers".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Boxes2DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Boxes2D::descriptor_half_sizes(),
+            Boxes2D::descriptor_centers(),
+            Boxes2D::descriptor_colors(),
+            Boxes2D::descriptor_indicator(),
+            Boxes2D::descriptor_radii(),
+            Boxes2D::descriptor_labels(),
+            Boxes2D::descriptor_show_labels(),
+            Boxes2D::descriptor_draw_order(),
+            Boxes2D::descriptor_class_ids(),
         ]
     });
 
@@ -443,11 +379,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
             (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                        archetype_field_name: Some(("half_sizes").into()),
-                        component_name: ("rerun.components.HalfSize2D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_half_sizes()),
                 }
             }),
             (self
@@ -456,11 +388,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                    archetype_field_name: Some(("centers").into()),
-                    component_name: ("rerun.components.Position2D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_centers()),
             }),
             (self
                 .colors
@@ -468,11 +396,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .radii
@@ -480,11 +404,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .labels
@@ -492,11 +412,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -504,11 +420,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .draw_order
@@ -516,11 +428,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
             (self
                 .class_ids
@@ -528,11 +436,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -110,6 +110,108 @@ pub struct Boxes3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl Boxes3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
+    #[inline]
+    pub fn descriptor_half_sizes() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.HalfSize3D".into(),
+            archetype_field_name: Some("half_sizes".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
+    #[inline]
+    pub fn descriptor_centers() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.PoseTranslation3D".into(),
+            archetype_field_name: Some("centers".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    #[inline]
+    pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.PoseRotationAxisAngle".into(),
+            archetype_field_name: Some("rotation_axis_angles".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    #[inline]
+    pub fn descriptor_quaternions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.PoseRotationQuat".into(),
+            archetype_field_name: Some("quaternions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
+    #[inline]
+    pub fn descriptor_fill_mode() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.FillMode".into(),
+            archetype_field_name: Some("fill_mode".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -210,137 +210,57 @@ impl Boxes3D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.Boxes3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-            component_name: "rerun.components.HalfSize3D".into(),
-            archetype_field_name: Some("half_sizes".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Boxes3D::descriptor_half_sizes()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("centers".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Boxes3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Boxes3D::descriptor_centers(),
+            Boxes3D::descriptor_colors(),
+            Boxes3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.FillMode".into(),
-                archetype_field_name: Some("fill_mode".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Boxes3D::descriptor_rotation_axis_angles(),
+            Boxes3D::descriptor_quaternions(),
+            Boxes3D::descriptor_radii(),
+            Boxes3D::descriptor_fill_mode(),
+            Boxes3D::descriptor_labels(),
+            Boxes3D::descriptor_show_labels(),
+            Boxes3D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.HalfSize3D".into(),
-                archetype_field_name: Some("half_sizes".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("centers".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Boxes3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.FillMode".into(),
-                archetype_field_name: Some("fill_mode".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Boxes3D::descriptor_half_sizes(),
+            Boxes3D::descriptor_centers(),
+            Boxes3D::descriptor_colors(),
+            Boxes3D::descriptor_indicator(),
+            Boxes3D::descriptor_rotation_axis_angles(),
+            Boxes3D::descriptor_quaternions(),
+            Boxes3D::descriptor_radii(),
+            Boxes3D::descriptor_fill_mode(),
+            Boxes3D::descriptor_labels(),
+            Boxes3D::descriptor_show_labels(),
+            Boxes3D::descriptor_class_ids(),
         ]
     });
 
@@ -542,11 +462,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
             (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                        archetype_field_name: Some(("half_sizes").into()),
-                        component_name: ("rerun.components.HalfSize3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_half_sizes()),
                 }
             }),
             (self
@@ -555,11 +471,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("centers").into()),
-                    component_name: ("rerun.components.PoseTranslation3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_centers()),
             }),
             (self
                 .rotation_axis_angles
@@ -567,11 +479,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("rotation_axis_angles").into()),
-                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_rotation_axis_angles()),
             }),
             (self
                 .quaternions
@@ -579,11 +487,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("quaternions").into()),
-                    component_name: ("rerun.components.PoseRotationQuat").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_quaternions()),
             }),
             (self
                 .colors
@@ -591,11 +495,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .radii
@@ -603,11 +503,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .fill_mode
@@ -615,11 +511,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("fill_mode").into()),
-                    component_name: ("rerun.components.FillMode").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fill_mode()),
             }),
             (self
                 .labels
@@ -627,11 +519,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -639,11 +527,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .class_ids
@@ -651,11 +535,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -202,129 +202,59 @@ impl Capsules3D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.Capsules3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Length".into(),
-                archetype_field_name: Some("lengths".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
+            Capsules3D::descriptor_lengths(),
+            Capsules3D::descriptor_radii(),
         ]
     });
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("translations".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Capsules3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Capsules3D::descriptor_translations(),
+            Capsules3D::descriptor_colors(),
+            Capsules3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Capsules3D::descriptor_rotation_axis_angles(),
+            Capsules3D::descriptor_quaternions(),
+            Capsules3D::descriptor_labels(),
+            Capsules3D::descriptor_show_labels(),
+            Capsules3D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Length".into(),
-                archetype_field_name: Some("lengths".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("translations".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Capsules3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Capsules3D::descriptor_lengths(),
+            Capsules3D::descriptor_radii(),
+            Capsules3D::descriptor_translations(),
+            Capsules3D::descriptor_colors(),
+            Capsules3D::descriptor_indicator(),
+            Capsules3D::descriptor_rotation_axis_angles(),
+            Capsules3D::descriptor_quaternions(),
+            Capsules3D::descriptor_labels(),
+            Capsules3D::descriptor_show_labels(),
+            Capsules3D::descriptor_class_ids(),
         ]
     });
 
@@ -516,21 +446,13 @@ impl ::re_types_core::AsComponents for Capsules3D {
             (Some(&self.lengths as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                        archetype_field_name: Some(("lengths").into()),
-                        component_name: ("rerun.components.Length").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_lengths()),
                 }
             }),
             (Some(&self.radii as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                        archetype_field_name: Some(("radii").into()),
-                        component_name: ("rerun.components.Radius").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_radii()),
                 }
             }),
             (self
@@ -539,11 +461,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                    archetype_field_name: Some(("translations").into()),
-                    component_name: ("rerun.components.PoseTranslation3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_translations()),
             }),
             (self
                 .rotation_axis_angles
@@ -551,11 +469,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                    archetype_field_name: Some(("rotation_axis_angles").into()),
-                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_rotation_axis_angles()),
             }),
             (self
                 .quaternions
@@ -563,11 +477,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                    archetype_field_name: Some(("quaternions").into()),
-                    component_name: ("rerun.components.PoseRotationQuat").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_quaternions()),
             }),
             (self
                 .colors
@@ -575,11 +485,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -587,11 +493,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -599,11 +501,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .class_ids
@@ -611,11 +509,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -112,6 +112,98 @@ pub struct Capsules3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl Capsules3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::lengths`].
+    #[inline]
+    pub fn descriptor_lengths() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.Length".into(),
+            archetype_field_name: Some("lengths".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
+    #[inline]
+    pub fn descriptor_translations() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.PoseTranslation3D".into(),
+            archetype_field_name: Some("translations".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    #[inline]
+    pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.PoseRotationAxisAngle".into(),
+            archetype_field_name: Some("rotation_axis_angles".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    #[inline]
+    pub fn descriptor_quaternions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.PoseRotationQuat".into(),
+            archetype_field_name: Some("quaternions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -114,6 +114,78 @@ pub struct DepthImage {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
+impl DepthImage {
+    /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
+    #[inline]
+    pub fn descriptor_buffer() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.ImageBuffer".into(),
+            archetype_field_name: Some("buffer".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::format`].
+    #[inline]
+    pub fn descriptor_format() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.ImageFormat".into(),
+            archetype_field_name: Some("format".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::meter`].
+    #[inline]
+    pub fn descriptor_meter() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.DepthMeter".into(),
+            archetype_field_name: Some("meter".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
+    #[inline]
+    pub fn descriptor_colormap() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.Colormap".into(),
+            archetype_field_name: Some("colormap".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::depth_range`].
+    #[inline]
+    pub fn descriptor_depth_range() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.ValueRange".into(),
+            archetype_field_name: Some("depth_range".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::point_fill_ratio`].
+    #[inline]
+    pub fn descriptor_point_fill_ratio() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.FillRatio".into(),
+            archetype_field_name: Some("point_fill_ratio".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -184,107 +184,51 @@ impl DepthImage {
             archetype_field_name: Some("draw_order".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "rerun.components.DepthImageIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("format".into()),
-            },
+            DepthImage::descriptor_buffer(),
+            DepthImage::descriptor_format(),
         ]
     });
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.DepthImage".into()),
-            component_name: "rerun.components.DepthImageIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [DepthImage::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.DepthMeter".into(),
-                archetype_field_name: Some("meter".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.Colormap".into(),
-                archetype_field_name: Some("colormap".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.ValueRange".into(),
-                archetype_field_name: Some("depth_range".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.FillRatio".into(),
-                archetype_field_name: Some("point_fill_ratio".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
+            DepthImage::descriptor_meter(),
+            DepthImage::descriptor_colormap(),
+            DepthImage::descriptor_depth_range(),
+            DepthImage::descriptor_point_fill_ratio(),
+            DepthImage::descriptor_draw_order(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("format".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.DepthImageIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.DepthMeter".into(),
-                archetype_field_name: Some("meter".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.Colormap".into(),
-                archetype_field_name: Some("colormap".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.ValueRange".into(),
-                archetype_field_name: Some("depth_range".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.FillRatio".into(),
-                archetype_field_name: Some("point_fill_ratio".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
+            DepthImage::descriptor_buffer(),
+            DepthImage::descriptor_format(),
+            DepthImage::descriptor_indicator(),
+            DepthImage::descriptor_meter(),
+            DepthImage::descriptor_colormap(),
+            DepthImage::descriptor_depth_range(),
+            DepthImage::descriptor_point_fill_ratio(),
+            DepthImage::descriptor_draw_order(),
         ]
     });
 
@@ -438,21 +382,13 @@ impl ::re_types_core::AsComponents for DepthImage {
             (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                        archetype_field_name: Some(("buffer").into()),
-                        component_name: ("rerun.components.ImageBuffer").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_buffer()),
                 }
             }),
             (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                        archetype_field_name: Some(("format").into()),
-                        component_name: ("rerun.components.ImageFormat").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_format()),
                 }
             }),
             (self
@@ -461,11 +397,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                    archetype_field_name: Some(("meter").into()),
-                    component_name: ("rerun.components.DepthMeter").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_meter()),
             }),
             (self
                 .colormap
@@ -473,11 +405,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                    archetype_field_name: Some(("colormap").into()),
-                    component_name: ("rerun.components.Colormap").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colormap()),
             }),
             (self
                 .depth_range
@@ -485,11 +413,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                    archetype_field_name: Some(("depth_range").into()),
-                    component_name: ("rerun.components.ValueRange").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_depth_range()),
             }),
             (self
                 .point_fill_ratio
@@ -497,11 +421,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                    archetype_field_name: Some(("point_fill_ratio").into()),
-                    component_name: ("rerun.components.FillRatio").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_point_fill_ratio()),
             }),
             (self
                 .draw_order
@@ -509,11 +429,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -125,6 +125,108 @@ pub struct Ellipsoids3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl Ellipsoids3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
+    #[inline]
+    pub fn descriptor_half_sizes() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.HalfSize3D".into(),
+            archetype_field_name: Some("half_sizes".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
+    #[inline]
+    pub fn descriptor_centers() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.PoseTranslation3D".into(),
+            archetype_field_name: Some("centers".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    #[inline]
+    pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.PoseRotationAxisAngle".into(),
+            archetype_field_name: Some("rotation_axis_angles".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    #[inline]
+    pub fn descriptor_quaternions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.PoseRotationQuat".into(),
+            archetype_field_name: Some("quaternions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::line_radii`].
+    #[inline]
+    pub fn descriptor_line_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("line_radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
+    #[inline]
+    pub fn descriptor_fill_mode() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.FillMode".into(),
+            archetype_field_name: Some("fill_mode".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -225,137 +225,57 @@ impl Ellipsoids3D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.Ellipsoids3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-            component_name: "rerun.components.HalfSize3D".into(),
-            archetype_field_name: Some("half_sizes".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Ellipsoids3D::descriptor_half_sizes()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("centers".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Ellipsoids3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Ellipsoids3D::descriptor_centers(),
+            Ellipsoids3D::descriptor_colors(),
+            Ellipsoids3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("line_radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.FillMode".into(),
-                archetype_field_name: Some("fill_mode".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Ellipsoids3D::descriptor_rotation_axis_angles(),
+            Ellipsoids3D::descriptor_quaternions(),
+            Ellipsoids3D::descriptor_line_radii(),
+            Ellipsoids3D::descriptor_fill_mode(),
+            Ellipsoids3D::descriptor_labels(),
+            Ellipsoids3D::descriptor_show_labels(),
+            Ellipsoids3D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.HalfSize3D".into(),
-                archetype_field_name: Some("half_sizes".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("centers".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Ellipsoids3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("line_radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.FillMode".into(),
-                archetype_field_name: Some("fill_mode".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Ellipsoids3D::descriptor_half_sizes(),
+            Ellipsoids3D::descriptor_centers(),
+            Ellipsoids3D::descriptor_colors(),
+            Ellipsoids3D::descriptor_indicator(),
+            Ellipsoids3D::descriptor_rotation_axis_angles(),
+            Ellipsoids3D::descriptor_quaternions(),
+            Ellipsoids3D::descriptor_line_radii(),
+            Ellipsoids3D::descriptor_fill_mode(),
+            Ellipsoids3D::descriptor_labels(),
+            Ellipsoids3D::descriptor_show_labels(),
+            Ellipsoids3D::descriptor_class_ids(),
         ]
     });
 
@@ -557,11 +477,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
             (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                        archetype_field_name: Some(("half_sizes").into()),
-                        component_name: ("rerun.components.HalfSize3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_half_sizes()),
                 }
             }),
             (self
@@ -570,11 +486,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("centers").into()),
-                    component_name: ("rerun.components.PoseTranslation3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_centers()),
             }),
             (self
                 .rotation_axis_angles
@@ -582,11 +494,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("rotation_axis_angles").into()),
-                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_rotation_axis_angles()),
             }),
             (self
                 .quaternions
@@ -594,11 +502,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("quaternions").into()),
-                    component_name: ("rerun.components.PoseRotationQuat").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_quaternions()),
             }),
             (self
                 .colors
@@ -606,11 +510,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .line_radii
@@ -618,11 +518,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("line_radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_line_radii()),
             }),
             (self
                 .fill_mode
@@ -630,11 +526,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("fill_mode").into()),
-                    component_name: ("rerun.components.FillMode").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fill_mode()),
             }),
             (self
                 .labels
@@ -642,11 +534,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -654,11 +542,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .class_ids
@@ -666,11 +550,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -66,6 +66,48 @@ pub struct EncodedImage {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
+impl EncodedImage {
+    /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
+    #[inline]
+    pub fn descriptor_blob() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+            component_name: "rerun.components.Blob".into(),
+            archetype_field_name: Some("blob".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    #[inline]
+    pub fn descriptor_media_type() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+            component_name: "rerun.components.MediaType".into(),
+            archetype_field_name: Some("media_type".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
+    #[inline]
+    pub fn descriptor_opacity() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+            component_name: "rerun.components.Opacity".into(),
+            archetype_field_name: Some("opacity".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -106,77 +106,45 @@ impl EncodedImage {
             archetype_field_name: Some("draw_order".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+            component_name: "rerun.components.EncodedImageIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-            component_name: "rerun.components.Blob".into(),
-            archetype_field_name: Some("blob".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [EncodedImage::descriptor_blob()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.MediaType".into(),
-                archetype_field_name: Some("media_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.EncodedImageIndicator".into(),
-                archetype_field_name: None,
-            },
+            EncodedImage::descriptor_media_type(),
+            EncodedImage::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.Opacity".into(),
-                archetype_field_name: Some("opacity".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
+            EncodedImage::descriptor_opacity(),
+            EncodedImage::descriptor_draw_order(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.Blob".into(),
-                archetype_field_name: Some("blob".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.MediaType".into(),
-                archetype_field_name: Some("media_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.EncodedImageIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.Opacity".into(),
-                archetype_field_name: Some("opacity".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
+            EncodedImage::descriptor_blob(),
+            EncodedImage::descriptor_media_type(),
+            EncodedImage::descriptor_indicator(),
+            EncodedImage::descriptor_opacity(),
+            EncodedImage::descriptor_draw_order(),
         ]
     });
 
@@ -295,11 +263,7 @@ impl ::re_types_core::AsComponents for EncodedImage {
             (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                        archetype_field_name: Some(("blob").into()),
-                        component_name: ("rerun.components.Blob").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_blob()),
                 }
             }),
             (self
@@ -308,11 +272,7 @@ impl ::re_types_core::AsComponents for EncodedImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                    archetype_field_name: Some(("media_type").into()),
-                    component_name: ("rerun.components.MediaType").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_media_type()),
             }),
             (self
                 .opacity
@@ -320,11 +280,7 @@ impl ::re_types_core::AsComponents for EncodedImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                    archetype_field_name: Some(("opacity").into()),
-                    component_name: ("rerun.components.Opacity").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_opacity()),
             }),
             (self
                 .draw_order
@@ -332,11 +288,7 @@ impl ::re_types_core::AsComponents for EncodedImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -69,6 +69,38 @@ pub struct GeoLineStrings {
     pub colors: Option<Vec<crate::components::Color>>,
 }
 
+impl GeoLineStrings {
+    /// Returns the [`ComponentDescriptor`] for [`Self::line_strings`].
+    #[inline]
+    pub fn descriptor_line_strings() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
+            component_name: "rerun.components.GeoLineString".into(),
+            archetype_field_name: Some("line_strings".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -99,35 +99,27 @@ impl GeoLineStrings {
             archetype_field_name: Some("colors".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
+            component_name: "rerun.components.GeoLineStringsIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-            component_name: "rerun.components.GeoLineString".into(),
-            archetype_field_name: Some("line_strings".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [GeoLineStrings::descriptor_line_strings()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "rerun.components.GeoLineStringsIndicator".into(),
-                archetype_field_name: None,
-            },
+            GeoLineStrings::descriptor_radii(),
+            GeoLineStrings::descriptor_colors(),
+            GeoLineStrings::descriptor_indicator(),
         ]
     });
 
@@ -137,26 +129,10 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "rerun.components.GeoLineString".into(),
-                archetype_field_name: Some("line_strings".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "rerun.components.GeoLineStringsIndicator".into(),
-                archetype_field_name: None,
-            },
+            GeoLineStrings::descriptor_line_strings(),
+            GeoLineStrings::descriptor_radii(),
+            GeoLineStrings::descriptor_colors(),
+            GeoLineStrings::descriptor_indicator(),
         ]
     });
 
@@ -270,11 +246,7 @@ impl ::re_types_core::AsComponents for GeoLineStrings {
             (Some(&self.line_strings as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                        archetype_field_name: Some(("line_strings").into()),
-                        component_name: ("rerun.components.GeoLineString").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_line_strings()),
                 }
             }),
             (self
@@ -283,11 +255,7 @@ impl ::re_types_core::AsComponents for GeoLineStrings {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -295,11 +263,7 @@ impl ::re_types_core::AsComponents for GeoLineStrings {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -65,6 +65,48 @@ pub struct GeoPoints {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl GeoPoints {
+    /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    #[inline]
+    pub fn descriptor_positions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            component_name: "rerun.components.LatLon".into(),
+            archetype_field_name: Some("positions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -105,75 +105,41 @@ impl GeoPoints {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            component_name: "rerun.components.GeoPointsIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-            component_name: "rerun.components.LatLon".into(),
-            archetype_field_name: Some("positions".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [GeoPoints::descriptor_positions()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.GeoPointsIndicator".into(),
-                archetype_field_name: None,
-            },
+            GeoPoints::descriptor_radii(),
+            GeoPoints::descriptor_colors(),
+            GeoPoints::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-            component_name: "rerun.components.ClassId".into(),
-            archetype_field_name: Some("class_ids".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [GeoPoints::descriptor_class_ids()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.LatLon".into(),
-                archetype_field_name: Some("positions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.GeoPointsIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            GeoPoints::descriptor_positions(),
+            GeoPoints::descriptor_radii(),
+            GeoPoints::descriptor_colors(),
+            GeoPoints::descriptor_indicator(),
+            GeoPoints::descriptor_class_ids(),
         ]
     });
 
@@ -300,11 +266,7 @@ impl ::re_types_core::AsComponents for GeoPoints {
             (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                        archetype_field_name: Some(("positions").into()),
-                        component_name: ("rerun.components.LatLon").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_positions()),
                 }
             }),
             (self
@@ -313,11 +275,7 @@ impl ::re_types_core::AsComponents for GeoPoints {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -325,11 +283,7 @@ impl ::re_types_core::AsComponents for GeoPoints {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .class_ids
@@ -337,11 +291,7 @@ impl ::re_types_core::AsComponents for GeoPoints {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -62,6 +62,28 @@ pub struct GraphEdges {
     pub graph_type: Option<crate::components::GraphType>,
 }
 
+impl GraphEdges {
+    /// Returns the [`ComponentDescriptor`] for [`Self::edges`].
+    #[inline]
+    pub fn descriptor_edges() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+            component_name: "rerun.components.GraphEdge".into(),
+            archetype_field_name: Some("edges".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::graph_type`].
+    #[inline]
+    pub fn descriptor_graph_type() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+            component_name: "rerun.components.GraphType".into(),
+            archetype_field_name: Some("graph_type".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -82,30 +82,26 @@ impl GraphEdges {
             archetype_field_name: Some("graph_type".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+            component_name: "rerun.components.GraphEdgesIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-            component_name: "rerun.components.GraphEdge".into(),
-            archetype_field_name: Some("edges".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [GraphEdges::descriptor_edges()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: "rerun.components.GraphType".into(),
-                archetype_field_name: Some("graph_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: "rerun.components.GraphEdgesIndicator".into(),
-                archetype_field_name: None,
-            },
+            GraphEdges::descriptor_graph_type(),
+            GraphEdges::descriptor_indicator(),
         ]
     });
 
@@ -115,21 +111,9 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: "rerun.components.GraphEdge".into(),
-                archetype_field_name: Some("edges".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: "rerun.components.GraphType".into(),
-                archetype_field_name: Some("graph_type".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: "rerun.components.GraphEdgesIndicator".into(),
-                archetype_field_name: None,
-            },
+            GraphEdges::descriptor_edges(),
+            GraphEdges::descriptor_graph_type(),
+            GraphEdges::descriptor_indicator(),
         ]
     });
 
@@ -224,11 +208,7 @@ impl ::re_types_core::AsComponents for GraphEdges {
             (Some(&self.edges as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                        archetype_field_name: Some(("edges").into()),
-                        component_name: ("rerun.components.GraphEdge").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_edges()),
                 }
             }),
             (self
@@ -237,11 +217,7 @@ impl ::re_types_core::AsComponents for GraphEdges {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                    archetype_field_name: Some(("graph_type").into()),
-                    component_name: ("rerun.components.GraphType").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_graph_type()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -130,95 +130,45 @@ impl GraphNodes {
             archetype_field_name: Some("radii".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-            component_name: "rerun.components.GraphNode".into(),
-            archetype_field_name: Some("node_ids".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.GraphNodes".into()),
             component_name: "rerun.components.GraphNodesIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [GraphNodes::descriptor_node_ids()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [GraphNodes::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("positions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
+            GraphNodes::descriptor_positions(),
+            GraphNodes::descriptor_colors(),
+            GraphNodes::descriptor_labels(),
+            GraphNodes::descriptor_show_labels(),
+            GraphNodes::descriptor_radii(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.GraphNode".into(),
-                archetype_field_name: Some("node_ids".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.GraphNodesIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("positions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
+            GraphNodes::descriptor_node_ids(),
+            GraphNodes::descriptor_indicator(),
+            GraphNodes::descriptor_positions(),
+            GraphNodes::descriptor_colors(),
+            GraphNodes::descriptor_labels(),
+            GraphNodes::descriptor_show_labels(),
+            GraphNodes::descriptor_radii(),
         ]
     });
 
@@ -368,11 +318,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
             (Some(&self.node_ids as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                        archetype_field_name: Some(("node_ids").into()),
-                        component_name: ("rerun.components.GraphNode").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_node_ids()),
                 }
             }),
             (self
@@ -381,11 +327,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                    archetype_field_name: Some(("positions").into()),
-                    component_name: ("rerun.components.Position2D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_positions()),
             }),
             (self
                 .colors
@@ -393,11 +335,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -405,11 +343,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -417,11 +351,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .radii
@@ -429,11 +359,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -70,6 +70,68 @@ pub struct GraphNodes {
     pub radii: Option<Vec<crate::components::Radius>>,
 }
 
+impl GraphNodes {
+    /// Returns the [`ComponentDescriptor`] for [`Self::node_ids`].
+    #[inline]
+    pub fn descriptor_node_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "rerun.components.GraphNode".into(),
+            archetype_field_name: Some("node_ids".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    #[inline]
+    pub fn descriptor_positions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "rerun.components.Position2D".into(),
+            archetype_field_name: Some("positions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -185,77 +185,35 @@ impl Image {
             archetype_field_name: Some("draw_order".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("format".into()),
-            },
-        ]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Image".into()),
             component_name: "rerun.components.ImageIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
+    once_cell::sync::Lazy::new(|| [Image::descriptor_buffer(), Image::descriptor_format()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Image::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.Opacity".into(),
-                archetype_field_name: Some("opacity".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-        ]
-    });
+    once_cell::sync::Lazy::new(|| [Image::descriptor_opacity(), Image::descriptor_draw_order()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("format".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.ImageIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.Opacity".into(),
-                archetype_field_name: Some("opacity".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
+            Image::descriptor_buffer(),
+            Image::descriptor_format(),
+            Image::descriptor_indicator(),
+            Image::descriptor_opacity(),
+            Image::descriptor_draw_order(),
         ]
     });
 
@@ -378,21 +336,13 @@ impl ::re_types_core::AsComponents for Image {
             (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Image".into()),
-                        archetype_field_name: Some(("buffer").into()),
-                        component_name: ("rerun.components.ImageBuffer").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_buffer()),
                 }
             }),
             (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Image".into()),
-                        archetype_field_name: Some(("format").into()),
-                        component_name: ("rerun.components.ImageFormat").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_format()),
                 }
             }),
             (self
@@ -401,11 +351,7 @@ impl ::re_types_core::AsComponents for Image {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Image".into()),
-                    archetype_field_name: Some(("opacity").into()),
-                    component_name: ("rerun.components.Opacity").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_opacity()),
             }),
             (self
                 .draw_order
@@ -413,11 +359,7 @@ impl ::re_types_core::AsComponents for Image {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Image".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -145,6 +145,48 @@ pub struct Image {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
+impl Image {
+    /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
+    #[inline]
+    pub fn descriptor_buffer() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Image".into()),
+            component_name: "rerun.components.ImageBuffer".into(),
+            archetype_field_name: Some("buffer".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::format`].
+    #[inline]
+    pub fn descriptor_format() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Image".into()),
+            component_name: "rerun.components.ImageFormat".into(),
+            archetype_field_name: Some("format".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
+    #[inline]
+    pub fn descriptor_opacity() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Image".into()),
+            component_name: "rerun.components.Opacity".into(),
+            archetype_field_name: Some("opacity".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Image".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -158,84 +158,44 @@ impl InstancePoses3D {
             archetype_field_name: Some("mat3x3".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            component_name: "rerun.components.InstancePoses3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-            component_name: "rerun.components.InstancePoses3DIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [InstancePoses3D::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("translations".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseScale3D".into(),
-                archetype_field_name: Some("scales".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseTransformMat3x3".into(),
-                archetype_field_name: Some("mat3x3".into()),
-            },
+            InstancePoses3D::descriptor_translations(),
+            InstancePoses3D::descriptor_rotation_axis_angles(),
+            InstancePoses3D::descriptor_quaternions(),
+            InstancePoses3D::descriptor_scales(),
+            InstancePoses3D::descriptor_mat3x3(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.InstancePoses3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseTranslation3D".into(),
-                archetype_field_name: Some("translations".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseRotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angles".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseRotationQuat".into(),
-                archetype_field_name: Some("quaternions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseScale3D".into(),
-                archetype_field_name: Some("scales".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "rerun.components.PoseTransformMat3x3".into(),
-                archetype_field_name: Some("mat3x3".into()),
-            },
+            InstancePoses3D::descriptor_indicator(),
+            InstancePoses3D::descriptor_translations(),
+            InstancePoses3D::descriptor_rotation_axis_angles(),
+            InstancePoses3D::descriptor_quaternions(),
+            InstancePoses3D::descriptor_scales(),
+            InstancePoses3D::descriptor_mat3x3(),
         ]
     });
 
@@ -382,11 +342,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                    archetype_field_name: Some(("translations").into()),
-                    component_name: ("rerun.components.PoseTranslation3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_translations()),
             }),
             (self
                 .rotation_axis_angles
@@ -394,11 +350,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                    archetype_field_name: Some(("rotation_axis_angles").into()),
-                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_rotation_axis_angles()),
             }),
             (self
                 .quaternions
@@ -406,11 +358,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                    archetype_field_name: Some(("quaternions").into()),
-                    component_name: ("rerun.components.PoseRotationQuat").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_quaternions()),
             }),
             (self
                 .scales
@@ -418,11 +366,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                    archetype_field_name: Some(("scales").into()),
-                    component_name: ("rerun.components.PoseScale3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_scales()),
             }),
             (self
                 .mat3x3
@@ -430,11 +374,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                    archetype_field_name: Some(("mat3x3").into()),
-                    component_name: ("rerun.components.PoseTransformMat3x3").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_mat3x3()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -108,6 +108,58 @@ pub struct InstancePoses3D {
     pub mat3x3: Option<Vec<crate::components::PoseTransformMat3x3>>,
 }
 
+impl InstancePoses3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
+    #[inline]
+    pub fn descriptor_translations() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            component_name: "rerun.components.PoseTranslation3D".into(),
+            archetype_field_name: Some("translations".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    #[inline]
+    pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            component_name: "rerun.components.PoseRotationAxisAngle".into(),
+            archetype_field_name: Some("rotation_axis_angles".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    #[inline]
+    pub fn descriptor_quaternions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            component_name: "rerun.components.PoseRotationQuat".into(),
+            archetype_field_name: Some("quaternions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::scales`].
+    #[inline]
+    pub fn descriptor_scales() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            component_name: "rerun.components.PoseScale3D".into(),
+            archetype_field_name: Some("scales".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
+    #[inline]
+    pub fn descriptor_mat3x3() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            component_name: "rerun.components.PoseTransformMat3x3".into(),
+            archetype_field_name: Some("mat3x3".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -116,6 +116,78 @@ pub struct LineStrips2D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl LineStrips2D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
+    #[inline]
+    pub fn descriptor_strips() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.LineStrip2D".into(),
+            archetype_field_name: Some("strips".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -186,107 +186,51 @@ impl LineStrips2D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.LineStrips2DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-            component_name: "rerun.components.LineStrip2D".into(),
-            archetype_field_name: Some("strips".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [LineStrips2D::descriptor_strips()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.LineStrips2DIndicator".into(),
-                archetype_field_name: None,
-            },
+            LineStrips2D::descriptor_radii(),
+            LineStrips2D::descriptor_colors(),
+            LineStrips2D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            LineStrips2D::descriptor_labels(),
+            LineStrips2D::descriptor_show_labels(),
+            LineStrips2D::descriptor_draw_order(),
+            LineStrips2D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.LineStrip2D".into(),
-                archetype_field_name: Some("strips".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.LineStrips2DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            LineStrips2D::descriptor_strips(),
+            LineStrips2D::descriptor_radii(),
+            LineStrips2D::descriptor_colors(),
+            LineStrips2D::descriptor_indicator(),
+            LineStrips2D::descriptor_labels(),
+            LineStrips2D::descriptor_show_labels(),
+            LineStrips2D::descriptor_draw_order(),
+            LineStrips2D::descriptor_class_ids(),
         ]
     });
 
@@ -446,11 +390,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
             (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                        archetype_field_name: Some(("strips").into()),
-                        component_name: ("rerun.components.LineStrip2D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_strips()),
                 }
             }),
             (self
@@ -459,11 +399,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -471,11 +407,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -483,11 +415,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -495,11 +423,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .draw_order
@@ -507,11 +431,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
             (self
                 .class_ids
@@ -519,11 +439,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -184,97 +184,49 @@ impl LineStrips3D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.LineStrips3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-            component_name: "rerun.components.LineStrip3D".into(),
-            archetype_field_name: Some("strips".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [LineStrips3D::descriptor_strips()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.LineStrips3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            LineStrips3D::descriptor_radii(),
+            LineStrips3D::descriptor_colors(),
+            LineStrips3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            LineStrips3D::descriptor_labels(),
+            LineStrips3D::descriptor_show_labels(),
+            LineStrips3D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.LineStrip3D".into(),
-                archetype_field_name: Some("strips".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.LineStrips3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            LineStrips3D::descriptor_strips(),
+            LineStrips3D::descriptor_radii(),
+            LineStrips3D::descriptor_colors(),
+            LineStrips3D::descriptor_indicator(),
+            LineStrips3D::descriptor_labels(),
+            LineStrips3D::descriptor_show_labels(),
+            LineStrips3D::descriptor_class_ids(),
         ]
     });
 
@@ -424,11 +376,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
             (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                        archetype_field_name: Some(("strips").into()),
-                        component_name: ("rerun.components.LineStrip3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_strips()),
                 }
             }),
             (self
@@ -437,11 +385,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -449,11 +393,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -461,11 +401,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -473,11 +409,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .class_ids
@@ -485,11 +417,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -124,6 +124,68 @@ pub struct LineStrips3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl LineStrips3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
+    #[inline]
+    pub fn descriptor_strips() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.LineStrip3D".into(),
+            archetype_field_name: Some("strips".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -235,127 +235,55 @@ impl Mesh3D {
             archetype_field_name: Some("class_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.Mesh3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-            component_name: "rerun.components.Position3D".into(),
-            archetype_field_name: Some("vertex_positions".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Mesh3D::descriptor_vertex_positions()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.TriangleIndices".into(),
-                archetype_field_name: Some("triangle_indices".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Vector3D".into(),
-                archetype_field_name: Some("vertex_normals".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Mesh3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Mesh3D::descriptor_triangle_indices(),
+            Mesh3D::descriptor_vertex_normals(),
+            Mesh3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("vertex_colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Texcoord2D".into(),
-                archetype_field_name: Some("vertex_texcoords".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.AlbedoFactor".into(),
-                archetype_field_name: Some("albedo_factor".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("albedo_texture_buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("albedo_texture_format".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Mesh3D::descriptor_vertex_colors(),
+            Mesh3D::descriptor_vertex_texcoords(),
+            Mesh3D::descriptor_albedo_factor(),
+            Mesh3D::descriptor_albedo_texture_buffer(),
+            Mesh3D::descriptor_albedo_texture_format(),
+            Mesh3D::descriptor_class_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Position3D".into(),
-                archetype_field_name: Some("vertex_positions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.TriangleIndices".into(),
-                archetype_field_name: Some("triangle_indices".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Vector3D".into(),
-                archetype_field_name: Some("vertex_normals".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Mesh3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("vertex_colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.Texcoord2D".into(),
-                archetype_field_name: Some("vertex_texcoords".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.AlbedoFactor".into(),
-                archetype_field_name: Some("albedo_factor".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("albedo_texture_buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("albedo_texture_format".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
+            Mesh3D::descriptor_vertex_positions(),
+            Mesh3D::descriptor_triangle_indices(),
+            Mesh3D::descriptor_vertex_normals(),
+            Mesh3D::descriptor_indicator(),
+            Mesh3D::descriptor_vertex_colors(),
+            Mesh3D::descriptor_vertex_texcoords(),
+            Mesh3D::descriptor_albedo_factor(),
+            Mesh3D::descriptor_albedo_texture_buffer(),
+            Mesh3D::descriptor_albedo_texture_format(),
+            Mesh3D::descriptor_class_ids(),
         ]
     });
 
@@ -543,11 +471,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
             (Some(&self.vertex_positions as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                        archetype_field_name: Some(("vertex_positions").into()),
-                        component_name: ("rerun.components.Position3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_vertex_positions()),
                 }
             }),
             (self
@@ -556,11 +480,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("triangle_indices").into()),
-                    component_name: ("rerun.components.TriangleIndices").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_triangle_indices()),
             }),
             (self
                 .vertex_normals
@@ -568,11 +488,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("vertex_normals").into()),
-                    component_name: ("rerun.components.Vector3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_vertex_normals()),
             }),
             (self
                 .vertex_colors
@@ -580,11 +496,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("vertex_colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_vertex_colors()),
             }),
             (self
                 .vertex_texcoords
@@ -592,11 +504,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("vertex_texcoords").into()),
-                    component_name: ("rerun.components.Texcoord2D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_vertex_texcoords()),
             }),
             (self
                 .albedo_factor
@@ -604,11 +512,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("albedo_factor").into()),
-                    component_name: ("rerun.components.AlbedoFactor").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_albedo_factor()),
             }),
             (self
                 .albedo_texture_buffer
@@ -616,11 +520,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("albedo_texture_buffer").into()),
-                    component_name: ("rerun.components.ImageBuffer").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_albedo_texture_buffer()),
             }),
             (self
                 .albedo_texture_format
@@ -628,11 +528,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("albedo_texture_format").into()),
-                    component_name: ("rerun.components.ImageFormat").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_albedo_texture_format()),
             }),
             (self
                 .class_ids
@@ -640,11 +536,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -145,6 +145,98 @@ pub struct Mesh3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
+impl Mesh3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::vertex_positions`].
+    #[inline]
+    pub fn descriptor_vertex_positions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.Position3D".into(),
+            archetype_field_name: Some("vertex_positions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::triangle_indices`].
+    #[inline]
+    pub fn descriptor_triangle_indices() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.TriangleIndices".into(),
+            archetype_field_name: Some("triangle_indices".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::vertex_normals`].
+    #[inline]
+    pub fn descriptor_vertex_normals() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.Vector3D".into(),
+            archetype_field_name: Some("vertex_normals".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::vertex_colors`].
+    #[inline]
+    pub fn descriptor_vertex_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("vertex_colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::vertex_texcoords`].
+    #[inline]
+    pub fn descriptor_vertex_texcoords() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.Texcoord2D".into(),
+            archetype_field_name: Some("vertex_texcoords".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
+    #[inline]
+    pub fn descriptor_albedo_factor() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.AlbedoFactor".into(),
+            archetype_field_name: Some("albedo_factor".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_buffer`].
+    #[inline]
+    pub fn descriptor_albedo_texture_buffer() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.ImageBuffer".into(),
+            archetype_field_name: Some("albedo_texture_buffer".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_format`].
+    #[inline]
+    pub fn descriptor_albedo_texture_format() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.ImageFormat".into(),
+            archetype_field_name: Some("albedo_texture_format".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -136,6 +136,48 @@ pub struct Pinhole {
     pub image_plane_distance: Option<crate::components::ImagePlaneDistance>,
 }
 
+impl Pinhole {
+    /// Returns the [`ComponentDescriptor`] for [`Self::image_from_camera`].
+    #[inline]
+    pub fn descriptor_image_from_camera() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Pinhole".into()),
+            component_name: "rerun.components.PinholeProjection".into(),
+            archetype_field_name: Some("image_from_camera".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::resolution`].
+    #[inline]
+    pub fn descriptor_resolution() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Pinhole".into()),
+            component_name: "rerun.components.Resolution".into(),
+            archetype_field_name: Some("resolution".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::camera_xyz`].
+    #[inline]
+    pub fn descriptor_camera_xyz() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Pinhole".into()),
+            component_name: "rerun.components.ViewCoordinates".into(),
+            archetype_field_name: Some("camera_xyz".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::image_plane_distance`].
+    #[inline]
+    pub fn descriptor_image_plane_distance() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Pinhole".into()),
+            component_name: "rerun.components.ImagePlaneDistance".into(),
+            archetype_field_name: Some("image_plane_distance".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -176,77 +176,45 @@ impl Pinhole {
             archetype_field_name: Some("image_plane_distance".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Pinhole".into()),
+            component_name: "rerun.components.PinholeIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Pinhole".into()),
-            component_name: "rerun.components.PinholeProjection".into(),
-            archetype_field_name: Some("image_from_camera".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Pinhole::descriptor_image_from_camera()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.Resolution".into(),
-                archetype_field_name: Some("resolution".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.PinholeIndicator".into(),
-                archetype_field_name: None,
-            },
+            Pinhole::descriptor_resolution(),
+            Pinhole::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.ViewCoordinates".into(),
-                archetype_field_name: Some("camera_xyz".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.ImagePlaneDistance".into(),
-                archetype_field_name: Some("image_plane_distance".into()),
-            },
+            Pinhole::descriptor_camera_xyz(),
+            Pinhole::descriptor_image_plane_distance(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.PinholeProjection".into(),
-                archetype_field_name: Some("image_from_camera".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.Resolution".into(),
-                archetype_field_name: Some("resolution".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.PinholeIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.ViewCoordinates".into(),
-                archetype_field_name: Some("camera_xyz".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "rerun.components.ImagePlaneDistance".into(),
-                archetype_field_name: Some("image_plane_distance".into()),
-            },
+            Pinhole::descriptor_image_from_camera(),
+            Pinhole::descriptor_resolution(),
+            Pinhole::descriptor_indicator(),
+            Pinhole::descriptor_camera_xyz(),
+            Pinhole::descriptor_image_plane_distance(),
         ]
     });
 
@@ -367,11 +335,7 @@ impl ::re_types_core::AsComponents for Pinhole {
             (Some(&self.image_from_camera as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                        archetype_field_name: Some(("image_from_camera").into()),
-                        component_name: ("rerun.components.PinholeProjection").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_image_from_camera()),
                 }
             }),
             (self
@@ -380,11 +344,7 @@ impl ::re_types_core::AsComponents for Pinhole {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                    archetype_field_name: Some(("resolution").into()),
-                    component_name: ("rerun.components.Resolution").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_resolution()),
             }),
             (self
                 .camera_xyz
@@ -392,11 +352,7 @@ impl ::re_types_core::AsComponents for Pinhole {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                    archetype_field_name: Some(("camera_xyz").into()),
-                    component_name: ("rerun.components.ViewCoordinates").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_camera_xyz()),
             }),
             (self
                 .image_plane_distance
@@ -404,11 +360,7 @@ impl ::re_types_core::AsComponents for Pinhole {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                    archetype_field_name: Some(("image_plane_distance").into()),
-                    component_name: ("rerun.components.ImagePlaneDistance").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_image_plane_distance()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -137,6 +137,88 @@ pub struct Points2D {
     pub keypoint_ids: Option<Vec<crate::components::KeypointId>>,
 }
 
+impl Points2D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    #[inline]
+    pub fn descriptor_positions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.Position2D".into(),
+            archetype_field_name: Some("positions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
+    #[inline]
+    pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.KeypointId".into(),
+            archetype_field_name: Some("keypoint_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -217,117 +217,53 @@ impl Points2D {
             archetype_field_name: Some("keypoint_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.Points2DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Points2D".into()),
-            component_name: "rerun.components.Position2D".into(),
-            archetype_field_name: Some("positions".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Points2D::descriptor_positions()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Points2DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Points2D::descriptor_radii(),
+            Points2D::descriptor_colors(),
+            Points2D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.KeypointId".into(),
-                archetype_field_name: Some("keypoint_ids".into()),
-            },
+            Points2D::descriptor_labels(),
+            Points2D::descriptor_show_labels(),
+            Points2D::descriptor_draw_order(),
+            Points2D::descriptor_class_ids(),
+            Points2D::descriptor_keypoint_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("positions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Points2DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "rerun.components.KeypointId".into(),
-                archetype_field_name: Some("keypoint_ids".into()),
-            },
+            Points2D::descriptor_positions(),
+            Points2D::descriptor_radii(),
+            Points2D::descriptor_colors(),
+            Points2D::descriptor_indicator(),
+            Points2D::descriptor_labels(),
+            Points2D::descriptor_show_labels(),
+            Points2D::descriptor_draw_order(),
+            Points2D::descriptor_class_ids(),
+            Points2D::descriptor_keypoint_ids(),
         ]
     });
 
@@ -500,11 +436,7 @@ impl ::re_types_core::AsComponents for Points2D {
             (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Points2D".into()),
-                        archetype_field_name: Some(("positions").into()),
-                        component_name: ("rerun.components.Position2D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_positions()),
                 }
             }),
             (self
@@ -513,11 +445,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points2D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -525,11 +453,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points2D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -537,11 +461,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points2D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -549,11 +469,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points2D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .draw_order
@@ -561,11 +477,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points2D".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
             (self
                 .class_ids
@@ -573,11 +485,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points2D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
             (self
                 .keypoint_ids
@@ -585,11 +493,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points2D".into()),
-                    archetype_field_name: Some(("keypoint_ids").into()),
-                    component_name: ("rerun.components.KeypointId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_keypoint_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -130,6 +130,78 @@ pub struct Points3D {
     pub keypoint_ids: Option<Vec<crate::components::KeypointId>>,
 }
 
+impl Points3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    #[inline]
+    pub fn descriptor_positions() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.Position3D".into(),
+            archetype_field_name: Some("positions".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    #[inline]
+    pub fn descriptor_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.Radius".into(),
+            archetype_field_name: Some("radii".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    #[inline]
+    pub fn descriptor_colors() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("colors".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    #[inline]
+    pub fn descriptor_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    #[inline]
+    pub fn descriptor_show_labels() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.ShowLabels".into(),
+            archetype_field_name: Some("show_labels".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    #[inline]
+    pub fn descriptor_class_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
+    #[inline]
+    pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.KeypointId".into(),
+            archetype_field_name: Some("keypoint_ids".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -200,107 +200,51 @@ impl Points3D {
             archetype_field_name: Some("keypoint_ids".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.Points3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Points3D".into()),
-            component_name: "rerun.components.Position3D".into(),
-            archetype_field_name: Some("positions".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Points3D::descriptor_positions()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Points3DIndicator".into(),
-                archetype_field_name: None,
-            },
+            Points3D::descriptor_radii(),
+            Points3D::descriptor_colors(),
+            Points3D::descriptor_indicator(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.KeypointId".into(),
-                archetype_field_name: Some("keypoint_ids".into()),
-            },
+            Points3D::descriptor_labels(),
+            Points3D::descriptor_show_labels(),
+            Points3D::descriptor_class_ids(),
+            Points3D::descriptor_keypoint_ids(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Position3D".into(),
-                archetype_field_name: Some("positions".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Radius".into(),
-                archetype_field_name: Some("radii".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("colors".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Points3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.ShowLabels".into(),
-                archetype_field_name: Some("show_labels".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.ClassId".into(),
-                archetype_field_name: Some("class_ids".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "rerun.components.KeypointId".into(),
-                archetype_field_name: Some("keypoint_ids".into()),
-            },
+            Points3D::descriptor_positions(),
+            Points3D::descriptor_radii(),
+            Points3D::descriptor_colors(),
+            Points3D::descriptor_indicator(),
+            Points3D::descriptor_labels(),
+            Points3D::descriptor_show_labels(),
+            Points3D::descriptor_class_ids(),
+            Points3D::descriptor_keypoint_ids(),
         ]
     });
 
@@ -463,11 +407,7 @@ impl ::re_types_core::AsComponents for Points3D {
             (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Points3D".into()),
-                        archetype_field_name: Some(("positions").into()),
-                        component_name: ("rerun.components.Position3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_positions()),
                 }
             }),
             (self
@@ -476,11 +416,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points3D".into()),
-                    archetype_field_name: Some(("radii").into()),
-                    component_name: ("rerun.components.Radius").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_radii()),
             }),
             (self
                 .colors
@@ -488,11 +424,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points3D".into()),
-                    archetype_field_name: Some(("colors").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colors()),
             }),
             (self
                 .labels
@@ -500,11 +432,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points3D".into()),
-                    archetype_field_name: Some(("labels").into()),
-                    component_name: ("rerun.components.Text").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_labels()),
             }),
             (self
                 .show_labels
@@ -512,11 +440,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points3D".into()),
-                    archetype_field_name: Some(("show_labels").into()),
-                    component_name: ("rerun.components.ShowLabels").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_show_labels()),
             }),
             (self
                 .class_ids
@@ -524,11 +448,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points3D".into()),
-                    archetype_field_name: Some(("class_ids").into()),
-                    component_name: ("rerun.components.ClassId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_class_ids()),
             }),
             (self
                 .keypoint_ids
@@ -536,11 +456,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Points3D".into()),
-                    archetype_field_name: Some(("keypoint_ids").into()),
-                    component_name: ("rerun.components.KeypointId").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_keypoint_ids()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -59,6 +59,18 @@ pub struct Scalar {
     pub scalar: crate::components::Scalar,
 }
 
+impl Scalar {
+    /// Returns the [`ComponentDescriptor`] for [`Self::scalar`].
+    #[inline]
+    pub fn descriptor_scalar() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Scalar".into()),
+            component_name: "rerun.components.Scalar".into(),
+            archetype_field_name: Some("scalar".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -69,44 +69,29 @@ impl Scalar {
             archetype_field_name: Some("scalar".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Scalar".into()),
-            component_name: "rerun.components.Scalar".into(),
-            archetype_field_name: Some("scalar".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Scalar".into()),
             component_name: "rerun.components.ScalarIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Scalar::descriptor_scalar()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Scalar::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Scalar".into()),
-                component_name: "rerun.components.Scalar".into(),
-                archetype_field_name: Some("scalar".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Scalar".into()),
-                component_name: "rerun.components.ScalarIndicator".into(),
-                archetype_field_name: None,
-            },
-        ]
-    });
+    once_cell::sync::Lazy::new(|| [Scalar::descriptor_scalar(), Scalar::descriptor_indicator()]);
 
 impl Scalar {
     /// The total number of components in the archetype: 1 required, 1 recommended, 0 optional
@@ -191,11 +176,7 @@ impl ::re_types_core::AsComponents for Scalar {
             (Some(&self.scalar as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Scalar".into()),
-                        archetype_field_name: Some(("scalar").into()),
-                        component_name: ("rerun.components.Scalar").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_scalar()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -83,6 +83,48 @@ pub struct SegmentationImage {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
+impl SegmentationImage {
+    /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
+    #[inline]
+    pub fn descriptor_buffer() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+            component_name: "rerun.components.ImageBuffer".into(),
+            archetype_field_name: Some("buffer".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::format`].
+    #[inline]
+    pub fn descriptor_format() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+            component_name: "rerun.components.ImageFormat".into(),
+            archetype_field_name: Some("format".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
+    #[inline]
+    pub fn descriptor_opacity() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+            component_name: "rerun.components.Opacity".into(),
+            archetype_field_name: Some("opacity".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    #[inline]
+    pub fn descriptor_draw_order() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+            component_name: "rerun.components.DrawOrder".into(),
+            archetype_field_name: Some("draw_order".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -123,77 +123,45 @@ impl SegmentationImage {
             archetype_field_name: Some("draw_order".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+            component_name: "rerun.components.SegmentationImageIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("format".into()),
-            },
+            SegmentationImage::descriptor_buffer(),
+            SegmentationImage::descriptor_format(),
         ]
     });
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-            component_name: "rerun.components.SegmentationImageIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [SegmentationImage::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.Opacity".into(),
-                archetype_field_name: Some("opacity".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
+            SegmentationImage::descriptor_opacity(),
+            SegmentationImage::descriptor_draw_order(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.ImageBuffer".into(),
-                archetype_field_name: Some("buffer".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.ImageFormat".into(),
-                archetype_field_name: Some("format".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.SegmentationImageIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.Opacity".into(),
-                archetype_field_name: Some("opacity".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "rerun.components.DrawOrder".into(),
-                archetype_field_name: Some("draw_order".into()),
-            },
+            SegmentationImage::descriptor_buffer(),
+            SegmentationImage::descriptor_format(),
+            SegmentationImage::descriptor_indicator(),
+            SegmentationImage::descriptor_opacity(),
+            SegmentationImage::descriptor_draw_order(),
         ]
     });
 
@@ -316,21 +284,13 @@ impl ::re_types_core::AsComponents for SegmentationImage {
             (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                        archetype_field_name: Some(("buffer").into()),
-                        component_name: ("rerun.components.ImageBuffer").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_buffer()),
                 }
             }),
             (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                        archetype_field_name: Some(("format").into()),
-                        component_name: ("rerun.components.ImageFormat").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_format()),
                 }
             }),
             (self
@@ -339,11 +299,7 @@ impl ::re_types_core::AsComponents for SegmentationImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                    archetype_field_name: Some(("opacity").into()),
-                    component_name: ("rerun.components.Opacity").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_opacity()),
             }),
             (self
                 .draw_order
@@ -351,11 +307,7 @@ impl ::re_types_core::AsComponents for SegmentationImage {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                    archetype_field_name: Some(("draw_order").into()),
-                    component_name: ("rerun.components.DrawOrder").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_draw_order()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -90,6 +90,48 @@ pub struct SeriesLine {
     pub aggregation_policy: Option<crate::components::AggregationPolicy>,
 }
 
+impl SeriesLine {
+    /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    #[inline]
+    pub fn descriptor_color() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::width`].
+    #[inline]
+    pub fn descriptor_width() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+            component_name: "rerun.components.StrokeWidth".into(),
+            archetype_field_name: Some("width".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::name`].
+    #[inline]
+    pub fn descriptor_name() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+            component_name: "rerun.components.Name".into(),
+            archetype_field_name: Some("name".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::aggregation_policy`].
+    #[inline]
+    pub fn descriptor_aggregation_policy() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+            component_name: "rerun.components.AggregationPolicy".into(),
+            archetype_field_name: Some("aggregation_policy".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -130,74 +130,42 @@ impl SeriesLine {
             archetype_field_name: Some("aggregation_policy".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+            component_name: "rerun.components.SeriesLineIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-            component_name: "rerun.components.SeriesLineIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [SeriesLine::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.StrokeWidth".into(),
-                archetype_field_name: Some("width".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.AggregationPolicy".into(),
-                archetype_field_name: Some("aggregation_policy".into()),
-            },
+            SeriesLine::descriptor_color(),
+            SeriesLine::descriptor_width(),
+            SeriesLine::descriptor_name(),
+            SeriesLine::descriptor_aggregation_policy(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.SeriesLineIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.StrokeWidth".into(),
-                archetype_field_name: Some("width".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "rerun.components.AggregationPolicy".into(),
-                archetype_field_name: Some("aggregation_policy".into()),
-            },
+            SeriesLine::descriptor_indicator(),
+            SeriesLine::descriptor_color(),
+            SeriesLine::descriptor_width(),
+            SeriesLine::descriptor_name(),
+            SeriesLine::descriptor_aggregation_policy(),
         ]
     });
 
@@ -316,11 +284,7 @@ impl ::re_types_core::AsComponents for SeriesLine {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                    archetype_field_name: Some(("color").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_color()),
             }),
             (self
                 .width
@@ -328,20 +292,12 @@ impl ::re_types_core::AsComponents for SeriesLine {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                    archetype_field_name: Some(("width").into()),
-                    component_name: ("rerun.components.StrokeWidth").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_width()),
             }),
             (self.name.as_ref().map(|comp| (comp as &dyn ComponentBatch))).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                        archetype_field_name: Some(("name").into()),
-                        component_name: ("rerun.components.Name").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_name()),
                 }
             }),
             (self
@@ -350,11 +306,7 @@ impl ::re_types_core::AsComponents for SeriesLine {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                    archetype_field_name: Some(("aggregation_policy").into()),
-                    component_name: ("rerun.components.AggregationPolicy").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_aggregation_policy()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -128,74 +128,42 @@ impl SeriesPoint {
             archetype_field_name: Some("marker_size".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+            component_name: "rerun.components.SeriesPointIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-            component_name: "rerun.components.SeriesPointIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [SeriesPoint::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.MarkerShape".into(),
-                archetype_field_name: Some("marker".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.MarkerSize".into(),
-                archetype_field_name: Some("marker_size".into()),
-            },
+            SeriesPoint::descriptor_color(),
+            SeriesPoint::descriptor_marker(),
+            SeriesPoint::descriptor_name(),
+            SeriesPoint::descriptor_marker_size(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.SeriesPointIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.MarkerShape".into(),
-                archetype_field_name: Some("marker".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "rerun.components.MarkerSize".into(),
-                archetype_field_name: Some("marker_size".into()),
-            },
+            SeriesPoint::descriptor_indicator(),
+            SeriesPoint::descriptor_color(),
+            SeriesPoint::descriptor_marker(),
+            SeriesPoint::descriptor_name(),
+            SeriesPoint::descriptor_marker_size(),
         ]
     });
 
@@ -313,11 +281,7 @@ impl ::re_types_core::AsComponents for SeriesPoint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                    archetype_field_name: Some(("color").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_color()),
             }),
             (self
                 .marker
@@ -325,20 +289,12 @@ impl ::re_types_core::AsComponents for SeriesPoint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                    archetype_field_name: Some(("marker").into()),
-                    component_name: ("rerun.components.MarkerShape").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_marker()),
             }),
             (self.name.as_ref().map(|comp| (comp as &dyn ComponentBatch))).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                        archetype_field_name: Some(("name").into()),
-                        component_name: ("rerun.components.Name").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_name()),
                 }
             }),
             (self
@@ -347,11 +303,7 @@ impl ::re_types_core::AsComponents for SeriesPoint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                    archetype_field_name: Some(("marker_size").into()),
-                    component_name: ("rerun.components.MarkerSize").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_marker_size()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -88,6 +88,48 @@ pub struct SeriesPoint {
     pub marker_size: Option<crate::components::MarkerSize>,
 }
 
+impl SeriesPoint {
+    /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    #[inline]
+    pub fn descriptor_color() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::marker`].
+    #[inline]
+    pub fn descriptor_marker() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+            component_name: "rerun.components.MarkerShape".into(),
+            archetype_field_name: Some("marker".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::name`].
+    #[inline]
+    pub fn descriptor_name() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+            component_name: "rerun.components.Name".into(),
+            archetype_field_name: Some("name".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::marker_size`].
+    #[inline]
+    pub fn descriptor_marker_size() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+            component_name: "rerun.components.MarkerSize".into(),
+            archetype_field_name: Some("marker_size".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -87,53 +87,33 @@ impl Tensor {
             archetype_field_name: Some("value_range".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Tensor".into()),
-            component_name: "rerun.components.TensorData".into(),
-            archetype_field_name: Some("data".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Tensor".into()),
             component_name: "rerun.components.TensorIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Tensor::descriptor_data()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Tensor::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Tensor".into()),
-            component_name: "rerun.components.ValueRange".into(),
-            archetype_field_name: Some("value_range".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Tensor::descriptor_value_range()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Tensor".into()),
-                component_name: "rerun.components.TensorData".into(),
-                archetype_field_name: Some("data".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Tensor".into()),
-                component_name: "rerun.components.TensorIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Tensor".into()),
-                component_name: "rerun.components.ValueRange".into(),
-                archetype_field_name: Some("value_range".into()),
-            },
+            Tensor::descriptor_data(),
+            Tensor::descriptor_indicator(),
+            Tensor::descriptor_value_range(),
         ]
     });
 
@@ -229,11 +209,7 @@ impl ::re_types_core::AsComponents for Tensor {
             (Some(&self.data as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Tensor".into()),
-                        archetype_field_name: Some(("data").into()),
-                        component_name: ("rerun.components.TensorData").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_data()),
                 }
             }),
             (self
@@ -242,11 +218,7 @@ impl ::re_types_core::AsComponents for Tensor {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.Tensor".into()),
-                    archetype_field_name: Some(("value_range").into()),
-                    component_name: ("rerun.components.ValueRange").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_value_range()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -67,6 +67,28 @@ pub struct Tensor {
     pub value_range: Option<crate::components::ValueRange>,
 }
 
+impl Tensor {
+    /// Returns the [`ComponentDescriptor`] for [`Self::data`].
+    #[inline]
+    pub fn descriptor_data() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Tensor".into()),
+            component_name: "rerun.components.TensorData".into(),
+            archetype_field_name: Some("data".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::value_range`].
+    #[inline]
+    pub fn descriptor_value_range() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Tensor".into()),
+            component_name: "rerun.components.ValueRange".into(),
+            archetype_field_name: Some("value_range".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -102,6 +102,28 @@ pub struct TextDocument {
     pub media_type: Option<crate::components::MediaType>,
 }
 
+impl TextDocument {
+    /// Returns the [`ComponentDescriptor`] for [`Self::text`].
+    #[inline]
+    pub fn descriptor_text() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextDocument".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("text".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    #[inline]
+    pub fn descriptor_media_type() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextDocument".into()),
+            component_name: "rerun.components.MediaType".into(),
+            archetype_field_name: Some("media_type".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -122,53 +122,33 @@ impl TextDocument {
             archetype_field_name: Some("media_type".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.TextDocument".into()),
-            component_name: "rerun.components.Text".into(),
-            archetype_field_name: Some("text".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.TextDocument".into()),
             component_name: "rerun.components.TextDocumentIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [TextDocument::descriptor_text()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [TextDocument::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.TextDocument".into()),
-            component_name: "rerun.components.MediaType".into(),
-            archetype_field_name: Some("media_type".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [TextDocument::descriptor_media_type()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextDocument".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("text".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextDocument".into()),
-                component_name: "rerun.components.TextDocumentIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextDocument".into()),
-                component_name: "rerun.components.MediaType".into(),
-                archetype_field_name: Some("media_type".into()),
-            },
+            TextDocument::descriptor_text(),
+            TextDocument::descriptor_indicator(),
+            TextDocument::descriptor_media_type(),
         ]
     });
 
@@ -264,11 +244,7 @@ impl ::re_types_core::AsComponents for TextDocument {
             (Some(&self.text as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.TextDocument".into()),
-                        archetype_field_name: Some(("text").into()),
-                        component_name: ("rerun.components.Text").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_text()),
                 }
             }),
             (self
@@ -277,11 +253,7 @@ impl ::re_types_core::AsComponents for TextDocument {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.TextDocument".into()),
-                    archetype_field_name: Some(("media_type").into()),
-                    component_name: ("rerun.components.MediaType").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_media_type()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -72,6 +72,38 @@ pub struct TextLog {
     pub color: Option<crate::components::Color>,
 }
 
+impl TextLog {
+    /// Returns the [`ComponentDescriptor`] for [`Self::text`].
+    #[inline]
+    pub fn descriptor_text() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextLog".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("text".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::level`].
+    #[inline]
+    pub fn descriptor_level() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextLog".into()),
+            component_name: "rerun.components.TextLogLevel".into(),
+            archetype_field_name: Some("level".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    #[inline]
+    pub fn descriptor_color() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextLog".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -102,65 +102,34 @@ impl TextLog {
             archetype_field_name: Some("color".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextLog".into()),
+            component_name: "rerun.components.TextLogIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.TextLog".into()),
-            component_name: "rerun.components.Text".into(),
-            archetype_field_name: Some("text".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [TextLog::descriptor_text()]);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "rerun.components.TextLogLevel".into(),
-                archetype_field_name: Some("level".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "rerun.components.TextLogIndicator".into(),
-                archetype_field_name: None,
-            },
-        ]
-    });
+    once_cell::sync::Lazy::new(|| [TextLog::descriptor_level(), TextLog::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.TextLog".into()),
-            component_name: "rerun.components.Color".into(),
-            archetype_field_name: Some("color".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [TextLog::descriptor_color()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "rerun.components.Text".into(),
-                archetype_field_name: Some("text".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "rerun.components.TextLogLevel".into(),
-                archetype_field_name: Some("level".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "rerun.components.TextLogIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
+            TextLog::descriptor_text(),
+            TextLog::descriptor_level(),
+            TextLog::descriptor_indicator(),
+            TextLog::descriptor_color(),
         ]
     });
 
@@ -265,11 +234,7 @@ impl ::re_types_core::AsComponents for TextLog {
             (Some(&self.text as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.TextLog".into()),
-                        archetype_field_name: Some(("text").into()),
-                        component_name: ("rerun.components.Text").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_text()),
                 }
             }),
             (self
@@ -278,11 +243,7 @@ impl ::re_types_core::AsComponents for TextLog {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.TextLog".into()),
-                    archetype_field_name: Some(("level").into()),
-                    component_name: ("rerun.components.TextLogLevel").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_level()),
             }),
             (self
                 .color
@@ -290,11 +251,7 @@ impl ::re_types_core::AsComponents for TextLog {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.TextLog".into()),
-                    archetype_field_name: Some(("color").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_color()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -193,6 +193,78 @@ pub struct Transform3D {
     pub axis_length: Option<crate::components::AxisLength>,
 }
 
+impl Transform3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::translation`].
+    #[inline]
+    pub fn descriptor_translation() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.Translation3D".into(),
+            archetype_field_name: Some("translation".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angle`].
+    #[inline]
+    pub fn descriptor_rotation_axis_angle() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.RotationAxisAngle".into(),
+            archetype_field_name: Some("rotation_axis_angle".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::quaternion`].
+    #[inline]
+    pub fn descriptor_quaternion() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.RotationQuat".into(),
+            archetype_field_name: Some("quaternion".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::scale`].
+    #[inline]
+    pub fn descriptor_scale() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.Scale3D".into(),
+            archetype_field_name: Some("scale".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
+    #[inline]
+    pub fn descriptor_mat3x3() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.TransformMat3x3".into(),
+            archetype_field_name: Some("mat3x3".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::relation`].
+    #[inline]
+    pub fn descriptor_relation() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.TransformRelation".into(),
+            archetype_field_name: Some("relation".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::axis_length`].
+    #[inline]
+    pub fn descriptor_axis_length() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.AxisLength".into(),
+            archetype_field_name: Some("axis_length".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -263,104 +263,48 @@ impl Transform3D {
             archetype_field_name: Some("axis_length".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "rerun.components.Transform3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Transform3D".into()),
-            component_name: "rerun.components.Transform3DIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Transform3D::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.Translation3D".into(),
-                archetype_field_name: Some("translation".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.RotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angle".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.RotationQuat".into(),
-                archetype_field_name: Some("quaternion".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.Scale3D".into(),
-                archetype_field_name: Some("scale".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.TransformMat3x3".into(),
-                archetype_field_name: Some("mat3x3".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.TransformRelation".into(),
-                archetype_field_name: Some("relation".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.AxisLength".into(),
-                archetype_field_name: Some("axis_length".into()),
-            },
+            Transform3D::descriptor_translation(),
+            Transform3D::descriptor_rotation_axis_angle(),
+            Transform3D::descriptor_quaternion(),
+            Transform3D::descriptor_scale(),
+            Transform3D::descriptor_mat3x3(),
+            Transform3D::descriptor_relation(),
+            Transform3D::descriptor_axis_length(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.Transform3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.Translation3D".into(),
-                archetype_field_name: Some("translation".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.RotationAxisAngle".into(),
-                archetype_field_name: Some("rotation_axis_angle".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.RotationQuat".into(),
-                archetype_field_name: Some("quaternion".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.Scale3D".into(),
-                archetype_field_name: Some("scale".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.TransformMat3x3".into(),
-                archetype_field_name: Some("mat3x3".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.TransformRelation".into(),
-                archetype_field_name: Some("relation".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "rerun.components.AxisLength".into(),
-                archetype_field_name: Some("axis_length".into()),
-            },
+            Transform3D::descriptor_indicator(),
+            Transform3D::descriptor_translation(),
+            Transform3D::descriptor_rotation_axis_angle(),
+            Transform3D::descriptor_quaternion(),
+            Transform3D::descriptor_scale(),
+            Transform3D::descriptor_mat3x3(),
+            Transform3D::descriptor_relation(),
+            Transform3D::descriptor_axis_length(),
         ]
     });
 
@@ -508,71 +452,43 @@ impl ::re_types_core::AsComponents for Transform3D {
             (Some(&self.translation as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                        archetype_field_name: Some(("translation").into()),
-                        component_name: ("rerun.components.Translation3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_translation()),
                 }
             }),
             (Some(&self.rotation_axis_angle as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                        archetype_field_name: Some(("rotation_axis_angle").into()),
-                        component_name: ("rerun.components.RotationAxisAngle").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_rotation_axis_angle()),
                 }
             }),
             (Some(&self.quaternion as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                        archetype_field_name: Some(("quaternion").into()),
-                        component_name: ("rerun.components.RotationQuat").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_quaternion()),
                 }
             }),
             (Some(&self.scale as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                        archetype_field_name: Some(("scale").into()),
-                        component_name: ("rerun.components.Scale3D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_scale()),
                 }
             }),
             (Some(&self.mat3x3 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                        archetype_field_name: Some(("mat3x3").into()),
-                        component_name: ("rerun.components.TransformMat3x3").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_mat3x3()),
                 }
             }),
             (Some(&self.relation as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                        archetype_field_name: Some(("relation").into()),
-                        component_name: ("rerun.components.TransformRelation").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_relation()),
                 }
             }),
             (Some(&self.axis_length as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                        archetype_field_name: Some(("axis_length").into()),
-                        component_name: ("rerun.components.AxisLength").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_axis_length()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -146,6 +146,28 @@ pub struct VideoFrameReference {
     pub video_reference: Option<crate::components::EntityPath>,
 }
 
+impl VideoFrameReference {
+    /// Returns the [`ComponentDescriptor`] for [`Self::timestamp`].
+    #[inline]
+    pub fn descriptor_timestamp() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
+            component_name: "rerun.components.VideoTimestamp".into(),
+            archetype_field_name: Some("timestamp".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::video_reference`].
+    #[inline]
+    pub fn descriptor_video_reference() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
+            component_name: "rerun.components.EntityPath".into(),
+            archetype_field_name: Some("video_reference".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -166,53 +166,33 @@ impl VideoFrameReference {
             archetype_field_name: Some("video_reference".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-            component_name: "rerun.components.VideoTimestamp".into(),
-            archetype_field_name: Some("timestamp".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
             component_name: "rerun.components.VideoFrameReferenceIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [VideoFrameReference::descriptor_timestamp()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [VideoFrameReference::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-            component_name: "rerun.components.EntityPath".into(),
-            archetype_field_name: Some("video_reference".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [VideoFrameReference::descriptor_video_reference()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-                component_name: "rerun.components.VideoTimestamp".into(),
-                archetype_field_name: Some("timestamp".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-                component_name: "rerun.components.VideoFrameReferenceIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-                component_name: "rerun.components.EntityPath".into(),
-                archetype_field_name: Some("video_reference".into()),
-            },
+            VideoFrameReference::descriptor_timestamp(),
+            VideoFrameReference::descriptor_indicator(),
+            VideoFrameReference::descriptor_video_reference(),
         ]
     });
 
@@ -313,11 +293,7 @@ impl ::re_types_core::AsComponents for VideoFrameReference {
             (Some(&self.timestamp as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-                        archetype_field_name: Some(("timestamp").into()),
-                        component_name: ("rerun.components.VideoTimestamp").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_timestamp()),
                 }
             }),
             (self
@@ -326,11 +302,7 @@ impl ::re_types_core::AsComponents for VideoFrameReference {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-                    archetype_field_name: Some(("video_reference").into()),
-                    component_name: ("rerun.components.EntityPath").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_video_reference()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -66,6 +66,18 @@ pub struct ViewCoordinates {
     pub xyz: crate::components::ViewCoordinates,
 }
 
+impl ViewCoordinates {
+    /// Returns the [`ComponentDescriptor`] for [`Self::xyz`].
+    #[inline]
+    pub fn descriptor_xyz() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
+            component_name: "rerun.components.ViewCoordinates".into(),
+            archetype_field_name: Some("xyz".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -76,25 +76,23 @@ impl ViewCoordinates {
             archetype_field_name: Some("xyz".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-            component_name: "rerun.components.ViewCoordinates".into(),
-            archetype_field_name: Some("xyz".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
             component_name: "rerun.components.ViewCoordinatesIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [ViewCoordinates::descriptor_xyz()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [ViewCoordinates::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
@@ -102,16 +100,8 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-                component_name: "rerun.components.ViewCoordinates".into(),
-                archetype_field_name: Some("xyz".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-                component_name: "rerun.components.ViewCoordinatesIndicator".into(),
-                archetype_field_name: None,
-            },
+            ViewCoordinates::descriptor_xyz(),
+            ViewCoordinates::descriptor_indicator(),
         ]
     });
 
@@ -198,11 +188,7 @@ impl ::re_types_core::AsComponents for ViewCoordinates {
             (Some(&self.xyz as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-                        archetype_field_name: Some(("xyz").into()),
-                        component_name: ("rerun.components.ViewCoordinates").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_xyz()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -48,53 +48,33 @@ impl Background {
             archetype_field_name: Some("color".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-            component_name: "rerun.blueprint.components.BackgroundKind".into(),
-            archetype_field_name: Some("kind".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
             component_name: "rerun.blueprint.components.BackgroundIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Background::descriptor_kind()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Background::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-            component_name: "rerun.components.Color".into(),
-            archetype_field_name: Some("color".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [Background::descriptor_color()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-                component_name: "rerun.blueprint.components.BackgroundKind".into(),
-                archetype_field_name: Some("kind".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-                component_name: "rerun.blueprint.components.BackgroundIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
+            Background::descriptor_kind(),
+            Background::descriptor_indicator(),
+            Background::descriptor_color(),
         ]
     });
 
@@ -190,11 +170,7 @@ impl ::re_types_core::AsComponents for Background {
             (Some(&self.kind as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-                        archetype_field_name: Some(("kind").into()),
-                        component_name: ("rerun.blueprint.components.BackgroundKind").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_kind()),
                 }
             }),
             (self
@@ -203,11 +179,7 @@ impl ::re_types_core::AsComponents for Background {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-                    archetype_field_name: Some(("color").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_color()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -28,6 +28,28 @@ pub struct Background {
     pub color: Option<crate::components::Color>,
 }
 
+impl Background {
+    /// Returns the [`ComponentDescriptor`] for [`Self::kind`].
+    #[inline]
+    pub fn descriptor_kind() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+            component_name: "rerun.blueprint.components.BackgroundKind".into(),
+            archetype_field_name: Some("kind".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    #[inline]
+    pub fn descriptor_color() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
@@ -62,6 +62,88 @@ pub struct ContainerBlueprint {
     pub grid_columns: Option<crate::blueprint::components::GridColumns>,
 }
 
+impl ContainerBlueprint {
+    /// Returns the [`ComponentDescriptor`] for [`Self::container_kind`].
+    #[inline]
+    pub fn descriptor_container_kind() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.ContainerKind".into(),
+            archetype_field_name: Some("container_kind".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
+    #[inline]
+    pub fn descriptor_display_name() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.components.Name".into(),
+            archetype_field_name: Some("display_name".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::contents`].
+    #[inline]
+    pub fn descriptor_contents() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.IncludedContent".into(),
+            archetype_field_name: Some("contents".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::col_shares`].
+    #[inline]
+    pub fn descriptor_col_shares() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.ColumnShare".into(),
+            archetype_field_name: Some("col_shares".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::row_shares`].
+    #[inline]
+    pub fn descriptor_row_shares() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.RowShare".into(),
+            archetype_field_name: Some("row_shares".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::active_tab`].
+    #[inline]
+    pub fn descriptor_active_tab() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.ActiveTab".into(),
+            archetype_field_name: Some("active_tab".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    #[inline]
+    pub fn descriptor_visible() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.Visible".into(),
+            archetype_field_name: Some("visible".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::grid_columns`].
+    #[inline]
+    pub fn descriptor_grid_columns() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.GridColumns".into(),
+            archetype_field_name: Some("grid_columns".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
@@ -142,115 +142,49 @@ impl ContainerBlueprint {
             archetype_field_name: Some("grid_columns".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-            component_name: "rerun.blueprint.components.ContainerKind".into(),
-            archetype_field_name: Some("container_kind".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
             component_name: "rerun.blueprint.components.ContainerBlueprintIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [ContainerBlueprint::descriptor_container_kind()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [ContainerBlueprint::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("display_name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.IncludedContent".into(),
-                archetype_field_name: Some("contents".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.ColumnShare".into(),
-                archetype_field_name: Some("col_shares".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.RowShare".into(),
-                archetype_field_name: Some("row_shares".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.ActiveTab".into(),
-                archetype_field_name: Some("active_tab".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.GridColumns".into(),
-                archetype_field_name: Some("grid_columns".into()),
-            },
+            ContainerBlueprint::descriptor_display_name(),
+            ContainerBlueprint::descriptor_contents(),
+            ContainerBlueprint::descriptor_col_shares(),
+            ContainerBlueprint::descriptor_row_shares(),
+            ContainerBlueprint::descriptor_active_tab(),
+            ContainerBlueprint::descriptor_visible(),
+            ContainerBlueprint::descriptor_grid_columns(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.ContainerKind".into(),
-                archetype_field_name: Some("container_kind".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.ContainerBlueprintIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("display_name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.IncludedContent".into(),
-                archetype_field_name: Some("contents".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.ColumnShare".into(),
-                archetype_field_name: Some("col_shares".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.RowShare".into(),
-                archetype_field_name: Some("row_shares".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.ActiveTab".into(),
-                archetype_field_name: Some("active_tab".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "rerun.blueprint.components.GridColumns".into(),
-                archetype_field_name: Some("grid_columns".into()),
-            },
+            ContainerBlueprint::descriptor_container_kind(),
+            ContainerBlueprint::descriptor_indicator(),
+            ContainerBlueprint::descriptor_display_name(),
+            ContainerBlueprint::descriptor_contents(),
+            ContainerBlueprint::descriptor_col_shares(),
+            ContainerBlueprint::descriptor_row_shares(),
+            ContainerBlueprint::descriptor_active_tab(),
+            ContainerBlueprint::descriptor_visible(),
+            ContainerBlueprint::descriptor_grid_columns(),
         ]
     });
 
@@ -425,13 +359,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
             (Some(&self.container_kind as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some(
-                            "rerun.blueprint.archetypes.ContainerBlueprint".into(),
-                        ),
-                        archetype_field_name: Some(("container_kind").into()),
-                        component_name: ("rerun.blueprint.components.ContainerKind").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_container_kind()),
                 }
             }),
             (self
@@ -440,11 +368,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                    archetype_field_name: Some(("display_name").into()),
-                    component_name: ("rerun.components.Name").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_display_name()),
             }),
             (self
                 .contents
@@ -452,11 +376,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                    archetype_field_name: Some(("contents").into()),
-                    component_name: ("rerun.blueprint.components.IncludedContent").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_contents()),
             }),
             (self
                 .col_shares
@@ -464,11 +384,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                    archetype_field_name: Some(("col_shares").into()),
-                    component_name: ("rerun.blueprint.components.ColumnShare").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_col_shares()),
             }),
             (self
                 .row_shares
@@ -476,11 +392,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                    archetype_field_name: Some(("row_shares").into()),
-                    component_name: ("rerun.blueprint.components.RowShare").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_row_shares()),
             }),
             (self
                 .active_tab
@@ -488,11 +400,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                    archetype_field_name: Some(("active_tab").into()),
-                    component_name: ("rerun.blueprint.components.ActiveTab").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_active_tab()),
             }),
             (self
                 .visible
@@ -500,11 +408,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                    archetype_field_name: Some(("visible").into()),
-                    component_name: ("rerun.blueprint.components.Visible").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_visible()),
             }),
             (self
                 .grid_columns
@@ -512,11 +416,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                    archetype_field_name: Some(("grid_columns").into()),
-                    component_name: ("rerun.blueprint.components.GridColumns").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_grid_columns()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -41,6 +41,58 @@ pub struct DataframeQuery {
     pub select: Option<crate::blueprint::components::SelectedColumns>,
 }
 
+impl DataframeQuery {
+    /// Returns the [`ComponentDescriptor`] for [`Self::timeline`].
+    #[inline]
+    pub fn descriptor_timeline() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            component_name: "rerun.blueprint.components.TimelineName".into(),
+            archetype_field_name: Some("timeline".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::filter_by_range`].
+    #[inline]
+    pub fn descriptor_filter_by_range() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            component_name: "rerun.blueprint.components.FilterByRange".into(),
+            archetype_field_name: Some("filter_by_range".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::filter_is_not_null`].
+    #[inline]
+    pub fn descriptor_filter_is_not_null() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            component_name: "rerun.blueprint.components.FilterIsNotNull".into(),
+            archetype_field_name: Some("filter_is_not_null".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::apply_latest_at`].
+    #[inline]
+    pub fn descriptor_apply_latest_at() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            component_name: "rerun.blueprint.components.ApplyLatestAt".into(),
+            archetype_field_name: Some("apply_latest_at".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::select`].
+    #[inline]
+    pub fn descriptor_select() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            component_name: "rerun.blueprint.components.SelectedColumns".into(),
+            archetype_field_name: Some("select".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -91,84 +91,44 @@ impl DataframeQuery {
             archetype_field_name: Some("select".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            component_name: "rerun.blueprint.components.DataframeQueryIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-            component_name: "rerun.blueprint.components.DataframeQueryIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [DataframeQuery::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.TimelineName".into(),
-                archetype_field_name: Some("timeline".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.FilterByRange".into(),
-                archetype_field_name: Some("filter_by_range".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.FilterIsNotNull".into(),
-                archetype_field_name: Some("filter_is_not_null".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.ApplyLatestAt".into(),
-                archetype_field_name: Some("apply_latest_at".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.SelectedColumns".into(),
-                archetype_field_name: Some("select".into()),
-            },
+            DataframeQuery::descriptor_timeline(),
+            DataframeQuery::descriptor_filter_by_range(),
+            DataframeQuery::descriptor_filter_is_not_null(),
+            DataframeQuery::descriptor_apply_latest_at(),
+            DataframeQuery::descriptor_select(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.DataframeQueryIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.TimelineName".into(),
-                archetype_field_name: Some("timeline".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.FilterByRange".into(),
-                archetype_field_name: Some("filter_by_range".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.FilterIsNotNull".into(),
-                archetype_field_name: Some("filter_is_not_null".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.ApplyLatestAt".into(),
-                archetype_field_name: Some("apply_latest_at".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "rerun.blueprint.components.SelectedColumns".into(),
-                archetype_field_name: Some("select".into()),
-            },
+            DataframeQuery::descriptor_indicator(),
+            DataframeQuery::descriptor_timeline(),
+            DataframeQuery::descriptor_filter_by_range(),
+            DataframeQuery::descriptor_filter_is_not_null(),
+            DataframeQuery::descriptor_apply_latest_at(),
+            DataframeQuery::descriptor_select(),
         ]
     });
 
@@ -301,11 +261,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                    archetype_field_name: Some(("timeline").into()),
-                    component_name: ("rerun.blueprint.components.TimelineName").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_timeline()),
             }),
             (self
                 .filter_by_range
@@ -313,11 +269,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                    archetype_field_name: Some(("filter_by_range").into()),
-                    component_name: ("rerun.blueprint.components.FilterByRange").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_filter_by_range()),
             }),
             (self
                 .filter_is_not_null
@@ -325,11 +277,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                    archetype_field_name: Some(("filter_is_not_null").into()),
-                    component_name: ("rerun.blueprint.components.FilterIsNotNull").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_filter_is_not_null()),
             }),
             (self
                 .apply_latest_at
@@ -337,11 +285,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                    archetype_field_name: Some(("apply_latest_at").into()),
-                    component_name: ("rerun.blueprint.components.ApplyLatestAt").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_apply_latest_at()),
             }),
             (self
                 .select
@@ -349,11 +293,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                    archetype_field_name: Some(("select").into()),
-                    component_name: ("rerun.blueprint.components.SelectedColumns").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_select()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/force_center.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_center.rs
@@ -50,54 +50,38 @@ impl ForceCenter {
             archetype_field_name: Some("strength".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
+            component_name: "rerun.blueprint.components.ForceCenterIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-            component_name: "rerun.blueprint.components.ForceCenterIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ForceCenter::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
+            ForceCenter::descriptor_enabled(),
+            ForceCenter::descriptor_strength(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-                component_name: "rerun.blueprint.components.ForceCenterIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
+            ForceCenter::descriptor_indicator(),
+            ForceCenter::descriptor_enabled(),
+            ForceCenter::descriptor_strength(),
         ]
     });
 
@@ -194,11 +178,7 @@ impl ::re_types_core::AsComponents for ForceCenter {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-                    archetype_field_name: Some(("enabled").into()),
-                    component_name: ("rerun.blueprint.components.Enabled").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_enabled()),
             }),
             (self
                 .strength
@@ -206,11 +186,7 @@ impl ::re_types_core::AsComponents for ForceCenter {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
-                    archetype_field_name: Some(("strength").into()),
-                    component_name: ("rerun.blueprint.components.ForceStrength").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_strength()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/force_center.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_center.rs
@@ -30,6 +30,28 @@ pub struct ForceCenter {
     pub strength: Option<crate::blueprint::components::ForceStrength>,
 }
 
+impl ForceCenter {
+    /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    #[inline]
+    pub fn descriptor_enabled() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
+            component_name: "rerun.blueprint.components.Enabled".into(),
+            archetype_field_name: Some("enabled".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    #[inline]
+    pub fn descriptor_strength() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
+            component_name: "rerun.blueprint.components.ForceStrength".into(),
+            archetype_field_name: Some("strength".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
@@ -35,6 +35,38 @@ pub struct ForceCollisionRadius {
     pub iterations: Option<crate::blueprint::components::ForceIterations>,
 }
 
+impl ForceCollisionRadius {
+    /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    #[inline]
+    pub fn descriptor_enabled() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
+            component_name: "rerun.blueprint.components.Enabled".into(),
+            archetype_field_name: Some("enabled".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    #[inline]
+    pub fn descriptor_strength() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
+            component_name: "rerun.blueprint.components.ForceStrength".into(),
+            archetype_field_name: Some("strength".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
+    #[inline]
+    pub fn descriptor_iterations() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
+            component_name: "rerun.blueprint.components.ForceIterations".into(),
+            archetype_field_name: Some("iterations".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
@@ -65,64 +65,40 @@ impl ForceCollisionRadius {
             archetype_field_name: Some("iterations".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
+            component_name: "rerun.blueprint.components.ForceCollisionRadiusIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-            component_name: "rerun.blueprint.components.ForceCollisionRadiusIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ForceCollisionRadius::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                component_name: "rerun.blueprint.components.ForceIterations".into(),
-                archetype_field_name: Some("iterations".into()),
-            },
+            ForceCollisionRadius::descriptor_enabled(),
+            ForceCollisionRadius::descriptor_strength(),
+            ForceCollisionRadius::descriptor_iterations(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                component_name: "rerun.blueprint.components.ForceCollisionRadiusIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                component_name: "rerun.blueprint.components.ForceIterations".into(),
-                archetype_field_name: Some("iterations".into()),
-            },
+            ForceCollisionRadius::descriptor_indicator(),
+            ForceCollisionRadius::descriptor_enabled(),
+            ForceCollisionRadius::descriptor_strength(),
+            ForceCollisionRadius::descriptor_iterations(),
         ]
     });
 
@@ -234,11 +210,7 @@ impl ::re_types_core::AsComponents for ForceCollisionRadius {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                    archetype_field_name: Some(("enabled").into()),
-                    component_name: ("rerun.blueprint.components.Enabled").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_enabled()),
             }),
             (self
                 .strength
@@ -246,11 +218,7 @@ impl ::re_types_core::AsComponents for ForceCollisionRadius {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                    archetype_field_name: Some(("strength").into()),
-                    component_name: ("rerun.blueprint.components.ForceStrength").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_strength()),
             }),
             (self
                 .iterations
@@ -258,11 +226,7 @@ impl ::re_types_core::AsComponents for ForceCollisionRadius {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
-                    archetype_field_name: Some(("iterations").into()),
-                    component_name: ("rerun.blueprint.components.ForceIterations").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_iterations()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/force_link.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_link.rs
@@ -65,64 +65,40 @@ impl ForceLink {
             archetype_field_name: Some("iterations".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
+            component_name: "rerun.blueprint.components.ForceLinkIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-            component_name: "rerun.blueprint.components.ForceLinkIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ForceLink::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                component_name: "rerun.blueprint.components.ForceDistance".into(),
-                archetype_field_name: Some("distance".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                component_name: "rerun.blueprint.components.ForceIterations".into(),
-                archetype_field_name: Some("iterations".into()),
-            },
+            ForceLink::descriptor_enabled(),
+            ForceLink::descriptor_distance(),
+            ForceLink::descriptor_iterations(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                component_name: "rerun.blueprint.components.ForceLinkIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                component_name: "rerun.blueprint.components.ForceDistance".into(),
-                archetype_field_name: Some("distance".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                component_name: "rerun.blueprint.components.ForceIterations".into(),
-                archetype_field_name: Some("iterations".into()),
-            },
+            ForceLink::descriptor_indicator(),
+            ForceLink::descriptor_enabled(),
+            ForceLink::descriptor_distance(),
+            ForceLink::descriptor_iterations(),
         ]
     });
 
@@ -233,11 +209,7 @@ impl ::re_types_core::AsComponents for ForceLink {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                    archetype_field_name: Some(("enabled").into()),
-                    component_name: ("rerun.blueprint.components.Enabled").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_enabled()),
             }),
             (self
                 .distance
@@ -245,11 +217,7 @@ impl ::re_types_core::AsComponents for ForceLink {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                    archetype_field_name: Some(("distance").into()),
-                    component_name: ("rerun.blueprint.components.ForceDistance").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_distance()),
             }),
             (self
                 .iterations
@@ -257,11 +225,7 @@ impl ::re_types_core::AsComponents for ForceLink {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
-                    archetype_field_name: Some(("iterations").into()),
-                    component_name: ("rerun.blueprint.components.ForceIterations").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_iterations()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/force_link.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_link.rs
@@ -35,6 +35,38 @@ pub struct ForceLink {
     pub iterations: Option<crate::blueprint::components::ForceIterations>,
 }
 
+impl ForceLink {
+    /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    #[inline]
+    pub fn descriptor_enabled() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
+            component_name: "rerun.blueprint.components.Enabled".into(),
+            archetype_field_name: Some("enabled".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::distance`].
+    #[inline]
+    pub fn descriptor_distance() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
+            component_name: "rerun.blueprint.components.ForceDistance".into(),
+            archetype_field_name: Some("distance".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
+    #[inline]
+    pub fn descriptor_iterations() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
+            component_name: "rerun.blueprint.components.ForceIterations".into(),
+            archetype_field_name: Some("iterations".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
@@ -55,54 +55,38 @@ impl ForceManyBody {
             archetype_field_name: Some("strength".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
+            component_name: "rerun.blueprint.components.ForceManyBodyIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-            component_name: "rerun.blueprint.components.ForceManyBodyIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ForceManyBody::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
+            ForceManyBody::descriptor_enabled(),
+            ForceManyBody::descriptor_strength(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-                component_name: "rerun.blueprint.components.ForceManyBodyIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
+            ForceManyBody::descriptor_indicator(),
+            ForceManyBody::descriptor_enabled(),
+            ForceManyBody::descriptor_strength(),
         ]
     });
 
@@ -199,11 +183,7 @@ impl ::re_types_core::AsComponents for ForceManyBody {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-                    archetype_field_name: Some(("enabled").into()),
-                    component_name: ("rerun.blueprint.components.Enabled").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_enabled()),
             }),
             (self
                 .strength
@@ -211,11 +191,7 @@ impl ::re_types_core::AsComponents for ForceManyBody {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
-                    archetype_field_name: Some(("strength").into()),
-                    component_name: ("rerun.blueprint.components.ForceStrength").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_strength()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
@@ -35,6 +35,28 @@ pub struct ForceManyBody {
     pub strength: Option<crate::blueprint::components::ForceStrength>,
 }
 
+impl ForceManyBody {
+    /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    #[inline]
+    pub fn descriptor_enabled() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
+            component_name: "rerun.blueprint.components.Enabled".into(),
+            archetype_field_name: Some("enabled".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    #[inline]
+    pub fn descriptor_strength() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
+            component_name: "rerun.blueprint.components.ForceStrength".into(),
+            archetype_field_name: Some("strength".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/force_position.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_position.rs
@@ -63,64 +63,40 @@ impl ForcePosition {
             archetype_field_name: Some("position".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
+            component_name: "rerun.blueprint.components.ForcePositionIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-            component_name: "rerun.blueprint.components.ForcePositionIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ForcePosition::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("position".into()),
-            },
+            ForcePosition::descriptor_enabled(),
+            ForcePosition::descriptor_strength(),
+            ForcePosition::descriptor_position(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                component_name: "rerun.blueprint.components.ForcePositionIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                component_name: "rerun.blueprint.components.Enabled".into(),
-                archetype_field_name: Some("enabled".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                component_name: "rerun.blueprint.components.ForceStrength".into(),
-                archetype_field_name: Some("strength".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                component_name: "rerun.components.Position2D".into(),
-                archetype_field_name: Some("position".into()),
-            },
+            ForcePosition::descriptor_indicator(),
+            ForcePosition::descriptor_enabled(),
+            ForcePosition::descriptor_strength(),
+            ForcePosition::descriptor_position(),
         ]
     });
 
@@ -230,11 +206,7 @@ impl ::re_types_core::AsComponents for ForcePosition {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                    archetype_field_name: Some(("enabled").into()),
-                    component_name: ("rerun.blueprint.components.Enabled").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_enabled()),
             }),
             (self
                 .strength
@@ -242,11 +214,7 @@ impl ::re_types_core::AsComponents for ForcePosition {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                    archetype_field_name: Some(("strength").into()),
-                    component_name: ("rerun.blueprint.components.ForceStrength").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_strength()),
             }),
             (self
                 .position
@@ -254,11 +222,7 @@ impl ::re_types_core::AsComponents for ForcePosition {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
-                    archetype_field_name: Some(("position").into()),
-                    component_name: ("rerun.components.Position2D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_position()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/force_position.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_position.rs
@@ -33,6 +33,38 @@ pub struct ForcePosition {
     pub position: Option<crate::components::Position2D>,
 }
 
+impl ForcePosition {
+    /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    #[inline]
+    pub fn descriptor_enabled() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
+            component_name: "rerun.blueprint.components.Enabled".into(),
+            archetype_field_name: Some("enabled".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    #[inline]
+    pub fn descriptor_strength() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
+            component_name: "rerun.blueprint.components.ForceStrength".into(),
+            archetype_field_name: Some("strength".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::position`].
+    #[inline]
+    pub fn descriptor_position() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
+            component_name: "rerun.components.Position2D".into(),
+            archetype_field_name: Some("position".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -99,84 +99,44 @@ impl LineGrid3D {
             archetype_field_name: Some("color".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            component_name: "rerun.blueprint.components.LineGrid3DIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-            component_name: "rerun.blueprint.components.LineGrid3DIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [LineGrid3D::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.blueprint.components.GridSpacing".into(),
-                archetype_field_name: Some("spacing".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.components.Plane3D".into(),
-                archetype_field_name: Some("plane".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.components.StrokeWidth".into(),
-                archetype_field_name: Some("stroke_width".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
+            LineGrid3D::descriptor_visible(),
+            LineGrid3D::descriptor_spacing(),
+            LineGrid3D::descriptor_plane(),
+            LineGrid3D::descriptor_stroke_width(),
+            LineGrid3D::descriptor_color(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.blueprint.components.LineGrid3DIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.blueprint.components.GridSpacing".into(),
-                archetype_field_name: Some("spacing".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.components.Plane3D".into(),
-                archetype_field_name: Some("plane".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.components.StrokeWidth".into(),
-                archetype_field_name: Some("stroke_width".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "rerun.components.Color".into(),
-                archetype_field_name: Some("color".into()),
-            },
+            LineGrid3D::descriptor_indicator(),
+            LineGrid3D::descriptor_visible(),
+            LineGrid3D::descriptor_spacing(),
+            LineGrid3D::descriptor_plane(),
+            LineGrid3D::descriptor_stroke_width(),
+            LineGrid3D::descriptor_color(),
         ]
     });
 
@@ -306,11 +266,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                    archetype_field_name: Some(("visible").into()),
-                    component_name: ("rerun.blueprint.components.Visible").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_visible()),
             }),
             (self
                 .spacing
@@ -318,11 +274,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                    archetype_field_name: Some(("spacing").into()),
-                    component_name: ("rerun.blueprint.components.GridSpacing").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_spacing()),
             }),
             (self
                 .plane
@@ -330,11 +282,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                    archetype_field_name: Some(("plane").into()),
-                    component_name: ("rerun.components.Plane3D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_plane()),
             }),
             (self
                 .stroke_width
@@ -342,11 +290,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                    archetype_field_name: Some(("stroke_width").into()),
-                    component_name: ("rerun.components.StrokeWidth").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_stroke_width()),
             }),
             (self
                 .color
@@ -354,11 +298,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                    archetype_field_name: Some(("color").into()),
-                    component_name: ("rerun.components.Color").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_color()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -49,6 +49,58 @@ pub struct LineGrid3D {
     pub color: Option<crate::components::Color>,
 }
 
+impl LineGrid3D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    #[inline]
+    pub fn descriptor_visible() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            component_name: "rerun.blueprint.components.Visible".into(),
+            archetype_field_name: Some("visible".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::spacing`].
+    #[inline]
+    pub fn descriptor_spacing() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            component_name: "rerun.blueprint.components.GridSpacing".into(),
+            archetype_field_name: Some("spacing".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::plane`].
+    #[inline]
+    pub fn descriptor_plane() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            component_name: "rerun.components.Plane3D".into(),
+            archetype_field_name: Some("plane".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::stroke_width`].
+    #[inline]
+    pub fn descriptor_stroke_width() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            component_name: "rerun.components.StrokeWidth".into(),
+            archetype_field_name: Some("stroke_width".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    #[inline]
+    pub fn descriptor_color() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -27,6 +27,18 @@ pub struct MapBackground {
     pub provider: crate::blueprint::components::MapProvider,
 }
 
+impl MapBackground {
+    /// Returns the [`ComponentDescriptor`] for [`Self::provider`].
+    #[inline]
+    pub fn descriptor_provider() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+            component_name: "rerun.blueprint.components.MapProvider".into(),
+            archetype_field_name: Some("provider".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -37,42 +37,32 @@ impl MapBackground {
             archetype_field_name: Some("provider".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+            component_name: "rerun.blueprint.components.MapBackgroundIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-            component_name: "rerun.blueprint.components.MapBackgroundIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [MapBackground::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-            component_name: "rerun.blueprint.components.MapProvider".into(),
-            archetype_field_name: Some("provider".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [MapBackground::descriptor_provider()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-                component_name: "rerun.blueprint.components.MapBackgroundIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-                component_name: "rerun.blueprint.components.MapProvider".into(),
-                archetype_field_name: Some("provider".into()),
-            },
+            MapBackground::descriptor_indicator(),
+            MapBackground::descriptor_provider(),
         ]
     });
 
@@ -159,11 +149,7 @@ impl ::re_types_core::AsComponents for MapBackground {
             (Some(&self.provider as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-                        archetype_field_name: Some(("provider").into()),
-                        component_name: ("rerun.blueprint.components.MapProvider").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_provider()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -37,44 +37,29 @@ impl MapZoom {
             archetype_field_name: Some("zoom".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+            component_name: "rerun.blueprint.components.MapZoomIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-            component_name: "rerun.blueprint.components.MapZoomIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [MapZoom::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-            component_name: "rerun.blueprint.components.ZoomLevel".into(),
-            archetype_field_name: Some("zoom".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [MapZoom::descriptor_zoom()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-                component_name: "rerun.blueprint.components.MapZoomIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-                component_name: "rerun.blueprint.components.ZoomLevel".into(),
-                archetype_field_name: Some("zoom".into()),
-            },
-        ]
-    });
+    once_cell::sync::Lazy::new(|| [MapZoom::descriptor_indicator(), MapZoom::descriptor_zoom()]);
 
 impl MapZoom {
     /// The total number of components in the archetype: 0 required, 1 recommended, 1 optional
@@ -159,11 +144,7 @@ impl ::re_types_core::AsComponents for MapZoom {
             (Some(&self.zoom as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-                        archetype_field_name: Some(("zoom").into()),
-                        component_name: ("rerun.blueprint.components.ZoomLevel").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_zoom()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -27,6 +27,18 @@ pub struct MapZoom {
     pub zoom: crate::blueprint::components::ZoomLevel,
 }
 
+impl MapZoom {
+    /// Returns the [`ComponentDescriptor`] for [`Self::zoom`].
+    #[inline]
+    pub fn descriptor_zoom() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+            component_name: "rerun.blueprint.components.ZoomLevel".into(),
+            archetype_field_name: Some("zoom".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
@@ -37,42 +37,32 @@ impl NearClipPlane {
             archetype_field_name: Some("near_clip_plane".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
+            component_name: "rerun.blueprint.components.NearClipPlaneIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
-            component_name: "rerun.blueprint.components.NearClipPlaneIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [NearClipPlane::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
-            component_name: "rerun.blueprint.components.NearClipPlane".into(),
-            archetype_field_name: Some("near_clip_plane".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [NearClipPlane::descriptor_near_clip_plane()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
-                component_name: "rerun.blueprint.components.NearClipPlaneIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
-                component_name: "rerun.blueprint.components.NearClipPlane".into(),
-                archetype_field_name: Some("near_clip_plane".into()),
-            },
+            NearClipPlane::descriptor_indicator(),
+            NearClipPlane::descriptor_near_clip_plane(),
         ]
     });
 
@@ -159,11 +149,7 @@ impl ::re_types_core::AsComponents for NearClipPlane {
             (Some(&self.near_clip_plane as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
-                        archetype_field_name: Some(("near_clip_plane").into()),
-                        component_name: ("rerun.blueprint.components.NearClipPlane").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_near_clip_plane()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
@@ -27,6 +27,18 @@ pub struct NearClipPlane {
     pub near_clip_plane: crate::blueprint::components::NearClipPlane,
 }
 
+impl NearClipPlane {
+    /// Returns the [`ComponentDescriptor`] for [`Self::near_clip_plane`].
+    #[inline]
+    pub fn descriptor_near_clip_plane() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
+            component_name: "rerun.blueprint.components.NearClipPlane".into(),
+            archetype_field_name: Some("near_clip_plane".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
@@ -35,42 +35,32 @@ impl PanelBlueprint {
             archetype_field_name: Some("state".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
+            component_name: "rerun.blueprint.components.PanelBlueprintIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-            component_name: "rerun.blueprint.components.PanelBlueprintIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [PanelBlueprint::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-            component_name: "rerun.blueprint.components.PanelState".into(),
-            archetype_field_name: Some("state".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [PanelBlueprint::descriptor_state()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-                component_name: "rerun.blueprint.components.PanelBlueprintIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-                component_name: "rerun.blueprint.components.PanelState".into(),
-                archetype_field_name: Some("state".into()),
-            },
+            PanelBlueprint::descriptor_indicator(),
+            PanelBlueprint::descriptor_state(),
         ]
     });
 
@@ -157,11 +147,7 @@ impl ::re_types_core::AsComponents for PanelBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-                    archetype_field_name: Some(("state").into()),
-                    component_name: ("rerun.blueprint.components.PanelState").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_state()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
@@ -25,6 +25,18 @@ pub struct PanelBlueprint {
     pub state: Option<crate::blueprint::components::PanelState>,
 }
 
+impl PanelBlueprint {
+    /// Returns the [`ComponentDescriptor`] for [`Self::state`].
+    #[inline]
+    pub fn descriptor_state() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
+            component_name: "rerun.blueprint.components.PanelState".into(),
+            archetype_field_name: Some("state".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -52,54 +52,38 @@ impl PlotLegend {
             archetype_field_name: Some("visible".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+            component_name: "rerun.blueprint.components.PlotLegendIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-            component_name: "rerun.blueprint.components.PlotLegendIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [PlotLegend::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                component_name: "rerun.blueprint.components.Corner2D".into(),
-                archetype_field_name: Some("corner".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
+            PlotLegend::descriptor_corner(),
+            PlotLegend::descriptor_visible(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                component_name: "rerun.blueprint.components.PlotLegendIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                component_name: "rerun.blueprint.components.Corner2D".into(),
-                archetype_field_name: Some("corner".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
+            PlotLegend::descriptor_indicator(),
+            PlotLegend::descriptor_corner(),
+            PlotLegend::descriptor_visible(),
         ]
     });
 
@@ -196,11 +180,7 @@ impl ::re_types_core::AsComponents for PlotLegend {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                    archetype_field_name: Some(("corner").into()),
-                    component_name: ("rerun.blueprint.components.Corner2D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_corner()),
             }),
             (self
                 .visible
@@ -208,11 +188,7 @@ impl ::re_types_core::AsComponents for PlotLegend {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                    archetype_field_name: Some(("visible").into()),
-                    component_name: ("rerun.blueprint.components.Visible").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_visible()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -32,6 +32,28 @@ pub struct PlotLegend {
     pub visible: Option<crate::blueprint::components::Visible>,
 }
 
+impl PlotLegend {
+    /// Returns the [`ComponentDescriptor`] for [`Self::corner`].
+    #[inline]
+    pub fn descriptor_corner() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+            component_name: "rerun.blueprint.components.Corner2D".into(),
+            archetype_field_name: Some("corner".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    #[inline]
+    pub fn descriptor_visible() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+            component_name: "rerun.blueprint.components.Visible".into(),
+            archetype_field_name: Some("visible".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -50,54 +50,38 @@ impl ScalarAxis {
             archetype_field_name: Some("zoom_lock".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+            component_name: "rerun.blueprint.components.ScalarAxisIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-            component_name: "rerun.blueprint.components.ScalarAxisIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ScalarAxis::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                component_name: "rerun.components.Range1D".into(),
-                archetype_field_name: Some("range".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                component_name: "rerun.blueprint.components.LockRangeDuringZoom".into(),
-                archetype_field_name: Some("zoom_lock".into()),
-            },
+            ScalarAxis::descriptor_range(),
+            ScalarAxis::descriptor_zoom_lock(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                component_name: "rerun.blueprint.components.ScalarAxisIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                component_name: "rerun.components.Range1D".into(),
-                archetype_field_name: Some("range".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                component_name: "rerun.blueprint.components.LockRangeDuringZoom".into(),
-                archetype_field_name: Some("zoom_lock".into()),
-            },
+            ScalarAxis::descriptor_indicator(),
+            ScalarAxis::descriptor_range(),
+            ScalarAxis::descriptor_zoom_lock(),
         ]
     });
 
@@ -194,11 +178,7 @@ impl ::re_types_core::AsComponents for ScalarAxis {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                    archetype_field_name: Some(("range").into()),
-                    component_name: ("rerun.components.Range1D").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_range()),
             }),
             (self
                 .zoom_lock
@@ -206,11 +186,7 @@ impl ::re_types_core::AsComponents for ScalarAxis {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                    archetype_field_name: Some(("zoom_lock").into()),
-                    component_name: ("rerun.blueprint.components.LockRangeDuringZoom").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_zoom_lock()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -30,6 +30,28 @@ pub struct ScalarAxis {
     pub zoom_lock: Option<crate::blueprint::components::LockRangeDuringZoom>,
 }
 
+impl ScalarAxis {
+    /// Returns the [`ComponentDescriptor`] for [`Self::range`].
+    #[inline]
+    pub fn descriptor_range() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+            component_name: "rerun.components.Range1D".into(),
+            archetype_field_name: Some("range".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::zoom_lock`].
+    #[inline]
+    pub fn descriptor_zoom_lock() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+            component_name: "rerun.blueprint.components.LockRangeDuringZoom".into(),
+            archetype_field_name: Some("zoom_lock".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -69,64 +69,40 @@ impl TensorScalarMapping {
             archetype_field_name: Some("gamma".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+            component_name: "rerun.blueprint.components.TensorScalarMappingIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-            component_name: "rerun.blueprint.components.TensorScalarMappingIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [TensorScalarMapping::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "rerun.components.MagnificationFilter".into(),
-                archetype_field_name: Some("mag_filter".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "rerun.components.Colormap".into(),
-                archetype_field_name: Some("colormap".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "rerun.components.GammaCorrection".into(),
-                archetype_field_name: Some("gamma".into()),
-            },
+            TensorScalarMapping::descriptor_mag_filter(),
+            TensorScalarMapping::descriptor_colormap(),
+            TensorScalarMapping::descriptor_gamma(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "rerun.blueprint.components.TensorScalarMappingIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "rerun.components.MagnificationFilter".into(),
-                archetype_field_name: Some("mag_filter".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "rerun.components.Colormap".into(),
-                archetype_field_name: Some("colormap".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "rerun.components.GammaCorrection".into(),
-                archetype_field_name: Some("gamma".into()),
-            },
+            TensorScalarMapping::descriptor_indicator(),
+            TensorScalarMapping::descriptor_mag_filter(),
+            TensorScalarMapping::descriptor_colormap(),
+            TensorScalarMapping::descriptor_gamma(),
         ]
     });
 
@@ -236,11 +212,7 @@ impl ::re_types_core::AsComponents for TensorScalarMapping {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                    archetype_field_name: Some(("mag_filter").into()),
-                    component_name: ("rerun.components.MagnificationFilter").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_mag_filter()),
             }),
             (self
                 .colormap
@@ -248,11 +220,7 @@ impl ::re_types_core::AsComponents for TensorScalarMapping {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                    archetype_field_name: Some(("colormap").into()),
-                    component_name: ("rerun.components.Colormap").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_colormap()),
             }),
             (self
                 .gamma
@@ -260,11 +228,7 @@ impl ::re_types_core::AsComponents for TensorScalarMapping {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                    archetype_field_name: Some(("gamma").into()),
-                    component_name: ("rerun.components.GammaCorrection").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_gamma()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -39,6 +39,38 @@ pub struct TensorScalarMapping {
     pub gamma: Option<crate::components::GammaCorrection>,
 }
 
+impl TensorScalarMapping {
+    /// Returns the [`ComponentDescriptor`] for [`Self::mag_filter`].
+    #[inline]
+    pub fn descriptor_mag_filter() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+            component_name: "rerun.components.MagnificationFilter".into(),
+            archetype_field_name: Some("mag_filter".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
+    #[inline]
+    pub fn descriptor_colormap() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+            component_name: "rerun.components.Colormap".into(),
+            archetype_field_name: Some("colormap".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::gamma`].
+    #[inline]
+    pub fn descriptor_gamma() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+            component_name: "rerun.components.GammaCorrection".into(),
+            archetype_field_name: Some("gamma".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -84,74 +84,42 @@ impl TensorSliceSelection {
             archetype_field_name: Some("slider".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+            component_name: "rerun.blueprint.components.TensorSliceSelectionIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-            component_name: "rerun.blueprint.components.TensorSliceSelectionIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [TensorSliceSelection::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.components.TensorWidthDimension".into(),
-                archetype_field_name: Some("width".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.components.TensorHeightDimension".into(),
-                archetype_field_name: Some("height".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.components.TensorDimensionIndexSelection".into(),
-                archetype_field_name: Some("indices".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.blueprint.components.TensorDimensionIndexSlider".into(),
-                archetype_field_name: Some("slider".into()),
-            },
+            TensorSliceSelection::descriptor_width(),
+            TensorSliceSelection::descriptor_height(),
+            TensorSliceSelection::descriptor_indices(),
+            TensorSliceSelection::descriptor_slider(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.blueprint.components.TensorSliceSelectionIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.components.TensorWidthDimension".into(),
-                archetype_field_name: Some("width".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.components.TensorHeightDimension".into(),
-                archetype_field_name: Some("height".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.components.TensorDimensionIndexSelection".into(),
-                archetype_field_name: Some("indices".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "rerun.blueprint.components.TensorDimensionIndexSlider".into(),
-                archetype_field_name: Some("slider".into()),
-            },
+            TensorSliceSelection::descriptor_indicator(),
+            TensorSliceSelection::descriptor_width(),
+            TensorSliceSelection::descriptor_height(),
+            TensorSliceSelection::descriptor_indices(),
+            TensorSliceSelection::descriptor_slider(),
         ]
     });
 
@@ -282,11 +250,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                    archetype_field_name: Some(("width").into()),
-                    component_name: ("rerun.components.TensorWidthDimension").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_width()),
             }),
             (self
                 .height
@@ -294,11 +258,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                    archetype_field_name: Some(("height").into()),
-                    component_name: ("rerun.components.TensorHeightDimension").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_height()),
             }),
             (self
                 .indices
@@ -306,11 +266,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                    archetype_field_name: Some(("indices").into()),
-                    component_name: ("rerun.components.TensorDimensionIndexSelection").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_indices()),
             }),
             (self
                 .slider
@@ -318,12 +274,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                    archetype_field_name: Some(("slider").into()),
-                    component_name: ("rerun.blueprint.components.TensorDimensionIndexSlider")
-                        .into(),
-                }),
+                descriptor_override: Some(Self::descriptor_slider()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -44,6 +44,48 @@ pub struct TensorSliceSelection {
     pub slider: Option<Vec<crate::blueprint::components::TensorDimensionIndexSlider>>,
 }
 
+impl TensorSliceSelection {
+    /// Returns the [`ComponentDescriptor`] for [`Self::width`].
+    #[inline]
+    pub fn descriptor_width() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+            component_name: "rerun.components.TensorWidthDimension".into(),
+            archetype_field_name: Some("width".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::height`].
+    #[inline]
+    pub fn descriptor_height() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+            component_name: "rerun.components.TensorHeightDimension".into(),
+            archetype_field_name: Some("height".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::indices`].
+    #[inline]
+    pub fn descriptor_indices() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+            component_name: "rerun.components.TensorDimensionIndexSelection".into(),
+            archetype_field_name: Some("indices".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::slider`].
+    #[inline]
+    pub fn descriptor_slider() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+            component_name: "rerun.blueprint.components.TensorDimensionIndexSlider".into(),
+            archetype_field_name: Some("slider".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -25,6 +25,18 @@ pub struct TensorViewFit {
     pub scaling: Option<crate::blueprint::components::ViewFit>,
 }
 
+impl TensorViewFit {
+    /// Returns the [`ComponentDescriptor`] for [`Self::scaling`].
+    #[inline]
+    pub fn descriptor_scaling() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+            component_name: "rerun.blueprint.components.ViewFit".into(),
+            archetype_field_name: Some("scaling".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -35,42 +35,32 @@ impl TensorViewFit {
             archetype_field_name: Some("scaling".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+            component_name: "rerun.blueprint.components.TensorViewFitIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-            component_name: "rerun.blueprint.components.TensorViewFitIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [TensorViewFit::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-            component_name: "rerun.blueprint.components.ViewFit".into(),
-            archetype_field_name: Some("scaling".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [TensorViewFit::descriptor_scaling()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-                component_name: "rerun.blueprint.components.TensorViewFitIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-                component_name: "rerun.blueprint.components.ViewFit".into(),
-                archetype_field_name: Some("scaling".into()),
-            },
+            TensorViewFit::descriptor_indicator(),
+            TensorViewFit::descriptor_scaling(),
         ]
     });
 
@@ -157,11 +147,7 @@ impl ::re_types_core::AsComponents for TensorViewFit {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-                    archetype_field_name: Some(("scaling").into()),
-                    component_name: ("rerun.blueprint.components.ViewFit").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_scaling()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
@@ -42,6 +42,48 @@ pub struct ViewBlueprint {
     pub visible: Option<crate::blueprint::components::Visible>,
 }
 
+impl ViewBlueprint {
+    /// Returns the [`ComponentDescriptor`] for [`Self::class_identifier`].
+    #[inline]
+    pub fn descriptor_class_identifier() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
+            component_name: "rerun.blueprint.components.ViewClass".into(),
+            archetype_field_name: Some("class_identifier".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
+    #[inline]
+    pub fn descriptor_display_name() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
+            component_name: "rerun.components.Name".into(),
+            archetype_field_name: Some("display_name".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::space_origin`].
+    #[inline]
+    pub fn descriptor_space_origin() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
+            component_name: "rerun.blueprint.components.ViewOrigin".into(),
+            archetype_field_name: Some("space_origin".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    #[inline]
+    pub fn descriptor_visible() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
+            component_name: "rerun.blueprint.components.Visible".into(),
+            archetype_field_name: Some("visible".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
@@ -82,75 +82,41 @@ impl ViewBlueprint {
             archetype_field_name: Some("visible".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-            component_name: "rerun.blueprint.components.ViewClass".into(),
-            archetype_field_name: Some("class_identifier".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
             component_name: "rerun.blueprint.components.ViewBlueprintIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [ViewBlueprint::descriptor_class_identifier()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [ViewBlueprint::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("display_name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewOrigin".into(),
-                archetype_field_name: Some("space_origin".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
+            ViewBlueprint::descriptor_display_name(),
+            ViewBlueprint::descriptor_space_origin(),
+            ViewBlueprint::descriptor_visible(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewClass".into(),
-                archetype_field_name: Some("class_identifier".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewBlueprintIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.components.Name".into(),
-                archetype_field_name: Some("display_name".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewOrigin".into(),
-                archetype_field_name: Some("space_origin".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                component_name: "rerun.blueprint.components.Visible".into(),
-                archetype_field_name: Some("visible".into()),
-            },
+            ViewBlueprint::descriptor_class_identifier(),
+            ViewBlueprint::descriptor_indicator(),
+            ViewBlueprint::descriptor_display_name(),
+            ViewBlueprint::descriptor_space_origin(),
+            ViewBlueprint::descriptor_visible(),
         ]
     });
 
@@ -271,11 +237,7 @@ impl ::re_types_core::AsComponents for ViewBlueprint {
             (Some(&self.class_identifier as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                        archetype_field_name: Some(("class_identifier").into()),
-                        component_name: ("rerun.blueprint.components.ViewClass").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_class_identifier()),
                 }
             }),
             (self
@@ -284,11 +246,7 @@ impl ::re_types_core::AsComponents for ViewBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                    archetype_field_name: Some(("display_name").into()),
-                    component_name: ("rerun.components.Name").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_display_name()),
             }),
             (self
                 .space_origin
@@ -296,11 +254,7 @@ impl ::re_types_core::AsComponents for ViewBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                    archetype_field_name: Some(("space_origin").into()),
-                    component_name: ("rerun.blueprint.components.ViewOrigin").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_space_origin()),
             }),
             (self
                 .visible
@@ -308,11 +262,7 @@ impl ::re_types_core::AsComponents for ViewBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
-                    archetype_field_name: Some(("visible").into()),
-                    component_name: ("rerun.blueprint.components.Visible").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_visible()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
@@ -64,6 +64,18 @@ pub struct ViewContents {
     pub query: Vec<crate::blueprint::components::QueryExpression>,
 }
 
+impl ViewContents {
+    /// Returns the [`ComponentDescriptor`] for [`Self::query`].
+    #[inline]
+    pub fn descriptor_query() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
+            component_name: "rerun.blueprint.components.QueryExpression".into(),
+            archetype_field_name: Some("query".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
@@ -74,42 +74,32 @@ impl ViewContents {
             archetype_field_name: Some("query".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
+            component_name: "rerun.blueprint.components.ViewContentsIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
-            component_name: "rerun.blueprint.components.ViewContentsIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ViewContents::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
-            component_name: "rerun.blueprint.components.QueryExpression".into(),
-            archetype_field_name: Some("query".into()),
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ViewContents::descriptor_query()]);
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
-                component_name: "rerun.blueprint.components.ViewContentsIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
-                component_name: "rerun.blueprint.components.QueryExpression".into(),
-                archetype_field_name: Some("query".into()),
-            },
+            ViewContents::descriptor_indicator(),
+            ViewContents::descriptor_query(),
         ]
     });
 
@@ -195,11 +185,7 @@ impl ::re_types_core::AsComponents for ViewContents {
             (Some(&self.query as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
-                        archetype_field_name: Some(("query").into()),
-                        component_name: ("rerun.blueprint.components.QueryExpression").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_query()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
@@ -100,84 +100,44 @@ impl ViewportBlueprint {
             archetype_field_name: Some("past_viewer_recommendations".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            component_name: "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-            component_name: "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [ViewportBlueprint::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.RootContainer".into(),
-                archetype_field_name: Some("root_container".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewMaximized".into(),
-                archetype_field_name: Some("maximized".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.AutoLayout".into(),
-                archetype_field_name: Some("auto_layout".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.AutoViews".into(),
-                archetype_field_name: Some("auto_views".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewerRecommendationHash".into(),
-                archetype_field_name: Some("past_viewer_recommendations".into()),
-            },
+            ViewportBlueprint::descriptor_root_container(),
+            ViewportBlueprint::descriptor_maximized(),
+            ViewportBlueprint::descriptor_auto_layout(),
+            ViewportBlueprint::descriptor_auto_views(),
+            ViewportBlueprint::descriptor_past_viewer_recommendations(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.RootContainer".into(),
-                archetype_field_name: Some("root_container".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewMaximized".into(),
-                archetype_field_name: Some("maximized".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.AutoLayout".into(),
-                archetype_field_name: Some("auto_layout".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.AutoViews".into(),
-                archetype_field_name: Some("auto_views".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "rerun.blueprint.components.ViewerRecommendationHash".into(),
-                archetype_field_name: Some("past_viewer_recommendations".into()),
-            },
+            ViewportBlueprint::descriptor_indicator(),
+            ViewportBlueprint::descriptor_root_container(),
+            ViewportBlueprint::descriptor_maximized(),
+            ViewportBlueprint::descriptor_auto_layout(),
+            ViewportBlueprint::descriptor_auto_views(),
+            ViewportBlueprint::descriptor_past_viewer_recommendations(),
         ]
     });
 
@@ -318,11 +278,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                    archetype_field_name: Some(("root_container").into()),
-                    component_name: ("rerun.blueprint.components.RootContainer").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_root_container()),
             }),
             (self
                 .maximized
@@ -330,11 +286,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                    archetype_field_name: Some(("maximized").into()),
-                    component_name: ("rerun.blueprint.components.ViewMaximized").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_maximized()),
             }),
             (self
                 .auto_layout
@@ -342,11 +294,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                    archetype_field_name: Some(("auto_layout").into()),
-                    component_name: ("rerun.blueprint.components.AutoLayout").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_auto_layout()),
             }),
             (self
                 .auto_views
@@ -354,11 +302,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                    archetype_field_name: Some(("auto_views").into()),
-                    component_name: ("rerun.blueprint.components.AutoViews").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_auto_views()),
             }),
             (self
                 .past_viewer_recommendations
@@ -366,11 +310,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                    archetype_field_name: Some(("past_viewer_recommendations").into()),
-                    component_name: ("rerun.blueprint.components.ViewerRecommendationHash").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_past_viewer_recommendations()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
@@ -50,6 +50,58 @@ pub struct ViewportBlueprint {
         Option<Vec<crate::blueprint::components::ViewerRecommendationHash>>,
 }
 
+impl ViewportBlueprint {
+    /// Returns the [`ComponentDescriptor`] for [`Self::root_container`].
+    #[inline]
+    pub fn descriptor_root_container() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            component_name: "rerun.blueprint.components.RootContainer".into(),
+            archetype_field_name: Some("root_container".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::maximized`].
+    #[inline]
+    pub fn descriptor_maximized() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            component_name: "rerun.blueprint.components.ViewMaximized".into(),
+            archetype_field_name: Some("maximized".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::auto_layout`].
+    #[inline]
+    pub fn descriptor_auto_layout() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            component_name: "rerun.blueprint.components.AutoLayout".into(),
+            archetype_field_name: Some("auto_layout".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::auto_views`].
+    #[inline]
+    pub fn descriptor_auto_views() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            component_name: "rerun.blueprint.components.AutoViews".into(),
+            archetype_field_name: Some("auto_views".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::past_viewer_recommendations`].
+    #[inline]
+    pub fn descriptor_past_viewer_recommendations() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            component_name: "rerun.blueprint.components.ViewerRecommendationHash".into(),
+            archetype_field_name: Some("past_viewer_recommendations".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -35,6 +35,18 @@ pub struct VisibleTimeRanges {
     pub ranges: Vec<crate::blueprint::components::VisibleTimeRange>,
 }
 
+impl VisibleTimeRanges {
+    /// Returns the [`ComponentDescriptor`] for [`Self::ranges`].
+    #[inline]
+    pub fn descriptor_ranges() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
+            component_name: "rerun.blueprint.components.VisibleTimeRange".into(),
+            archetype_field_name: Some("ranges".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -45,25 +45,23 @@ impl VisibleTimeRanges {
             archetype_field_name: Some("ranges".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-            component_name: "rerun.blueprint.components.VisibleTimeRange".into(),
-            archetype_field_name: Some("ranges".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
             component_name: "rerun.blueprint.components.VisibleTimeRangesIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [VisibleTimeRanges::descriptor_ranges()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [VisibleTimeRanges::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
@@ -71,16 +69,8 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-                component_name: "rerun.blueprint.components.VisibleTimeRange".into(),
-                archetype_field_name: Some("ranges".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-                component_name: "rerun.blueprint.components.VisibleTimeRangesIndicator".into(),
-                archetype_field_name: None,
-            },
+            VisibleTimeRanges::descriptor_ranges(),
+            VisibleTimeRanges::descriptor_indicator(),
         ]
     });
 
@@ -166,11 +156,7 @@ impl ::re_types_core::AsComponents for VisibleTimeRanges {
             (Some(&self.ranges as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-                        archetype_field_name: Some(("ranges").into()),
-                        component_name: ("rerun.blueprint.components.VisibleTimeRange").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_ranges()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -43,25 +43,23 @@ impl VisualBounds2D {
             archetype_field_name: Some("range".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-            component_name: "rerun.blueprint.components.VisualBounds2D".into(),
-            archetype_field_name: Some("range".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
             component_name: "rerun.blueprint.components.VisualBounds2DIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [VisualBounds2D::descriptor_range()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [VisualBounds2D::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
@@ -69,16 +67,8 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-                component_name: "rerun.blueprint.components.VisualBounds2D".into(),
-                archetype_field_name: Some("range".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-                component_name: "rerun.blueprint.components.VisualBounds2DIndicator".into(),
-                archetype_field_name: None,
-            },
+            VisualBounds2D::descriptor_range(),
+            VisualBounds2D::descriptor_indicator(),
         ]
     });
 
@@ -165,11 +155,7 @@ impl ::re_types_core::AsComponents for VisualBounds2D {
             (Some(&self.range as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-                        archetype_field_name: Some(("range").into()),
-                        component_name: ("rerun.blueprint.components.VisualBounds2D").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_range()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -33,6 +33,18 @@ pub struct VisualBounds2D {
     pub range: crate::blueprint::components::VisualBounds2D,
 }
 
+impl VisualBounds2D {
+    /// Returns the [`ComponentDescriptor`] for [`Self::range`].
+    #[inline]
+    pub fn descriptor_range() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
+            component_name: "rerun.blueprint.components.VisualBounds2D".into(),
+            archetype_field_name: Some("range".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -44,6 +44,228 @@ pub struct AffixFuzzer1 {
     pub fuzz1022: crate::testing::components::AffixFuzzer22,
 }
 
+impl AffixFuzzer1 {
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1001`].
+    #[inline]
+    pub fn descriptor_fuzz1001() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer1".into(),
+            archetype_field_name: Some("fuzz1001".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1002`].
+    #[inline]
+    pub fn descriptor_fuzz1002() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer2".into(),
+            archetype_field_name: Some("fuzz1002".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1003`].
+    #[inline]
+    pub fn descriptor_fuzz1003() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer3".into(),
+            archetype_field_name: Some("fuzz1003".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1004`].
+    #[inline]
+    pub fn descriptor_fuzz1004() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer4".into(),
+            archetype_field_name: Some("fuzz1004".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1005`].
+    #[inline]
+    pub fn descriptor_fuzz1005() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer5".into(),
+            archetype_field_name: Some("fuzz1005".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1006`].
+    #[inline]
+    pub fn descriptor_fuzz1006() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer6".into(),
+            archetype_field_name: Some("fuzz1006".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1007`].
+    #[inline]
+    pub fn descriptor_fuzz1007() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer7".into(),
+            archetype_field_name: Some("fuzz1007".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1008`].
+    #[inline]
+    pub fn descriptor_fuzz1008() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer8".into(),
+            archetype_field_name: Some("fuzz1008".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1009`].
+    #[inline]
+    pub fn descriptor_fuzz1009() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer9".into(),
+            archetype_field_name: Some("fuzz1009".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1010`].
+    #[inline]
+    pub fn descriptor_fuzz1010() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer10".into(),
+            archetype_field_name: Some("fuzz1010".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1011`].
+    #[inline]
+    pub fn descriptor_fuzz1011() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer11".into(),
+            archetype_field_name: Some("fuzz1011".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1012`].
+    #[inline]
+    pub fn descriptor_fuzz1012() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer12".into(),
+            archetype_field_name: Some("fuzz1012".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1013`].
+    #[inline]
+    pub fn descriptor_fuzz1013() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer13".into(),
+            archetype_field_name: Some("fuzz1013".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1014`].
+    #[inline]
+    pub fn descriptor_fuzz1014() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer14".into(),
+            archetype_field_name: Some("fuzz1014".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1015`].
+    #[inline]
+    pub fn descriptor_fuzz1015() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer15".into(),
+            archetype_field_name: Some("fuzz1015".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1016`].
+    #[inline]
+    pub fn descriptor_fuzz1016() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer16".into(),
+            archetype_field_name: Some("fuzz1016".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1017`].
+    #[inline]
+    pub fn descriptor_fuzz1017() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer17".into(),
+            archetype_field_name: Some("fuzz1017".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1018`].
+    #[inline]
+    pub fn descriptor_fuzz1018() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer18".into(),
+            archetype_field_name: Some("fuzz1018".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1019`].
+    #[inline]
+    pub fn descriptor_fuzz1019() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer19".into(),
+            archetype_field_name: Some("fuzz1019".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1020`].
+    #[inline]
+    pub fn descriptor_fuzz1020() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer20".into(),
+            archetype_field_name: Some("fuzz1020".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1021`].
+    #[inline]
+    pub fn descriptor_fuzz1021() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer21".into(),
+            archetype_field_name: Some("fuzz1021".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1022`].
+    #[inline]
+    pub fn descriptor_fuzz1022() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer22".into(),
+            archetype_field_name: Some("fuzz1022".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 22usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -264,132 +264,48 @@ impl AffixFuzzer1 {
             archetype_field_name: Some("fuzz1022".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "rerun.testing.components.AffixFuzzer1Indicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 22usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz1001".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz1002".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz1003".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz1004".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz1005".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz1006".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz1007".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz1008".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz1009".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz1010".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz1011".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz1012".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz1013".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz1014".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz1015".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz1016".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz1017".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz1018".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer19".into(),
-                archetype_field_name: Some("fuzz1019".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer20".into(),
-                archetype_field_name: Some("fuzz1020".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer21".into(),
-                archetype_field_name: Some("fuzz1021".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer22".into(),
-                archetype_field_name: Some("fuzz1022".into()),
-            },
+            AffixFuzzer1::descriptor_fuzz1001(),
+            AffixFuzzer1::descriptor_fuzz1002(),
+            AffixFuzzer1::descriptor_fuzz1003(),
+            AffixFuzzer1::descriptor_fuzz1004(),
+            AffixFuzzer1::descriptor_fuzz1005(),
+            AffixFuzzer1::descriptor_fuzz1006(),
+            AffixFuzzer1::descriptor_fuzz1007(),
+            AffixFuzzer1::descriptor_fuzz1008(),
+            AffixFuzzer1::descriptor_fuzz1009(),
+            AffixFuzzer1::descriptor_fuzz1010(),
+            AffixFuzzer1::descriptor_fuzz1011(),
+            AffixFuzzer1::descriptor_fuzz1012(),
+            AffixFuzzer1::descriptor_fuzz1013(),
+            AffixFuzzer1::descriptor_fuzz1014(),
+            AffixFuzzer1::descriptor_fuzz1015(),
+            AffixFuzzer1::descriptor_fuzz1016(),
+            AffixFuzzer1::descriptor_fuzz1017(),
+            AffixFuzzer1::descriptor_fuzz1018(),
+            AffixFuzzer1::descriptor_fuzz1019(),
+            AffixFuzzer1::descriptor_fuzz1020(),
+            AffixFuzzer1::descriptor_fuzz1021(),
+            AffixFuzzer1::descriptor_fuzz1022(),
         ]
     });
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-            component_name: "rerun.testing.components.AffixFuzzer1Indicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [AffixFuzzer1::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
@@ -397,121 +313,29 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 23usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz1001".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz1002".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz1003".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz1004".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz1005".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz1006".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz1007".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz1008".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz1009".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz1010".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz1011".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz1012".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz1013".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz1014".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz1015".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz1016".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz1017".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz1018".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer19".into(),
-                archetype_field_name: Some("fuzz1019".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer20".into(),
-                archetype_field_name: Some("fuzz1020".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer21".into(),
-                archetype_field_name: Some("fuzz1021".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer22".into(),
-                archetype_field_name: Some("fuzz1022".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1Indicator".into(),
-                archetype_field_name: None,
-            },
+            AffixFuzzer1::descriptor_fuzz1001(),
+            AffixFuzzer1::descriptor_fuzz1002(),
+            AffixFuzzer1::descriptor_fuzz1003(),
+            AffixFuzzer1::descriptor_fuzz1004(),
+            AffixFuzzer1::descriptor_fuzz1005(),
+            AffixFuzzer1::descriptor_fuzz1006(),
+            AffixFuzzer1::descriptor_fuzz1007(),
+            AffixFuzzer1::descriptor_fuzz1008(),
+            AffixFuzzer1::descriptor_fuzz1009(),
+            AffixFuzzer1::descriptor_fuzz1010(),
+            AffixFuzzer1::descriptor_fuzz1011(),
+            AffixFuzzer1::descriptor_fuzz1012(),
+            AffixFuzzer1::descriptor_fuzz1013(),
+            AffixFuzzer1::descriptor_fuzz1014(),
+            AffixFuzzer1::descriptor_fuzz1015(),
+            AffixFuzzer1::descriptor_fuzz1016(),
+            AffixFuzzer1::descriptor_fuzz1017(),
+            AffixFuzzer1::descriptor_fuzz1018(),
+            AffixFuzzer1::descriptor_fuzz1019(),
+            AffixFuzzer1::descriptor_fuzz1020(),
+            AffixFuzzer1::descriptor_fuzz1021(),
+            AffixFuzzer1::descriptor_fuzz1022(),
+            AffixFuzzer1::descriptor_indicator(),
         ]
     });
 
@@ -894,221 +718,133 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
             (Some(&self.fuzz1001 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1001").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer1").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1001()),
                 }
             }),
             (Some(&self.fuzz1002 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1002").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer2").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1002()),
                 }
             }),
             (Some(&self.fuzz1003 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1003").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer3").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1003()),
                 }
             }),
             (Some(&self.fuzz1004 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1004").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer4").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1004()),
                 }
             }),
             (Some(&self.fuzz1005 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1005").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer5").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1005()),
                 }
             }),
             (Some(&self.fuzz1006 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1006").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer6").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1006()),
                 }
             }),
             (Some(&self.fuzz1007 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1007").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer7").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1007()),
                 }
             }),
             (Some(&self.fuzz1008 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1008").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer8").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1008()),
                 }
             }),
             (Some(&self.fuzz1009 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1009").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer9").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1009()),
                 }
             }),
             (Some(&self.fuzz1010 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1010").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer10").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1010()),
                 }
             }),
             (Some(&self.fuzz1011 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1011").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer11").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1011()),
                 }
             }),
             (Some(&self.fuzz1012 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1012").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer12").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1012()),
                 }
             }),
             (Some(&self.fuzz1013 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1013").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer13").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1013()),
                 }
             }),
             (Some(&self.fuzz1014 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1014").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer14").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1014()),
                 }
             }),
             (Some(&self.fuzz1015 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1015").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer15").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1015()),
                 }
             }),
             (Some(&self.fuzz1016 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1016").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer16").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1016()),
                 }
             }),
             (Some(&self.fuzz1017 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1017").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer17").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1017()),
                 }
             }),
             (Some(&self.fuzz1018 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1018").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer18").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1018()),
                 }
             }),
             (Some(&self.fuzz1019 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1019").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer19").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1019()),
                 }
             }),
             (Some(&self.fuzz1020 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1020").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer20").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1020()),
                 }
             }),
             (Some(&self.fuzz1021 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1021").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer21").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1021()),
                 }
             }),
             (Some(&self.fuzz1022 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                        archetype_field_name: Some(("fuzz1022").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer22").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1022()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -41,6 +41,198 @@ pub struct AffixFuzzer2 {
     pub fuzz1122: Vec<crate::testing::components::AffixFuzzer22>,
 }
 
+impl AffixFuzzer2 {
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1101`].
+    #[inline]
+    pub fn descriptor_fuzz1101() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer1".into(),
+            archetype_field_name: Some("fuzz1101".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1102`].
+    #[inline]
+    pub fn descriptor_fuzz1102() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer2".into(),
+            archetype_field_name: Some("fuzz1102".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1103`].
+    #[inline]
+    pub fn descriptor_fuzz1103() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer3".into(),
+            archetype_field_name: Some("fuzz1103".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1104`].
+    #[inline]
+    pub fn descriptor_fuzz1104() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer4".into(),
+            archetype_field_name: Some("fuzz1104".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1105`].
+    #[inline]
+    pub fn descriptor_fuzz1105() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer5".into(),
+            archetype_field_name: Some("fuzz1105".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1106`].
+    #[inline]
+    pub fn descriptor_fuzz1106() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer6".into(),
+            archetype_field_name: Some("fuzz1106".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1107`].
+    #[inline]
+    pub fn descriptor_fuzz1107() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer7".into(),
+            archetype_field_name: Some("fuzz1107".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1108`].
+    #[inline]
+    pub fn descriptor_fuzz1108() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer8".into(),
+            archetype_field_name: Some("fuzz1108".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1109`].
+    #[inline]
+    pub fn descriptor_fuzz1109() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer9".into(),
+            archetype_field_name: Some("fuzz1109".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1110`].
+    #[inline]
+    pub fn descriptor_fuzz1110() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer10".into(),
+            archetype_field_name: Some("fuzz1110".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1111`].
+    #[inline]
+    pub fn descriptor_fuzz1111() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer11".into(),
+            archetype_field_name: Some("fuzz1111".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1112`].
+    #[inline]
+    pub fn descriptor_fuzz1112() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer12".into(),
+            archetype_field_name: Some("fuzz1112".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1113`].
+    #[inline]
+    pub fn descriptor_fuzz1113() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer13".into(),
+            archetype_field_name: Some("fuzz1113".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1114`].
+    #[inline]
+    pub fn descriptor_fuzz1114() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer14".into(),
+            archetype_field_name: Some("fuzz1114".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1115`].
+    #[inline]
+    pub fn descriptor_fuzz1115() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer15".into(),
+            archetype_field_name: Some("fuzz1115".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1116`].
+    #[inline]
+    pub fn descriptor_fuzz1116() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer16".into(),
+            archetype_field_name: Some("fuzz1116".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1117`].
+    #[inline]
+    pub fn descriptor_fuzz1117() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer17".into(),
+            archetype_field_name: Some("fuzz1117".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1118`].
+    #[inline]
+    pub fn descriptor_fuzz1118() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer18".into(),
+            archetype_field_name: Some("fuzz1118".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1122`].
+    #[inline]
+    pub fn descriptor_fuzz1122() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer22".into(),
+            archetype_field_name: Some("fuzz1122".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -231,117 +231,45 @@ impl AffixFuzzer2 {
             archetype_field_name: Some("fuzz1122".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "rerun.testing.components.AffixFuzzer2Indicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz1101".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz1102".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz1103".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz1104".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz1105".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz1106".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz1107".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz1108".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz1109".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz1110".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz1111".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz1112".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz1113".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz1114".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz1115".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz1116".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz1117".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz1118".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer22".into(),
-                archetype_field_name: Some("fuzz1122".into()),
-            },
+            AffixFuzzer2::descriptor_fuzz1101(),
+            AffixFuzzer2::descriptor_fuzz1102(),
+            AffixFuzzer2::descriptor_fuzz1103(),
+            AffixFuzzer2::descriptor_fuzz1104(),
+            AffixFuzzer2::descriptor_fuzz1105(),
+            AffixFuzzer2::descriptor_fuzz1106(),
+            AffixFuzzer2::descriptor_fuzz1107(),
+            AffixFuzzer2::descriptor_fuzz1108(),
+            AffixFuzzer2::descriptor_fuzz1109(),
+            AffixFuzzer2::descriptor_fuzz1110(),
+            AffixFuzzer2::descriptor_fuzz1111(),
+            AffixFuzzer2::descriptor_fuzz1112(),
+            AffixFuzzer2::descriptor_fuzz1113(),
+            AffixFuzzer2::descriptor_fuzz1114(),
+            AffixFuzzer2::descriptor_fuzz1115(),
+            AffixFuzzer2::descriptor_fuzz1116(),
+            AffixFuzzer2::descriptor_fuzz1117(),
+            AffixFuzzer2::descriptor_fuzz1118(),
+            AffixFuzzer2::descriptor_fuzz1122(),
         ]
     });
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-            component_name: "rerun.testing.components.AffixFuzzer2Indicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [AffixFuzzer2::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
@@ -349,106 +277,26 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 20usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz1101".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz1102".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz1103".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz1104".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz1105".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz1106".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz1107".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz1108".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz1109".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz1110".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz1111".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz1112".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz1113".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz1114".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz1115".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz1116".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz1117".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz1118".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer22".into(),
-                archetype_field_name: Some("fuzz1122".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2Indicator".into(),
-                archetype_field_name: None,
-            },
+            AffixFuzzer2::descriptor_fuzz1101(),
+            AffixFuzzer2::descriptor_fuzz1102(),
+            AffixFuzzer2::descriptor_fuzz1103(),
+            AffixFuzzer2::descriptor_fuzz1104(),
+            AffixFuzzer2::descriptor_fuzz1105(),
+            AffixFuzzer2::descriptor_fuzz1106(),
+            AffixFuzzer2::descriptor_fuzz1107(),
+            AffixFuzzer2::descriptor_fuzz1108(),
+            AffixFuzzer2::descriptor_fuzz1109(),
+            AffixFuzzer2::descriptor_fuzz1110(),
+            AffixFuzzer2::descriptor_fuzz1111(),
+            AffixFuzzer2::descriptor_fuzz1112(),
+            AffixFuzzer2::descriptor_fuzz1113(),
+            AffixFuzzer2::descriptor_fuzz1114(),
+            AffixFuzzer2::descriptor_fuzz1115(),
+            AffixFuzzer2::descriptor_fuzz1116(),
+            AffixFuzzer2::descriptor_fuzz1117(),
+            AffixFuzzer2::descriptor_fuzz1118(),
+            AffixFuzzer2::descriptor_fuzz1122(),
+            AffixFuzzer2::descriptor_indicator(),
         ]
     });
 
@@ -770,191 +618,115 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
             (Some(&self.fuzz1101 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1101").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer1").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1101()),
                 }
             }),
             (Some(&self.fuzz1102 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1102").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer2").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1102()),
                 }
             }),
             (Some(&self.fuzz1103 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1103").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer3").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1103()),
                 }
             }),
             (Some(&self.fuzz1104 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1104").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer4").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1104()),
                 }
             }),
             (Some(&self.fuzz1105 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1105").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer5").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1105()),
                 }
             }),
             (Some(&self.fuzz1106 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1106").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer6").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1106()),
                 }
             }),
             (Some(&self.fuzz1107 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1107").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer7").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1107()),
                 }
             }),
             (Some(&self.fuzz1108 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1108").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer8").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1108()),
                 }
             }),
             (Some(&self.fuzz1109 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1109").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer9").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1109()),
                 }
             }),
             (Some(&self.fuzz1110 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1110").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer10").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1110()),
                 }
             }),
             (Some(&self.fuzz1111 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1111").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer11").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1111()),
                 }
             }),
             (Some(&self.fuzz1112 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1112").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer12").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1112()),
                 }
             }),
             (Some(&self.fuzz1113 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1113").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer13").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1113()),
                 }
             }),
             (Some(&self.fuzz1114 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1114").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer14").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1114()),
                 }
             }),
             (Some(&self.fuzz1115 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1115").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer15").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1115()),
                 }
             }),
             (Some(&self.fuzz1116 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1116").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer16").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1116()),
                 }
             }),
             (Some(&self.fuzz1117 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1117").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer17").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1117()),
                 }
             }),
             (Some(&self.fuzz1118 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1118").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer18").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1118()),
                 }
             }),
             (Some(&self.fuzz1122 as &dyn ComponentBatch)).map(|batch| {
                 ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                        archetype_field_name: Some(("fuzz1122").into()),
-                        component_name: ("rerun.testing.components.AffixFuzzer22").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_fuzz1122()),
                 }
             }),
         ]

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -220,214 +220,70 @@ impl AffixFuzzer3 {
             archetype_field_name: Some("fuzz2018".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer3Indicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-            component_name: "rerun.testing.components.AffixFuzzer3Indicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [AffixFuzzer3::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 18usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz2001".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz2002".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz2003".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz2004".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz2005".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz2006".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz2007".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz2008".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz2009".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz2010".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz2011".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz2012".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz2013".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz2014".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz2015".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz2016".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz2017".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz2018".into()),
-            },
+            AffixFuzzer3::descriptor_fuzz2001(),
+            AffixFuzzer3::descriptor_fuzz2002(),
+            AffixFuzzer3::descriptor_fuzz2003(),
+            AffixFuzzer3::descriptor_fuzz2004(),
+            AffixFuzzer3::descriptor_fuzz2005(),
+            AffixFuzzer3::descriptor_fuzz2006(),
+            AffixFuzzer3::descriptor_fuzz2007(),
+            AffixFuzzer3::descriptor_fuzz2008(),
+            AffixFuzzer3::descriptor_fuzz2009(),
+            AffixFuzzer3::descriptor_fuzz2010(),
+            AffixFuzzer3::descriptor_fuzz2011(),
+            AffixFuzzer3::descriptor_fuzz2012(),
+            AffixFuzzer3::descriptor_fuzz2013(),
+            AffixFuzzer3::descriptor_fuzz2014(),
+            AffixFuzzer3::descriptor_fuzz2015(),
+            AffixFuzzer3::descriptor_fuzz2016(),
+            AffixFuzzer3::descriptor_fuzz2017(),
+            AffixFuzzer3::descriptor_fuzz2018(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3Indicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz2001".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz2002".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz2003".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz2004".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz2005".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz2006".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz2007".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz2008".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz2009".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz2010".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz2011".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz2012".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz2013".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz2014".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz2015".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz2016".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz2017".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz2018".into()),
-            },
+            AffixFuzzer3::descriptor_indicator(),
+            AffixFuzzer3::descriptor_fuzz2001(),
+            AffixFuzzer3::descriptor_fuzz2002(),
+            AffixFuzzer3::descriptor_fuzz2003(),
+            AffixFuzzer3::descriptor_fuzz2004(),
+            AffixFuzzer3::descriptor_fuzz2005(),
+            AffixFuzzer3::descriptor_fuzz2006(),
+            AffixFuzzer3::descriptor_fuzz2007(),
+            AffixFuzzer3::descriptor_fuzz2008(),
+            AffixFuzzer3::descriptor_fuzz2009(),
+            AffixFuzzer3::descriptor_fuzz2010(),
+            AffixFuzzer3::descriptor_fuzz2011(),
+            AffixFuzzer3::descriptor_fuzz2012(),
+            AffixFuzzer3::descriptor_fuzz2013(),
+            AffixFuzzer3::descriptor_fuzz2014(),
+            AffixFuzzer3::descriptor_fuzz2015(),
+            AffixFuzzer3::descriptor_fuzz2016(),
+            AffixFuzzer3::descriptor_fuzz2017(),
+            AffixFuzzer3::descriptor_fuzz2018(),
         ]
     });
 
@@ -703,11 +559,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2001").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer1").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2001()),
             }),
             (self
                 .fuzz2002
@@ -715,11 +567,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2002").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer2").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2002()),
             }),
             (self
                 .fuzz2003
@@ -727,11 +575,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2003").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer3").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2003()),
             }),
             (self
                 .fuzz2004
@@ -739,11 +583,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2004").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer4").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2004()),
             }),
             (self
                 .fuzz2005
@@ -751,11 +591,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2005").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer5").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2005()),
             }),
             (self
                 .fuzz2006
@@ -763,11 +599,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2006").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer6").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2006()),
             }),
             (self
                 .fuzz2007
@@ -775,11 +607,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2007").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer7").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2007()),
             }),
             (self
                 .fuzz2008
@@ -787,11 +615,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2008").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer8").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2008()),
             }),
             (self
                 .fuzz2009
@@ -799,11 +623,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2009").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer9").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2009()),
             }),
             (self
                 .fuzz2010
@@ -811,11 +631,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2010").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer10").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2010()),
             }),
             (self
                 .fuzz2011
@@ -823,11 +639,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2011").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer11").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2011()),
             }),
             (self
                 .fuzz2012
@@ -835,11 +647,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2012").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer12").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2012()),
             }),
             (self
                 .fuzz2013
@@ -847,11 +655,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2013").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer13").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2013()),
             }),
             (self
                 .fuzz2014
@@ -859,11 +663,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2014").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer14").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2014()),
             }),
             (self
                 .fuzz2015
@@ -871,11 +671,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2015").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer15").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2015()),
             }),
             (self
                 .fuzz2016
@@ -883,11 +679,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2016").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer16").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2016()),
             }),
             (self
                 .fuzz2017
@@ -895,11 +687,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2017").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer17").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2017()),
             }),
             (self
                 .fuzz2018
@@ -907,11 +695,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .map(|comp| (comp as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                    archetype_field_name: Some(("fuzz2018").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer18").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2018()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -40,6 +40,188 @@ pub struct AffixFuzzer3 {
     pub fuzz2018: Option<crate::testing::components::AffixFuzzer18>,
 }
 
+impl AffixFuzzer3 {
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2001`].
+    #[inline]
+    pub fn descriptor_fuzz2001() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer1".into(),
+            archetype_field_name: Some("fuzz2001".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2002`].
+    #[inline]
+    pub fn descriptor_fuzz2002() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer2".into(),
+            archetype_field_name: Some("fuzz2002".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2003`].
+    #[inline]
+    pub fn descriptor_fuzz2003() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer3".into(),
+            archetype_field_name: Some("fuzz2003".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2004`].
+    #[inline]
+    pub fn descriptor_fuzz2004() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer4".into(),
+            archetype_field_name: Some("fuzz2004".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2005`].
+    #[inline]
+    pub fn descriptor_fuzz2005() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer5".into(),
+            archetype_field_name: Some("fuzz2005".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2006`].
+    #[inline]
+    pub fn descriptor_fuzz2006() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer6".into(),
+            archetype_field_name: Some("fuzz2006".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2007`].
+    #[inline]
+    pub fn descriptor_fuzz2007() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer7".into(),
+            archetype_field_name: Some("fuzz2007".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2008`].
+    #[inline]
+    pub fn descriptor_fuzz2008() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer8".into(),
+            archetype_field_name: Some("fuzz2008".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2009`].
+    #[inline]
+    pub fn descriptor_fuzz2009() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer9".into(),
+            archetype_field_name: Some("fuzz2009".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2010`].
+    #[inline]
+    pub fn descriptor_fuzz2010() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer10".into(),
+            archetype_field_name: Some("fuzz2010".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2011`].
+    #[inline]
+    pub fn descriptor_fuzz2011() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer11".into(),
+            archetype_field_name: Some("fuzz2011".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2012`].
+    #[inline]
+    pub fn descriptor_fuzz2012() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer12".into(),
+            archetype_field_name: Some("fuzz2012".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2013`].
+    #[inline]
+    pub fn descriptor_fuzz2013() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer13".into(),
+            archetype_field_name: Some("fuzz2013".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2014`].
+    #[inline]
+    pub fn descriptor_fuzz2014() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer14".into(),
+            archetype_field_name: Some("fuzz2014".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2015`].
+    #[inline]
+    pub fn descriptor_fuzz2015() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer15".into(),
+            archetype_field_name: Some("fuzz2015".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2016`].
+    #[inline]
+    pub fn descriptor_fuzz2016() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer16".into(),
+            archetype_field_name: Some("fuzz2016".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2017`].
+    #[inline]
+    pub fn descriptor_fuzz2017() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer17".into(),
+            archetype_field_name: Some("fuzz2017".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2018`].
+    #[inline]
+    pub fn descriptor_fuzz2018() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "rerun.testing.components.AffixFuzzer18".into(),
+            archetype_field_name: Some("fuzz2018".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -40,6 +40,188 @@ pub struct AffixFuzzer4 {
     pub fuzz2118: Option<Vec<crate::testing::components::AffixFuzzer18>>,
 }
 
+impl AffixFuzzer4 {
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2101`].
+    #[inline]
+    pub fn descriptor_fuzz2101() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer1".into(),
+            archetype_field_name: Some("fuzz2101".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2102`].
+    #[inline]
+    pub fn descriptor_fuzz2102() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer2".into(),
+            archetype_field_name: Some("fuzz2102".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2103`].
+    #[inline]
+    pub fn descriptor_fuzz2103() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer3".into(),
+            archetype_field_name: Some("fuzz2103".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2104`].
+    #[inline]
+    pub fn descriptor_fuzz2104() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer4".into(),
+            archetype_field_name: Some("fuzz2104".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2105`].
+    #[inline]
+    pub fn descriptor_fuzz2105() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer5".into(),
+            archetype_field_name: Some("fuzz2105".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2106`].
+    #[inline]
+    pub fn descriptor_fuzz2106() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer6".into(),
+            archetype_field_name: Some("fuzz2106".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2107`].
+    #[inline]
+    pub fn descriptor_fuzz2107() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer7".into(),
+            archetype_field_name: Some("fuzz2107".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2108`].
+    #[inline]
+    pub fn descriptor_fuzz2108() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer8".into(),
+            archetype_field_name: Some("fuzz2108".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2109`].
+    #[inline]
+    pub fn descriptor_fuzz2109() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer9".into(),
+            archetype_field_name: Some("fuzz2109".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2110`].
+    #[inline]
+    pub fn descriptor_fuzz2110() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer10".into(),
+            archetype_field_name: Some("fuzz2110".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2111`].
+    #[inline]
+    pub fn descriptor_fuzz2111() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer11".into(),
+            archetype_field_name: Some("fuzz2111".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2112`].
+    #[inline]
+    pub fn descriptor_fuzz2112() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer12".into(),
+            archetype_field_name: Some("fuzz2112".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2113`].
+    #[inline]
+    pub fn descriptor_fuzz2113() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer13".into(),
+            archetype_field_name: Some("fuzz2113".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2114`].
+    #[inline]
+    pub fn descriptor_fuzz2114() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer14".into(),
+            archetype_field_name: Some("fuzz2114".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2115`].
+    #[inline]
+    pub fn descriptor_fuzz2115() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer15".into(),
+            archetype_field_name: Some("fuzz2115".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2116`].
+    #[inline]
+    pub fn descriptor_fuzz2116() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer16".into(),
+            archetype_field_name: Some("fuzz2116".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2117`].
+    #[inline]
+    pub fn descriptor_fuzz2117() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer17".into(),
+            archetype_field_name: Some("fuzz2117".into()),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2118`].
+    #[inline]
+    pub fn descriptor_fuzz2118() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer18".into(),
+            archetype_field_name: Some("fuzz2118".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -220,214 +220,70 @@ impl AffixFuzzer4 {
             archetype_field_name: Some("fuzz2118".into()),
         }
     }
+
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "rerun.testing.components.AffixFuzzer4Indicator".into(),
+            archetype_field_name: None,
+        }
+    }
 }
 
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-            component_name: "rerun.testing.components.AffixFuzzer4Indicator".into(),
-            archetype_field_name: None,
-        }]
-    });
+    once_cell::sync::Lazy::new(|| [AffixFuzzer4::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 18usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz2101".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz2102".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz2103".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz2104".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz2105".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz2106".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz2107".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz2108".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz2109".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz2110".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz2111".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz2112".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz2113".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz2114".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz2115".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz2116".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz2117".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz2118".into()),
-            },
+            AffixFuzzer4::descriptor_fuzz2101(),
+            AffixFuzzer4::descriptor_fuzz2102(),
+            AffixFuzzer4::descriptor_fuzz2103(),
+            AffixFuzzer4::descriptor_fuzz2104(),
+            AffixFuzzer4::descriptor_fuzz2105(),
+            AffixFuzzer4::descriptor_fuzz2106(),
+            AffixFuzzer4::descriptor_fuzz2107(),
+            AffixFuzzer4::descriptor_fuzz2108(),
+            AffixFuzzer4::descriptor_fuzz2109(),
+            AffixFuzzer4::descriptor_fuzz2110(),
+            AffixFuzzer4::descriptor_fuzz2111(),
+            AffixFuzzer4::descriptor_fuzz2112(),
+            AffixFuzzer4::descriptor_fuzz2113(),
+            AffixFuzzer4::descriptor_fuzz2114(),
+            AffixFuzzer4::descriptor_fuzz2115(),
+            AffixFuzzer4::descriptor_fuzz2116(),
+            AffixFuzzer4::descriptor_fuzz2117(),
+            AffixFuzzer4::descriptor_fuzz2118(),
         ]
     });
 
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4Indicator".into(),
-                archetype_field_name: None,
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer1".into(),
-                archetype_field_name: Some("fuzz2101".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer2".into(),
-                archetype_field_name: Some("fuzz2102".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer3".into(),
-                archetype_field_name: Some("fuzz2103".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer4".into(),
-                archetype_field_name: Some("fuzz2104".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer5".into(),
-                archetype_field_name: Some("fuzz2105".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer6".into(),
-                archetype_field_name: Some("fuzz2106".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer7".into(),
-                archetype_field_name: Some("fuzz2107".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer8".into(),
-                archetype_field_name: Some("fuzz2108".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer9".into(),
-                archetype_field_name: Some("fuzz2109".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer10".into(),
-                archetype_field_name: Some("fuzz2110".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer11".into(),
-                archetype_field_name: Some("fuzz2111".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer12".into(),
-                archetype_field_name: Some("fuzz2112".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer13".into(),
-                archetype_field_name: Some("fuzz2113".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer14".into(),
-                archetype_field_name: Some("fuzz2114".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer15".into(),
-                archetype_field_name: Some("fuzz2115".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer16".into(),
-                archetype_field_name: Some("fuzz2116".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer17".into(),
-                archetype_field_name: Some("fuzz2117".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "rerun.testing.components.AffixFuzzer18".into(),
-                archetype_field_name: Some("fuzz2118".into()),
-            },
+            AffixFuzzer4::descriptor_indicator(),
+            AffixFuzzer4::descriptor_fuzz2101(),
+            AffixFuzzer4::descriptor_fuzz2102(),
+            AffixFuzzer4::descriptor_fuzz2103(),
+            AffixFuzzer4::descriptor_fuzz2104(),
+            AffixFuzzer4::descriptor_fuzz2105(),
+            AffixFuzzer4::descriptor_fuzz2106(),
+            AffixFuzzer4::descriptor_fuzz2107(),
+            AffixFuzzer4::descriptor_fuzz2108(),
+            AffixFuzzer4::descriptor_fuzz2109(),
+            AffixFuzzer4::descriptor_fuzz2110(),
+            AffixFuzzer4::descriptor_fuzz2111(),
+            AffixFuzzer4::descriptor_fuzz2112(),
+            AffixFuzzer4::descriptor_fuzz2113(),
+            AffixFuzzer4::descriptor_fuzz2114(),
+            AffixFuzzer4::descriptor_fuzz2115(),
+            AffixFuzzer4::descriptor_fuzz2116(),
+            AffixFuzzer4::descriptor_fuzz2117(),
+            AffixFuzzer4::descriptor_fuzz2118(),
         ]
     });
 
@@ -757,11 +613,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2101").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer1").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2101()),
             }),
             (self
                 .fuzz2102
@@ -769,11 +621,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2102").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer2").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2102()),
             }),
             (self
                 .fuzz2103
@@ -781,11 +629,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2103").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer3").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2103()),
             }),
             (self
                 .fuzz2104
@@ -793,11 +637,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2104").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer4").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2104()),
             }),
             (self
                 .fuzz2105
@@ -805,11 +645,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2105").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer5").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2105()),
             }),
             (self
                 .fuzz2106
@@ -817,11 +653,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2106").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer6").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2106()),
             }),
             (self
                 .fuzz2107
@@ -829,11 +661,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2107").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer7").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2107()),
             }),
             (self
                 .fuzz2108
@@ -841,11 +669,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2108").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer8").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2108()),
             }),
             (self
                 .fuzz2109
@@ -853,11 +677,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2109").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer9").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2109()),
             }),
             (self
                 .fuzz2110
@@ -865,11 +685,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2110").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer10").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2110()),
             }),
             (self
                 .fuzz2111
@@ -877,11 +693,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2111").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer11").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2111()),
             }),
             (self
                 .fuzz2112
@@ -889,11 +701,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2112").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer12").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2112()),
             }),
             (self
                 .fuzz2113
@@ -901,11 +709,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2113").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer13").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2113()),
             }),
             (self
                 .fuzz2114
@@ -913,11 +717,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2114").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer14").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2114()),
             }),
             (self
                 .fuzz2115
@@ -925,11 +725,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2115").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer15").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2115()),
             }),
             (self
                 .fuzz2116
@@ -937,11 +733,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2116").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer16").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2116()),
             }),
             (self
                 .fuzz2117
@@ -949,11 +741,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2117").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer17").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2117()),
             }),
             (self
                 .fuzz2118
@@ -961,11 +749,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
             .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
-                descriptor_override: Some(ComponentDescriptor {
-                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                    archetype_field_name: Some(("fuzz2118").into()),
-                    component_name: ("rerun.testing.components.AffixFuzzer18").into(),
-                }),
+                descriptor_override: Some(Self::descriptor_fuzz2118()),
             }),
         ]
         .into_iter()

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -78,6 +78,18 @@ pub struct Clear {
     pub is_recursive: crate::components::ClearIsRecursive,
 }
 
+impl Clear {
+    /// Returns the [`ComponentDescriptor`] for [`Self::is_recursive`].
+    #[inline]
+    pub fn descriptor_is_recursive() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Clear".into()),
+            component_name: "rerun.components.ClearIsRecursive".into(),
+            archetype_field_name: Some("is_recursive".into()),
+        }
+    }
+}
+
 static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -88,25 +88,23 @@ impl Clear {
             archetype_field_name: Some("is_recursive".into()),
         }
     }
-}
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Clear".into()),
-            component_name: "rerun.components.ClearIsRecursive".into(),
-            archetype_field_name: Some("is_recursive".into()),
-        }]
-    });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| {
-        [ComponentDescriptor {
+    /// Returns the [`ComponentDescriptor`] for the associated indicator component.
+    #[inline]
+    pub fn descriptor_indicator() -> ComponentDescriptor {
+        ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Clear".into()),
             component_name: "rerun.components.ClearIndicator".into(),
             archetype_field_name: None,
-        }]
-    });
+        }
+    }
+}
+
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Clear::descriptor_is_recursive()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [Clear::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
@@ -114,16 +112,8 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Clear".into()),
-                component_name: "rerun.components.ClearIsRecursive".into(),
-                archetype_field_name: Some("is_recursive".into()),
-            },
-            ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Clear".into()),
-                component_name: "rerun.components.ClearIndicator".into(),
-                archetype_field_name: None,
-            },
+            Clear::descriptor_is_recursive(),
+            Clear::descriptor_indicator(),
         ]
     });
 
@@ -210,11 +200,7 @@ impl crate::AsComponents for Clear {
             (Some(&self.is_recursive as &dyn ComponentBatch)).map(|batch| {
                 crate::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
-                    descriptor_override: Some(ComponentDescriptor {
-                        archetype_name: Some("rerun.archetypes.Clear".into()),
-                        archetype_field_name: Some(("is_recursive").into()),
-                        component_name: ("rerun.components.ClearIsRecursive").into(),
-                    }),
+                    descriptor_override: Some(Self::descriptor_is_recursive()),
                 }
             }),
         ]


### PR DESCRIPTION
Generate methods for all archetypes that allow retrieving the fully-qualified descriptor for any of the archetype's field.
E.g. this method returns the descriptor for the `radii` field of `Points3D`:
```rust
impl Points3D {
    /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
    #[inline]
    pub fn descriptor_radii() -> ComponentDescriptor {
        ComponentDescriptor {
            archetype_name: Some("rerun.archetypes.Points3D".into()),
            component_name: "rerun.components.Radius".into(),
            archetype_field_name: Some("radii".into()),
        }
    }
}
```

This becomes a must as we start require tags in more and more places (e.g. partial updates APIs).

* DNM: requires #8642 
* Part of https://github.com/rerun-io/rerun/issues/8581