### PR TITLE
Fix performance regression due to extra arrow round-tripping

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -83,6 +83,20 @@ impl ChunkComponents {
             .map(|la| la.into())
     }
 
+    #[inline]
+    pub fn insert_descriptor_arrow2(
+        &mut self,
+        component_desc: ComponentDescriptor,
+        list_array: Arrow2ListArray<i32>,
+    ) -> Option<Arrow2ListArray<i32>> {
+        // TODO(cmc): revert me
+        let component_desc = component_desc.untagged();
+        self.0
+            .entry(component_desc.component_name)
+            .or_default()
+            .insert(component_desc, list_array)
+    }
+
     /// Returns all list arrays for the given component name.
     ///
     /// I.e semantically equivalent to `get("MyComponent:*.*")`
@@ -181,7 +195,7 @@ impl FromIterator<(ComponentDescriptor, Arrow2ListArray<i32>)> for ChunkComponen
         let mut this = Self::default();
         {
             for (component_desc, list_array) in iter {
-                this.insert_descriptor(component_desc, list_array.into());
+                this.insert_descriptor_arrow2(component_desc, list_array);
             }
         }
         this
@@ -956,7 +970,7 @@ impl Chunk {
         list_array: Arrow2ListArray<i32>,
     ) -> ChunkResult<()> {
         self.components
-            .insert_descriptor(component_desc, list_array.into());
+            .insert_descriptor_arrow2(component_desc, list_array);
         self.sanity_check()
     }
 

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -173,7 +173,7 @@ impl Chunk {
         let components = {
             let mut per_name = ChunkComponents::default();
             for (component_desc, list_array) in components {
-                per_name.insert_descriptor(component_desc.clone(), list_array.into());
+                per_name.insert_descriptor_arrow2(component_desc.clone(), list_array);
             }
             per_name
         };

--- a/crates/store/re_chunk/src/migration.rs
+++ b/crates/store/re_chunk/src/migration.rs
@@ -88,7 +88,7 @@ impl Chunk {
         }
 
         for (desc, list_array) in components_patched {
-            chunk.components.insert_descriptor(desc, list_array.into());
+            chunk.components.insert_descriptor_arrow2(desc, list_array);
         }
 
         chunk

--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -705,7 +705,7 @@ impl Chunk {
                 let component_desc = TransportChunk::component_descriptor_from_field(field);
 
                 if components
-                    .insert_descriptor(component_desc, column.clone().into())
+                    .insert_descriptor_arrow2(component_desc, column.clone())
                     .is_some()
                 {
                     return Err(ChunkError::Malformed {


### PR DESCRIPTION
I'm not 100% sure why this happenes.
It looks like roundtripping `ListArray` marks the inner datatype field as nullable, even when it wasn't originally.
I'm taking a look at fixing this in `re_arrow2`, but I wanted to open this quick-fix in the meantime.

* Closes https://github.com/rerun-io/rerun/issues/8668
* Introduced in PR #8617
* Introduced in commit 78f676f94dc6a5488b0ef55d23856f583ac428db
