### PR TITLE
Make `Image` & `Mesh3D` archetypes in Rust eager serialized

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/image.fbs
@@ -24,7 +24,7 @@ namespace rerun.archetypes;
 /// \example archetypes/image_formats title="Logging images with various formats" image="https://static.rerun.io/image_formats/7b8a162fcfd266f303980439beea997dc8544c24/full.png"
 /// \example archetypes/image_send_columns !api title="Image from file, PIL & OpenCV" image="https://static.rerun.io/image_advanced/81fc8a255488615510790ee41be314e054978d51/full.png"
 table Image (
-  // TODO(#7245): "attr.rust.archetype_eager",
+  "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.cpp.no_field_ctors",
   "attr.docs.category": "Image & tensor",

--- a/crates/store/re_types/definitions/rerun/archetypes/mesh3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/mesh3d.fbs
@@ -13,7 +13,7 @@ namespace rerun.archetypes;
 /// \example archetypes/mesh3d_partial_updates !api title="3D mesh with partial updates" image="https://static.rerun.io/mesh3d_partial_updates/7de33d26220585691a403098c953cd46f94c3262/1200w.png"
 /// \example archetypes/mesh3d_instancing title="3D mesh with instancing" image="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/1200w.png"
 table Mesh3D (
-  // TODO(#7245): "attr.rust.archetype_eager",
+  "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial3DView, Spatial2DView: if logged above active projection"

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -106,27 +106,27 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///   <img src="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/full.png" width="640">
 /// </picture>
 /// </center>
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Mesh3D {
     /// The positions of each vertex.
     ///
     /// If no `triangle_indices` are specified, then each triplet of positions is interpreted as a triangle.
-    pub vertex_positions: Vec<crate::components::Position3D>,
+    pub vertex_positions: Option<SerializedComponentBatch>,
 
     /// Optional indices for the triangles that make up the mesh.
-    pub triangle_indices: Option<Vec<crate::components::TriangleIndices>>,
+    pub triangle_indices: Option<SerializedComponentBatch>,
 
     /// An optional normal for each vertex.
-    pub vertex_normals: Option<Vec<crate::components::Vector3D>>,
+    pub vertex_normals: Option<SerializedComponentBatch>,
 
     /// An optional color for each vertex.
-    pub vertex_colors: Option<Vec<crate::components::Color>>,
+    pub vertex_colors: Option<SerializedComponentBatch>,
 
     /// An optional uv texture coordinate for each vertex.
-    pub vertex_texcoords: Option<Vec<crate::components::Texcoord2D>>,
+    pub vertex_texcoords: Option<SerializedComponentBatch>,
 
     /// A color multiplier applied to the whole mesh.
-    pub albedo_factor: Option<crate::components::AlbedoFactor>,
+    pub albedo_factor: Option<SerializedComponentBatch>,
 
     /// Optional albedo texture.
     ///
@@ -134,15 +134,15 @@ pub struct Mesh3D {
     ///
     /// Currently supports only sRGB(A) textures, ignoring alpha.
     /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
-    pub albedo_texture_buffer: Option<crate::components::ImageBuffer>,
+    pub albedo_texture_buffer: Option<SerializedComponentBatch>,
 
     /// The format of the `albedo_texture_buffer`, if any.
-    pub albedo_texture_format: Option<crate::components::ImageFormat>,
+    pub albedo_texture_format: Option<SerializedComponentBatch>,
 
     /// Optional class Ids for the vertices.
     ///
     /// The [`components::ClassId`][crate::components::ClassId] provides colors and labels if not specified explicitly.
-    pub class_ids: Option<Vec<crate::components::ClassId>>,
+    pub class_ids: Option<SerializedComponentBatch>,
 }
 
 impl Mesh3D {
@@ -341,112 +341,57 @@ impl ::re_types_core::Archetype for Mesh3D {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
-        let vertex_positions = {
-            let array = arrays_by_descr
-                .get(&Self::descriptor_vertex_positions())
-                .ok_or_else(DeserializationError::missing_data)
-                .with_context("rerun.archetypes.Mesh3D#vertex_positions")?;
-            <crate::components::Position3D>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Mesh3D#vertex_positions")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .collect::<DeserializationResult<Vec<_>>>()
-                .with_context("rerun.archetypes.Mesh3D#vertex_positions")?
-        };
-        let triangle_indices =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_triangle_indices()) {
-                Some({
-                    <crate::components::TriangleIndices>::from_arrow_opt(&**array)
-                        .with_context("rerun.archetypes.Mesh3D#triangle_indices")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.archetypes.Mesh3D#triangle_indices")?
-                })
-            } else {
-                None
-            };
-        let vertex_normals =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_vertex_normals()) {
-                Some({
-                    <crate::components::Vector3D>::from_arrow_opt(&**array)
-                        .with_context("rerun.archetypes.Mesh3D#vertex_normals")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.archetypes.Mesh3D#vertex_normals")?
-                })
-            } else {
-                None
-            };
-        let vertex_colors =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_vertex_colors()) {
-                Some({
-                    <crate::components::Color>::from_arrow_opt(&**array)
-                        .with_context("rerun.archetypes.Mesh3D#vertex_colors")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.archetypes.Mesh3D#vertex_colors")?
-                })
-            } else {
-                None
-            };
-        let vertex_texcoords =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_vertex_texcoords()) {
-                Some({
-                    <crate::components::Texcoord2D>::from_arrow_opt(&**array)
-                        .with_context("rerun.archetypes.Mesh3D#vertex_texcoords")?
-                        .into_iter()
-                        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                        .collect::<DeserializationResult<Vec<_>>>()
-                        .with_context("rerun.archetypes.Mesh3D#vertex_texcoords")?
-                })
-            } else {
-                None
-            };
-        let albedo_factor =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_albedo_factor()) {
-                <crate::components::AlbedoFactor>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Mesh3D#albedo_factor")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let albedo_texture_buffer =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_albedo_texture_buffer()) {
-                <crate::components::ImageBuffer>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Mesh3D#albedo_texture_buffer")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let albedo_texture_format =
-            if let Some(array) = arrays_by_descr.get(&Self::descriptor_albedo_texture_format()) {
-                <crate::components::ImageFormat>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Mesh3D#albedo_texture_format")?
-                    .into_iter()
-                    .next()
-                    .flatten()
-            } else {
-                None
-            };
-        let class_ids = if let Some(array) = arrays_by_descr.get(&Self::descriptor_class_ids()) {
-            Some({
-                <crate::components::ClassId>::from_arrow_opt(&**array)
-                    .with_context("rerun.archetypes.Mesh3D#class_ids")?
-                    .into_iter()
-                    .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                    .collect::<DeserializationResult<Vec<_>>>()
-                    .with_context("rerun.archetypes.Mesh3D#class_ids")?
-            })
-        } else {
-            None
-        };
+        let vertex_positions = arrays_by_descr
+            .get(&Self::descriptor_vertex_positions())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_vertex_positions())
+            });
+        let triangle_indices = arrays_by_descr
+            .get(&Self::descriptor_triangle_indices())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_triangle_indices())
+            });
+        let vertex_normals = arrays_by_descr
+            .get(&Self::descriptor_vertex_normals())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_vertex_normals())
+            });
+        let vertex_colors = arrays_by_descr
+            .get(&Self::descriptor_vertex_colors())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_vertex_colors())
+            });
+        let vertex_texcoords = arrays_by_descr
+            .get(&Self::descriptor_vertex_texcoords())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_vertex_texcoords())
+            });
+        let albedo_factor = arrays_by_descr
+            .get(&Self::descriptor_albedo_factor())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_albedo_factor())
+            });
+        let albedo_texture_buffer = arrays_by_descr
+            .get(&Self::descriptor_albedo_texture_buffer())
+            .map(|array| {
+                SerializedComponentBatch::new(
+                    array.clone(),
+                    Self::descriptor_albedo_texture_buffer(),
+                )
+            });
+        let albedo_texture_format = arrays_by_descr
+            .get(&Self::descriptor_albedo_texture_format())
+            .map(|array| {
+                SerializedComponentBatch::new(
+                    array.clone(),
+                    Self::descriptor_albedo_texture_format(),
+                )
+            });
+        let class_ids = arrays_by_descr
+            .get(&Self::descriptor_class_ids())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_class_ids())
+            });
         Ok(Self {
             vertex_positions,
             triangle_indices,
@@ -462,81 +407,20 @@ impl ::re_types_core::Archetype for Mesh3D {
 }
 
 impl ::re_types_core::AsComponents for Mesh3D {
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        re_tracing::profile_function!();
+    #[inline]
+    fn as_serialized_batches(&self) -> Vec<SerializedComponentBatch> {
         use ::re_types_core::Archetype as _;
         [
-            Some(Self::indicator()),
-            (Some(&self.vertex_positions as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::ComponentBatchCowWithDescriptor {
-                    batch: batch.into(),
-                    descriptor_override: Some(Self::descriptor_vertex_positions()),
-                }
-            }),
-            (self
-                .triangle_indices
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_triangle_indices()),
-            }),
-            (self
-                .vertex_normals
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_vertex_normals()),
-            }),
-            (self
-                .vertex_colors
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_vertex_colors()),
-            }),
-            (self
-                .vertex_texcoords
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_vertex_texcoords()),
-            }),
-            (self
-                .albedo_factor
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_albedo_factor()),
-            }),
-            (self
-                .albedo_texture_buffer
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_albedo_texture_buffer()),
-            }),
-            (self
-                .albedo_texture_format
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_albedo_texture_format()),
-            }),
-            (self
-                .class_ids
-                .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_class_ids()),
-            }),
+            Self::indicator().serialized(),
+            self.vertex_positions.clone(),
+            self.triangle_indices.clone(),
+            self.vertex_normals.clone(),
+            self.vertex_colors.clone(),
+            self.vertex_texcoords.clone(),
+            self.albedo_factor.clone(),
+            self.albedo_texture_buffer.clone(),
+            self.albedo_texture_format.clone(),
+            self.class_ids.clone(),
         ]
         .into_iter()
         .flatten()
@@ -553,7 +437,10 @@ impl Mesh3D {
         vertex_positions: impl IntoIterator<Item = impl Into<crate::components::Position3D>>,
     ) -> Self {
         Self {
-            vertex_positions: vertex_positions.into_iter().map(Into::into).collect(),
+            vertex_positions: try_serialize_field(
+                Self::descriptor_vertex_positions(),
+                vertex_positions,
+            ),
             triangle_indices: None,
             vertex_normals: None,
             vertex_colors: None,
@@ -565,13 +452,160 @@ impl Mesh3D {
         }
     }
 
+    /// Update only some specific fields of a `Mesh3D`.
+    #[inline]
+    pub fn update_fields() -> Self {
+        Self::default()
+    }
+
+    /// Clear all the fields of a `Mesh3D`.
+    #[inline]
+    pub fn clear_fields() -> Self {
+        use ::re_types_core::Loggable as _;
+        Self {
+            vertex_positions: Some(SerializedComponentBatch::new(
+                crate::components::Position3D::arrow_empty(),
+                Self::descriptor_vertex_positions(),
+            )),
+            triangle_indices: Some(SerializedComponentBatch::new(
+                crate::components::TriangleIndices::arrow_empty(),
+                Self::descriptor_triangle_indices(),
+            )),
+            vertex_normals: Some(SerializedComponentBatch::new(
+                crate::components::Vector3D::arrow_empty(),
+                Self::descriptor_vertex_normals(),
+            )),
+            vertex_colors: Some(SerializedComponentBatch::new(
+                crate::components::Color::arrow_empty(),
+                Self::descriptor_vertex_colors(),
+            )),
+            vertex_texcoords: Some(SerializedComponentBatch::new(
+                crate::components::Texcoord2D::arrow_empty(),
+                Self::descriptor_vertex_texcoords(),
+            )),
+            albedo_factor: Some(SerializedComponentBatch::new(
+                crate::components::AlbedoFactor::arrow_empty(),
+                Self::descriptor_albedo_factor(),
+            )),
+            albedo_texture_buffer: Some(SerializedComponentBatch::new(
+                crate::components::ImageBuffer::arrow_empty(),
+                Self::descriptor_albedo_texture_buffer(),
+            )),
+            albedo_texture_format: Some(SerializedComponentBatch::new(
+                crate::components::ImageFormat::arrow_empty(),
+                Self::descriptor_albedo_texture_format(),
+            )),
+            class_ids: Some(SerializedComponentBatch::new(
+                crate::components::ClassId::arrow_empty(),
+                Self::descriptor_class_ids(),
+            )),
+        }
+    }
+
+    /// Partitions the component data into multiple sub-batches.
+    ///
+    /// Specifically, this transforms the existing [`SerializedComponentBatch`]es data into [`SerializedComponentColumn`]s
+    /// instead, via [`SerializedComponentBatch::partitioned`].
+    ///
+    /// This makes it possible to use `RecordingStream::send_columns` to send columnar data directly into Rerun.
+    ///
+    /// The specified `lengths` must sum to the total length of the component batch.
+    ///
+    /// [`SerializedComponentColumn`]: [::re_types_core::SerializedComponentColumn]
+    #[inline]
+    pub fn columns<I>(
+        self,
+        _lengths: I,
+    ) -> SerializationResult<impl Iterator<Item = ::re_types_core::SerializedComponentColumn>>
+    where
+        I: IntoIterator<Item = usize> + Clone,
+    {
+        let columns = [
+            self.vertex_positions
+                .map(|vertex_positions| vertex_positions.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.triangle_indices
+                .map(|triangle_indices| triangle_indices.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.vertex_normals
+                .map(|vertex_normals| vertex_normals.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.vertex_colors
+                .map(|vertex_colors| vertex_colors.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.vertex_texcoords
+                .map(|vertex_texcoords| vertex_texcoords.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.albedo_factor
+                .map(|albedo_factor| albedo_factor.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.albedo_texture_buffer
+                .map(|albedo_texture_buffer| albedo_texture_buffer.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.albedo_texture_format
+                .map(|albedo_texture_format| albedo_texture_format.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.class_ids
+                .map(|class_ids| class_ids.partitioned(_lengths.clone()))
+                .transpose()?,
+        ];
+        let indicator_column =
+            ::re_types_core::indicator_column::<Self>(_lengths.into_iter().count())?;
+        Ok(columns.into_iter().chain([indicator_column]).flatten())
+    }
+
+    /// Helper to partition the component data into unit-length sub-batches.
+    ///
+    /// This is semantically similar to calling [`Self::columns`] with `std::iter::take(1).repeat(n)`,
+    /// where `n` is automatically guessed.
+    #[inline]
+    pub fn columns_of_unit_batches(
+        self,
+    ) -> SerializationResult<impl Iterator<Item = ::re_types_core::SerializedComponentColumn>> {
+        let len_vertex_positions = self.vertex_positions.as_ref().map(|b| b.array.len());
+        let len_triangle_indices = self.triangle_indices.as_ref().map(|b| b.array.len());
+        let len_vertex_normals = self.vertex_normals.as_ref().map(|b| b.array.len());
+        let len_vertex_colors = self.vertex_colors.as_ref().map(|b| b.array.len());
+        let len_vertex_texcoords = self.vertex_texcoords.as_ref().map(|b| b.array.len());
+        let len_albedo_factor = self.albedo_factor.as_ref().map(|b| b.array.len());
+        let len_albedo_texture_buffer = self.albedo_texture_buffer.as_ref().map(|b| b.array.len());
+        let len_albedo_texture_format = self.albedo_texture_format.as_ref().map(|b| b.array.len());
+        let len_class_ids = self.class_ids.as_ref().map(|b| b.array.len());
+        let len = None
+            .or(len_vertex_positions)
+            .or(len_triangle_indices)
+            .or(len_vertex_normals)
+            .or(len_vertex_colors)
+            .or(len_vertex_texcoords)
+            .or(len_albedo_factor)
+            .or(len_albedo_texture_buffer)
+            .or(len_albedo_texture_format)
+            .or(len_class_ids)
+            .unwrap_or(0);
+        self.columns(std::iter::repeat(1).take(len))
+    }
+
+    /// The positions of each vertex.
+    ///
+    /// If no `triangle_indices` are specified, then each triplet of positions is interpreted as a triangle.
+    #[inline]
+    pub fn with_vertex_positions(
+        mut self,
+        vertex_positions: impl IntoIterator<Item = impl Into<crate::components::Position3D>>,
+    ) -> Self {
+        self.vertex_positions =
+            try_serialize_field(Self::descriptor_vertex_positions(), vertex_positions);
+        self
+    }
+
     /// Optional indices for the triangles that make up the mesh.
     #[inline]
     pub fn with_triangle_indices(
         mut self,
         triangle_indices: impl IntoIterator<Item = impl Into<crate::components::TriangleIndices>>,
     ) -> Self {
-        self.triangle_indices = Some(triangle_indices.into_iter().map(Into::into).collect());
+        self.triangle_indices =
+            try_serialize_field(Self::descriptor_triangle_indices(), triangle_indices);
         self
     }
 
@@ -581,7 +615,8 @@ impl Mesh3D {
         mut self,
         vertex_normals: impl IntoIterator<Item = impl Into<crate::components::Vector3D>>,
     ) -> Self {
-        self.vertex_normals = Some(vertex_normals.into_iter().map(Into::into).collect());
+        self.vertex_normals =
+            try_serialize_field(Self::descriptor_vertex_normals(), vertex_normals);
         self
     }
 
@@ -591,7 +626,7 @@ impl Mesh3D {
         mut self,
         vertex_colors: impl IntoIterator<Item = impl Into<crate::components::Color>>,
     ) -> Self {
-        self.vertex_colors = Some(vertex_colors.into_iter().map(Into::into).collect());
+        self.vertex_colors = try_serialize_field(Self::descriptor_vertex_colors(), vertex_colors);
         self
     }
 
@@ -601,7 +636,8 @@ impl Mesh3D {
         mut self,
         vertex_texcoords: impl IntoIterator<Item = impl Into<crate::components::Texcoord2D>>,
     ) -> Self {
-        self.vertex_texcoords = Some(vertex_texcoords.into_iter().map(Into::into).collect());
+        self.vertex_texcoords =
+            try_serialize_field(Self::descriptor_vertex_texcoords(), vertex_texcoords);
         self
     }
 
@@ -611,7 +647,20 @@ impl Mesh3D {
         mut self,
         albedo_factor: impl Into<crate::components::AlbedoFactor>,
     ) -> Self {
-        self.albedo_factor = Some(albedo_factor.into());
+        self.albedo_factor = try_serialize_field(Self::descriptor_albedo_factor(), [albedo_factor]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::AlbedoFactor`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_albedo_factor`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_albedo_factor(
+        mut self,
+        albedo_factor: impl IntoIterator<Item = impl Into<crate::components::AlbedoFactor>>,
+    ) -> Self {
+        self.albedo_factor = try_serialize_field(Self::descriptor_albedo_factor(), albedo_factor);
         self
     }
 
@@ -626,7 +675,26 @@ impl Mesh3D {
         mut self,
         albedo_texture_buffer: impl Into<crate::components::ImageBuffer>,
     ) -> Self {
-        self.albedo_texture_buffer = Some(albedo_texture_buffer.into());
+        self.albedo_texture_buffer = try_serialize_field(
+            Self::descriptor_albedo_texture_buffer(),
+            [albedo_texture_buffer],
+        );
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::ImageBuffer`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_albedo_texture_buffer`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_albedo_texture_buffer(
+        mut self,
+        albedo_texture_buffer: impl IntoIterator<Item = impl Into<crate::components::ImageBuffer>>,
+    ) -> Self {
+        self.albedo_texture_buffer = try_serialize_field(
+            Self::descriptor_albedo_texture_buffer(),
+            albedo_texture_buffer,
+        );
         self
     }
 
@@ -636,7 +704,26 @@ impl Mesh3D {
         mut self,
         albedo_texture_format: impl Into<crate::components::ImageFormat>,
     ) -> Self {
-        self.albedo_texture_format = Some(albedo_texture_format.into());
+        self.albedo_texture_format = try_serialize_field(
+            Self::descriptor_albedo_texture_format(),
+            [albedo_texture_format],
+        );
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::ImageFormat`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_albedo_texture_format`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_albedo_texture_format(
+        mut self,
+        albedo_texture_format: impl IntoIterator<Item = impl Into<crate::components::ImageFormat>>,
+    ) -> Self {
+        self.albedo_texture_format = try_serialize_field(
+            Self::descriptor_albedo_texture_format(),
+            albedo_texture_format,
+        );
         self
     }
 
@@ -648,7 +735,7 @@ impl Mesh3D {
         mut self,
         class_ids: impl IntoIterator<Item = impl Into<crate::components::ClassId>>,
     ) -> Self {
-        self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
+        self.class_ids = try_serialize_field(Self::descriptor_class_ids(), class_ids);
         self
     }
 }
@@ -665,18 +752,5 @@ impl ::re_byte_size::SizeBytes for Mesh3D {
             + self.albedo_texture_buffer.heap_size_bytes()
             + self.albedo_texture_format.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::Position3D>>::is_pod()
-            && <Option<Vec<crate::components::TriangleIndices>>>::is_pod()
-            && <Option<Vec<crate::components::Vector3D>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Texcoord2D>>>::is_pod()
-            && <Option<crate::components::AlbedoFactor>>::is_pod()
-            && <Option<crate::components::ImageBuffer>>::is_pod()
-            && <Option<crate::components::ImageFormat>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/mesh3d_ext.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d_ext.rs
@@ -24,6 +24,7 @@ pub enum Mesh3DError {
 
 impl Mesh3D {
     /// Use this image as the albedo texture.
+    #[inline]
     pub fn with_albedo_texture_image(mut self, image: impl Into<archetypes::Image>) -> Self {
         let image = image.into();
 
@@ -37,6 +38,7 @@ impl Mesh3D {
     }
 
     /// Use this image as the albedo texture.
+    #[inline]
     pub fn with_albedo_texture(
         self,
         image_format: impl Into<components::ImageFormat>,

--- a/crates/store/re_types/src/archetypes/mesh3d_ext.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d_ext.rs
@@ -1,7 +1,8 @@
+use arrow::{array, datatypes::UInt32Type};
+
 use crate::{
     archetypes,
-    components::{self, TriangleIndices},
-    datatypes::UVec3D,
+    components::{self},
 };
 
 use super::Mesh3D;
@@ -22,11 +23,24 @@ pub enum Mesh3DError {
 }
 
 impl Mesh3D {
+    /// Iterates over all individual indices.
+    fn iter_indices(&self) -> Option<array::PrimitiveIter<'_, UInt32Type>> {
+        self.triangle_indices
+            .as_ref()
+            .map(|indices| array::as_primitive_array::<UInt32Type>(&indices.array).iter())
+    }
+
     /// Use this image as the albedo texture.
-    pub fn with_albedo_texture_image(self, image: impl Into<archetypes::Image>) -> Self {
+    pub fn with_albedo_texture_image(mut self, image: impl Into<archetypes::Image>) -> Self {
         let image = image.into();
-        self.with_albedo_texture_format(image.format)
-            .with_albedo_texture_buffer(image.buffer)
+
+        self.albedo_texture_format = image
+            .format
+            .map(|batch| batch.with_descriptor_override(Self::descriptor_albedo_texture_format()));
+        self.albedo_texture_buffer = image
+            .buffer
+            .map(|batch| batch.with_descriptor_override(Self::descriptor_albedo_texture_buffer()));
+        self
     }
 
     /// Use this image as the albedo texture.
@@ -41,41 +55,34 @@ impl Mesh3D {
 
     /// Check that this is a valid mesh, e.g. that the vertex indices are within bounds
     /// and that we have the same number of positions and normals (if any).
+    ///
+    /// Only use this when logging a whole new mesh. Not meaningful for field updates!
     pub fn sanity_check(&self) -> Result<(), Mesh3DError> {
         let num_vertices = self.num_vertices();
 
-        if let Some(indices) = self.triangle_indices.as_ref() {
-            for &TriangleIndices(UVec3D([x, y, z])) in indices {
-                if num_vertices <= x as usize {
+        if let Some(indices) = self.iter_indices() {
+            // TODO: test this again
+            for index in indices {
+                let Some(index) = index else {
+                    // TODO: check with Clement or Emil how to cast this so we don't have to deal with this.
+                    continue;
+                };
+                if num_vertices <= index as usize {
                     return Err(Mesh3DError::IndexOutOfBounds {
-                        index: x,
-                        num_vertices,
-                    });
-                }
-                if num_vertices <= y as usize {
-                    return Err(Mesh3DError::IndexOutOfBounds {
-                        index: y,
-                        num_vertices,
-                    });
-                }
-                if num_vertices <= z as usize {
-                    return Err(Mesh3DError::IndexOutOfBounds {
-                        index: z,
+                        index,
                         num_vertices,
                     });
                 }
             }
-        } else if self.vertex_positions.len() % 9 != 0 {
-            return Err(Mesh3DError::PositionsAreNotTriangles(
-                self.vertex_positions.len(),
-            ));
+        } else if num_vertices % 9 != 0 {
+            return Err(Mesh3DError::PositionsAreNotTriangles(num_vertices));
         }
 
         if let Some(normals) = &self.vertex_normals {
-            if normals.len() != self.vertex_positions.len() {
+            if normals.array.len() != num_vertices {
                 return Err(Mesh3DError::MismatchedPositionsNormals(
-                    self.vertex_positions.len(),
-                    normals.len(),
+                    num_vertices,
+                    normals.array.len(),
                 ));
             }
         }
@@ -86,14 +93,16 @@ impl Mesh3D {
     /// The total number of vertices.
     #[inline]
     pub fn num_vertices(&self) -> usize {
-        self.vertex_positions.len()
+        self.vertex_positions
+            .as_ref()
+            .map_or(0, |positions| positions.array.len())
     }
 
     /// The total number of triangles.
     #[inline]
     pub fn num_triangles(&self) -> usize {
-        if let Some(indices) = self.triangle_indices.as_ref() {
-            indices.len()
+        if let Some(triangle_indices) = self.triangle_indices.as_ref() {
+            triangle_indices.array.len()
         } else {
             self.num_vertices() / 3
         }

--- a/crates/store/re_types/src/components/image_buffer_ext.rs
+++ b/crates/store/re_types/src/components/image_buffer_ext.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "image")]
 use crate::{datatypes::ColorModel, image::ImageChannelType};
 
+#[cfg(feature = "image")]
 use super::{ImageBuffer, ImageFormat};
 
 #[cfg(feature = "image")]

--- a/crates/store/re_types/src/components/image_buffer_ext.rs
+++ b/crates/store/re_types/src/components/image_buffer_ext.rs
@@ -1,7 +1,4 @@
-use crate::{
-    datatypes::ColorModel,
-    image::{ImageChannelType, ImageConversionError},
-};
+use crate::{datatypes::ColorModel, image::ImageChannelType};
 
 use super::{ImageBuffer, ImageFormat};
 
@@ -33,7 +30,7 @@ impl ImageBuffer {
     /// Requires the `image` feature.
     pub fn from_image(
         image: impl Into<image::DynamicImage>,
-    ) -> Result<(Self, ImageFormat), ImageConversionError> {
+    ) -> Result<(Self, ImageFormat), crate::image::ImageConversionError> {
         Self::from_dynamic_image(image.into())
     }
 
@@ -42,7 +39,7 @@ impl ImageBuffer {
     /// Requires the `image` feature.
     pub fn from_dynamic_image(
         image: image::DynamicImage,
-    ) -> Result<(Self, ImageFormat), ImageConversionError> {
+    ) -> Result<(Self, ImageFormat), crate::image::ImageConversionError> {
         re_tracing::profile_function!();
 
         let res = [image.width(), image.height()];
@@ -90,9 +87,7 @@ impl ImageBuffer {
 
             _ => {
                 // It is very annoying that DynamicImage is #[non_exhaustive]
-                Err(ImageConversionError::UnsupportedImageColorType(
-                    image.color(),
-                ))
+                Err(crate::image::ImageConversionError::UnsupportedImageColorType(image.color()))
             }
         }
     }

--- a/crates/store/re_types/src/components/image_buffer_ext.rs
+++ b/crates/store/re_types/src/components/image_buffer_ext.rs
@@ -1,0 +1,99 @@
+use crate::{
+    datatypes::ColorModel,
+    image::{ImageChannelType, ImageConversionError},
+};
+
+use super::{ImageBuffer, ImageFormat};
+
+#[cfg(feature = "image")]
+impl ImageBuffer {
+    /// Utility method for constructing an image & format
+    /// from a byte buffer given its resolution and using the data type of the given vector.
+    fn from_elements<T: ImageChannelType>(
+        elements: &[T],
+        [width, height]: [u32; 2],
+        color_model: ColorModel,
+    ) -> (Self, ImageFormat) {
+        let datatype = T::CHANNEL_TYPE;
+        let bytes: &[u8] = bytemuck::cast_slice(elements);
+        let image_format = ImageFormat::from_color_model([width, height], color_model, datatype);
+
+        let num_expected_bytes = image_format.num_bytes();
+        if bytes.len() != num_expected_bytes {
+            re_log::warn_once!(
+                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B", bytes.len()
+            );
+        }
+
+        (Self(bytes.into()), image_format)
+    }
+
+    /// Construct an image buffer & image format from something that can be turned into a [`image::DynamicImage`].
+    ///
+    /// Requires the `image` feature.
+    pub fn from_image(
+        image: impl Into<image::DynamicImage>,
+    ) -> Result<(Self, ImageFormat), ImageConversionError> {
+        Self::from_dynamic_image(image.into())
+    }
+
+    /// Construct an image buffer & image format from [`image::DynamicImage`].
+    ///
+    /// Requires the `image` feature.
+    pub fn from_dynamic_image(
+        image: image::DynamicImage,
+    ) -> Result<(Self, ImageFormat), ImageConversionError> {
+        re_tracing::profile_function!();
+
+        let res = [image.width(), image.height()];
+
+        match image {
+            image::DynamicImage::ImageLuma8(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::L))
+            }
+            image::DynamicImage::ImageLuma16(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::L))
+            }
+
+            image::DynamicImage::ImageLumaA8(image) => {
+                re_log::warn!(
+                        "Rerun doesn't have native support for 8-bit Luma + Alpha. The image will be convert to RGBA."
+                    );
+                Self::from_image(image::DynamicImage::ImageLumaA8(image).to_rgba8())
+            }
+            image::DynamicImage::ImageLumaA16(image) => {
+                re_log::warn!(
+                        "Rerun doesn't have native support for 16-bit Luma + Alpha. The image will be convert to RGBA."
+                    );
+                Self::from_image(image::DynamicImage::ImageLumaA16(image).to_rgba16())
+            }
+
+            image::DynamicImage::ImageRgb8(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::RGB))
+            }
+            image::DynamicImage::ImageRgb16(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::RGB))
+            }
+            image::DynamicImage::ImageRgb32F(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::RGB))
+            }
+
+            image::DynamicImage::ImageRgba8(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::RGBA))
+            }
+            image::DynamicImage::ImageRgba16(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::RGBA))
+            }
+            image::DynamicImage::ImageRgba32F(image) => {
+                Ok(Self::from_elements(image.as_raw(), res, ColorModel::RGBA))
+            }
+
+            _ => {
+                // It is very annoying that DynamicImage is #[non_exhaustive]
+                Err(ImageConversionError::UnsupportedImageColorType(
+                    image.color(),
+                ))
+            }
+        }
+    }
+}

--- a/crates/store/re_types/src/components/image_format_ext.rs
+++ b/crates/store/re_types/src/components/image_format_ext.rs
@@ -32,6 +32,15 @@ impl ImageFormat {
         datatypes::ImageFormat::from_pixel_format([width, height], pixel_format).into()
     }
 
+    /// Create a new image format from a color model and datatype.
+    pub fn from_color_model(
+        [width, height]: [u32; 2],
+        color_model: ColorModel,
+        datatype: ChannelDatatype,
+    ) -> Self {
+        datatypes::ImageFormat::from_color_model([width, height], color_model, datatype).into()
+    }
+
     /// Determine if the image format has an alpha channel.
     #[inline]
     pub fn has_alpha(&self) -> bool {

--- a/crates/store/re_types/src/components/mod.rs
+++ b/crates/store/re_types/src/components/mod.rs
@@ -35,6 +35,7 @@ mod half_size2d_ext;
 mod half_size3d;
 mod half_size3d_ext;
 mod image_buffer;
+mod image_buffer_ext;
 mod image_format;
 mod image_format_ext;
 mod image_plane_distance;

--- a/crates/store/re_types/src/datatypes/blob_ext.rs
+++ b/crates/store/re_types/src/datatypes/blob_ext.rs
@@ -20,6 +20,12 @@ impl From<Vec<u8>> for Blob {
     }
 }
 
+impl From<&[u8]> for Blob {
+    fn from(bytes: &[u8]) -> Self {
+        Self(bytes.into())
+    }
+}
+
 impl std::ops::Deref for Blob {
     type Target = re_types_core::ArrowBuffer<u8>;
 

--- a/crates/store/re_types/src/datatypes/image_format_ext.rs
+++ b/crates/store/re_types/src/datatypes/image_format_ext.rs
@@ -61,6 +61,22 @@ impl ImageFormat {
         }
     }
 
+    /// Create a new image format from a color model and datatype.
+    #[inline]
+    pub fn from_color_model(
+        [width, height]: [u32; 2],
+        color_model: ColorModel,
+        datatype: ChannelDatatype,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            pixel_format: None,
+            channel_datatype: Some(datatype),
+            color_model: Some(color_model),
+        }
+    }
+
     /// Determine if the image format has an alpha channel.
     #[inline]
     pub fn has_alpha(&self) -> bool {

--- a/crates/store/re_types/tests/types/mesh3d.rs
+++ b/crates/store/re_types/tests/types/mesh3d.rs
@@ -1,8 +1,8 @@
 use re_types::{
     archetypes::Mesh3D,
-    components::{ClassId, Position3D, Texcoord2D, TriangleIndices, Vector3D},
+    components::{AlbedoFactor, ClassId, Color, Position3D, Texcoord2D, TriangleIndices, Vector3D},
     datatypes::{Rgba32, UVec3D, Vec2D, Vec3D},
-    Archetype as _, AsComponents as _,
+    Archetype as _, AsComponents as _, ComponentBatch,
 };
 
 #[test]
@@ -14,30 +14,48 @@ fn roundtrip() {
         vertex_positions: vec![
             Position3D(Vec3D([1.0, 2.0, 3.0])),
             Position3D(Vec3D([10.0, 20.0, 30.0])),
-        ],
-        triangle_indices: Some(vec![
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(Mesh3D::descriptor_vertex_positions())),
+        triangle_indices: vec![
             TriangleIndices(UVec3D([1, 2, 3])), //
             TriangleIndices(UVec3D([4, 5, 6])), //
-        ]),
-        vertex_normals: Some(vec![
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(Mesh3D::descriptor_triangle_indices())),
+        vertex_normals: vec![
             Vector3D(Vec3D([4.0, 5.0, 6.0])),    //
             Vector3D(Vec3D([40.0, 50.0, 60.0])), //
-        ]),
-        vertex_colors: Some(vec![
-            Rgba32::from_unmultiplied_rgba(0xAA, 0x00, 0x00, 0xCC).into(), //
-            Rgba32::from_unmultiplied_rgba(0x00, 0xBB, 0x00, 0xDD).into(),
-        ]),
-        vertex_texcoords: Some(vec![
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(Mesh3D::descriptor_vertex_normals())),
+        vertex_colors: vec![
+            Color::from_unmultiplied_rgba(0xAA, 0x00, 0x00, 0xCC),
+            Color::from_unmultiplied_rgba(0x00, 0xBB, 0x00, 0xDD),
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(Mesh3D::descriptor_vertex_colors())),
+        vertex_texcoords: vec![
             Texcoord2D(Vec2D([0.0, 1.0])), //
             Texcoord2D(Vec2D([2.0, 3.0])), //
-        ]),
-        albedo_factor: Some(Rgba32::from_unmultiplied_rgba(0xEE, 0x11, 0x22, 0x33).into()),
-        albedo_texture_format: Some(texture_format),
-        albedo_texture_buffer: Some(texture_buffer.clone()),
-        class_ids: Some(vec![
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(Mesh3D::descriptor_vertex_texcoords())),
+        albedo_factor: AlbedoFactor(Rgba32::from_unmultiplied_rgba(0xEE, 0x11, 0x22, 0x33))
+            .serialized()
+            .map(|batch| batch.with_descriptor_override(Mesh3D::descriptor_albedo_factor())),
+        albedo_texture_format: texture_format.serialized().map(|batch| {
+            batch.with_descriptor_override(Mesh3D::descriptor_albedo_texture_format())
+        }),
+        albedo_texture_buffer: texture_buffer.serialized().map(|batch| {
+            batch.with_descriptor_override(Mesh3D::descriptor_albedo_texture_buffer())
+        }),
+        class_ids: vec![
             ClassId::from(126), //
             ClassId::from(127), //
-        ]),
+        ]
+        .serialized()
+        .map(|batch| batch.with_descriptor_override(Mesh3D::descriptor_class_ids())),
     };
 
     let arch = Mesh3D::new([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]])

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -8,7 +8,7 @@ use re_types::{
     archetypes, components,
     datatypes::{ChannelDatatype, ColorModel},
     image::ImageKind,
-    static_assert_struct_has_fields, Archetype, Component, ComponentName,
+    Archetype, Component, ComponentName,
 };
 use re_ui::UiExt as _;
 use re_viewer_context::{
@@ -273,7 +273,7 @@ fn preview_if_image_ui(
     component_map: &IntMap<ComponentName, UnitChunkShared>,
 ) -> Option<()> {
     // First check assumptions:
-    static_assert_struct_has_fields!(
+    debug_assert_archetype_has_components!(
         archetypes::Image,
         buffer: components::ImageBuffer,
         format: components::ImageFormat

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -46,7 +46,6 @@ use re_types::{
     archetypes,
     blueprint::components::BackgroundKind,
     components::{self, Color, ImageFormat, MediaType, Resolution},
-    static_assert_struct_has_fields,
 };
 use re_viewport_blueprint::{ViewProperty, ViewPropertyQueryError};
 
@@ -64,7 +63,7 @@ fn resolution_of_image_at(
     entity_path: &re_log_types::EntityPath,
 ) -> Option<Resolution> {
     // First check assumptions:
-    static_assert_struct_has_fields!(archetypes::Image, format: components::ImageFormat);
+    debug_assert_archetype_has_components!(archetypes::Image, format: components::ImageFormat);
     debug_assert_archetype_has_components!(archetypes::EncodedImage, blob: components::Blob);
 
     let db = ctx.recording();

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -44,9 +44,8 @@ use re_viewer_context::{ImageDecodeCache, ViewerContext};
 use re_log_types::debug_assert_archetype_has_components;
 use re_renderer::RenderContext;
 use re_types::{
-    archetypes,
     blueprint::components::BackgroundKind,
-    components::{self, Color, ImageFormat, MediaType, Resolution},
+    components::{Color, ImageFormat, MediaType, Resolution},
 };
 use re_viewport_blueprint::{ViewProperty, ViewPropertyQueryError};
 
@@ -64,8 +63,8 @@ fn resolution_of_image_at(
     entity_path: &re_log_types::EntityPath,
 ) -> Option<Resolution> {
     // First check assumptions:
-    debug_assert_archetype_has_components!(archetypes::Image, format: components::ImageFormat);
-    debug_assert_archetype_has_components!(archetypes::EncodedImage, blob: components::Blob);
+    debug_assert_archetype_has_components!(re_types::archetypes::Image, format: re_types::components::ImageFormat);
+    debug_assert_archetype_has_components!(re_types::archetypes::EncodedImage, blob: re_types::components::Blob);
 
     let db = ctx.recording();
 

--- a/crates/viewer/re_view_spatial/src/mesh_cache.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_cache.rs
@@ -10,7 +10,7 @@ use re_renderer::RenderContext;
 use re_types::{components::MediaType, Component as _};
 use re_viewer_context::Cache;
 
-use crate::mesh_loader::{LoadedMesh, NativeAsset3D};
+use crate::mesh_loader::{LoadedMesh, NativeAsset3D, NativeMesh3D};
 
 // ----------------------------------------------------------------------------
 
@@ -40,7 +40,7 @@ pub enum AnyMesh<'a> {
         asset: NativeAsset3D<'a>,
     },
     Mesh {
-        mesh: &'a re_types::archetypes::Mesh3D,
+        mesh: NativeMesh3D<'a>,
 
         /// If there are any textures associated with that mesh (albedo etc), they use this
         /// hash for texture manager lookup.

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -1,16 +1,31 @@
 use itertools::Itertools;
 use re_chunk_store::RowId;
 use re_renderer::{mesh::GpuMesh, RenderContext, Rgba32Unmul};
-use re_types::{archetypes::Mesh3D, components::MediaType};
+use re_types::components::MediaType;
 use re_viewer_context::{gpu_bridge::texture_creation_desc_from_color_image, ImageInfo};
 
-use crate::mesh_cache::AnyMesh;
+use crate::{mesh_cache::AnyMesh, visualizers::entity_iterator::clamped_vec_or};
 
 #[derive(Debug, Clone)]
 pub struct NativeAsset3D<'a> {
     pub bytes: &'a [u8],
     pub media_type: Option<MediaType>,
     pub albedo_factor: Option<re_renderer::Rgba>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NativeMesh3D<'a> {
+    pub vertex_positions: &'a [glam::Vec3],
+    pub vertex_normals: Option<&'a [glam::Vec3]>,
+    pub vertex_colors: Option<&'a [re_renderer::Rgba32Unmul]>,
+    pub vertex_texcoords: Option<&'a [glam::Vec2]>,
+
+    pub triangle_indices: Option<&'a [glam::UVec3]>,
+
+    pub albedo_factor: Option<re_renderer::Rgba>,
+
+    pub albedo_texture_buffer: Option<re_types::datatypes::Blob>,
+    pub albedo_texture_format: Option<re_types::datatypes::ImageFormat>,
 }
 
 pub struct LoadedMesh {
@@ -84,31 +99,28 @@ impl LoadedMesh {
 
     fn load_mesh3d(
         name: String,
-        mesh3d: &Mesh3D,
+        mesh3d: NativeMesh3D<'_>,
         texture_key: u64,
         render_ctx: &RenderContext,
     ) -> anyhow::Result<Self> {
         re_tracing::profile_function!();
 
-        let Mesh3D {
+        let NativeMesh3D {
             vertex_positions,
             vertex_normals,
             vertex_colors,
             vertex_texcoords,
             triangle_indices,
             albedo_factor,
-            class_ids: _,
             albedo_texture_buffer,
             albedo_texture_format,
         } = mesh3d;
 
-        let vertex_positions: &[glam::Vec3] = bytemuck::cast_slice(vertex_positions.as_slice());
         let num_positions = vertex_positions.len();
 
-        let triangle_indices = if let Some(indices) = triangle_indices {
+        let triangle_indices = if let Some(triangle_indices) = triangle_indices {
             re_tracing::profile_scope!("copy_indices");
-            let indices: &[glam::UVec3] = bytemuck::cast_slice(indices);
-            indices.to_vec()
+            triangle_indices.to_vec()
         } else {
             re_tracing::profile_scope!("generate_indices");
             anyhow::ensure!(num_positions % 3 == 0);
@@ -121,17 +133,14 @@ impl LoadedMesh {
 
         let vertex_colors = if let Some(vertex_colors) = vertex_colors {
             re_tracing::profile_scope!("copy_colors");
-            vertex_colors
-                .iter()
-                .map(|c| Rgba32Unmul::from_rgba_unmul_array(c.to_array()))
-                .collect()
+            clamped_vec_or(vertex_colors, num_positions, &Rgba32Unmul::WHITE)
         } else {
             vec![Rgba32Unmul::WHITE; num_positions]
         };
 
         let vertex_normals = if let Some(normals) = vertex_normals {
             re_tracing::profile_scope!("collect_normals");
-            normals.iter().map(|v| v.0.into()).collect::<Vec<_>>()
+            clamped_vec_or(normals, num_positions, &glam::Vec3::ZERO)
         } else {
             // TODO(andreas): Calculate normals
             vec![glam::Vec3::ZERO; num_positions]
@@ -139,7 +148,7 @@ impl LoadedMesh {
 
         let vertex_texcoords = if let Some(texcoords) = vertex_texcoords {
             re_tracing::profile_scope!("collect_texcoords");
-            texcoords.iter().map(|v| v.0.into()).collect::<Vec<_>>()
+            clamped_vec_or(texcoords, num_positions, &glam::Vec2::ZERO)
         } else {
             vec![glam::Vec2::ZERO; num_positions]
         };
@@ -150,8 +159,8 @@ impl LoadedMesh {
         };
 
         let albedo = try_get_or_create_albedo_texture(
-            albedo_texture_buffer,
-            albedo_texture_format,
+            &albedo_texture_buffer,
+            &albedo_texture_format,
             render_ctx,
             texture_key,
             &name,
@@ -174,7 +183,7 @@ impl LoadedMesh {
                 label: name.clone().into(),
                 index_range: 0..num_indices as _,
                 albedo,
-                albedo_factor: albedo_factor.map_or(re_renderer::Rgba::WHITE, |c| c.0.into()),
+                albedo_factor: albedo_factor.unwrap_or(re_renderer::Rgba::WHITE),
             }],
         };
 
@@ -200,22 +209,24 @@ impl LoadedMesh {
 }
 
 fn try_get_or_create_albedo_texture(
-    albedo_texture_buffer: &Option<re_types::components::ImageBuffer>,
-    albedo_texture_format: &Option<re_types::components::ImageFormat>,
+    albedo_texture_buffer: &Option<re_types::datatypes::Blob>,
+    albedo_texture_format: &Option<re_types::datatypes::ImageFormat>,
     render_ctx: &RenderContext,
     texture_key: u64,
     name: &str,
 ) -> Option<re_renderer::resource_managers::GpuTexture2D> {
     let (Some(albedo_texture_buffer), Some(albedo_texture_format)) =
-        (&albedo_texture_buffer, albedo_texture_format)
+        (albedo_texture_buffer, albedo_texture_format)
     else {
         return None;
     };
 
+    re_tracing::profile_function!();
+
     let image_info = ImageInfo {
-        buffer_row_id: RowId::ZERO, // unused
-        buffer: albedo_texture_buffer.0.clone(),
-        format: albedo_texture_format.0,
+        buffer_row_id: RowId::ZERO,            // unused
+        buffer: albedo_texture_buffer.clone(), // shallow clone
+        format: *albedo_texture_format,
         kind: re_types::image::ImageKind::Color,
     };
 

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -22,7 +22,7 @@ pub struct NativeMesh3D<'a> {
 
     pub triangle_indices: Option<&'a [glam::UVec3]>,
 
-    pub albedo_factor: Option<re_renderer::Rgba>,
+    pub albedo_factor: Option<re_renderer::Color32>,
 
     pub albedo_texture_buffer: Option<re_types::datatypes::Blob>,
     pub albedo_texture_format: Option<re_types::datatypes::ImageFormat>,
@@ -183,7 +183,7 @@ impl LoadedMesh {
                 label: name.clone().into(),
                 index_range: 0..num_indices as _,
                 albedo,
-                albedo_factor: albedo_factor.unwrap_or(re_renderer::Rgba::WHITE),
+                albedo_factor: albedo_factor.unwrap_or(re_renderer::Color32::WHITE).into(),
             }],
         };
 

--- a/crates/viewer/re_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -21,7 +21,7 @@ pub fn clamped_or<'a, T>(values: &'a [T], if_empty: &'a T) -> impl Iterator<Item
 
 /// Clamp the last value in `values` in order to reach a length of `clamped_len`.
 ///
-/// Returns an empty vctor if values is empty.
+/// Returns an empty vector if values is empty.
 #[inline]
 pub fn clamped_vec_or_empty<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T> {
     if values.len() == clamped_len {
@@ -44,6 +44,19 @@ pub fn clamped_vec_or_empty<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T
     } else {
         // Empty input
         Vec::new()
+    }
+}
+
+/// Clamp the last value in `values` in order to reach a length of `clamped_len`.
+///
+/// If the input slice is empty, the second argument is repeated `clamped_len` times.
+#[inline]
+pub fn clamped_vec_or<T: Clone>(values: &[T], clamped_len: usize, if_empty: &T) -> Vec<T> {
+    let clamped = clamped_vec_or_empty(values, clamped_len);
+    if clamped.is_empty() {
+        vec![if_empty.clone(); clamped_len]
+    } else {
+        clamped
     }
 }
 

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -5,8 +5,7 @@ use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_types::{
-    archetypes::Image,
-    components::MediaType,
+    components::{ImageBuffer, MediaType},
     image::{ImageKind, ImageLoadError},
     Component as _,
 };
@@ -96,9 +95,7 @@ fn decode_image(
 
     let dynamic_image = reader.decode()?;
 
-    let image_arch = Image::from_dynamic_image(dynamic_image)?;
-
-    let Image { buffer, format, .. } = image_arch;
+    let (buffer, format) = ImageBuffer::from_dynamic_image(dynamic_image)?;
 
     Ok(ImageInfo {
         buffer_row_id: blob_row_id,

--- a/crates/viewer/re_viewer_context/src/image_info.rs
+++ b/crates/viewer/re_viewer_context/src/image_info.rs
@@ -399,11 +399,14 @@ mod tests {
         elements: &[T],
     ) -> ImageInfo {
         assert_eq!(elements.len(), 2 * 2);
-        let image = re_types::archetypes::Image::from_elements(elements, [2, 2], color_model);
         ImageInfo {
             buffer_row_id: RowId::ZERO, // unused
-            buffer: image.buffer.0,
-            format: image.format.0,
+            buffer: re_types::datatypes::Blob(bytemuck::cast_slice::<_, u8>(elements).into()),
+            format: re_types::datatypes::ImageFormat::from_color_model(
+                [2, 2],
+                color_model,
+                T::CHANNEL_TYPE,
+            ),
             kind: re_types::image::ImageKind::Color,
         }
     }


### PR DESCRIPTION
### Related

* sister PR to..
	* https://github.com/rerun-io/rerun/pull/8789
	* https://github.com/rerun-io/rerun/pull/8785
* fixes https://github.com/rerun-io/rerun/issues/3381
* fixes https://github.com/rerun-io/rerun/issues/7245

### What

Similar to the previous PRs. These two had a few touching points, so this comes in bulk.
Led actually to a few nice cleanups around Meshes. Image cache on the other hand got a little bit hairy, resolved this by moving some extensions from the archetype down to the components.

No breaking changes & deprecations.

Next step: Remove `"attr.rust.archetype_eager"`, making this always on.


* [x] pass full check ci