### PR TITLE
fix clippy::unwrap_used in re_viewer with Option::expect

### DIFF
--- a/crates/viewer/re_viewer/src/app_blueprint.rs
+++ b/crates/viewer/re_viewer/src/app_blueprint.rs
@@ -197,11 +197,11 @@ pub fn setup_welcome_screen_blueprint(welcome_screen_blueprint: &mut EntityDb) {
         let chunk = Chunk::builder(entity_path)
             .with_component_batches(RowId::new(), timepoint, [&value as &dyn ComponentBatch])
             .build()
-            .unwrap(); // Can only fail if we have the wrong number of instances for the component, and we don't
+            .expect("Failed to build chunk - incorrect number of instances for the component");
 
         welcome_screen_blueprint
             .add_chunk(&Arc::new(chunk))
-            .unwrap(); // Can only fail if we have the wrong number of instances for the component, and we don't
+            .expect("Failed to add new chunk for welcome screen");
     }
 }
 
@@ -222,7 +222,7 @@ impl AppBlueprint<'_> {
             let chunk = Chunk::builder(entity_path)
                 .with_component_batches(RowId::new(), timepoint, [&value as &dyn ComponentBatch])
                 .build()
-                .unwrap(); // Can only fail if we have the wrong number of instances for the component, and we don't
+                .expect("Failed to build chunk - incorrect number of instances for the component");
 
             command_sender.send_system(SystemCommand::UpdateBlueprint(
                 store_ctx.blueprint.store_id().clone(),

--- a/crates/viewer/re_viewer/src/background_tasks.rs
+++ b/crates/viewer/re_viewer/src/background_tasks.rs
@@ -60,7 +60,10 @@ impl BackgroundTasks {
         self.promises
             .remove(name.as_ref())
             .and_then(|promise| match promise.try_take() {
-                Ok(any) => Some(*any.downcast::<T>().unwrap()),
+                Ok(any) => Some(
+                    *any.downcast::<T>()
+                        .unwrap_or_else(|err| panic!("downcast failure: {err:?}")),
+                ),
                 Err(promise) => {
                     self.promises.insert(name.as_ref().to_owned(), promise);
                     None

--- a/crates/viewer/re_viewer/src/background_tasks.rs
+++ b/crates/viewer/re_viewer/src/background_tasks.rs
@@ -62,7 +62,7 @@ impl BackgroundTasks {
             .and_then(|promise| match promise.try_take() {
                 Ok(any) => Some(
                     *any.downcast::<T>()
-                        .unwrap_or_else(|err| panic!("downcast failure: {err:?}")),
+                        .expect("Downcast failure in poll_promise"),
                 ),
                 Err(promise) => {
                     self.promises.insert(name.as_ref().to_owned(), promise);

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -3,9 +3,6 @@
 //! This crate contains all the GUI code for the Rerun Viewer,
 //! including all 2D and 3D visualization code.
 
-// TODO(#6330): remove unwrap()
-#![allow(clippy::unwrap_used)]
-
 mod app;
 mod app_blueprint;
 mod app_state;
@@ -243,7 +240,7 @@ pub fn wake_up_ui_thread_on_each_msg<T: Send + 'static>(
             }
             re_log::trace!("Shutting down ui_waker thread");
         })
-        .unwrap();
+        .expect("Failed to spawn UI waker thread");
     new_rx
 }
 

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use egui::{hex_color, Ui};
 
 use re_ui::UiExt as _;
 
@@ -56,7 +56,7 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
         if ui
             .button(
                 egui::RichText::new("Go to documentation →")
-                    .color(egui::Color32::from_hex("#60A0FF").expect("this color is valid"))
+                    .color(hex_color!("#60A0FF"))
                     .text_style(re_ui::DesignTokens::welcome_screen_body()),
             )
             .on_hover_cursor(egui::CursorIcon::PointingHand)


### PR DESCRIPTION
### Related

Part of: #6330

### What

- remove allow directive & TODO comment from `crates/viewer/re_viewer/src/lib.rs`
- use `. unwrap_or_else` with panic in 1 case
- use focused `#[allow(clippy::unwrap_used)]` directives in limited, focused cases
- use `.expect` with descriptive messages in all other cases

(no changelog updates)

__General rationale:__

Most of the cases using `.unwrap` seem to need these to work. I think the best solution is to use `.expect` with a clear message in most of these cases.

__Sanity checks done:__

These succeed for me with no warnings:

- `cargo clippy -p re_viewer --all-features`
- `cargo build -p re_viewer --all-features`
- `cargo fmt` does not introduce inconsistent formatting of the updated code