### PR TITLE
Respect max width of formatter when formatting ChunkStore/Chunk

### DIFF
--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -63,6 +63,7 @@ impl std::fmt::Display for TransportChunk {
                 .iter()
                 .map(|list_array| ArrowArrayRef::from(list_array.clone()))
                 .collect_vec(),
+            f.width(),
         )
         .fmt(f)
     }

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -530,7 +530,12 @@ impl std::fmt::Display for ChunkStore {
         f.write_str(&indent::indent_all_by(4, "chunks: [\n"))?;
         for chunk_id in chunk_id_per_min_row_id.values().flatten() {
             if let Some(chunk) = chunks_per_chunk_id.get(chunk_id) {
-                f.write_str(&indent::indent_all_by(8, format!("{chunk}\n")))?;
+                if let Some(width) = f.width() {
+                    let chunk_width = width.saturating_sub(8);
+                    f.write_str(&indent::indent_all_by(8, format!("{chunk:chunk_width$}\n")))?;
+                } else {
+                    f.write_str(&indent::indent_all_by(8, format!("{chunk}\n")))?;
+                }
             } else {
                 f.write_str(&indent::indent_all_by(8, "<not_found>\n"))?;
             }

--- a/crates/store/re_chunk_store/tests/formatting.rs
+++ b/crates/store/re_chunk_store/tests/formatting.rs
@@ -42,7 +42,7 @@ fn format_chunk_store() -> anyhow::Result<()> {
             .build()?,
     ))?;
 
-    insta::assert_snapshot!("format_chunk_store", store.to_string());
+    insta::assert_snapshot!("format_chunk_store", format!("{:200}", store));
 
     Ok(())
 }

--- a/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/store/re_chunk_store/tests/formatting.rs
 assertion_line: 45
-expression: store.to_string()
+expression: "format!(\"{:200}\", store)"
 snapshot_kind: text
 ---
 ChunkStore {

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -212,7 +212,12 @@ fn trim_name(name: &str) -> &str {
         .trim_start_matches("rerun.")
 }
 
-pub fn format_dataframe(metadata: &Metadata, fields: &Fields, columns: &[ArrayRef]) -> Table {
+pub fn format_dataframe(
+    metadata: &Metadata,
+    fields: &Fields,
+    columns: &[ArrayRef],
+    width: Option<usize>,
+) -> Table {
     const MAXIMUM_CELL_CONTENT_WIDTH: u16 = 100;
 
     let mut outer_table = Table::new();
@@ -220,6 +225,16 @@ pub fn format_dataframe(metadata: &Metadata, fields: &Fields, columns: &[ArrayRe
 
     let mut table = Table::new();
     table.load_preset(presets::UTF8_FULL);
+
+    if let Some(width) = width {
+        outer_table.set_width(width as _);
+        outer_table.set_content_arrangement(comfy_table::ContentArrangement::Disabled);
+        table.set_width(width as _);
+        table.set_content_arrangement(comfy_table::ContentArrangement::Disabled);
+    } else {
+        outer_table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+        table.set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+    }
 
     outer_table.add_row({
         let mut row = Row::new();


### PR DESCRIPTION
Makes the test predictable, regardless of terminal width