### PR TITLE
Fix regression in container blueprint saving

### DIFF
--- a/crates/viewer/re_viewport_blueprint/src/container.rs
+++ b/crates/viewer/re_viewport_blueprint/src/container.rs
@@ -194,8 +194,8 @@ impl ContainerBlueprint {
             arch = arch.with_grid_columns(*cols);
         } else {
             arch.grid_columns = Some(re_types::SerializedComponentBatch::new(
-                re_types::blueprint::components::ContainerKind::arrow_empty(),
-                re_types::blueprint::archetypes::ContainerBlueprint::descriptor_container_kind(),
+                re_types::blueprint::components::GridColumns::arrow_empty(),
+                re_types::blueprint::archetypes::ContainerBlueprint::descriptor_grid_columns(),
             ));
         }
 


### PR DESCRIPTION
oops!

Luckily @abey79 's new tests caught this 🥳 

Tested locally with `cargo test -p re_blueprint_tree --all-features` (before fail, now not fail)