### PR TITLE
docs: use `connect_tcp` instead of deprecated `connect`

### DIFF
--- a/docs/content/getting-started/data-in/rust.md
+++ b/docs/content/getting-started/data-in/rust.md
@@ -61,12 +61,12 @@ Checkout `rerun --help` for more options.
 
 To get going we want to create a [`RecordingStream`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html):
 We can do all of this with the [`rerun::RecordingStreamBuilder::new`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.new) function which allows us to name the dataset we're working on by setting its [`ApplicationId`](https://docs.rs/rerun/latest/rerun/struct.ApplicationId.html).
-We then connect it to the already running Viewer via [`connect`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.connect), returning the `RecordingStream` upon success.
+We then connect it to the already running Viewer via [`connect_tcp`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.connect_tcp), returning the `RecordingStream` upon success.
 
 ```rust
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacus")
-        .connect(rerun::default_server_addr(), rerun::default_flush_timeout())?;
+        .connect_tcp()?;
 
     Ok(())
 }


### PR DESCRIPTION
Hi I'm going thru the docs for the first time, I did some copy and pasta to connect to the server and I got hit by some deprecated warning. It seems the code wasn't even working and `connect_opts` should have been the one.