### PR TITLE
Fix doc comments for `query_catalog` in `rerun_bindings.pyi`

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -581,14 +581,14 @@ class StorageNodeClient:
         self, columns: Optional[list[str]] = None, recording_ids: Optional[list[str]] = None
     ) -> pa.RecordBatchReader:
         """
-        Get the metadata recordings in the storage node.
+        Get the metadata for recordings in the storage node.
 
         Parameters
         ----------
-        columns : Optional[list[str]], optional
-            The columns to include in the output, by default None.
+        columns : Optional[list[str]]
+            The columns to fetch. If `None`, fetch all columns.
         recording_ids : Optional[list[str]]
-            Filter specific recordings by Recording Id
+            Fetch metadata of only specific recordings. If `None`, fetch for all.
 
         """
         ...

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -195,9 +195,9 @@ impl PyStorageNodeClient {
     /// Parameters
     /// ----------
     /// columns : Optional[list[str]]
-    ///    The columns to fetch. If `None`, fetch all columns.
+    ///     The columns to fetch. If `None`, fetch all columns.
     /// recording_ids : Optional[list[str]]
-    ///   Fetch metadata of only specific recordings. If `None`, fetch for all.
+    ///     Fetch metadata of only specific recordings. If `None`, fetch for all.
     #[pyo3(signature = (
         columns = None,
         recording_ids = None,

--- a/scripts/ci/build_and_upload_wheels.py
+++ b/scripts/ci/build_and_upload_wheels.py
@@ -70,7 +70,8 @@ def build_and_upload(bucket: Bucket | None, mode: BuildMode, gcs_dir: str, targe
     if mode is BuildMode.PYPI:
         maturin_feature_flags = "--no-default-features --features pypi"
     elif mode is BuildMode.PR:
-        maturin_feature_flags = "--no-default-features --features extension-module"
+        # Remote is necessary to fully validate the signature match on the wheels
+        maturin_feature_flags = "--no-default-features --features extension-module,remote"
     elif mode is BuildMode.EXTRA:
         maturin_feature_flags = "--no-default-features --features pypi,extra"
 


### PR DESCRIPTION
### What

Fixing the CI failure, by updating the `rerun_bindings.pyi`.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
