### PR TITLE
re_viewer welcome screen code cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6946,6 +6946,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cfg-if",
+ "color-hex",
  "eframe",
  "egui",
  "egui-wgpu",

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -45,6 +45,8 @@ grpc = ["re_data_source/grpc", "dep:re_grpc_client"]
 
 
 [dependencies]
+# XXX TODO FIX THIS IMPORT:
+color-hex = { version = "*", default-features = false }
 # Internal:
 re_blueprint_tree.workspace = true
 re_build_info.workspace = true

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -10,12 +10,18 @@ pub(super) const WELCOME_SCREEN_BULLET_TEXT: &[&str] = &[
     "Configure the viewer interactively or through code",
 ];
 
+// XXX TODO MOVE MACRO TO UTILITY MODULE OR UTILITY CRATE
+macro_rules! color_from_rgb_hex {
+    ($hex:literal) => {
+        match color_hex::color_from_hex!($hex).as_slice() {
+            [a, b, c] => Color32::from_rgb(*a, *b, *c),
+            _ => panic!("XXX"),
+        }
+    };
+}
+
 const DOC_BTN_TEXT: &str = "Go to documentation →";
-// XXX TODO MAKE & USE WRAPPER MACRO FOR THIS:
-const DOC_BTN_COLOR: Color32 = match color_hex::color_from_hex!("#60A0FF").as_slice() {
-    [a, b, c] => Color32::from_rgb(*a, *b, *c),
-    _ => panic!("XXX"),
-};
+const DOC_BTN_COLOR: Color32 = color_from_rgb_hex!("#60A0FF");
 
 /// Show the welcome section.
 pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use egui::{hex_color, Color32, Ui};
 
 use re_ui::UiExt as _;
 
@@ -11,7 +11,7 @@ pub(super) const WELCOME_SCREEN_BULLET_TEXT: &[&str] = &[
 ];
 
 const DOC_BTN_TEXT: &str = "Go to documentation →";
-const DOC_BTN_COLOR: &str = "#60A0FF";
+const DOC_BTN_COLOR: Color32 = hex_color!("#60A0FF");
 
 /// Show the welcome section.
 pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
@@ -59,10 +59,7 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
         if ui
             .button(
                 egui::RichText::new(DOC_BTN_TEXT)
-                    .color(
-                        egui::Color32::from_hex(DOC_BTN_COLOR)
-                            .expect("color failure (internal error)"),
-                    )
+                    .color(DOC_BTN_COLOR)
                     .text_style(re_ui::DesignTokens::welcome_screen_body()),
             )
             .on_hover_cursor(egui::CursorIcon::PointingHand)

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -1,4 +1,4 @@
-use egui::{hex_color, Color32, Ui};
+use egui::{Color32, Ui};
 
 use re_ui::UiExt as _;
 
@@ -11,7 +11,11 @@ pub(super) const WELCOME_SCREEN_BULLET_TEXT: &[&str] = &[
 ];
 
 const DOC_BTN_TEXT: &str = "Go to documentation →";
-const DOC_BTN_COLOR: Color32 = hex_color!("#60A0FF");
+// XXX TODO MAKE & USE WRAPPER MACRO FOR THIS:
+const DOC_BTN_COLOR: Color32 = match color_hex::color_from_hex!("#60A0FF").as_slice() {
+    [a, b, c] => Color32::from_rgb(*a, *b, *c),
+    _ => panic!("XXX"),
+};
 
 /// Show the welcome section.
 pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -10,6 +10,9 @@ pub(super) const WELCOME_SCREEN_BULLET_TEXT: &[&str] = &[
     "Configure the viewer interactively or through code",
 ];
 
+const DOC_BTN_TEXT: &str = "Go to documentation →";
+const DOC_BTN_COLOR: &str = "#60A0FF";
+
 /// Show the welcome section.
 pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
     ui.vertical(|ui| {
@@ -55,8 +58,11 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
         ui.add_space(9.0);
         if ui
             .button(
-                egui::RichText::new("Go to documentation →")
-                    .color(egui::Color32::from_hex("#60A0FF").expect("this color is valid"))
+                egui::RichText::new(DOC_BTN_TEXT)
+                    .color(
+                        egui::Color32::from_hex(DOC_BTN_COLOR)
+                            .expect("color failure (internal error)"),
+                    )
                     .text_style(re_ui::DesignTokens::welcome_screen_body()),
             )
             .on_hover_cursor(egui::CursorIcon::PointingHand)


### PR DESCRIPTION
### Related

- probably should have been combined with unwrap_unused cleanup in PR #8745

### What

refactoring to extract welcome doc button text & color into constants

probably should have been part of PR #8745 - I didn't want to slow it down any further

__OPEN QUESTION:__

I considered proposing this kind of cleanup throughout the `re_viewer` code. From a quick look through this module gives me a serious doubt: `crates/viewer/re_viewer/src/ui/memory_panel.rs`

I would love to find a way to make a more data-driven approach for functions like `MemoryPanel::gpu_stats` & `MemoryPanel::caches_stats`.

Maybe best to close & reject this one for now.