### PR TITLE
Eagerly serialized, partially updatable 2D & 3D line strips

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/line_strips2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/line_strips2d.fbs
@@ -9,6 +9,7 @@ namespace rerun.archetypes;
 /// \example archetypes/line_strips2d_batch image="https://static.rerun.io/line_strip2d_batch/c6f4062bcf510462d298a5dfe9fdbe87c754acee/1200w.png"
 /// \example archetypes/line_strips2d_ui_radius title="Lines with scene & UI radius each" image="https://static.rerun.io/line_strip2d_ui_radius/d3d7d5bd36278564ee37e2ed6932963ec16f5131/1200w.png
 table LineStrips2D (
+  "attr.rust.archetype_eager": "",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 2D",
   "attr.docs.view_types": "Spatial2DView, Spatial3DView: if logged under a projection"

--- a/crates/store/re_types/definitions/rerun/archetypes/line_strips3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/line_strips3d.fbs
@@ -9,6 +9,7 @@ namespace rerun.archetypes;
 /// \example archetypes/line_strips3d_batch title="Many strips" image="https://static.rerun.io/line_strip3d_batch/15e8ff18a6c95a3191acb0eae6eb04adea3b4874/1200w.png"
 /// \example archetypes/line_strips3d_ui_radius title="Lines with scene & UI radius each" image="https://static.rerun.io/line_strip3d_ui_radius/36b98f47e45747b5a3601511ff39b8d74c61d120/1200w.png"
 table LineStrips3D (
+  "attr.rust.archetype_eager": "",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial3DView, Spatial2DView: if logged above active projection"

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -85,35 +85,35 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     Ok(())
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct LineStrips2D {
     /// All the actual 2D line strips that make up the batch.
-    pub strips: Vec<crate::components::LineStrip2D>,
+    pub strips: Option<SerializedComponentBatch>,
 
     /// Optional radii for the line strips.
-    pub radii: Option<Vec<crate::components::Radius>>,
+    pub radii: Option<SerializedComponentBatch>,
 
     /// Optional colors for the line strips.
-    pub colors: Option<Vec<crate::components::Color>>,
+    pub colors: Option<SerializedComponentBatch>,
 
     /// Optional text labels for the line strips.
     ///
     /// If there's a single label present, it will be placed at the center of the entity.
     /// Otherwise, each instance will have its own label.
-    pub labels: Option<Vec<crate::components::Text>>,
+    pub labels: Option<SerializedComponentBatch>,
 
     /// Optional choice of whether the text labels should be shown by default.
-    pub show_labels: Option<crate::components::ShowLabels>,
+    pub show_labels: Option<SerializedComponentBatch>,
 
     /// An optional floating point value that specifies the 2D drawing order of each line strip.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
-    pub draw_order: Option<crate::components::DrawOrder>,
+    pub draw_order: Option<SerializedComponentBatch>,
 
     /// Optional [`components::ClassId`][crate::components::ClassId]s for the lines.
     ///
     /// The [`components::ClassId`][crate::components::ClassId] provides colors and labels if not specified explicitly.
-    pub class_ids: Option<Vec<crate::components::ClassId>>,
+    pub class_ids: Option<SerializedComponentBatch>,
 }
 
 impl LineStrips2D {
@@ -288,85 +288,33 @@ impl ::re_types_core::Archetype for LineStrips2D {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
-        let strips = {
-            let array = arrays_by_descr
-                .get(&Self::descriptor_strips())
-                .ok_or_else(DeserializationError::missing_data)
-                .with_context("rerun.archetypes.LineStrips2D#strips")?;
-            <crate::components::LineStrip2D>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.LineStrips2D#strips")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .collect::<DeserializationResult<Vec<_>>>()
-                .with_context("rerun.archetypes.LineStrips2D#strips")?
-        };
-        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
-            Some({
-                <crate::components::Radius>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips2D#radii")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips2D#radii")?
-            })
-        } else {
-            None
-        };
-        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
-            Some({
-                <crate::components::Color>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips2D#colors")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips2D#colors")?
-            })
-        } else {
-            None
-        };
-        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
-            Some({
-                <crate::components::Text>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips2D#labels")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips2D#labels")?
-            })
-        } else {
-            None
-        };
-        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
-        {
-            <crate::components::ShowLabels>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.LineStrips2D#show_labels")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
-        let draw_order = if let Some(array) = arrays_by_descr.get(&Self::descriptor_draw_order()) {
-            <crate::components::DrawOrder>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.LineStrips2D#draw_order")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
-        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
-            Some({
-                <crate::components::ClassId>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips2D#class_ids")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips2D#class_ids")?
-            })
-        } else {
-            None
-        };
+        let strips = arrays_by_descr
+            .get(&Self::descriptor_strips())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_strips()));
+        let radii = arrays_by_descr
+            .get(&Self::descriptor_radii())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_radii()));
+        let colors = arrays_by_descr
+            .get(&Self::descriptor_colors())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_colors()));
+        let labels = arrays_by_descr
+            .get(&Self::descriptor_labels())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_labels()));
+        let show_labels = arrays_by_descr
+            .get(&Self::descriptor_show_labels())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_show_labels())
+            });
+        let draw_order = arrays_by_descr
+            .get(&Self::descriptor_draw_order())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_draw_order())
+            });
+        let class_ids = arrays_by_descr
+            .get(&Self::descriptor_class_ids())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_class_ids())
+            });
         Ok(Self {
             strips,
             radii,
@@ -380,65 +328,18 @@ impl ::re_types_core::Archetype for LineStrips2D {
 }
 
 impl ::re_types_core::AsComponents for LineStrips2D {
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        re_tracing::profile_function!();
+    #[inline]
+    fn as_serialized_batches(&self) -> Vec<SerializedComponentBatch> {
         use ::re_types_core::Archetype as _;
         [
-            Some(Self::indicator()),
-            (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::ComponentBatchCowWithDescriptor {
-                    batch: batch.into(),
-                    descriptor_override: Some(Self::descriptor_strips()),
-                }
-            }),
-            (self
-                .radii
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_radii()),
-            }),
-            (self
-                .colors
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_colors()),
-            }),
-            (self
-                .labels
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_labels()),
-            }),
-            (self
-                .show_labels
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_show_labels()),
-            }),
-            (self
-                .draw_order
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_draw_order()),
-            }),
-            (self
-                .class_ids
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_class_ids()),
-            }),
+            Self::indicator().serialized(),
+            self.strips.clone(),
+            self.radii.clone(),
+            self.colors.clone(),
+            self.labels.clone(),
+            self.show_labels.clone(),
+            self.draw_order.clone(),
+            self.class_ids.clone(),
         ]
         .into_iter()
         .flatten()
@@ -455,7 +356,7 @@ impl LineStrips2D {
         strips: impl IntoIterator<Item = impl Into<crate::components::LineStrip2D>>,
     ) -> Self {
         Self {
-            strips: strips.into_iter().map(Into::into).collect(),
+            strips: try_serialize_field(Self::descriptor_strips(), strips),
             radii: None,
             colors: None,
             labels: None,
@@ -465,13 +366,65 @@ impl LineStrips2D {
         }
     }
 
+    /// Update only some specific fields of a `LineStrips2D`.
+    #[inline]
+    pub fn update_fields() -> Self {
+        Self::default()
+    }
+
+    /// Clear all the fields of a `LineStrips2D`.
+    #[inline]
+    pub fn clear_fields() -> Self {
+        use ::re_types_core::Loggable as _;
+        Self {
+            strips: Some(SerializedComponentBatch::new(
+                crate::components::LineStrip2D::arrow_empty(),
+                Self::descriptor_strips(),
+            )),
+            radii: Some(SerializedComponentBatch::new(
+                crate::components::Radius::arrow_empty(),
+                Self::descriptor_radii(),
+            )),
+            colors: Some(SerializedComponentBatch::new(
+                crate::components::Color::arrow_empty(),
+                Self::descriptor_colors(),
+            )),
+            labels: Some(SerializedComponentBatch::new(
+                crate::components::Text::arrow_empty(),
+                Self::descriptor_labels(),
+            )),
+            show_labels: Some(SerializedComponentBatch::new(
+                crate::components::ShowLabels::arrow_empty(),
+                Self::descriptor_show_labels(),
+            )),
+            draw_order: Some(SerializedComponentBatch::new(
+                crate::components::DrawOrder::arrow_empty(),
+                Self::descriptor_draw_order(),
+            )),
+            class_ids: Some(SerializedComponentBatch::new(
+                crate::components::ClassId::arrow_empty(),
+                Self::descriptor_class_ids(),
+            )),
+        }
+    }
+
+    /// All the actual 2D line strips that make up the batch.
+    #[inline]
+    pub fn with_strips(
+        mut self,
+        strips: impl IntoIterator<Item = impl Into<crate::components::LineStrip2D>>,
+    ) -> Self {
+        self.strips = try_serialize_field(Self::descriptor_strips(), strips);
+        self
+    }
+
     /// Optional radii for the line strips.
     #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
     ) -> Self {
-        self.radii = Some(radii.into_iter().map(Into::into).collect());
+        self.radii = try_serialize_field(Self::descriptor_radii(), radii);
         self
     }
 
@@ -481,7 +434,7 @@ impl LineStrips2D {
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
     ) -> Self {
-        self.colors = Some(colors.into_iter().map(Into::into).collect());
+        self.colors = try_serialize_field(Self::descriptor_colors(), colors);
         self
     }
 
@@ -494,7 +447,7 @@ impl LineStrips2D {
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
     ) -> Self {
-        self.labels = Some(labels.into_iter().map(Into::into).collect());
+        self.labels = try_serialize_field(Self::descriptor_labels(), labels);
         self
     }
 
@@ -504,7 +457,7 @@ impl LineStrips2D {
         mut self,
         show_labels: impl Into<crate::components::ShowLabels>,
     ) -> Self {
-        self.show_labels = Some(show_labels.into());
+        self.show_labels = try_serialize_field(Self::descriptor_show_labels(), [show_labels]);
         self
     }
 
@@ -513,7 +466,7 @@ impl LineStrips2D {
     /// Objects with higher values are drawn on top of those with lower values.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
-        self.draw_order = Some(draw_order.into());
+        self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);
         self
     }
 
@@ -525,7 +478,7 @@ impl LineStrips2D {
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
-        self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
+        self.class_ids = try_serialize_field(Self::descriptor_class_ids(), class_ids);
         self
     }
 }
@@ -540,16 +493,5 @@ impl ::re_byte_size::SizeBytes for LineStrips2D {
             + self.show_labels.heap_size_bytes()
             + self.draw_order.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::LineStrip2D>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -98,30 +98,30 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///   <img src="https://static.rerun.io/line_strip3d_ui_radius/36b98f47e45747b5a3601511ff39b8d74c61d120/full.png" width="640">
 /// </picture>
 /// </center>
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct LineStrips3D {
     /// All the actual 3D line strips that make up the batch.
-    pub strips: Vec<crate::components::LineStrip3D>,
+    pub strips: Option<SerializedComponentBatch>,
 
     /// Optional radii for the line strips.
-    pub radii: Option<Vec<crate::components::Radius>>,
+    pub radii: Option<SerializedComponentBatch>,
 
     /// Optional colors for the line strips.
-    pub colors: Option<Vec<crate::components::Color>>,
+    pub colors: Option<SerializedComponentBatch>,
 
     /// Optional text labels for the line strips.
     ///
     /// If there's a single label present, it will be placed at the center of the entity.
     /// Otherwise, each instance will have its own label.
-    pub labels: Option<Vec<crate::components::Text>>,
+    pub labels: Option<SerializedComponentBatch>,
 
     /// Optional choice of whether the text labels should be shown by default.
-    pub show_labels: Option<crate::components::ShowLabels>,
+    pub show_labels: Option<SerializedComponentBatch>,
 
     /// Optional [`components::ClassId`][crate::components::ClassId]s for the lines.
     ///
     /// The [`components::ClassId`][crate::components::ClassId] provides colors and labels if not specified explicitly.
-    pub class_ids: Option<Vec<crate::components::ClassId>>,
+    pub class_ids: Option<SerializedComponentBatch>,
 }
 
 impl LineStrips3D {
@@ -284,76 +284,28 @@ impl ::re_types_core::Archetype for LineStrips3D {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
-        let strips = {
-            let array = arrays_by_descr
-                .get(&Self::descriptor_strips())
-                .ok_or_else(DeserializationError::missing_data)
-                .with_context("rerun.archetypes.LineStrips3D#strips")?;
-            <crate::components::LineStrip3D>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.LineStrips3D#strips")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .collect::<DeserializationResult<Vec<_>>>()
-                .with_context("rerun.archetypes.LineStrips3D#strips")?
-        };
-        let radii = if let Some(array) = arrays_by_descr.get(&Self::descriptor_radii()) {
-            Some({
-                <crate::components::Radius>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips3D#radii")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips3D#radii")?
-            })
-        } else {
-            None
-        };
-        let colors = if let Some(array) = arrays_by_descr.get(&Self::descriptor_colors()) {
-            Some({
-                <crate::components::Color>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips3D#colors")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips3D#colors")?
-            })
-        } else {
-            None
-        };
-        let labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_labels()) {
-            Some({
-                <crate::components::Text>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips3D#labels")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips3D#labels")?
-            })
-        } else {
-            None
-        };
-        let show_labels = if let Some(array) = arrays_by_descr.get(&Self::descriptor_show_labels())
-        {
-            <crate::components::ShowLabels>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.LineStrips3D#show_labels")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
-        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
-            Some({
-                <crate::components::ClassId>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.LineStrips3D#class_ids")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.LineStrips3D#class_ids")?
-            })
-        } else {
-            None
-        };
+        let strips = arrays_by_descr
+            .get(&Self::descriptor_strips())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_strips()));
+        let radii = arrays_by_descr
+            .get(&Self::descriptor_radii())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_radii()));
+        let colors = arrays_by_descr
+            .get(&Self::descriptor_colors())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_colors()));
+        let labels = arrays_by_descr
+            .get(&Self::descriptor_labels())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_labels()));
+        let show_labels = arrays_by_descr
+            .get(&Self::descriptor_show_labels())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_show_labels())
+            });
+        let class_ids = arrays_by_descr
+            .get(&Self::descriptor_class_ids())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_class_ids())
+            });
         Ok(Self {
             strips,
             radii,
@@ -366,57 +318,17 @@ impl ::re_types_core::Archetype for LineStrips3D {
 }
 
 impl ::re_types_core::AsComponents for LineStrips3D {
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        re_tracing::profile_function!();
+    #[inline]
+    fn as_serialized_batches(&self) -> Vec<SerializedComponentBatch> {
         use ::re_types_core::Archetype as _;
         [
-            Some(Self::indicator()),
-            (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::ComponentBatchCowWithDescriptor {
-                    batch: batch.into(),
-                    descriptor_override: Some(Self::descriptor_strips()),
-                }
-            }),
-            (self
-                .radii
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_radii()),
-            }),
-            (self
-                .colors
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_colors()),
-            }),
-            (self
-                .labels
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_labels()),
-            }),
-            (self
-                .show_labels
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_show_labels()),
-            }),
-            (self
-                .class_ids
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_class_ids()),
-            }),
+            Self::indicator().serialized(),
+            self.strips.clone(),
+            self.radii.clone(),
+            self.colors.clone(),
+            self.labels.clone(),
+            self.show_labels.clone(),
+            self.class_ids.clone(),
         ]
         .into_iter()
         .flatten()
@@ -433,7 +345,7 @@ impl LineStrips3D {
         strips: impl IntoIterator<Item = impl Into<crate::components::LineStrip3D>>,
     ) -> Self {
         Self {
-            strips: strips.into_iter().map(Into::into).collect(),
+            strips: try_serialize_field(Self::descriptor_strips(), strips),
             radii: None,
             colors: None,
             labels: None,
@@ -442,13 +354,61 @@ impl LineStrips3D {
         }
     }
 
+    /// Update only some specific fields of a `LineStrips3D`.
+    #[inline]
+    pub fn update_fields() -> Self {
+        Self::default()
+    }
+
+    /// Clear all the fields of a `LineStrips3D`.
+    #[inline]
+    pub fn clear_fields() -> Self {
+        use ::re_types_core::Loggable as _;
+        Self {
+            strips: Some(SerializedComponentBatch::new(
+                crate::components::LineStrip3D::arrow_empty(),
+                Self::descriptor_strips(),
+            )),
+            radii: Some(SerializedComponentBatch::new(
+                crate::components::Radius::arrow_empty(),
+                Self::descriptor_radii(),
+            )),
+            colors: Some(SerializedComponentBatch::new(
+                crate::components::Color::arrow_empty(),
+                Self::descriptor_colors(),
+            )),
+            labels: Some(SerializedComponentBatch::new(
+                crate::components::Text::arrow_empty(),
+                Self::descriptor_labels(),
+            )),
+            show_labels: Some(SerializedComponentBatch::new(
+                crate::components::ShowLabels::arrow_empty(),
+                Self::descriptor_show_labels(),
+            )),
+            class_ids: Some(SerializedComponentBatch::new(
+                crate::components::ClassId::arrow_empty(),
+                Self::descriptor_class_ids(),
+            )),
+        }
+    }
+
+    /// All the actual 3D line strips that make up the batch.
+    #[inline]
+    pub fn with_strips(
+        mut self,
+        strips: impl IntoIterator<Item = impl Into<crate::components::LineStrip3D>>,
+    ) -> Self {
+        self.strips = try_serialize_field(Self::descriptor_strips(), strips);
+        self
+    }
+
     /// Optional radii for the line strips.
     #[inline]
     pub fn with_radii(
         mut self,
         radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
     ) -> Self {
-        self.radii = Some(radii.into_iter().map(Into::into).collect());
+        self.radii = try_serialize_field(Self::descriptor_radii(), radii);
         self
     }
 
@@ -458,7 +418,7 @@ impl LineStrips3D {
         mut self,
         colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
     ) -> Self {
-        self.colors = Some(colors.into_iter().map(Into::into).collect());
+        self.colors = try_serialize_field(Self::descriptor_colors(), colors);
         self
     }
 
@@ -471,7 +431,7 @@ impl LineStrips3D {
         mut self,
         labels: impl IntoIterator<Item = impl Into<crate::components::Text>>,
     ) -> Self {
-        self.labels = Some(labels.into_iter().map(Into::into).collect());
+        self.labels = try_serialize_field(Self::descriptor_labels(), labels);
         self
     }
 
@@ -481,7 +441,7 @@ impl LineStrips3D {
         mut self,
         show_labels: impl Into<crate::components::ShowLabels>,
     ) -> Self {
-        self.show_labels = Some(show_labels.into());
+        self.show_labels = try_serialize_field(Self::descriptor_show_labels(), [show_labels]);
         self
     }
 
@@ -493,7 +453,7 @@ impl LineStrips3D {
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
-        self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
+        self.class_ids = try_serialize_field(Self::descriptor_class_ids(), class_ids);
         self
     }
 }
@@ -507,15 +467,5 @@ impl ::re_byte_size::SizeBytes for LineStrips3D {
             + self.labels.heap_size_bytes()
             + self.show_labels.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::LineStrip3D>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/tests/types/line_strips2d.rs
+++ b/crates/store/re_types/tests/types/line_strips2d.rs
@@ -1,7 +1,5 @@
 use re_types::{
-    archetypes::LineStrips2D,
-    components::{ClassId, Color, DrawOrder, LineStrip2D, Radius},
-    Archetype as _, AsComponents as _,
+    archetypes::LineStrips2D, components, Archetype as _, AsComponents as _, ComponentBatch,
 };
 
 #[test]
@@ -9,27 +7,38 @@ fn roundtrip() {
     let expected = LineStrips2D {
         #[rustfmt::skip]
         strips: vec![
-            LineStrip2D::from_iter([[0., 0.], [2., 1.], [4., -1.], [6., 0.]]), //
-            LineStrip2D::from_iter([[0., 3.], [1., 4.], [2., 2.], [3., 4.], [4., 2.], [5., 4.], [6., 3.]]), //
-        ],
-        radii: Some(vec![
-            Radius::from(42.0), //
-            Radius::from(43.0),
-        ]),
-        colors: Some(vec![
-            Color::from_unmultiplied_rgba(0xAA, 0x00, 0x00, 0xCC), //
-            Color::from_unmultiplied_rgba(0x00, 0xBB, 0x00, 0xDD),
-        ]),
-        labels: Some(vec![
-            "hello".into(),  //
-            "friend".into(), //
-        ]),
-        draw_order: Some(DrawOrder(300.0.into())),
-        class_ids: Some(vec![
-            ClassId::from(126), //
-            ClassId::from(127), //
-        ]),
-        show_labels: Some(false.into()),
+            components::LineStrip2D::from_iter([[0., 0.], [2., 1.], [4., -1.], [6., 0.]]), //
+            components::LineStrip2D::from_iter([[0., 3.], [1., 4.], [2., 2.], [3., 4.], [4., 2.], [5., 4.], [6., 3.]]), //
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips2D::descriptor_strips())),
+        radii: vec![
+            components::Radius::from(42.0), //
+            components::Radius::from(43.0),
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips2D::descriptor_radii())),
+        colors: vec![
+            components::Color::from_unmultiplied_rgba(0xAA, 0x00, 0x00, 0xCC), //
+            components::Color::from_unmultiplied_rgba(0x00, 0xBB, 0x00, 0xDD),
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips2D::descriptor_colors())),
+        labels: (vec!["hello".into(), "friend".into()] as Vec<components::Text>)
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(LineStrips2D::descriptor_labels())),
+        draw_order: vec![components::DrawOrder(300.0.into())]
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(LineStrips2D::descriptor_draw_order())),
+        class_ids: vec![
+            components::ClassId::from(126), //
+            components::ClassId::from(127), //
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips2D::descriptor_class_ids())),
+        show_labels: components::ShowLabels(false.into())
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(LineStrips2D::descriptor_show_labels())),
     };
 
     #[rustfmt::skip]

--- a/crates/store/re_types/tests/types/line_strips3d.rs
+++ b/crates/store/re_types/tests/types/line_strips3d.rs
@@ -1,7 +1,5 @@
 use re_types::{
-    archetypes::LineStrips3D,
-    components::{ClassId, Color, LineStrip3D, Radius},
-    Archetype as _, AsComponents as _,
+    archetypes::LineStrips3D, components, Archetype as _, AsComponents as _, ComponentBatch,
 };
 
 #[test]
@@ -9,26 +7,35 @@ fn roundtrip() {
     let expected = LineStrips3D {
         #[rustfmt::skip]
         strips: vec![
-            LineStrip3D::from_iter([[0., 0., 1.], [2., 1., 2.], [4., -1., 3.], [6., 0., 4.]]),
-            LineStrip3D::from_iter([[0., 3., 1.], [1., 4., 2.], [2.,  2., 3.], [3., 4., 4.], [4., 2., 5.], [5., 4., 6.], [6., 3., 7.]]),
-        ],
-        radii: Some(vec![
-            Radius::from(42.0), //
-            Radius::from(43.0),
-        ]),
-        colors: Some(vec![
-            Color::from_unmultiplied_rgba(0xAA, 0x00, 0x00, 0xCC), //
-            Color::from_unmultiplied_rgba(0x00, 0xBB, 0x00, 0xDD),
-        ]),
-        labels: Some(vec![
-            "hello".into(),  //
-            "friend".into(), //
-        ]),
-        class_ids: Some(vec![
-            ClassId::from(126), //
-            ClassId::from(127), //
-        ]),
-        show_labels: Some(true.into()),
+            components::LineStrip3D::from_iter([[0., 0., 1.], [2., 1., 2.], [4., -1., 3.], [6., 0., 4.]]),
+            components::LineStrip3D::from_iter([[0., 3., 1.], [1., 4., 2.], [2.,  2., 3.], [3., 4., 4.], [4., 2., 5.], [5., 4., 6.], [6., 3., 7.]]),
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips3D::descriptor_strips())),
+        radii: vec![
+            components::Radius::from(42.0), //
+            components::Radius::from(43.0),
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips3D::descriptor_radii())),
+        colors: vec![
+            components::Color::from_unmultiplied_rgba(0xAA, 0x00, 0x00, 0xCC), //
+            components::Color::from_unmultiplied_rgba(0x00, 0xBB, 0x00, 0xDD),
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips3D::descriptor_colors())),
+        labels: (vec!["hello".into(), "friend".into()] as Vec<components::Text>)
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(LineStrips3D::descriptor_labels())),
+        class_ids: vec![
+            components::ClassId::from(126), //
+            components::ClassId::from(127), //
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(LineStrips3D::descriptor_class_ids())),
+        show_labels: components::ShowLabels(true.into())
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(LineStrips3D::descriptor_show_labels())),
     };
 
     #[rustfmt::skip]


### PR DESCRIPTION
This PR makes `LineStrips2D` and `LineStrips3D` eagerly serialized and partially update-able.

This demonstrates how to migrate an archetype in the simple case.

* DNM: requires #8649  
* Part of #8581 