### PR TITLE
Draw nodes above edges in graph view

### DIFF
--- a/crates/viewer/re_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_view_graph/src/ui/draw.rs
@@ -338,6 +338,13 @@ pub fn draw_graph(
     // For now we compute the entity rectangles on the fly.
     let mut current_rect = egui::Rect::NOTHING;
 
+    for (_, geometries) in layout.edges() {
+        for geometry in geometries {
+            let response = draw_edge(ui, geometry, geometry.target_arrow);
+            current_rect = current_rect.union(response.rect);
+        }
+    }
+
     for node in graph.nodes() {
         let center = layout.get_node(&node.id()).unwrap_or(Rect::ZERO).center();
 
@@ -389,13 +396,6 @@ pub fn draw_graph(
         };
 
         current_rect = current_rect.union(response.rect);
-    }
-
-    for (_, geometries) in layout.edges() {
-        for geometry in geometries {
-            let response = draw_edge(ui, geometry, geometry.target_arrow);
-            current_rect = current_rect.union(response.rect);
-        }
     }
 
     // We only show entity rects if there are multiple entities.


### PR DESCRIPTION
### Related

* Closes #8737 

### What

This changes the drawing order of graph nodes and edges so that nodes are always on top:

| Before | After |
|--------| ------|
| <img width="401" alt="image" src="https://github.com/user-attachments/assets/fb65125d-e87b-4106-bb8a-02041394b528" /> | <img width="401" alt="image" src="https://github.com/user-attachments/assets/d4eaf199-369f-410b-b3e2-06f29966408a" /> |

