### PR TITLE
Filter entities in the UI (part 5): Add snapshot tests for the blueprint tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6764,7 +6764,6 @@ version = "0.22.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "egui",
- "egui_kittest",
  "fjadra",
  "itertools 0.13.0",
  "nohash-hasher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5637,6 +5637,7 @@ version = "0.22.0-alpha.1+dev"
 dependencies = [
  "egui",
  "itertools 0.13.0",
+ "re_chunk_store",
  "re_context_menu",
  "re_data_ui",
  "re_entity_db",
@@ -5645,6 +5646,7 @@ dependencies = [
  "re_tracing",
  "re_types",
  "re_ui",
+ "re_view_spatial",
  "re_viewer_context",
  "re_viewport_blueprint",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,8 +5635,8 @@ dependencies = [
 name = "re_blueprint_tree"
 version = "0.22.0-alpha.1+dev"
 dependencies = [
- "ahash",
  "egui",
+ "egui_kittest",
  "itertools 0.13.0",
  "re_chunk_store",
  "re_context_menu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,7 @@ dependencies = [
 name = "re_blueprint_tree"
 version = "0.22.0-alpha.1+dev"
 dependencies = [
+ "ahash",
  "egui",
  "itertools 0.13.0",
  "re_chunk_store",

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -19,6 +19,7 @@ pub enum EntityPathFilterError {
 ///
 /// Important: the same substitutions must be used in every place we resolve [`EntityPathFilter`] to
 /// [`ResolvedEntityPathFilter`].
+#[derive(Debug)]
 pub struct EntityPathSubs(HashMap<String, String>);
 
 impl EntityPathSubs {

--- a/crates/viewer/re_blueprint_tree/Cargo.toml
+++ b/crates/viewer/re_blueprint_tree/Cargo.toml
@@ -37,5 +37,8 @@ smallvec.workspace = true
 
 [dev-dependencies]
 re_viewer_context = { workspace = true, features = ["testing"] }
+re_viewport_blueprint = { workspace = true, features = ["testing"] }
 re_chunk_store.workspace = true
 re_view_spatial.workspace = true
+
+ahash.workspace = true

--- a/crates/viewer/re_blueprint_tree/Cargo.toml
+++ b/crates/viewer/re_blueprint_tree/Cargo.toml
@@ -41,4 +41,4 @@ re_viewport_blueprint = { workspace = true, features = ["testing"] }
 re_chunk_store.workspace = true
 re_view_spatial.workspace = true
 
-ahash.workspace = true
+egui_kittest.workspace = true

--- a/crates/viewer/re_blueprint_tree/Cargo.toml
+++ b/crates/viewer/re_blueprint_tree/Cargo.toml
@@ -33,3 +33,9 @@ re_viewport_blueprint.workspace = true
 egui.workspace = true
 itertools.workspace = true
 smallvec.workspace = true
+
+
+[dev-dependencies]
+re_viewer_context = { workspace = true, features = ["testing"] }
+re_chunk_store.workspace = true
+re_view_spatial.workspace = true

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -53,6 +53,11 @@ pub struct BlueprintTree {
 }
 
 impl BlueprintTree {
+    /// Activates the search filter (for e.g. test purposes).
+    pub fn activate_filter(&mut self, query: &str) {
+        self.filter_state.activate(query);
+    }
+
     /// Show the Blueprint section of the left panel based on the current [`ViewportBlueprint`]
     pub fn show(
         &mut self,

--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -1,19 +1,21 @@
 use egui::Vec2;
-use std::sync::Arc;
 
 use re_blueprint_tree::BlueprintTree;
 use re_chunk_store::external::re_chunk::ChunkBuilder;
-use re_chunk_store::{Chunk, RowId};
+use re_chunk_store::RowId;
 use re_entity_db::external::re_chunk_store::LatestAtQuery;
-use re_log_types::{build_frame_nr, EntityPath};
+use re_log_types::build_frame_nr;
 use re_types::archetypes::Points3D;
 use re_viewer_context::{
-    blueprint_timeline, test_context::TestContext, RecommendedView, ViewClass, ViewId,
+    blueprint_timeline, test_context::TestContext, RecommendedView, ViewClass,
 };
-use re_viewport_blueprint::{ViewBlueprint, ViewportBlueprint};
+use re_viewport_blueprint::{
+    test_context_ext::TestContextExt as _, ViewBlueprint, ViewportBlueprint,
+};
 
+/// Basic blueprint panel test
 #[test]
-fn blueprint_panel_should_match_snapshot() {
+fn basic_blueprint_panel_should_match_snapshot() {
     let mut test_context = TestContext::default();
 
     test_context.register_view_class::<re_view_spatial::SpatialView3D>();
@@ -22,27 +24,19 @@ fn blueprint_panel_should_match_snapshot() {
     test_context.log_entity("/entity/1".into(), add_point_to_chunk_builder);
     test_context.log_entity("/entity/2".into(), add_point_to_chunk_builder);
 
-    egui::__run_test_ctx(|egui_ctx| {
-        test_context.run(egui_ctx, |ctx| {
-            let viewport_blueprint = ViewportBlueprint::try_from_db(
-                &test_context.blueprint_store,
-                &test_context.blueprint_query,
-            );
-            viewport_blueprint.add_views(
-                std::iter::once(ViewBlueprint::new(
-                    re_view_spatial::SpatialView3D::identifier(),
-                    RecommendedView::root(),
-                )),
-                None,
-                None,
-            );
-
-            viewport_blueprint.save_to_blueprint_store(ctx, &ctx.view_class_registry);
-        })
+    test_context.setup_viewport_blueprint(|_, blueprint| {
+        blueprint.add_views(
+            std::iter::once(ViewBlueprint::new(
+                re_view_spatial::SpatialView3D::identifier(),
+                RecommendedView::root(),
+            )),
+            None,
+            None,
+        );
     });
 
     let blueprint_tree = BlueprintTree::default();
-    run_blueprint_panel_and_save_snapshot(test_context, blueprint_tree, "blueprint_panel")
+    run_blueprint_panel_and_save_snapshot(test_context, blueprint_tree, "basic_blueprint_panel")
 }
 
 fn add_point_to_chunk_builder(builder: ChunkBuilder) -> ChunkBuilder {

--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -3,12 +3,9 @@ use egui::Vec2;
 use re_blueprint_tree::BlueprintTree;
 use re_chunk_store::external::re_chunk::ChunkBuilder;
 use re_chunk_store::RowId;
-use re_entity_db::external::re_chunk_store::LatestAtQuery;
 use re_log_types::build_frame_nr;
 use re_types::archetypes::Points3D;
-use re_viewer_context::{
-    blueprint_timeline, test_context::TestContext, RecommendedView, ViewClass,
-};
+use re_viewer_context::{test_context::TestContext, RecommendedView, ViewClass};
 use re_viewport_blueprint::{
     test_context_ext::TestContextExt as _, ViewBlueprint, ViewportBlueprint,
 };
@@ -101,10 +98,8 @@ fn setup_filter_test(query: Option<&str>) -> (TestContext, BlueprintTree) {
     // application id. This way, the blueprint panel will not discard the filter state we set up
     // when it's run for the snapshot.
     test_context.run_in_egui_central_panel(|ctx, ui| {
-        let blueprint = ViewportBlueprint::try_from_db(
-            ctx.store_context.blueprint,
-            &LatestAtQuery::latest(blueprint_timeline()),
-        );
+        let blueprint =
+            ViewportBlueprint::try_from_db(ctx.store_context.blueprint, ctx.blueprint_query);
 
         blueprint_tree.show(ctx, &blueprint, ui);
     });
@@ -136,7 +131,7 @@ fn run_blueprint_panel_and_save_snapshot(
             test_context.run(&ui.ctx().clone(), |viewer_ctx| {
                 let blueprint = ViewportBlueprint::try_from_db(
                     viewer_ctx.store_context.blueprint,
-                    &LatestAtQuery::latest(blueprint_timeline()),
+                    viewer_ctx.blueprint_query,
                 );
 
                 blueprint_tree.show(viewer_ctx, &blueprint, ui);

--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -1,0 +1,79 @@
+use egui::Vec2;
+use std::sync::Arc;
+
+use re_blueprint_tree::BlueprintTree;
+use re_chunk_store::external::re_chunk::ChunkBuilder;
+use re_chunk_store::{Chunk, RowId};
+use re_entity_db::external::re_chunk_store::LatestAtQuery;
+use re_log_types::{build_frame_nr, EntityPath};
+use re_types::archetypes::Points3D;
+use re_viewer_context::{
+    blueprint_timeline, test_context::TestContext, RecommendedView, ViewClass, ViewId,
+};
+use re_viewport_blueprint::{ViewBlueprint, ViewportBlueprint};
+
+#[test]
+fn blueprint_panel_should_match_snapshot() {
+    let mut test_context = TestContext::default();
+
+    test_context.register_view_class::<re_view_spatial::SpatialView3D>();
+
+    test_context.log_entity("/entity/0".into(), add_point_to_chunk_builder);
+    test_context.log_entity("/entity/1".into(), add_point_to_chunk_builder);
+    test_context.log_entity("/entity/2".into(), add_point_to_chunk_builder);
+
+    egui::__run_test_ctx(|egui_ctx| {
+        test_context.run(egui_ctx, |ctx| {
+            let viewport_blueprint = ViewportBlueprint::try_from_db(
+                &test_context.blueprint_store,
+                &test_context.blueprint_query,
+            );
+            viewport_blueprint.add_views(
+                std::iter::once(ViewBlueprint::new(
+                    re_view_spatial::SpatialView3D::identifier(),
+                    RecommendedView::root(),
+                )),
+                None,
+                None,
+            );
+
+            viewport_blueprint.save_to_blueprint_store(ctx, &ctx.view_class_registry);
+        })
+    });
+
+    let blueprint_tree = BlueprintTree::default();
+    run_blueprint_panel_and_save_snapshot(test_context, blueprint_tree, "blueprint_panel")
+}
+
+fn add_point_to_chunk_builder(builder: ChunkBuilder) -> ChunkBuilder {
+    builder.with_archetype(
+        RowId::new(),
+        [build_frame_nr(0)],
+        &Points3D::new([[0.0, 0.0, 0.0]]),
+    )
+}
+
+fn run_blueprint_panel_and_save_snapshot(
+    mut test_context: TestContext,
+    mut blueprint_tree: BlueprintTree,
+    snapshot_name: &str,
+) {
+    let mut harness = test_context
+        .setup_kittest_for_rendering()
+        .with_size(Vec2::new(400.0, 800.0))
+        .build_ui(|ui| {
+            test_context.run(&ui.ctx().clone(), |viewer_ctx| {
+                let blueprint = ViewportBlueprint::try_from_db(
+                    viewer_ctx.store_context.blueprint,
+                    &LatestAtQuery::latest(blueprint_timeline()),
+                );
+
+                blueprint_tree.show(viewer_ctx, &blueprint, ui);
+            });
+
+            test_context.handle_system_commands();
+        });
+
+    harness.run();
+    harness.snapshot(snapshot_name);
+}

--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -5,7 +5,7 @@ use re_chunk_store::external::re_chunk::ChunkBuilder;
 use re_chunk_store::RowId;
 use re_log_types::build_frame_nr;
 use re_types::archetypes::Points3D;
-use re_viewer_context::{test_context::TestContext, RecommendedView, ViewClass};
+use re_viewer_context::{test_context::TestContext, CollapseScope, RecommendedView, ViewClass};
 use re_viewport_blueprint::{
     test_context_ext::TestContextExt as _, ViewBlueprint, ViewportBlueprint,
 };
@@ -34,6 +34,69 @@ fn basic_blueprint_panel_should_match_snapshot() {
     let blueprint_tree = BlueprintTree::default();
     run_blueprint_panel_and_save_snapshot(test_context, blueprint_tree, "basic_blueprint_panel");
 }
+
+// ---
+
+#[test]
+fn collapse_expand_all_blueprint_panel_should_match_snapshot() {
+    for (snapshot_name, should_expand) in &[
+        ("expand_all_blueprint_panel", true),
+        ("collapse_all_blueprint_panel", false),
+    ] {
+        let mut test_context = TestContext::default();
+
+        test_context.register_view_class::<re_view_spatial::SpatialView3D>();
+
+        test_context.log_entity("/path/to/entity0".into(), add_point_to_chunk_builder);
+        test_context.log_entity("/path/to/entity1".into(), add_point_to_chunk_builder);
+        test_context.log_entity("/another/way/to/entity2".into(), add_point_to_chunk_builder);
+
+        let view_id = test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+            let view = ViewBlueprint::new(
+                re_view_spatial::SpatialView3D::identifier(),
+                RecommendedView::root(),
+            );
+
+            let view_id = view.id;
+            blueprint.add_views(std::iter::once(view), None, None);
+
+            // TODO(ab): add containers in the hierarchy (requires work on the container API,
+            // currently very cumbersome to use for testing purposes).
+
+            view_id
+        });
+
+        let mut blueprint_tree = BlueprintTree::default();
+
+        let mut harness = test_context
+            .setup_kittest_for_rendering()
+            .with_size(Vec2::new(400.0, 800.0))
+            .build_ui(|ui| {
+                test_context.run(&ui.ctx().clone(), |viewer_ctx| {
+                    re_context_menu::collapse_expand::collapse_expand_view(
+                        viewer_ctx,
+                        &view_id,
+                        CollapseScope::BlueprintTree,
+                        *should_expand,
+                    );
+
+                    let blueprint = ViewportBlueprint::try_from_db(
+                        viewer_ctx.store_context.blueprint,
+                        viewer_ctx.blueprint_query,
+                    );
+
+                    blueprint_tree.show(viewer_ctx, &blueprint, ui);
+                });
+
+                test_context.handle_system_commands();
+            });
+
+        harness.run();
+        harness.snapshot(snapshot_name);
+    }
+}
+
+// ---
 
 #[test]
 fn blueprint_panel_filter_active_inside_origin_should_match_snapshot() {
@@ -67,8 +130,6 @@ fn blueprint_panel_filter_active_above_origin_should_match_snapshot() {
         "blueprint_panel_filter_active_above_origin",
     );
 }
-
-// ---
 
 fn setup_filter_test(query: Option<&str>) -> (TestContext, BlueprintTree) {
     let mut test_context = TestContext::default();
@@ -110,6 +171,8 @@ fn setup_filter_test(query: Option<&str>) -> (TestContext, BlueprintTree) {
 
     (test_context, blueprint_tree)
 }
+
+// ---
 
 fn add_point_to_chunk_builder(builder: ChunkBuilder) -> ChunkBuilder {
     builder.with_archetype(

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/basic_blueprint_panel.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/basic_blueprint_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:856663346b399727c2dd57d085f421086ec8fc523301be7c4be18081af9c7ed6
+size 14096

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/basic_blueprint_panel.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/basic_blueprint_panel.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:856663346b399727c2dd57d085f421086ec8fc523301be7c4be18081af9c7ed6
-size 14096
+oid sha256:769ca0cce66cec8bc8e7621aa2ae48353b3d26e191b486e6e5bd4a3f2c1299d9
+size 20147

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/blueprint_panel_filter_active_above_origin.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/blueprint_panel_filter_active_above_origin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6d2f7f5ee34fa4fc0609c55a3dca06cea2984d1d6a99569014e8801fcb07a0
+size 22280

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/blueprint_panel_filter_active_inside_origin.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/blueprint_panel_filter_active_inside_origin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36a77c9ce18d5ebc02d81159e9797df347a86156b76057bf4a54309885a72675
+size 16574

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/blueprint_panel_filter_active_outside_origin.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/blueprint_panel_filter_active_outside_origin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d4c2af6873f1d57ba79f2058a9016adb1a91a59503f004ae8e9b2ab9f5f20b7
+size 22099

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/collapse_all_blueprint_panel.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/collapse_all_blueprint_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:856663346b399727c2dd57d085f421086ec8fc523301be7c4be18081af9c7ed6
+size 14096

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/expand_all_blueprint_panel.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/expand_all_blueprint_panel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d42b9a800aa1c9d9fb7bafcab051fb387522da5d1b3fa9afdd3ffcdeaba4347
+size 25646

--- a/crates/viewer/re_view_graph/Cargo.toml
+++ b/crates/viewer/re_view_graph/Cargo.toml
@@ -41,7 +41,7 @@ itertools.workspace = true
 nohash-hasher.workspace = true
 
 [dev-dependencies]
-egui_kittest.workspace = true
 re_chunk_store.workspace = true
 re_viewer_context = { workspace = true, features = ["testing"] }
 re_viewport.workspace = true
+re_viewport_blueprint = { workspace = true, features = ["testing"] }

--- a/crates/viewer/re_view_graph/tests/basic.rs
+++ b/crates/viewer/re_view_graph/tests/basic.rs
@@ -8,7 +8,7 @@ use re_chunk_store::{Chunk, RowId};
 use re_entity_db::EntityPath;
 use re_types::{components, Component as _};
 use re_view_graph::{GraphView, GraphViewState};
-use re_viewer_context::{test_context::TestContext, RecommendedView, ViewClass, ViewId};
+use re_viewer_context::{test_context::TestContext, RecommendedView, ViewClass};
 use re_viewport_blueprint::test_context_ext::TestContextExt as _;
 use re_viewport_blueprint::ViewBlueprint;
 
@@ -127,20 +127,15 @@ fn run_graph_view_and_save_snapshot(
     name: &str,
     size: Vec2,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let view_id = ViewId::hashed_from_str("/graph");
-
-    test_context.setup_viewport_blueprint(|_, blueprint| {
-        // make the view id known
-        let mut view_blueprint = ViewBlueprint::new(
+    let view_id = test_context.setup_viewport_blueprint(|_, blueprint| {
+        let view_blueprint = ViewBlueprint::new(
             re_view_graph::GraphView::identifier(),
-            RecommendedView {
-                origin: EntityPath::root(),
-                query_filter: format!("+ /{name}").as_str().try_into().unwrap(),
-            },
+            RecommendedView::root(),
         );
-        view_blueprint.id = view_id;
 
+        let view_id = view_blueprint.id;
         blueprint.add_views(std::iter::once(view_blueprint), None, None);
+        view_id
     });
 
     let mut view_state = GraphViewState::default();

--- a/crates/viewer/re_view_graph/tests/basic.rs
+++ b/crates/viewer/re_view_graph/tests/basic.rs
@@ -55,7 +55,7 @@ pub fn coincident_nodes() {
         .add_chunk(&Arc::new(builder.build().unwrap()))
         .unwrap();
 
-    run_graph_view_and_save_snapshot(&mut test_context, name, Vec2::new(100.0, 100.0)).unwrap();
+    run_graph_view_and_save_snapshot(&mut test_context, name, Vec2::new(100.0, 100.0));
 }
 
 #[test]
@@ -119,14 +119,10 @@ pub fn self_and_multi_edges() {
         .add_chunk(&Arc::new(builder.build().unwrap()))
         .unwrap();
 
-    run_graph_view_and_save_snapshot(&mut test_context, name, Vec2::new(400.0, 400.0)).unwrap();
+    run_graph_view_and_save_snapshot(&mut test_context, name, Vec2::new(400.0, 400.0));
 }
 
-fn run_graph_view_and_save_snapshot(
-    test_context: &mut TestContext,
-    name: &str,
-    size: Vec2,
-) -> Result<(), Box<dyn std::error::Error>> {
+fn run_graph_view_and_save_snapshot(test_context: &mut TestContext, name: &str, size: Vec2) {
     let view_id = test_context.setup_viewport_blueprint(|_, blueprint| {
         let view_blueprint = ViewBlueprint::new(
             re_view_graph::GraphView::identifier(),
@@ -180,6 +176,4 @@ fn run_graph_view_and_save_snapshot(
 
     harness.run();
     harness.snapshot(name);
-
-    Ok(())
 }

--- a/crates/viewer/re_view_graph/tests/basic.rs
+++ b/crates/viewer/re_view_graph/tests/basic.rs
@@ -3,11 +3,13 @@
 use std::sync::Arc;
 
 use egui::Vec2;
+
 use re_chunk_store::{Chunk, RowId};
 use re_entity_db::EntityPath;
 use re_types::{components, Component as _};
 use re_view_graph::{GraphView, GraphViewState};
-use re_viewer_context::{test_context::TestContext, ViewClass, ViewClassExt as _, ViewId};
+use re_viewer_context::{test_context::TestContext, RecommendedView, ViewClass, ViewId};
+use re_viewport_blueprint::test_context_ext::TestContextExt as _;
 use re_viewport_blueprint::ViewBlueprint;
 
 #[test]
@@ -18,10 +20,7 @@ pub fn coincident_nodes() {
     // It's important to first register the view class before adding any entities,
     // otherwise the `VisualizerEntitySubscriber` for our visualizers doesn't exist yet,
     // and thus will not find anything applicable to the visualizer.
-    test_context
-        .view_class_registry
-        .add_class::<GraphView>()
-        .unwrap();
+    test_context.register_view_class::<re_view_graph::GraphView>();
 
     let entity_path = EntityPath::from(name);
 
@@ -123,121 +122,56 @@ pub fn self_and_multi_edges() {
     run_graph_view_and_save_snapshot(&mut test_context, name, Vec2::new(400.0, 400.0)).unwrap();
 }
 
-pub fn setup_graph_view_blueprint(
-    test_context: &mut TestContext,
-) -> Result<ViewId, Box<dyn std::error::Error>> {
-    // Views are always logged at `/{view_id}` in the blueprint store.
-    let view_id = ViewId::hashed_from_str("/graph");
-
-    // Use the timeline that is queried for blueprints.
-    let timepoint = [(test_context.blueprint_query.timeline(), 0)];
-
-    let view_chunk = Chunk::builder(view_id.as_entity_path().clone())
-        .with_archetype(
-            RowId::new(),
-            timepoint,
-            &re_types::blueprint::archetypes::ViewBlueprint::new(GraphView::identifier().as_str()),
-        )
-        .build()?;
-    test_context
-        .blueprint_store
-        .add_chunk(&Arc::new(view_chunk))?;
-
-    // TODO(andreas): can we use the `ViewProperty` utilities for this?
-    let view_contents_chunk =
-        Chunk::builder(format!("{}/ViewContents", view_id.as_entity_path()).into())
-            .with_archetype(
-                RowId::new(),
-                timepoint,
-                &re_types::blueprint::archetypes::ViewContents::new(std::iter::once(
-                    re_types::datatypes::Utf8::from("/**"),
-                )),
-            )
-            .build()?;
-    test_context
-        .blueprint_store
-        .add_chunk(&Arc::new(view_contents_chunk))?;
-
-    Ok(view_id)
-}
-
 fn run_graph_view_and_save_snapshot(
     test_context: &mut TestContext,
-    _name: &str,
+    name: &str,
     size: Vec2,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let view_id = setup_graph_view_blueprint(test_context)?;
-    let view_blueprint = ViewBlueprint::try_from_db(
-        view_id,
-        &test_context.blueprint_store,
-        &test_context.blueprint_query,
-    )
-    .expect("failed to get view blueprint");
+    let view_id = ViewId::hashed_from_str("/graph");
+
+    test_context.setup_viewport_blueprint(|_, blueprint| {
+        // make the view id known
+        let mut view_blueprint = ViewBlueprint::new(
+            re_view_graph::GraphView::identifier(),
+            RecommendedView {
+                origin: EntityPath::root(),
+                query_filter: format!("+ /{name}").as_str().try_into().unwrap(),
+            },
+        );
+        view_blueprint.id = view_id;
+
+        blueprint.add_views(std::iter::once(view_blueprint), None, None);
+    });
 
     let mut view_state = GraphViewState::default();
-    let class_identifier = GraphView::identifier();
 
-    let view_class_registry = &mut test_context.view_class_registry;
-    let applicable_entities_per_visualizer = view_class_registry
-        .applicable_entities_for_visualizer_systems(&test_context.recording_store.store_id());
-
-    // TODO(andreas): this is c&p from TestContext::run. Make it nicer plz ;)
-    let store_context = re_viewer_context::StoreContext {
-        app_id: "rerun_test".into(),
-        blueprint: &test_context.blueprint_store,
-        default_blueprint: None,
-        recording: &test_context.recording_store,
-        bundle: &Default::default(),
-        caches: &Default::default(),
-        hub: &Default::default(),
-        should_enable_heuristics: false,
-    };
-
-    // Execute the queries for every `View`
-    test_context.query_results = std::iter::once((view_id, {
-        // TODO(andreas): This needs to be done in a store subscriber that exists per view (instance, not class!).
-        // Note that right now we determine *all* visualizable entities, not just the queried ones.
-        // In a store subscriber set this is fine, but on a per-frame basis it's wasteful.
-        let visualizable_entities = view_class_registry
-            .get_class_or_log_error(class_identifier)
-            .determine_visualizable_entities(
-                &applicable_entities_per_visualizer,
-                &test_context.recording_store,
-                &view_class_registry.new_visualizer_collection(class_identifier),
-                &view_blueprint.space_origin,
-            );
-
-        view_blueprint.contents.execute_query(
-            &store_context,
-            view_class_registry,
-            &test_context.blueprint_query,
-            view_id,
-            &visualizable_entities,
-        )
-    }))
-    .collect();
-
-    //TODO(ab): this contains a lot of boilerplate which should be provided by helpers
     let mut harness = test_context
         .setup_kittest_for_rendering()
         .with_size(size)
         .with_max_steps(256) // Give it some time to settle the graph.
         .build_ui(|ui| {
-            test_context.run(&ui.ctx().clone(), |viewer_ctx| {
-                let view_class = test_context
+            test_context.run(&ui.ctx().clone(), |ctx| {
+                let view_class = ctx
                     .view_class_registry
                     .get_class_or_log_error(GraphView::identifier());
 
+                let view_blueprint = ViewBlueprint::try_from_db(
+                    view_id,
+                    ctx.store_context.blueprint,
+                    ctx.blueprint_query,
+                )
+                .expect("we just created that view");
+
                 let (view_query, system_execution_output) = re_viewport::execute_systems_for_view(
-                    viewer_ctx,
+                    ctx,
                     &view_blueprint,
-                    viewer_ctx.current_query().at(), // TODO(andreas): why is this even needed to be passed in?
+                    ctx.current_query().at(), // TODO(andreas): why is this even needed to be passed in?
                     &view_state,
                 );
 
                 view_class
                     .ui(
-                        viewer_ctx,
+                        ctx,
                         ui,
                         &mut view_state,
                         &view_query,
@@ -250,7 +184,7 @@ fn run_graph_view_and_save_snapshot(
         });
 
     harness.run();
-    harness.snapshot(_name);
+    harness.snapshot(name);
 
     Ok(())
 }

--- a/crates/viewer/re_viewer_context/src/query_context.rs
+++ b/crates/viewer/re_viewer_context/src/query_context.rs
@@ -49,6 +49,7 @@ impl QueryContext<'_> {
 }
 
 /// The result of executing a single data query for a specific view.
+#[derive(Debug)]
 pub struct DataQueryResult {
     /// The [`DataResultTree`] for the query
     pub tree: DataResultTree,

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -208,7 +208,9 @@ impl TestContext {
         self.selection_state.on_frame_start(|_| true, None);
     }
 
-    //TODO: docstrinc
+    /// Log an entity to the recording store.
+    ///
+    /// The provided closure should add content using the [`ChunkBuilder`] passed as argument.
     pub fn log_entity(
         &mut self,
         entity_path: EntityPath,
@@ -216,13 +218,17 @@ impl TestContext {
     ) {
         let builder = build_chunk(Chunk::builder(entity_path));
         self.recording_store
-            .add_chunk(&Arc::new(builder.build().unwrap()))
-            .unwrap();
+            .add_chunk(&Arc::new(
+                builder.build().expect("chunk should be successfully built"),
+            ))
+            .expect("chunk should be successfully added");
     }
 
-    //TODO::docstring
+    /// Register a view class.
     pub fn register_view_class<T: ViewClass + Default + 'static>(&mut self) {
-        self.view_class_registry.add_class::<T>().unwrap()
+        self.view_class_registry
+            .add_class::<T>()
+            .expect("registering a class should succeed");
     }
 
     /// Run the provided closure with a [`ViewerContext`] produced by the [`Self`].

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -5,15 +5,16 @@ use ahash::HashMap;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
+use re_chunk::{Chunk, ChunkBuilder};
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
-use re_log_types::{StoreId, StoreKind};
+use re_log_types::{EntityPath, StoreId, StoreKind};
 use re_types_core::reflection::Reflection;
 
 use crate::{
     blueprint_timeline, command_channel, ApplicationSelectionState, CommandReceiver, CommandSender,
     ComponentUiRegistry, DataQueryResult, ItemCollection, RecordingConfig, StoreContext,
-    SystemCommand, ViewClassRegistry, ViewId, ViewerContext,
+    SystemCommand, ViewClass, ViewClassRegistry, ViewId, ViewerContext,
 };
 
 /// Harness to execute code that rely on [`crate::ViewerContext`].
@@ -205,6 +206,23 @@ impl TestContext {
 
         // the selection state is double-buffered, so let's ensure it's updated
         self.selection_state.on_frame_start(|_| true, None);
+    }
+
+    //TODO: docstrinc
+    pub fn log_entity(
+        &mut self,
+        entity_path: EntityPath,
+        build_chunk: impl FnOnce(ChunkBuilder) -> ChunkBuilder,
+    ) {
+        let mut builder = build_chunk(Chunk::builder(entity_path));
+        self.recording_store
+            .add_chunk(&Arc::new(builder.build().unwrap()))
+            .unwrap();
+    }
+
+    //TODO::docstring
+    pub fn register_view_class<T: ViewClass + Default + 'static>(&mut self) {
+        self.view_class_registry.add_class::<T>().unwrap()
     }
 
     /// Run the provided closure with a [`ViewerContext`] produced by the [`Self`].

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -214,7 +214,7 @@ impl TestContext {
         entity_path: EntityPath,
         build_chunk: impl FnOnce(ChunkBuilder) -> ChunkBuilder,
     ) {
-        let mut builder = build_chunk(Chunk::builder(entity_path));
+        let builder = build_chunk(Chunk::builder(entity_path));
         self.recording_store
             .add_chunk(&Arc::new(builder.build().unwrap()))
             .unwrap();

--- a/crates/viewer/re_viewer_context/src/view/view_class_registry.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_class_registry.rs
@@ -238,7 +238,7 @@ impl ViewClassRegistry {
     }
 
     /// Queries a View type by class name, returning `None` if it is not registered.
-    fn get_class(&self, name: ViewClassIdentifier) -> Option<&dyn ViewClass> {
+    pub fn class(&self, name: ViewClassIdentifier) -> Option<&dyn ViewClass> {
         self.view_classes
             .get(&name)
             .map(|boxed| boxed.class.as_ref())
@@ -255,7 +255,7 @@ impl ViewClassRegistry {
 
     /// Queries a View type by class name and logs if it fails, returning a placeholder class.
     pub fn get_class_or_log_error(&self, name: ViewClassIdentifier) -> &dyn ViewClass {
-        if let Some(result) = self.get_class(name) {
+        if let Some(result) = self.class(name) {
             result
         } else {
             re_log::error_once!("Unknown view class {:?}", name);

--- a/crates/viewer/re_viewport_blueprint/Cargo.toml
+++ b/crates/viewer/re_viewport_blueprint/Cargo.toml
@@ -18,6 +18,10 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+## Enable for testing utilities.
+testing = ["re_viewer_context/testing"]
+
 [dependencies]
 re_chunk.workspace = true
 re_chunk_store.workspace = true

--- a/crates/viewer/re_viewport_blueprint/src/lib.rs
+++ b/crates/viewer/re_viewport_blueprint/src/lib.rs
@@ -5,6 +5,8 @@
 mod auto_layout;
 mod container;
 mod entity_add_info;
+#[cfg(feature = "testing")]
+pub mod test_context_ext;
 pub mod ui;
 mod view;
 mod view_contents;

--- a/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
+++ b/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
@@ -1,0 +1,100 @@
+use ahash::HashMap;
+
+use re_viewer_context::{test_context::TestContext, Contents, ViewClassExt, ViewerContext};
+
+use crate::ViewportBlueprint;
+
+/// Extension trait to [`TestContext`] for blueprint-related features.
+pub trait TestContextExt {
+    /// See docstring on the implementation below.
+    fn setup_viewport_blueprint(
+        &mut self,
+        setup_blueprint: impl FnOnce(&ViewerContext<'_>, &mut ViewportBlueprint),
+    );
+}
+
+impl TestContextExt for TestContext {
+    /// Inspect or update the blueprint of a [`TestContext`].
+    ///
+    /// This helper works by deserializing the current blueprint, providing it to the provided
+    /// closure, and saving it back to the blueprint store. The closure should call the appropriate
+    /// methods of [`ViewportBlueprint`] to inspect and/or create views and containers as required.
+    ///
+    /// Each time [`setup_viewport_blueprint`], it entirely recomputes the "query results", i.e.,
+    /// the [`re_viewer_context::DataResult`]s that each view contains, based on the current content
+    /// of the recording store.
+    ///
+    /// Important pre-requisite:
+    /// - The view classes used by view must be already registered (see
+    ///   [`TestContext::register_view_class`]).
+    /// - The data store must be already populated for the views to have any content (see, e.g.,
+    ///   [`TestContext::log_entity`]).
+    ///
+    fn setup_viewport_blueprint(
+        &mut self,
+        setup_blueprint: impl FnOnce(&ViewerContext<'_>, &mut ViewportBlueprint),
+    ) {
+        let mut setup_blueprint: Option<_> = Some(setup_blueprint);
+
+        egui::__run_test_ctx(|egui_ctx| {
+            // We use `take` to ensure that the blueprint is setup only once, since egui forces
+            // us to a `FnMut` closure.
+            if let Some(setup_blueprint) = setup_blueprint.take() {
+                self.run(egui_ctx, |ctx| {
+                    let mut viewport_blueprint = ViewportBlueprint::try_from_db(
+                        &self.blueprint_store,
+                        &self.blueprint_query,
+                    );
+                    setup_blueprint(ctx, &mut viewport_blueprint);
+                    viewport_blueprint.save_to_blueprint_store(ctx);
+                });
+
+                self.handle_system_commands();
+
+                // Reload the blueprint store and execute all view queries.
+                let viewport_blueprint =
+                    ViewportBlueprint::try_from_db(&self.blueprint_store, &self.blueprint_query);
+
+                let applicable_entities_per_visualizer = self
+                    .view_class_registry
+                    .applicable_entities_for_visualizer_systems(&self.recording_store.store_id());
+                let mut query_results = HashMap::default();
+
+                self.run(egui_ctx, |ctx| {
+                    viewport_blueprint.visit_contents(&mut |contents, _| {
+                        if let Contents::View(view_id) = contents {
+                            let view_blueprint = viewport_blueprint.view(view_id).unwrap();
+                            let class_identifier = view_blueprint.class_identifier();
+
+                            let data_query_result = {
+                                let visualizable_entities = ctx
+                                    .view_class_registry
+                                    .get_class_or_log_error(class_identifier)
+                                    .determine_visualizable_entities(
+                                        &applicable_entities_per_visualizer,
+                                        ctx.recording(),
+                                        &ctx.view_class_registry
+                                            .new_visualizer_collection(class_identifier),
+                                        &view_blueprint.space_origin,
+                                    );
+
+                                view_blueprint.contents.execute_query(
+                                    ctx.store_context,
+                                    ctx.view_class_registry,
+                                    ctx.blueprint_query,
+                                    *view_id,
+                                    &visualizable_entities,
+                                )
+                            };
+                            query_results.insert(*view_id, data_query_result);
+                        }
+
+                        true
+                    })
+                });
+
+                self.query_results = query_results;
+            }
+        });
+    }
+}

--- a/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
+++ b/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
@@ -20,9 +20,9 @@ impl TestContextExt for TestContext {
     /// closure, and saving it back to the blueprint store. The closure should call the appropriate
     /// methods of [`ViewportBlueprint`] to inspect and/or create views and containers as required.
     ///
-    /// Each time [`setup_viewport_blueprint`] is called, it entirely recomputes the "query
-    /// results", i.e., the [`re_viewer_context::DataResult`]s that each view contains, based on the
-    /// current content of the recording store.
+    /// Each time [`TestContextExt::setup_viewport_blueprint`] is called, it entirely recomputes the
+    /// "query results", i.e., the [`re_viewer_context::DataResult`]s that each view contains, based
+    /// on the current content of the recording store.
     ///
     /// Important pre-requisite:
     /// - The view classes used by view must be already registered (see

--- a/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
+++ b/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
@@ -63,7 +63,9 @@ impl TestContextExt for TestContext {
                 self.run(egui_ctx, |ctx| {
                     viewport_blueprint.visit_contents(&mut |contents, _| {
                         if let Contents::View(view_id) = contents {
-                            let view_blueprint = viewport_blueprint.view(view_id).unwrap();
+                            let view_blueprint = viewport_blueprint
+                                .view(view_id)
+                                .expect("view is known to exist");
                             let class_identifier = view_blueprint.class_identifier();
 
                             let data_query_result = {
@@ -90,7 +92,7 @@ impl TestContextExt for TestContext {
                         }
 
                         true
-                    })
+                    });
                 });
 
                 self.query_results = query_results;

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -148,7 +148,7 @@ impl ViewBlueprint {
 
         let space_env = EntityPathSubs::new_with_origin(&space_origin);
 
-        let content =
+        let contents =
             ViewContents::from_db_or_default(id, blueprint_db, query, class_identifier, &space_env);
         let visible = visible.map_or(true, |v| *v.0);
         let defaults_path = id.as_entity_path().join(&"defaults".into());
@@ -158,7 +158,7 @@ impl ViewBlueprint {
             display_name,
             class_identifier,
             space_origin,
-            contents: content,
+            contents,
             visible,
             defaults_path,
             pending_writes: Default::default(),

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -26,6 +26,7 @@ impl From<ViewPropertyQueryError> for ViewSystemExecutionError {
 }
 
 /// Utility for querying view properties.
+#[derive(Debug)]
 pub struct ViewProperty {
     /// Entity path in the blueprint store where all components of this view property archetype are
     /// stored.


### PR DESCRIPTION
### Related

- Part of #8586
- Part of a series of PR:
  - #8645
  - #8652
  - #8654
  - #8672
  - #8706
  - #8728
  - …


### What

This PR adds snapshot tests for the blueprint tree. It includes several improvements to the testing rig, such that those test are now quite compact. The graph view test is simplified to benefit from these changes.
