### PR TITLE
Give `PendingRow` its `BTreeMap` back

### DIFF
--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     hash::{Hash as _, Hasher},
     sync::Arc,
     time::{Duration, Instant},
@@ -681,12 +682,12 @@ pub struct PendingRow {
     /// The component data.
     ///
     /// Each array is a single component, i.e. _not_ a list array.
-    pub components: IntMap<ComponentDescriptor, ArrayRef>,
+    pub components: BTreeMap<ComponentDescriptor, ArrayRef>,
 }
 
 impl PendingRow {
     #[inline]
-    pub fn new(timepoint: TimePoint, components: IntMap<ComponentDescriptor, ArrayRef>) -> Self {
+    pub fn new(timepoint: TimePoint, components: BTreeMap<ComponentDescriptor, ArrayRef>) -> Self {
         Self {
             row_id: RowId::new(),
             timepoint,

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::io::IsTerminal;
 use std::sync::Weak;
@@ -1188,7 +1189,7 @@ impl RecordingStream {
                     .map(|array| (comp_batch.descriptor().into_owned(), array))
             })
             .collect();
-        let components: IntMap<_, _> = comp_batches?.into_iter().collect();
+        let components: BTreeMap<_, _> = comp_batches?.into_iter().collect();
 
         // NOTE: The timepoint is irrelevant, the `RecordingStream` will overwrite it using its
         // internal clock.
@@ -1261,7 +1262,7 @@ impl RecordingStream {
             .into_iter()
             .map(|comp_batch| (comp_batch.descriptor, comp_batch.array))
             .collect();
-        let components: IntMap<_, _> = comp_batches.into_iter().collect();
+        let components: BTreeMap<_, _> = comp_batches.into_iter().collect();
 
         // NOTE: The timepoint is irrelevant, the `RecordingStream` will overwrite it using its
         // internal clock.

--- a/crates/top/rerun_c/src/lib.rs
+++ b/crates/top/rerun_c/src/lib.rs
@@ -12,7 +12,10 @@ mod ptr;
 mod recording_streams;
 mod video;
 
-use std::ffi::{c_char, c_uchar, CString};
+use std::{
+    collections::BTreeMap,
+    ffi::{c_char, c_uchar, CString},
+};
 
 use arrow::array::{ArrayRef as ArrowArrayRef, ListArray as ArrowListArray};
 use arrow_utils::arrow_array_from_c_ffi;
@@ -811,7 +814,7 @@ fn rr_recording_stream_log_impl(
 
     let batches = unsafe { std::slice::from_raw_parts_mut(batches, num_data_cells) };
 
-    let mut components = IntMap::default();
+    let mut components = BTreeMap::default();
     {
         let component_type_registry = COMPONENT_TYPES.read();
 

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -1,6 +1,6 @@
 //! Methods for handling Arrow datamodel log ingest
 
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use arrow::{
     array::{
@@ -82,7 +82,7 @@ pub fn build_row_from_components(
     // TODO(emilk): move to before we arrow-serialize the data
     let row_id = RowId::new();
 
-    let mut components = IntMap::default();
+    let mut components = BTreeMap::default();
     for (component_descr, array) in components_per_descr {
         let component_descr = descriptor_to_rust(&component_descr)?;
         let (list_array, _field) = array_to_rust(&array, &component_descr)?;


### PR DESCRIPTION
This is a fun one: it's by all account a mistake, and therefore a bug... but actually it's pretty nice, so I'm not quite sure I want to fix it :no_mouth:.

I was looking into the micro-batcher's code for unrelated reasons, when I stumbled upon this:
```rust
let mut hasher = ahash::AHasher::default();
row.components
    .values()
    .for_each(|array| array.data_type().hash(&mut hasher));
```
Looks legit at first glance, except... `row.components` is a `Hashmap`. Or a `IntMap`, rather. And `HashMap`s have a random iteration order **per-instance per-execution** (it is then fixed for the lifetime of that instance).
The reason it's a `IntMap` is because I went a bit too far with my search-n-replace during https://github.com/rerun-io/rerun/pull/8207:
* https://github.com/rerun-io/rerun/pull/8207

So, that raises the question... why on earth is the micro-batcher still working? The reason it's still working is that, by virtue of not doing any hashing nor salting, an `IntMap` ends up with stronger guarantees that a vanilla `HashMap`. Specifically,  all `IntMap`s that share the same keys have the same iteration order, **iff these keys were inserted in the same order**.
Put differently, this test always passes:
```rust
#[test]
#[allow(clippy::zero_sized_map_values)]
fn intmap_order_is_well_defined() {
    let descriptors = [
        MyPoint::descriptor(),
        MyColor::descriptor(),
        MyLabel::descriptor(),
        MyPoint64::descriptor(),
        MyIndex::descriptor(),
    ];

    let expected: IntMap<ComponentDescriptor, ()> =
        descriptors.iter().cloned().map(|d| (d, ())).collect();
    let expected: Vec<_> = expected.into_keys().collect();

    for _ in 0..1_000 {
        let got: IntMap<ComponentDescriptor, ()> =
            descriptors.clone().into_iter().map(|d| (d, ())).collect();
        let got: Vec<_> = got.into_keys().collect();

        assert_eq!(expected, got);
    }
}
```
whereas this one will always fail, as you'd expect:
```rust
#[test]
#[allow(clippy::zero_sized_map_values)]
fn intmap_order_is_well_defined() {
    let descriptors = [
        MyPoint::descriptor(),
        MyColor::descriptor(),
        MyLabel::descriptor(),
        MyPoint64::descriptor(),
        MyIndex::descriptor(),
    ];

    let expected: HashMap<ComponentDescriptor, ()> =
        descriptors.iter().cloned().map(|d| (d, ())).collect();
    let expected: Vec<_> = expected.into_keys().collect();

    for _ in 0..1_000 {
        let got: HashMap<ComponentDescriptor, ()> =
            descriptors.clone().into_iter().map(|d| (d, ())).collect();
        let got: Vec<_> = got.into_keys().collect();

        assert_eq!(expected, got);
    }
}
```

And that's why batching still works: the order in which you insert your components into your `PendingRow` is always the same during the execution of your program.
Not only it works, but it's 50% faster than with the BTree-based approach, as we know. Eh.