### PR TITLE
Use serde to encode arrow datatype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
 dependencies = [
  "bitflags 2.6.0",
+ "serde",
 ]
 
 [[package]]
@@ -5747,6 +5748,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "arrow",
+ "arrow-schema",
  "criterion",
  "document-features",
  "indent",
@@ -5768,6 +5770,7 @@ dependencies = [
  "re_tracing",
  "re_types",
  "re_types_core",
+ "serde_json",
  "similar-asserts",
  "thiserror 1.0.65",
  "tinyvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ anyhow = { version = "1.0", default-features = false }
 argh = "0.1.12"
 array-init = "2.1"
 arrow = { version = "53.4", default-features = false }
+arrow-schema = { version = "53.4", default-features = false }
 arrow2 = { package = "re_arrow2", version = "0.18", features = ["arrow"] }
 async-executor = "1.0"
 backtrace = "0.3"

--- a/crates/store/re_chunk_store/Cargo.toml
+++ b/crates/store/re_chunk_store/Cargo.toml
@@ -18,6 +18,12 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[package.metadata.cargo-machete]
+ignored = [
+  # Needed to enable the serde feature of arrow `Datatype`
+  "arrow-schema",
+]
+
 
 [features]
 default = []
@@ -43,12 +49,14 @@ re_types_core.workspace = true
 ahash.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
+arrow-schema = { workspace = true, features = ["serde"] }
 document-features.workspace = true
 indent.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true
 parking_lot = { workspace = true, features = ["arc_lock"] }
+serde_json.workspace = true
 thiserror.workspace = true
 web-time.workspace = true
 

--- a/crates/store/re_protos/proto/rerun/v0/common.proto
+++ b/crates/store/re_protos/proto/rerun/v0/common.proto
@@ -94,7 +94,7 @@ message Query {
 
     // The specific _columns_ to sample from the final view contents.
     // The order of the samples will be respected in the final result.
-    ///
+    //
     // If unspecified, it means - everything.
     ColumnSelection column_selection = 10;
 
@@ -113,9 +113,8 @@ message TimeColumnDescriptor {
     // The timeline this column is associated with.
     Timeline timeline = 1;
     // The Arrow datatype of the column.
-    ///
-    // Currently this is just the `Display` of the `arrow-rs` `DataType`.
-    // TODO(emilk): use arrow IPC instead.
+    //
+    // Currently this is a JSON-encoded `arrow-rs` `DataType`.
     string datatype = 2;
 }
 
@@ -130,9 +129,8 @@ message ComponentColumnDescriptor {
     // Semantic name associated with this data.
     string component_name = 4;
     // The Arrow datatype of the column.
-    ///
-    // Currently this is just the `Display` of the `arrow-rs` `DataType`.
-    // TODO(emilk): use arrow IPC instead.
+    //
+    // Currently this is a JSON-encoded `arrow-rs` `DataType`.
     string datatype = 5;
     // Whether the column is a static column.
     bool is_static = 6;

--- a/crates/store/re_protos/src/v0/rerun.common.v0.rs
+++ b/crates/store/re_protos/src/v0/rerun.common.v0.rs
@@ -142,7 +142,7 @@ pub struct Query {
     pub filtered_is_not_null: ::core::option::Option<ComponentColumnSelector>,
     /// The specific _columns_ to sample from the final view contents.
     /// The order of the samples will be respected in the final result.
-    /// /
+    ///
     /// If unspecified, it means - everything.
     #[prost(message, optional, tag = "10")]
     pub column_selection: ::core::option::Option<ColumnSelection>,
@@ -191,9 +191,8 @@ pub struct TimeColumnDescriptor {
     #[prost(message, optional, tag = "1")]
     pub timeline: ::core::option::Option<Timeline>,
     /// The Arrow datatype of the column.
-    /// /
-    /// Currently this is just the `Display` of the `arrow-rs` `DataType`.
-    /// TODO(emilk): use arrow IPC instead.
+    ///
+    /// Currently this is a JSON-encoded `arrow-rs` `DataType`.
     #[prost(string, tag = "2")]
     pub datatype: ::prost::alloc::string::String,
 }
@@ -223,9 +222,8 @@ pub struct ComponentColumnDescriptor {
     #[prost(string, tag = "4")]
     pub component_name: ::prost::alloc::string::String,
     /// The Arrow datatype of the column.
-    /// /
-    /// Currently this is just the `Display` of the `arrow-rs` `DataType`.
-    /// TODO(emilk): use arrow IPC instead.
+    ///
+    /// Currently this is a JSON-encoded `arrow-rs` `DataType`.
     #[prost(string, tag = "5")]
     pub datatype: ::prost::alloc::string::String,
     /// Whether the column is a static column.


### PR DESCRIPTION
### Related
* https://github.com/rerun-io/rerun/pull/8719

Apparently `arrow::Datatype::to_string/parse` doesn't roundtrip, despite claiming so. Let's hope serde/json works better.

We probably want to replace the whole of `crates/store/re_protos/proto/rerun/v0/common.proto` with just a IPC-encoded RecordBath at some point, but not today.