### PR TITLE
Make rust `Tensor` archetype eager serialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6562,6 +6562,7 @@ dependencies = [
  "rayon",
  "re_build_tools",
  "re_byte_size",
+ "re_error",
  "re_format",
  "re_log",
  "re_log_types",

--- a/crates/store/re_types/Cargo.toml
+++ b/crates/store/re_types/Cargo.toml
@@ -53,9 +53,10 @@ testing = []
 [dependencies]
 # Rerun
 re_byte_size.workspace = true
+re_error.workspace = true
 re_format.workspace = true
-re_log.workspace = true
 re_log_types.workspace = true
+re_log.workspace = true
 re_tracing.workspace = true
 re_types_core.workspace = true
 re_video = { workspace = true, optional = true }

--- a/crates/store/re_types/definitions/rerun/archetypes/tensor.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/tensor.fbs
@@ -13,7 +13,7 @@ namespace rerun.archetypes;
 ///
 /// \example archetypes/tensor_simple title="Simple tensor" image="https://static.rerun.io/tensor_simple/baacb07712f7b706e3c80e696f70616c6c20b367/1200w.png"
 table Tensor (
-  // TODO(#7245): "attr.rust.archetype_eager",
+  "attr.rust.archetype_eager",
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Image & tensor",
   "attr.docs.view_types": "TensorView, BarChartView: for 1D tensors"

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -48,10 +48,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///   <img src="https://static.rerun.io/tensor_simple/baacb07712f7b706e3c80e696f70616c6c20b367/full.png" width="640">
 /// </picture>
 /// </center>
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Tensor {
     /// The tensor data
-    pub data: crate::components::TensorData,
+    pub data: Option<SerializedComponentBatch>,
 
     /// The expected range of values.
     ///
@@ -64,7 +64,7 @@ pub struct Tensor {
     /// in the contents of the tensor.
     /// E.g. if all values are positive, some bigger than 1.0 and all smaller than 255.0,
     /// the Viewer will guess that the data likely came from an 8bit image, thus assuming a range of 0-255.
-    pub value_range: Option<crate::components::ValueRange>,
+    pub value_range: Option<SerializedComponentBatch>,
 }
 
 impl Tensor {
@@ -171,53 +171,26 @@ impl ::re_types_core::Archetype for Tensor {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
-        let data = {
-            let array = arrays_by_descr
-                .get(&Self::descriptor_data())
-                .ok_or_else(DeserializationError::missing_data)
-                .with_context("rerun.archetypes.Tensor#data")?;
-            <crate::components::TensorData>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Tensor#data")?
-                .into_iter()
-                .next()
-                .flatten()
-                .ok_or_else(DeserializationError::missing_data)
-                .with_context("rerun.archetypes.Tensor#data")?
-        };
-        let value_range = if let Some(array) = arrays_by_descr.get(&Self::descriptor_value_range())
-        {
-            <crate::components::ValueRange>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Tensor#value_range")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
+        let data = arrays_by_descr
+            .get(&Self::descriptor_data())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_data()));
+        let value_range = arrays_by_descr
+            .get(&Self::descriptor_value_range())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_value_range())
+            });
         Ok(Self { data, value_range })
     }
 }
 
 impl ::re_types_core::AsComponents for Tensor {
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        re_tracing::profile_function!();
+    #[inline]
+    fn as_serialized_batches(&self) -> Vec<SerializedComponentBatch> {
         use ::re_types_core::Archetype as _;
         [
-            Some(Self::indicator()),
-            (Some(&self.data as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::ComponentBatchCowWithDescriptor {
-                    batch: batch.into(),
-                    descriptor_override: Some(Self::descriptor_data()),
-                }
-            }),
-            (self
-                .value_range
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
-                batch: batch.into(),
-                descriptor_override: Some(Self::descriptor_value_range()),
-            }),
+            Self::indicator().serialized(),
+            self.data.clone(),
+            self.value_range.clone(),
         ]
         .into_iter()
         .flatten()
@@ -232,9 +205,96 @@ impl Tensor {
     #[inline]
     pub fn new(data: impl Into<crate::components::TensorData>) -> Self {
         Self {
-            data: data.into(),
+            data: try_serialize_field(Self::descriptor_data(), [data]),
             value_range: None,
         }
+    }
+
+    /// Update only some specific fields of a `Tensor`.
+    #[inline]
+    pub fn update_fields() -> Self {
+        Self::default()
+    }
+
+    /// Clear all the fields of a `Tensor`.
+    #[inline]
+    pub fn clear_fields() -> Self {
+        use ::re_types_core::Loggable as _;
+        Self {
+            data: Some(SerializedComponentBatch::new(
+                crate::components::TensorData::arrow_empty(),
+                Self::descriptor_data(),
+            )),
+            value_range: Some(SerializedComponentBatch::new(
+                crate::components::ValueRange::arrow_empty(),
+                Self::descriptor_value_range(),
+            )),
+        }
+    }
+
+    /// Partitions the component data into multiple sub-batches.
+    ///
+    /// Specifically, this transforms the existing [`SerializedComponentBatch`]es data into [`SerializedComponentColumn`]s
+    /// instead, via [`SerializedComponentBatch::partitioned`].
+    ///
+    /// This makes it possible to use `RecordingStream::send_columns` to send columnar data directly into Rerun.
+    ///
+    /// The specified `lengths` must sum to the total length of the component batch.
+    ///
+    /// [`SerializedComponentColumn`]: [::re_types_core::SerializedComponentColumn]
+    #[inline]
+    pub fn columns<I>(
+        self,
+        _lengths: I,
+    ) -> SerializationResult<impl Iterator<Item = ::re_types_core::SerializedComponentColumn>>
+    where
+        I: IntoIterator<Item = usize> + Clone,
+    {
+        let columns = [
+            self.data
+                .map(|data| data.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.value_range
+                .map(|value_range| value_range.partitioned(_lengths.clone()))
+                .transpose()?,
+        ];
+        let indicator_column =
+            ::re_types_core::indicator_column::<Self>(_lengths.into_iter().count())?;
+        Ok(columns.into_iter().chain([indicator_column]).flatten())
+    }
+
+    /// Helper to partition the component data into unit-length sub-batches.
+    ///
+    /// This is semantically similar to calling [`Self::columns`] with `std::iter::take(1).repeat(n)`,
+    /// where `n` is automatically guessed.
+    #[inline]
+    pub fn columns_of_unit_batches(
+        self,
+    ) -> SerializationResult<impl Iterator<Item = ::re_types_core::SerializedComponentColumn>> {
+        let len_data = self.data.as_ref().map(|b| b.array.len());
+        let len_value_range = self.value_range.as_ref().map(|b| b.array.len());
+        let len = None.or(len_data).or(len_value_range).unwrap_or(0);
+        self.columns(std::iter::repeat(1).take(len))
+    }
+
+    /// The tensor data
+    #[inline]
+    pub fn with_data(mut self, data: impl Into<crate::components::TensorData>) -> Self {
+        self.data = try_serialize_field(Self::descriptor_data(), [data]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::TensorData`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_data`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_data(
+        mut self,
+        data: impl IntoIterator<Item = impl Into<crate::components::TensorData>>,
+    ) -> Self {
+        self.data = try_serialize_field(Self::descriptor_data(), data);
+        self
     }
 
     /// The expected range of values.
@@ -253,7 +313,20 @@ impl Tensor {
         mut self,
         value_range: impl Into<crate::components::ValueRange>,
     ) -> Self {
-        self.value_range = Some(value_range.into());
+        self.value_range = try_serialize_field(Self::descriptor_value_range(), [value_range]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::ValueRange`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_value_range`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_value_range(
+        mut self,
+        value_range: impl IntoIterator<Item = impl Into<crate::components::ValueRange>>,
+    ) -> Self {
+        self.value_range = try_serialize_field(Self::descriptor_value_range(), value_range);
         self
     }
 }
@@ -262,11 +335,5 @@ impl ::re_byte_size::SizeBytes for Tensor {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
         self.data.heap_size_bytes() + self.value_range.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::TensorData>::is_pod()
-            && <Option<crate::components::ValueRange>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/tensor_ext.rs
+++ b/crates/store/re_types/src/archetypes/tensor_ext.rs
@@ -1,25 +1,19 @@
-use crate::datatypes::TensorData;
+use crate::{
+    components::{self},
+    datatypes::TensorData,
+};
 
-use re_types_core::ArrowString;
+use re_types_core::{try_serialize_field, ArrowString, Loggable};
 
 use super::Tensor;
 
 impl Tensor {
-    /// Accessor to the underlying [`TensorData`].
-    pub fn data(&self) -> &TensorData {
-        &self.data.0
-    }
-
     /// Try to construct a [`Tensor`] from anything that can be converted into [`TensorData`]
     ///
     /// This is useful for constructing a tensor from an ndarray.
     pub fn try_from<T: TryInto<TensorData>>(data: T) -> Result<Self, T::Error> {
         let data: TensorData = data.try_into()?;
-
-        Ok(Self {
-            data: data.into(),
-            value_range: None,
-        })
+        Ok(Self::new(data))
     }
 
     /// Update the `names` of the contained [`TensorData`] dimensions.
@@ -32,7 +26,35 @@ impl Tensor {
         mut self,
         names: impl IntoIterator<Item = impl Into<ArrowString>>,
     ) -> Self {
-        self.data.0 = self.data.0.with_dim_names(names);
+        if let Some(data) = self.data.take() {
+            match components::TensorData::from_arrow(&data.array) {
+                Ok(tensor_data) => {
+                    if tensor_data.len() > 1 {
+                        re_log::warn!(
+                            "Can't set dimension names on a tensor archetype with multiple tensor data instances."
+                        );
+                        return self;
+                    }
+                    let Some(tensor_data) = tensor_data.into_iter().next() else {
+                        re_log::warn!(
+                            "Can't set dimension names on a tensor archetype without any tensor data instances."
+                        );
+                        return self;
+                    };
+
+                    self.data = try_serialize_field::<components::TensorData>(
+                        Self::descriptor_data(),
+                        [components::TensorData(tensor_data.0.with_dim_names(names))],
+                    );
+                }
+                Err(err) => re_log::warn!(
+                    "Failed to read arrow tensor data: {}",
+                    re_error::format_ref(&err)
+                ),
+            }
+        } else {
+            re_log::warn!("Can't set names on a tensor that doesn't have any data");
+        }
         self
     }
 }
@@ -45,10 +67,7 @@ impl Tensor {
     pub fn from_image(
         image: impl Into<image::DynamicImage>,
     ) -> Result<Self, crate::tensor_data::TensorImageLoadError> {
-        TensorData::from_image(image).map(|data| Self {
-            data: data.into(),
-            value_range: None,
-        })
+        TensorData::from_image(image).map(Self::new)
     }
 
     /// Construct a tensor from [`image::DynamicImage`].
@@ -57,62 +76,6 @@ impl Tensor {
     pub fn from_dynamic_image(
         image: image::DynamicImage,
     ) -> Result<Self, crate::tensor_data::TensorImageLoadError> {
-        TensorData::from_dynamic_image(image).map(|data| Self {
-            data: data.into(),
-            value_range: None,
-        })
+        TensorData::from_dynamic_image(image).map(Self::new)
     }
 }
-
-impl AsRef<TensorData> for Tensor {
-    #[inline(always)]
-    fn as_ref(&self) -> &TensorData {
-        &self.data
-    }
-}
-
-impl std::ops::Deref for Tensor {
-    type Target = TensorData;
-
-    #[inline(always)]
-    fn deref(&self) -> &TensorData {
-        &self.data
-    }
-}
-
-impl std::borrow::Borrow<TensorData> for Tensor {
-    #[inline(always)]
-    fn borrow(&self) -> &TensorData {
-        &self.data
-    }
-}
-
-// ----------------------------------------------------------------------------
-// Make it possible to create an ArrayView directly from a Tensor.
-
-macro_rules! forward_array_views {
-    ($type:ty, $alias:ty) => {
-        impl<'a> TryFrom<&'a $alias> for ::ndarray::ArrayViewD<'a, $type> {
-            type Error = crate::tensor_data::TensorCastError;
-
-            #[inline]
-            fn try_from(value: &'a $alias) -> Result<Self, Self::Error> {
-                value.data().try_into()
-            }
-        }
-    };
-}
-
-forward_array_views!(u8, Tensor);
-forward_array_views!(u16, Tensor);
-forward_array_views!(u32, Tensor);
-forward_array_views!(u64, Tensor);
-
-forward_array_views!(i8, Tensor);
-forward_array_views!(i16, Tensor);
-forward_array_views!(i32, Tensor);
-forward_array_views!(i64, Tensor);
-
-forward_array_views!(half::f16, Tensor);
-forward_array_views!(f32, Tensor);
-forward_array_views!(f64, Tensor);

--- a/crates/store/re_types/tests/types/tensor.rs
+++ b/crates/store/re_types/tests/types/tensor.rs
@@ -25,10 +25,10 @@ fn tensor_data_roundtrip() {
 
 #[test]
 fn tensor_roundtrip() {
-    let all_expected = [Tensor {
-        data: TensorData::new(vec![2, 3], TensorBuffer::U8(vec![1, 2, 3, 4, 5, 6].into())).into(),
-        value_range: None,
-    }];
+    let all_expected = [Tensor::new(TensorData::new(
+        vec![2, 3],
+        TensorBuffer::U8(vec![1, 2, 3, 4, 5, 6].into()),
+    ))];
 
     let all_arch_serialized = [Tensor::try_from(ndarray::array![[1u8, 2, 3], [4, 5, 6]])
         .unwrap()

--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -32,3 +32,9 @@ For logging custom components, use [`rr.AnyValue`](https://ref.rerun.io/docs/pyt
 As part of the switch to "eager archetype serialization" (serialization of archetype components now occurs at time of archetype instantiation rather than logging), we can no longer offer constants for the `ViewCoordinates` archetype like `ViewCoordinates::RUB`.
 
 Instead, there's now methods with the same name, i.e. `ViewCoordinates::RUB()`.
+
+### Rust's `Tensor` archetype can no longer access tensor data as `ndarray` view directly
+
+As part of the switch to "eager archetype serialization" (serialization of archetype components now occurs at time of archetype instantiation rather than logging), we can no longer offer exposing the `Tensor` **archetype** as `ndarray::ArrayView` directly.
+
+However, it is still possible to do so with the `TensorData` component.

--- a/rerun_cpp/src/rerun/archetypes/tensor_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor_ext.cpp
@@ -68,10 +68,16 @@ RR_DISABLE_MAYBE_UNINITIALIZED_POP
         if (!data_struct_array) {
             return Error(ErrorCode::InvalidArchetypeField, "Tensor data is not a struct array");
         }
-        if (data_struct_array->length() != 1) {
+        if (data_struct_array->length() == 0) {
             return Error(
                 ErrorCode::InvalidArchetypeField,
-                "Can't set dimnesion names on a tensor archetype with multiple fields."
+                "Can't set names on a tensor that doesn't have any data"
+            );
+        }
+        if (data_struct_array->length() > 1) {
+            return Error(
+                ErrorCode::InvalidArchetypeField,
+                "Can't set dimension names on a tensor archetype with multiple tensor data instances."
             );
         }
 


### PR DESCRIPTION
### Related

* sister PR to..
	* https://github.com/rerun-io/rerun/pull/8789
	* https://github.com/rerun-io/rerun/pull/8785
	* https://github.com/rerun-io/rerun/pull/8793
* missed piece of https://github.com/rerun-io/rerun/issues/7245

### What

Ports the Tensor archetype in rust to the new eager serialized interface.
Unfortunately this meant I had to remove some direct access methods of the underlying tensor data. Curiously, this didn't affect any of our test/snippet/example code.
While doing so I also fixed some wording issues in the (very similar) C++ implementation of `with_dim_names`