### PR TITLE
Fix mesh casting color components incorrectly

### DIFF
--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use re_chunk_store::RowId;
 use re_renderer::{mesh::GpuMesh, RenderContext, Rgba32Unmul};
-use re_types::components::MediaType;
+use re_types::{components::MediaType, datatypes};
 use re_viewer_context::{gpu_bridge::texture_creation_desc_from_color_image, ImageInfo};
 
 use crate::{mesh_cache::AnyMesh, visualizers::entity_iterator::clamped_vec_or};
@@ -17,15 +17,15 @@ pub struct NativeAsset3D<'a> {
 pub struct NativeMesh3D<'a> {
     pub vertex_positions: &'a [glam::Vec3],
     pub vertex_normals: Option<&'a [glam::Vec3]>,
-    pub vertex_colors: Option<&'a [re_renderer::Rgba32Unmul]>,
+    pub vertex_colors: Option<&'a [datatypes::Rgba32]>,
     pub vertex_texcoords: Option<&'a [glam::Vec2]>,
 
     pub triangle_indices: Option<&'a [glam::UVec3]>,
 
-    pub albedo_factor: Option<re_renderer::Color32>,
+    pub albedo_factor: Option<datatypes::Rgba32>,
 
-    pub albedo_texture_buffer: Option<re_types::datatypes::Blob>,
-    pub albedo_texture_format: Option<re_types::datatypes::ImageFormat>,
+    pub albedo_texture_buffer: Option<datatypes::Blob>,
+    pub albedo_texture_format: Option<datatypes::ImageFormat>,
 }
 
 pub struct LoadedMesh {
@@ -133,7 +133,12 @@ impl LoadedMesh {
 
         let vertex_colors = if let Some(vertex_colors) = vertex_colors {
             re_tracing::profile_scope!("copy_colors");
-            clamped_vec_or(vertex_colors, num_positions, &Rgba32Unmul::WHITE)
+            vertex_colors
+                .iter()
+                .map(|c| Rgba32Unmul::from_rgba_unmul_array(c.to_array()))
+                .chain(std::iter::repeat(Rgba32Unmul::WHITE))
+                .take(num_positions)
+                .collect::<Vec<_>>()
         } else {
             vec![Rgba32Unmul::WHITE; num_positions]
         };
@@ -183,7 +188,7 @@ impl LoadedMesh {
                 label: name.clone().into(),
                 index_range: 0..num_indices as _,
                 albedo,
-                albedo_factor: albedo_factor.unwrap_or(re_renderer::Color32::WHITE).into(),
+                albedo_factor: albedo_factor.unwrap_or(datatypes::Rgba32::WHITE).into(),
             }],
         };
 
@@ -209,8 +214,8 @@ impl LoadedMesh {
 }
 
 fn try_get_or_create_albedo_texture(
-    albedo_texture_buffer: &Option<re_types::datatypes::Blob>,
-    albedo_texture_format: &Option<re_types::datatypes::ImageFormat>,
+    albedo_texture_buffer: &Option<datatypes::Blob>,
+    albedo_texture_format: &Option<datatypes::ImageFormat>,
     render_ctx: &RenderContext,
     texture_key: u64,
     name: &str,

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use re_chunk_store::RowId;
-use re_renderer::{mesh::GpuMesh, RenderContext, Rgba32Unmul};
+use re_renderer::{mesh::GpuMesh, RenderContext};
 use re_types::{components::MediaType, datatypes};
 use re_viewer_context::{gpu_bridge::texture_creation_desc_from_color_image, ImageInfo};
 
@@ -135,12 +135,12 @@ impl LoadedMesh {
             re_tracing::profile_scope!("copy_colors");
             vertex_colors
                 .iter()
-                .map(|c| Rgba32Unmul::from_rgba_unmul_array(c.to_array()))
-                .chain(std::iter::repeat(Rgba32Unmul::WHITE))
+                .map(|c| re_renderer::Rgba32Unmul::from_rgba_unmul_array(c.to_array()))
+                .chain(std::iter::repeat(re_renderer::Rgba32Unmul::WHITE))
                 .take(num_positions)
                 .collect::<Vec<_>>()
         } else {
-            vec![Rgba32Unmul::WHITE; num_positions]
+            vec![re_renderer::Rgba32Unmul::WHITE; num_positions]
         };
 
         let vertex_normals = if let Some(normals) = vertex_normals {


### PR DESCRIPTION
Messed up the swizzling of colors when doing to aggressive bytemuck slice casts. Causing this
![image](https://github.com/user-attachments/assets/734f02dd-7c54-4d01-b13e-b72b869dad71)


This pr gets us back to
![image](https://github.com/user-attachments/assets/59457732-0c34-403e-be17-5d30c49f1fc9)


---

What did we re-learn today that we knew all along but didn't pay attention to?

Our user facing API says `The color is stored as a 32-bit integer, where the most significant byte is `R` and the least significant byte is `A`.` - which allows you to write `0xFF00FFFF` for a beautiful magenta and is what everyone is used to. But written as an array this is `[a, b, g, r]` because most of the world is [little endian](https://en.wikipedia.org/wiki/Endianness#/media/File:32bit-Endianess.svg) and that means that the least significant byte (alpha!) comes first. But in rendering (that includes re_renderer & egui) everything is `[r,g,b,a]`!