### PR TITLE
Port Transform3D to eager serialization & update API

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
@@ -17,10 +17,11 @@ namespace rerun.archetypes;
 /// \example archetypes/transform3d_simple title="Variety of 3D transforms" image="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1200w.png"
 /// \example archetypes/transform3d_hierarchy title="Transform hierarchy" image="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1200w.png"
 table Transform3D (
+  "attr.rust.archetype_eager",
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial3DView, Spatial2DView: if logged above active projection",
   "attr.rerun.log_missing_as_empty", // See https://github.com/rerun-io/rerun/issues/6909
-  "attr.rust.derive": "Copy, PartialEq"
+  "attr.rust.derive": "PartialEq"
 ) {
   /// Translation vector.
   translation: rerun.components.Translation3D ("attr.rerun.component_optional", nullable, order: 1100);

--- a/crates/store/re_types/src/archetypes/transform3d_ext.rs
+++ b/crates/store/re_types/src/archetypes/transform3d_ext.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Scale3D, TransformMat3x3, TransformRelation, Translation3D},
+    components::{Scale3D, TransformMat3x3, Translation3D},
     Rotation3D,
 };
 
@@ -20,128 +20,100 @@ impl Transform3D {
         axis_length: None,
     };
 
+    /// Clear all the fields of a `Transform3D`.
+    #[deprecated(since = "0.22.0", note = "Use `Self::clear_fields()` instead.")]
+    pub fn clear() -> Self {
+        Self::clear_fields()
+    }
+
     /// Convenience method that takes any kind of (single) rotation representation and sets it on this transform.
     #[inline]
     pub fn with_rotation(self, rotation: impl Into<Rotation3D>) -> Self {
         match rotation.into() {
-            Rotation3D::Quaternion(quaternion) => Self {
-                quaternion: Some(quaternion),
-                ..self
-            },
-            Rotation3D::AxisAngle(rotation_axis_angle) => Self {
-                rotation_axis_angle: Some(rotation_axis_angle),
-                ..self
-            },
+            Rotation3D::Quaternion(quaternion) => self.with_quaternion(quaternion),
+            Rotation3D::AxisAngle(rotation_axis_angle) => {
+                self.with_rotation_axis_angle(rotation_axis_angle)
+            }
         }
     }
 
-    /// From a translation.
+    /// From a translation, clearing all other fields.
     #[inline]
     pub fn from_translation(translation: impl Into<Translation3D>) -> Self {
-        Self {
-            translation: Some(translation.into()),
-            ..Self::clear()
-        }
+        Self::clear_fields().with_translation(translation)
     }
 
-    /// From a translation.
+    /// From a 3x3 matrix, clearing all other fields.
     #[inline]
     pub fn from_mat3x3(mat3x3: impl Into<TransformMat3x3>) -> Self {
-        Self {
-            mat3x3: Some(mat3x3.into()),
-            ..Self::clear()
-        }
+        Self::clear_fields().with_mat3x3(mat3x3)
     }
 
-    /// From a rotation
+    /// From a rotation, clearing all other fields.
     #[inline]
     pub fn from_rotation(rotation: impl Into<Rotation3D>) -> Self {
-        Self::clear().with_rotation(rotation)
+        Self::clear_fields().with_rotation(rotation)
     }
 
-    /// From a scale
+    /// From a scale, clearing all other fields.
     #[inline]
     pub fn from_scale(scale: impl Into<Scale3D>) -> Self {
-        Self {
-            scale: Some(scale.into()),
-            ..Self::clear()
-        }
+        Self::clear_fields().with_scale(scale)
     }
 
     /// From a translation applied after a rotation, known as a rigid transformation.
+    ///
+    /// Clears all other fields.
     #[inline]
     pub fn from_translation_rotation(
         translation: impl Into<Translation3D>,
         rotation: impl Into<Rotation3D>,
     ) -> Self {
-        Self {
-            translation: Some(translation.into()),
-            ..Self::clear()
-        }
-        .with_rotation(rotation)
+        Self::clear_fields()
+            .with_translation(translation)
+            .with_rotation(rotation)
     }
 
-    /// From a translation applied after a 3x3 matrix.
+    /// From a translation applied after a 3x3 matrix, clearing all other fields.
     #[inline]
     pub fn from_translation_mat3x3(
         translation: impl Into<Translation3D>,
         mat3x3: impl Into<TransformMat3x3>,
     ) -> Self {
-        Self {
-            mat3x3: Some(mat3x3.into()),
-            translation: Some(translation.into()),
-            ..Self::clear()
-        }
+        Self::clear_fields()
+            .with_mat3x3(mat3x3)
+            .with_translation(translation)
     }
 
-    /// From a translation applied after a scale.
+    /// From a translation applied after a scale, clearing all other fields.
     #[inline]
     pub fn from_translation_scale(
         translation: impl Into<Translation3D>,
         scale: impl Into<Scale3D>,
     ) -> Self {
-        Self {
-            scale: Some(scale.into()),
-            translation: Some(translation.into()),
-            ..Self::clear()
-        }
+        Self::clear_fields()
+            .with_scale(scale)
+            .with_translation(translation)
     }
 
-    /// From a translation, applied after a rotation & scale, known as an affine transformation.
+    /// From a translation, applied after a rotation & scale, known as an affine transformation, clearing all other fields.
     #[inline]
     pub fn from_translation_rotation_scale(
         translation: impl Into<Translation3D>,
         rotation: impl Into<Rotation3D>,
         scale: impl Into<Scale3D>,
     ) -> Self {
-        Self {
-            scale: Some(scale.into()),
-            translation: Some(translation.into()),
-            ..Self::clear()
-        }
-        .with_rotation(rotation)
+        Self::clear_fields()
+            .with_scale(scale)
+            .with_translation(translation)
+            .with_rotation(rotation)
     }
 
-    /// From a rotation & scale
+    /// From a rotation & scale, clearing all other fields.
     #[inline]
     pub fn from_rotation_scale(rotation: impl Into<Rotation3D>, scale: impl Into<Scale3D>) -> Self {
-        Self {
-            scale: Some(scale.into()),
-            ..Self::clear()
-        }
-        .with_rotation(rotation)
-    }
-
-    /// Indicate that this transform is from parent to child.
-    ///
-    /// This is the opposite of the default, which is from child to parent.
-    #[allow(clippy::wrong_self_convention)]
-    #[inline]
-    #[deprecated(
-        since = "0.18.0",
-        note = "Use `.with_relation(rerun::TransformRelation::ChildFromParent)` instead."
-    )]
-    pub fn from_parent(self) -> Self {
-        self.with_relation(TransformRelation::ChildFromParent)
+        Self::clear_fields()
+            .with_rotation(rotation)
+            .with_scale(scale)
     }
 }

--- a/docs/snippets/all/archetypes/transform3d_axes.rs
+++ b/docs/snippets/all/archetypes/transform3d_axes.rs
@@ -3,25 +3,26 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d_axes").spawn()?;
 
-    let base_axes = rerun::Transform3D::clear().with_axis_length(1.0);
-    let other_axes = rerun::Transform3D::clear().with_axis_length(0.5);
-
     rec.set_time_sequence("step", 0);
 
-    rec.log("base", &base_axes)?;
+    rec.log("base", &rerun::Transform3D::clear().with_axis_length(1.0))?;
 
     for deg in 0..360 {
         rec.set_time_sequence("step", deg);
         rec.log(
             "base/rotated",
-            &other_axes.with_rotation(rerun::RotationAxisAngle::new(
-                [1.0, 1.0, 1.0],
-                rerun::Angle::from_degrees(deg as f32),
-            )),
+            &rerun::Transform3D::clear()
+                .with_axis_length(0.5)
+                .with_rotation(rerun::RotationAxisAngle::new(
+                    [1.0, 1.0, 1.0],
+                    rerun::Angle::from_degrees(deg as f32),
+                )),
         )?;
         rec.log(
             "base/rotated/translated",
-            &other_axes.with_translation([2.0, 0.0, 0.0]),
+            &rerun::Transform3D::clear()
+                .with_axis_length(0.5)
+                .with_translation([2.0, 0.0, 0.0]),
         )?;
     }
 

--- a/docs/snippets/all/archetypes/transform3d_axes.rs
+++ b/docs/snippets/all/archetypes/transform3d_axes.rs
@@ -5,13 +5,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.set_time_sequence("step", 0);
 
-    rec.log("base", &rerun::Transform3D::clear().with_axis_length(1.0))?;
+    rec.log(
+        "base",
+        &rerun::Transform3D::clear_fields().with_axis_length(1.0),
+    )?;
 
     for deg in 0..360 {
         rec.set_time_sequence("step", deg);
         rec.log(
             "base/rotated",
-            &rerun::Transform3D::clear()
+            &rerun::Transform3D::clear_fields()
                 .with_axis_length(0.5)
                 .with_rotation(rerun::RotationAxisAngle::new(
                     [1.0, 1.0, 1.0],
@@ -20,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )?;
         rec.log(
             "base/rotated/translated",
-            &rerun::Transform3D::clear()
+            &rerun::Transform3D::clear_fields()
                 .with_axis_length(0.5)
                 .with_translation([2.0, 0.0, 0.0]),
         )?;


### PR DESCRIPTION
### Related

* Part of https://github.com/rerun-io/rerun/issues/7245

### What

Use new eager serialization & update API for transforms.

The only breaking change here is that Transform3D is no longer copy, otherwise it's fully compatible.