### PR TITLE
Fix Python bridge losing descriptor/tags information during transit

### DIFF
--- a/rerun_py/src/video.rs
+++ b/rerun_py/src/video.rs
@@ -3,7 +3,6 @@
 use pyo3::{exceptions::PyRuntimeError, pyfunction, Bound, PyAny, PyResult};
 
 use re_arrow_util::ArrowArrayDowncastRef as _;
-use re_sdk::ComponentDescriptor;
 use re_video::VideoLoadError;
 
 use crate::arrow::array_to_rust;
@@ -20,12 +19,7 @@ pub fn asset_video_read_frame_timestamps_ns(
     video_bytes_arrow_array: &Bound<'_, PyAny>,
     media_type: Option<&str>,
 ) -> PyResult<Vec<i64>> {
-    let component_descr = ComponentDescriptor {
-        archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-        archetype_field_name: Some("blob".into()),
-        component_name: "rerun.components.Blob".into(),
-    };
-    let video_bytes_arrow_array = array_to_rust(video_bytes_arrow_array, &component_descr)?.0;
+    let video_bytes_arrow_array = array_to_rust(video_bytes_arrow_array)?;
 
     let video_bytes_arrow_uint8_array = video_bytes_arrow_array
         .downcast_array_ref::<arrow::array::ListArray>()


### PR DESCRIPTION
Not sure how it got that way, but that fixes it and generally simplifies the pipeline, in any case.