### PR TITLE
fix machine name on rust contributor ci

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -94,7 +94,7 @@ jobs:
   rs-lints:
     name: Rust lints (fmt, check, clippy, tests, doc)
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
-    runs-on: ubuntu-22.04-16core
+    runs-on: ubuntu-22.04-large
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
