### PR TITLE
`rs-checks`: continue on failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,10 @@ rfd = { version = "0.15", default-features = false, features = [
 ] }
 rmp-serde = "1"
 ron = "0.8.0"
+roxmltree = "0.19.0"
 rust-format = "0.3"
+rustdoc-json = "0.9.2"
+rustdoc-types = "0.29.1"
 seq-macro = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"

--- a/crates/build/re_dev_tools/Cargo.toml
+++ b/crates/build/re_dev_tools/Cargo.toml
@@ -32,9 +32,9 @@ glob.workspace = true
 indicatif.workspace = true
 itertools.workspace = true
 rayon.workspace = true
-roxmltree = "0.19.0"
-rustdoc-json = "0.9.2"
-rustdoc-types = "0.29.1"
+roxmltree.workspace = true
+rustdoc-json.workspace = true
+rustdoc-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/store/re_types_core/Cargo.toml
+++ b/crates/store/re_types_core/Cargo.toml
@@ -47,7 +47,7 @@ re_tuid.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
 backtrace.workspace = true
-bytemuck.workspace = true
+bytemuck = { workspace = true, features = ["derive"] }
 document-features.workspace = true
 half.workspace = true
 itertools.workspace = true

--- a/pixi.toml
+++ b/pixi.toml
@@ -173,13 +173,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -195,7 +195,7 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --release -g"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --release -g"
 
 rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/ci/rust_checks.py", depends-on = [
   "rerun-build-web", # The checks require the web viewer wasm to be around.
@@ -239,8 +239,8 @@ py-lint = "mypy --install-types --non-interactive --no-warn-unused-ignore"
 
 rs-plot-dashboard = { cmd = "cargo r -p plot_dashboard_stress --release --" }
 
-dev-tools = "cargo run -q --locked -p re_dev_tools --"
-build-examples = "cargo run -q --locked -p re_dev_tools -- build-examples"
+dev-tools = "cargo run -q --locked --quiet -p re_dev_tools --"
+build-examples = "cargo run -q --locked --quiet -p re_dev_tools -- build-examples"
 
 # Start a local meilisearch instance at `localhost:7700` with master key `test`.
 # This should only be used for testing the search index locally.
@@ -357,7 +357,7 @@ py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends-on = [
 [feature.python-docs.tasks]
 # Build the documentation search index.
 # See `pixi run search-index --help` for more information.
-search-index = "cargo run --locked -p re_dev_tools -- search-index"
+search-index = "cargo run --locked --quiet -p re_dev_tools -- search-index"
 
 # Serve python docs locally
 py-docs-serve = "mkdocs serve -f rerun_py/mkdocs.yml -w rerun_py"

--- a/pixi.toml
+++ b/pixi.toml
@@ -239,8 +239,8 @@ py-lint = "mypy --install-types --non-interactive --no-warn-unused-ignore"
 
 rs-plot-dashboard = { cmd = "cargo r -p plot_dashboard_stress --release --" }
 
-dev-tools = "cargo run -q --locked --quiet -p re_dev_tools --"
-build-examples = "cargo run -q --locked --quiet -p re_dev_tools -- build-examples"
+dev-tools = "cargo run --quiet --locked -p re_dev_tools --"
+build-examples = "cargo run --quiet --locked -p re_dev_tools -- build-examples"
 
 # Start a local meilisearch instance at `localhost:7700` with master key `test`.
 # This should only be used for testing the search index locally.

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -137,15 +137,19 @@ def main() -> None:
     # NOTE: a lot of these jobs use very little CPU, but we cannot parallelize them because they all take a lock on the `target` directory.
 
     results: list[Result] = []
+    start_time = time.time()
 
     for enabled_check_name in enabled_check_names:
         checks[check_names.index(enabled_check_name)][1](results)
+
+    time.time() - start_time
 
     # ----------------------
 
     # Print timings overview
     print("-----------------")
-    print("Timings:")
+    print("Ran {len(results)} checks in {total_duration:.0f}s")
+    print("Individual timings, slowest first:")
     results.sort(key=lambda result: result.duration, reverse=True)
     for result in results:
         print(f"{result.duration:.2f}s \t {result.command}")

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -148,7 +148,7 @@ def main() -> None:
 
     # Print timings overview
     print("-----------------")
-    print("Ran {len(results)} checks in {total_duration:.0f}s")
+    print(f"Ran {len(results)} checks in {total_duration:.0f}s")
     print("Individual timings, slowest first:")
     results.sort(key=lambda result: result.duration, reverse=True)
     for result in results:


### PR DESCRIPTION
When we run our rust checks, we no longer stop after the first failure. This means that if there are more than one failure, we can see them all in the CI output, and fix them all in one go.

See commit messages for details

Example output (partial):

![image](https://github.com/user-attachments/assets/22e87c10-80c5-4ba3-aae6-a5fc0fca9014)

…

![image](https://github.com/user-attachments/assets/5a2e2a19-3877-46d1-8993-47f578e821ec)
