### PR TITLE
Fix display of compacted arrow-data

### DIFF
--- a/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
@@ -7,7 +7,7 @@ ChunkStore {
     config: ChunkStoreConfig { enable_changelog: true, chunk_max_bytes: 393216, chunk_max_rows: 4096, chunk_max_rows_if_unsorted: 1024 }
     stats: {
         num_chunks: 1
-        total_size_bytes: 2.0 KiB
+        total_size_bytes: 1.3 KiB
         num_rows: 1
         num_events: 2
     }
@@ -15,7 +15,7 @@ ChunkStore {
         ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
         │ CHUNK METADATA:                                                                                                              │
         │ * entity_path: "/this/that"                                                                                                  │
-        │ * heap_size_bytes: "1784"                                                                                                    │
+        │ * heap_size_bytes: "1072"                                                                                                    │
         │ * id: "661EFDF2E3B19F7C045F15"                                                                                               │
         │ * is_sorted: ""                                                                                                              │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤

--- a/crates/utils/re_byte_size/src/arrow_sizes.rs
+++ b/crates/utils/re_byte_size/src/arrow_sizes.rs
@@ -9,21 +9,21 @@ use super::SizeBytes;
 impl SizeBytes for dyn Array {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
-        self.get_array_memory_size() as u64
+        self.get_buffer_memory_size() as u64
     }
 }
 
 impl<T: Array> SizeBytes for &T {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
-        self.get_array_memory_size() as u64
+        self.get_buffer_memory_size() as u64
     }
 }
 
 impl SizeBytes for ArrayRef {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
-        self.get_array_memory_size() as u64
+        self.get_buffer_memory_size() as u64
     }
 }
 
@@ -37,7 +37,7 @@ impl<T: ArrowNativeType> SizeBytes for ScalarBuffer<T> {
 impl SizeBytes for ListArray {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
-        self.get_array_memory_size() as u64
+        self.get_buffer_memory_size() as u64
     }
 }
 

--- a/crates/utils/re_byte_size/src/lib.rs
+++ b/crates/utils/re_byte_size/src/lib.rs
@@ -27,7 +27,13 @@ pub trait SizeBytes {
         std::mem::size_of_val(self) as _
     }
 
-    /// Returns the total size of `self` on the heap, in bytes.
+    /// Returns how many bytes `self` uses on the heap.
+    ///
+    /// In some cases `self` may be just a slice of a larger buffer.
+    /// This will in that case only return the memory used by that smaller slice.
+    ///
+    /// If we however are the sole owner of the memory (e.g. a `Vec`), then we return
+    /// the heap size of all children plus the capacity of the buffer.
     fn heap_size_bytes(&self) -> u64;
 
     /// Is `Self` just plain old data?

--- a/crates/utils/re_byte_size/src/smallvec_sizes.rs
+++ b/crates/utils/re_byte_size/src/smallvec_sizes.rs
@@ -18,9 +18,10 @@ impl<T: SizeBytes, const N: usize> SizeBytes for SmallVec<[T; N]> {
         } else {
             // NOTE: It's all on the heap at this point.
             if T::is_pod() {
-                (self.len() * std::mem::size_of::<T>()) as _
+                (self.capacity() * std::mem::size_of::<T>()) as _
             } else {
-                self.iter().map(SizeBytes::total_size_bytes).sum::<u64>()
+                (self.capacity() * std::mem::size_of::<T>()) as u64
+                    + self.iter().map(SizeBytes::heap_size_bytes).sum::<u64>()
             }
         }
     }

--- a/crates/utils/re_byte_size/src/std_sizes.rs
+++ b/crates/utils/re_byte_size/src/std_sizes.rs
@@ -8,10 +8,9 @@ use std::{
 use crate::SizeBytes;
 
 impl SizeBytes for String {
-    /// Does not take capacity into account.
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
-        self.len() as u64
+        self.capacity() as u64
     }
 }
 
@@ -85,27 +84,27 @@ impl<T: SizeBytes, const N: usize> SizeBytes for [T; N] {
 }
 
 impl<T: SizeBytes> SizeBytes for Vec<T> {
-    /// Does not take capacity into account.
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
         // NOTE: It's all on the heap at this point.
         if T::is_pod() {
-            (self.len() * std::mem::size_of::<T>()) as _
+            (self.capacity() * std::mem::size_of::<T>()) as _
         } else {
-            self.iter().map(SizeBytes::total_size_bytes).sum::<u64>()
+            (self.capacity() * std::mem::size_of::<T>()) as u64
+                + self.iter().map(SizeBytes::heap_size_bytes).sum::<u64>()
         }
     }
 }
 
 impl<T: SizeBytes> SizeBytes for VecDeque<T> {
-    /// Does not take capacity into account.
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
         // NOTE: It's all on the heap at this point.
         if T::is_pod() {
-            (self.len() * std::mem::size_of::<T>()) as _
+            (self.capacity() * std::mem::size_of::<T>()) as _
         } else {
-            self.iter().map(SizeBytes::total_size_bytes).sum::<u64>()
+            (self.capacity() * std::mem::size_of::<T>()) as u64
+                + self.iter().map(SizeBytes::heap_size_bytes).sum::<u64>()
         }
     }
 }

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/any_value_any_value_f64.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/any_value_any_value_f64.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6974e84f775a7383889949123d406bea5ddb66be069a45f70914f821a55a691
+size 3802

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/any_value_any_value_f64.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/any_value_any_value_f64.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b34ddb88ba014f6147bfe7d71e7653507590bdc990c6f95f5ad14f69d37e031
+size 4663

--- a/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
+++ b/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
-use std::collections::HashSet;
-use std::fmt::Formatter;
-use std::fs;
+use std::{collections::HashSet, fmt::Formatter, fs, sync::Arc};
 
 use arrow::array::ArrayRef;
 use egui::Vec2;
@@ -69,6 +67,17 @@ fn test_cases(reflection: &Reflection) -> Vec<TestCase> {
             "simple",
         ),
         TestCase::from_component(Text::from("Hello World!"), "simple"),
+        TestCase::from_arrow(
+            ComponentName::from("any_value"),
+            arrow::array::ListArray::new(
+                arrow::datatypes::Field::new("item", arrow::datatypes::DataType::Float64, false)
+                    .into(),
+                arrow::buffer::OffsetBuffer::from_lengths([3]),
+                Arc::new(arrow::array::Float64Array::from(vec![1.2, 3.4, 5.6])),
+                None,
+            ),
+            "any_value_f64",
+        ),
     ];
 
     //
@@ -261,6 +270,18 @@ impl TestCase {
             label,
             component_name,
             component_data,
+        }
+    }
+
+    fn from_arrow(
+        component_name: ComponentName,
+        component_data: impl arrow::array::Array + 'static,
+        label: &'static str,
+    ) -> Self {
+        Self {
+            label,
+            component_name,
+            component_data: Arc::new(component_data),
         }
     }
 }

--- a/crates/viewer/re_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_ui/src/arrow_ui.rs
@@ -43,9 +43,10 @@ pub fn arrow_ui(ui: &mut egui::Ui, ui_layout: UiLayout, array: &dyn arrow::array
                     ui.monospace(formatter.value(0).to_string());
                     return;
                 } else {
-                    ui_layout
-                        .label(ui, format!("{instance_count} items"))
-                        .on_hover_ui(|ui| {
+                    let response = ui_layout.label(ui, format!("{instance_count} items"));
+
+                    if instance_count < 100 {
+                        response.on_hover_ui(|ui| {
                             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
                             ui.monospace(format!(
                                 "[{}]",
@@ -54,6 +55,7 @@ pub fn arrow_ui(ui: &mut egui::Ui, ui_layout: UiLayout, array: &dyn arrow::array
                                     .join(", ")
                             ));
                         });
+                    }
                 }
             }
             return;

--- a/crates/viewer/re_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_ui/src/arrow_ui.rs
@@ -33,7 +33,7 @@ pub fn arrow_ui(ui: &mut egui::Ui, ui_layout: UiLayout, array: &dyn arrow::array
             }
         }
 
-        let num_bytes = array.get_array_memory_size();
+        let num_bytes = array.get_buffer_memory_size();
         if num_bytes < 3_000 {
             let instance_count = array.len();
 

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -179,7 +179,7 @@ fn component_ui(
 fn format_arrow(array: &dyn arrow::array::Array) -> String {
     use arrow::util::display::{ArrayFormatter, FormatOptions};
 
-    let num_bytes = array.get_array_memory_size();
+    let num_bytes = array.get_buffer_memory_size();
     if array.len() == 1 && num_bytes < 256 {
         // Print small items:
         let options = FormatOptions::default();


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/8777

The problem was using the wrong function to calculate the size of the buffer (using the size of the whole buffer, rather than just the part we are slicing).

I decided to also update the docs for `SizeBytes` and improve the size estimation of `Vec` and friends to take capacity into account.