### PR TITLE
Make `Archetype::{from_arrow, to_arrow}` and friends tag compliant

### DIFF
--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -163,17 +163,14 @@ impl ::re_types_core::Archetype for AnnotationContext {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let context = {
-            let array = arrays_by_name
-                .get("rerun.components.AnnotationContext")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_context())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.AnnotationContext#context")?;
             <crate::components::AnnotationContext>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -266,17 +266,14 @@ impl ::re_types_core::Archetype for Arrows2D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let vectors = {
-            let array = arrays_by_name
-                .get("rerun.components.Vector2D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_vectors())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Arrows2D#vectors")?;
             <crate::components::Vector2D>::from_arrow_opt(&**array)
@@ -286,7 +283,7 @@ impl ::re_types_core::Archetype for Arrows2D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.Arrows2D#vectors")?
         };
-        let origins = if let Some(array) = arrays_by_name.get("rerun.components.Position2D") {
+        let origins = if let Some(array) = arrays_by_descr.get(&Self::descriptor_origins()) {
             Some({
                 <crate::components::Position2D>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows2D#origins")?
@@ -298,7 +295,7 @@ impl ::re_types_core::Archetype for Arrows2D {
         } else {
             None
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows2D#radii")?
@@ -310,7 +307,7 @@ impl ::re_types_core::Archetype for Arrows2D {
         } else {
             None
         };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows2D#colors")?
@@ -322,7 +319,7 @@ impl ::re_types_core::Archetype for Arrows2D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows2D#labels")?
@@ -334,7 +331,8 @@ impl ::re_types_core::Archetype for Arrows2D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Arrows2D#show_labels")?
                 .into_iter()
@@ -343,7 +341,7 @@ impl ::re_types_core::Archetype for Arrows2D {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Arrows2D#draw_order")?
                 .into_iter()
@@ -352,7 +350,7 @@ impl ::re_types_core::Archetype for Arrows2D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows2D#class_ids")?

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -262,17 +262,14 @@ impl ::re_types_core::Archetype for Arrows3D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let vectors = {
-            let array = arrays_by_name
-                .get("rerun.components.Vector3D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_vectors())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Arrows3D#vectors")?;
             <crate::components::Vector3D>::from_arrow_opt(&**array)
@@ -282,7 +279,7 @@ impl ::re_types_core::Archetype for Arrows3D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.Arrows3D#vectors")?
         };
-        let origins = if let Some(array) = arrays_by_name.get("rerun.components.Position3D") {
+        let origins = if let Some(array) = arrays_by_descr.get(&Self::descriptor_origins()) {
             Some({
                 <crate::components::Position3D>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows3D#origins")?
@@ -294,7 +291,7 @@ impl ::re_types_core::Archetype for Arrows3D {
         } else {
             None
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows3D#radii")?
@@ -306,7 +303,7 @@ impl ::re_types_core::Archetype for Arrows3D {
         } else {
             None
         };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows3D#colors")?
@@ -318,7 +315,7 @@ impl ::re_types_core::Archetype for Arrows3D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows3D#labels")?
@@ -330,7 +327,8 @@ impl ::re_types_core::Archetype for Arrows3D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Arrows3D#show_labels")?
                 .into_iter()
@@ -339,7 +337,7 @@ impl ::re_types_core::Archetype for Arrows3D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Arrows3D#class_ids")?

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -243,17 +243,14 @@ impl ::re_types_core::Archetype for AssetVideo {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let blob = {
-            let array = arrays_by_name
-                .get("rerun.components.Blob")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_blob())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.AssetVideo#blob")?;
             <crate::components::Blob>::from_arrow_opt(&**array)
@@ -264,7 +261,7 @@ impl ::re_types_core::Archetype for AssetVideo {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.AssetVideo#blob")?
         };
-        let media_type = if let Some(array) = arrays_by_name.get("rerun.components.MediaType") {
+        let media_type = if let Some(array) = arrays_by_descr.get(&Self::descriptor_media_type()) {
             <crate::components::MediaType>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.AssetVideo#media_type")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -154,17 +154,14 @@ impl ::re_types_core::Archetype for BarChart {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let values = {
-            let array = arrays_by_name
-                .get("rerun.components.TensorData")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_values())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.BarChart#values")?;
             <crate::components::TensorData>::from_arrow_opt(&**array)
@@ -175,7 +172,7 @@ impl ::re_types_core::Archetype for BarChart {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.BarChart#values")?
         };
-        let color = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let color = if let Some(array) = arrays_by_descr.get(&Self::descriptor_color()) {
             <crate::components::Color>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.BarChart#color")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -259,17 +259,14 @@ impl ::re_types_core::Archetype for Boxes2D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let half_sizes = {
-            let array = arrays_by_name
-                .get("rerun.components.HalfSize2D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_half_sizes())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Boxes2D#half_sizes")?;
             <crate::components::HalfSize2D>::from_arrow_opt(&**array)
@@ -279,7 +276,7 @@ impl ::re_types_core::Archetype for Boxes2D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.Boxes2D#half_sizes")?
         };
-        let centers = if let Some(array) = arrays_by_name.get("rerun.components.Position2D") {
+        let centers = if let Some(array) = arrays_by_descr.get(&Self::descriptor_centers()) {
             Some({
                 <crate::components::Position2D>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Boxes2D#centers")?
@@ -291,7 +288,7 @@ impl ::re_types_core::Archetype for Boxes2D {
         } else {
             None
         };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Boxes2D#colors")?
@@ -303,7 +300,7 @@ impl ::re_types_core::Archetype for Boxes2D {
         } else {
             None
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Boxes2D#radii")?
@@ -315,7 +312,7 @@ impl ::re_types_core::Archetype for Boxes2D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Boxes2D#labels")?
@@ -327,7 +324,8 @@ impl ::re_types_core::Archetype for Boxes2D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Boxes2D#show_labels")?
                 .into_iter()
@@ -336,7 +334,7 @@ impl ::re_types_core::Archetype for Boxes2D {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Boxes2D#draw_order")?
                 .into_iter()
@@ -345,7 +343,7 @@ impl ::re_types_core::Archetype for Boxes2D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Boxes2D#class_ids")?

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -281,17 +281,14 @@ impl ::re_types_core::Archetype for DepthImage {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let buffer = {
-            let array = arrays_by_name
-                .get("rerun.components.ImageBuffer")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_buffer())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.DepthImage#buffer")?;
             <crate::components::ImageBuffer>::from_arrow_opt(&**array)
@@ -303,8 +300,8 @@ impl ::re_types_core::Archetype for DepthImage {
                 .with_context("rerun.archetypes.DepthImage#buffer")?
         };
         let format = {
-            let array = arrays_by_name
-                .get("rerun.components.ImageFormat")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_format())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.DepthImage#format")?;
             <crate::components::ImageFormat>::from_arrow_opt(&**array)
@@ -315,7 +312,7 @@ impl ::re_types_core::Archetype for DepthImage {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.DepthImage#format")?
         };
-        let meter = if let Some(array) = arrays_by_name.get("rerun.components.DepthMeter") {
+        let meter = if let Some(array) = arrays_by_descr.get(&Self::descriptor_meter()) {
             <crate::components::DepthMeter>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.DepthImage#meter")?
                 .into_iter()
@@ -324,7 +321,7 @@ impl ::re_types_core::Archetype for DepthImage {
         } else {
             None
         };
-        let colormap = if let Some(array) = arrays_by_name.get("rerun.components.Colormap") {
+        let colormap = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colormap()) {
             <crate::components::Colormap>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.DepthImage#colormap")?
                 .into_iter()
@@ -333,7 +330,8 @@ impl ::re_types_core::Archetype for DepthImage {
         } else {
             None
         };
-        let depth_range = if let Some(array) = arrays_by_name.get("rerun.components.ValueRange") {
+        let depth_range = if let Some(array) = arrays_by_descr.get(&Self::descriptor_depth_range())
+        {
             <crate::components::ValueRange>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.DepthImage#depth_range")?
                 .into_iter()
@@ -342,17 +340,17 @@ impl ::re_types_core::Archetype for DepthImage {
         } else {
             None
         };
-        let point_fill_ratio = if let Some(array) = arrays_by_name.get("rerun.components.FillRatio")
-        {
-            <crate::components::FillRatio>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.DepthImage#point_fill_ratio")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let point_fill_ratio =
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_point_fill_ratio()) {
+                <crate::components::FillRatio>::from_arrow_opt(&**array)
+                    .with_context("rerun.archetypes.DepthImage#point_fill_ratio")?
+                    .into_iter()
+                    .next()
+                    .flatten()
+            } else {
+                None
+            };
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.DepthImage#draw_order")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -328,17 +328,14 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let half_sizes = {
-            let array = arrays_by_name
-                .get("rerun.components.HalfSize3D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_half_sizes())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Ellipsoids3D#half_sizes")?;
             <crate::components::HalfSize3D>::from_arrow_opt(&**array)
@@ -348,8 +345,7 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.Ellipsoids3D#half_sizes")?
         };
-        let centers = if let Some(array) = arrays_by_name.get("rerun.components.PoseTranslation3D")
-        {
+        let centers = if let Some(array) = arrays_by_descr.get(&Self::descriptor_centers()) {
             Some({
                 <crate::components::PoseTranslation3D>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Ellipsoids3D#centers")?
@@ -362,7 +358,7 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
             None
         };
         let rotation_axis_angles =
-            if let Some(array) = arrays_by_name.get("rerun.components.PoseRotationAxisAngle") {
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_rotation_axis_angles()) {
                 Some({
                     <crate::components::PoseRotationAxisAngle>::from_arrow_opt(&**array)
                         .with_context("rerun.archetypes.Ellipsoids3D#rotation_axis_angles")?
@@ -374,20 +370,20 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
             } else {
                 None
             };
-        let quaternions =
-            if let Some(array) = arrays_by_name.get("rerun.components.PoseRotationQuat") {
-                Some({
-                    <crate::components::PoseRotationQuat>::from_arrow_opt(&**array)
-                        .with_context("rerun.archetypes.Ellipsoids3D#quaternions")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.archetypes.Ellipsoids3D#quaternions")?
-                })
-            } else {
-                None
-            };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let quaternions = if let Some(array) = arrays_by_descr.get(&Self::descriptor_quaternions())
+        {
+            Some({
+                <crate::components::PoseRotationQuat>::from_arrow_opt(&**array)
+                    .with_context("rerun.archetypes.Ellipsoids3D#quaternions")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.archetypes.Ellipsoids3D#quaternions")?
+            })
+        } else {
+            None
+        };
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Ellipsoids3D#colors")?
@@ -399,7 +395,7 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
         } else {
             None
         };
-        let line_radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let line_radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_line_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Ellipsoids3D#line_radii")?
@@ -411,7 +407,7 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
         } else {
             None
         };
-        let fill_mode = if let Some(array) = arrays_by_name.get("rerun.components.FillMode") {
+        let fill_mode = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fill_mode()) {
             <crate::components::FillMode>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Ellipsoids3D#fill_mode")?
                 .into_iter()
@@ -420,7 +416,7 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Ellipsoids3D#labels")?
@@ -432,7 +428,8 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Ellipsoids3D#show_labels")?
                 .into_iter()
@@ -441,7 +438,7 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Ellipsoids3D#class_ids")?

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -197,17 +197,14 @@ impl ::re_types_core::Archetype for EncodedImage {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let blob = {
-            let array = arrays_by_name
-                .get("rerun.components.Blob")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_blob())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.EncodedImage#blob")?;
             <crate::components::Blob>::from_arrow_opt(&**array)
@@ -218,7 +215,7 @@ impl ::re_types_core::Archetype for EncodedImage {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.EncodedImage#blob")?
         };
-        let media_type = if let Some(array) = arrays_by_name.get("rerun.components.MediaType") {
+        let media_type = if let Some(array) = arrays_by_descr.get(&Self::descriptor_media_type()) {
             <crate::components::MediaType>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.EncodedImage#media_type")?
                 .into_iter()
@@ -227,7 +224,7 @@ impl ::re_types_core::Archetype for EncodedImage {
         } else {
             None
         };
-        let opacity = if let Some(array) = arrays_by_name.get("rerun.components.Opacity") {
+        let opacity = if let Some(array) = arrays_by_descr.get(&Self::descriptor_opacity()) {
             <crate::components::Opacity>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.EncodedImage#opacity")?
                 .into_iter()
@@ -236,7 +233,7 @@ impl ::re_types_core::Archetype for EncodedImage {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.EncodedImage#draw_order")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -166,17 +166,14 @@ impl ::re_types_core::Archetype for GraphEdges {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let edges = {
-            let array = arrays_by_name
-                .get("rerun.components.GraphEdge")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_edges())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.GraphEdges#edges")?;
             <crate::components::GraphEdge>::from_arrow_opt(&**array)
@@ -186,7 +183,7 @@ impl ::re_types_core::Archetype for GraphEdges {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.GraphEdges#edges")?
         };
-        let graph_type = if let Some(array) = arrays_by_name.get("rerun.components.GraphType") {
+        let graph_type = if let Some(array) = arrays_by_descr.get(&Self::descriptor_graph_type()) {
             <crate::components::GraphType>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.GraphEdges#graph_type")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -266,17 +266,14 @@ impl ::re_types_core::Archetype for Image {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let buffer = {
-            let array = arrays_by_name
-                .get("rerun.components.ImageBuffer")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_buffer())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Image#buffer")?;
             <crate::components::ImageBuffer>::from_arrow_opt(&**array)
@@ -288,8 +285,8 @@ impl ::re_types_core::Archetype for Image {
                 .with_context("rerun.archetypes.Image#buffer")?
         };
         let format = {
-            let array = arrays_by_name
-                .get("rerun.components.ImageFormat")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_format())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Image#format")?;
             <crate::components::ImageFormat>::from_arrow_opt(&**array)
@@ -300,7 +297,7 @@ impl ::re_types_core::Archetype for Image {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Image#format")?
         };
-        let opacity = if let Some(array) = arrays_by_name.get("rerun.components.Opacity") {
+        let opacity = if let Some(array) = arrays_by_descr.get(&Self::descriptor_opacity()) {
             <crate::components::Opacity>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Image#opacity")?
                 .into_iter()
@@ -309,7 +306,7 @@ impl ::re_types_core::Archetype for Image {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Image#draw_order")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -283,17 +283,14 @@ impl ::re_types_core::Archetype for LineStrips2D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let strips = {
-            let array = arrays_by_name
-                .get("rerun.components.LineStrip2D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_strips())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.LineStrips2D#strips")?;
             <crate::components::LineStrip2D>::from_arrow_opt(&**array)
@@ -303,7 +300,7 @@ impl ::re_types_core::Archetype for LineStrips2D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.LineStrips2D#strips")?
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips2D#radii")?
@@ -315,7 +312,7 @@ impl ::re_types_core::Archetype for LineStrips2D {
         } else {
             None
         };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips2D#colors")?
@@ -327,7 +324,7 @@ impl ::re_types_core::Archetype for LineStrips2D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips2D#labels")?
@@ -339,7 +336,8 @@ impl ::re_types_core::Archetype for LineStrips2D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.LineStrips2D#show_labels")?
                 .into_iter()
@@ -348,7 +346,7 @@ impl ::re_types_core::Archetype for LineStrips2D {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.LineStrips2D#draw_order")?
                 .into_iter()
@@ -357,7 +355,7 @@ impl ::re_types_core::Archetype for LineStrips2D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips2D#class_ids")?

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -279,17 +279,14 @@ impl ::re_types_core::Archetype for LineStrips3D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let strips = {
-            let array = arrays_by_name
-                .get("rerun.components.LineStrip3D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_strips())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.LineStrips3D#strips")?;
             <crate::components::LineStrip3D>::from_arrow_opt(&**array)
@@ -299,7 +296,7 @@ impl ::re_types_core::Archetype for LineStrips3D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.LineStrips3D#strips")?
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips3D#radii")?
@@ -311,7 +308,7 @@ impl ::re_types_core::Archetype for LineStrips3D {
         } else {
             None
         };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips3D#colors")?
@@ -323,7 +320,7 @@ impl ::re_types_core::Archetype for LineStrips3D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips3D#labels")?
@@ -335,7 +332,8 @@ impl ::re_types_core::Archetype for LineStrips3D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.LineStrips3D#show_labels")?
                 .into_iter()
@@ -344,7 +342,7 @@ impl ::re_types_core::Archetype for LineStrips3D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.LineStrips3D#class_ids")?

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -316,17 +316,14 @@ impl ::re_types_core::Archetype for Points2D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let positions = {
-            let array = arrays_by_name
-                .get("rerun.components.Position2D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_positions())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Points2D#positions")?;
             <crate::components::Position2D>::from_arrow_opt(&**array)
@@ -336,7 +333,7 @@ impl ::re_types_core::Archetype for Points2D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.Points2D#positions")?
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points2D#radii")?
@@ -348,7 +345,7 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points2D#colors")?
@@ -360,7 +357,7 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points2D#labels")?
@@ -372,7 +369,8 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Points2D#show_labels")?
                 .into_iter()
@@ -381,7 +379,7 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Points2D#draw_order")?
                 .into_iter()
@@ -390,7 +388,7 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points2D#class_ids")?
@@ -402,18 +400,19 @@ impl ::re_types_core::Archetype for Points2D {
         } else {
             None
         };
-        let keypoint_ids = if let Some(array) = arrays_by_name.get("rerun.components.KeypointId") {
-            Some({
-                <crate::components::KeypointId>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Points2D#keypoint_ids")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Points2D#keypoint_ids")?
-            })
-        } else {
-            None
-        };
+        let keypoint_ids =
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_keypoint_ids()) {
+                Some({
+                    <crate::components::KeypointId>::from_arrow_opt(&**array)
+                        .with_context("rerun.archetypes.Points2D#keypoint_ids")?
+                        .into_iter()
+                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                        .collect::<DeserializationResult<Vec<_>>>()
+                        .with_context("rerun.archetypes.Points2D#keypoint_ids")?
+                })
+            } else {
+                None
+            };
         Ok(Self {
             positions,
             radii,

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -297,17 +297,14 @@ impl ::re_types_core::Archetype for Points3D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let positions = {
-            let array = arrays_by_name
-                .get("rerun.components.Position3D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_positions())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Points3D#positions")?;
             <crate::components::Position3D>::from_arrow_opt(&**array)
@@ -317,7 +314,7 @@ impl ::re_types_core::Archetype for Points3D {
                 .collect::<DeserializationResult<Vec<_>>>()
                 .with_context("rerun.archetypes.Points3D#positions")?
         };
-        let radii = if let Some(array) = arrays_by_name.get("rerun.components.Radius") {
+        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
             Some({
                 <crate::components::Radius>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points3D#radii")?
@@ -329,7 +326,7 @@ impl ::re_types_core::Archetype for Points3D {
         } else {
             None
         };
-        let colors = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
             Some({
                 <crate::components::Color>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points3D#colors")?
@@ -341,7 +338,7 @@ impl ::re_types_core::Archetype for Points3D {
         } else {
             None
         };
-        let labels = if let Some(array) = arrays_by_name.get("rerun.components.Text") {
+        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
             Some({
                 <crate::components::Text>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points3D#labels")?
@@ -353,7 +350,8 @@ impl ::re_types_core::Archetype for Points3D {
         } else {
             None
         };
-        let show_labels = if let Some(array) = arrays_by_name.get("rerun.components.ShowLabels") {
+        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
+        {
             <crate::components::ShowLabels>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Points3D#show_labels")?
                 .into_iter()
@@ -362,7 +360,7 @@ impl ::re_types_core::Archetype for Points3D {
         } else {
             None
         };
-        let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
+        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Points3D#class_ids")?
@@ -374,18 +372,19 @@ impl ::re_types_core::Archetype for Points3D {
         } else {
             None
         };
-        let keypoint_ids = if let Some(array) = arrays_by_name.get("rerun.components.KeypointId") {
-            Some({
-                <crate::components::KeypointId>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Points3D#keypoint_ids")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Points3D#keypoint_ids")?
-            })
-        } else {
-            None
-        };
+        let keypoint_ids =
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_keypoint_ids()) {
+                Some({
+                    <crate::components::KeypointId>::from_arrow_opt(&**array)
+                        .with_context("rerun.archetypes.Points3D#keypoint_ids")?
+                        .into_iter()
+                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                        .collect::<DeserializationResult<Vec<_>>>()
+                        .with_context("rerun.archetypes.Points3D#keypoint_ids")?
+                })
+            } else {
+                None
+            };
         Ok(Self {
             positions,
             radii,

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -142,17 +142,14 @@ impl ::re_types_core::Archetype for Scalar {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let scalar = {
-            let array = arrays_by_name
-                .get("rerun.components.Scalar")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_scalar())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Scalar#scalar")?;
             <crate::components::Scalar>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -214,17 +214,14 @@ impl ::re_types_core::Archetype for SegmentationImage {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let buffer = {
-            let array = arrays_by_name
-                .get("rerun.components.ImageBuffer")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_buffer())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.SegmentationImage#buffer")?;
             <crate::components::ImageBuffer>::from_arrow_opt(&**array)
@@ -236,8 +233,8 @@ impl ::re_types_core::Archetype for SegmentationImage {
                 .with_context("rerun.archetypes.SegmentationImage#buffer")?
         };
         let format = {
-            let array = arrays_by_name
-                .get("rerun.components.ImageFormat")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_format())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.SegmentationImage#format")?;
             <crate::components::ImageFormat>::from_arrow_opt(&**array)
@@ -248,7 +245,7 @@ impl ::re_types_core::Archetype for SegmentationImage {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.SegmentationImage#format")?
         };
-        let opacity = if let Some(array) = arrays_by_name.get("rerun.components.Opacity") {
+        let opacity = if let Some(array) = arrays_by_descr.get(&Self::descriptor_opacity()) {
             <crate::components::Opacity>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SegmentationImage#opacity")?
                 .into_iter()
@@ -257,7 +254,7 @@ impl ::re_types_core::Archetype for SegmentationImage {
         } else {
             None
         };
-        let draw_order = if let Some(array) = arrays_by_name.get("rerun.components.DrawOrder") {
+        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
             <crate::components::DrawOrder>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SegmentationImage#draw_order")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -218,15 +218,12 @@ impl ::re_types_core::Archetype for SeriesLine {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let color = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let color = if let Some(array) = arrays_by_descr.get(&Self::descriptor_color()) {
             <crate::components::Color>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SeriesLine#color")?
                 .into_iter()
@@ -235,7 +232,7 @@ impl ::re_types_core::Archetype for SeriesLine {
         } else {
             None
         };
-        let width = if let Some(array) = arrays_by_name.get("rerun.components.StrokeWidth") {
+        let width = if let Some(array) = arrays_by_descr.get(&Self::descriptor_width()) {
             <crate::components::StrokeWidth>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SeriesLine#width")?
                 .into_iter()
@@ -244,7 +241,7 @@ impl ::re_types_core::Archetype for SeriesLine {
         } else {
             None
         };
-        let name = if let Some(array) = arrays_by_name.get("rerun.components.Name") {
+        let name = if let Some(array) = arrays_by_descr.get(&Self::descriptor_name()) {
             <crate::components::Name>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SeriesLine#name")?
                 .into_iter()
@@ -254,7 +251,7 @@ impl ::re_types_core::Archetype for SeriesLine {
             None
         };
         let aggregation_policy =
-            if let Some(array) = arrays_by_name.get("rerun.components.AggregationPolicy") {
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_aggregation_policy()) {
                 <crate::components::AggregationPolicy>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.SeriesLine#aggregation_policy")?
                     .into_iter()

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -216,15 +216,12 @@ impl ::re_types_core::Archetype for SeriesPoint {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let color = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let color = if let Some(array) = arrays_by_descr.get(&Self::descriptor_color()) {
             <crate::components::Color>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SeriesPoint#color")?
                 .into_iter()
@@ -233,7 +230,7 @@ impl ::re_types_core::Archetype for SeriesPoint {
         } else {
             None
         };
-        let marker = if let Some(array) = arrays_by_name.get("rerun.components.MarkerShape") {
+        let marker = if let Some(array) = arrays_by_descr.get(&Self::descriptor_marker()) {
             <crate::components::MarkerShape>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SeriesPoint#marker")?
                 .into_iter()
@@ -242,7 +239,7 @@ impl ::re_types_core::Archetype for SeriesPoint {
         } else {
             None
         };
-        let name = if let Some(array) = arrays_by_name.get("rerun.components.Name") {
+        let name = if let Some(array) = arrays_by_descr.get(&Self::descriptor_name()) {
             <crate::components::Name>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SeriesPoint#name")?
                 .into_iter()
@@ -251,7 +248,8 @@ impl ::re_types_core::Archetype for SeriesPoint {
         } else {
             None
         };
-        let marker_size = if let Some(array) = arrays_by_name.get("rerun.components.MarkerSize") {
+        let marker_size = if let Some(array) = arrays_by_descr.get(&Self::descriptor_marker_size())
+        {
             <crate::components::MarkerSize>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.SeriesPoint#marker_size")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -166,17 +166,14 @@ impl ::re_types_core::Archetype for Tensor {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let data = {
-            let array = arrays_by_name
-                .get("rerun.components.TensorData")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_data())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Tensor#data")?;
             <crate::components::TensorData>::from_arrow_opt(&**array)
@@ -187,7 +184,8 @@ impl ::re_types_core::Archetype for Tensor {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Tensor#data")?
         };
-        let value_range = if let Some(array) = arrays_by_name.get("rerun.components.ValueRange") {
+        let value_range = if let Some(array) = arrays_by_descr.get(&Self::descriptor_value_range())
+        {
             <crate::components::ValueRange>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Tensor#value_range")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -201,17 +201,14 @@ impl ::re_types_core::Archetype for TextDocument {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let text = {
-            let array = arrays_by_name
-                .get("rerun.components.Text")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_text())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.TextDocument#text")?;
             <crate::components::Text>::from_arrow_opt(&**array)
@@ -222,7 +219,7 @@ impl ::re_types_core::Archetype for TextDocument {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.TextDocument#text")?
         };
-        let media_type = if let Some(array) = arrays_by_name.get("rerun.components.MediaType") {
+        let media_type = if let Some(array) = arrays_by_descr.get(&Self::descriptor_media_type()) {
             <crate::components::MediaType>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.TextDocument#media_type")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -357,15 +357,12 @@ impl ::re_types_core::Archetype for Transform3D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let translation = if let Some(array) = arrays_by_name.get("rerun.components.Translation3D")
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let translation = if let Some(array) = arrays_by_descr.get(&Self::descriptor_translation())
         {
             <crate::components::Translation3D>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Transform3D#translation")?
@@ -376,7 +373,7 @@ impl ::re_types_core::Archetype for Transform3D {
             None
         };
         let rotation_axis_angle =
-            if let Some(array) = arrays_by_name.get("rerun.components.RotationAxisAngle") {
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_rotation_axis_angle()) {
                 <crate::components::RotationAxisAngle>::from_arrow_opt(&**array)
                     .with_context("rerun.archetypes.Transform3D#rotation_axis_angle")?
                     .into_iter()
@@ -385,7 +382,7 @@ impl ::re_types_core::Archetype for Transform3D {
             } else {
                 None
             };
-        let quaternion = if let Some(array) = arrays_by_name.get("rerun.components.RotationQuat") {
+        let quaternion = if let Some(array) = arrays_by_descr.get(&Self::descriptor_quaternion()) {
             <crate::components::RotationQuat>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Transform3D#quaternion")?
                 .into_iter()
@@ -394,7 +391,7 @@ impl ::re_types_core::Archetype for Transform3D {
         } else {
             None
         };
-        let scale = if let Some(array) = arrays_by_name.get("rerun.components.Scale3D") {
+        let scale = if let Some(array) = arrays_by_descr.get(&Self::descriptor_scale()) {
             <crate::components::Scale3D>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Transform3D#scale")?
                 .into_iter()
@@ -403,7 +400,7 @@ impl ::re_types_core::Archetype for Transform3D {
         } else {
             None
         };
-        let mat3x3 = if let Some(array) = arrays_by_name.get("rerun.components.TransformMat3x3") {
+        let mat3x3 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_mat3x3()) {
             <crate::components::TransformMat3x3>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Transform3D#mat3x3")?
                 .into_iter()
@@ -412,8 +409,7 @@ impl ::re_types_core::Archetype for Transform3D {
         } else {
             None
         };
-        let relation = if let Some(array) = arrays_by_name.get("rerun.components.TransformRelation")
-        {
+        let relation = if let Some(array) = arrays_by_descr.get(&Self::descriptor_relation()) {
             <crate::components::TransformRelation>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Transform3D#relation")?
                 .into_iter()
@@ -422,7 +418,8 @@ impl ::re_types_core::Archetype for Transform3D {
         } else {
             None
         };
-        let axis_length = if let Some(array) = arrays_by_name.get("rerun.components.AxisLength") {
+        let axis_length = if let Some(array) = arrays_by_descr.get(&Self::descriptor_axis_length())
+        {
             <crate::components::AxisLength>::from_arrow_opt(&**array)
                 .with_context("rerun.archetypes.Transform3D#axis_length")?
                 .into_iter()

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -246,17 +246,14 @@ impl ::re_types_core::Archetype for VideoFrameReference {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let timestamp = {
-            let array = arrays_by_name
-                .get("rerun.components.VideoTimestamp")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_timestamp())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.VideoFrameReference#timestamp")?;
             <crate::components::VideoTimestamp>::from_arrow_opt(&**array)
@@ -267,16 +264,16 @@ impl ::re_types_core::Archetype for VideoFrameReference {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.VideoFrameReference#timestamp")?
         };
-        let video_reference = if let Some(array) = arrays_by_name.get("rerun.components.EntityPath")
-        {
-            <crate::components::EntityPath>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.VideoFrameReference#video_reference")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
+        let video_reference =
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_video_reference()) {
+                <crate::components::EntityPath>::from_arrow_opt(&**array)
+                    .with_context("rerun.archetypes.VideoFrameReference#video_reference")?
+                    .into_iter()
+                    .next()
+                    .flatten()
+            } else {
+                None
+            };
         Ok(Self {
             timestamp,
             video_reference,

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -154,17 +154,14 @@ impl ::re_types_core::Archetype for ViewCoordinates {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let xyz = {
-            let array = arrays_by_name
-                .get("rerun.components.ViewCoordinates")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_xyz())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.ViewCoordinates#xyz")?;
             <crate::components::ViewCoordinates>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -127,17 +127,14 @@ impl ::re_types_core::Archetype for Background {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let kind = {
-            let array = arrays_by_name
-                .get("rerun.blueprint.components.BackgroundKind")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_kind())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.Background#kind")?;
             <crate::blueprint::components::BackgroundKind>::from_arrow_opt(&**array)
@@ -148,7 +145,7 @@ impl ::re_types_core::Archetype for Background {
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.Background#kind")?
         };
-        let color = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let color = if let Some(array) = arrays_by_descr.get(&Self::descriptor_color()) {
             <crate::components::Color>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.Background#color")?
                 .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/force_center.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_center.rs
@@ -134,16 +134,12 @@ impl ::re_types_core::Archetype for ForceCenter {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let enabled = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.Enabled")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let enabled = if let Some(array) = arrays_by_descr.get(&Self::descriptor_enabled()) {
             <crate::blueprint::components::Enabled>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.ForceCenter#enabled")?
                 .into_iter()
@@ -152,16 +148,15 @@ impl ::re_types_core::Archetype for ForceCenter {
         } else {
             None
         };
-        let strength =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ForceStrength") {
-                <crate::blueprint::components::ForceStrength>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ForceCenter#strength")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
+        let strength = if let Some(array) = arrays_by_descr.get(&Self::descriptor_strength()) {
+            <crate::blueprint::components::ForceStrength>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ForceCenter#strength")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
         Ok(Self { enabled, strength })
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
@@ -152,16 +152,12 @@ impl ::re_types_core::Archetype for ForceCollisionRadius {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let enabled = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.Enabled")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let enabled = if let Some(array) = arrays_by_descr.get(&Self::descriptor_enabled()) {
             <crate::blueprint::components::Enabled>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.ForceCollisionRadius#enabled")?
                 .into_iter()
@@ -170,26 +166,24 @@ impl ::re_types_core::Archetype for ForceCollisionRadius {
         } else {
             None
         };
-        let strength =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ForceStrength") {
-                <crate::blueprint::components::ForceStrength>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ForceCollisionRadius#strength")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let iterations =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ForceIterations") {
-                <crate::blueprint::components::ForceIterations>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ForceCollisionRadius#iterations")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
+        let strength = if let Some(array) = arrays_by_descr.get(&Self::descriptor_strength()) {
+            <crate::blueprint::components::ForceStrength>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ForceCollisionRadius#strength")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let iterations = if let Some(array) = arrays_by_descr.get(&Self::descriptor_iterations()) {
+            <crate::blueprint::components::ForceIterations>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ForceCollisionRadius#iterations")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
         Ok(Self {
             enabled,
             strength,

--- a/crates/store/re_types/src/blueprint/archetypes/force_link.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_link.rs
@@ -151,16 +151,12 @@ impl ::re_types_core::Archetype for ForceLink {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let enabled = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.Enabled")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let enabled = if let Some(array) = arrays_by_descr.get(&Self::descriptor_enabled()) {
             <crate::blueprint::components::Enabled>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.ForceLink#enabled")?
                 .into_iter()
@@ -169,26 +165,24 @@ impl ::re_types_core::Archetype for ForceLink {
         } else {
             None
         };
-        let distance =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ForceDistance") {
-                <crate::blueprint::components::ForceDistance>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ForceLink#distance")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let iterations =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ForceIterations") {
-                <crate::blueprint::components::ForceIterations>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ForceLink#iterations")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
+        let distance = if let Some(array) = arrays_by_descr.get(&Self::descriptor_distance()) {
+            <crate::blueprint::components::ForceDistance>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ForceLink#distance")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let iterations = if let Some(array) = arrays_by_descr.get(&Self::descriptor_iterations()) {
+            <crate::blueprint::components::ForceIterations>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ForceLink#iterations")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
         Ok(Self {
             enabled,
             distance,

--- a/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
@@ -139,16 +139,12 @@ impl ::re_types_core::Archetype for ForceManyBody {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let enabled = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.Enabled")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let enabled = if let Some(array) = arrays_by_descr.get(&Self::descriptor_enabled()) {
             <crate::blueprint::components::Enabled>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.ForceManyBody#enabled")?
                 .into_iter()
@@ -157,16 +153,15 @@ impl ::re_types_core::Archetype for ForceManyBody {
         } else {
             None
         };
-        let strength =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ForceStrength") {
-                <crate::blueprint::components::ForceStrength>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ForceManyBody#strength")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
+        let strength = if let Some(array) = arrays_by_descr.get(&Self::descriptor_strength()) {
+            <crate::blueprint::components::ForceStrength>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ForceManyBody#strength")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
         Ok(Self { enabled, strength })
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -189,16 +189,12 @@ impl ::re_types_core::Archetype for LineGrid3D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let visible = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.Visible")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let visible = if let Some(array) = arrays_by_descr.get(&Self::descriptor_visible()) {
             <crate::blueprint::components::Visible>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.LineGrid3D#visible")?
                 .into_iter()
@@ -207,17 +203,16 @@ impl ::re_types_core::Archetype for LineGrid3D {
         } else {
             None
         };
-        let spacing =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.GridSpacing") {
-                <crate::blueprint::components::GridSpacing>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.LineGrid3D#spacing")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let plane = if let Some(array) = arrays_by_name.get("rerun.components.Plane3D") {
+        let spacing = if let Some(array) = arrays_by_descr.get(&Self::descriptor_spacing()) {
+            <crate::blueprint::components::GridSpacing>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.LineGrid3D#spacing")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let plane = if let Some(array) = arrays_by_descr.get(&Self::descriptor_plane()) {
             <crate::components::Plane3D>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.LineGrid3D#plane")?
                 .into_iter()
@@ -226,16 +221,17 @@ impl ::re_types_core::Archetype for LineGrid3D {
         } else {
             None
         };
-        let stroke_width = if let Some(array) = arrays_by_name.get("rerun.components.StrokeWidth") {
-            <crate::components::StrokeWidth>::from_arrow_opt(&**array)
-                .with_context("rerun.blueprint.archetypes.LineGrid3D#stroke_width")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
-        let color = if let Some(array) = arrays_by_name.get("rerun.components.Color") {
+        let stroke_width =
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_stroke_width()) {
+                <crate::components::StrokeWidth>::from_arrow_opt(&**array)
+                    .with_context("rerun.blueprint.archetypes.LineGrid3D#stroke_width")?
+                    .into_iter()
+                    .next()
+                    .flatten()
+            } else {
+                None
+            };
+        let color = if let Some(array) = arrays_by_descr.get(&Self::descriptor_color()) {
             <crate::components::Color>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.LineGrid3D#color")?
                 .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -115,17 +115,14 @@ impl ::re_types_core::Archetype for MapBackground {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let provider = {
-            let array = arrays_by_name
-                .get("rerun.blueprint.components.MapProvider")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_provider())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.MapBackground#provider")?;
             <crate::blueprint::components::MapProvider>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -110,17 +110,14 @@ impl ::re_types_core::Archetype for MapZoom {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let zoom = {
-            let array = arrays_by_name
-                .get("rerun.blueprint.components.ZoomLevel")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_zoom())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.MapZoom#zoom")?;
             <crate::blueprint::components::ZoomLevel>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
@@ -115,17 +115,14 @@ impl ::re_types_core::Archetype for NearClipPlane {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let near_clip_plane = {
-            let array = arrays_by_name
-                .get("rerun.blueprint.components.NearClipPlane")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_near_clip_plane())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.NearClipPlane#near_clip_plane")?;
             <crate::blueprint::components::NearClipPlane>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
@@ -113,16 +113,12 @@ impl ::re_types_core::Archetype for PanelBlueprint {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let state = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.PanelState")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let state = if let Some(array) = arrays_by_descr.get(&Self::descriptor_state()) {
             <crate::blueprint::components::PanelState>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.PanelBlueprint#state")?
                 .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -136,16 +136,12 @@ impl ::re_types_core::Archetype for PlotLegend {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let corner = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.Corner2D")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let corner = if let Some(array) = arrays_by_descr.get(&Self::descriptor_corner()) {
             <crate::blueprint::components::Corner2D>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.PlotLegend#corner")?
                 .into_iter()
@@ -154,8 +150,7 @@ impl ::re_types_core::Archetype for PlotLegend {
         } else {
             None
         };
-        let visible = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.Visible")
-        {
+        let visible = if let Some(array) = arrays_by_descr.get(&Self::descriptor_visible()) {
             <crate::blueprint::components::Visible>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.PlotLegend#visible")?
                 .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -134,15 +134,12 @@ impl ::re_types_core::Archetype for ScalarAxis {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let range = if let Some(array) = arrays_by_name.get("rerun.components.Range1D") {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let range = if let Some(array) = arrays_by_descr.get(&Self::descriptor_range()) {
             <crate::components::Range1D>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.ScalarAxis#range")?
                 .into_iter()
@@ -151,9 +148,7 @@ impl ::re_types_core::Archetype for ScalarAxis {
         } else {
             None
         };
-        let zoom_lock = if let Some(array) =
-            arrays_by_name.get("rerun.blueprint.components.LockRangeDuringZoom")
-        {
+        let zoom_lock = if let Some(array) = arrays_by_descr.get(&Self::descriptor_zoom_lock()) {
             <crate::blueprint::components::LockRangeDuringZoom>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.ScalarAxis#zoom_lock")?
                 .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -173,16 +173,12 @@ impl ::re_types_core::Archetype for TensorSliceSelection {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let width = if let Some(array) = arrays_by_name.get("rerun.components.TensorWidthDimension")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let width = if let Some(array) = arrays_by_descr.get(&Self::descriptor_width()) {
             <crate::components::TensorWidthDimension>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.TensorSliceSelection#width")?
                 .into_iter()
@@ -191,19 +187,16 @@ impl ::re_types_core::Archetype for TensorSliceSelection {
         } else {
             None
         };
-        let height =
-            if let Some(array) = arrays_by_name.get("rerun.components.TensorHeightDimension") {
-                <crate::components::TensorHeightDimension>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.TensorSliceSelection#height")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let indices = if let Some(array) =
-            arrays_by_name.get("rerun.components.TensorDimensionIndexSelection")
-        {
+        let height = if let Some(array) = arrays_by_descr.get(&Self::descriptor_height()) {
+            <crate::components::TensorHeightDimension>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.TensorSliceSelection#height")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let indices = if let Some(array) = arrays_by_descr.get(&Self::descriptor_indices()) {
             Some({
                 <crate::components::TensorDimensionIndexSelection>::from_arrow_opt(&**array)
                     .with_context("rerun.blueprint.archetypes.TensorSliceSelection#indices")?
@@ -215,9 +208,7 @@ impl ::re_types_core::Archetype for TensorSliceSelection {
         } else {
             None
         };
-        let slider = if let Some(array) =
-            arrays_by_name.get("rerun.blueprint.components.TensorDimensionIndexSlider")
-        {
+        let slider = if let Some(array) = arrays_by_descr.get(&Self::descriptor_slider()) {
             Some({
                 <crate::blueprint::components::TensorDimensionIndexSlider>::from_arrow_opt(&**array)
                     .with_context("rerun.blueprint.archetypes.TensorSliceSelection#slider")?

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -113,16 +113,12 @@ impl ::re_types_core::Archetype for TensorViewFit {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let scaling = if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ViewFit")
-        {
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let scaling = if let Some(array) = arrays_by_descr.get(&Self::descriptor_scaling()) {
             <crate::blueprint::components::ViewFit>::from_arrow_opt(&**array)
                 .with_context("rerun.blueprint.archetypes.TensorViewFit#scaling")?
                 .into_iter()

--- a/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
@@ -152,17 +152,14 @@ impl ::re_types_core::Archetype for ViewContents {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let query = {
-            let array = arrays_by_name
-                .get("rerun.blueprint.components.QueryExpression")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_query())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.ViewContents#query")?;
             <crate::blueprint::components::QueryExpression>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
@@ -190,16 +190,13 @@ impl ::re_types_core::Archetype for ViewportBlueprint {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let root_container =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.RootContainer") {
+            if let Some(array) = arrays_by_descr.get(&Self::descriptor_root_container()) {
                 <crate::blueprint::components::RootContainer>::from_arrow_opt(&**array)
                     .with_context("rerun.blueprint.archetypes.ViewportBlueprint#root_container")?
                     .into_iter()
@@ -208,38 +205,36 @@ impl ::re_types_core::Archetype for ViewportBlueprint {
             } else {
                 None
             };
-        let maximized =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.ViewMaximized") {
-                <crate::blueprint::components::ViewMaximized>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ViewportBlueprint#maximized")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let auto_layout =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.AutoLayout") {
-                <crate::blueprint::components::AutoLayout>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ViewportBlueprint#auto_layout")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let auto_views =
-            if let Some(array) = arrays_by_name.get("rerun.blueprint.components.AutoViews") {
-                <crate::blueprint::components::AutoViews>::from_arrow_opt(&**array)
-                    .with_context("rerun.blueprint.archetypes.ViewportBlueprint#auto_views")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
+        let maximized = if let Some(array) = arrays_by_descr.get(&Self::descriptor_maximized()) {
+            <crate::blueprint::components::ViewMaximized>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ViewportBlueprint#maximized")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let auto_layout = if let Some(array) = arrays_by_descr.get(&Self::descriptor_auto_layout())
+        {
+            <crate::blueprint::components::AutoLayout>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ViewportBlueprint#auto_layout")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let auto_views = if let Some(array) = arrays_by_descr.get(&Self::descriptor_auto_views()) {
+            <crate::blueprint::components::AutoViews>::from_arrow_opt(&**array)
+                .with_context("rerun.blueprint.archetypes.ViewportBlueprint#auto_views")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
         let past_viewer_recommendations = if let Some(array) =
-            arrays_by_name.get("rerun.blueprint.components.ViewerRecommendationHash")
+            arrays_by_descr.get(&Self::descriptor_past_viewer_recommendations())
         {
             Some({
                 <crate::blueprint::components::ViewerRecommendationHash>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -123,17 +123,14 @@ impl ::re_types_core::Archetype for VisibleTimeRanges {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let ranges = {
-            let array = arrays_by_name
-                .get("rerun.blueprint.components.VisibleTimeRange")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_ranges())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.VisibleTimeRanges#ranges")?;
             <crate::blueprint::components::VisibleTimeRange>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -121,17 +121,14 @@ impl ::re_types_core::Archetype for VisualBounds2D {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let range = {
-            let array = arrays_by_name
-                .get("rerun.blueprint.components.VisualBounds2D")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_range())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.blueprint.archetypes.VisualBounds2D#range")?;
             <crate::blueprint::components::VisualBounds2D>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -388,17 +388,14 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let fuzz1001 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer1")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1001())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1001")?;
             <crate::testing::components::AffixFuzzer1>::from_arrow_opt(&**array)
@@ -410,8 +407,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1001")?
         };
         let fuzz1002 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer2")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1002())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1002")?;
             <crate::testing::components::AffixFuzzer2>::from_arrow_opt(&**array)
@@ -423,8 +420,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1002")?
         };
         let fuzz1003 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer3")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1003())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1003")?;
             <crate::testing::components::AffixFuzzer3>::from_arrow_opt(&**array)
@@ -436,8 +433,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1003")?
         };
         let fuzz1004 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer4")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1004())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1004")?;
             <crate::testing::components::AffixFuzzer4>::from_arrow_opt(&**array)
@@ -449,8 +446,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1004")?
         };
         let fuzz1005 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer5")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1005())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1005")?;
             <crate::testing::components::AffixFuzzer5>::from_arrow_opt(&**array)
@@ -462,8 +459,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1005")?
         };
         let fuzz1006 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer6")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1006())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1006")?;
             <crate::testing::components::AffixFuzzer6>::from_arrow_opt(&**array)
@@ -475,8 +472,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1006")?
         };
         let fuzz1007 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer7")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1007())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1007")?;
             <crate::testing::components::AffixFuzzer7>::from_arrow_opt(&**array)
@@ -488,8 +485,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1007")?
         };
         let fuzz1008 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer8")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1008())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1008")?;
             <crate::testing::components::AffixFuzzer8>::from_arrow_opt(&**array)
@@ -501,8 +498,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1008")?
         };
         let fuzz1009 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer9")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1009())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1009")?;
             <crate::testing::components::AffixFuzzer9>::from_arrow_opt(&**array)
@@ -514,8 +511,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1009")?
         };
         let fuzz1010 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer10")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1010())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1010")?;
             <crate::testing::components::AffixFuzzer10>::from_arrow_opt(&**array)
@@ -527,8 +524,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1010")?
         };
         let fuzz1011 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer11")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1011())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1011")?;
             <crate::testing::components::AffixFuzzer11>::from_arrow_opt(&**array)
@@ -540,8 +537,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1011")?
         };
         let fuzz1012 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer12")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1012())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1012")?;
             <crate::testing::components::AffixFuzzer12>::from_arrow_opt(&**array)
@@ -553,8 +550,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1012")?
         };
         let fuzz1013 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer13")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1013())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1013")?;
             <crate::testing::components::AffixFuzzer13>::from_arrow_opt(&**array)
@@ -566,8 +563,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1013")?
         };
         let fuzz1014 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer14")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1014())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1014")?;
             <crate::testing::components::AffixFuzzer14>::from_arrow_opt(&**array)
@@ -579,8 +576,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1014")?
         };
         let fuzz1015 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer15")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1015())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1015")?;
             <crate::testing::components::AffixFuzzer15>::from_arrow_opt(&**array)
@@ -592,8 +589,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1015")?
         };
         let fuzz1016 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer16")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1016())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1016")?;
             <crate::testing::components::AffixFuzzer16>::from_arrow_opt(&**array)
@@ -605,8 +602,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1016")?
         };
         let fuzz1017 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer17")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1017())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1017")?;
             <crate::testing::components::AffixFuzzer17>::from_arrow_opt(&**array)
@@ -618,8 +615,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1017")?
         };
         let fuzz1018 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer18")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1018())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1018")?;
             <crate::testing::components::AffixFuzzer18>::from_arrow_opt(&**array)
@@ -631,8 +628,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1018")?
         };
         let fuzz1019 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer19")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1019())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1019")?;
             <crate::testing::components::AffixFuzzer19>::from_arrow_opt(&**array)
@@ -644,8 +641,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1019")?
         };
         let fuzz1020 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer20")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1020())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1020")?;
             <crate::testing::components::AffixFuzzer20>::from_arrow_opt(&**array)
@@ -657,8 +654,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1020")?
         };
         let fuzz1021 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer21")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1021())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1021")?;
             <crate::testing::components::AffixFuzzer21>::from_arrow_opt(&**array)
@@ -670,8 +667,8 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1021")?
         };
         let fuzz1022 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer22")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1022())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer1#fuzz1022")?;
             <crate::testing::components::AffixFuzzer22>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -349,17 +349,14 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let fuzz1101 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer1")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1101())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1101")?;
             <crate::testing::components::AffixFuzzer1>::from_arrow_opt(&**array)
@@ -370,8 +367,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1101")?
         };
         let fuzz1102 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer2")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1102())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1102")?;
             <crate::testing::components::AffixFuzzer2>::from_arrow_opt(&**array)
@@ -382,8 +379,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1102")?
         };
         let fuzz1103 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer3")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1103())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1103")?;
             <crate::testing::components::AffixFuzzer3>::from_arrow_opt(&**array)
@@ -394,8 +391,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1103")?
         };
         let fuzz1104 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer4")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1104())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1104")?;
             <crate::testing::components::AffixFuzzer4>::from_arrow_opt(&**array)
@@ -406,8 +403,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1104")?
         };
         let fuzz1105 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer5")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1105())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1105")?;
             <crate::testing::components::AffixFuzzer5>::from_arrow_opt(&**array)
@@ -418,8 +415,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1105")?
         };
         let fuzz1106 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer6")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1106())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1106")?;
             <crate::testing::components::AffixFuzzer6>::from_arrow_opt(&**array)
@@ -430,8 +427,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1106")?
         };
         let fuzz1107 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer7")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1107())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1107")?;
             <crate::testing::components::AffixFuzzer7>::from_arrow_opt(&**array)
@@ -442,8 +439,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1107")?
         };
         let fuzz1108 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer8")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1108())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1108")?;
             <crate::testing::components::AffixFuzzer8>::from_arrow_opt(&**array)
@@ -454,8 +451,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1108")?
         };
         let fuzz1109 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer9")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1109())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1109")?;
             <crate::testing::components::AffixFuzzer9>::from_arrow_opt(&**array)
@@ -466,8 +463,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1109")?
         };
         let fuzz1110 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer10")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1110())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1110")?;
             <crate::testing::components::AffixFuzzer10>::from_arrow_opt(&**array)
@@ -478,8 +475,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1110")?
         };
         let fuzz1111 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer11")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1111())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1111")?;
             <crate::testing::components::AffixFuzzer11>::from_arrow_opt(&**array)
@@ -490,8 +487,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1111")?
         };
         let fuzz1112 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer12")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1112())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1112")?;
             <crate::testing::components::AffixFuzzer12>::from_arrow_opt(&**array)
@@ -502,8 +499,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1112")?
         };
         let fuzz1113 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer13")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1113())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1113")?;
             <crate::testing::components::AffixFuzzer13>::from_arrow_opt(&**array)
@@ -514,8 +511,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1113")?
         };
         let fuzz1114 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer14")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1114())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1114")?;
             <crate::testing::components::AffixFuzzer14>::from_arrow_opt(&**array)
@@ -526,8 +523,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1114")?
         };
         let fuzz1115 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer15")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1115())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1115")?;
             <crate::testing::components::AffixFuzzer15>::from_arrow_opt(&**array)
@@ -538,8 +535,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1115")?
         };
         let fuzz1116 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer16")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1116())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1116")?;
             <crate::testing::components::AffixFuzzer16>::from_arrow_opt(&**array)
@@ -550,8 +547,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1116")?
         };
         let fuzz1117 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer17")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1117())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1117")?;
             <crate::testing::components::AffixFuzzer17>::from_arrow_opt(&**array)
@@ -562,8 +559,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1117")?
         };
         let fuzz1118 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer18")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1118())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1118")?;
             <crate::testing::components::AffixFuzzer18>::from_arrow_opt(&**array)
@@ -574,8 +571,8 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1118")?
         };
         let fuzz1122 = {
-            let array = arrays_by_name
-                .get("rerun.testing.components.AffixFuzzer22")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_fuzz1122())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.testing.archetypes.AffixFuzzer2#fuzz1122")?;
             <crate::testing::components::AffixFuzzer22>::from_arrow_opt(&**array)

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -336,194 +336,173 @@ impl ::re_types_core::Archetype for AffixFuzzer3 {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let fuzz2001 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer1") {
-                <crate::testing::components::AffixFuzzer1>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2001")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2002 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer2") {
-                <crate::testing::components::AffixFuzzer2>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2002")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2003 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer3") {
-                <crate::testing::components::AffixFuzzer3>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2003")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2004 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer4") {
-                <crate::testing::components::AffixFuzzer4>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2004")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2005 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer5") {
-                <crate::testing::components::AffixFuzzer5>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2005")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2006 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer6") {
-                <crate::testing::components::AffixFuzzer6>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2006")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2007 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer7") {
-                <crate::testing::components::AffixFuzzer7>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2007")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2008 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer8") {
-                <crate::testing::components::AffixFuzzer8>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2008")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2009 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer9") {
-                <crate::testing::components::AffixFuzzer9>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2009")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2010 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer10") {
-                <crate::testing::components::AffixFuzzer10>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2010")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2011 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer11") {
-                <crate::testing::components::AffixFuzzer11>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2011")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2012 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer12") {
-                <crate::testing::components::AffixFuzzer12>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2012")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2013 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer13") {
-                <crate::testing::components::AffixFuzzer13>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2013")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2014 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer14") {
-                <crate::testing::components::AffixFuzzer14>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2014")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2015 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer15") {
-                <crate::testing::components::AffixFuzzer15>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2015")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2016 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer16") {
-                <crate::testing::components::AffixFuzzer16>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2016")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2017 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer17") {
-                <crate::testing::components::AffixFuzzer17>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2017")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let fuzz2018 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer18") {
-                <crate::testing::components::AffixFuzzer18>::from_arrow_opt(&**array)
-                    .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2018")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let fuzz2001 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2001()) {
+            <crate::testing::components::AffixFuzzer1>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2001")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2002 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2002()) {
+            <crate::testing::components::AffixFuzzer2>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2002")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2003 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2003()) {
+            <crate::testing::components::AffixFuzzer3>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2003")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2004 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2004()) {
+            <crate::testing::components::AffixFuzzer4>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2004")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2005 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2005()) {
+            <crate::testing::components::AffixFuzzer5>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2005")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2006 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2006()) {
+            <crate::testing::components::AffixFuzzer6>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2006")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2007 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2007()) {
+            <crate::testing::components::AffixFuzzer7>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2007")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2008 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2008()) {
+            <crate::testing::components::AffixFuzzer8>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2008")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2009 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2009()) {
+            <crate::testing::components::AffixFuzzer9>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2009")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2010 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2010()) {
+            <crate::testing::components::AffixFuzzer10>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2010")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2011 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2011()) {
+            <crate::testing::components::AffixFuzzer11>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2011")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2012 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2012()) {
+            <crate::testing::components::AffixFuzzer12>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2012")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2013 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2013()) {
+            <crate::testing::components::AffixFuzzer13>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2013")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2014 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2014()) {
+            <crate::testing::components::AffixFuzzer14>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2014")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2015 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2015()) {
+            <crate::testing::components::AffixFuzzer15>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2015")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2016 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2016()) {
+            <crate::testing::components::AffixFuzzer16>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2016")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2017 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2017()) {
+            <crate::testing::components::AffixFuzzer17>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2017")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
+        let fuzz2018 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2018()) {
+            <crate::testing::components::AffixFuzzer18>::from_arrow_opt(&**array)
+                .with_context("rerun.testing.archetypes.AffixFuzzer3#fuzz2018")?
+                .into_iter()
+                .next()
+                .flatten()
+        } else {
+            None
+        };
         Ok(Self {
             fuzz2001,
             fuzz2002,

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -336,248 +336,227 @@ impl ::re_types_core::Archetype for AffixFuzzer4 {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
-        let fuzz2101 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer1") {
-                Some({
-                    <crate::testing::components::AffixFuzzer1>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2101")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2101")?
-                })
-            } else {
-                None
-            };
-        let fuzz2102 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer2") {
-                Some({
-                    <crate::testing::components::AffixFuzzer2>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2102")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2102")?
-                })
-            } else {
-                None
-            };
-        let fuzz2103 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer3") {
-                Some({
-                    <crate::testing::components::AffixFuzzer3>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2103")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2103")?
-                })
-            } else {
-                None
-            };
-        let fuzz2104 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer4") {
-                Some({
-                    <crate::testing::components::AffixFuzzer4>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2104")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2104")?
-                })
-            } else {
-                None
-            };
-        let fuzz2105 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer5") {
-                Some({
-                    <crate::testing::components::AffixFuzzer5>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2105")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2105")?
-                })
-            } else {
-                None
-            };
-        let fuzz2106 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer6") {
-                Some({
-                    <crate::testing::components::AffixFuzzer6>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2106")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2106")?
-                })
-            } else {
-                None
-            };
-        let fuzz2107 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer7") {
-                Some({
-                    <crate::testing::components::AffixFuzzer7>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2107")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2107")?
-                })
-            } else {
-                None
-            };
-        let fuzz2108 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer8") {
-                Some({
-                    <crate::testing::components::AffixFuzzer8>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2108")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2108")?
-                })
-            } else {
-                None
-            };
-        let fuzz2109 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer9") {
-                Some({
-                    <crate::testing::components::AffixFuzzer9>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2109")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2109")?
-                })
-            } else {
-                None
-            };
-        let fuzz2110 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer10") {
-                Some({
-                    <crate::testing::components::AffixFuzzer10>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2110")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2110")?
-                })
-            } else {
-                None
-            };
-        let fuzz2111 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer11") {
-                Some({
-                    <crate::testing::components::AffixFuzzer11>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2111")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2111")?
-                })
-            } else {
-                None
-            };
-        let fuzz2112 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer12") {
-                Some({
-                    <crate::testing::components::AffixFuzzer12>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2112")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2112")?
-                })
-            } else {
-                None
-            };
-        let fuzz2113 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer13") {
-                Some({
-                    <crate::testing::components::AffixFuzzer13>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2113")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2113")?
-                })
-            } else {
-                None
-            };
-        let fuzz2114 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer14") {
-                Some({
-                    <crate::testing::components::AffixFuzzer14>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2114")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2114")?
-                })
-            } else {
-                None
-            };
-        let fuzz2115 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer15") {
-                Some({
-                    <crate::testing::components::AffixFuzzer15>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2115")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2115")?
-                })
-            } else {
-                None
-            };
-        let fuzz2116 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer16") {
-                Some({
-                    <crate::testing::components::AffixFuzzer16>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2116")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2116")?
-                })
-            } else {
-                None
-            };
-        let fuzz2117 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer17") {
-                Some({
-                    <crate::testing::components::AffixFuzzer17>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2117")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2117")?
-                })
-            } else {
-                None
-            };
-        let fuzz2118 =
-            if let Some(array) = arrays_by_name.get("rerun.testing.components.AffixFuzzer18") {
-                Some({
-                    <crate::testing::components::AffixFuzzer18>::from_arrow_opt(&**array)
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2118")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2118")?
-                })
-            } else {
-                None
-            };
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
+        let fuzz2101 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2101()) {
+            Some({
+                <crate::testing::components::AffixFuzzer1>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2101")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2101")?
+            })
+        } else {
+            None
+        };
+        let fuzz2102 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2102()) {
+            Some({
+                <crate::testing::components::AffixFuzzer2>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2102")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2102")?
+            })
+        } else {
+            None
+        };
+        let fuzz2103 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2103()) {
+            Some({
+                <crate::testing::components::AffixFuzzer3>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2103")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2103")?
+            })
+        } else {
+            None
+        };
+        let fuzz2104 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2104()) {
+            Some({
+                <crate::testing::components::AffixFuzzer4>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2104")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2104")?
+            })
+        } else {
+            None
+        };
+        let fuzz2105 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2105()) {
+            Some({
+                <crate::testing::components::AffixFuzzer5>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2105")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2105")?
+            })
+        } else {
+            None
+        };
+        let fuzz2106 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2106()) {
+            Some({
+                <crate::testing::components::AffixFuzzer6>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2106")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2106")?
+            })
+        } else {
+            None
+        };
+        let fuzz2107 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2107()) {
+            Some({
+                <crate::testing::components::AffixFuzzer7>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2107")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2107")?
+            })
+        } else {
+            None
+        };
+        let fuzz2108 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2108()) {
+            Some({
+                <crate::testing::components::AffixFuzzer8>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2108")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2108")?
+            })
+        } else {
+            None
+        };
+        let fuzz2109 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2109()) {
+            Some({
+                <crate::testing::components::AffixFuzzer9>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2109")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2109")?
+            })
+        } else {
+            None
+        };
+        let fuzz2110 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2110()) {
+            Some({
+                <crate::testing::components::AffixFuzzer10>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2110")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2110")?
+            })
+        } else {
+            None
+        };
+        let fuzz2111 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2111()) {
+            Some({
+                <crate::testing::components::AffixFuzzer11>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2111")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2111")?
+            })
+        } else {
+            None
+        };
+        let fuzz2112 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2112()) {
+            Some({
+                <crate::testing::components::AffixFuzzer12>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2112")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2112")?
+            })
+        } else {
+            None
+        };
+        let fuzz2113 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2113()) {
+            Some({
+                <crate::testing::components::AffixFuzzer13>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2113")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2113")?
+            })
+        } else {
+            None
+        };
+        let fuzz2114 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2114()) {
+            Some({
+                <crate::testing::components::AffixFuzzer14>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2114")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2114")?
+            })
+        } else {
+            None
+        };
+        let fuzz2115 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2115()) {
+            Some({
+                <crate::testing::components::AffixFuzzer15>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2115")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2115")?
+            })
+        } else {
+            None
+        };
+        let fuzz2116 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2116()) {
+            Some({
+                <crate::testing::components::AffixFuzzer16>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2116")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2116")?
+            })
+        } else {
+            None
+        };
+        let fuzz2117 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2117()) {
+            Some({
+                <crate::testing::components::AffixFuzzer17>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2117")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2117")?
+            })
+        } else {
+            None
+        };
+        let fuzz2118 = if let Some(array) = arrays_by_descr.get(&Self::descriptor_fuzz2118()) {
+            Some({
+                <crate::testing::components::AffixFuzzer18>::from_arrow_opt(&**array)
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2118")?
+                    .into_iter()
+                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
+                    .collect::<DeserializationResult<Vec<_>>>()
+                    .with_context("rerun.testing.archetypes.AffixFuzzer4#fuzz2118")?
+            })
+        } else {
+            None
+        };
         Ok(Self {
             fuzz2101,
             fuzz2102,

--- a/crates/store/re_types/tests/types/points3d.rs
+++ b/crates/store/re_types/tests/types/points3d.rs
@@ -43,9 +43,9 @@ fn roundtrip() {
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
-        // eprintln!("field = {field:#?}");
-        // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name());
+        eprintln!("field = {field:#?}");
+        eprintln!("array = {array:#?}");
+        // eprintln!("{} = {array:#?}", field.name());
     }
 
     let deserialized = Points3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -109,7 +109,7 @@ pub trait Archetype {
     {
         Self::from_arrow_components(
             data.into_iter()
-                .map(|(field, array)| (ComponentName::new(field.name()), array)),
+                .map(|(field, array)| (ComponentDescriptor::from(field), array)),
         )
     }
 
@@ -120,7 +120,7 @@ pub trait Archetype {
     /// logged to stderr.
     #[inline]
     fn from_arrow_components(
-        data: impl IntoIterator<Item = (ComponentName, ::arrow::array::ArrayRef)>,
+        data: impl IntoIterator<Item = (ComponentDescriptor, ::arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self>
     where
         Self: Sized,
@@ -139,14 +139,15 @@ pub trait Archetype {
     /// logged to stderr.
     #[inline]
     fn from_arrow2_components(
-        data: impl IntoIterator<Item = (ComponentName, Box<dyn ::arrow2::array::Array>)>,
+        data: impl IntoIterator<Item = (ComponentDescriptor, Box<dyn ::arrow2::array::Array>)>,
     ) -> DeserializationResult<Self>
     where
         Self: Sized,
     {
-        Self::from_arrow_components(data.into_iter().map(|(component, arrow2_array)| {
-            (component, arrow::array::ArrayRef::from(arrow2_array))
-        }))
+        Self::from_arrow_components(
+            data.into_iter()
+                .map(|(descr, arrow2_array)| (descr, arrow::array::ArrayRef::from(arrow2_array))),
+        )
     }
 }
 

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -166,17 +166,14 @@ impl crate::Archetype for Clear {
 
     #[inline]
     fn from_arrow_components(
-        arrow_data: impl IntoIterator<Item = (ComponentName, arrow::array::ArrayRef)>,
+        arrow_data: impl IntoIterator<Item = (ComponentDescriptor, arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self> {
         re_tracing::profile_function!();
         use crate::{Loggable as _, ResultExt as _};
-        let arrays_by_name: ::std::collections::HashMap<_, _> = arrow_data
-            .into_iter()
-            .map(|(name, array)| (name.full_name(), array))
-            .collect();
+        let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
         let is_recursive = {
-            let array = arrays_by_name
-                .get("rerun.components.ClearIsRecursive")
+            let array = arrays_by_descr
+                .get(&Self::descriptor_is_recursive())
                 .ok_or_else(DeserializationError::missing_data)
                 .with_context("rerun.archetypes.Clear#is_recursive")?;
             <crate::components::ClearIsRecursive>::from_arrow_opt(&**array)

--- a/crates/store/re_types_core/src/as_components.rs
+++ b/crates/store/re_types_core/src/as_components.rs
@@ -81,14 +81,7 @@ pub trait AsComponents {
     ) -> SerializationResult<Vec<(::arrow::datatypes::Field, ::arrow::array::ArrayRef)>> {
         self.as_serialized_batches()
             .into_iter()
-            .map(|comp_batch| {
-                let field = arrow::datatypes::Field::new(
-                    comp_batch.descriptor.component_name.to_string(),
-                    comp_batch.array.data_type().clone(),
-                    false,
-                );
-                Ok((field, comp_batch.array))
-            })
+            .map(|comp_batch| Ok((arrow::datatypes::Field::from(&comp_batch), comp_batch.array)))
             .collect()
     }
 
@@ -106,12 +99,10 @@ pub trait AsComponents {
         self.as_serialized_batches()
             .into_iter()
             .map(|comp_batch| {
-                let field = arrow2::datatypes::Field::new(
-                    comp_batch.descriptor.component_name.to_string(),
-                    comp_batch.array.data_type().clone().into(),
-                    false,
-                );
-                Ok((field, comp_batch.array.into()))
+                Ok((
+                    arrow2::datatypes::Field::from(&comp_batch),
+                    comp_batch.array.into(),
+                ))
             })
             .collect()
     }

--- a/crates/store/re_types_core/src/component_descriptor.rs
+++ b/crates/store/re_types_core/src/component_descriptor.rs
@@ -181,3 +181,36 @@ impl ComponentDescriptor {
         self
     }
 }
+
+// ---
+
+// TODO(cmc): This is far from ideal and feels very hackish, but for now the priority is getting
+// all things related to tags up and running so we can gather learnings.
+// This is only used on the archetype deserialization path, which isn't ever used outside of tests anyway.
+
+// TODO(cmc): we really shouldn't be duplicating these.
+
+/// The key used to identify the [`crate::ArchetypeName`] in field-level metadata.
+const FIELD_METADATA_KEY_ARCHETYPE_NAME: &str = "rerun.archetype_name";
+
+/// The key used to identify the [`crate::ArchetypeFieldName`] in field-level metadata.
+const FIELD_METADATA_KEY_ARCHETYPE_FIELD_NAME: &str = "rerun.archetype_field_name";
+
+impl From<arrow::datatypes::Field> for ComponentDescriptor {
+    #[inline]
+    fn from(field: arrow::datatypes::Field) -> Self {
+        let md = field.metadata();
+
+        Self {
+            archetype_name: md
+                .get(FIELD_METADATA_KEY_ARCHETYPE_NAME)
+                .cloned()
+                .map(Into::into),
+            archetype_field_name: md
+                .get(FIELD_METADATA_KEY_ARCHETYPE_FIELD_NAME)
+                .cloned()
+                .map(Into::into),
+            component_name: field.name().clone().into(),
+        }
+    }
+}

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -234,6 +234,82 @@ impl SerializedComponentBatch {
     }
 }
 
+// ---
+
+// TODO(cmc): This is far from ideal and feels very hackish, but for now the priority is getting
+// all things related to tags up and running so we can gather learnings.
+// This is only used on the archetype deserialization path, which isn't ever used outside of tests anyway.
+
+// TODO(cmc): we really shouldn't be duplicating these.
+
+/// The key used to identify the [`crate::ArchetypeName`] in field-level metadata.
+const FIELD_METADATA_KEY_ARCHETYPE_NAME: &str = "rerun.archetype_name";
+
+/// The key used to identify the [`crate::ArchetypeFieldName`] in field-level metadata.
+const FIELD_METADATA_KEY_ARCHETYPE_FIELD_NAME: &str = "rerun.archetype_field_name";
+
+impl From<&SerializedComponentBatch> for arrow::datatypes::Field {
+    #[inline]
+    fn from(batch: &SerializedComponentBatch) -> Self {
+        Self::new(
+            batch.descriptor.component_name.to_string(),
+            batch.array.data_type().clone(),
+            false,
+        )
+        .with_metadata(
+            [
+                batch.descriptor.archetype_name.map(|name| {
+                    (
+                        FIELD_METADATA_KEY_ARCHETYPE_NAME.to_owned(),
+                        name.to_string(),
+                    )
+                }),
+                batch.descriptor.archetype_field_name.map(|name| {
+                    (
+                        FIELD_METADATA_KEY_ARCHETYPE_FIELD_NAME.to_owned(),
+                        name.to_string(),
+                    )
+                }),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+        )
+    }
+}
+
+impl From<&SerializedComponentBatch> for arrow2::datatypes::Field {
+    #[inline]
+    fn from(batch: &SerializedComponentBatch) -> Self {
+        Self::new(
+            batch.descriptor.component_name.to_string(),
+            batch.array.data_type().clone().into(),
+            false,
+        )
+        .with_metadata(
+            [
+                batch.descriptor.archetype_name.map(|name| {
+                    (
+                        FIELD_METADATA_KEY_ARCHETYPE_NAME.to_owned(),
+                        name.to_string(),
+                    )
+                }),
+                batch.descriptor.archetype_field_name.map(|name| {
+                    (
+                        FIELD_METADATA_KEY_ARCHETYPE_FIELD_NAME.to_owned(),
+                        name.to_string(),
+                    )
+                }),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+        )
+    }
+}
+
+// ---
+
 // TODO(cmc): All these crazy types are about to disappear. ComponentBatch should only live at the
 // edge, and therefore not require all these crazy kinds of derivatives (require eager serialization).
 


### PR DESCRIPTION
These methods were still `ComponentName`-based, which just won't work as we start introducing archetypes with multiple instances of the same component.

Note that these methods are very seldom used (only for tests, IIRC), so I went for the path of least resistance and took a few shortcuts.
We can build something sturdier later on if need be (I highly doubt it... in fact I expect these methods don't have that much time left to live). 

* DNM: requires #8643 