### PR TITLE
Store: get rid of `query_id`

### DIFF
--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -350,7 +350,6 @@ impl ChunkStore {
                 static_chunk_ids_per_entity: _, // we don't GC static data
                 static_chunks_stats: _,         // we don't GC static data
                 insert_id: _,
-                query_id: _,
                 gc_id: _,
                 event_id: _,
             } = self;

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::BTreeSet,
-    sync::{atomic::Ordering, Arc},
-};
+use std::{collections::BTreeSet, sync::Arc};
 
 use itertools::Itertools;
 use nohash_hasher::IntSet;
@@ -116,8 +113,6 @@ impl ChunkStore {
     ) -> Option<UnorderedComponentNameSet> {
         re_tracing::profile_function!();
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         let static_components: Option<UnorderedComponentNameSet> = self
             .static_chunk_ids_per_entity
             .get(entity_path)
@@ -160,8 +155,6 @@ impl ChunkStore {
     ) -> Option<ComponentNameSet> {
         re_tracing::profile_function!();
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         let static_components: Option<ComponentNameSet> = self
             .static_chunk_ids_per_entity
             .get(entity_path)
@@ -202,8 +195,6 @@ impl ChunkStore {
     ) -> Option<UnorderedComponentNameSet> {
         re_tracing::profile_function!();
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         let static_components: Option<UnorderedComponentNameSet> = self
             .static_chunk_ids_per_entity
             .get(entity_path)
@@ -242,8 +233,6 @@ impl ChunkStore {
         entity_path: &EntityPath,
     ) -> Option<ComponentNameSet> {
         re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         let static_components: Option<ComponentNameSet> = self
             .static_chunk_ids_per_entity
@@ -314,8 +303,6 @@ impl ChunkStore {
     ) -> bool {
         // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         self.static_chunk_ids_per_entity
             .get(entity_path)
             .is_some_and(|static_chunk_ids_per_component| {
@@ -333,8 +320,6 @@ impl ChunkStore {
         component_name: &ComponentName,
     ) -> bool {
         // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         self.temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
@@ -356,8 +341,6 @@ impl ChunkStore {
         component_name: &ComponentName,
     ) -> bool {
         // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         self.temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
@@ -405,8 +388,6 @@ impl ChunkStore {
     pub fn entity_has_static_data(&self, entity_path: &EntityPath) -> bool {
         // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         self.static_chunk_ids_per_entity
             .get(entity_path)
             .is_some_and(|static_chunk_ids_per_component| {
@@ -423,8 +404,6 @@ impl ChunkStore {
     #[inline]
     pub fn entity_has_temporal_data(&self, entity_path: &EntityPath) -> bool {
         // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         self.temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
@@ -451,8 +430,6 @@ impl ChunkStore {
         entity_path: &EntityPath,
     ) -> bool {
         // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         self.temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
@@ -506,8 +483,6 @@ impl ChunkStore {
     ) -> Option<ResolvedTimeRange> {
         re_tracing::profile_function!();
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         let temporal_chunk_ids_per_timeline =
             self.temporal_chunk_ids_per_entity.get(entity_path)?;
         let chunk_id_sets = temporal_chunk_ids_per_timeline.get(timeline)?;
@@ -524,8 +499,6 @@ impl ChunkStore {
     /// This ignores static data.
     pub fn time_range(&self, timeline: &Timeline) -> Option<ResolvedTimeRange> {
         re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         self.temporal_chunk_ids_per_entity
             .values()
@@ -620,8 +593,6 @@ impl ChunkStore {
     ) -> Vec<Arc<Chunk>> {
         re_tracing::profile_function!(format!("{query:?}"));
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         let chunks = self
             .temporal_chunk_ids_per_entity
             .get(entity_path)
@@ -711,8 +682,6 @@ impl ChunkStore {
     ) -> Vec<Arc<Chunk>> {
         re_tracing::profile_function!(format!("{query:?}"));
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         if let Some(static_chunk) = self
             .static_chunk_ids_per_entity
             .get(entity_path)
@@ -777,8 +746,6 @@ impl ChunkStore {
         entity_path: &EntityPath,
     ) -> Vec<Arc<Chunk>> {
         re_tracing::profile_function!(format!("{query:?}"));
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         let chunks = self
             .range(

--- a/crates/store/re_chunk_store/src/stats.rs
+++ b/crates/store/re_chunk_store/src/stats.rs
@@ -1,4 +1,4 @@
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::Arc;
 
 use re_byte_size::SizeBytes;
 use re_chunk::{Chunk, ComponentName, EntityPath, Timeline};
@@ -216,8 +216,6 @@ impl ChunkStore {
     pub fn entity_stats_static(&self, entity_path: &EntityPath) -> ChunkStoreChunkStats {
         re_tracing::profile_function!();
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         self.static_chunk_ids_per_entity.get(entity_path).map_or(
             ChunkStoreChunkStats::default(),
             |static_chunks_per_component| {
@@ -242,8 +240,6 @@ impl ChunkStore {
         timeline: &Timeline,
     ) -> ChunkStoreChunkStats {
         re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         self.temporal_chunk_ids_per_entity
             .get(entity_path)
@@ -277,8 +273,6 @@ impl ChunkStore {
     ) -> u64 {
         re_tracing::profile_function!();
 
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
         self.static_chunk_ids_per_entity
             .get(entity_path)
             .and_then(|static_chunks_per_component| {
@@ -299,8 +293,6 @@ impl ChunkStore {
         component_name: ComponentName,
     ) -> u64 {
         re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
 
         self.temporal_chunk_ids_per_entity_per_component
             .get(entity_path)

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -458,9 +458,6 @@ pub struct ChunkStore {
     /// Monotonically increasing ID for insertions.
     pub(crate) insert_id: u64,
 
-    /// Monotonically increasing ID for queries.
-    pub(crate) query_id: AtomicU64,
-
     /// Monotonically increasing ID for GCs.
     pub(crate) gc_id: u64,
 
@@ -487,7 +484,6 @@ impl Clone for ChunkStore {
             static_chunk_ids_per_entity: self.static_chunk_ids_per_entity.clone(),
             static_chunks_stats: self.static_chunks_stats,
             insert_id: Default::default(),
-            query_id: Default::default(),
             gc_id: Default::default(),
             event_id: Default::default(),
         }
@@ -510,7 +506,6 @@ impl std::fmt::Display for ChunkStore {
             static_chunk_ids_per_entity: _,
             static_chunks_stats,
             insert_id: _,
-            query_id: _,
             gc_id: _,
             event_id: _,
         } = self;
@@ -572,7 +567,6 @@ impl ChunkStore {
             static_chunk_ids_per_entity: Default::default(),
             static_chunks_stats: Default::default(),
             insert_id: 0,
-            query_id: AtomicU64::new(0),
             gc_id: 0,
             event_id: AtomicU64::new(0),
         }

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -566,7 +566,6 @@ impl ChunkStore {
             static_chunk_ids_per_entity,
             static_chunks_stats,
             insert_id: _,
-            query_id: _,
             gc_id: _,
             event_id,
         } = self;


### PR DESCRIPTION
We haven't used `query_id` for anything in ages, and as such its implementation has bitrotted into inconsistency, and now it's unreliable.

Get rid of it.