### PR TITLE
Add JS timeline control and callback APIs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,11 +46,7 @@
     // Uncomment the following options and restart rust-analyzer to get it to check code behind `cfg(target_arch=wasm32)`.
     // Don't forget to put it in a comment again before committing.
     // "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
-    // "rust-analyzer.cargo.cfgs": {
-    //     "web": null,
-    //     "webgl": null,
-    //     "webgpu": null,
-    // },
+    // "rust-analyzer.cargo.cfgs": ["web","webgl","webgpu"],
 
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools", // Use cmake-tools to grab configs.
     "C_Cpp.autoAddFileAssociations": false,

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -82,6 +82,13 @@ pub struct StartupOptions {
     /// This also can be changed in the viewer's option menu.
     pub video_decoder_hw_acceleration: Option<re_video::decode::DecodeHardwareAcceleration>,
 
+    /// Interaction between JS and timeline.
+    ///
+    /// This field isn't used directly, but is propagated to all recording configs
+    /// when they are created.
+    #[cfg(target_arch = "wasm32")]
+    pub timeline_options: Option<crate::web::TimelineOptions>,
+
     /// Fullscreen is handled by JS on web.
     ///
     /// This holds some callbacks which we use to communicate
@@ -130,6 +137,9 @@ impl Default for StartupOptions {
             expect_data_soon: None,
             force_wgpu_backend: None,
             video_decoder_hw_acceleration: None,
+
+            #[cfg(target_arch = "wasm32")]
+            timeline_options: Default::default(),
 
             #[cfg(target_arch = "wasm32")]
             fullscreen_options: Default::default(),
@@ -220,6 +230,12 @@ pub struct App {
     pub(crate) panel_state_overrides: PanelStateOverrides,
 
     reflection: re_types_core::reflection::Reflection,
+
+    /// Interaction between JS and timeline.
+    ///
+    /// This field isn't used directly, but is propagated to all recording configs
+    /// when they are created.
+    pub timeline_callbacks: Option<re_viewer_context::TimelineCallbacks>,
 }
 
 impl App {
@@ -325,6 +341,46 @@ impl App {
             Default::default()
         });
 
+        #[cfg(target_arch = "wasm32")]
+        let timeline_callbacks = {
+            use crate::web_tools::string_from_js_value;
+            use std::rc::Rc;
+            use wasm_bindgen::JsValue;
+
+            startup_options.timeline_options.clone().map(|opts| {
+                re_viewer_context::TimelineCallbacks {
+                    on_timelinechange: Rc::new(move |timeline, time| {
+                        if let Err(err) = opts.on_timelinechange.call2(
+                            &JsValue::from_str(&timeline.name().as_str()),
+                            &JsValue::from_f64(time.as_f64()),
+                        ) {
+                            re_log::error!("{}", string_from_js_value(err));
+                        };
+                    }),
+                    on_timeupdate: Rc::new(move |time| {
+                        if let Err(err) =
+                            opts.on_timeupdate.call1(&JsValue::from_f64(time.as_f64()))
+                        {
+                            re_log::error!("{}", string_from_js_value(err));
+                        }
+                    }),
+                    on_play: Rc::new(move || {
+                        if let Err(err) = opts.on_play.call0() {
+                            re_log::error!("{}", string_from_js_value(err));
+                        }
+                    }),
+                    on_pause: Rc::new(move || {
+                        if let Err(err) = opts.on_pause.call0() {
+                            re_log::error!("{}", string_from_js_value(err));
+                        }
+                    }),
+                }
+            })
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let timeline_callbacks = None;
+
         Self {
             main_thread_token,
             build_info,
@@ -374,6 +430,8 @@ impl App {
             panel_state_overrides,
 
             reflection,
+
+            timeline_callbacks,
         }
     }
 
@@ -1128,6 +1186,7 @@ impl App {
                                 opacity: self.welcome_screen_opacity(egui_ctx),
                             },
                             is_history_enabled,
+                            self.timeline_callbacks.as_ref(),
                         );
                         render_ctx.before_submit();
                     }
@@ -1575,7 +1634,7 @@ impl App {
         {
             if let Some(options) = &self.startup_options.fullscreen_options {
                 // Tell JS to toggle fullscreen.
-                if let Err(err) = options.on_toggle.call() {
+                if let Err(err) = options.on_toggle.call0() {
                     re_log::error!("{}", crate::web_tools::string_from_js_value(err));
                 };
             }
@@ -1591,7 +1650,7 @@ impl App {
     pub(crate) fn is_fullscreen_mode(&self) -> bool {
         if let Some(options) = &self.startup_options.fullscreen_options {
             // Ask JS if fullscreen is on or not.
-            match options.get_state.call() {
+            match options.get_state.call0() {
                 Ok(v) => return v.is_truthy(),
                 Err(err) => re_log::error_once!("{}", crate::web_tools::string_from_js_value(err)),
             }

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -151,6 +151,7 @@ impl AppState {
         command_sender: &CommandSender,
         welcome_screen_state: &WelcomeScreenState,
         is_history_enabled: bool,
+        timeline_callbacks: Option<&re_viewer_context::TimelineCallbacks>,
     ) {
         re_tracing::profile_function!();
 
@@ -284,7 +285,8 @@ impl AppState {
 
         // We move the time at the very start of the frame,
         // so that we always show the latest data when we're in "follow" mode.
-        move_time(&ctx, recording, rx);
+
+        move_time(&ctx, recording, rx, timeline_callbacks);
 
         // Update the viewport. May spawn new views and handle queued requests (like screenshots).
         viewport_ui.on_frame_start(&ctx);
@@ -539,6 +541,11 @@ impl AppState {
         *focused_item = None;
     }
 
+    #[cfg(target_arch = "wasm32")] // Only used in Wasm
+    pub fn recording_config(&self, rec_id: &StoreId) -> Option<&RecordingConfig> {
+        self.recording_configs.get(rec_id)
+    }
+
     pub fn recording_config_mut(&mut self, rec_id: &StoreId) -> Option<&mut RecordingConfig> {
         self.recording_configs.get_mut(rec_id)
     }
@@ -577,7 +584,12 @@ impl AppState {
     }
 }
 
-fn move_time(ctx: &ViewerContext<'_>, recording: &EntityDb, rx: &ReceiveSet<LogMsg>) {
+fn move_time(
+    ctx: &ViewerContext<'_>,
+    recording: &EntityDb,
+    rx: &ReceiveSet<LogMsg>,
+    timeline_callbacks: Option<&re_viewer_context::TimelineCallbacks>,
+) {
     let dt = ctx.egui_ctx.input(|i| i.stable_dt);
 
     // Are we still connected to the data source for the current store?
@@ -591,6 +603,7 @@ fn move_time(ctx: &ViewerContext<'_>, recording: &EntityDb, rx: &ReceiveSet<LogM
         recording.times_per_timeline(),
         dt,
         more_data_is_coming,
+        timeline_callbacks,
     );
 
     let blueprint_needs_repaint = if ctx.app_options.inspect_blueprint_timeline {
@@ -598,6 +611,7 @@ fn move_time(ctx: &ViewerContext<'_>, recording: &EntityDb, rx: &ReceiveSet<LogM
             ctx.store_context.blueprint.times_per_timeline(),
             dt,
             more_data_is_coming,
+            None,
         )
     } else {
         re_viewer_context::NeedsRepaint::No

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -279,6 +279,298 @@ impl WebHandle {
             );
         }
     }
+
+    #[wasm_bindgen]
+    pub fn get_active_recording_id(&self) -> Option<String> {
+        let Some(app) = self.runner.app_mut::<crate::App>() else {
+            return None;
+        };
+
+        let Some(hub) = app.store_hub.as_ref() else {
+            return None;
+        };
+        let Some(recording) = hub.active_recording() else {
+            return None;
+        };
+
+        Some(recording.store_id().to_string())
+    }
+
+    #[wasm_bindgen]
+    pub fn set_active_recording_id(&self, store_id: String) {
+        let Some(mut app) = self.runner.app_mut::<crate::App>() else {
+            return;
+        };
+
+        let Some(hub) = app.store_hub.as_mut() else {
+            return;
+        };
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        if !hub.store_bundle().contains(&store_id) {
+            return;
+        };
+
+        hub.set_activate_recording(store_id);
+
+        app.egui_ctx.request_repaint();
+    }
+
+    #[wasm_bindgen]
+    pub fn get_active_timeline(&self, store_id: &str) -> Option<String> {
+        let Some(mut app) = self.runner.app_mut::<crate::App>() else {
+            return None;
+        };
+        let crate::App {
+            store_hub: Some(ref hub),
+            state,
+            ..
+        } = &mut *app
+        else {
+            return None;
+        };
+
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        if !hub.store_bundle().contains(&store_id) {
+            return None;
+        };
+        let Some(rec_cfg) = state.recording_config_mut(&store_id) else {
+            return None;
+        };
+
+        let time_ctrl = rec_cfg.time_ctrl.read();
+        Some(time_ctrl.timeline().name().as_str().to_owned())
+    }
+
+    /// Set the active timeline.
+    ///
+    /// This does nothing if the timeline can't be found.
+    #[wasm_bindgen]
+    pub fn set_active_timeline(&self, store_id: &str, timeline: &str) {
+        let Some(mut app) = self.runner.app_mut::<crate::App>() else {
+            return;
+        };
+        let crate::App {
+            store_hub: Some(ref hub),
+            state,
+            egui_ctx,
+            ..
+        } = &mut *app
+        else {
+            return;
+        };
+
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        let Some(recording) = hub.store_bundle().get(&store_id) else {
+            return;
+        };
+        let Some(rec_cfg) = state.recording_config_mut(&store_id) else {
+            return;
+        };
+        let Some(timeline) = recording
+            .timelines()
+            .find(|t| t.name().as_str() == timeline)
+        else {
+            return;
+        };
+
+        rec_cfg.time_ctrl.write().set_timeline(*timeline);
+
+        egui_ctx.request_repaint();
+    }
+
+    #[wasm_bindgen]
+    pub fn get_time_for_timeline(&self, store_id: String, timeline: String) -> Option<f64> {
+        let Some(app) = self.runner.app_mut::<crate::App>() else {
+            return None;
+        };
+        let crate::App {
+            store_hub: Some(ref hub),
+            state,
+            ..
+        } = &*app
+        else {
+            return None;
+        };
+
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        let Some(recording) = hub.store_bundle().get(&store_id) else {
+            return None;
+        };
+        let Some(rec_cfg) = state.recording_config(&store_id) else {
+            return None;
+        };
+        let Some(timeline) = recording
+            .timelines()
+            .find(|t| t.name().as_str() == timeline)
+        else {
+            return None;
+        };
+
+        let time_ctrl = rec_cfg.time_ctrl.read();
+        time_ctrl
+            .get_time_for_timeline(*timeline)
+            .map(|v| v.as_f64())
+    }
+
+    #[wasm_bindgen]
+    pub fn set_time_for_timeline(&self, store_id: String, timeline: String, time: f64) {
+        let Some(mut app) = self.runner.app_mut::<crate::App>() else {
+            return;
+        };
+        let crate::App {
+            store_hub: Some(ref hub),
+            state,
+            egui_ctx,
+            ..
+        } = &mut *app
+        else {
+            return;
+        };
+
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        let Some(recording) = hub.store_bundle().get(&store_id) else {
+            return;
+        };
+        let Some(rec_cfg) = state.recording_config_mut(&store_id) else {
+            return;
+        };
+        let Some(timeline) = recording
+            .timelines()
+            .find(|t| t.name().as_str() == timeline)
+        else {
+            return;
+        };
+
+        rec_cfg
+            .time_ctrl
+            .write()
+            .set_timeline_and_time(*timeline, time);
+        egui_ctx.request_repaint();
+    }
+
+    #[wasm_bindgen]
+    pub fn get_timeline_time_range(&self, store_id: String, timeline: String) -> JsValue {
+        let Some(app) = self.runner.app_mut::<crate::App>() else {
+            return JsValue::null();
+        };
+        let crate::App {
+            store_hub: Some(ref hub),
+            ..
+        } = &*app
+        else {
+            return JsValue::null();
+        };
+
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        let Some(recording) = hub.store_bundle().get(&store_id) else {
+            return JsValue::null();
+        };
+        let Some(timeline) = recording
+            .timelines()
+            .find(|t| t.name().as_str() == timeline)
+        else {
+            return JsValue::null();
+        };
+
+        let Some(time_range) = recording.time_range_for(&timeline) else {
+            return JsValue::null();
+        };
+
+        let min = time_range.min().as_f64();
+        let max = time_range.max().as_f64();
+
+        let obj = js_sys::Object::new();
+        js_sys::Reflect::set(&obj, &"min".into(), &min.into()).ok_or_log_js_error();
+        js_sys::Reflect::set(&obj, &"max".into(), &max.into()).ok_or_log_js_error();
+
+        JsValue::from(obj)
+    }
+
+    #[wasm_bindgen]
+    pub fn get_playing(&self, store_id: String) -> Option<bool> {
+        let Some(app) = self.runner.app_mut::<crate::App>() else {
+            return None;
+        };
+        let crate::App {
+            store_hub: Some(ref hub),
+            state,
+            ..
+        } = &*app
+        else {
+            return None;
+        };
+
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        if !hub.store_bundle().contains(&store_id) {
+            return None;
+        };
+        let Some(rec_cfg) = state.recording_config(&store_id) else {
+            return None;
+        };
+
+        let time_ctrl = rec_cfg.time_ctrl.read();
+        Some(time_ctrl.play_state() == re_viewer_context::PlayState::Playing)
+    }
+
+    #[wasm_bindgen]
+    pub fn set_playing(&self, store_id: String, value: bool) {
+        let Some(mut app) = self.runner.app_mut::<crate::App>() else {
+            return;
+        };
+        let crate::App {
+            store_hub,
+            state,
+            egui_ctx,
+            ..
+        } = &mut *app;
+
+        let Some(hub) = store_hub.as_ref() else {
+            return;
+        };
+        let store_id = re_log_types::StoreId::from_string(
+            re_log_types::StoreKind::Recording,
+            store_id.to_owned(),
+        );
+        let Some(recording) = hub.store_bundle().get(&store_id) else {
+            return;
+        };
+        let Some(rec_cfg) = state.recording_config_mut(&store_id) else {
+            return;
+        };
+
+        let play_state = if value {
+            re_viewer_context::PlayState::Playing
+        } else {
+            re_viewer_context::PlayState::Paused
+        };
+
+        rec_cfg
+            .time_ctrl
+            .write()
+            .set_play_state(recording.times_per_timeline(), play_state);
+        egui_ctx.request_repaint();
+    }
 }
 
 // TODO(jprochazk): figure out a way to auto-generate these types on JS side
@@ -321,11 +613,30 @@ pub struct AppOptions {
     video_decoder: Option<String>,
     hide_welcome_screen: Option<bool>,
     panel_state_overrides: Option<PanelStateOverrides>,
+    timeline: Option<TimelineOptions>,
     fullscreen: Option<FullscreenOptions>,
     enable_history: Option<bool>,
 
     notebook: Option<bool>,
     persist: Option<bool>,
+}
+
+// Keep in sync with the `TimelineOptions` interface in `rerun_js/web-viewer/index.ts`
+#[derive(Clone, Deserialize)]
+pub struct TimelineOptions {
+    /// Fired when the a different timeline is selected.
+    pub on_timelinechange: Callback,
+
+    /// Fired when the timepoint changes.
+    ///
+    /// Does not fire when `on_seek` is called.
+    pub on_timeupdate: Callback,
+
+    /// Fired when the timeline is paused.
+    pub on_pause: Callback,
+
+    /// Fired when the timeline is played.
+    pub on_play: Callback,
 }
 
 // Keep in sync with the `FullscreenOptions` interface in `rerun_js/web-viewer/index.ts`
@@ -374,6 +685,7 @@ fn create_app(
         video_decoder,
         hide_welcome_screen,
         panel_state_overrides,
+        timeline,
         fullscreen,
         enable_history,
 
@@ -403,6 +715,7 @@ fn create_app(
         force_wgpu_backend: render_backend.clone(),
         video_decoder_hw_acceleration,
         hide_welcome_screen: hide_welcome_screen.unwrap_or(false),
+        timeline_options: timeline.clone(),
         fullscreen_options: fullscreen.clone(),
         panel_state_overrides: panel_state_overrides.unwrap_or_default().into(),
 

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -191,9 +191,21 @@ pub struct Callback(#[serde(with = "serde_wasm_bindgen::preserve")] js_sys::Func
 
 impl Callback {
     #[inline]
-    pub fn call(&self) -> Result<JsValue, JsValue> {
+    pub fn call0(&self) -> Result<JsValue, JsValue> {
         let window: JsValue = window()?.into();
         self.0.call0(&window)
+    }
+
+    #[inline]
+    pub fn call1(&self, arg0: &JsValue) -> Result<JsValue, JsValue> {
+        let window: JsValue = window()?.into();
+        self.0.call1(&window, arg0)
+    }
+
+    #[inline]
+    pub fn call2(&self, arg0: &JsValue, arg1: &JsValue) -> Result<JsValue, JsValue> {
+        let window: JsValue = window()?.into();
+        self.0.call2(&window, arg0, arg1)
     }
 }
 

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -71,7 +71,7 @@ pub use self::{
     store_context::StoreContext,
     store_hub::StoreHub,
     tensor::{ImageStats, TensorStats},
-    time_control::{Looping, PlayState, TimeControl, TimeView},
+    time_control::{Looping, PlayState, TimeControl, TimeView, TimelineCallbacks},
     time_drag_value::TimeDragValue,
     typed_entity_collections::{
         ApplicableEntities, IndicatedEntities, PerVisualizer, VisualizableEntities,

--- a/crates/viewer/re_viewer_context/src/time_control.rs
+++ b/crates/viewer/re_viewer_context/src/time_control.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::rc::Rc;
 
 use re_entity_db::{TimeCounts, TimesPerTimeline};
 use re_log_types::{
@@ -107,14 +108,65 @@ impl std::ops::Deref for ActiveTimeline {
     }
 }
 
+#[derive(Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+struct TimeStateEntry {
+    prev: TimeState,
+    current: TimeState,
+}
+
+impl TimeStateEntry {
+    fn new(time: impl Into<TimeReal>) -> Self {
+        let state = TimeState::new(time);
+        Self {
+            prev: state,
+            current: state,
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, PartialEq)]
+struct LastFrame {
+    timeline: Option<Timeline>,
+    playing: bool,
+}
+
+impl Default for LastFrame {
+    fn default() -> Self {
+        Self {
+            timeline: None,
+            playing: true,
+        }
+    }
+}
+
+// Keep in sync with the `TimelineOptions` interface in `rerun_js/web-viewer/index.ts`
+#[derive(Clone)]
+pub struct TimelineCallbacks {
+    /// Fired when the a different timeline is selected.
+    pub on_timelinechange: Rc<dyn Fn(Timeline, TimeReal)>,
+
+    /// Fired when the timepoint changes.
+    ///
+    /// Does not fire when `on_seek` is called.
+    pub on_timeupdate: Rc<dyn Fn(TimeReal)>,
+
+    /// Fired when the timeline is paused.
+    pub on_pause: Rc<dyn Fn()>,
+
+    /// Fired when the timeline is played.
+    pub on_play: Rc<dyn Fn()>,
+}
+
 /// Controls the global view and progress of the time.
 #[derive(serde::Deserialize, serde::Serialize, Clone, PartialEq)]
 #[serde(default)]
 pub struct TimeControl {
+    last_frame: LastFrame,
+
     /// Name of the timeline (e.g. `log_time`).
     timeline: ActiveTimeline,
 
-    states: BTreeMap<Timeline, TimeState>,
+    states: BTreeMap<Timeline, TimeStateEntry>,
 
     /// If true, we are either in [`PlayState::Playing`] or [`PlayState::Following`].
     playing: bool,
@@ -137,6 +189,7 @@ pub struct TimeControl {
 impl Default for TimeControl {
     fn default() -> Self {
         Self {
+            last_frame: Default::default(),
             timeline: ActiveTimeline::Auto(default_timeline([])),
             states: Default::default(),
             playing: true,
@@ -156,6 +209,7 @@ impl TimeControl {
         times_per_timeline: &TimesPerTimeline,
         stable_dt: f32,
         more_data_is_coming: bool,
+        callbacks: Option<&TimelineCallbacks>,
     ) -> NeedsRepaint {
         self.select_a_valid_timeline(times_per_timeline);
 
@@ -163,14 +217,14 @@ impl TimeControl {
             return NeedsRepaint::No; // we have no data on this timeline yet, so bail
         };
 
-        match self.play_state() {
+        let needs_repaint = match self.play_state() {
             PlayState::Paused => {
                 // It's possible that the playback is paused because e.g. it reached its end, but
                 // then the user decides to switch timelines.
                 // When they do so, it might be the case that they switch to a timeline they've
                 // never interacted with before, in which case we don't even have a time state yet.
                 self.states.entry(*self.timeline).or_insert_with(|| {
-                    TimeState::new(if self.following {
+                    TimeStateEntry::new(if self.following {
                         full_range.max()
                     } else {
                         full_range.min()
@@ -184,11 +238,11 @@ impl TimeControl {
                 let state = self
                     .states
                     .entry(*self.timeline)
-                    .or_insert_with(|| TimeState::new(full_range.min()));
+                    .or_insert_with(|| TimeStateEntry::new(full_range.min()));
 
-                if self.looping == Looping::Off && full_range.max() <= state.time {
+                if self.looping == Looping::Off && full_range.max() <= state.current.time {
                     // We've reached the end of the data
-                    state.time = full_range.max().into();
+                    state.current.time = full_range.max().into();
 
                     if more_data_is_coming {
                         // then let's wait for it without pausing!
@@ -201,24 +255,24 @@ impl TimeControl {
 
                 let loop_range = match self.looping {
                     Looping::Off => None,
-                    Looping::Selection => state.loop_selection,
+                    Looping::Selection => state.current.loop_selection,
                     Looping::All => Some(full_range.into()),
                 };
 
                 if let Some(loop_range) = loop_range {
-                    state.time = state.time.max(loop_range.min);
+                    state.current.time = state.current.time.max(loop_range.min);
                 }
 
                 match self.timeline.typ() {
                     TimeType::Sequence => {
-                        state.time += TimeReal::from(state.fps * dt);
+                        state.current.time += TimeReal::from(state.current.fps * dt);
                     }
-                    TimeType::Time => state.time += TimeReal::from(Duration::from_secs(dt)),
+                    TimeType::Time => state.current.time += TimeReal::from(Duration::from_secs(dt)),
                 }
 
                 if let Some(loop_range) = loop_range {
-                    if loop_range.max < state.time {
-                        state.time = loop_range.min; // loop!
+                    if loop_range.max < state.current.time {
+                        state.current.time = loop_range.min; // loop!
                     }
                 }
 
@@ -228,13 +282,51 @@ impl TimeControl {
                 // Set the time to the max:
                 match self.states.entry(*self.timeline) {
                     std::collections::btree_map::Entry::Vacant(entry) => {
-                        entry.insert(TimeState::new(full_range.max()));
+                        entry.insert(TimeStateEntry::new(full_range.max()));
                     }
                     std::collections::btree_map::Entry::Occupied(mut entry) => {
-                        entry.get_mut().time = full_range.max().into();
+                        entry.get_mut().current.time = full_range.max().into();
                     }
                 }
                 NeedsRepaint::No // no need for request_repaint - we already repaint when new data arrives
+            }
+        };
+
+        if let Some(callbacks) = callbacks {
+            self.handle_callbacks(callbacks);
+        }
+
+        needs_repaint
+    }
+
+    /// Handle updating last frame state and trigger callbacks on changes.
+    pub fn handle_callbacks(&mut self, callbacks: &TimelineCallbacks) {
+        if self.last_frame.playing != self.playing {
+            self.last_frame.playing = self.playing;
+
+            if self.playing {
+                (callbacks.on_play)();
+            } else {
+                (callbacks.on_pause)();
+            }
+        }
+
+        if self.last_frame.timeline != Some(*self.timeline) {
+            self.last_frame.timeline = Some(*self.timeline);
+
+            let time = self
+                .get_time_for_timeline(*self.timeline)
+                .unwrap_or(TimeReal::MIN);
+
+            (callbacks.on_timelinechange)(*self.timeline, time);
+        }
+
+        if let Some(state) = self.states.get_mut(&self.timeline) {
+            // TODO(jan): throttle?
+            if state.prev.time != state.current.time {
+                state.prev.time = state.current.time;
+
+                (callbacks.on_timeupdate)(state.current.time);
             }
         }
     }
@@ -279,12 +371,12 @@ impl TimeControl {
                 // Start from beginning if we are at the end:
                 if let Some(time_points) = times_per_timeline.get(&self.timeline) {
                     if let Some(state) = self.states.get_mut(&self.timeline) {
-                        if max(time_points) <= state.time {
-                            state.time = min(time_points).into();
+                        if max(time_points) <= state.current.time {
+                            state.current.time = min(time_points).into();
                         }
                     } else {
                         self.states
-                            .insert(*self.timeline, TimeState::new(min(time_points)));
+                            .insert(*self.timeline, TimeStateEntry::new(min(time_points)));
                     }
                 }
             }
@@ -296,10 +388,10 @@ impl TimeControl {
                     // Set the time to the max:
                     match self.states.entry(*self.timeline) {
                         std::collections::btree_map::Entry::Vacant(entry) => {
-                            entry.insert(TimeState::new(max(time_points)));
+                            entry.insert(TimeStateEntry::new(max(time_points)));
                         }
                         std::collections::btree_map::Entry::Occupied(mut entry) => {
-                            entry.get_mut().time = max(time_points).into();
+                            entry.get_mut().current.time = max(time_points).into();
                         }
                     }
                 }
@@ -350,7 +442,7 @@ impl TimeControl {
     pub fn restart(&mut self, times_per_timeline: &TimesPerTimeline) {
         if let Some(time_points) = times_per_timeline.get(&self.timeline) {
             if let Some(state) = self.states.get_mut(&self.timeline) {
-                state.time = min(time_points).into();
+                state.current.time = min(time_points).into();
                 self.following = false;
             }
         }
@@ -386,8 +478,8 @@ impl TimeControl {
             // Start from beginning if we are at the end:
             if let Some(time_points) = times_per_timeline.get(&self.timeline) {
                 if let Some(state) = self.states.get_mut(&self.timeline) {
-                    if max(time_points) <= state.time {
-                        state.time = min(time_points).into();
+                    if max(time_points) <= state.current.time {
+                        state.current.time = min(time_points).into();
                         self.playing = true;
                         self.following = false;
                         return;
@@ -415,13 +507,15 @@ impl TimeControl {
 
     /// playback fps
     pub fn fps(&self) -> Option<f32> {
-        self.states.get(self.timeline()).map(|state| state.fps)
+        self.states
+            .get(self.timeline())
+            .map(|state| state.current.fps)
     }
 
     /// playback fps
     pub fn set_fps(&mut self, fps: f32) {
         if let Some(state) = self.states.get_mut(&self.timeline) {
-            state.fps = fps;
+            state.current.fps = fps;
         }
     }
 
@@ -461,7 +555,9 @@ impl TimeControl {
 
     /// The current time.
     pub fn time(&self) -> Option<TimeReal> {
-        self.states.get(self.timeline()).map(|state| state.time)
+        self.states
+            .get(self.timeline())
+            .map(|state| state.current.time)
     }
 
     /// The current time.
@@ -485,7 +581,7 @@ impl TimeControl {
     /// The current loop range, iff selection looping is turned on.
     pub fn active_loop_selection(&self) -> Option<ResolvedTimeRangeF> {
         if self.looping == Looping::Selection {
-            self.states.get(self.timeline())?.loop_selection
+            self.states.get(self.timeline())?.current.loop_selection
         } else {
             None
         }
@@ -500,21 +596,22 @@ impl TimeControl {
     ///
     /// This can still return `Some` even if looping is currently off.
     pub fn loop_selection(&self) -> Option<ResolvedTimeRangeF> {
-        self.states.get(self.timeline())?.loop_selection
+        self.states.get(self.timeline())?.current.loop_selection
     }
 
     /// Set the current loop selection without enabling looping.
     pub fn set_loop_selection(&mut self, selection: ResolvedTimeRangeF) {
         self.states
             .entry(*self.timeline)
-            .or_insert_with(|| TimeState::new(selection.min))
+            .or_insert_with(|| TimeStateEntry::new(selection.min))
+            .current
             .loop_selection = Some(selection);
     }
 
     /// Remove the current loop selection.
     pub fn remove_loop_selection(&mut self) {
         if let Some(state) = self.states.get_mut(&self.timeline) {
-            state.loop_selection = None;
+            state.current.loop_selection = None;
         }
         if self.looping() == Looping::Selection {
             self.set_looping(Looping::Off);
@@ -528,7 +625,7 @@ impl TimeControl {
         }
 
         if let Some(state) = self.states.get(self.timeline()) {
-            state.time.floor() == needle
+            state.current.time.floor() == needle
         } else {
             false
         }
@@ -539,12 +636,27 @@ impl TimeControl {
         self.set_time(time);
     }
 
+    pub fn get_time_for_timeline(&self, timeline: Timeline) -> Option<TimeReal> {
+        self.states.get(&timeline).map(|state| state.current.time)
+    }
+
+    pub fn set_time_for_timeline(&mut self, timeline: Timeline, time: impl Into<TimeReal>) {
+        let time = time.into();
+
+        self.states
+            .entry(timeline)
+            .or_insert_with(|| TimeStateEntry::new(time))
+            .current
+            .time = time;
+    }
+
     pub fn set_time(&mut self, time: impl Into<TimeReal>) {
         let time = time.into();
 
         self.states
             .entry(*self.timeline)
-            .or_insert_with(|| TimeState::new(time))
+            .or_insert_with(|| TimeStateEntry::new(time))
+            .current
             .time = time;
     }
 
@@ -552,21 +664,22 @@ impl TimeControl {
     pub fn time_view(&self) -> Option<TimeView> {
         self.states
             .get(self.timeline())
-            .and_then(|state| state.view)
+            .and_then(|state| state.current.view)
     }
 
     /// The range of time we are currently zoomed in on.
     pub fn set_time_view(&mut self, view: TimeView) {
         self.states
             .entry(*self.timeline)
-            .or_insert_with(|| TimeState::new(view.min))
+            .or_insert_with(|| TimeStateEntry::new(view.min))
+            .current
             .view = Some(view);
     }
 
     /// The range of time we are currently zoomed in on.
     pub fn reset_time_view(&mut self) {
         if let Some(state) = self.states.get_mut(&self.timeline) {
-            state.view = None;
+            state.current.view = None;
         }
     }
 }

--- a/rerun_js/package.json
+++ b/rerun_js/package.json
@@ -11,5 +11,6 @@
   "workspaces": [
     "web-viewer",
     "web-viewer-react"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/8329

### What

Adds the following methods to `WebViewer`:

```ts
get_active_recording_id(): string | null;
set_active_recording_id(value: string): void;
get_playing(recording_id: string): boolean;
set_playing(recording_id: string, value: boolean): void;
get_current_time(recording_id: string, timeline: string): number;
set_current_time(recording_id: string, timeline: string, time: number): void;
get_active_timeline(recording_id: string): string | null;
set_active_timeline(recording_id: string, timeline: string): void;
get_time_range(recording_id: string, timeline: string): { min: number; max: number; } | null;
```

As well as the following events:
```ts
interface Events {
  timelinechange: [timeline: string, time: number];
  timeupdate: number;
  play: void;
  pause: void;
}
```

See https://github.com/rerun-io/web-viewer-example/blob/jan/temp-timeline-controls-example/src/main.ts#L15 for an example usage of these new APIs