### PR TITLE
Make `Pinhole` archetype in Rust eager serialized

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/pinhole.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/pinhole.fbs
@@ -6,7 +6,7 @@ namespace rerun.archetypes;
 /// \example archetypes/pinhole_simple title="Simple pinhole camera" image="https://static.rerun.io/pinhole_simple/9af9441a94bcd9fd54e1fea44fb0c59ff381a7f2/1200w.png"
 /// \example archetypes/pinhole_perspective title="Perspective pinhole camera" image="https://static.rerun.io/pinhole_perspective/317e2de6d212b238dcdad5b67037e9e2a2afafa0/1200w.png"
 table Pinhole (
-  // TODO(#7245): "attr.rust.archetype_eager"
+  "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial2DView, Spatial2DView"

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -405,6 +405,27 @@ impl Pinhole {
         Ok(columns.into_iter().chain([indicator_column]).flatten())
     }
 
+    /// Helper to partition the component data into unit-length sub-batches.
+    ///
+    /// This is semantically similar to calling [`Self::columns`] with `std::iter::take(1).repeat(n)`,
+    /// where `n` is automatically guessed.
+    #[inline]
+    pub fn columns_of_unit_batches(
+        self,
+    ) -> SerializationResult<impl Iterator<Item = ::re_types_core::SerializedComponentColumn>> {
+        let len_image_from_camera = self.image_from_camera.as_ref().map(|b| b.array.len());
+        let len_resolution = self.resolution.as_ref().map(|b| b.array.len());
+        let len_camera_xyz = self.camera_xyz.as_ref().map(|b| b.array.len());
+        let len_image_plane_distance = self.image_plane_distance.as_ref().map(|b| b.array.len());
+        let len = None
+            .or(len_image_from_camera)
+            .or(len_resolution)
+            .or(len_camera_xyz)
+            .or(len_image_plane_distance)
+            .unwrap_or(0);
+        self.columns(std::iter::repeat(1).take(len))
+    }
+
     /// Camera projection, from image coordinates to view coordinates.
     #[inline]
     pub fn with_image_from_camera(

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -86,10 +86,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///   <img src="https://static.rerun.io/pinhole_perspective/317e2de6d212b238dcdad5b67037e9e2a2afafa0/full.png" width="640">
 /// </picture>
 /// </center>
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Pinhole {
     /// Camera projection, from image coordinates to view coordinates.
-    pub image_from_camera: crate::components::PinholeProjection,
+    pub image_from_camera: Option<SerializedComponentBatch>,
 
     /// Pixel resolution (usually integers) of child image space. Width and height.
     ///
@@ -99,7 +99,7 @@ pub struct Pinhole {
     /// ```
     ///
     /// `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
-    pub resolution: Option<crate::components::Resolution>,
+    pub resolution: Option<SerializedComponentBatch>,
 
     /// Sets the view coordinates for the camera.
     ///
@@ -128,12 +128,12 @@ pub struct Pinhole {
     ///
     /// The pinhole matrix (the `image_from_camera` argument) always project along the third (Z) axis,
     /// but will be re-oriented to project along the forward axis of the `camera_xyz` argument.
-    pub camera_xyz: Option<crate::components::ViewCoordinates>,
+    pub camera_xyz: Option<SerializedComponentBatch>,
 
     /// The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.
     ///
     /// This is only used for visualization purposes, and does not affect the projection itself.
-    pub image_plane_distance: Option<crate::components::ImagePlaneDistance>,
+    pub image_plane_distance: Option<SerializedComponentBatch>,
 }
 
 impl Pinhole {
@@ -272,47 +272,29 @@ impl ::re_types_core::Archetype for Pinhole {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
-        let image_from_camera = {
-            let array = arrays_by_descr
-                .get(&Self::descriptor_image_from_camera())
-                .ok_or_else(DeserializationError::missing_data)
-                .with_context("rerun.archetypes.Pinhole#image_from_camera")?;
-            <crate::components::PinholeProjection>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Pinhole#image_from_camera")?
-                .into_iter()
-                .next()
-                .flatten()
-                .ok_or_else(DeserializationError::missing_data)
-                .with_context("rerun.archetypes.Pinhole#image_from_camera")?
-        };
-        let resolution = if let Some(array) = arrays_by_descr.get(&Self::descriptor_resolution()) {
-            <crate::components::Resolution>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Pinhole#resolution")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
-        let camera_xyz = if let Some(array) = arrays_by_descr.get(&Self::descriptor_camera_xyz()) {
-            <crate::components::ViewCoordinates>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Pinhole#camera_xyz")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
-        let image_plane_distance =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_image_plane_distance()) {
-                <crate::components::ImagePlaneDistance>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Pinhole#image_plane_distance")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
+        let image_from_camera = arrays_by_descr
+            .get(&Self::descriptor_image_from_camera())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_image_from_camera())
+            });
+        let resolution = arrays_by_descr
+            .get(&Self::descriptor_resolution())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_resolution())
+            });
+        let camera_xyz = arrays_by_descr
+            .get(&Self::descriptor_camera_xyz())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_camera_xyz())
+            });
+        let image_plane_distance = arrays_by_descr
+            .get(&Self::descriptor_image_plane_distance())
+            .map(|array| {
+                SerializedComponentBatch::new(
+                    array.clone(),
+                    Self::descriptor_image_plane_distance(),
+                )
+            });
         Ok(Self {
             image_from_camera,
             resolution,
@@ -323,41 +305,15 @@ impl ::re_types_core::Archetype for Pinhole {
 }
 
 impl ::re_types_core::AsComponents for Pinhole {
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        re_tracing::profile_function!();
+    #[inline]
+    fn as_serialized_batches(&self) -> Vec<SerializedComponentBatch> {
         use ::re_types_core::Archetype as _;
         [
-            Some(Self::indicator()),
-            (Some(&self.image_from_camera as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::ComponentBatchCowWithDescriptor {
-                    batch: batch.into(),
-                    descriptor_override: Some(Self::descriptor_image_from_camera()),
-                }
-            }),
-            (self
-                .resolution
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_resolution()),
-            }),
-            (self
-                .camera_xyz
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_camera_xyz()),
-            }),
-            (self
-                .image_plane_distance
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_image_plane_distance()),
-            }),
+            Self::indicator().serialized(),
+            self.image_from_camera.clone(),
+            self.resolution.clone(),
+            self.camera_xyz.clone(),
+            self.image_plane_distance.clone(),
         ]
         .into_iter()
         .flatten()
@@ -372,11 +328,106 @@ impl Pinhole {
     #[inline]
     pub fn new(image_from_camera: impl Into<crate::components::PinholeProjection>) -> Self {
         Self {
-            image_from_camera: image_from_camera.into(),
+            image_from_camera: try_serialize_field(
+                Self::descriptor_image_from_camera(),
+                [image_from_camera],
+            ),
             resolution: None,
             camera_xyz: None,
             image_plane_distance: None,
         }
+    }
+
+    /// Update only some specific fields of a `Pinhole`.
+    #[inline]
+    pub fn update_fields() -> Self {
+        Self::default()
+    }
+
+    /// Clear all the fields of a `Pinhole`.
+    #[inline]
+    pub fn clear_fields() -> Self {
+        use ::re_types_core::Loggable as _;
+        Self {
+            image_from_camera: Some(SerializedComponentBatch::new(
+                crate::components::PinholeProjection::arrow_empty(),
+                Self::descriptor_image_from_camera(),
+            )),
+            resolution: Some(SerializedComponentBatch::new(
+                crate::components::Resolution::arrow_empty(),
+                Self::descriptor_resolution(),
+            )),
+            camera_xyz: Some(SerializedComponentBatch::new(
+                crate::components::ViewCoordinates::arrow_empty(),
+                Self::descriptor_camera_xyz(),
+            )),
+            image_plane_distance: Some(SerializedComponentBatch::new(
+                crate::components::ImagePlaneDistance::arrow_empty(),
+                Self::descriptor_image_plane_distance(),
+            )),
+        }
+    }
+
+    /// Partitions the component data into multiple sub-batches.
+    ///
+    /// Specifically, this transforms the existing [`SerializedComponentBatch`]es data into [`SerializedComponentColumn`]s
+    /// instead, via [`SerializedComponentBatch::partitioned`].
+    ///
+    /// This makes it possible to use `RecordingStream::send_columns` to send columnar data directly into Rerun.
+    ///
+    /// The specified `lengths` must sum to the total length of the component batch.
+    ///
+    /// [`SerializedComponentColumn`]: [::re_types_core::SerializedComponentColumn]
+    #[inline]
+    pub fn columns<I>(
+        self,
+        _lengths: I,
+    ) -> SerializationResult<impl Iterator<Item = ::re_types_core::SerializedComponentColumn>>
+    where
+        I: IntoIterator<Item = usize> + Clone,
+    {
+        let columns = [
+            self.image_from_camera
+                .map(|image_from_camera| image_from_camera.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.resolution
+                .map(|resolution| resolution.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.camera_xyz
+                .map(|camera_xyz| camera_xyz.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.image_plane_distance
+                .map(|image_plane_distance| image_plane_distance.partitioned(_lengths.clone()))
+                .transpose()?,
+        ];
+        let indicator_column =
+            ::re_types_core::indicator_column::<Self>(_lengths.into_iter().count())?;
+        Ok(columns.into_iter().chain([indicator_column]).flatten())
+    }
+
+    /// Camera projection, from image coordinates to view coordinates.
+    #[inline]
+    pub fn with_image_from_camera(
+        mut self,
+        image_from_camera: impl Into<crate::components::PinholeProjection>,
+    ) -> Self {
+        self.image_from_camera =
+            try_serialize_field(Self::descriptor_image_from_camera(), [image_from_camera]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::PinholeProjection`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_image_from_camera`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_image_from_camera(
+        mut self,
+        image_from_camera: impl IntoIterator<Item = impl Into<crate::components::PinholeProjection>>,
+    ) -> Self {
+        self.image_from_camera =
+            try_serialize_field(Self::descriptor_image_from_camera(), image_from_camera);
+        self
     }
 
     /// Pixel resolution (usually integers) of child image space. Width and height.
@@ -389,7 +440,20 @@ impl Pinhole {
     /// `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
     #[inline]
     pub fn with_resolution(mut self, resolution: impl Into<crate::components::Resolution>) -> Self {
-        self.resolution = Some(resolution.into());
+        self.resolution = try_serialize_field(Self::descriptor_resolution(), [resolution]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::Resolution`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_resolution`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_resolution(
+        mut self,
+        resolution: impl IntoIterator<Item = impl Into<crate::components::Resolution>>,
+    ) -> Self {
+        self.resolution = try_serialize_field(Self::descriptor_resolution(), resolution);
         self
     }
 
@@ -425,7 +489,20 @@ impl Pinhole {
         mut self,
         camera_xyz: impl Into<crate::components::ViewCoordinates>,
     ) -> Self {
-        self.camera_xyz = Some(camera_xyz.into());
+        self.camera_xyz = try_serialize_field(Self::descriptor_camera_xyz(), [camera_xyz]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::ViewCoordinates`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_camera_xyz`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_camera_xyz(
+        mut self,
+        camera_xyz: impl IntoIterator<Item = impl Into<crate::components::ViewCoordinates>>,
+    ) -> Self {
+        self.camera_xyz = try_serialize_field(Self::descriptor_camera_xyz(), camera_xyz);
         self
     }
 
@@ -437,7 +514,26 @@ impl Pinhole {
         mut self,
         image_plane_distance: impl Into<crate::components::ImagePlaneDistance>,
     ) -> Self {
-        self.image_plane_distance = Some(image_plane_distance.into());
+        self.image_plane_distance = try_serialize_field(
+            Self::descriptor_image_plane_distance(),
+            [image_plane_distance],
+        );
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::ImagePlaneDistance`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_image_plane_distance`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_image_plane_distance(
+        mut self,
+        image_plane_distance: impl IntoIterator<Item = impl Into<crate::components::ImagePlaneDistance>>,
+    ) -> Self {
+        self.image_plane_distance = try_serialize_field(
+            Self::descriptor_image_plane_distance(),
+            image_plane_distance,
+        );
         self
     }
 }
@@ -449,13 +545,5 @@ impl ::re_byte_size::SizeBytes for Pinhole {
             + self.resolution.heap_size_bytes()
             + self.camera_xyz.heap_size_bytes()
             + self.image_plane_distance.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::PinholeProjection>::is_pod()
-            && <Option<crate::components::Resolution>>::is_pod()
-            && <Option<crate::components::ViewCoordinates>>::is_pod()
-            && <Option<crate::components::ImagePlaneDistance>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/pinhole_ext.rs
+++ b/crates/store/re_types/src/archetypes/pinhole_ext.rs
@@ -1,4 +1,9 @@
-use crate::{components::ViewCoordinates, datatypes::Vec2D};
+use re_types_core::{DeserializationResult, Loggable};
+
+use crate::{
+    components::{PinholeProjection, Resolution, ViewCoordinates},
+    datatypes::Vec2D,
+};
 
 use super::Pinhole;
 
@@ -49,42 +54,121 @@ impl Pinhole {
     /// i.e. the intersection of the optical axis and the image plane.
     ///
     /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    ///
+    /// <div class="warning">
+    /// This method can be relatively costly since it has to deserialize & reserialize the [`PinholeProjection`] component
+    /// from/to its arrow representation.
+    /// On performance critical paths, prefer first setting up the [`PinholeProjection`] component fully
+    /// before passing it to the archetype.
+    /// </div>
     #[cfg(feature = "glam")]
     #[inline]
     pub fn with_principal_point(mut self, principal_point: impl Into<Vec2D>) -> Self {
-        self.image_from_camera = self.image_from_camera.with_principal_point(principal_point);
+        use re_types_core::ComponentBatch as _;
+
+        let image_from_camera = self.image_from_camera_from_arrow().unwrap_or_default();
+        self.image_from_camera = image_from_camera
+            .with_principal_point(principal_point)
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(Self::descriptor_image_from_camera()));
         self
     }
 
     /// Field of View on the Y axis, i.e. the angle between top and bottom (in radians).
+    ///
+    /// Only returns a result if both projection & resolution are set.
     #[inline]
+    #[deprecated(
+        note = "Use `Pinhole::image_from_camera_from_arrow` & `Pinhole::resolution_from_arrow` to deserialize the components back,
+                or better use the components prior to passing it to the archetype, and then call `PinholeProjection::fov_y`",
+        since = "0.22.0"
+    )]
     pub fn fov_y(&self) -> Option<f32> {
-        self.resolution
-            .map(|resolution| 2.0 * (0.5 * resolution[1] / self.image_from_camera.col(1)[1]).atan())
+        self.image_from_camera_from_arrow()
+            .ok()
+            .and_then(|projection| {
+                self.resolution_from_arrow()
+                    .ok()
+                    .map(|r| projection.fov_y(r))
+            })
     }
 
     /// The resolution of the camera sensor in pixels.
     #[inline]
     #[cfg(feature = "glam")]
+    #[deprecated(
+        note = "Use `Pinhole::resolution_from_arrow` to deserialize back to a `Resolution` component,
+                or better use the `Resolution` prior to passing it to the archetype, and then use `Resolution::into` for the conversion",
+        since = "0.22.0"
+    )]
     pub fn resolution(&self) -> Option<glam::Vec2> {
-        self.resolution.map(|r| (*r).into())
+        self.resolution_from_arrow().ok().map(|r| r.into())
     }
 
     /// Width/height ratio of the camera sensor.
     #[inline]
+    #[deprecated(
+        note = "Use `Pinhole::resolution_from_arrow` to deserialize back to a `Resolution` component,
+                or better use the `Resolution` prior to passing it to the archetype, and then use `Resolution::aspect_ratio`",
+        since = "0.22.0"
+    )]
     pub fn aspect_ratio(&self) -> Option<f32> {
-        self.resolution.map(|r| r[0] / r[1])
+        self.resolution_from_arrow().ok().map(|r| r.aspect_ratio())
+    }
+
+    /// Deserializes the pinhole projection from the `image_from_camera` field.
+    ///
+    /// Returns [`re_types_core::DeserializationError::MissingData`] if the component is not present.
+    pub fn image_from_camera_from_arrow(&self) -> DeserializationResult<PinholeProjection> {
+        self.image_from_camera.as_ref().map_or(
+            Err(re_types_core::DeserializationError::missing_data()),
+            |data| {
+                PinholeProjection::from_arrow(&data.array).and_then(|v| {
+                    v.first()
+                        .copied()
+                        .ok_or(re_types_core::DeserializationError::missing_data())
+                })
+            },
+        )
+    }
+
+    /// Deserializes the resolution from the `resolution` field.
+    ///
+    /// Returns [`re_types_core::DeserializationError::MissingData`] if the component is not present.
+    pub fn resolution_from_arrow(&self) -> DeserializationResult<Resolution> {
+        self.resolution.as_ref().map_or(
+            Err(re_types_core::DeserializationError::missing_data()),
+            |data| {
+                Resolution::from_arrow(&data.array).and_then(|v| {
+                    v.first()
+                        .copied()
+                        .ok_or(re_types_core::DeserializationError::missing_data())
+                })
+            },
+        )
     }
 
     // ------------------------------------------------------------------------
     // Forwarding calls to `PinholeProjection`:
+    //
+    // Starting with 0.22 all component data is stored serialized in the archetype,
+    // therefore it's recommended to instead use the `PinholeProjection` component before passing it to the archetype.
+    // Using `Pinhole::image_from_camera_from_arrow()` it is possible to deserialize the `PinholeProjection` component
+    // if it has been already serialized/stored in the archetype struct.
 
     /// X & Y focal length in pixels.
     ///
     /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
     #[inline]
+    #[deprecated(
+        note = "Use `Pinhole::image_from_camera_from_arrow` instead to deserialize back to a `PinholeProjection` component,
+                or better use the `PinholeProjection` component prior to passing it to the archetype, and then call PinholeProjection::focal_length_in_pixels",
+        since = "0.22.0"
+    )]
     pub fn focal_length_in_pixels(&self) -> Vec2D {
-        self.image_from_camera.focal_length_in_pixels()
+        self.image_from_camera_from_arrow()
+            .unwrap_or_default()
+            .focal_length_in_pixels()
     }
 
     /// Principal point of the pinhole camera,
@@ -93,16 +177,30 @@ impl Pinhole {
     /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
     #[cfg(feature = "glam")]
     #[inline]
+    #[deprecated(
+        note = "Use `Pinhole::image_from_camera_from_arrow` instead to deserialize back to a `PinholeProjection` component,
+                or better use the `PinholeProjection` component prior to passing it to the archetype, and then call PinholeProjection::principal_point",
+        since = "0.22.0"
+    )]
     pub fn principal_point(&self) -> glam::Vec2 {
-        self.image_from_camera.principal_point()
+        self.image_from_camera_from_arrow()
+            .unwrap_or_default()
+            .principal_point()
     }
 
     /// Project camera-space coordinates into pixel coordinates,
     /// returning the same z/depth.
     #[cfg(feature = "glam")]
     #[inline]
+    #[deprecated(
+        note = "Use `Pinhole::image_from_camera_from_arrow` instead to deserialize back to a `PinholeProjection` component,
+                or better use the `PinholeProjection` component prior to passing it to the archetype, and then call PinholeProjection::project",
+        since = "0.22.0"
+    )]
     pub fn project(&self, pixel: glam::Vec3) -> glam::Vec3 {
-        self.image_from_camera.project(pixel)
+        self.image_from_camera_from_arrow()
+            .unwrap_or_default()
+            .project(pixel)
     }
 
     /// Given pixel coordinates and a world-space depth,
@@ -111,7 +209,14 @@ impl Pinhole {
     /// The returned z is the same as the input z (depth).
     #[cfg(feature = "glam")]
     #[inline]
+    #[deprecated(
+        note = "Use `Pinhole::image_from_camera_from_arrow` instead to deserialize back to a `PinholeProjection` component,
+                or better use the `PinholeProjection` component prior to passing it to the archetype, and then call PinholeProjection::unproject",
+        since = "0.22.0"
+    )]
     pub fn unproject(&self, pixel: glam::Vec3) -> glam::Vec3 {
-        self.image_from_camera.unproject(pixel)
+        self.image_from_camera_from_arrow()
+            .unwrap_or_default()
+            .unproject(pixel)
     }
 }

--- a/crates/store/re_types/src/components/pinhole_projection_ext.rs
+++ b/crates/store/re_types/src/components/pinhole_projection_ext.rs
@@ -71,6 +71,12 @@ impl PinholeProjection {
             / glam::Vec2::from(self.focal_length_in_pixels()))
         .extend(pixel.z)
     }
+
+    /// Field of View on the Y axis, i.e. the angle between top and bottom (in radians).
+    pub fn fov_y(&self, resolution: impl Into<super::Resolution>) -> f32 {
+        let resolution = resolution.into();
+        2.0 * (0.5 * resolution[1] / self.col(1)[1]).atan()
+    }
 }
 
 impl Default for PinholeProjection {

--- a/crates/store/re_types/src/components/resolution_ext.rs
+++ b/crates/store/re_types/src/components/resolution_ext.rs
@@ -7,3 +7,19 @@ impl Default for Resolution {
         [0.0, 0.0].into()
     }
 }
+
+impl Resolution {
+    /// Width/height ratio.
+    #[inline]
+    pub fn aspect_ratio(&self) -> f32 {
+        self[0] / self[1]
+    }
+}
+
+#[cfg(feature = "glam")]
+impl From<Resolution> for glam::Vec2 {
+    #[inline]
+    fn from(resolution: Resolution) -> Self {
+        glam::vec2(resolution[0], resolution[1])
+    }
+}

--- a/crates/store/re_types/tests/types/pinhole.rs
+++ b/crates/store/re_types/tests/types/pinhole.rs
@@ -1,13 +1,21 @@
-use re_types::{archetypes::Pinhole, components, Archetype as _, AsComponents as _};
+use re_types::{
+    archetypes::Pinhole, components, Archetype as _, AsComponents as _, ComponentBatch,
+};
 
 #[test]
 fn roundtrip() {
     let expected = Pinhole {
         image_from_camera: components::PinholeProjection(
             [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]].into(),
-        ),
-        resolution: Some(components::Resolution([1.0, 2.0].into())),
-        camera_xyz: Some(components::ViewCoordinates::RDF),
+        )
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(Pinhole::descriptor_image_from_camera())),
+        resolution: components::Resolution([1.0, 2.0].into())
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(Pinhole::descriptor_resolution())),
+        camera_xyz: components::ViewCoordinates::RDF
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(Pinhole::descriptor_camera_xyz())),
         image_plane_distance: None,
     };
 

--- a/crates/viewer/re_view_spatial/src/eye.rs
+++ b/crates/viewer/re_view_spatial/src/eye.rs
@@ -30,8 +30,7 @@ impl Eye {
         let fov_y = space_cameras
             .pinhole
             .as_ref()
-            .and_then(|pinhole| pinhole.fov_y())
-            .unwrap_or(Self::DEFAULT_FOV_Y);
+            .map_or(Self::DEFAULT_FOV_Y, |pinhole| pinhole.fov_y());
 
         Some(Self {
             world_from_rub_view: space_cameras.world_from_rub_view()?,

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -15,6 +15,7 @@ mod pickable_textured_rect;
 mod picking;
 mod picking_ui;
 mod picking_ui_pixel;
+mod pinhole;
 mod proc_mesh;
 mod scene_bounding_boxes;
 mod space_camera_3d;
@@ -34,11 +35,11 @@ pub use view_2d::SpatialView2D;
 pub use view_3d::SpatialView3D;
 
 pub(crate) use pickable_textured_rect::{PickableRectSourceData, PickableTexturedRect};
+pub(crate) use pinhole::Pinhole;
 
 // ---
 
-use re_view::DataResultQuery as _;
-use re_viewer_context::{ImageDecodeCache, ViewContext, ViewerContext};
+use re_viewer_context::{ImageDecodeCache, ViewerContext};
 
 use re_log_types::debug_assert_archetype_has_components;
 use re_renderer::RenderContext;
@@ -97,63 +98,6 @@ fn resolution_of_image_at(
     }
 
     None
-}
-
-/// Utility for querying a pinhole archetype instance.
-fn query_pinhole(
-    ctx: &ViewContext<'_>,
-    query: &re_chunk_store::LatestAtQuery,
-    data_result: &re_viewer_context::DataResult,
-) -> Option<re_types::archetypes::Pinhole> {
-    let results = data_result
-        .latest_at_with_blueprint_resolved_data::<re_types::archetypes::Pinhole>(ctx, query);
-
-    let image_from_camera = results.get_mono()?;
-
-    let resolution = results.get_mono().or_else(|| {
-        // If the Pinhole has no resolution, use the resolution for the image logged at the same path.
-        // See https://github.com/rerun-io/rerun/issues/3852
-        resolution_of_image_at(ctx.viewer_ctx, query, &data_result.entity_path)
-    });
-
-    let camera_xyz = results.get_mono();
-
-    let image_plane_distance = Some(results.get_mono_with_fallback());
-
-    Some(re_types::archetypes::Pinhole {
-        image_from_camera,
-        resolution,
-        camera_xyz,
-        image_plane_distance,
-    })
-}
-
-/// Deprecated utility for querying a pinhole archetype instance.
-///
-/// This function won't handle fallbacks correctly.
-///
-// TODO(andreas): This is duplicated into `re_viewport`
-fn query_pinhole_legacy(
-    ctx: &ViewerContext<'_>,
-    query: &re_chunk_store::LatestAtQuery,
-    entity_path: &re_log_types::EntityPath,
-) -> Option<re_types::archetypes::Pinhole> {
-    let entity_db = ctx.recording();
-    entity_db
-        .latest_at_component::<re_types::components::PinholeProjection>(entity_path, query)
-        .map(
-            |(_index, image_from_camera)| re_types::archetypes::Pinhole {
-                image_from_camera,
-                resolution: entity_db
-                    .latest_at_component(entity_path, query)
-                    .map(|(_index, c)| c)
-                    .or_else(|| resolution_of_image_at(ctx, query, entity_path)),
-                camera_xyz: entity_db
-                    .latest_at_component(entity_path, query)
-                    .map(|(_index, c)| c),
-                image_plane_distance: None,
-            },
-        )
 }
 
 pub(crate) fn configure_background(

--- a/crates/viewer/re_view_spatial/src/pinhole.rs
+++ b/crates/viewer/re_view_spatial/src/pinhole.rs
@@ -1,0 +1,125 @@
+use re_types::{archetypes, components};
+
+use crate::resolution_of_image_at;
+
+/// A pinhole camera model.
+///
+/// Corresponds roughly to the [`re_types::archetypes::Pinhole`] archetype, but uses `glam` types.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Pinhole {
+    pub image_from_camera: glam::Mat3,
+    pub resolution: glam::Vec2,
+}
+
+impl Pinhole {
+    /// Width/height ratio of the camera sensor.
+    #[inline]
+    pub fn aspect_ratio(&self) -> f32 {
+        self.resolution.x / self.resolution.y
+    }
+
+    /// Principal point of the pinhole camera,
+    /// i.e. the intersection of the optical axis and the image plane.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[inline]
+    pub fn principal_point(&self) -> glam::Vec2 {
+        glam::vec2(
+            self.image_from_camera.col(2)[0],
+            self.image_from_camera.col(2)[1],
+        )
+    }
+
+    /// X & Y focal length in pixels.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[inline]
+    pub fn focal_length_in_pixels(&self) -> glam::Vec2 {
+        glam::vec2(
+            self.image_from_camera.col(0)[0],
+            self.image_from_camera.col(1)[1],
+        )
+    }
+
+    /// Field of View on the Y axis, i.e. the angle between top and bottom (in radians).
+    #[inline]
+    pub fn fov_y(&self) -> f32 {
+        2.0 * (0.5 * self.resolution[1] / self.image_from_camera.col(1)[1]).atan()
+    }
+
+    /// The pinhole sensor rectangle: [0, 0] - [width, height],
+    /// ignoring principal point.
+    #[inline]
+    pub fn resolution_rect(&self) -> egui::Rect {
+        egui::Rect::from_min_max(
+            egui::Pos2::ZERO,
+            egui::pos2(self.resolution.x, self.resolution.y),
+        )
+    }
+
+    /// Project camera-space coordinates into pixel coordinates,
+    /// returning the same z/depth.
+    #[inline]
+    pub fn project(&self, pixel: glam::Vec3) -> glam::Vec3 {
+        ((pixel.truncate() * self.focal_length_in_pixels()) / pixel.z + self.principal_point())
+            .extend(pixel.z)
+    }
+
+    /// Given pixel coordinates and a world-space depth,
+    /// return a position in the camera space.
+    ///
+    /// The returned z is the same as the input z (depth).
+    #[inline]
+    pub fn unproject(&self, pixel: glam::Vec3) -> glam::Vec3 {
+        ((pixel.truncate() - self.principal_point()) * pixel.z / self.focal_length_in_pixels())
+            .extend(pixel.z)
+    }
+}
+
+/// Utility for querying the pinhole from the store.
+///
+/// Fallback provider will be used for everything but the projection itself.
+/// Does NOT take into account blueprint overrides, defaults and fallbacks.
+/// However, it will use the resolution of the image at the entity path if available.
+///
+/// If the projection isn't present, returns `None`.
+// TODO(andreas): Give this another pass and think about how we can remove this.
+// Being disconnected from the blueprint & fallbacks makes this a weird snowflake with unexpected behavior.
+// Also, figure out how this might actually relate to the transform cache.
+pub fn query_pinhole_and_view_coordinates_from_store_without_blueprint(
+    ctx: &re_viewer_context::ViewerContext<'_>,
+    query: &re_chunk_store::LatestAtQuery,
+    entity_path: &re_log_types::EntityPath,
+) -> Option<(Pinhole, components::ViewCoordinates)> {
+    let entity_db = ctx.recording();
+
+    let query_results = entity_db.latest_at(
+        query,
+        entity_path,
+        [
+            archetypes::Pinhole::descriptor_image_from_camera().component_name,
+            archetypes::Pinhole::descriptor_resolution().component_name,
+            archetypes::Pinhole::descriptor_camera_xyz().component_name,
+        ],
+    );
+
+    let pinhole_projection =
+        query_results.component_mono_quiet::<components::PinholeProjection>()?;
+
+    let resolution = query_results
+        .component_mono_quiet::<components::Resolution>()
+        .unwrap_or_else(|| {
+            resolution_of_image_at(ctx, query, entity_path).unwrap_or([100.0, 100.0].into())
+        });
+    let camera_xyz = query_results
+        .component_mono_quiet::<components::ViewCoordinates>()
+        .unwrap_or(archetypes::Pinhole::DEFAULT_CAMERA_XYZ);
+
+    Some((
+        Pinhole {
+            image_from_camera: pinhole_projection.0.into(),
+            resolution: resolution.into(),
+        },
+        camera_xyz,
+    ))
+}

--- a/crates/viewer/re_view_spatial/src/space_camera_3d.rs
+++ b/crates/viewer/re_view_spatial/src/space_camera_3d.rs
@@ -2,10 +2,9 @@ use glam::Vec3;
 use re_math::IsoTransform;
 
 use re_log_types::EntityPath;
-use re_types::archetypes::Pinhole;
 use re_types::components::ViewCoordinates;
 
-use crate::visualizers::image_view_coordinates;
+use crate::{visualizers::image_view_coordinates, Pinhole};
 
 /// A logged camera that connects spaces.
 #[derive(Clone, PartialEq)]

--- a/crates/viewer/re_view_spatial/src/ui.rs
+++ b/crates/viewer/re_view_spatial/src/ui.rs
@@ -3,8 +3,7 @@ use egui::{epaint::util::OrderedFloat, text::TextWrapping, NumExt as _, WidgetTe
 use re_format::format_f32;
 use re_math::BoundingBox;
 use re_types::{
-    archetypes::Pinhole, blueprint::components::VisualBounds2D, components::ViewCoordinates,
-    image::ImageKind,
+    blueprint::components::VisualBounds2D, components::ViewCoordinates, image::ImageKind,
 };
 use re_ui::UiExt as _;
 use re_viewer_context::{HoverHighlight, SelectionHighlight, ViewHighlights, ViewState};
@@ -16,6 +15,7 @@ use crate::{
     scene_bounding_boxes::SceneBoundingBoxes,
     view_kind::SpatialViewKind,
     visualizers::{SpatialViewVisualizerData, UiLabel, UiLabelStyle, UiLabelTarget},
+    Pinhole,
 };
 
 use super::{eye::Eye, ui_3d::View3DState};

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -4,12 +4,9 @@ use re_math::IsoTransform;
 use re_entity_db::EntityPath;
 use re_log::ResultExt as _;
 use re_renderer::view_builder::{TargetConfiguration, ViewBuilder};
-use re_types::{
-    archetypes::Pinhole,
-    blueprint::{
-        archetypes::{Background, NearClipPlane, VisualBounds2D},
-        components as blueprint_components,
-    },
+use re_types::blueprint::{
+    archetypes::{Background, NearClipPlane, VisualBounds2D},
+    components as blueprint_components,
 };
 use re_ui::{ContextExt as _, ModifiersMarkdown, MouseButtonMarkdown};
 use re_view::controls::{DRAG_PAN2D_BUTTON, ZOOM_SCROLL_MODIFIER};
@@ -20,8 +17,8 @@ use re_viewport_blueprint::ViewProperty;
 
 use super::{eye::Eye, ui::create_labels};
 use crate::{
-    query_pinhole_legacy, ui::SpatialViewState, view_kind::SpatialViewKind,
-    visualizers::collect_ui_labels, SpatialView2D,
+    ui::SpatialViewState, view_kind::SpatialViewKind, visualizers::collect_ui_labels, Pinhole,
+    SpatialView2D,
 };
 
 // ---
@@ -153,11 +150,15 @@ impl SpatialView2D {
         // Note that we can't rely on the camera being part of scene.space_cameras since that requires
         // the camera to be added to the scene!
         //
-        // TODO(jleibs): Would be nice to use `query_pinhole` here, but we don't have a data-result or the other pieces
-        // necessary to properly handle overrides, defaults, or fallbacks. We don't actually use the image_plane_distance
-        // so it doesnt technically matter.
+        // TODO(jleibs, andreas): We don't have a data-result or the other pieces
+        // necessary to properly handle overrides, defaults, or fallbacks.
         state.pinhole_at_origin =
-            query_pinhole_legacy(ctx, &ctx.current_query(), query.space_origin);
+            crate::pinhole::query_pinhole_and_view_coordinates_from_store_without_blueprint(
+                ctx,
+                &ctx.current_query(),
+                query.space_origin,
+            )
+            .map(|(pinhole, _view_coordinates)| pinhole);
 
         let (response, painter) =
             ui.allocate_painter(ui.available_size(), egui::Sense::click_and_drag());
@@ -319,54 +320,38 @@ fn setup_target_config(
 
     // TODO(andreas): Support anamorphic pinhole cameras properly.
 
-    // For simplicity (and to reduce surprises!) we always render with a pinhole camera.
-    // Make up a default pinhole camera if we don't have one placing it in a way to look at the entire space.
-    let scene_bounds_size = glam::vec2(scene_bounds.width(), scene_bounds.height());
-
-    let pinhole;
-    let resolution;
-
-    if let Some(scene_pinhole) = scene_pinhole {
+    let pinhole = if let Some(scene_pinhole) = scene_pinhole {
         // The user has a pinhole, and we may want to project 3D stuff into this 2D space,
         // and we want to use that pinhole projection to do so.
-        pinhole = scene_pinhole.clone();
-
-        resolution = pinhole.resolution().unwrap_or_else(|| {
-            // This is weird - we have a projection with an unknown resolution.
-            // Let's just pick something plausible and hope for the best 😬.
-            re_log::warn_once!("Pinhole projection lacks resolution.");
-            glam::Vec2::splat(1000.0)
-        });
+        *scene_pinhole
     } else {
         // The user didn't pick a pinhole, but we still set up a 3D projection.
         // So we just pick _any_ pinhole camera, but we pick a "plausible" one so that
         // it is similar to real-life pinhole cameras, so that we get similar scales and precision.
         let focal_length = 1000.0; // Whatever, but small values can cause precision issues, noticeable on rectangle corners.
         let principal_point = glam::Vec2::splat(500.0); // Whatever
-        resolution = glam::Vec2::splat(1000.0); // Whatever
-        pinhole = Pinhole {
+        let resolution = glam::Vec2::splat(1000.0); // Whatever
+        Pinhole {
             image_from_camera: glam::Mat3::from_cols(
                 glam::vec3(focal_length, 0.0, 0.0),
                 glam::vec3(0.0, focal_length, 0.0),
                 principal_point.extend(1.0),
-            )
-            .into(),
-            resolution: Some([resolution.x, resolution.y].into()),
-            camera_xyz: Some(Pinhole::DEFAULT_CAMERA_XYZ),
-            image_plane_distance: None,
-        };
-    }
-    let pinhole_rect = Rect::from_min_size(Pos2::ZERO, egui::vec2(resolution.x, resolution.y));
+            ),
+            resolution,
+        }
+    };
+    let pinhole_rect = Rect::from_min_size(
+        Pos2::ZERO,
+        egui::vec2(pinhole.resolution.x, pinhole.resolution.y),
+    );
 
     let focal_length = pinhole.focal_length_in_pixels();
-    let focal_length = 2.0 / (1.0 / focal_length.x() + 1.0 / focal_length.y()); // harmonic mean (lack of anamorphic support)
+    let focal_length = 2.0 / (1.0 / focal_length.x + 1.0 / focal_length.y); // harmonic mean (lack of anamorphic support)
 
     let projection_from_view = re_renderer::view_builder::Projection::Perspective {
-        vertical_fov: pinhole.fov_y().unwrap_or(Eye::DEFAULT_FOV_Y),
+        vertical_fov: pinhole.fov_y(),
         near_plane_distance: near_clip_plane * focal_length / 500.0, // TODO(#8373): The need to scale this by 500 is quite hacky.
-        aspect_ratio: pinhole
-            .aspect_ratio()
-            .unwrap_or(scene_bounds_size.x / scene_bounds_size.y), // only happens if the pinhole lacks resolution
+        aspect_ratio: pinhole.aspect_ratio(),
     };
 
     // Position the camera looking straight at the principal point:
@@ -386,7 +371,7 @@ fn setup_target_config(
     // We want to look at the center of the scene bounds,
     // but we set up the camera to look at the principal point,
     // so we need to translate the view camera to compensate for that:
-    let image_center = 0.5 * resolution;
+    let image_center = 0.5 * pinhole.resolution;
     viewport_transformation.region_of_interest.min += image_center - pinhole.principal_point();
 
     // ----------------------

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -150,7 +150,7 @@ impl SpatialView2D {
         // Note that we can't rely on the camera being part of scene.space_cameras since that requires
         // the camera to be added to the scene!
         //
-        // TODO(jleibs, andreas): We don't have a data-result or the other pieces
+        // TODO(#6743): We don't have a data-result or the other pieces
         // necessary to properly handle overrides, defaults, or fallbacks.
         state.pinhole_at_origin =
             crate::pinhole::query_pinhole_and_view_coordinates_from_store_without_blueprint(

--- a/crates/viewer/re_view_spatial/src/view_2d_properties.rs
+++ b/crates/viewer/re_view_spatial/src/view_2d_properties.rs
@@ -1,5 +1,4 @@
 use re_types::{
-    archetypes::Pinhole,
     blueprint::{
         archetypes::Background,
         components::{BackgroundKind, VisualBounds2D},
@@ -32,14 +31,6 @@ fn valid_bound(rect: &egui::Rect) -> bool {
     rect.is_finite() && rect.is_positive()
 }
 
-/// The pinhole sensor rectangle: [0, 0] - [width, height],
-/// ignoring principal point.
-fn pinhole_resolution_rect(pinhole: &Pinhole) -> Option<egui::Rect> {
-    pinhole
-        .resolution()
-        .map(|res| egui::Rect::from_min_max(egui::Pos2::ZERO, egui::pos2(res.x, res.y)))
-}
-
 impl TypedComponentFallbackProvider<VisualBounds2D> for SpatialView2D {
     fn fallback_for(&self, ctx: &re_viewer_context::QueryContext<'_>) -> VisualBounds2D {
         let Ok(view_state) = ctx.view_state.downcast_ref::<SpatialViewState>() else {
@@ -51,7 +42,7 @@ impl TypedComponentFallbackProvider<VisualBounds2D> for SpatialView2D {
         let default_scene_rect = view_state
             .pinhole_at_origin
             .as_ref()
-            .and_then(pinhole_resolution_rect)
+            .map(|pinhole| pinhole.resolution_rect())
             .unwrap_or_else(|| {
                 // TODO(emilk): if there is a single image in this view, use that as the default bounds
                 let scene_rect_smoothed = view_state.bounding_boxes.smoothed;


### PR DESCRIPTION
### Related

* sister PR to
    * https://github.com/rerun-io/rerun/pull/8785
    * https://github.com/rerun-io/rerun/pull/8793
* Part of
    * https://github.com/rerun-io/rerun/issues/3381
    * https://github.com/rerun-io/rerun/issues/7245 

### What

Deprecates a bunch of methods on `Pinhole`, all of them still functional though through ad-hoc deserialization utilities.

In the Viewer (concrete, `re_spatial_view`) we don't use any of that and have now a new purpose-built type - I considered using the generated (`attr.rust.archetype_native`) type, but a custom built made a lot more sense for untangling the mess of adhoc queries we have around Pinhole. It might not look like it but the aspiration here was to not change how things work by much while having things better decoupled & cleaner.
Bonus: the odd resolution oracle we _already_ used is now visible on the pinhole visualizers's ui