### PR TITLE
Update to flatbuffers 24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,9 +2476,9 @@ checksum = "c1671b620ba6e60c11c62b0ea5fec4f8621991e7b1229fa13c010a2cd04e4342"
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ env_logger = { version = "0.10", default-features = false }
 ffmpeg-sidecar = { version = "2.0.2", default-features = false }
 fixed = { version = "1.28", default-features = false }
 fjadra = "0.2.1"
-flatbuffers = "23.0"
+flatbuffers = "24.12.23"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 getrandom = "0.2"


### PR DESCRIPTION
In order to avoid duplicated versions when we start using `arrow_ipc`