### PR TITLE
Pin ci machines with Vulkan setup to Ubuntu 22.04

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -76,7 +76,8 @@ jobs:
 
   no-codegen-changes:
     name: Check if running codegen would produce any changes
-    runs-on: ubuntu-latest-16-cores
+    # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
+    runs-on: ubuntu-22.04-large
     steps:
       # Note: We explicitly don't override `ref` here. We need to see if changes would be made
       # in a context where we have merged with main. Otherwise we might miss changes such as one

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -92,7 +92,8 @@ jobs:
 
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
-    runs-on: ubuntu-latest-16-cores
+    # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -93,7 +93,7 @@ jobs:
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-16-cores
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -93,7 +93,7 @@ jobs:
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04-16core
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -53,7 +53,7 @@ jobs:
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
-    runs-on: ubuntu-22.04-16core
+    runs-on: ubuntu-22.04-large
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -53,7 +53,7 @@ jobs:
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-16-cores
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -52,7 +52,8 @@ jobs:
 
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
-    runs-on: ubuntu-latest-16-cores
+    # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -53,7 +53,7 @@ jobs:
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
-    runs-on: ubuntu-22.04-16-cores
+    runs-on: ubuntu-22.04-16core
     steps:
       - uses: actions/checkout@v4
         with:

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -337,7 +337,7 @@ pub enum PixelFormat {
     Yuv {
         layout: YuvPixelLayout,
         range: YuvRange,
-        // TODO(andreas): color primaries should also apply to RGB data,
+        // TODO(andreas): Color primaries should also apply to RGB data,
         // but for now we just always assume RGB to be BT.709 ~= sRGB.
         coefficients: YuvMatrixCoefficients,
         // Note that we don't handle chroma sample location at all so far.


### PR DESCRIPTION
`ubuntu-latest` got updated to imply Ubuntu 24. This makes our software rasterizer script fail with
```
ERROR: [Loader Message] Code 0 : libLLVM-15.so.1: cannot open shared object file: No such file or directory
ERROR:             libLLVM-15.so.1: cannot open shared object file: No such file or directory
```
when running vulkaninfo. Surely we can fix this by installing the necessary dependencies, but for now let's just pin this to the previous OS version.