### PR TITLE
Handle static transforms in the transform cache & add tests for these cases

### DIFF
--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -287,7 +287,7 @@ impl TransformCacheStoreSubscriber {
                 .or_insert_with(|| TransformsForEntity::new(None, None));
 
             // Technically this doesn't query static components but rather just what's at the beginning of the tick timeline,
-            // but it's the most convenient way to the the data we want.
+            // but it's the most convenient way to the data we want.
             let query = LatestAtQuery::new(Timeline::log_tick(), TimeInt::MIN);
 
             if aspects.contains(TransformAspect::Tree) {
@@ -826,7 +826,7 @@ mod tests {
     use super::*;
 
     #[derive(Debug, Clone, Copy)]
-    enum StaticTestFlavour {
+    enum StaticTestFlavor {
         /// First log a static chunk and then a regular chunk.
         StaticThenRegular { update_inbetween: bool },
 
@@ -838,23 +838,23 @@ mod tests {
         PriorStaticThenRegularThenStatic { update_inbetween: bool },
     }
 
-    const ALL_STATIC_TEST_FLAVOURS: [StaticTestFlavour; 6] = [
-        StaticTestFlavour::StaticThenRegular {
+    const ALL_STATIC_TEST_FLAVOURS: [StaticTestFlavor; 6] = [
+        StaticTestFlavor::StaticThenRegular {
             update_inbetween: true,
         },
-        StaticTestFlavour::RegularThenStatic {
+        StaticTestFlavor::RegularThenStatic {
             update_inbetween: true,
         },
-        StaticTestFlavour::PriorStaticThenRegularThenStatic {
+        StaticTestFlavor::PriorStaticThenRegularThenStatic {
             update_inbetween: true,
         },
-        StaticTestFlavour::StaticThenRegular {
+        StaticTestFlavor::StaticThenRegular {
             update_inbetween: false,
         },
-        StaticTestFlavour::RegularThenStatic {
+        StaticTestFlavor::RegularThenStatic {
             update_inbetween: false,
         },
-        StaticTestFlavour::PriorStaticThenRegularThenStatic {
+        StaticTestFlavor::PriorStaticThenRegularThenStatic {
             update_inbetween: false,
         },
     ];
@@ -863,16 +863,16 @@ mod tests {
         prior_static_chunk: Chunk,
         final_static_chunk: Chunk,
         regular_chunk: Chunk,
-        flavour: StaticTestFlavour,
+        flavor: StaticTestFlavor,
     ) -> EntityDb {
-        // Print the flavour to its shown on test failure.
-        println!("{:?}", flavour);
+        // Print the flavor to its shown on test failure.
+        println!("{flavor:?}");
 
         let mut entity_db = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         ensure_subscriber_registered(&entity_db);
 
-        match flavour {
-            StaticTestFlavour::StaticThenRegular { update_inbetween } => {
+        match flavor {
+            StaticTestFlavor::StaticThenRegular { update_inbetween } => {
                 entity_db.add_chunk(&Arc::new(final_static_chunk)).unwrap();
                 if update_inbetween {
                     TransformCacheStoreSubscriber::access_mut(&entity_db.store_id(), |cache| {
@@ -882,7 +882,7 @@ mod tests {
                 entity_db.add_chunk(&Arc::new(regular_chunk)).unwrap();
             }
 
-            StaticTestFlavour::RegularThenStatic { update_inbetween } => {
+            StaticTestFlavor::RegularThenStatic { update_inbetween } => {
                 entity_db.add_chunk(&Arc::new(regular_chunk)).unwrap();
                 if update_inbetween {
                     TransformCacheStoreSubscriber::access_mut(&entity_db.store_id(), |cache| {
@@ -892,7 +892,7 @@ mod tests {
                 entity_db.add_chunk(&Arc::new(final_static_chunk)).unwrap();
             }
 
-            StaticTestFlavour::PriorStaticThenRegularThenStatic { update_inbetween } => {
+            StaticTestFlavor::PriorStaticThenRegularThenStatic { update_inbetween } => {
                 entity_db.add_chunk(&Arc::new(prior_static_chunk)).unwrap();
                 entity_db.add_chunk(&Arc::new(regular_chunk)).unwrap();
                 if update_inbetween {
@@ -961,7 +961,7 @@ mod tests {
 
     #[test]
     fn test_static_tree_transforms() {
-        for flavour in &ALL_STATIC_TEST_FLAVOURS {
+        for flavor in &ALL_STATIC_TEST_FLAVOURS {
             // Log a few tree transforms at different times.
             let timeline = Timeline::new_sequence("t");
             let prior_static_chunk =
@@ -998,7 +998,7 @@ mod tests {
                 prior_static_chunk,
                 final_static_chunk,
                 regular_chunk,
-                *flavour,
+                *flavor,
             );
 
             // Check that the transform cache has the expected transforms.
@@ -1047,7 +1047,7 @@ mod tests {
 
     #[test]
     fn test_static_pose_transforms() {
-        for flavour in &ALL_STATIC_TEST_FLAVOURS {
+        for flavor in &ALL_STATIC_TEST_FLAVOURS {
             // Log a few tree transforms at different times.
             let timeline = Timeline::new_sequence("t");
             let prior_static_chunk =
@@ -1084,7 +1084,7 @@ mod tests {
                 prior_static_chunk,
                 final_static_chunk,
                 regular_chunk,
-                *flavour,
+                *flavor,
             );
 
             // Check that the transform cache has the expected transforms.
@@ -1146,7 +1146,7 @@ mod tests {
 
     #[test]
     fn test_static_pinhole_projection() {
-        for flavour in &ALL_STATIC_TEST_FLAVOURS {
+        for flavor in &ALL_STATIC_TEST_FLAVOURS {
             let image_from_camera_prior =
                 components::PinholeProjection::from_focal_length_and_principal_point(
                     [123.0, 123.0],
@@ -1191,7 +1191,7 @@ mod tests {
                 prior_static_chunk,
                 final_static_chunk,
                 regular_chunk,
-                *flavour,
+                *flavor,
             );
 
             // Check that the transform cache has the expected transforms.
@@ -1240,7 +1240,7 @@ mod tests {
 
     #[test]
     fn test_static_view_coordinates_projection() {
-        for flavour in &ALL_STATIC_TEST_FLAVOURS {
+        for flavor in &ALL_STATIC_TEST_FLAVOURS {
             let image_from_camera =
                 components::PinholeProjection::from_focal_length_and_principal_point(
                     [1.0, 2.0],
@@ -1280,7 +1280,7 @@ mod tests {
                 prior_static_chunk,
                 final_static_chunk,
                 regular_chunk,
-                *flavour,
+                *flavor,
             );
 
             // Check that the transform cache has the expected transforms.

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -201,7 +201,9 @@ impl TransformsForEntity {
 
     #[inline]
     pub fn latest_at_tree_transform(&self, query: &LatestAtQuery) -> Affine3A {
+        #[cfg(debug_assertions)] // `self.timeline` is only present with `debug_assertions` enabled.
         debug_assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
+
         self.tree_transforms
             .range(..query.at().inc())
             .next_back()
@@ -211,7 +213,9 @@ impl TransformsForEntity {
 
     #[inline]
     pub fn latest_at_instance_poses(&self, query: &LatestAtQuery) -> &[Affine3A] {
+        #[cfg(debug_assertions)] // `self.timeline` is only present with `debug_assertions` enabled.
         debug_assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
+
         self.pose_transforms
             .as_ref()
             .and_then(|pose_transforms| pose_transforms.range(..query.at().inc()).next_back())
@@ -221,7 +225,9 @@ impl TransformsForEntity {
 
     #[inline]
     pub fn latest_at_pinhole(&self, query: &LatestAtQuery) -> Option<&ResolvedPinholeProjection> {
+        #[cfg(debug_assertions)] // `self.timeline` is only present with `debug_assertions` enabled.
         debug_assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
+
         self.pinhole_projections
             .as_ref()
             .and_then(|pinhole_projections| {

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -90,7 +90,7 @@ bitflags::bitflags! {
 
 /// Points in time that have changed for a given entity,
 /// i.e. the cache is invalid for these times.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct InvalidatedTransforms {
     entity_path: EntityPath,
     times: Vec<TimeInt>,
@@ -112,7 +112,9 @@ pub struct CachedTransformsForTimeline {
 impl CachedTransformsForTimeline {
     fn new(timeline: &Timeline, static_transforms: &Self) -> Self {
         Self {
-            invalidated_transforms: Default::default(),
+            // It's crucial to take over any invalidated transform events from the static timeline,
+            // otherwise we'd miss any pending static transforms that should ALSO be added to this timeline.
+            invalidated_transforms: static_transforms.invalidated_transforms.clone(),
             per_entity: static_transforms
                 .per_entity
                 .iter()

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -286,9 +286,14 @@ impl TransformCacheStoreSubscriber {
                 // into that entity for static transforms.
                 .or_insert_with(|| TransformsForEntity::new(None, None));
 
-            // Technically this doesn't query static components but rather just what's at the beginning of the tick timeline,
+            // Technically this doesn't query static components but rather just what's at the beginning of this arbitrary timeline,
             // but it's the most convenient way to the data we want.
-            let query = LatestAtQuery::new(Timeline::log_tick(), TimeInt::MIN);
+            let query = LatestAtQuery::new(
+                Timeline::new_sequence(
+                    "placeholder timeline (only actually interested in static components)",
+                ),
+                TimeInt::MIN,
+            );
 
             if aspects.contains(TransformAspect::Tree) {
                 if let Some(transform) =

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -458,11 +458,11 @@ impl TransformCacheStoreSubscriber {
                 // All of these require complex latest-at queries that would require a lot more context,
                 // are fairly expensive, and may depend on other components that may come in at the same time.
                 // (we could inject that here, but it's not entirely straight forward).
-                // So instead, we note down that the caches is invalidated for the given entity & times.
+                // So instead, we note down that the caches are invalidated for the given entity & times.
 
                 // This invalidates any time _after_ the first event in this chunk.
                 // (e.g. if a rotation is added prior to translations later on,
-                // then the resulting transforms at those translations changes as well for latest-at queries)
+                // then the resulting transforms at those translations change as well for latest-at queries)
 
                 let mut invalidated_times = Vec::new();
                 let Some(min_time) = time_column.times().min() else {

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -201,7 +201,7 @@ impl TransformsForEntity {
 
     #[inline]
     pub fn latest_at_tree_transform(&self, query: &LatestAtQuery) -> Affine3A {
-        assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
+        debug_assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
         self.tree_transforms
             .range(..query.at().inc())
             .next_back()
@@ -211,7 +211,7 @@ impl TransformsForEntity {
 
     #[inline]
     pub fn latest_at_instance_poses(&self, query: &LatestAtQuery) -> &[Affine3A] {
-        assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
+        debug_assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
         self.pose_transforms
             .as_ref()
             .and_then(|pose_transforms| pose_transforms.range(..query.at().inc()).next_back())
@@ -221,7 +221,7 @@ impl TransformsForEntity {
 
     #[inline]
     pub fn latest_at_pinhole(&self, query: &LatestAtQuery) -> Option<&ResolvedPinholeProjection> {
-        assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
+        debug_assert!(Some(query.timeline()) == self.timeline || self.timeline.is_none());
         self.pinhole_projections
             .as_ref()
             .and_then(|pinhole_projections| {


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/8723

### What

The transform cache previously ignored static transforms by accident, thus breaking some of our example scenes.

After some back and forth I decided to handle them transparently: In order to avoid additional lookups, we make sure that we add timepoints for the occurence of static chunks to our cached transform `BTreeMap`s.
The drawback of that is that..
* whenever a static transform changes there's a ripple through all existing cached transforms
* whenever someone queries a timeline we haven't seen yet, we have to present them the static transforms

The logic for all of this isn't terribly complicated, but very easy to get wrong. So this comes with a ton of new tests.