### PR TITLE
Filter entities in the UI (part 2): Introduce entity filtering in the time panel

### DIFF
--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -139,6 +139,7 @@ pub struct TimePanel {
     source: TimePanelSource,
 
     /// The filter widget state
+    #[serde(skip)]
     filter_state: filter_widget::FilterState,
 }
 

--- a/crates/viewer/re_viewer_context/src/collapsed_id.rs
+++ b/crates/viewer/re_viewer_context/src/collapsed_id.rs
@@ -14,8 +14,14 @@ pub enum CollapseScope {
     /// Stream tree from the time panel
     StreamsTree,
 
+    /// Stream tree from the time panel, when the filter is active
+    StreamsTreeFiltered { session_id: egui::Id },
+
     /// The stream tree from the blueprint debug time panel
     BlueprintStreamsTree,
+
+    /// The stream tree from the blueprint debug time panel, when the filter is active
+    BlueprintStreamsTreeFiltered { session_id: egui::Id },
 
     /// Blueprint tree from the blueprint panel (left panel)
     BlueprintTree,

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -40,6 +40,8 @@ pub enum ItemContext {
     StreamsTree {
         /// Which store does this streams tree correspond to?
         store_kind: StoreKind,
+
+        filter_session_id: Option<egui::Id>,
     },
 }
 


### PR DESCRIPTION
### Related

- Part of #8586
- Part of a series of PR:
  - #8645
  - #8652
  - ...

### What

This PR introduces the filter widget to the time panel. In doing so, it deals with several shenanigans:

- The item collapsedness must not be shared between the unfiltered view, and across different filtering sessions
  **Note**: the collapsed state being persisted, we are now accumulating collapsedness state for every single filter session in the persistant storage. This is not ideal, but addressing that would required rolling our own collapsed state, which would leak all over the place (list item and many of its users).
- The collapse/expend all context menu must be made aware of what precedes.
- The time panel filter state must be invalidated upon switching active recording (otherwise it's weird UX).
- The streams tree UI area needs to have a minimum width otherwise search icon placement/layout breaks.

And of course the actual filtering logic must be implement. For now, the semantics are: "one of the entity part must contain the query string in its entirety". This is very (too) basic and will evolve in future PR (see https://github.com/rerun-io/rerun/issues/8586#issuecomment-2578060663).