### PR TITLE
Remove `attr.cpp.archetype_eager` codegen attribute

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -587,11 +587,6 @@ impl QuotedObject {
             let field_type = quote_archetype_unserialized_type(&mut hpp_includes, obj_field);
             let descriptor = archetype_component_descriptor_constant_ident(obj_field);
 
-            // TODO: Haven't tested this again since introducing eager serialization.
-            hpp_includes.insert_rerun("compiler_utils.hpp");
-            let gcc_ignore_comment =
-                quote_comment("See: https://github.com/rerun-io/rerun/issues/4027");
-
             methods.push(Method {
                     docs: obj_field.docs.clone().into(),
                     declaration: MethodDeclaration {
@@ -604,8 +599,7 @@ impl QuotedObject {
                     definition_body: quote! {
                         #field_ident = ComponentBatch::from_loggable(#parameter_ident, #descriptor).value_or_throw();
                         #NEWLINE_TOKEN
-                        #gcc_ignore_comment
-                        RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+                        return std::move(*this);
                     },
                     inline: true,
                 });

--- a/crates/build/re_types_builder/src/lib.rs
+++ b/crates/build/re_types_builder/src/lib.rs
@@ -194,7 +194,6 @@ pub const ATTR_RERUN_EXPERIMENTAL: &str = "attr.rerun.experimental";
 pub const ATTR_PYTHON_ALIASES: &str = "attr.python.aliases";
 pub const ATTR_PYTHON_ARRAY_ALIASES: &str = "attr.python.array_aliases";
 
-pub const ATTR_CPP_ARCHETYPE_EAGER: &str = "attr.cpp.archetype_eager";
 pub const ATTR_CPP_NO_DEFAULT_CTOR: &str = "attr.cpp.no_default_ctor";
 pub const ATTR_CPP_NO_FIELD_CTORS: &str = "attr.cpp.no_field_ctors";
 pub const ATTR_CPP_RENAME_FIELD: &str = "attr.cpp.rename_field";

--- a/crates/store/re_types/definitions/attributes/cpp.fbs
+++ b/crates/store/re_types/definitions/attributes/cpp.fbs
@@ -11,9 +11,3 @@ attribute "attr.cpp.no_default_ctor";
 /// Changes the name of a field in the generated C++ code.
 /// This can be used to avoid name clashes with C++ keywords or methods.
 attribute "attr.cpp.rename_field";
-
-/// The generated C++ object should be eagerly serialized, i.e. only comprised of Arrow arrays.
-///
-/// Applies only to archetypes. No-op otherwise.
-// TODO(#7245): This should be always enabled.
-attribute "attr.cpp.archetype_eager";

--- a/crates/store/re_types/definitions/rerun/archetypes/annotation_context.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/annotation_context.fbs
@@ -16,7 +16,6 @@ namespace rerun.archetypes;
 /// \example archetypes/annotation_context_connections !api title="Connections" image="https://static.rerun.io/annotation_context_connections/4a8422bc154699c5334f574ff01b55c5cd1748e3/1200w.png"
 table AnnotationContext (
   // TODO(#7245): "attr.rust.archetype_eager",
-  "attr.cpp.archetype_eager",
   "attr.rust.derive": "Eq, PartialEq",
   "attr.docs.view_types": "Spatial2DView, Spatial3DView"
 ) {

--- a/crates/store/re_types/definitions/rerun/archetypes/arrows2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/arrows2d.fbs
@@ -8,7 +8,6 @@ namespace rerun.archetypes;
 /// \example archetypes/arrows2d_simple title="Simple batch of 2D arrows" image="https://static.rerun.io/arrow2d_simple/59f044ccc03f7bc66ee802288f75706618b29a6e/1200w.png"
 table Arrows2D (
   "attr.rust.archetype_eager",
-  "attr.cpp.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",
   "attr.cpp.no_field_ctors",

--- a/crates/store/re_types/definitions/rerun/archetypes/arrows3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/arrows3d.fbs
@@ -7,7 +7,6 @@ namespace rerun.archetypes;
 /// \example archetypes/arrows3d_simple title="Simple batch of 3D arrows" image="https://static.rerun.io/arrow3d_simple/55e2f794a520bbf7527d7b828b0264732146c5d0/1200w.png"
 table Arrows3D (
   "attr.rust.archetype_eager",
-  "attr.cpp.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",
   "attr.cpp.no_field_ctors",

--- a/crates/store/re_types/definitions/rerun/archetypes/asset3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/asset3d.fbs
@@ -11,7 +11,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/asset3d_simple title="Simple 3D asset" image="https://static.rerun.io/asset3d_simple/af238578188d3fd0de3e330212120e2842a8ddb2/1200w.png"
 table Asset3D (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq, Eq",
   "attr.docs.category": "Spatial 3D",

--- a/crates/store/re_types/definitions/rerun/archetypes/asset_video.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/asset_video.fbs
@@ -12,7 +12,6 @@ namespace rerun.archetypes;
 /// \example archetypes/video_auto_frames title="Video with automatically determined frames" image="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png"
 /// \example archetypes/video_manual_frames title="Demonstrates manual use of video frame references" image="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png"
 table AssetVideo (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.docs.category": "Video",
   "attr.docs.view_types": "Spatial2DView, Spatial3DView: if logged under a projection"

--- a/crates/store/re_types/definitions/rerun/archetypes/bar_chart.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/bar_chart.fbs
@@ -8,7 +8,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/bar_chart title="Simple bar chart" image="https://static.rerun.io/barchart_simple/cf6014b18265edfcaa562c06526c0716b296b193/1200w.png"
 table BarChart (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Plotting",

--- a/crates/store/re_types/definitions/rerun/archetypes/boxes2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/boxes2d.fbs
@@ -6,7 +6,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/boxes2d_simple title="Simple 2D boxes" image="https://static.rerun.io/box2d_simple/ac4424f3cf747382867649610cbd749c45b2020b/1200w.png"
 table Boxes2D (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/definitions/rerun/archetypes/boxes3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/boxes3d.fbs
@@ -11,7 +11,6 @@ namespace rerun.archetypes;
 /// \example archetypes/boxes3d_simple !api title="Simple 3D boxes" image="https://static.rerun.io/box3d_simple/d6a3f38d2e3360fbacac52bb43e44762635be9c8/1200w.png"
 /// \example archetypes/boxes3d_batch title="Batch of 3D boxes" image="https://static.rerun.io/box3d_batch/5aac5b5d29c9f2ecd572c93f6970fcec17f4984b/1200w.png"
 table Boxes3D (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/definitions/rerun/archetypes/capsules3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/capsules3d.fbs
@@ -14,7 +14,6 @@ namespace rerun.archetypes;
 // TODO(#1361): This archetype should eventually generalize to cylinders without caps, truncated
 // cones, and tapered capsules -- all common shapes based on expanding a line segment circularly.
 table Capsules3D (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/definitions/rerun/archetypes/clear.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/clear.fbs
@@ -18,7 +18,6 @@ namespace rerun.archetypes;
 /// \example archetypes/clear_recursive !api "Recursive"
 table Clear (
   "attr.cpp.no_default_ctor",
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.override_crate": "re_types_core",

--- a/crates/store/re_types/definitions/rerun/archetypes/depth_image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/depth_image.fbs
@@ -12,7 +12,6 @@ namespace rerun.archetypes;
 /// \example archetypes/depth_image_simple !api title="Simple example" image="https://static.rerun.io/depth_image_simple/77a6fa4f938a742bdc7c5350f668c4f31eed4d01/1200w.png"
 /// \example archetypes/depth_image_3d title="Depth to 3D example" image="https://static.rerun.io/depth_image_3d/924e9d4d6a39d63d4fdece82582855fdaa62d15e/1200w.png"
 table DepthImage (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.cpp.no_field_ctors",

--- a/crates/store/re_types/definitions/rerun/archetypes/ellipsoids3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/ellipsoids3d.fbs
@@ -14,7 +14,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/ellipsoids3d_simple title="Covariance ellipsoid" image="https://static.rerun.io/elliopsoid3d_simple/bd5d46e61b80ae44792b52ee07d750a7137002ea/1200w.png"
 table Ellipsoids3D (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/definitions/rerun/archetypes/encoded_image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/encoded_image.fbs
@@ -10,7 +10,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/encoded_image
 table EncodedImage (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.cpp.no_field_ctors",
   "attr.docs.category": "Image & tensor",

--- a/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
@@ -8,7 +8,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/geo_line_strings_simple title="Log a geospatial line string" image="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1200w.png"
 table GeoLineStrings (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/definitions/rerun/archetypes/geo_points.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/geo_points.fbs
@@ -4,7 +4,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/geo_points_simple title="Log a geospatial point" image="https://static.rerun.io/geopoint_simple/b86ce83e5871837587bd33a0ad639358b96e9010/1200w.png"
 table GeoPoints (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/definitions/rerun/archetypes/graph_edges.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/graph_edges.fbs
@@ -9,7 +9,6 @@ namespace rerun.archetypes;
 /// \example archetypes/graph_undirected !api title="Simple undirected graph" image="https://static.rerun.io/graph_undirected/15f46bec77452a8c6220558e4403b99cac188e2e/1200w.png"
 /// \example archetypes/graph_directed title="Simple directed graph" image="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png"
 table GraphEdges (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.docs.category": "Graph",
   "attr.docs.view_types": "GraphView",

--- a/crates/store/re_types/definitions/rerun/archetypes/graph_nodes.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/graph_nodes.fbs
@@ -7,7 +7,6 @@ namespace rerun.archetypes;
 /// \example archetypes/graph_undirected !api title="Simple undirected graph" image="https://static.rerun.io/graph_undirected/15f46bec77452a8c6220558e4403b99cac188e2e/1200w.png"
 /// \example archetypes/graph_directed title="Simple directed graph" image="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png"
 table GraphNodes (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.docs.category": "Graph",
   "attr.docs.view_types": "GraphView",

--- a/crates/store/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/image.fbs
@@ -24,7 +24,6 @@ namespace rerun.archetypes;
 /// \example archetypes/image_formats title="Logging images with various formats" image="https://static.rerun.io/image_formats/7b8a162fcfd266f303980439beea997dc8544c24/full.png"
 /// \example archetypes/image_send_columns !api title="Image from file, PIL & OpenCV" image="https://static.rerun.io/image_advanced/81fc8a255488615510790ee41be314e054978d51/full.png"
 table Image (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.cpp.no_field_ctors",

--- a/crates/store/re_types/definitions/rerun/archetypes/instance_poses3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/instance_poses3d.fbs
@@ -19,7 +19,6 @@ namespace rerun.archetypes;
 /// \example archetypes/instance_poses3d_combined title="Regular & instance transforms in tandem" image="https://static.rerun.io/leaf_transform3d/41674f0082d6de489f8a1cd1583f60f6b5820ddf/1200w.png"
 /// \example archetypes/mesh3d_instancing !api title="3D mesh with instancing" image="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/1200w.png"
 table InstancePoses3D (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial3DView, Spatial2DView: if logged above active projection",

--- a/crates/store/re_types/definitions/rerun/archetypes/line_strips2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/line_strips2d.fbs
@@ -9,7 +9,6 @@ namespace rerun.archetypes;
 /// \example archetypes/line_strips2d_batch image="https://static.rerun.io/line_strip2d_batch/c6f4062bcf510462d298a5dfe9fdbe87c754acee/1200w.png"
 /// \example archetypes/line_strips2d_ui_radius title="Lines with scene & UI radius each" image="https://static.rerun.io/line_strip2d_ui_radius/d3d7d5bd36278564ee37e2ed6932963ec16f5131/1200w.png
 table LineStrips2D (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 2D",

--- a/crates/store/re_types/definitions/rerun/archetypes/line_strips3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/line_strips3d.fbs
@@ -9,7 +9,6 @@ namespace rerun.archetypes;
 /// \example archetypes/line_strips3d_batch title="Many strips" image="https://static.rerun.io/line_strip3d_batch/15e8ff18a6c95a3191acb0eae6eb04adea3b4874/1200w.png"
 /// \example archetypes/line_strips3d_ui_radius title="Lines with scene & UI radius each" image="https://static.rerun.io/line_strip3d_ui_radius/36b98f47e45747b5a3601511ff39b8d74c61d120/1200w.png"
 table LineStrips3D (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",

--- a/crates/store/re_types/definitions/rerun/archetypes/mesh3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/mesh3d.fbs
@@ -13,7 +13,6 @@ namespace rerun.archetypes;
 /// \example archetypes/mesh3d_partial_updates !api title="3D mesh with partial updates" image="https://static.rerun.io/mesh3d_partial_updates/7de33d26220585691a403098c953cd46f94c3262/1200w.png"
 /// \example archetypes/mesh3d_instancing title="3D mesh with instancing" image="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/1200w.png"
 table Mesh3D (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",

--- a/crates/store/re_types/definitions/rerun/archetypes/pinhole.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/pinhole.fbs
@@ -6,7 +6,6 @@ namespace rerun.archetypes;
 /// \example archetypes/pinhole_simple title="Simple pinhole camera" image="https://static.rerun.io/pinhole_simple/9af9441a94bcd9fd54e1fea44fb0c59ff381a7f2/1200w.png"
 /// \example archetypes/pinhole_perspective title="Perspective pinhole camera" image="https://static.rerun.io/pinhole_perspective/317e2de6d212b238dcdad5b67037e9e2a2afafa0/1200w.png"
 table Pinhole (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager"
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",

--- a/crates/store/re_types/definitions/rerun/archetypes/points2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/points2d.fbs
@@ -10,8 +10,7 @@ namespace rerun.archetypes;
 /// \example archetypes/points2d_random title="Randomly distributed 2D points with varying color and radius" image="https://static.rerun.io/point2d_random/8e8ac75373677bd72bd3f56a15e44fcab309a168/1200w.png"
 /// \example archetypes/points2d_ui_radius title="Log points with radii given in UI points" image="https://static.rerun.io/point2d_ui_radius/ce804fc77300d89c348b4ab5960395171497b7ac/1200w.png"
 table Points2D (
-   "attr.cpp.archetype_eager",
-  "attr.rust.archetype_eager",
+   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 2D",
   "attr.docs.view_types": "Spatial2DView, Spatial3DView: if logged under a projection"

--- a/crates/store/re_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/points3d.fbs
@@ -10,7 +10,6 @@ namespace rerun.archetypes;
 /// \example archetypes/points3d_send_columns title="Send several point clouds with varying point count over time in a single call" image="https://static.rerun.io/points3d_send_columns/633b524a2ee439b0e3afc3f894f4927ce938a3ec/1200w.png"
 table Points3D (
   "attr.rust.archetype_eager",
-  "attr.cpp.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial3DView, Spatial2DView: if logged above active projection"

--- a/crates/store/re_types/definitions/rerun/archetypes/scalar.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/scalar.fbs
@@ -16,7 +16,6 @@ namespace rerun.archetypes;
 /// \example archetypes/scalar_multiple_plots !api title="Multiple time series plots" image="https://static.rerun.io/scalar_multiple/15845c2a348f875248fbd694e03eabd922741c4c/1200w.png"
 /// \example archetypes/scalar_send_columns title="Multiple scalars in a single `send_columns` call" image="https://static.rerun.io/scalar_send_columns/b4bf172256f521f4851dfec5c2c6e3143f5d6923/1200w.png"
 table Scalar (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Plotting",

--- a/crates/store/re_types/definitions/rerun/archetypes/segmentation_image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/segmentation_image.fbs
@@ -16,7 +16,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/segmentation_image_simple title="Simple segmentation image" image="https://static.rerun.io/segmentation_image_simple/f8aac62abcf4c59c5d62f9ebc2d86fd0285c1736/1200w.png"
 table SegmentationImage (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.cpp.no_field_ctors",

--- a/crates/store/re_types/definitions/rerun/archetypes/series_line.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/series_line.fbs
@@ -10,8 +10,7 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/series_line_style title="Line series" image="https://static.rerun.io/series_line_style/d2616d98b1e46bdb85849b8669154fdf058e3453/1200w.png"
 table SeriesLine (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.docs.category": "Plotting",
     "attr.docs.view_types": "TimeSeriesView"
 ) {

--- a/crates/store/re_types/definitions/rerun/archetypes/series_point.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/series_point.fbs
@@ -10,8 +10,7 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/series_point_style title="Point series" image="https://static.rerun.io/series_point_style/82207a705da6c086b28ce161db1db9e8b12258b7/1200w.png"
 table SeriesPoint (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.docs.category": "Plotting",
     "attr.docs.view_types": "TimeSeriesView"
 ) {

--- a/crates/store/re_types/definitions/rerun/archetypes/tensor.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/tensor.fbs
@@ -13,7 +13,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/tensor_simple title="Simple tensor" image="https://static.rerun.io/tensor_simple/baacb07712f7b706e3c80e696f70616c6c20b367/1200w.png"
 table Tensor (
-"attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Image & tensor",

--- a/crates/store/re_types/definitions/rerun/archetypes/text_document.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/text_document.fbs
@@ -8,7 +8,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/text_document title="Markdown text document" image="https://static.rerun.io/textdocument/babda19558ee32ed8d730495b595aee7a5e2c174/1200w.png"
 table TextDocument (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Text",

--- a/crates/store/re_types/definitions/rerun/archetypes/text_log.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/text_log.fbs
@@ -6,7 +6,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/text_log_integration text="Logging text directly or via a logger" image="https://static.rerun.io/text_log_integration/9737d0c986325802a9885499d6fcc773b1736488/1200w.png"
 table TextLog (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Text",

--- a/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
@@ -18,7 +18,6 @@ namespace rerun.archetypes;
 /// \example archetypes/transform3d_hierarchy title="Transform hierarchy" image="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1200w.png"
 table Transform3D (
   "attr.rust.archetype_eager",
-  "attr.cpp.archetype_eager",
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial3DView, Spatial2DView: if logged above active projection",
   "attr.rerun.log_missing_as_empty", // See https://github.com/rerun-io/rerun/issues/6909

--- a/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
@@ -10,7 +10,6 @@ namespace rerun.archetypes;
 /// \example archetypes/video_auto_frames title="Video with automatically determined frames" image="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png"
 /// \example archetypes/video_manual_frames title="Demonstrates manual use of video frame references" image="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png"
 table VideoFrameReference (
-  "attr.cpp.archetype_eager",
   "attr.rust.archetype_eager",
   "attr.docs.category": "Video",
   "attr.docs.view_types": "Spatial2DView, Spatial3DView: if logged under a projection"

--- a/crates/store/re_types/definitions/rerun/archetypes/view_coordinates.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/view_coordinates.fbs
@@ -17,7 +17,6 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/view_coordinates_simple title="View coordinates for adjusting the eye camera" image="https://static.rerun.io/viewcoordinates/0833f0dc8616a676b7b2c566f2a6f613363680c5/1200w.png"
 table ViewCoordinates (
-  "attr.cpp.archetype_eager",
   // TODO(#7245): "attr.rust.archetype_eager",
   "attr.rust.derive": "Copy, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent",

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/background.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/background.fbs
@@ -3,8 +3,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configuration for the background of a view.
 table Background (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.python.aliases": "datatypes.Rgba32Like, blueprint_components.BackgroundKindLike",
     "attr.rerun.scope": "blueprint"
 ) {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/container_blueprint.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/container_blueprint.fbs
@@ -5,8 +5,7 @@ namespace rerun.blueprint.archetypes;
 /// The description of a container.
 table ContainerBlueprint (
     "attr.rerun.scope": "blueprint",
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rust.archetype_native"
 ) {
     // --- Required ---

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/dataframe_query.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/dataframe_query.fbs
@@ -3,8 +3,7 @@ namespace rerun.blueprint.archetypes;
 
 /// The query for the dataframe view.
 table DataframeQuery (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     // --- Optional ---

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_center.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_center.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Tries to move the center of mass of the graph to the origin.
 struct ForceCenter (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Whether the center force is enabled.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_collision_radius.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_collision_radius.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Resolves collisions between the bounding circles, according to the radius of the nodes.
 struct ForceCollisionRadius (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Whether the collision force is enabled.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_link.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_link.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Aims to achieve a target distance between two nodes that are connected by an edge.
 struct ForceLink (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Whether the link force is enabled.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_many_body.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_many_body.fbs
@@ -4,8 +4,7 @@ namespace rerun.blueprint.archetypes;
 ///
 /// If `strength` is smaller than 0, it pushes nodes apart, if it is larger than 0 it pulls them together.
 struct ForceManyBody (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Whether the many body force is enabled.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_position.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/force_position.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Similar to gravity, this force pulls nodes towards a specific position.
 struct ForcePosition (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Whether the position force is enabled.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/line_grid3d.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/line_grid3d.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configuration for the 3D line grid.
 table LineGrid3D (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Whether the grid is visible.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/map_background.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/map_background.fbs
@@ -3,8 +3,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configuration for the background map of the map view.
 table MapBackground (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.python.aliases": "blueprint_components.MapProviderLike"
 ) {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/map_zoom.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/map_zoom.fbs
@@ -4,8 +4,7 @@ namespace rerun.blueprint.archetypes;
 /// Configuration of the map view zoom level.
 //TODO(ab): Turn this archetype into `MapArea` and include a `center: LatLon` componnent or similar
 table MapZoom (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.python.aliases": "datatypes.Float64Like"
 ) {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/near_clip_plane.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/near_clip_plane.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Controls the distance to the near clip plane in 3D scene units.
 table NearClipPlane (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Controls the distance to the near clip plane in 3D scene units.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/panel_blueprint.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/panel_blueprint.fbs
@@ -4,8 +4,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Shared state for the 3 collapsible panels.
 table PanelBlueprint (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default"
 ) {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/plot_legend.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/plot_legend.fbs
@@ -5,8 +5,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configuration for the legend of a plot.
 table PlotLegend (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default",
     "attr.python.aliases": "blueprint_components.Corner2D"

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/scalar_axis.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/scalar_axis.fbs
@@ -5,8 +5,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configuration for the scalar axis of a plot.
 table ScalarAxis (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default"
 ) {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/tensor_scalar_mapping.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/tensor_scalar_mapping.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configures how tensor scalars are mapped to color.
 table TensorScalarMapping (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default"
 ) {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/tensor_slice_selection.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/tensor_slice_selection.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Specifies a 2D slice of a tensor.
 table TensorSliceSelection (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Which dimension to map to width.

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/tensor_view_fit.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/tensor_view_fit.fbs
@@ -2,8 +2,7 @@ namespace rerun.blueprint.archetypes;
 
 /// Configures how a selected tensor slice is shown on screen.
 table TensorViewFit (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default",
     "attr.python.aliases": "blueprint_components.ViewFitLike"

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/view_blueprint.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/view_blueprint.fbs
@@ -4,8 +4,7 @@ namespace rerun.blueprint.archetypes;
 
 /// The description of a single view.
 table ViewBlueprint (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     // --- Required ---

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/view_contents.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/view_contents.fbs
@@ -41,8 +41,7 @@ namespace rerun.blueprint.archetypes;
 /// The last rule matching `/world` is `- /world`, so it is excluded.
 /// The last rule matching `/world/house` is `+ /world/**`, so it is included.
 table ViewContents (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default"
 )  {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/viewport_blueprint.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/viewport_blueprint.fbs
@@ -4,8 +4,7 @@ namespace rerun.blueprint.archetypes;
 
 /// The top-level description of the viewport.
 table ViewportBlueprint (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default"
 ) {

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
@@ -12,8 +12,7 @@ namespace rerun.blueprint.archetypes;
 /// - For time series views, the default is to show the entire timeline.
 /// - For any other view, the default is to apply latest-at semantics.
 table VisibleTimeRanges (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default",
     "attr.python.aliases": "datatypes.VisibleTimeRangeLike, Sequence[datatypes.VisibleTimeRangeLike]"

--- a/crates/store/re_types/definitions/rerun/blueprint/archetypes/visual_bounds2d.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/archetypes/visual_bounds2d.fbs
@@ -8,8 +8,7 @@ namespace rerun.blueprint.archetypes;
 /// If no visual bounds are set, it will be determined automatically,
 /// based on the bounding-box of the data or other camera information present in the view.
 table VisualBounds2D (
-    "attr.cpp.archetype_eager",
-    "attr.rust.archetype_eager",
+      "attr.rust.archetype_eager",
     "attr.rerun.scope": "blueprint"
 ) {
     /// Controls the visible range of a 2D view.

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/annotation_context.hpp"
 #include "../indicator_component.hpp"
@@ -105,8 +104,7 @@ namespace rerun::archetypes {
         /// List of class descriptions, mapping class indices to class names, colors etc.
         AnnotationContext with_context(const rerun::components::AnnotationContext& _context) && {
             context = ComponentBatch::from_loggable(_context, Descriptor_context).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -156,8 +155,7 @@ namespace rerun::archetypes {
         /// All the vectors for each arrow in the batch.
         Arrows2D with_vectors(const Collection<rerun::components::Vector2D>& _vectors) && {
             vectors = ComponentBatch::from_loggable(_vectors, Descriptor_vectors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// All the origin (base) positions for each arrow in the batch.
@@ -165,8 +163,7 @@ namespace rerun::archetypes {
         /// If no origins are set, (0, 0) is used as the origin for each arrow.
         Arrows2D with_origins(const Collection<rerun::components::Position2D>& _origins) && {
             origins = ComponentBatch::from_loggable(_origins, Descriptor_origins).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the arrows.
@@ -175,15 +172,13 @@ namespace rerun::archetypes {
         /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
         Arrows2D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the points.
         Arrows2D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the arrows.
@@ -192,16 +187,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         Arrows2D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Arrows2D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order.
@@ -210,8 +203,7 @@ namespace rerun::archetypes {
         Arrows2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class Ids for the points.
@@ -220,8 +212,7 @@ namespace rerun::archetypes {
         Arrows2D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -162,8 +161,7 @@ namespace rerun::archetypes {
         /// All the vectors for each arrow in the batch.
         Arrows3D with_vectors(const Collection<rerun::components::Vector3D>& _vectors) && {
             vectors = ComponentBatch::from_loggable(_vectors, Descriptor_vectors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// All the origin (base) positions for each arrow in the batch.
@@ -171,8 +169,7 @@ namespace rerun::archetypes {
         /// If no origins are set, (0, 0, 0) is used as the origin for each arrow.
         Arrows3D with_origins(const Collection<rerun::components::Position3D>& _origins) && {
             origins = ComponentBatch::from_loggable(_origins, Descriptor_origins).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the arrows.
@@ -181,15 +178,13 @@ namespace rerun::archetypes {
         /// The tip is rendered with `height = 2.0 * radius` and `radius = 1.0 * radius`.
         Arrows3D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the points.
         Arrows3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the arrows.
@@ -198,16 +193,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         Arrows3D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Arrows3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class Ids for the points.
@@ -216,8 +209,7 @@ namespace rerun::archetypes {
         Arrows3D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/albedo_factor.hpp"
 #include "../components/blob.hpp"
@@ -145,8 +144,7 @@ namespace rerun::archetypes {
         /// The asset's bytes.
         Asset3D with_blob(const rerun::components::Blob& _blob) && {
             blob = ComponentBatch::from_loggable(_blob, Descriptor_blob).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The Media Type of the asset.
@@ -162,8 +160,7 @@ namespace rerun::archetypes {
         Asset3D with_media_type(const rerun::components::MediaType& _media_type) && {
             media_type =
                 ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// A color multiplier applied to the whole asset.
@@ -173,8 +170,7 @@ namespace rerun::archetypes {
         Asset3D with_albedo_factor(const rerun::components::AlbedoFactor& _albedo_factor) && {
             albedo_factor = ComponentBatch::from_loggable(_albedo_factor, Descriptor_albedo_factor)
                                 .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/blob.hpp"
 #include "../components/media_type.hpp"
@@ -201,8 +200,7 @@ namespace rerun::archetypes {
         /// The asset's bytes.
         AssetVideo with_blob(const rerun::components::Blob& _blob) && {
             blob = ComponentBatch::from_loggable(_blob, Descriptor_blob).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The Media Type of the asset.
@@ -215,8 +213,7 @@ namespace rerun::archetypes {
         AssetVideo with_media_type(const rerun::components::MediaType& _media_type) && {
             media_type =
                 ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/color.hpp"
 #include "../components/tensor_data.hpp"
@@ -201,15 +200,13 @@ namespace rerun::archetypes {
         /// The values. Should always be a 1-dimensional tensor (i.e. a vector).
         BarChart with_values(const rerun::components::TensorData& _values) && {
             values = ComponentBatch::from_loggable(_values, Descriptor_values).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The color of the bar chart
         BarChart with_color(const rerun::components::Color& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -183,29 +182,25 @@ namespace rerun::archetypes {
         Boxes2D with_half_sizes(const Collection<rerun::components::HalfSize2D>& _half_sizes) && {
             half_sizes =
                 ComponentBatch::from_loggable(_half_sizes, Descriptor_half_sizes).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional center positions of the boxes.
         Boxes2D with_centers(const Collection<rerun::components::Position2D>& _centers) && {
             centers = ComponentBatch::from_loggable(_centers, Descriptor_centers).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the boxes.
         Boxes2D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the lines that make up the boxes.
         Boxes2D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the boxes.
@@ -214,16 +209,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         Boxes2D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Boxes2D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order.
@@ -234,8 +227,7 @@ namespace rerun::archetypes {
         Boxes2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional `components::ClassId`s for the boxes.
@@ -244,8 +236,7 @@ namespace rerun::archetypes {
         Boxes2D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -233,8 +232,7 @@ namespace rerun::archetypes {
         Boxes3D with_half_sizes(const Collection<rerun::components::HalfSize3D>& _half_sizes) && {
             half_sizes =
                 ComponentBatch::from_loggable(_half_sizes, Descriptor_half_sizes).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional center positions of the boxes.
@@ -243,8 +241,7 @@ namespace rerun::archetypes {
         /// Note that this uses a `components::PoseTranslation3D` which is also used by `archetypes::InstancePoses3D`.
         Boxes3D with_centers(const Collection<rerun::components::PoseTranslation3D>& _centers) && {
             centers = ComponentBatch::from_loggable(_centers, Descriptor_centers).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via axis + angle.
@@ -259,8 +256,7 @@ namespace rerun::archetypes {
                                        Descriptor_rotation_axis_angles
             )
                                        .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via quaternion.
@@ -271,30 +267,26 @@ namespace rerun::archetypes {
         ) && {
             quaternions = ComponentBatch::from_loggable(_quaternions, Descriptor_quaternions)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the boxes.
         Boxes3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the lines that make up the boxes.
         Boxes3D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optionally choose whether the boxes are drawn with lines or solid.
         Boxes3D with_fill_mode(const rerun::components::FillMode& _fill_mode) && {
             fill_mode =
                 ComponentBatch::from_loggable(_fill_mode, Descriptor_fill_mode).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the boxes.
@@ -303,16 +295,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         Boxes3D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Boxes3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional `components::ClassId`s for the boxes.
@@ -321,8 +311,7 @@ namespace rerun::archetypes {
         Boxes3D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -211,15 +210,13 @@ namespace rerun::archetypes {
         /// Lengths of the capsules, defined as the distance between the centers of the endcaps.
         Capsules3D with_lengths(const Collection<rerun::components::Length>& _lengths) && {
             lengths = ComponentBatch::from_loggable(_lengths, Descriptor_lengths).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Radii of the capsules.
         Capsules3D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional translations of the capsules.
@@ -231,8 +228,7 @@ namespace rerun::archetypes {
         ) && {
             translations = ComponentBatch::from_loggable(_translations, Descriptor_translations)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via axis + angle.
@@ -247,8 +243,7 @@ namespace rerun::archetypes {
                                        Descriptor_rotation_axis_angles
             )
                                        .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via quaternion.
@@ -260,30 +255,26 @@ namespace rerun::archetypes {
         ) && {
             quaternions = ComponentBatch::from_loggable(_quaternions, Descriptor_quaternions)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the capsules.
         Capsules3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the capsules, which will be located at their centers.
         Capsules3D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Capsules3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class ID for the ellipsoids.
@@ -292,8 +283,7 @@ namespace rerun::archetypes {
         Capsules3D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/clear_is_recursive.hpp"
 #include "../indicator_component.hpp"
@@ -132,8 +131,7 @@ namespace rerun::archetypes {
         Clear with_is_recursive(const rerun::components::ClearIsRecursive& _is_recursive) && {
             is_recursive = ComponentBatch::from_loggable(_is_recursive, Descriptor_is_recursive)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/colormap.hpp"
 #include "../components/depth_meter.hpp"
@@ -246,15 +245,13 @@ namespace rerun::archetypes {
         /// The raw depth image data.
         DepthImage with_buffer(const rerun::components::ImageBuffer& _buffer) && {
             buffer = ComponentBatch::from_loggable(_buffer, Descriptor_buffer).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The format of the image.
         DepthImage with_format(const rerun::components::ImageFormat& _format) && {
             format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies how long a meter is in the native depth units.
@@ -266,8 +263,7 @@ namespace rerun::archetypes {
         /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
         DepthImage with_meter(const rerun::components::DepthMeter& _meter) && {
             meter = ComponentBatch::from_loggable(_meter, Descriptor_meter).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Colormap to use for rendering the depth image.
@@ -276,8 +272,7 @@ namespace rerun::archetypes {
         DepthImage with_colormap(const rerun::components::Colormap& _colormap) && {
             colormap =
                 ComponentBatch::from_loggable(_colormap, Descriptor_colormap).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The expected range of depth values.
@@ -294,8 +289,7 @@ namespace rerun::archetypes {
         DepthImage with_depth_range(const rerun::components::ValueRange& _depth_range) && {
             depth_range = ComponentBatch::from_loggable(_depth_range, Descriptor_depth_range)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Scale the radii of the points in the point cloud generated from this image.
@@ -309,8 +303,7 @@ namespace rerun::archetypes {
             point_fill_ratio =
                 ComponentBatch::from_loggable(_point_fill_ratio, Descriptor_point_fill_ratio)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
@@ -319,8 +312,7 @@ namespace rerun::archetypes {
         DepthImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -244,8 +243,7 @@ namespace rerun::archetypes {
         ) && {
             half_sizes =
                 ComponentBatch::from_loggable(_half_sizes, Descriptor_half_sizes).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional center positions of the ellipsoids.
@@ -255,8 +253,7 @@ namespace rerun::archetypes {
         Ellipsoids3D with_centers(const Collection<rerun::components::PoseTranslation3D>& _centers
         ) && {
             centers = ComponentBatch::from_loggable(_centers, Descriptor_centers).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via axis + angle.
@@ -271,8 +268,7 @@ namespace rerun::archetypes {
                                        Descriptor_rotation_axis_angles
             )
                                        .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via quaternion.
@@ -284,46 +280,40 @@ namespace rerun::archetypes {
         ) && {
             quaternions = ComponentBatch::from_loggable(_quaternions, Descriptor_quaternions)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the ellipsoids.
         Ellipsoids3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the lines used when the ellipsoid is rendered as a wireframe.
         Ellipsoids3D with_line_radii(const Collection<rerun::components::Radius>& _line_radii) && {
             line_radii =
                 ComponentBatch::from_loggable(_line_radii, Descriptor_line_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optionally choose whether the ellipsoids are drawn with lines or solid.
         Ellipsoids3D with_fill_mode(const rerun::components::FillMode& _fill_mode) && {
             fill_mode =
                 ComponentBatch::from_loggable(_fill_mode, Descriptor_fill_mode).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the ellipsoids.
         Ellipsoids3D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Ellipsoids3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class ID for the ellipsoids.
@@ -332,8 +322,7 @@ namespace rerun::archetypes {
         Ellipsoids3D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/blob.hpp"
 #include "../components/draw_order.hpp"
@@ -139,8 +138,7 @@ namespace rerun::archetypes {
         /// The encoded content of some image file, e.g. a PNG or JPEG.
         EncodedImage with_blob(const rerun::components::Blob& _blob) && {
             blob = ComponentBatch::from_loggable(_blob, Descriptor_blob).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The Media Type of the asset.
@@ -154,8 +152,7 @@ namespace rerun::archetypes {
         EncodedImage with_media_type(const rerun::components::MediaType& _media_type) && {
             media_type =
                 ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Opacity of the image, useful for layering several images.
@@ -163,8 +160,7 @@ namespace rerun::archetypes {
         /// Defaults to 1.0 (fully opaque).
         EncodedImage with_opacity(const rerun::components::Opacity& _opacity) && {
             opacity = ComponentBatch::from_loggable(_opacity, Descriptor_opacity).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order.
@@ -173,8 +169,7 @@ namespace rerun::archetypes {
         EncodedImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/color.hpp"
 #include "../components/geo_line_string.hpp"
@@ -113,8 +112,7 @@ namespace rerun::archetypes {
         ) && {
             line_strings = ComponentBatch::from_loggable(_line_strings, Descriptor_line_strings)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the line strings.
@@ -123,15 +121,13 @@ namespace rerun::archetypes {
         /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
         GeoLineStrings with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the line strings.
         GeoLineStrings with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/geo_points.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_points.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -117,8 +116,7 @@ namespace rerun::archetypes {
         GeoPoints with_positions(const Collection<rerun::components::LatLon>& _positions) && {
             positions =
                 ComponentBatch::from_loggable(_positions, Descriptor_positions).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the points, effectively turning them into circles.
@@ -126,15 +124,13 @@ namespace rerun::archetypes {
         /// *Note*: scene units radiii are interpreted as meters.
         GeoPoints with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the points.
         GeoPoints with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class Ids for the points.
@@ -143,8 +139,7 @@ namespace rerun::archetypes {
         GeoPoints with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/graph_edge.hpp"
 #include "../components/graph_type.hpp"
@@ -95,8 +94,7 @@ namespace rerun::archetypes {
         /// A list of node tuples.
         GraphEdges with_edges(const Collection<rerun::components::GraphEdge>& _edges) && {
             edges = ComponentBatch::from_loggable(_edges, Descriptor_edges).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Specifies if the graph is directed or undirected.
@@ -105,8 +103,7 @@ namespace rerun::archetypes {
         GraphEdges with_graph_type(const rerun::components::GraphType& _graph_type) && {
             graph_type =
                 ComponentBatch::from_loggable(_graph_type, Descriptor_graph_type).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/color.hpp"
 #include "../components/graph_node.hpp"
@@ -125,45 +124,39 @@ namespace rerun::archetypes {
         GraphNodes with_node_ids(const Collection<rerun::components::GraphNode>& _node_ids) && {
             node_ids =
                 ComponentBatch::from_loggable(_node_ids, Descriptor_node_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional center positions of the nodes.
         GraphNodes with_positions(const Collection<rerun::components::Position2D>& _positions) && {
             positions =
                 ComponentBatch::from_loggable(_positions, Descriptor_positions).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the boxes.
         GraphNodes with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the node.
         GraphNodes with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         GraphNodes with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for nodes.
         GraphNodes with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/image_buffer.hpp"
@@ -336,15 +335,13 @@ namespace rerun::archetypes {
         /// The raw image data.
         Image with_buffer(const rerun::components::ImageBuffer& _buffer) && {
             buffer = ComponentBatch::from_loggable(_buffer, Descriptor_buffer).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The format of the image.
         Image with_format(const rerun::components::ImageFormat& _format) && {
             format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Opacity of the image, useful for layering several images.
@@ -352,8 +349,7 @@ namespace rerun::archetypes {
         /// Defaults to 1.0 (fully opaque).
         Image with_opacity(const rerun::components::Opacity& _opacity) && {
             opacity = ComponentBatch::from_loggable(_opacity, Descriptor_opacity).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order.
@@ -362,8 +358,7 @@ namespace rerun::archetypes {
         Image with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/pose_rotation_axis_angle.hpp"
 #include "../components/pose_rotation_quat.hpp"
@@ -148,8 +147,7 @@ namespace rerun::archetypes {
         ) && {
             translations = ComponentBatch::from_loggable(_translations, Descriptor_translations)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via axis + angle.
@@ -161,8 +159,7 @@ namespace rerun::archetypes {
                                        Descriptor_rotation_axis_angles
             )
                                        .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotations via quaternion.
@@ -171,15 +168,13 @@ namespace rerun::archetypes {
         ) && {
             quaternions = ComponentBatch::from_loggable(_quaternions, Descriptor_quaternions)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Scaling factors.
         InstancePoses3D with_scales(const Collection<rerun::components::PoseScale3D>& _scales) && {
             scales = ComponentBatch::from_loggable(_scales, Descriptor_scales).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// 3x3 transformation matrices.
@@ -187,8 +182,7 @@ namespace rerun::archetypes {
             const Collection<rerun::components::PoseTransformMat3x3>& _mat3x3
         ) && {
             mat3x3 = ComponentBatch::from_loggable(_mat3x3, Descriptor_mat3x3).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -179,22 +178,19 @@ namespace rerun::archetypes {
         /// All the actual 2D line strips that make up the batch.
         LineStrips2D with_strips(const Collection<rerun::components::LineStrip2D>& _strips) && {
             strips = ComponentBatch::from_loggable(_strips, Descriptor_strips).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the line strips.
         LineStrips2D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the line strips.
         LineStrips2D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the line strips.
@@ -203,16 +199,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         LineStrips2D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         LineStrips2D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order of each line strip.
@@ -221,8 +215,7 @@ namespace rerun::archetypes {
         LineStrips2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional `components::ClassId`s for the lines.
@@ -231,8 +224,7 @@ namespace rerun::archetypes {
         LineStrips2D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -183,22 +182,19 @@ namespace rerun::archetypes {
         /// All the actual 3D line strips that make up the batch.
         LineStrips3D with_strips(const Collection<rerun::components::LineStrip3D>& _strips) && {
             strips = ComponentBatch::from_loggable(_strips, Descriptor_strips).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the line strips.
         LineStrips3D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the line strips.
         LineStrips3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the line strips.
@@ -207,16 +203,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         LineStrips3D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         LineStrips3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional `components::ClassId`s for the lines.
@@ -225,8 +219,7 @@ namespace rerun::archetypes {
         LineStrips3D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/albedo_factor.hpp"
 #include "../components/class_id.hpp"
@@ -228,8 +227,7 @@ namespace rerun::archetypes {
             vertex_positions =
                 ComponentBatch::from_loggable(_vertex_positions, Descriptor_vertex_positions)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional indices for the triangles that make up the mesh.
@@ -239,8 +237,7 @@ namespace rerun::archetypes {
             triangle_indices =
                 ComponentBatch::from_loggable(_triangle_indices, Descriptor_triangle_indices)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional normal for each vertex.
@@ -249,16 +246,14 @@ namespace rerun::archetypes {
             vertex_normals =
                 ComponentBatch::from_loggable(_vertex_normals, Descriptor_vertex_normals)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional color for each vertex.
         Mesh3D with_vertex_colors(const Collection<rerun::components::Color>& _vertex_colors) && {
             vertex_colors = ComponentBatch::from_loggable(_vertex_colors, Descriptor_vertex_colors)
                                 .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional uv texture coordinate for each vertex.
@@ -268,16 +263,14 @@ namespace rerun::archetypes {
             vertex_texcoords =
                 ComponentBatch::from_loggable(_vertex_texcoords, Descriptor_vertex_texcoords)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// A color multiplier applied to the whole mesh.
         Mesh3D with_albedo_factor(const rerun::components::AlbedoFactor& _albedo_factor) && {
             albedo_factor = ComponentBatch::from_loggable(_albedo_factor, Descriptor_albedo_factor)
                                 .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional albedo texture.
@@ -294,8 +287,7 @@ namespace rerun::archetypes {
                                         Descriptor_albedo_texture_buffer
             )
                                         .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The format of the `albedo_texture_buffer`, if any.
@@ -307,8 +299,7 @@ namespace rerun::archetypes {
                                         Descriptor_albedo_texture_format
             )
                                         .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class Ids for the vertices.
@@ -317,8 +308,7 @@ namespace rerun::archetypes {
         Mesh3D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/image_plane_distance.hpp"
 #include "../components/pinhole_projection.hpp"
@@ -234,8 +233,7 @@ namespace rerun::archetypes {
             image_from_camera =
                 ComponentBatch::from_loggable(_image_from_camera, Descriptor_image_from_camera)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Pixel resolution (usually integers) of child image space. Width and height.
@@ -249,8 +247,7 @@ namespace rerun::archetypes {
         Pinhole with_resolution(const rerun::components::Resolution& _resolution) && {
             resolution =
                 ComponentBatch::from_loggable(_resolution, Descriptor_resolution).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Sets the view coordinates for the camera.
@@ -283,8 +280,7 @@ namespace rerun::archetypes {
         Pinhole with_camera_xyz(const rerun::components::ViewCoordinates& _camera_xyz) && {
             camera_xyz =
                 ComponentBatch::from_loggable(_camera_xyz, Descriptor_camera_xyz).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.
@@ -298,8 +294,7 @@ namespace rerun::archetypes {
                                        Descriptor_image_plane_distance
             )
                                        .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -212,22 +211,19 @@ namespace rerun::archetypes {
         Points2D with_positions(const Collection<rerun::components::Position2D>& _positions) && {
             positions =
                 ComponentBatch::from_loggable(_positions, Descriptor_positions).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the points, effectively turning them into circles.
         Points2D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the points.
         Points2D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the points.
@@ -236,16 +232,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         Points2D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Points2D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order.
@@ -254,8 +248,7 @@ namespace rerun::archetypes {
         Points2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class Ids for the points.
@@ -264,8 +257,7 @@ namespace rerun::archetypes {
         Points2D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional keypoint IDs for the points, identifying them within a class.
@@ -280,8 +272,7 @@ namespace rerun::archetypes {
         ) && {
             keypoint_ids = ComponentBatch::from_loggable(_keypoint_ids, Descriptor_keypoint_ids)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
@@ -257,22 +256,19 @@ namespace rerun::archetypes {
         Points3D with_positions(const Collection<rerun::components::Position3D>& _positions) && {
             positions =
                 ComponentBatch::from_loggable(_positions, Descriptor_positions).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional radii for the points, effectively turning them into circles.
         Points3D with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional colors for the points.
         Points3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional text labels for the points.
@@ -281,16 +277,14 @@ namespace rerun::archetypes {
         /// Otherwise, each instance will have its own label.
         Points3D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional choice of whether the text labels should be shown by default.
         Points3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional class Ids for the points.
@@ -299,8 +293,7 @@ namespace rerun::archetypes {
         Points3D with_class_ids(const Collection<rerun::components::ClassId>& _class_ids) && {
             class_ids =
                 ComponentBatch::from_loggable(_class_ids, Descriptor_class_ids).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional keypoint IDs for the points, identifying them within a class.
@@ -315,8 +308,7 @@ namespace rerun::archetypes {
         ) && {
             keypoint_ids = ComponentBatch::from_loggable(_keypoint_ids, Descriptor_keypoint_ids)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/scalar.hpp"
 #include "../indicator_component.hpp"
@@ -117,8 +116,7 @@ namespace rerun::archetypes {
         /// The scalar value to log.
         Scalar with_scalar(const rerun::components::Scalar& _scalar) && {
             scalar = ComponentBatch::from_loggable(_scalar, Descriptor_scalar).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/draw_order.hpp"
 #include "../components/image_buffer.hpp"
@@ -200,15 +199,13 @@ namespace rerun::archetypes {
         /// The raw image data.
         SegmentationImage with_buffer(const rerun::components::ImageBuffer& _buffer) && {
             buffer = ComponentBatch::from_loggable(_buffer, Descriptor_buffer).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The format of the image.
         SegmentationImage with_format(const rerun::components::ImageFormat& _format) && {
             format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Opacity of the image, useful for layering the segmentation image on top of another image.
@@ -216,8 +213,7 @@ namespace rerun::archetypes {
         /// Defaults to 0.5 if there's any other images in the scene, otherwise 1.0.
         SegmentationImage with_opacity(const rerun::components::Opacity& _opacity) && {
             opacity = ComponentBatch::from_loggable(_opacity, Descriptor_opacity).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// An optional floating point value that specifies the 2D drawing order.
@@ -226,8 +222,7 @@ namespace rerun::archetypes {
         SegmentationImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/aggregation_policy.hpp"
 #include "../components/color.hpp"
@@ -127,15 +126,13 @@ namespace rerun::archetypes {
         /// Color for the corresponding series.
         SeriesLine with_color(const rerun::components::Color& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Stroke width for the corresponding series.
         SeriesLine with_width(const rerun::components::StrokeWidth& _width) && {
             width = ComponentBatch::from_loggable(_width, Descriptor_width).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Display name of the series.
@@ -143,8 +140,7 @@ namespace rerun::archetypes {
         /// Used in the legend.
         SeriesLine with_name(const rerun::components::Name& _name) && {
             name = ComponentBatch::from_loggable(_name, Descriptor_name).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Configures the zoom-dependent scalar aggregation.
@@ -158,8 +154,7 @@ namespace rerun::archetypes {
             aggregation_policy =
                 ComponentBatch::from_loggable(_aggregation_policy, Descriptor_aggregation_policy)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/color.hpp"
 #include "../components/marker_shape.hpp"
@@ -131,15 +130,13 @@ namespace rerun::archetypes {
         /// Color for the corresponding series.
         SeriesPoint with_color(const rerun::components::Color& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// What shape to use to represent the point
         SeriesPoint with_marker(const rerun::components::MarkerShape& _marker) && {
             marker = ComponentBatch::from_loggable(_marker, Descriptor_marker).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Display name of the series.
@@ -147,16 +144,14 @@ namespace rerun::archetypes {
         /// Used in the legend.
         SeriesPoint with_name(const rerun::components::Name& _name) && {
             name = ComponentBatch::from_loggable(_name, Descriptor_name).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Size of the marker.
         SeriesPoint with_marker_size(const rerun::components::MarkerSize& _marker_size) && {
             marker_size = ComponentBatch::from_loggable(_marker_size, Descriptor_marker_size)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/tensor_data.hpp"
 #include "../components/value_range.hpp"
@@ -140,8 +139,7 @@ namespace rerun::archetypes {
         /// The tensor data
         Tensor with_data(const rerun::components::TensorData& _data) && {
             data = ComponentBatch::from_loggable(_data, Descriptor_data).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The expected range of values.
@@ -158,8 +156,7 @@ namespace rerun::archetypes {
         Tensor with_value_range(const rerun::components::ValueRange& _value_range) && {
             value_range = ComponentBatch::from_loggable(_value_range, Descriptor_value_range)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/media_type.hpp"
 #include "../components/text.hpp"
@@ -128,8 +127,7 @@ namespace rerun::archetypes {
         /// Contents of the text document.
         TextDocument with_text(const rerun::components::Text& _text) && {
             text = ComponentBatch::from_loggable(_text, Descriptor_text).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The Media Type of the text.
@@ -142,8 +140,7 @@ namespace rerun::archetypes {
         TextDocument with_media_type(const rerun::components::MediaType& _media_type) && {
             media_type =
                 ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/color.hpp"
 #include "../components/text.hpp"
@@ -134,8 +133,7 @@ namespace rerun::archetypes {
         /// The body of the message.
         TextLog with_text(const rerun::components::Text& _text) && {
             text = ComponentBatch::from_loggable(_text, Descriptor_text).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The verbosity level of the message.
@@ -143,15 +141,13 @@ namespace rerun::archetypes {
         /// This can be used to filter the log messages in the Rerun Viewer.
         TextLog with_level(const rerun::components::TextLogLevel& _level) && {
             level = ComponentBatch::from_loggable(_level, Descriptor_level).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional color to use for the log line in the Rerun Viewer.
         TextLog with_color(const rerun::components::Color& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -611,8 +611,7 @@ namespace rerun::archetypes {
         Transform3D with_translation(const rerun::components::Translation3D& _translation) && {
             translation = ComponentBatch::from_loggable(_translation, Descriptor_translation)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotation via axis + angle.
@@ -622,38 +621,33 @@ namespace rerun::archetypes {
             rotation_axis_angle =
                 ComponentBatch::from_loggable(_rotation_axis_angle, Descriptor_rotation_axis_angle)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Rotation via quaternion.
         Transform3D with_quaternion(const rerun::components::RotationQuat& _quaternion) && {
             quaternion =
                 ComponentBatch::from_loggable(_quaternion, Descriptor_quaternion).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Scaling factor.
         Transform3D with_scale(const rerun::components::Scale3D& _scale) && {
             scale = ComponentBatch::from_loggable(_scale, Descriptor_scale).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// 3x3 transformation matrix.
         Transform3D with_mat3x3(const rerun::components::TransformMat3x3& _mat3x3) && {
             mat3x3 = ComponentBatch::from_loggable(_mat3x3, Descriptor_mat3x3).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Specifies the relation this transform establishes between this entity and its parent.
         Transform3D with_relation(const rerun::components::TransformRelation& _relation) && {
             relation =
                 ComponentBatch::from_loggable(_relation, Descriptor_relation).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Visual length of the 3 axes.
@@ -663,8 +657,7 @@ namespace rerun::archetypes {
         Transform3D with_axis_length(const rerun::components::AxisLength& _axis_length) && {
             axis_length = ComponentBatch::from_loggable(_axis_length, Descriptor_axis_length)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/entity_path.hpp"
 #include "../components/video_timestamp.hpp"
@@ -183,8 +182,7 @@ namespace rerun::archetypes {
         VideoFrameReference with_timestamp(const rerun::components::VideoTimestamp& _timestamp) && {
             timestamp =
                 ComponentBatch::from_loggable(_timestamp, Descriptor_timestamp).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Optional reference to an entity with a `archetypes::AssetVideo`.
@@ -202,8 +200,7 @@ namespace rerun::archetypes {
             video_reference =
                 ComponentBatch::from_loggable(_video_reference, Descriptor_video_reference)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../compiler_utils.hpp"
 #include "../component_batch.hpp"
 #include "../components/view_coordinates.hpp"
 #include "../indicator_component.hpp"
@@ -342,8 +341,7 @@ namespace rerun::archetypes {
         /// The directions of the [x, y, z] axes.
         ViewCoordinates with_xyz(const rerun::components::ViewCoordinates& _xyz) && {
             xyz = ComponentBatch::from_loggable(_xyz, Descriptor_xyz).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/background.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/background.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/background_kind.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/color.hpp"
 #include "../../indicator_component.hpp"
@@ -66,15 +65,13 @@ namespace rerun::blueprint::archetypes {
         /// The type of the background.
         Background with_kind(const rerun::blueprint::components::BackgroundKind& _kind) && {
             kind = ComponentBatch::from_loggable(_kind, Descriptor_kind).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Color used for the solid background type.
         Background with_color(const rerun::components::Color& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.hpp
@@ -11,7 +11,6 @@
 #include "../../blueprint/components/row_share.hpp"
 #include "../../blueprint/components/visible.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/name.hpp"
 #include "../../indicator_component.hpp"
@@ -144,16 +143,14 @@ namespace rerun::blueprint::archetypes {
             container_kind =
                 ComponentBatch::from_loggable(_container_kind, Descriptor_container_kind)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The name of the container.
         ContainerBlueprint with_display_name(const rerun::components::Name& _display_name) && {
             display_name = ComponentBatch::from_loggable(_display_name, Descriptor_display_name)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// `ContainerId`s or `ViewId`s that are children of this container.
@@ -162,8 +159,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             contents =
                 ComponentBatch::from_loggable(_contents, Descriptor_contents).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The layout shares of each column in the container.
@@ -176,8 +172,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             col_shares =
                 ComponentBatch::from_loggable(_col_shares, Descriptor_col_shares).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The layout shares of each row of the container.
@@ -190,8 +185,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             row_shares =
                 ComponentBatch::from_loggable(_row_shares, Descriptor_row_shares).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Which tab is active.
@@ -202,8 +196,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             active_tab =
                 ComponentBatch::from_loggable(_active_tab, Descriptor_active_tab).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Whether this container is visible.
@@ -211,8 +204,7 @@ namespace rerun::blueprint::archetypes {
         /// Defaults to true if not specified.
         ContainerBlueprint with_visible(const rerun::blueprint::components::Visible& _visible) && {
             visible = ComponentBatch::from_loggable(_visible, Descriptor_visible).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// How many columns this grid should have.
@@ -225,8 +217,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             grid_columns = ComponentBatch::from_loggable(_grid_columns, Descriptor_grid_columns)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.hpp
@@ -9,7 +9,6 @@
 #include "../../blueprint/components/selected_columns.hpp"
 #include "../../blueprint/components/timeline_name.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -98,8 +97,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             timeline =
                 ComponentBatch::from_loggable(_timeline, Descriptor_timeline).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// If provided, only rows whose timestamp is within this range will be shown.
@@ -111,8 +109,7 @@ namespace rerun::blueprint::archetypes {
             filter_by_range =
                 ComponentBatch::from_loggable(_filter_by_range, Descriptor_filter_by_range)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// If provided, only show rows which contains a logged event for the specified component.
@@ -122,8 +119,7 @@ namespace rerun::blueprint::archetypes {
             filter_is_not_null =
                 ComponentBatch::from_loggable(_filter_is_not_null, Descriptor_filter_is_not_null)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Should empty cells be filled with latest-at queries?
@@ -133,16 +129,14 @@ namespace rerun::blueprint::archetypes {
             apply_latest_at =
                 ComponentBatch::from_loggable(_apply_latest_at, Descriptor_apply_latest_at)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Selected columns. If unset, all columns are selected.
         DataframeQuery with_select(const rerun::blueprint::components::SelectedColumns& _select
         ) && {
             select = ComponentBatch::from_loggable(_select, Descriptor_select).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_center.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_center.hpp
@@ -6,7 +6,6 @@
 #include "../../blueprint/components/enabled.hpp"
 #include "../../blueprint/components/force_strength.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -67,16 +66,14 @@ namespace rerun::blueprint::archetypes {
         /// The center force tries to move the center of mass of the graph towards the origin.
         ForceCenter with_enabled(const rerun::blueprint::components::Enabled& _enabled) && {
             enabled = ComponentBatch::from_loggable(_enabled, Descriptor_enabled).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The strength of the force.
         ForceCenter with_strength(const rerun::blueprint::components::ForceStrength& _strength) && {
             strength =
                 ComponentBatch::from_loggable(_strength, Descriptor_strength).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.hpp
@@ -7,7 +7,6 @@
 #include "../../blueprint/components/force_iterations.hpp"
 #include "../../blueprint/components/force_strength.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -80,8 +79,7 @@ namespace rerun::blueprint::archetypes {
         ForceCollisionRadius with_enabled(const rerun::blueprint::components::Enabled& _enabled
         ) && {
             enabled = ComponentBatch::from_loggable(_enabled, Descriptor_enabled).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The strength of the force.
@@ -90,8 +88,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             strength =
                 ComponentBatch::from_loggable(_strength, Descriptor_strength).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Specifies how often this force should be applied per iteration.
@@ -102,8 +99,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             iterations =
                 ComponentBatch::from_loggable(_iterations, Descriptor_iterations).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_link.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_link.hpp
@@ -7,7 +7,6 @@
 #include "../../blueprint/components/force_distance.hpp"
 #include "../../blueprint/components/force_iterations.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -78,16 +77,14 @@ namespace rerun::blueprint::archetypes {
         /// The link force aims to achieve a target distance between two nodes that are connected by one ore more edges.
         ForceLink with_enabled(const rerun::blueprint::components::Enabled& _enabled) && {
             enabled = ComponentBatch::from_loggable(_enabled, Descriptor_enabled).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The target distance between two nodes.
         ForceLink with_distance(const rerun::blueprint::components::ForceDistance& _distance) && {
             distance =
                 ComponentBatch::from_loggable(_distance, Descriptor_distance).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Specifies how often this force should be applied per iteration.
@@ -97,8 +94,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             iterations =
                 ComponentBatch::from_loggable(_iterations, Descriptor_iterations).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.hpp
@@ -6,7 +6,6 @@
 #include "../../blueprint/components/enabled.hpp"
 #include "../../blueprint/components/force_strength.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -73,8 +72,7 @@ namespace rerun::blueprint::archetypes {
         /// strength is smaller than 0, it pushes nodes apart; if it is larger than 0, it pulls them together.
         ForceManyBody with_enabled(const rerun::blueprint::components::Enabled& _enabled) && {
             enabled = ComponentBatch::from_loggable(_enabled, Descriptor_enabled).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The strength of the force.
@@ -84,8 +82,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             strength =
                 ComponentBatch::from_loggable(_strength, Descriptor_strength).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_position.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_position.hpp
@@ -6,7 +6,6 @@
 #include "../../blueprint/components/enabled.hpp"
 #include "../../blueprint/components/force_strength.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/position2d.hpp"
 #include "../../indicator_component.hpp"
@@ -76,8 +75,7 @@ namespace rerun::blueprint::archetypes {
         /// The position force pulls nodes towards a specific position, similar to gravity.
         ForcePosition with_enabled(const rerun::blueprint::components::Enabled& _enabled) && {
             enabled = ComponentBatch::from_loggable(_enabled, Descriptor_enabled).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The strength of the force.
@@ -85,16 +83,14 @@ namespace rerun::blueprint::archetypes {
         ) && {
             strength =
                 ComponentBatch::from_loggable(_strength, Descriptor_strength).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The position where the nodes should be pulled towards.
         ForcePosition with_position(const rerun::components::Position2D& _position) && {
             position =
                 ComponentBatch::from_loggable(_position, Descriptor_position).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.hpp
@@ -6,7 +6,6 @@
 #include "../../blueprint/components/grid_spacing.hpp"
 #include "../../blueprint/components/visible.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/color.hpp"
 #include "../../components/plane3d.hpp"
@@ -102,8 +101,7 @@ namespace rerun::blueprint::archetypes {
         /// Defaults to true.
         LineGrid3D with_visible(const rerun::blueprint::components::Visible& _visible) && {
             visible = ComponentBatch::from_loggable(_visible, Descriptor_visible).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Space between grid lines spacing of one line to the next in scene units.
@@ -112,8 +110,7 @@ namespace rerun::blueprint::archetypes {
         /// This controls the closest zoom level.
         LineGrid3D with_spacing(const rerun::blueprint::components::GridSpacing& _spacing) && {
             spacing = ComponentBatch::from_loggable(_spacing, Descriptor_spacing).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// In what plane the grid is drawn.
@@ -121,8 +118,7 @@ namespace rerun::blueprint::archetypes {
         /// Defaults to whatever plane is determined as the plane at zero units up/down as defined by `components::ViewCoordinates` if present.
         LineGrid3D with_plane(const rerun::components::Plane3D& _plane) && {
             plane = ComponentBatch::from_loggable(_plane, Descriptor_plane).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// How thick the lines should be in ui units.
@@ -131,8 +127,7 @@ namespace rerun::blueprint::archetypes {
         LineGrid3D with_stroke_width(const rerun::components::StrokeWidth& _stroke_width) && {
             stroke_width = ComponentBatch::from_loggable(_stroke_width, Descriptor_stroke_width)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Color used for the grid.
@@ -141,8 +136,7 @@ namespace rerun::blueprint::archetypes {
         /// Defaults to a slightly transparent light gray.
         LineGrid3D with_color(const rerun::components::Color& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_background.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_background.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/map_provider.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -63,8 +62,7 @@ namespace rerun::blueprint::archetypes {
         MapBackground with_provider(const rerun::blueprint::components::MapProvider& _provider) && {
             provider =
                 ComponentBatch::from_loggable(_provider, Descriptor_provider).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/zoom_level.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -62,8 +61,7 @@ namespace rerun::blueprint::archetypes {
         /// Zoom level follow the [`OpenStreetMap` definition](https://wiki.openstreetmap.org/wiki/Zoom_levels).
         MapZoom with_zoom(const rerun::blueprint::components::ZoomLevel& _zoom) && {
             zoom = ComponentBatch::from_loggable(_zoom, Descriptor_zoom).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/near_clip_plane.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -68,8 +67,7 @@ namespace rerun::blueprint::archetypes {
             near_clip_plane =
                 ComponentBatch::from_loggable(_near_clip_plane, Descriptor_near_clip_plane)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/panel_state.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -54,8 +53,7 @@ namespace rerun::blueprint::archetypes {
         /// Current state of the panels.
         PanelBlueprint with_state(const rerun::blueprint::components::PanelState& _state) && {
             state = ComponentBatch::from_loggable(_state, Descriptor_state).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.hpp
@@ -6,7 +6,6 @@
 #include "../../blueprint/components/corner2d.hpp"
 #include "../../blueprint/components/visible.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -69,8 +68,7 @@ namespace rerun::blueprint::archetypes {
         /// Defaults to the right bottom corner.
         PlotLegend with_corner(const rerun::blueprint::components::Corner2D& _corner) && {
             corner = ComponentBatch::from_loggable(_corner, Descriptor_corner).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Whether the legend is shown at all.
@@ -78,8 +76,7 @@ namespace rerun::blueprint::archetypes {
         /// True by default.
         PlotLegend with_visible(const rerun::blueprint::components::Visible& _visible) && {
             visible = ComponentBatch::from_loggable(_visible, Descriptor_visible).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/lock_range_during_zoom.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/range1d.hpp"
 #include "../../indicator_component.hpp"
@@ -66,8 +65,7 @@ namespace rerun::blueprint::archetypes {
         /// If unset, the range well be automatically determined based on the queried data.
         ScalarAxis with_range(const rerun::components::Range1D& _range) && {
             range = ComponentBatch::from_loggable(_range, Descriptor_range).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// If enabled, the Y axis range will remain locked to the specified range when zooming.
@@ -76,8 +74,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             zoom_lock =
                 ComponentBatch::from_loggable(_zoom_lock, Descriptor_zoom_lock).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/colormap.hpp"
 #include "../../components/gamma_correction.hpp"
@@ -86,16 +85,14 @@ namespace rerun::blueprint::archetypes {
         ) && {
             mag_filter =
                 ComponentBatch::from_loggable(_mag_filter, Descriptor_mag_filter).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// How scalar values map to colors.
         TensorScalarMapping with_colormap(const rerun::components::Colormap& _colormap) && {
             colormap =
                 ComponentBatch::from_loggable(_colormap, Descriptor_colormap).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Gamma exponent applied to normalized values before mapping to color.
@@ -107,8 +104,7 @@ namespace rerun::blueprint::archetypes {
         /// `colormap( ((value - data_display_range.min) / (data_display_range.max - data_display_range.min)) ** gamma )`
         TensorScalarMapping with_gamma(const rerun::components::GammaCorrection& _gamma) && {
             gamma = ComponentBatch::from_loggable(_gamma, Descriptor_gamma).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/tensor_dimension_index_slider.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/tensor_dimension_index_selection.hpp"
 #include "../../components/tensor_height_dimension.hpp"
@@ -95,8 +94,7 @@ namespace rerun::blueprint::archetypes {
         /// If not specified, the height will be determined automatically based on the name and index of the dimension.
         TensorSliceSelection with_width(const rerun::components::TensorWidthDimension& _width) && {
             width = ComponentBatch::from_loggable(_width, Descriptor_width).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Which dimension to map to height.
@@ -105,8 +103,7 @@ namespace rerun::blueprint::archetypes {
         TensorSliceSelection with_height(const rerun::components::TensorHeightDimension& _height
         ) && {
             height = ComponentBatch::from_loggable(_height, Descriptor_height).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Selected indices for all other dimensions.
@@ -116,8 +113,7 @@ namespace rerun::blueprint::archetypes {
             const Collection<rerun::components::TensorDimensionIndexSelection>& _indices
         ) && {
             indices = ComponentBatch::from_loggable(_indices, Descriptor_indices).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Any dimension listed here will have a slider for the index.
@@ -129,8 +125,7 @@ namespace rerun::blueprint::archetypes {
             const Collection<rerun::blueprint::components::TensorDimensionIndexSlider>& _slider
         ) && {
             slider = ComponentBatch::from_loggable(_slider, Descriptor_slider).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/view_fit.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -54,8 +53,7 @@ namespace rerun::blueprint::archetypes {
         /// How the image is scaled to fit the view.
         TensorViewFit with_scaling(const rerun::blueprint::components::ViewFit& _scaling) && {
             scaling = ComponentBatch::from_loggable(_scaling, Descriptor_scaling).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.hpp
@@ -7,7 +7,6 @@
 #include "../../blueprint/components/view_origin.hpp"
 #include "../../blueprint/components/visible.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../components/name.hpp"
 #include "../../indicator_component.hpp"
@@ -99,16 +98,14 @@ namespace rerun::blueprint::archetypes {
             class_identifier =
                 ComponentBatch::from_loggable(_class_identifier, Descriptor_class_identifier)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The name of the view.
         ViewBlueprint with_display_name(const rerun::components::Name& _display_name) && {
             display_name = ComponentBatch::from_loggable(_display_name, Descriptor_display_name)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// The "anchor point" of this view.
@@ -123,8 +120,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             space_origin = ComponentBatch::from_loggable(_space_origin, Descriptor_space_origin)
                                .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Whether this view is visible.
@@ -132,8 +128,7 @@ namespace rerun::blueprint::archetypes {
         /// Defaults to true if not specified.
         ViewBlueprint with_visible(const rerun::blueprint::components::Visible& _visible) && {
             visible = ComponentBatch::from_loggable(_visible, Descriptor_visible).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/query_expression.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -101,8 +100,7 @@ namespace rerun::blueprint::archetypes {
             const Collection<rerun::blueprint::components::QueryExpression>& _query
         ) && {
             query = ComponentBatch::from_loggable(_query, Descriptor_query).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
@@ -9,7 +9,6 @@
 #include "../../blueprint/components/view_maximized.hpp"
 #include "../../blueprint/components/viewer_recommendation_hash.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -108,8 +107,7 @@ namespace rerun::blueprint::archetypes {
             root_container =
                 ComponentBatch::from_loggable(_root_container, Descriptor_root_container)
                     .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Show one tab as maximized?
@@ -118,8 +116,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             maximized =
                 ComponentBatch::from_loggable(_maximized, Descriptor_maximized).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Whether the viewport layout is determined automatically.
@@ -131,8 +128,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             auto_layout = ComponentBatch::from_loggable(_auto_layout, Descriptor_auto_layout)
                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Whether or not views should be created automatically.
@@ -144,8 +140,7 @@ namespace rerun::blueprint::archetypes {
         ) && {
             auto_views =
                 ComponentBatch::from_loggable(_auto_views, Descriptor_auto_views).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         /// Hashes of all recommended views the viewer has already added and that should not be added again.
@@ -163,8 +158,7 @@ namespace rerun::blueprint::archetypes {
                                               Descriptor_past_viewer_recommendations
             )
                                               .value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/visible_time_range.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -75,8 +74,7 @@ namespace rerun::blueprint::archetypes {
             const Collection<rerun::blueprint::components::VisibleTimeRange>& _ranges
         ) && {
             ranges = ComponentBatch::from_loggable(_ranges, Descriptor_ranges).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.hpp
@@ -5,7 +5,6 @@
 
 #include "../../blueprint/components/visual_bounds2d.hpp"
 #include "../../collection.hpp"
-#include "../../compiler_utils.hpp"
 #include "../../component_batch.hpp"
 #include "../../indicator_component.hpp"
 #include "../../result.hpp"
@@ -68,8 +67,7 @@ namespace rerun::blueprint::archetypes {
         /// Use this to control pan & zoom of the view.
         VisualBounds2D with_range(const rerun::blueprint::components::VisualBounds2D& _range) && {
             range = ComponentBatch::from_loggable(_range, Descriptor_range).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -5,7 +5,78 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {}
+namespace rerun::archetypes {
+    AffixFuzzer1 AffixFuzzer1::clear_fields() {
+        auto archetype = AffixFuzzer1();
+        archetype.fuzz1001 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer1>(Descriptor_fuzz1001)
+                .value_or_throw();
+        archetype.fuzz1002 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer2>(Descriptor_fuzz1002)
+                .value_or_throw();
+        archetype.fuzz1003 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer3>(Descriptor_fuzz1003)
+                .value_or_throw();
+        archetype.fuzz1004 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer4>(Descriptor_fuzz1004)
+                .value_or_throw();
+        archetype.fuzz1005 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer5>(Descriptor_fuzz1005)
+                .value_or_throw();
+        archetype.fuzz1006 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer6>(Descriptor_fuzz1006)
+                .value_or_throw();
+        archetype.fuzz1007 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer7>(Descriptor_fuzz1007)
+                .value_or_throw();
+        archetype.fuzz1008 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer8>(Descriptor_fuzz1008)
+                .value_or_throw();
+        archetype.fuzz1009 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer9>(Descriptor_fuzz1009)
+                .value_or_throw();
+        archetype.fuzz1010 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer10>(Descriptor_fuzz1010)
+                .value_or_throw();
+        archetype.fuzz1011 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer11>(Descriptor_fuzz1011)
+                .value_or_throw();
+        archetype.fuzz1012 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer12>(Descriptor_fuzz1012)
+                .value_or_throw();
+        archetype.fuzz1013 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer13>(Descriptor_fuzz1013)
+                .value_or_throw();
+        archetype.fuzz1014 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer14>(Descriptor_fuzz1014)
+                .value_or_throw();
+        archetype.fuzz1015 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer15>(Descriptor_fuzz1015)
+                .value_or_throw();
+        archetype.fuzz1016 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer16>(Descriptor_fuzz1016)
+                .value_or_throw();
+        archetype.fuzz1017 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer17>(Descriptor_fuzz1017)
+                .value_or_throw();
+        archetype.fuzz1018 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer18>(Descriptor_fuzz1018)
+                .value_or_throw();
+        archetype.fuzz1019 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer19>(Descriptor_fuzz1019)
+                .value_or_throw();
+        archetype.fuzz1020 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer20>(Descriptor_fuzz1020)
+                .value_or_throw();
+        archetype.fuzz1021 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer21>(Descriptor_fuzz1021)
+                .value_or_throw();
+        archetype.fuzz1022 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer22>(Descriptor_fuzz1022)
+                .value_or_throw();
+        return archetype;
+    }
+} // namespace rerun::archetypes
 
 namespace rerun {
 
@@ -16,269 +87,71 @@ namespace rerun {
         std::vector<ComponentBatch> cells;
         cells.reserve(23);
 
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1001,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1001",
-                    "rerun.testing.components.AffixFuzzer1"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1001.has_value()) {
+            cells.push_back(archetype.fuzz1001.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1002,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1002",
-                    "rerun.testing.components.AffixFuzzer2"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1002.has_value()) {
+            cells.push_back(archetype.fuzz1002.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1003,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1003",
-                    "rerun.testing.components.AffixFuzzer3"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1003.has_value()) {
+            cells.push_back(archetype.fuzz1003.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1004,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1004",
-                    "rerun.testing.components.AffixFuzzer4"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1004.has_value()) {
+            cells.push_back(archetype.fuzz1004.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1005,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1005",
-                    "rerun.testing.components.AffixFuzzer5"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1005.has_value()) {
+            cells.push_back(archetype.fuzz1005.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1006,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1006",
-                    "rerun.testing.components.AffixFuzzer6"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1006.has_value()) {
+            cells.push_back(archetype.fuzz1006.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1007,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1007",
-                    "rerun.testing.components.AffixFuzzer7"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1007.has_value()) {
+            cells.push_back(archetype.fuzz1007.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1008,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1008",
-                    "rerun.testing.components.AffixFuzzer8"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1008.has_value()) {
+            cells.push_back(archetype.fuzz1008.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1009,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1009",
-                    "rerun.testing.components.AffixFuzzer9"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1009.has_value()) {
+            cells.push_back(archetype.fuzz1009.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1010,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1010",
-                    "rerun.testing.components.AffixFuzzer10"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1010.has_value()) {
+            cells.push_back(archetype.fuzz1010.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1011,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1011",
-                    "rerun.testing.components.AffixFuzzer11"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1011.has_value()) {
+            cells.push_back(archetype.fuzz1011.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1012,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1012",
-                    "rerun.testing.components.AffixFuzzer12"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1012.has_value()) {
+            cells.push_back(archetype.fuzz1012.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1013,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1013",
-                    "rerun.testing.components.AffixFuzzer13"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1013.has_value()) {
+            cells.push_back(archetype.fuzz1013.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1014,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1014",
-                    "rerun.testing.components.AffixFuzzer14"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1014.has_value()) {
+            cells.push_back(archetype.fuzz1014.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1015,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1015",
-                    "rerun.testing.components.AffixFuzzer15"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1015.has_value()) {
+            cells.push_back(archetype.fuzz1015.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1016,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1016",
-                    "rerun.testing.components.AffixFuzzer16"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1016.has_value()) {
+            cells.push_back(archetype.fuzz1016.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1017,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1017",
-                    "rerun.testing.components.AffixFuzzer17"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1017.has_value()) {
+            cells.push_back(archetype.fuzz1017.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1018,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1018",
-                    "rerun.testing.components.AffixFuzzer18"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1018.has_value()) {
+            cells.push_back(archetype.fuzz1018.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1019,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1019",
-                    "rerun.testing.components.AffixFuzzer19"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1019.has_value()) {
+            cells.push_back(archetype.fuzz1019.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1020,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1020",
-                    "rerun.testing.components.AffixFuzzer20"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1020.has_value()) {
+            cells.push_back(archetype.fuzz1020.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1021,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1021",
-                    "rerun.testing.components.AffixFuzzer21"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1021.has_value()) {
+            cells.push_back(archetype.fuzz1021.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1022,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer1",
-                    "fuzz1022",
-                    "rerun.testing.components.AffixFuzzer22"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1022.has_value()) {
+            cells.push_back(archetype.fuzz1022.value());
         }
         {
             auto indicator = AffixFuzzer1::IndicatorComponent();

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -27,7 +27,9 @@
 #include "../components/affix_fuzzer9.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <rerun/collection.hpp>
+#include <rerun/compiler_utils.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
@@ -36,49 +38,49 @@
 
 namespace rerun::archetypes {
     struct AffixFuzzer1 {
-        rerun::components::AffixFuzzer1 fuzz1001;
+        std::optional<ComponentBatch> fuzz1001;
 
-        rerun::components::AffixFuzzer2 fuzz1002;
+        std::optional<ComponentBatch> fuzz1002;
 
-        rerun::components::AffixFuzzer3 fuzz1003;
+        std::optional<ComponentBatch> fuzz1003;
 
-        rerun::components::AffixFuzzer4 fuzz1004;
+        std::optional<ComponentBatch> fuzz1004;
 
-        rerun::components::AffixFuzzer5 fuzz1005;
+        std::optional<ComponentBatch> fuzz1005;
 
-        rerun::components::AffixFuzzer6 fuzz1006;
+        std::optional<ComponentBatch> fuzz1006;
 
-        rerun::components::AffixFuzzer7 fuzz1007;
+        std::optional<ComponentBatch> fuzz1007;
 
-        rerun::components::AffixFuzzer8 fuzz1008;
+        std::optional<ComponentBatch> fuzz1008;
 
-        rerun::components::AffixFuzzer9 fuzz1009;
+        std::optional<ComponentBatch> fuzz1009;
 
-        rerun::components::AffixFuzzer10 fuzz1010;
+        std::optional<ComponentBatch> fuzz1010;
 
-        rerun::components::AffixFuzzer11 fuzz1011;
+        std::optional<ComponentBatch> fuzz1011;
 
-        rerun::components::AffixFuzzer12 fuzz1012;
+        std::optional<ComponentBatch> fuzz1012;
 
-        rerun::components::AffixFuzzer13 fuzz1013;
+        std::optional<ComponentBatch> fuzz1013;
 
-        rerun::components::AffixFuzzer14 fuzz1014;
+        std::optional<ComponentBatch> fuzz1014;
 
-        rerun::components::AffixFuzzer15 fuzz1015;
+        std::optional<ComponentBatch> fuzz1015;
 
-        rerun::components::AffixFuzzer16 fuzz1016;
+        std::optional<ComponentBatch> fuzz1016;
 
-        rerun::components::AffixFuzzer17 fuzz1017;
+        std::optional<ComponentBatch> fuzz1017;
 
-        rerun::components::AffixFuzzer18 fuzz1018;
+        std::optional<ComponentBatch> fuzz1018;
 
-        rerun::components::AffixFuzzer19 fuzz1019;
+        std::optional<ComponentBatch> fuzz1019;
 
-        rerun::components::AffixFuzzer20 fuzz1020;
+        std::optional<ComponentBatch> fuzz1020;
 
-        rerun::components::AffixFuzzer21 fuzz1021;
+        std::optional<ComponentBatch> fuzz1021;
 
-        rerun::components::AffixFuzzer22 fuzz1022;
+        std::optional<ComponentBatch> fuzz1022;
 
       public:
         static constexpr const char IndicatorComponentName[] =
@@ -88,6 +90,117 @@ namespace rerun::archetypes {
         using IndicatorComponent = rerun::components::IndicatorComponent<IndicatorComponentName>;
         /// The name of the archetype as used in `ComponentDescriptor`s.
         static constexpr const char ArchetypeName[] = "rerun.testing.archetypes.AffixFuzzer1";
+
+        /// `ComponentDescriptor` for the `fuzz1001` field.
+        static constexpr auto Descriptor_fuzz1001 = ComponentDescriptor(
+            ArchetypeName, "fuzz1001",
+            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1002` field.
+        static constexpr auto Descriptor_fuzz1002 = ComponentDescriptor(
+            ArchetypeName, "fuzz1002",
+            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1003` field.
+        static constexpr auto Descriptor_fuzz1003 = ComponentDescriptor(
+            ArchetypeName, "fuzz1003",
+            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1004` field.
+        static constexpr auto Descriptor_fuzz1004 = ComponentDescriptor(
+            ArchetypeName, "fuzz1004",
+            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1005` field.
+        static constexpr auto Descriptor_fuzz1005 = ComponentDescriptor(
+            ArchetypeName, "fuzz1005",
+            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1006` field.
+        static constexpr auto Descriptor_fuzz1006 = ComponentDescriptor(
+            ArchetypeName, "fuzz1006",
+            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1007` field.
+        static constexpr auto Descriptor_fuzz1007 = ComponentDescriptor(
+            ArchetypeName, "fuzz1007",
+            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1008` field.
+        static constexpr auto Descriptor_fuzz1008 = ComponentDescriptor(
+            ArchetypeName, "fuzz1008",
+            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1009` field.
+        static constexpr auto Descriptor_fuzz1009 = ComponentDescriptor(
+            ArchetypeName, "fuzz1009",
+            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1010` field.
+        static constexpr auto Descriptor_fuzz1010 = ComponentDescriptor(
+            ArchetypeName, "fuzz1010",
+            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1011` field.
+        static constexpr auto Descriptor_fuzz1011 = ComponentDescriptor(
+            ArchetypeName, "fuzz1011",
+            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1012` field.
+        static constexpr auto Descriptor_fuzz1012 = ComponentDescriptor(
+            ArchetypeName, "fuzz1012",
+            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1013` field.
+        static constexpr auto Descriptor_fuzz1013 = ComponentDescriptor(
+            ArchetypeName, "fuzz1013",
+            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1014` field.
+        static constexpr auto Descriptor_fuzz1014 = ComponentDescriptor(
+            ArchetypeName, "fuzz1014",
+            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1015` field.
+        static constexpr auto Descriptor_fuzz1015 = ComponentDescriptor(
+            ArchetypeName, "fuzz1015",
+            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1016` field.
+        static constexpr auto Descriptor_fuzz1016 = ComponentDescriptor(
+            ArchetypeName, "fuzz1016",
+            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1017` field.
+        static constexpr auto Descriptor_fuzz1017 = ComponentDescriptor(
+            ArchetypeName, "fuzz1017",
+            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1018` field.
+        static constexpr auto Descriptor_fuzz1018 = ComponentDescriptor(
+            ArchetypeName, "fuzz1018",
+            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1019` field.
+        static constexpr auto Descriptor_fuzz1019 = ComponentDescriptor(
+            ArchetypeName, "fuzz1019",
+            Loggable<rerun::components::AffixFuzzer19>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1020` field.
+        static constexpr auto Descriptor_fuzz1020 = ComponentDescriptor(
+            ArchetypeName, "fuzz1020",
+            Loggable<rerun::components::AffixFuzzer20>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1021` field.
+        static constexpr auto Descriptor_fuzz1021 = ComponentDescriptor(
+            ArchetypeName, "fuzz1021",
+            Loggable<rerun::components::AffixFuzzer21>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1022` field.
+        static constexpr auto Descriptor_fuzz1022 = ComponentDescriptor(
+            ArchetypeName, "fuzz1022",
+            Loggable<rerun::components::AffixFuzzer22>::Descriptor.component_name
+        );
 
       public:
         AffixFuzzer1() = default;
@@ -109,28 +222,212 @@ namespace rerun::archetypes {
             rerun::components::AffixFuzzer19 _fuzz1019, rerun::components::AffixFuzzer20 _fuzz1020,
             rerun::components::AffixFuzzer21 _fuzz1021, rerun::components::AffixFuzzer22 _fuzz1022
         )
-            : fuzz1001(std::move(_fuzz1001)),
-              fuzz1002(std::move(_fuzz1002)),
-              fuzz1003(std::move(_fuzz1003)),
-              fuzz1004(std::move(_fuzz1004)),
-              fuzz1005(std::move(_fuzz1005)),
-              fuzz1006(std::move(_fuzz1006)),
-              fuzz1007(std::move(_fuzz1007)),
-              fuzz1008(std::move(_fuzz1008)),
-              fuzz1009(std::move(_fuzz1009)),
-              fuzz1010(std::move(_fuzz1010)),
-              fuzz1011(std::move(_fuzz1011)),
-              fuzz1012(std::move(_fuzz1012)),
-              fuzz1013(std::move(_fuzz1013)),
-              fuzz1014(std::move(_fuzz1014)),
-              fuzz1015(std::move(_fuzz1015)),
-              fuzz1016(std::move(_fuzz1016)),
-              fuzz1017(std::move(_fuzz1017)),
-              fuzz1018(std::move(_fuzz1018)),
-              fuzz1019(std::move(_fuzz1019)),
-              fuzz1020(std::move(_fuzz1020)),
-              fuzz1021(std::move(_fuzz1021)),
-              fuzz1022(std::move(_fuzz1022)) {}
+            : fuzz1001(ComponentBatch::from_loggable(std::move(_fuzz1001), Descriptor_fuzz1001)
+                           .value_or_throw()),
+              fuzz1002(ComponentBatch::from_loggable(std::move(_fuzz1002), Descriptor_fuzz1002)
+                           .value_or_throw()),
+              fuzz1003(ComponentBatch::from_loggable(std::move(_fuzz1003), Descriptor_fuzz1003)
+                           .value_or_throw()),
+              fuzz1004(ComponentBatch::from_loggable(std::move(_fuzz1004), Descriptor_fuzz1004)
+                           .value_or_throw()),
+              fuzz1005(ComponentBatch::from_loggable(std::move(_fuzz1005), Descriptor_fuzz1005)
+                           .value_or_throw()),
+              fuzz1006(ComponentBatch::from_loggable(std::move(_fuzz1006), Descriptor_fuzz1006)
+                           .value_or_throw()),
+              fuzz1007(ComponentBatch::from_loggable(std::move(_fuzz1007), Descriptor_fuzz1007)
+                           .value_or_throw()),
+              fuzz1008(ComponentBatch::from_loggable(std::move(_fuzz1008), Descriptor_fuzz1008)
+                           .value_or_throw()),
+              fuzz1009(ComponentBatch::from_loggable(std::move(_fuzz1009), Descriptor_fuzz1009)
+                           .value_or_throw()),
+              fuzz1010(ComponentBatch::from_loggable(std::move(_fuzz1010), Descriptor_fuzz1010)
+                           .value_or_throw()),
+              fuzz1011(ComponentBatch::from_loggable(std::move(_fuzz1011), Descriptor_fuzz1011)
+                           .value_or_throw()),
+              fuzz1012(ComponentBatch::from_loggable(std::move(_fuzz1012), Descriptor_fuzz1012)
+                           .value_or_throw()),
+              fuzz1013(ComponentBatch::from_loggable(std::move(_fuzz1013), Descriptor_fuzz1013)
+                           .value_or_throw()),
+              fuzz1014(ComponentBatch::from_loggable(std::move(_fuzz1014), Descriptor_fuzz1014)
+                           .value_or_throw()),
+              fuzz1015(ComponentBatch::from_loggable(std::move(_fuzz1015), Descriptor_fuzz1015)
+                           .value_or_throw()),
+              fuzz1016(ComponentBatch::from_loggable(std::move(_fuzz1016), Descriptor_fuzz1016)
+                           .value_or_throw()),
+              fuzz1017(ComponentBatch::from_loggable(std::move(_fuzz1017), Descriptor_fuzz1017)
+                           .value_or_throw()),
+              fuzz1018(ComponentBatch::from_loggable(std::move(_fuzz1018), Descriptor_fuzz1018)
+                           .value_or_throw()),
+              fuzz1019(ComponentBatch::from_loggable(std::move(_fuzz1019), Descriptor_fuzz1019)
+                           .value_or_throw()),
+              fuzz1020(ComponentBatch::from_loggable(std::move(_fuzz1020), Descriptor_fuzz1020)
+                           .value_or_throw()),
+              fuzz1021(ComponentBatch::from_loggable(std::move(_fuzz1021), Descriptor_fuzz1021)
+                           .value_or_throw()),
+              fuzz1022(ComponentBatch::from_loggable(std::move(_fuzz1022), Descriptor_fuzz1022)
+                           .value_or_throw()) {}
+
+        /// Update only some specific fields of a `AffixFuzzer1`.
+        static AffixFuzzer1 update_fields() {
+            return AffixFuzzer1();
+        }
+
+        /// Clear all the fields of a `AffixFuzzer1`.
+        static AffixFuzzer1 clear_fields();
+
+        AffixFuzzer1 with_fuzz1001(const rerun::components::AffixFuzzer1& _fuzz1001) && {
+            fuzz1001 =
+                ComponentBatch::from_loggable(_fuzz1001, Descriptor_fuzz1001).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1002(const rerun::components::AffixFuzzer2& _fuzz1002) && {
+            fuzz1002 =
+                ComponentBatch::from_loggable(_fuzz1002, Descriptor_fuzz1002).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1003(const rerun::components::AffixFuzzer3& _fuzz1003) && {
+            fuzz1003 =
+                ComponentBatch::from_loggable(_fuzz1003, Descriptor_fuzz1003).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1004(const rerun::components::AffixFuzzer4& _fuzz1004) && {
+            fuzz1004 =
+                ComponentBatch::from_loggable(_fuzz1004, Descriptor_fuzz1004).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1005(const rerun::components::AffixFuzzer5& _fuzz1005) && {
+            fuzz1005 =
+                ComponentBatch::from_loggable(_fuzz1005, Descriptor_fuzz1005).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1006(const rerun::components::AffixFuzzer6& _fuzz1006) && {
+            fuzz1006 =
+                ComponentBatch::from_loggable(_fuzz1006, Descriptor_fuzz1006).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1007(const rerun::components::AffixFuzzer7& _fuzz1007) && {
+            fuzz1007 =
+                ComponentBatch::from_loggable(_fuzz1007, Descriptor_fuzz1007).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1008(const rerun::components::AffixFuzzer8& _fuzz1008) && {
+            fuzz1008 =
+                ComponentBatch::from_loggable(_fuzz1008, Descriptor_fuzz1008).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1009(const rerun::components::AffixFuzzer9& _fuzz1009) && {
+            fuzz1009 =
+                ComponentBatch::from_loggable(_fuzz1009, Descriptor_fuzz1009).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1010(const rerun::components::AffixFuzzer10& _fuzz1010) && {
+            fuzz1010 =
+                ComponentBatch::from_loggable(_fuzz1010, Descriptor_fuzz1010).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1011(const rerun::components::AffixFuzzer11& _fuzz1011) && {
+            fuzz1011 =
+                ComponentBatch::from_loggable(_fuzz1011, Descriptor_fuzz1011).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1012(const rerun::components::AffixFuzzer12& _fuzz1012) && {
+            fuzz1012 =
+                ComponentBatch::from_loggable(_fuzz1012, Descriptor_fuzz1012).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1013(const rerun::components::AffixFuzzer13& _fuzz1013) && {
+            fuzz1013 =
+                ComponentBatch::from_loggable(_fuzz1013, Descriptor_fuzz1013).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1014(const rerun::components::AffixFuzzer14& _fuzz1014) && {
+            fuzz1014 =
+                ComponentBatch::from_loggable(_fuzz1014, Descriptor_fuzz1014).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1015(const rerun::components::AffixFuzzer15& _fuzz1015) && {
+            fuzz1015 =
+                ComponentBatch::from_loggable(_fuzz1015, Descriptor_fuzz1015).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1016(const rerun::components::AffixFuzzer16& _fuzz1016) && {
+            fuzz1016 =
+                ComponentBatch::from_loggable(_fuzz1016, Descriptor_fuzz1016).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1017(const rerun::components::AffixFuzzer17& _fuzz1017) && {
+            fuzz1017 =
+                ComponentBatch::from_loggable(_fuzz1017, Descriptor_fuzz1017).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1018(const rerun::components::AffixFuzzer18& _fuzz1018) && {
+            fuzz1018 =
+                ComponentBatch::from_loggable(_fuzz1018, Descriptor_fuzz1018).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1019(const rerun::components::AffixFuzzer19& _fuzz1019) && {
+            fuzz1019 =
+                ComponentBatch::from_loggable(_fuzz1019, Descriptor_fuzz1019).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1020(const rerun::components::AffixFuzzer20& _fuzz1020) && {
+            fuzz1020 =
+                ComponentBatch::from_loggable(_fuzz1020, Descriptor_fuzz1020).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1021(const rerun::components::AffixFuzzer21& _fuzz1021) && {
+            fuzz1021 =
+                ComponentBatch::from_loggable(_fuzz1021, Descriptor_fuzz1021).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer1 with_fuzz1022(const rerun::components::AffixFuzzer22& _fuzz1022) && {
+            fuzz1022 =
+                ComponentBatch::from_loggable(_fuzz1022, Descriptor_fuzz1022).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
     };
 
 } // namespace rerun::archetypes

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -29,7 +29,6 @@
 #include <cstdint>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/compiler_utils.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
@@ -278,155 +277,133 @@ namespace rerun::archetypes {
         AffixFuzzer1 with_fuzz1001(const rerun::components::AffixFuzzer1& _fuzz1001) && {
             fuzz1001 =
                 ComponentBatch::from_loggable(_fuzz1001, Descriptor_fuzz1001).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1002(const rerun::components::AffixFuzzer2& _fuzz1002) && {
             fuzz1002 =
                 ComponentBatch::from_loggable(_fuzz1002, Descriptor_fuzz1002).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1003(const rerun::components::AffixFuzzer3& _fuzz1003) && {
             fuzz1003 =
                 ComponentBatch::from_loggable(_fuzz1003, Descriptor_fuzz1003).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1004(const rerun::components::AffixFuzzer4& _fuzz1004) && {
             fuzz1004 =
                 ComponentBatch::from_loggable(_fuzz1004, Descriptor_fuzz1004).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1005(const rerun::components::AffixFuzzer5& _fuzz1005) && {
             fuzz1005 =
                 ComponentBatch::from_loggable(_fuzz1005, Descriptor_fuzz1005).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1006(const rerun::components::AffixFuzzer6& _fuzz1006) && {
             fuzz1006 =
                 ComponentBatch::from_loggable(_fuzz1006, Descriptor_fuzz1006).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1007(const rerun::components::AffixFuzzer7& _fuzz1007) && {
             fuzz1007 =
                 ComponentBatch::from_loggable(_fuzz1007, Descriptor_fuzz1007).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1008(const rerun::components::AffixFuzzer8& _fuzz1008) && {
             fuzz1008 =
                 ComponentBatch::from_loggable(_fuzz1008, Descriptor_fuzz1008).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1009(const rerun::components::AffixFuzzer9& _fuzz1009) && {
             fuzz1009 =
                 ComponentBatch::from_loggable(_fuzz1009, Descriptor_fuzz1009).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1010(const rerun::components::AffixFuzzer10& _fuzz1010) && {
             fuzz1010 =
                 ComponentBatch::from_loggable(_fuzz1010, Descriptor_fuzz1010).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1011(const rerun::components::AffixFuzzer11& _fuzz1011) && {
             fuzz1011 =
                 ComponentBatch::from_loggable(_fuzz1011, Descriptor_fuzz1011).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1012(const rerun::components::AffixFuzzer12& _fuzz1012) && {
             fuzz1012 =
                 ComponentBatch::from_loggable(_fuzz1012, Descriptor_fuzz1012).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1013(const rerun::components::AffixFuzzer13& _fuzz1013) && {
             fuzz1013 =
                 ComponentBatch::from_loggable(_fuzz1013, Descriptor_fuzz1013).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1014(const rerun::components::AffixFuzzer14& _fuzz1014) && {
             fuzz1014 =
                 ComponentBatch::from_loggable(_fuzz1014, Descriptor_fuzz1014).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1015(const rerun::components::AffixFuzzer15& _fuzz1015) && {
             fuzz1015 =
                 ComponentBatch::from_loggable(_fuzz1015, Descriptor_fuzz1015).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1016(const rerun::components::AffixFuzzer16& _fuzz1016) && {
             fuzz1016 =
                 ComponentBatch::from_loggable(_fuzz1016, Descriptor_fuzz1016).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1017(const rerun::components::AffixFuzzer17& _fuzz1017) && {
             fuzz1017 =
                 ComponentBatch::from_loggable(_fuzz1017, Descriptor_fuzz1017).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1018(const rerun::components::AffixFuzzer18& _fuzz1018) && {
             fuzz1018 =
                 ComponentBatch::from_loggable(_fuzz1018, Descriptor_fuzz1018).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1019(const rerun::components::AffixFuzzer19& _fuzz1019) && {
             fuzz1019 =
                 ComponentBatch::from_loggable(_fuzz1019, Descriptor_fuzz1019).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1020(const rerun::components::AffixFuzzer20& _fuzz1020) && {
             fuzz1020 =
                 ComponentBatch::from_loggable(_fuzz1020, Descriptor_fuzz1020).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1021(const rerun::components::AffixFuzzer21& _fuzz1021) && {
             fuzz1021 =
                 ComponentBatch::from_loggable(_fuzz1021, Descriptor_fuzz1021).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer1 with_fuzz1022(const rerun::components::AffixFuzzer22& _fuzz1022) && {
             fuzz1022 =
                 ComponentBatch::from_loggable(_fuzz1022, Descriptor_fuzz1022).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -5,7 +5,69 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {}
+namespace rerun::archetypes {
+    AffixFuzzer2 AffixFuzzer2::clear_fields() {
+        auto archetype = AffixFuzzer2();
+        archetype.fuzz1101 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer1>(Descriptor_fuzz1101)
+                .value_or_throw();
+        archetype.fuzz1102 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer2>(Descriptor_fuzz1102)
+                .value_or_throw();
+        archetype.fuzz1103 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer3>(Descriptor_fuzz1103)
+                .value_or_throw();
+        archetype.fuzz1104 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer4>(Descriptor_fuzz1104)
+                .value_or_throw();
+        archetype.fuzz1105 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer5>(Descriptor_fuzz1105)
+                .value_or_throw();
+        archetype.fuzz1106 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer6>(Descriptor_fuzz1106)
+                .value_or_throw();
+        archetype.fuzz1107 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer7>(Descriptor_fuzz1107)
+                .value_or_throw();
+        archetype.fuzz1108 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer8>(Descriptor_fuzz1108)
+                .value_or_throw();
+        archetype.fuzz1109 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer9>(Descriptor_fuzz1109)
+                .value_or_throw();
+        archetype.fuzz1110 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer10>(Descriptor_fuzz1110)
+                .value_or_throw();
+        archetype.fuzz1111 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer11>(Descriptor_fuzz1111)
+                .value_or_throw();
+        archetype.fuzz1112 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer12>(Descriptor_fuzz1112)
+                .value_or_throw();
+        archetype.fuzz1113 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer13>(Descriptor_fuzz1113)
+                .value_or_throw();
+        archetype.fuzz1114 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer14>(Descriptor_fuzz1114)
+                .value_or_throw();
+        archetype.fuzz1115 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer15>(Descriptor_fuzz1115)
+                .value_or_throw();
+        archetype.fuzz1116 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer16>(Descriptor_fuzz1116)
+                .value_or_throw();
+        archetype.fuzz1117 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer17>(Descriptor_fuzz1117)
+                .value_or_throw();
+        archetype.fuzz1118 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer18>(Descriptor_fuzz1118)
+                .value_or_throw();
+        archetype.fuzz1122 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer22>(Descriptor_fuzz1122)
+                .value_or_throw();
+        return archetype;
+    }
+} // namespace rerun::archetypes
 
 namespace rerun {
 
@@ -16,233 +78,62 @@ namespace rerun {
         std::vector<ComponentBatch> cells;
         cells.reserve(20);
 
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1101,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1101",
-                    "rerun.testing.components.AffixFuzzer1"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1101.has_value()) {
+            cells.push_back(archetype.fuzz1101.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1102,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1102",
-                    "rerun.testing.components.AffixFuzzer2"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1102.has_value()) {
+            cells.push_back(archetype.fuzz1102.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1103,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1103",
-                    "rerun.testing.components.AffixFuzzer3"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1103.has_value()) {
+            cells.push_back(archetype.fuzz1103.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1104,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1104",
-                    "rerun.testing.components.AffixFuzzer4"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1104.has_value()) {
+            cells.push_back(archetype.fuzz1104.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1105,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1105",
-                    "rerun.testing.components.AffixFuzzer5"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1105.has_value()) {
+            cells.push_back(archetype.fuzz1105.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1106,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1106",
-                    "rerun.testing.components.AffixFuzzer6"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1106.has_value()) {
+            cells.push_back(archetype.fuzz1106.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1107,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1107",
-                    "rerun.testing.components.AffixFuzzer7"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1107.has_value()) {
+            cells.push_back(archetype.fuzz1107.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1108,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1108",
-                    "rerun.testing.components.AffixFuzzer8"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1108.has_value()) {
+            cells.push_back(archetype.fuzz1108.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1109,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1109",
-                    "rerun.testing.components.AffixFuzzer9"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1109.has_value()) {
+            cells.push_back(archetype.fuzz1109.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1110,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1110",
-                    "rerun.testing.components.AffixFuzzer10"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1110.has_value()) {
+            cells.push_back(archetype.fuzz1110.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1111,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1111",
-                    "rerun.testing.components.AffixFuzzer11"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1111.has_value()) {
+            cells.push_back(archetype.fuzz1111.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1112,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1112",
-                    "rerun.testing.components.AffixFuzzer12"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1112.has_value()) {
+            cells.push_back(archetype.fuzz1112.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1113,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1113",
-                    "rerun.testing.components.AffixFuzzer13"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1113.has_value()) {
+            cells.push_back(archetype.fuzz1113.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1114,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1114",
-                    "rerun.testing.components.AffixFuzzer14"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1114.has_value()) {
+            cells.push_back(archetype.fuzz1114.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1115,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1115",
-                    "rerun.testing.components.AffixFuzzer15"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1115.has_value()) {
+            cells.push_back(archetype.fuzz1115.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1116,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1116",
-                    "rerun.testing.components.AffixFuzzer16"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1116.has_value()) {
+            cells.push_back(archetype.fuzz1116.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1117,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1117",
-                    "rerun.testing.components.AffixFuzzer17"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1117.has_value()) {
+            cells.push_back(archetype.fuzz1117.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1118,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1118",
-                    "rerun.testing.components.AffixFuzzer18"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1118.has_value()) {
+            cells.push_back(archetype.fuzz1118.value());
         }
-        {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz1122,
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer2",
-                    "fuzz1122",
-                    "rerun.testing.components.AffixFuzzer22"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+        if (archetype.fuzz1122.has_value()) {
+            cells.push_back(archetype.fuzz1122.value());
         }
         {
             auto indicator = AffixFuzzer2::IndicatorComponent();

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -24,7 +24,9 @@
 #include "../components/affix_fuzzer9.hpp"
 
 #include <cstdint>
+#include <optional>
 #include <rerun/collection.hpp>
+#include <rerun/compiler_utils.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
@@ -33,43 +35,43 @@
 
 namespace rerun::archetypes {
     struct AffixFuzzer2 {
-        Collection<rerun::components::AffixFuzzer1> fuzz1101;
+        std::optional<ComponentBatch> fuzz1101;
 
-        Collection<rerun::components::AffixFuzzer2> fuzz1102;
+        std::optional<ComponentBatch> fuzz1102;
 
-        Collection<rerun::components::AffixFuzzer3> fuzz1103;
+        std::optional<ComponentBatch> fuzz1103;
 
-        Collection<rerun::components::AffixFuzzer4> fuzz1104;
+        std::optional<ComponentBatch> fuzz1104;
 
-        Collection<rerun::components::AffixFuzzer5> fuzz1105;
+        std::optional<ComponentBatch> fuzz1105;
 
-        Collection<rerun::components::AffixFuzzer6> fuzz1106;
+        std::optional<ComponentBatch> fuzz1106;
 
-        Collection<rerun::components::AffixFuzzer7> fuzz1107;
+        std::optional<ComponentBatch> fuzz1107;
 
-        Collection<rerun::components::AffixFuzzer8> fuzz1108;
+        std::optional<ComponentBatch> fuzz1108;
 
-        Collection<rerun::components::AffixFuzzer9> fuzz1109;
+        std::optional<ComponentBatch> fuzz1109;
 
-        Collection<rerun::components::AffixFuzzer10> fuzz1110;
+        std::optional<ComponentBatch> fuzz1110;
 
-        Collection<rerun::components::AffixFuzzer11> fuzz1111;
+        std::optional<ComponentBatch> fuzz1111;
 
-        Collection<rerun::components::AffixFuzzer12> fuzz1112;
+        std::optional<ComponentBatch> fuzz1112;
 
-        Collection<rerun::components::AffixFuzzer13> fuzz1113;
+        std::optional<ComponentBatch> fuzz1113;
 
-        Collection<rerun::components::AffixFuzzer14> fuzz1114;
+        std::optional<ComponentBatch> fuzz1114;
 
-        Collection<rerun::components::AffixFuzzer15> fuzz1115;
+        std::optional<ComponentBatch> fuzz1115;
 
-        Collection<rerun::components::AffixFuzzer16> fuzz1116;
+        std::optional<ComponentBatch> fuzz1116;
 
-        Collection<rerun::components::AffixFuzzer17> fuzz1117;
+        std::optional<ComponentBatch> fuzz1117;
 
-        Collection<rerun::components::AffixFuzzer18> fuzz1118;
+        std::optional<ComponentBatch> fuzz1118;
 
-        Collection<rerun::components::AffixFuzzer22> fuzz1122;
+        std::optional<ComponentBatch> fuzz1122;
 
       public:
         static constexpr const char IndicatorComponentName[] =
@@ -79,6 +81,102 @@ namespace rerun::archetypes {
         using IndicatorComponent = rerun::components::IndicatorComponent<IndicatorComponentName>;
         /// The name of the archetype as used in `ComponentDescriptor`s.
         static constexpr const char ArchetypeName[] = "rerun.testing.archetypes.AffixFuzzer2";
+
+        /// `ComponentDescriptor` for the `fuzz1101` field.
+        static constexpr auto Descriptor_fuzz1101 = ComponentDescriptor(
+            ArchetypeName, "fuzz1101",
+            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1102` field.
+        static constexpr auto Descriptor_fuzz1102 = ComponentDescriptor(
+            ArchetypeName, "fuzz1102",
+            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1103` field.
+        static constexpr auto Descriptor_fuzz1103 = ComponentDescriptor(
+            ArchetypeName, "fuzz1103",
+            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1104` field.
+        static constexpr auto Descriptor_fuzz1104 = ComponentDescriptor(
+            ArchetypeName, "fuzz1104",
+            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1105` field.
+        static constexpr auto Descriptor_fuzz1105 = ComponentDescriptor(
+            ArchetypeName, "fuzz1105",
+            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1106` field.
+        static constexpr auto Descriptor_fuzz1106 = ComponentDescriptor(
+            ArchetypeName, "fuzz1106",
+            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1107` field.
+        static constexpr auto Descriptor_fuzz1107 = ComponentDescriptor(
+            ArchetypeName, "fuzz1107",
+            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1108` field.
+        static constexpr auto Descriptor_fuzz1108 = ComponentDescriptor(
+            ArchetypeName, "fuzz1108",
+            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1109` field.
+        static constexpr auto Descriptor_fuzz1109 = ComponentDescriptor(
+            ArchetypeName, "fuzz1109",
+            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1110` field.
+        static constexpr auto Descriptor_fuzz1110 = ComponentDescriptor(
+            ArchetypeName, "fuzz1110",
+            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1111` field.
+        static constexpr auto Descriptor_fuzz1111 = ComponentDescriptor(
+            ArchetypeName, "fuzz1111",
+            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1112` field.
+        static constexpr auto Descriptor_fuzz1112 = ComponentDescriptor(
+            ArchetypeName, "fuzz1112",
+            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1113` field.
+        static constexpr auto Descriptor_fuzz1113 = ComponentDescriptor(
+            ArchetypeName, "fuzz1113",
+            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1114` field.
+        static constexpr auto Descriptor_fuzz1114 = ComponentDescriptor(
+            ArchetypeName, "fuzz1114",
+            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1115` field.
+        static constexpr auto Descriptor_fuzz1115 = ComponentDescriptor(
+            ArchetypeName, "fuzz1115",
+            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1116` field.
+        static constexpr auto Descriptor_fuzz1116 = ComponentDescriptor(
+            ArchetypeName, "fuzz1116",
+            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1117` field.
+        static constexpr auto Descriptor_fuzz1117 = ComponentDescriptor(
+            ArchetypeName, "fuzz1117",
+            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1118` field.
+        static constexpr auto Descriptor_fuzz1118 = ComponentDescriptor(
+            ArchetypeName, "fuzz1118",
+            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz1122` field.
+        static constexpr auto Descriptor_fuzz1122 = ComponentDescriptor(
+            ArchetypeName, "fuzz1122",
+            Loggable<rerun::components::AffixFuzzer22>::Descriptor.component_name
+        );
 
       public:
         AffixFuzzer2() = default;
@@ -108,25 +206,204 @@ namespace rerun::archetypes {
             Collection<rerun::components::AffixFuzzer18> _fuzz1118,
             Collection<rerun::components::AffixFuzzer22> _fuzz1122
         )
-            : fuzz1101(std::move(_fuzz1101)),
-              fuzz1102(std::move(_fuzz1102)),
-              fuzz1103(std::move(_fuzz1103)),
-              fuzz1104(std::move(_fuzz1104)),
-              fuzz1105(std::move(_fuzz1105)),
-              fuzz1106(std::move(_fuzz1106)),
-              fuzz1107(std::move(_fuzz1107)),
-              fuzz1108(std::move(_fuzz1108)),
-              fuzz1109(std::move(_fuzz1109)),
-              fuzz1110(std::move(_fuzz1110)),
-              fuzz1111(std::move(_fuzz1111)),
-              fuzz1112(std::move(_fuzz1112)),
-              fuzz1113(std::move(_fuzz1113)),
-              fuzz1114(std::move(_fuzz1114)),
-              fuzz1115(std::move(_fuzz1115)),
-              fuzz1116(std::move(_fuzz1116)),
-              fuzz1117(std::move(_fuzz1117)),
-              fuzz1118(std::move(_fuzz1118)),
-              fuzz1122(std::move(_fuzz1122)) {}
+            : fuzz1101(ComponentBatch::from_loggable(std::move(_fuzz1101), Descriptor_fuzz1101)
+                           .value_or_throw()),
+              fuzz1102(ComponentBatch::from_loggable(std::move(_fuzz1102), Descriptor_fuzz1102)
+                           .value_or_throw()),
+              fuzz1103(ComponentBatch::from_loggable(std::move(_fuzz1103), Descriptor_fuzz1103)
+                           .value_or_throw()),
+              fuzz1104(ComponentBatch::from_loggable(std::move(_fuzz1104), Descriptor_fuzz1104)
+                           .value_or_throw()),
+              fuzz1105(ComponentBatch::from_loggable(std::move(_fuzz1105), Descriptor_fuzz1105)
+                           .value_or_throw()),
+              fuzz1106(ComponentBatch::from_loggable(std::move(_fuzz1106), Descriptor_fuzz1106)
+                           .value_or_throw()),
+              fuzz1107(ComponentBatch::from_loggable(std::move(_fuzz1107), Descriptor_fuzz1107)
+                           .value_or_throw()),
+              fuzz1108(ComponentBatch::from_loggable(std::move(_fuzz1108), Descriptor_fuzz1108)
+                           .value_or_throw()),
+              fuzz1109(ComponentBatch::from_loggable(std::move(_fuzz1109), Descriptor_fuzz1109)
+                           .value_or_throw()),
+              fuzz1110(ComponentBatch::from_loggable(std::move(_fuzz1110), Descriptor_fuzz1110)
+                           .value_or_throw()),
+              fuzz1111(ComponentBatch::from_loggable(std::move(_fuzz1111), Descriptor_fuzz1111)
+                           .value_or_throw()),
+              fuzz1112(ComponentBatch::from_loggable(std::move(_fuzz1112), Descriptor_fuzz1112)
+                           .value_or_throw()),
+              fuzz1113(ComponentBatch::from_loggable(std::move(_fuzz1113), Descriptor_fuzz1113)
+                           .value_or_throw()),
+              fuzz1114(ComponentBatch::from_loggable(std::move(_fuzz1114), Descriptor_fuzz1114)
+                           .value_or_throw()),
+              fuzz1115(ComponentBatch::from_loggable(std::move(_fuzz1115), Descriptor_fuzz1115)
+                           .value_or_throw()),
+              fuzz1116(ComponentBatch::from_loggable(std::move(_fuzz1116), Descriptor_fuzz1116)
+                           .value_or_throw()),
+              fuzz1117(ComponentBatch::from_loggable(std::move(_fuzz1117), Descriptor_fuzz1117)
+                           .value_or_throw()),
+              fuzz1118(ComponentBatch::from_loggable(std::move(_fuzz1118), Descriptor_fuzz1118)
+                           .value_or_throw()),
+              fuzz1122(ComponentBatch::from_loggable(std::move(_fuzz1122), Descriptor_fuzz1122)
+                           .value_or_throw()) {}
+
+        /// Update only some specific fields of a `AffixFuzzer2`.
+        static AffixFuzzer2 update_fields() {
+            return AffixFuzzer2();
+        }
+
+        /// Clear all the fields of a `AffixFuzzer2`.
+        static AffixFuzzer2 clear_fields();
+
+        AffixFuzzer2 with_fuzz1101(const Collection<rerun::components::AffixFuzzer1>& _fuzz1101
+        ) && {
+            fuzz1101 =
+                ComponentBatch::from_loggable(_fuzz1101, Descriptor_fuzz1101).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1102(const Collection<rerun::components::AffixFuzzer2>& _fuzz1102
+        ) && {
+            fuzz1102 =
+                ComponentBatch::from_loggable(_fuzz1102, Descriptor_fuzz1102).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1103(const Collection<rerun::components::AffixFuzzer3>& _fuzz1103
+        ) && {
+            fuzz1103 =
+                ComponentBatch::from_loggable(_fuzz1103, Descriptor_fuzz1103).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1104(const Collection<rerun::components::AffixFuzzer4>& _fuzz1104
+        ) && {
+            fuzz1104 =
+                ComponentBatch::from_loggable(_fuzz1104, Descriptor_fuzz1104).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1105(const Collection<rerun::components::AffixFuzzer5>& _fuzz1105
+        ) && {
+            fuzz1105 =
+                ComponentBatch::from_loggable(_fuzz1105, Descriptor_fuzz1105).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1106(const Collection<rerun::components::AffixFuzzer6>& _fuzz1106
+        ) && {
+            fuzz1106 =
+                ComponentBatch::from_loggable(_fuzz1106, Descriptor_fuzz1106).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1107(const Collection<rerun::components::AffixFuzzer7>& _fuzz1107
+        ) && {
+            fuzz1107 =
+                ComponentBatch::from_loggable(_fuzz1107, Descriptor_fuzz1107).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1108(const Collection<rerun::components::AffixFuzzer8>& _fuzz1108
+        ) && {
+            fuzz1108 =
+                ComponentBatch::from_loggable(_fuzz1108, Descriptor_fuzz1108).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1109(const Collection<rerun::components::AffixFuzzer9>& _fuzz1109
+        ) && {
+            fuzz1109 =
+                ComponentBatch::from_loggable(_fuzz1109, Descriptor_fuzz1109).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1110(const Collection<rerun::components::AffixFuzzer10>& _fuzz1110
+        ) && {
+            fuzz1110 =
+                ComponentBatch::from_loggable(_fuzz1110, Descriptor_fuzz1110).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1111(const Collection<rerun::components::AffixFuzzer11>& _fuzz1111
+        ) && {
+            fuzz1111 =
+                ComponentBatch::from_loggable(_fuzz1111, Descriptor_fuzz1111).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1112(const Collection<rerun::components::AffixFuzzer12>& _fuzz1112
+        ) && {
+            fuzz1112 =
+                ComponentBatch::from_loggable(_fuzz1112, Descriptor_fuzz1112).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1113(const Collection<rerun::components::AffixFuzzer13>& _fuzz1113
+        ) && {
+            fuzz1113 =
+                ComponentBatch::from_loggable(_fuzz1113, Descriptor_fuzz1113).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1114(const Collection<rerun::components::AffixFuzzer14>& _fuzz1114
+        ) && {
+            fuzz1114 =
+                ComponentBatch::from_loggable(_fuzz1114, Descriptor_fuzz1114).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1115(const Collection<rerun::components::AffixFuzzer15>& _fuzz1115
+        ) && {
+            fuzz1115 =
+                ComponentBatch::from_loggable(_fuzz1115, Descriptor_fuzz1115).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1116(const Collection<rerun::components::AffixFuzzer16>& _fuzz1116
+        ) && {
+            fuzz1116 =
+                ComponentBatch::from_loggable(_fuzz1116, Descriptor_fuzz1116).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1117(const Collection<rerun::components::AffixFuzzer17>& _fuzz1117
+        ) && {
+            fuzz1117 =
+                ComponentBatch::from_loggable(_fuzz1117, Descriptor_fuzz1117).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1118(const Collection<rerun::components::AffixFuzzer18>& _fuzz1118
+        ) && {
+            fuzz1118 =
+                ComponentBatch::from_loggable(_fuzz1118, Descriptor_fuzz1118).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        AffixFuzzer2 with_fuzz1122(const Collection<rerun::components::AffixFuzzer22>& _fuzz1122
+        ) && {
+            fuzz1122 =
+                ComponentBatch::from_loggable(_fuzz1122, Descriptor_fuzz1122).value_or_throw();
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
     };
 
 } // namespace rerun::archetypes

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/compiler_utils.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
@@ -257,152 +256,133 @@ namespace rerun::archetypes {
         ) && {
             fuzz1101 =
                 ComponentBatch::from_loggable(_fuzz1101, Descriptor_fuzz1101).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1102(const Collection<rerun::components::AffixFuzzer2>& _fuzz1102
         ) && {
             fuzz1102 =
                 ComponentBatch::from_loggable(_fuzz1102, Descriptor_fuzz1102).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1103(const Collection<rerun::components::AffixFuzzer3>& _fuzz1103
         ) && {
             fuzz1103 =
                 ComponentBatch::from_loggable(_fuzz1103, Descriptor_fuzz1103).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1104(const Collection<rerun::components::AffixFuzzer4>& _fuzz1104
         ) && {
             fuzz1104 =
                 ComponentBatch::from_loggable(_fuzz1104, Descriptor_fuzz1104).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1105(const Collection<rerun::components::AffixFuzzer5>& _fuzz1105
         ) && {
             fuzz1105 =
                 ComponentBatch::from_loggable(_fuzz1105, Descriptor_fuzz1105).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1106(const Collection<rerun::components::AffixFuzzer6>& _fuzz1106
         ) && {
             fuzz1106 =
                 ComponentBatch::from_loggable(_fuzz1106, Descriptor_fuzz1106).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1107(const Collection<rerun::components::AffixFuzzer7>& _fuzz1107
         ) && {
             fuzz1107 =
                 ComponentBatch::from_loggable(_fuzz1107, Descriptor_fuzz1107).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1108(const Collection<rerun::components::AffixFuzzer8>& _fuzz1108
         ) && {
             fuzz1108 =
                 ComponentBatch::from_loggable(_fuzz1108, Descriptor_fuzz1108).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1109(const Collection<rerun::components::AffixFuzzer9>& _fuzz1109
         ) && {
             fuzz1109 =
                 ComponentBatch::from_loggable(_fuzz1109, Descriptor_fuzz1109).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1110(const Collection<rerun::components::AffixFuzzer10>& _fuzz1110
         ) && {
             fuzz1110 =
                 ComponentBatch::from_loggable(_fuzz1110, Descriptor_fuzz1110).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1111(const Collection<rerun::components::AffixFuzzer11>& _fuzz1111
         ) && {
             fuzz1111 =
                 ComponentBatch::from_loggable(_fuzz1111, Descriptor_fuzz1111).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1112(const Collection<rerun::components::AffixFuzzer12>& _fuzz1112
         ) && {
             fuzz1112 =
                 ComponentBatch::from_loggable(_fuzz1112, Descriptor_fuzz1112).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1113(const Collection<rerun::components::AffixFuzzer13>& _fuzz1113
         ) && {
             fuzz1113 =
                 ComponentBatch::from_loggable(_fuzz1113, Descriptor_fuzz1113).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1114(const Collection<rerun::components::AffixFuzzer14>& _fuzz1114
         ) && {
             fuzz1114 =
                 ComponentBatch::from_loggable(_fuzz1114, Descriptor_fuzz1114).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1115(const Collection<rerun::components::AffixFuzzer15>& _fuzz1115
         ) && {
             fuzz1115 =
                 ComponentBatch::from_loggable(_fuzz1115, Descriptor_fuzz1115).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1116(const Collection<rerun::components::AffixFuzzer16>& _fuzz1116
         ) && {
             fuzz1116 =
                 ComponentBatch::from_loggable(_fuzz1116, Descriptor_fuzz1116).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1117(const Collection<rerun::components::AffixFuzzer17>& _fuzz1117
         ) && {
             fuzz1117 =
                 ComponentBatch::from_loggable(_fuzz1117, Descriptor_fuzz1117).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1118(const Collection<rerun::components::AffixFuzzer18>& _fuzz1118
         ) && {
             fuzz1118 =
                 ComponentBatch::from_loggable(_fuzz1118, Descriptor_fuzz1118).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer2 with_fuzz1122(const Collection<rerun::components::AffixFuzzer22>& _fuzz1122
         ) && {
             fuzz1122 =
                 ComponentBatch::from_loggable(_fuzz1122, Descriptor_fuzz1122).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -5,7 +5,66 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {}
+namespace rerun::archetypes {
+    AffixFuzzer3 AffixFuzzer3::clear_fields() {
+        auto archetype = AffixFuzzer3();
+        archetype.fuzz2001 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer1>(Descriptor_fuzz2001)
+                .value_or_throw();
+        archetype.fuzz2002 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer2>(Descriptor_fuzz2002)
+                .value_or_throw();
+        archetype.fuzz2003 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer3>(Descriptor_fuzz2003)
+                .value_or_throw();
+        archetype.fuzz2004 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer4>(Descriptor_fuzz2004)
+                .value_or_throw();
+        archetype.fuzz2005 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer5>(Descriptor_fuzz2005)
+                .value_or_throw();
+        archetype.fuzz2006 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer6>(Descriptor_fuzz2006)
+                .value_or_throw();
+        archetype.fuzz2007 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer7>(Descriptor_fuzz2007)
+                .value_or_throw();
+        archetype.fuzz2008 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer8>(Descriptor_fuzz2008)
+                .value_or_throw();
+        archetype.fuzz2009 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer9>(Descriptor_fuzz2009)
+                .value_or_throw();
+        archetype.fuzz2010 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer10>(Descriptor_fuzz2010)
+                .value_or_throw();
+        archetype.fuzz2011 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer11>(Descriptor_fuzz2011)
+                .value_or_throw();
+        archetype.fuzz2012 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer12>(Descriptor_fuzz2012)
+                .value_or_throw();
+        archetype.fuzz2013 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer13>(Descriptor_fuzz2013)
+                .value_or_throw();
+        archetype.fuzz2014 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer14>(Descriptor_fuzz2014)
+                .value_or_throw();
+        archetype.fuzz2015 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer15>(Descriptor_fuzz2015)
+                .value_or_throw();
+        archetype.fuzz2016 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer16>(Descriptor_fuzz2016)
+                .value_or_throw();
+        archetype.fuzz2017 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer17>(Descriptor_fuzz2017)
+                .value_or_throw();
+        archetype.fuzz2018 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer18>(Descriptor_fuzz2018)
+                .value_or_throw();
+        return archetype;
+    }
+} // namespace rerun::archetypes
 
 namespace rerun {
 
@@ -17,220 +76,58 @@ namespace rerun {
         cells.reserve(19);
 
         if (archetype.fuzz2001.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2001.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2001",
-                    "rerun.testing.components.AffixFuzzer1"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2001.value());
         }
         if (archetype.fuzz2002.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2002.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2002",
-                    "rerun.testing.components.AffixFuzzer2"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2002.value());
         }
         if (archetype.fuzz2003.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2003.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2003",
-                    "rerun.testing.components.AffixFuzzer3"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2003.value());
         }
         if (archetype.fuzz2004.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2004.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2004",
-                    "rerun.testing.components.AffixFuzzer4"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2004.value());
         }
         if (archetype.fuzz2005.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2005.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2005",
-                    "rerun.testing.components.AffixFuzzer5"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2005.value());
         }
         if (archetype.fuzz2006.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2006.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2006",
-                    "rerun.testing.components.AffixFuzzer6"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2006.value());
         }
         if (archetype.fuzz2007.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2007.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2007",
-                    "rerun.testing.components.AffixFuzzer7"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2007.value());
         }
         if (archetype.fuzz2008.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2008.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2008",
-                    "rerun.testing.components.AffixFuzzer8"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2008.value());
         }
         if (archetype.fuzz2009.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2009.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2009",
-                    "rerun.testing.components.AffixFuzzer9"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2009.value());
         }
         if (archetype.fuzz2010.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2010.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2010",
-                    "rerun.testing.components.AffixFuzzer10"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2010.value());
         }
         if (archetype.fuzz2011.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2011.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2011",
-                    "rerun.testing.components.AffixFuzzer11"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2011.value());
         }
         if (archetype.fuzz2012.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2012.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2012",
-                    "rerun.testing.components.AffixFuzzer12"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2012.value());
         }
         if (archetype.fuzz2013.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2013.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2013",
-                    "rerun.testing.components.AffixFuzzer13"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2013.value());
         }
         if (archetype.fuzz2014.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2014.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2014",
-                    "rerun.testing.components.AffixFuzzer14"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2014.value());
         }
         if (archetype.fuzz2015.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2015.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2015",
-                    "rerun.testing.components.AffixFuzzer15"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2015.value());
         }
         if (archetype.fuzz2016.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2016.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2016",
-                    "rerun.testing.components.AffixFuzzer16"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2016.value());
         }
         if (archetype.fuzz2017.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2017.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2017",
-                    "rerun.testing.components.AffixFuzzer17"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2017.value());
         }
         if (archetype.fuzz2018.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2018.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer3",
-                    "fuzz2018",
-                    "rerun.testing.components.AffixFuzzer18"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2018.value());
         }
         {
             auto indicator = AffixFuzzer3::IndicatorComponent();

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/compiler_utils.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
@@ -188,127 +187,109 @@ namespace rerun::archetypes {
         AffixFuzzer3 with_fuzz2001(const rerun::components::AffixFuzzer1& _fuzz2001) && {
             fuzz2001 =
                 ComponentBatch::from_loggable(_fuzz2001, Descriptor_fuzz2001).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2002(const rerun::components::AffixFuzzer2& _fuzz2002) && {
             fuzz2002 =
                 ComponentBatch::from_loggable(_fuzz2002, Descriptor_fuzz2002).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2003(const rerun::components::AffixFuzzer3& _fuzz2003) && {
             fuzz2003 =
                 ComponentBatch::from_loggable(_fuzz2003, Descriptor_fuzz2003).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2004(const rerun::components::AffixFuzzer4& _fuzz2004) && {
             fuzz2004 =
                 ComponentBatch::from_loggable(_fuzz2004, Descriptor_fuzz2004).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2005(const rerun::components::AffixFuzzer5& _fuzz2005) && {
             fuzz2005 =
                 ComponentBatch::from_loggable(_fuzz2005, Descriptor_fuzz2005).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2006(const rerun::components::AffixFuzzer6& _fuzz2006) && {
             fuzz2006 =
                 ComponentBatch::from_loggable(_fuzz2006, Descriptor_fuzz2006).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2007(const rerun::components::AffixFuzzer7& _fuzz2007) && {
             fuzz2007 =
                 ComponentBatch::from_loggable(_fuzz2007, Descriptor_fuzz2007).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2008(const rerun::components::AffixFuzzer8& _fuzz2008) && {
             fuzz2008 =
                 ComponentBatch::from_loggable(_fuzz2008, Descriptor_fuzz2008).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2009(const rerun::components::AffixFuzzer9& _fuzz2009) && {
             fuzz2009 =
                 ComponentBatch::from_loggable(_fuzz2009, Descriptor_fuzz2009).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2010(const rerun::components::AffixFuzzer10& _fuzz2010) && {
             fuzz2010 =
                 ComponentBatch::from_loggable(_fuzz2010, Descriptor_fuzz2010).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2011(const rerun::components::AffixFuzzer11& _fuzz2011) && {
             fuzz2011 =
                 ComponentBatch::from_loggable(_fuzz2011, Descriptor_fuzz2011).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2012(const rerun::components::AffixFuzzer12& _fuzz2012) && {
             fuzz2012 =
                 ComponentBatch::from_loggable(_fuzz2012, Descriptor_fuzz2012).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2013(const rerun::components::AffixFuzzer13& _fuzz2013) && {
             fuzz2013 =
                 ComponentBatch::from_loggable(_fuzz2013, Descriptor_fuzz2013).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2014(const rerun::components::AffixFuzzer14& _fuzz2014) && {
             fuzz2014 =
                 ComponentBatch::from_loggable(_fuzz2014, Descriptor_fuzz2014).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2015(const rerun::components::AffixFuzzer15& _fuzz2015) && {
             fuzz2015 =
                 ComponentBatch::from_loggable(_fuzz2015, Descriptor_fuzz2015).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2016(const rerun::components::AffixFuzzer16& _fuzz2016) && {
             fuzz2016 =
                 ComponentBatch::from_loggable(_fuzz2016, Descriptor_fuzz2016).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2017(const rerun::components::AffixFuzzer17& _fuzz2017) && {
             fuzz2017 =
                 ComponentBatch::from_loggable(_fuzz2017, Descriptor_fuzz2017).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer3 with_fuzz2018(const rerun::components::AffixFuzzer18& _fuzz2018) && {
             fuzz2018 =
                 ComponentBatch::from_loggable(_fuzz2018, Descriptor_fuzz2018).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -34,41 +34,41 @@
 
 namespace rerun::archetypes {
     struct AffixFuzzer3 {
-        std::optional<rerun::components::AffixFuzzer1> fuzz2001;
+        std::optional<ComponentBatch> fuzz2001;
 
-        std::optional<rerun::components::AffixFuzzer2> fuzz2002;
+        std::optional<ComponentBatch> fuzz2002;
 
-        std::optional<rerun::components::AffixFuzzer3> fuzz2003;
+        std::optional<ComponentBatch> fuzz2003;
 
-        std::optional<rerun::components::AffixFuzzer4> fuzz2004;
+        std::optional<ComponentBatch> fuzz2004;
 
-        std::optional<rerun::components::AffixFuzzer5> fuzz2005;
+        std::optional<ComponentBatch> fuzz2005;
 
-        std::optional<rerun::components::AffixFuzzer6> fuzz2006;
+        std::optional<ComponentBatch> fuzz2006;
 
-        std::optional<rerun::components::AffixFuzzer7> fuzz2007;
+        std::optional<ComponentBatch> fuzz2007;
 
-        std::optional<rerun::components::AffixFuzzer8> fuzz2008;
+        std::optional<ComponentBatch> fuzz2008;
 
-        std::optional<rerun::components::AffixFuzzer9> fuzz2009;
+        std::optional<ComponentBatch> fuzz2009;
 
-        std::optional<rerun::components::AffixFuzzer10> fuzz2010;
+        std::optional<ComponentBatch> fuzz2010;
 
-        std::optional<rerun::components::AffixFuzzer11> fuzz2011;
+        std::optional<ComponentBatch> fuzz2011;
 
-        std::optional<rerun::components::AffixFuzzer12> fuzz2012;
+        std::optional<ComponentBatch> fuzz2012;
 
-        std::optional<rerun::components::AffixFuzzer13> fuzz2013;
+        std::optional<ComponentBatch> fuzz2013;
 
-        std::optional<rerun::components::AffixFuzzer14> fuzz2014;
+        std::optional<ComponentBatch> fuzz2014;
 
-        std::optional<rerun::components::AffixFuzzer15> fuzz2015;
+        std::optional<ComponentBatch> fuzz2015;
 
-        std::optional<rerun::components::AffixFuzzer16> fuzz2016;
+        std::optional<ComponentBatch> fuzz2016;
 
-        std::optional<rerun::components::AffixFuzzer17> fuzz2017;
+        std::optional<ComponentBatch> fuzz2017;
 
-        std::optional<rerun::components::AffixFuzzer18> fuzz2018;
+        std::optional<ComponentBatch> fuzz2018;
 
       public:
         static constexpr const char IndicatorComponentName[] =
@@ -79,6 +79,97 @@ namespace rerun::archetypes {
         /// The name of the archetype as used in `ComponentDescriptor`s.
         static constexpr const char ArchetypeName[] = "rerun.testing.archetypes.AffixFuzzer3";
 
+        /// `ComponentDescriptor` for the `fuzz2001` field.
+        static constexpr auto Descriptor_fuzz2001 = ComponentDescriptor(
+            ArchetypeName, "fuzz2001",
+            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2002` field.
+        static constexpr auto Descriptor_fuzz2002 = ComponentDescriptor(
+            ArchetypeName, "fuzz2002",
+            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2003` field.
+        static constexpr auto Descriptor_fuzz2003 = ComponentDescriptor(
+            ArchetypeName, "fuzz2003",
+            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2004` field.
+        static constexpr auto Descriptor_fuzz2004 = ComponentDescriptor(
+            ArchetypeName, "fuzz2004",
+            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2005` field.
+        static constexpr auto Descriptor_fuzz2005 = ComponentDescriptor(
+            ArchetypeName, "fuzz2005",
+            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2006` field.
+        static constexpr auto Descriptor_fuzz2006 = ComponentDescriptor(
+            ArchetypeName, "fuzz2006",
+            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2007` field.
+        static constexpr auto Descriptor_fuzz2007 = ComponentDescriptor(
+            ArchetypeName, "fuzz2007",
+            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2008` field.
+        static constexpr auto Descriptor_fuzz2008 = ComponentDescriptor(
+            ArchetypeName, "fuzz2008",
+            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2009` field.
+        static constexpr auto Descriptor_fuzz2009 = ComponentDescriptor(
+            ArchetypeName, "fuzz2009",
+            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2010` field.
+        static constexpr auto Descriptor_fuzz2010 = ComponentDescriptor(
+            ArchetypeName, "fuzz2010",
+            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2011` field.
+        static constexpr auto Descriptor_fuzz2011 = ComponentDescriptor(
+            ArchetypeName, "fuzz2011",
+            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2012` field.
+        static constexpr auto Descriptor_fuzz2012 = ComponentDescriptor(
+            ArchetypeName, "fuzz2012",
+            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2013` field.
+        static constexpr auto Descriptor_fuzz2013 = ComponentDescriptor(
+            ArchetypeName, "fuzz2013",
+            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2014` field.
+        static constexpr auto Descriptor_fuzz2014 = ComponentDescriptor(
+            ArchetypeName, "fuzz2014",
+            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2015` field.
+        static constexpr auto Descriptor_fuzz2015 = ComponentDescriptor(
+            ArchetypeName, "fuzz2015",
+            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2016` field.
+        static constexpr auto Descriptor_fuzz2016 = ComponentDescriptor(
+            ArchetypeName, "fuzz2016",
+            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2017` field.
+        static constexpr auto Descriptor_fuzz2017 = ComponentDescriptor(
+            ArchetypeName, "fuzz2017",
+            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2018` field.
+        static constexpr auto Descriptor_fuzz2018 = ComponentDescriptor(
+            ArchetypeName, "fuzz2018",
+            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+        );
+
       public:
         AffixFuzzer3() = default;
         AffixFuzzer3(AffixFuzzer3&& other) = default;
@@ -86,110 +177,136 @@ namespace rerun::archetypes {
         AffixFuzzer3& operator=(const AffixFuzzer3& other) = default;
         AffixFuzzer3& operator=(AffixFuzzer3&& other) = default;
 
-        AffixFuzzer3 with_fuzz2001(rerun::components::AffixFuzzer1 _fuzz2001) && {
-            fuzz2001 = std::move(_fuzz2001);
+        /// Update only some specific fields of a `AffixFuzzer3`.
+        static AffixFuzzer3 update_fields() {
+            return AffixFuzzer3();
+        }
+
+        /// Clear all the fields of a `AffixFuzzer3`.
+        static AffixFuzzer3 clear_fields();
+
+        AffixFuzzer3 with_fuzz2001(const rerun::components::AffixFuzzer1& _fuzz2001) && {
+            fuzz2001 =
+                ComponentBatch::from_loggable(_fuzz2001, Descriptor_fuzz2001).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2002(rerun::components::AffixFuzzer2 _fuzz2002) && {
-            fuzz2002 = std::move(_fuzz2002);
+        AffixFuzzer3 with_fuzz2002(const rerun::components::AffixFuzzer2& _fuzz2002) && {
+            fuzz2002 =
+                ComponentBatch::from_loggable(_fuzz2002, Descriptor_fuzz2002).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2003(rerun::components::AffixFuzzer3 _fuzz2003) && {
-            fuzz2003 = std::move(_fuzz2003);
+        AffixFuzzer3 with_fuzz2003(const rerun::components::AffixFuzzer3& _fuzz2003) && {
+            fuzz2003 =
+                ComponentBatch::from_loggable(_fuzz2003, Descriptor_fuzz2003).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2004(rerun::components::AffixFuzzer4 _fuzz2004) && {
-            fuzz2004 = std::move(_fuzz2004);
+        AffixFuzzer3 with_fuzz2004(const rerun::components::AffixFuzzer4& _fuzz2004) && {
+            fuzz2004 =
+                ComponentBatch::from_loggable(_fuzz2004, Descriptor_fuzz2004).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2005(rerun::components::AffixFuzzer5 _fuzz2005) && {
-            fuzz2005 = std::move(_fuzz2005);
+        AffixFuzzer3 with_fuzz2005(const rerun::components::AffixFuzzer5& _fuzz2005) && {
+            fuzz2005 =
+                ComponentBatch::from_loggable(_fuzz2005, Descriptor_fuzz2005).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2006(rerun::components::AffixFuzzer6 _fuzz2006) && {
-            fuzz2006 = std::move(_fuzz2006);
+        AffixFuzzer3 with_fuzz2006(const rerun::components::AffixFuzzer6& _fuzz2006) && {
+            fuzz2006 =
+                ComponentBatch::from_loggable(_fuzz2006, Descriptor_fuzz2006).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2007(rerun::components::AffixFuzzer7 _fuzz2007) && {
-            fuzz2007 = std::move(_fuzz2007);
+        AffixFuzzer3 with_fuzz2007(const rerun::components::AffixFuzzer7& _fuzz2007) && {
+            fuzz2007 =
+                ComponentBatch::from_loggable(_fuzz2007, Descriptor_fuzz2007).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2008(rerun::components::AffixFuzzer8 _fuzz2008) && {
-            fuzz2008 = std::move(_fuzz2008);
+        AffixFuzzer3 with_fuzz2008(const rerun::components::AffixFuzzer8& _fuzz2008) && {
+            fuzz2008 =
+                ComponentBatch::from_loggable(_fuzz2008, Descriptor_fuzz2008).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2009(rerun::components::AffixFuzzer9 _fuzz2009) && {
-            fuzz2009 = std::move(_fuzz2009);
+        AffixFuzzer3 with_fuzz2009(const rerun::components::AffixFuzzer9& _fuzz2009) && {
+            fuzz2009 =
+                ComponentBatch::from_loggable(_fuzz2009, Descriptor_fuzz2009).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2010(rerun::components::AffixFuzzer10 _fuzz2010) && {
-            fuzz2010 = std::move(_fuzz2010);
+        AffixFuzzer3 with_fuzz2010(const rerun::components::AffixFuzzer10& _fuzz2010) && {
+            fuzz2010 =
+                ComponentBatch::from_loggable(_fuzz2010, Descriptor_fuzz2010).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2011(rerun::components::AffixFuzzer11 _fuzz2011) && {
-            fuzz2011 = std::move(_fuzz2011);
+        AffixFuzzer3 with_fuzz2011(const rerun::components::AffixFuzzer11& _fuzz2011) && {
+            fuzz2011 =
+                ComponentBatch::from_loggable(_fuzz2011, Descriptor_fuzz2011).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2012(rerun::components::AffixFuzzer12 _fuzz2012) && {
-            fuzz2012 = std::move(_fuzz2012);
+        AffixFuzzer3 with_fuzz2012(const rerun::components::AffixFuzzer12& _fuzz2012) && {
+            fuzz2012 =
+                ComponentBatch::from_loggable(_fuzz2012, Descriptor_fuzz2012).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2013(rerun::components::AffixFuzzer13 _fuzz2013) && {
-            fuzz2013 = std::move(_fuzz2013);
+        AffixFuzzer3 with_fuzz2013(const rerun::components::AffixFuzzer13& _fuzz2013) && {
+            fuzz2013 =
+                ComponentBatch::from_loggable(_fuzz2013, Descriptor_fuzz2013).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2014(rerun::components::AffixFuzzer14 _fuzz2014) && {
-            fuzz2014 = std::move(_fuzz2014);
+        AffixFuzzer3 with_fuzz2014(const rerun::components::AffixFuzzer14& _fuzz2014) && {
+            fuzz2014 =
+                ComponentBatch::from_loggable(_fuzz2014, Descriptor_fuzz2014).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2015(rerun::components::AffixFuzzer15 _fuzz2015) && {
-            fuzz2015 = std::move(_fuzz2015);
+        AffixFuzzer3 with_fuzz2015(const rerun::components::AffixFuzzer15& _fuzz2015) && {
+            fuzz2015 =
+                ComponentBatch::from_loggable(_fuzz2015, Descriptor_fuzz2015).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2016(rerun::components::AffixFuzzer16 _fuzz2016) && {
-            fuzz2016 = std::move(_fuzz2016);
+        AffixFuzzer3 with_fuzz2016(const rerun::components::AffixFuzzer16& _fuzz2016) && {
+            fuzz2016 =
+                ComponentBatch::from_loggable(_fuzz2016, Descriptor_fuzz2016).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2017(rerun::components::AffixFuzzer17 _fuzz2017) && {
-            fuzz2017 = std::move(_fuzz2017);
+        AffixFuzzer3 with_fuzz2017(const rerun::components::AffixFuzzer17& _fuzz2017) && {
+            fuzz2017 =
+                ComponentBatch::from_loggable(_fuzz2017, Descriptor_fuzz2017).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer3 with_fuzz2018(rerun::components::AffixFuzzer18 _fuzz2018) && {
-            fuzz2018 = std::move(_fuzz2018);
+        AffixFuzzer3 with_fuzz2018(const rerun::components::AffixFuzzer18& _fuzz2018) && {
+            fuzz2018 =
+                ComponentBatch::from_loggable(_fuzz2018, Descriptor_fuzz2018).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -5,7 +5,66 @@
 
 #include <rerun/collection_adapter_builtins.hpp>
 
-namespace rerun::archetypes {}
+namespace rerun::archetypes {
+    AffixFuzzer4 AffixFuzzer4::clear_fields() {
+        auto archetype = AffixFuzzer4();
+        archetype.fuzz2101 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer1>(Descriptor_fuzz2101)
+                .value_or_throw();
+        archetype.fuzz2102 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer2>(Descriptor_fuzz2102)
+                .value_or_throw();
+        archetype.fuzz2103 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer3>(Descriptor_fuzz2103)
+                .value_or_throw();
+        archetype.fuzz2104 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer4>(Descriptor_fuzz2104)
+                .value_or_throw();
+        archetype.fuzz2105 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer5>(Descriptor_fuzz2105)
+                .value_or_throw();
+        archetype.fuzz2106 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer6>(Descriptor_fuzz2106)
+                .value_or_throw();
+        archetype.fuzz2107 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer7>(Descriptor_fuzz2107)
+                .value_or_throw();
+        archetype.fuzz2108 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer8>(Descriptor_fuzz2108)
+                .value_or_throw();
+        archetype.fuzz2109 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer9>(Descriptor_fuzz2109)
+                .value_or_throw();
+        archetype.fuzz2110 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer10>(Descriptor_fuzz2110)
+                .value_or_throw();
+        archetype.fuzz2111 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer11>(Descriptor_fuzz2111)
+                .value_or_throw();
+        archetype.fuzz2112 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer12>(Descriptor_fuzz2112)
+                .value_or_throw();
+        archetype.fuzz2113 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer13>(Descriptor_fuzz2113)
+                .value_or_throw();
+        archetype.fuzz2114 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer14>(Descriptor_fuzz2114)
+                .value_or_throw();
+        archetype.fuzz2115 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer15>(Descriptor_fuzz2115)
+                .value_or_throw();
+        archetype.fuzz2116 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer16>(Descriptor_fuzz2116)
+                .value_or_throw();
+        archetype.fuzz2117 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer17>(Descriptor_fuzz2117)
+                .value_or_throw();
+        archetype.fuzz2118 =
+            ComponentBatch::empty<rerun::components::AffixFuzzer18>(Descriptor_fuzz2118)
+                .value_or_throw();
+        return archetype;
+    }
+} // namespace rerun::archetypes
 
 namespace rerun {
 
@@ -17,220 +76,58 @@ namespace rerun {
         cells.reserve(19);
 
         if (archetype.fuzz2101.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2101.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2101",
-                    "rerun.testing.components.AffixFuzzer1"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2101.value());
         }
         if (archetype.fuzz2102.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2102.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2102",
-                    "rerun.testing.components.AffixFuzzer2"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2102.value());
         }
         if (archetype.fuzz2103.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2103.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2103",
-                    "rerun.testing.components.AffixFuzzer3"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2103.value());
         }
         if (archetype.fuzz2104.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2104.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2104",
-                    "rerun.testing.components.AffixFuzzer4"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2104.value());
         }
         if (archetype.fuzz2105.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2105.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2105",
-                    "rerun.testing.components.AffixFuzzer5"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2105.value());
         }
         if (archetype.fuzz2106.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2106.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2106",
-                    "rerun.testing.components.AffixFuzzer6"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2106.value());
         }
         if (archetype.fuzz2107.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2107.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2107",
-                    "rerun.testing.components.AffixFuzzer7"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2107.value());
         }
         if (archetype.fuzz2108.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2108.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2108",
-                    "rerun.testing.components.AffixFuzzer8"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2108.value());
         }
         if (archetype.fuzz2109.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2109.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2109",
-                    "rerun.testing.components.AffixFuzzer9"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2109.value());
         }
         if (archetype.fuzz2110.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2110.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2110",
-                    "rerun.testing.components.AffixFuzzer10"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2110.value());
         }
         if (archetype.fuzz2111.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2111.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2111",
-                    "rerun.testing.components.AffixFuzzer11"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2111.value());
         }
         if (archetype.fuzz2112.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2112.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2112",
-                    "rerun.testing.components.AffixFuzzer12"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2112.value());
         }
         if (archetype.fuzz2113.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2113.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2113",
-                    "rerun.testing.components.AffixFuzzer13"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2113.value());
         }
         if (archetype.fuzz2114.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2114.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2114",
-                    "rerun.testing.components.AffixFuzzer14"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2114.value());
         }
         if (archetype.fuzz2115.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2115.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2115",
-                    "rerun.testing.components.AffixFuzzer15"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2115.value());
         }
         if (archetype.fuzz2116.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2116.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2116",
-                    "rerun.testing.components.AffixFuzzer16"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2116.value());
         }
         if (archetype.fuzz2117.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2117.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2117",
-                    "rerun.testing.components.AffixFuzzer17"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2117.value());
         }
         if (archetype.fuzz2118.has_value()) {
-            auto result = ComponentBatch::from_loggable(
-                archetype.fuzz2118.value(),
-                ComponentDescriptor(
-                    "rerun.testing.archetypes.AffixFuzzer4",
-                    "fuzz2118",
-                    "rerun.testing.components.AffixFuzzer18"
-                )
-            );
-            RR_RETURN_NOT_OK(result.error);
-            cells.push_back(std::move(result.value));
+            cells.push_back(archetype.fuzz2118.value());
         }
         {
             auto indicator = AffixFuzzer4::IndicatorComponent();

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/compiler_utils.hpp>
 #include <rerun/component_batch.hpp>
 #include <rerun/indicator_component.hpp>
 #include <rerun/result.hpp>
@@ -189,144 +188,126 @@ namespace rerun::archetypes {
         ) && {
             fuzz2101 =
                 ComponentBatch::from_loggable(_fuzz2101, Descriptor_fuzz2101).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2102(const Collection<rerun::components::AffixFuzzer2>& _fuzz2102
         ) && {
             fuzz2102 =
                 ComponentBatch::from_loggable(_fuzz2102, Descriptor_fuzz2102).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2103(const Collection<rerun::components::AffixFuzzer3>& _fuzz2103
         ) && {
             fuzz2103 =
                 ComponentBatch::from_loggable(_fuzz2103, Descriptor_fuzz2103).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2104(const Collection<rerun::components::AffixFuzzer4>& _fuzz2104
         ) && {
             fuzz2104 =
                 ComponentBatch::from_loggable(_fuzz2104, Descriptor_fuzz2104).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2105(const Collection<rerun::components::AffixFuzzer5>& _fuzz2105
         ) && {
             fuzz2105 =
                 ComponentBatch::from_loggable(_fuzz2105, Descriptor_fuzz2105).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2106(const Collection<rerun::components::AffixFuzzer6>& _fuzz2106
         ) && {
             fuzz2106 =
                 ComponentBatch::from_loggable(_fuzz2106, Descriptor_fuzz2106).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2107(const Collection<rerun::components::AffixFuzzer7>& _fuzz2107
         ) && {
             fuzz2107 =
                 ComponentBatch::from_loggable(_fuzz2107, Descriptor_fuzz2107).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2108(const Collection<rerun::components::AffixFuzzer8>& _fuzz2108
         ) && {
             fuzz2108 =
                 ComponentBatch::from_loggable(_fuzz2108, Descriptor_fuzz2108).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2109(const Collection<rerun::components::AffixFuzzer9>& _fuzz2109
         ) && {
             fuzz2109 =
                 ComponentBatch::from_loggable(_fuzz2109, Descriptor_fuzz2109).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2110(const Collection<rerun::components::AffixFuzzer10>& _fuzz2110
         ) && {
             fuzz2110 =
                 ComponentBatch::from_loggable(_fuzz2110, Descriptor_fuzz2110).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2111(const Collection<rerun::components::AffixFuzzer11>& _fuzz2111
         ) && {
             fuzz2111 =
                 ComponentBatch::from_loggable(_fuzz2111, Descriptor_fuzz2111).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2112(const Collection<rerun::components::AffixFuzzer12>& _fuzz2112
         ) && {
             fuzz2112 =
                 ComponentBatch::from_loggable(_fuzz2112, Descriptor_fuzz2112).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2113(const Collection<rerun::components::AffixFuzzer13>& _fuzz2113
         ) && {
             fuzz2113 =
                 ComponentBatch::from_loggable(_fuzz2113, Descriptor_fuzz2113).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2114(const Collection<rerun::components::AffixFuzzer14>& _fuzz2114
         ) && {
             fuzz2114 =
                 ComponentBatch::from_loggable(_fuzz2114, Descriptor_fuzz2114).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2115(const Collection<rerun::components::AffixFuzzer15>& _fuzz2115
         ) && {
             fuzz2115 =
                 ComponentBatch::from_loggable(_fuzz2115, Descriptor_fuzz2115).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2116(const Collection<rerun::components::AffixFuzzer16>& _fuzz2116
         ) && {
             fuzz2116 =
                 ComponentBatch::from_loggable(_fuzz2116, Descriptor_fuzz2116).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2117(const Collection<rerun::components::AffixFuzzer17>& _fuzz2117
         ) && {
             fuzz2117 =
                 ComponentBatch::from_loggable(_fuzz2117, Descriptor_fuzz2117).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
 
         AffixFuzzer4 with_fuzz2118(const Collection<rerun::components::AffixFuzzer18>& _fuzz2118
         ) && {
             fuzz2118 =
                 ComponentBatch::from_loggable(_fuzz2118, Descriptor_fuzz2118).value_or_throw();
-            // See: https://github.com/rerun-io/rerun/issues/4027
-            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+            return std::move(*this);
         }
     };
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -34,41 +34,41 @@
 
 namespace rerun::archetypes {
     struct AffixFuzzer4 {
-        std::optional<Collection<rerun::components::AffixFuzzer1>> fuzz2101;
+        std::optional<ComponentBatch> fuzz2101;
 
-        std::optional<Collection<rerun::components::AffixFuzzer2>> fuzz2102;
+        std::optional<ComponentBatch> fuzz2102;
 
-        std::optional<Collection<rerun::components::AffixFuzzer3>> fuzz2103;
+        std::optional<ComponentBatch> fuzz2103;
 
-        std::optional<Collection<rerun::components::AffixFuzzer4>> fuzz2104;
+        std::optional<ComponentBatch> fuzz2104;
 
-        std::optional<Collection<rerun::components::AffixFuzzer5>> fuzz2105;
+        std::optional<ComponentBatch> fuzz2105;
 
-        std::optional<Collection<rerun::components::AffixFuzzer6>> fuzz2106;
+        std::optional<ComponentBatch> fuzz2106;
 
-        std::optional<Collection<rerun::components::AffixFuzzer7>> fuzz2107;
+        std::optional<ComponentBatch> fuzz2107;
 
-        std::optional<Collection<rerun::components::AffixFuzzer8>> fuzz2108;
+        std::optional<ComponentBatch> fuzz2108;
 
-        std::optional<Collection<rerun::components::AffixFuzzer9>> fuzz2109;
+        std::optional<ComponentBatch> fuzz2109;
 
-        std::optional<Collection<rerun::components::AffixFuzzer10>> fuzz2110;
+        std::optional<ComponentBatch> fuzz2110;
 
-        std::optional<Collection<rerun::components::AffixFuzzer11>> fuzz2111;
+        std::optional<ComponentBatch> fuzz2111;
 
-        std::optional<Collection<rerun::components::AffixFuzzer12>> fuzz2112;
+        std::optional<ComponentBatch> fuzz2112;
 
-        std::optional<Collection<rerun::components::AffixFuzzer13>> fuzz2113;
+        std::optional<ComponentBatch> fuzz2113;
 
-        std::optional<Collection<rerun::components::AffixFuzzer14>> fuzz2114;
+        std::optional<ComponentBatch> fuzz2114;
 
-        std::optional<Collection<rerun::components::AffixFuzzer15>> fuzz2115;
+        std::optional<ComponentBatch> fuzz2115;
 
-        std::optional<Collection<rerun::components::AffixFuzzer16>> fuzz2116;
+        std::optional<ComponentBatch> fuzz2116;
 
-        std::optional<Collection<rerun::components::AffixFuzzer17>> fuzz2117;
+        std::optional<ComponentBatch> fuzz2117;
 
-        std::optional<Collection<rerun::components::AffixFuzzer18>> fuzz2118;
+        std::optional<ComponentBatch> fuzz2118;
 
       public:
         static constexpr const char IndicatorComponentName[] =
@@ -79,6 +79,97 @@ namespace rerun::archetypes {
         /// The name of the archetype as used in `ComponentDescriptor`s.
         static constexpr const char ArchetypeName[] = "rerun.testing.archetypes.AffixFuzzer4";
 
+        /// `ComponentDescriptor` for the `fuzz2101` field.
+        static constexpr auto Descriptor_fuzz2101 = ComponentDescriptor(
+            ArchetypeName, "fuzz2101",
+            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2102` field.
+        static constexpr auto Descriptor_fuzz2102 = ComponentDescriptor(
+            ArchetypeName, "fuzz2102",
+            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2103` field.
+        static constexpr auto Descriptor_fuzz2103 = ComponentDescriptor(
+            ArchetypeName, "fuzz2103",
+            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2104` field.
+        static constexpr auto Descriptor_fuzz2104 = ComponentDescriptor(
+            ArchetypeName, "fuzz2104",
+            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2105` field.
+        static constexpr auto Descriptor_fuzz2105 = ComponentDescriptor(
+            ArchetypeName, "fuzz2105",
+            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2106` field.
+        static constexpr auto Descriptor_fuzz2106 = ComponentDescriptor(
+            ArchetypeName, "fuzz2106",
+            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2107` field.
+        static constexpr auto Descriptor_fuzz2107 = ComponentDescriptor(
+            ArchetypeName, "fuzz2107",
+            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2108` field.
+        static constexpr auto Descriptor_fuzz2108 = ComponentDescriptor(
+            ArchetypeName, "fuzz2108",
+            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2109` field.
+        static constexpr auto Descriptor_fuzz2109 = ComponentDescriptor(
+            ArchetypeName, "fuzz2109",
+            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2110` field.
+        static constexpr auto Descriptor_fuzz2110 = ComponentDescriptor(
+            ArchetypeName, "fuzz2110",
+            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2111` field.
+        static constexpr auto Descriptor_fuzz2111 = ComponentDescriptor(
+            ArchetypeName, "fuzz2111",
+            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2112` field.
+        static constexpr auto Descriptor_fuzz2112 = ComponentDescriptor(
+            ArchetypeName, "fuzz2112",
+            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2113` field.
+        static constexpr auto Descriptor_fuzz2113 = ComponentDescriptor(
+            ArchetypeName, "fuzz2113",
+            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2114` field.
+        static constexpr auto Descriptor_fuzz2114 = ComponentDescriptor(
+            ArchetypeName, "fuzz2114",
+            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2115` field.
+        static constexpr auto Descriptor_fuzz2115 = ComponentDescriptor(
+            ArchetypeName, "fuzz2115",
+            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2116` field.
+        static constexpr auto Descriptor_fuzz2116 = ComponentDescriptor(
+            ArchetypeName, "fuzz2116",
+            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2117` field.
+        static constexpr auto Descriptor_fuzz2117 = ComponentDescriptor(
+            ArchetypeName, "fuzz2117",
+            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `fuzz2118` field.
+        static constexpr auto Descriptor_fuzz2118 = ComponentDescriptor(
+            ArchetypeName, "fuzz2118",
+            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+        );
+
       public:
         AffixFuzzer4() = default;
         AffixFuzzer4(AffixFuzzer4&& other) = default;
@@ -86,110 +177,154 @@ namespace rerun::archetypes {
         AffixFuzzer4& operator=(const AffixFuzzer4& other) = default;
         AffixFuzzer4& operator=(AffixFuzzer4&& other) = default;
 
-        AffixFuzzer4 with_fuzz2101(Collection<rerun::components::AffixFuzzer1> _fuzz2101) && {
-            fuzz2101 = std::move(_fuzz2101);
+        /// Update only some specific fields of a `AffixFuzzer4`.
+        static AffixFuzzer4 update_fields() {
+            return AffixFuzzer4();
+        }
+
+        /// Clear all the fields of a `AffixFuzzer4`.
+        static AffixFuzzer4 clear_fields();
+
+        AffixFuzzer4 with_fuzz2101(const Collection<rerun::components::AffixFuzzer1>& _fuzz2101
+        ) && {
+            fuzz2101 =
+                ComponentBatch::from_loggable(_fuzz2101, Descriptor_fuzz2101).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2102(Collection<rerun::components::AffixFuzzer2> _fuzz2102) && {
-            fuzz2102 = std::move(_fuzz2102);
+        AffixFuzzer4 with_fuzz2102(const Collection<rerun::components::AffixFuzzer2>& _fuzz2102
+        ) && {
+            fuzz2102 =
+                ComponentBatch::from_loggable(_fuzz2102, Descriptor_fuzz2102).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2103(Collection<rerun::components::AffixFuzzer3> _fuzz2103) && {
-            fuzz2103 = std::move(_fuzz2103);
+        AffixFuzzer4 with_fuzz2103(const Collection<rerun::components::AffixFuzzer3>& _fuzz2103
+        ) && {
+            fuzz2103 =
+                ComponentBatch::from_loggable(_fuzz2103, Descriptor_fuzz2103).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2104(Collection<rerun::components::AffixFuzzer4> _fuzz2104) && {
-            fuzz2104 = std::move(_fuzz2104);
+        AffixFuzzer4 with_fuzz2104(const Collection<rerun::components::AffixFuzzer4>& _fuzz2104
+        ) && {
+            fuzz2104 =
+                ComponentBatch::from_loggable(_fuzz2104, Descriptor_fuzz2104).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2105(Collection<rerun::components::AffixFuzzer5> _fuzz2105) && {
-            fuzz2105 = std::move(_fuzz2105);
+        AffixFuzzer4 with_fuzz2105(const Collection<rerun::components::AffixFuzzer5>& _fuzz2105
+        ) && {
+            fuzz2105 =
+                ComponentBatch::from_loggable(_fuzz2105, Descriptor_fuzz2105).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2106(Collection<rerun::components::AffixFuzzer6> _fuzz2106) && {
-            fuzz2106 = std::move(_fuzz2106);
+        AffixFuzzer4 with_fuzz2106(const Collection<rerun::components::AffixFuzzer6>& _fuzz2106
+        ) && {
+            fuzz2106 =
+                ComponentBatch::from_loggable(_fuzz2106, Descriptor_fuzz2106).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2107(Collection<rerun::components::AffixFuzzer7> _fuzz2107) && {
-            fuzz2107 = std::move(_fuzz2107);
+        AffixFuzzer4 with_fuzz2107(const Collection<rerun::components::AffixFuzzer7>& _fuzz2107
+        ) && {
+            fuzz2107 =
+                ComponentBatch::from_loggable(_fuzz2107, Descriptor_fuzz2107).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2108(Collection<rerun::components::AffixFuzzer8> _fuzz2108) && {
-            fuzz2108 = std::move(_fuzz2108);
+        AffixFuzzer4 with_fuzz2108(const Collection<rerun::components::AffixFuzzer8>& _fuzz2108
+        ) && {
+            fuzz2108 =
+                ComponentBatch::from_loggable(_fuzz2108, Descriptor_fuzz2108).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2109(Collection<rerun::components::AffixFuzzer9> _fuzz2109) && {
-            fuzz2109 = std::move(_fuzz2109);
+        AffixFuzzer4 with_fuzz2109(const Collection<rerun::components::AffixFuzzer9>& _fuzz2109
+        ) && {
+            fuzz2109 =
+                ComponentBatch::from_loggable(_fuzz2109, Descriptor_fuzz2109).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2110(Collection<rerun::components::AffixFuzzer10> _fuzz2110) && {
-            fuzz2110 = std::move(_fuzz2110);
+        AffixFuzzer4 with_fuzz2110(const Collection<rerun::components::AffixFuzzer10>& _fuzz2110
+        ) && {
+            fuzz2110 =
+                ComponentBatch::from_loggable(_fuzz2110, Descriptor_fuzz2110).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2111(Collection<rerun::components::AffixFuzzer11> _fuzz2111) && {
-            fuzz2111 = std::move(_fuzz2111);
+        AffixFuzzer4 with_fuzz2111(const Collection<rerun::components::AffixFuzzer11>& _fuzz2111
+        ) && {
+            fuzz2111 =
+                ComponentBatch::from_loggable(_fuzz2111, Descriptor_fuzz2111).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2112(Collection<rerun::components::AffixFuzzer12> _fuzz2112) && {
-            fuzz2112 = std::move(_fuzz2112);
+        AffixFuzzer4 with_fuzz2112(const Collection<rerun::components::AffixFuzzer12>& _fuzz2112
+        ) && {
+            fuzz2112 =
+                ComponentBatch::from_loggable(_fuzz2112, Descriptor_fuzz2112).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2113(Collection<rerun::components::AffixFuzzer13> _fuzz2113) && {
-            fuzz2113 = std::move(_fuzz2113);
+        AffixFuzzer4 with_fuzz2113(const Collection<rerun::components::AffixFuzzer13>& _fuzz2113
+        ) && {
+            fuzz2113 =
+                ComponentBatch::from_loggable(_fuzz2113, Descriptor_fuzz2113).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2114(Collection<rerun::components::AffixFuzzer14> _fuzz2114) && {
-            fuzz2114 = std::move(_fuzz2114);
+        AffixFuzzer4 with_fuzz2114(const Collection<rerun::components::AffixFuzzer14>& _fuzz2114
+        ) && {
+            fuzz2114 =
+                ComponentBatch::from_loggable(_fuzz2114, Descriptor_fuzz2114).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2115(Collection<rerun::components::AffixFuzzer15> _fuzz2115) && {
-            fuzz2115 = std::move(_fuzz2115);
+        AffixFuzzer4 with_fuzz2115(const Collection<rerun::components::AffixFuzzer15>& _fuzz2115
+        ) && {
+            fuzz2115 =
+                ComponentBatch::from_loggable(_fuzz2115, Descriptor_fuzz2115).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2116(Collection<rerun::components::AffixFuzzer16> _fuzz2116) && {
-            fuzz2116 = std::move(_fuzz2116);
+        AffixFuzzer4 with_fuzz2116(const Collection<rerun::components::AffixFuzzer16>& _fuzz2116
+        ) && {
+            fuzz2116 =
+                ComponentBatch::from_loggable(_fuzz2116, Descriptor_fuzz2116).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2117(Collection<rerun::components::AffixFuzzer17> _fuzz2117) && {
-            fuzz2117 = std::move(_fuzz2117);
+        AffixFuzzer4 with_fuzz2117(const Collection<rerun::components::AffixFuzzer17>& _fuzz2117
+        ) && {
+            fuzz2117 =
+                ComponentBatch::from_loggable(_fuzz2117, Descriptor_fuzz2117).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }
 
-        AffixFuzzer4 with_fuzz2118(Collection<rerun::components::AffixFuzzer18> _fuzz2118) && {
-            fuzz2118 = std::move(_fuzz2118);
+        AffixFuzzer4 with_fuzz2118(const Collection<rerun::components::AffixFuzzer18>& _fuzz2118
+        ) && {
+            fuzz2118 =
+                ComponentBatch::from_loggable(_fuzz2118, Descriptor_fuzz2118).value_or_throw();
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }


### PR DESCRIPTION
### Related

* follow-up to https://github.com/rerun-io/rerun/pull/8779

### What

Makes eager serialization & update/clear apis the norm in C++ with no opt out.

Also removes no longer needed warning suppression on builder methods!

* [x] said warning suppression is actually no longer needed on any compiler we test