### PR TITLE
Improve performance for Blueprint & Streams Panel for many entities

### DIFF
--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -174,6 +174,7 @@ impl BlueprintTree {
 
         let item_response = ui
             .list_item()
+            .render_offscreen(false)
             .selected(ctx.selection().contains_item(&item))
             .draggable(true) // allowed for consistency but results in an invalid drag
             .drop_target_style(self.is_candidate_drop_parent_container(&container_data.id))
@@ -272,6 +273,7 @@ impl BlueprintTree {
             ..
         } = ui
             .list_item()
+            .render_offscreen(false)
             .selected(ctx.selection().contains_item(&item))
             .draggable(true)
             .drop_target_style(self.is_candidate_drop_parent_container(&container_data.id))
@@ -360,6 +362,7 @@ impl BlueprintTree {
             ..
         } = ui
             .list_item()
+            .render_offscreen(false)
             .selected(ctx.selection().contains_item(&item))
             .draggable(true)
             .force_hovered(is_item_hovered)
@@ -375,10 +378,13 @@ impl BlueprintTree {
                 }
 
                 if !view_data.projection_trees.is_empty() {
-                    ui.list_item().interactive(false).show_flat(
-                        ui,
-                        list_item::LabelContent::new("Projections:").italics(true),
-                    );
+                    ui.list_item()
+                        .render_offscreen(false)
+                        .interactive(false)
+                        .show_flat(
+                            ui,
+                            list_item::LabelContent::new("Projections:").italics(true),
+                        );
 
                     for projection in &view_data.projection_trees {
                         self.data_result_ui(ctx, viewport_blueprint, ui, projection, view_visible);
@@ -481,6 +487,7 @@ impl BlueprintTree {
             DataResultKind::OriginProjectionPlaceholder => {
                 if ui
                     .list_item()
+                    .render_offscreen(false)
                     .show_hierarchical(
                         ui,
                         list_item::LabelContent::new("$origin")
@@ -507,6 +514,7 @@ impl BlueprintTree {
 
         let list_item = ui
             .list_item()
+            .render_offscreen(false)
             .draggable(true)
             .selected(is_selected)
             .force_hovered(is_item_hovered);

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -760,6 +760,7 @@ impl TimePanel {
             ..
         } = ui
             .list_item()
+            .render_offscreen(false)
             .selected(is_selected)
             .draggable(true)
             .force_hovered(is_item_hovered)
@@ -925,6 +926,7 @@ impl TimePanel {
 
                 let response = ui
                     .list_item()
+                    .render_offscreen(false)
                     .selected(ctx.selection().contains_item(&item.to_item()))
                     .force_hovered(
                         ctx.selection_state()
@@ -975,18 +977,21 @@ impl TimePanel {
                                 format!("{} times", re_format::format_uint(num_messages))
                             };
 
-                            ui.list_item().interactive(false).show_flat(
-                                ui,
-                                list_item::LabelContent::new(format!(
-                                    "{kind} component, logged {num_messages}"
-                                ))
-                                .truncate(false)
-                                .with_icon(if is_static {
-                                    &re_ui::icons::COMPONENT_STATIC
-                                } else {
-                                    &re_ui::icons::COMPONENT_TEMPORAL
-                                }),
-                            );
+                            ui.list_item()
+                                .interactive(false)
+                                .render_offscreen(false)
+                                .show_flat(
+                                    ui,
+                                    list_item::LabelContent::new(format!(
+                                        "{kind} component, logged {num_messages}"
+                                    ))
+                                    .truncate(false)
+                                    .with_icon(if is_static {
+                                        &re_ui::icons::COMPONENT_STATIC
+                                    } else {
+                                        &re_ui::icons::COMPONENT_TEMPORAL
+                                    }),
+                                );
 
                             // Static components are not displayed at all on the timeline, so cannot be
                             // previewed there. So we display their content in this tooltip instead.

--- a/crates/viewer/re_ui/src/list_item/list_item.rs
+++ b/crates/viewer/re_ui/src/list_item/list_item.rs
@@ -49,6 +49,7 @@ pub struct ListItem {
     force_background: Option<egui::Color32>,
     pub collapse_openness: Option<f32>,
     height: f32,
+    render_offscreen: bool,
 }
 
 impl Default for ListItem {
@@ -62,6 +63,7 @@ impl Default for ListItem {
             force_background: None,
             collapse_openness: None,
             height: DesignTokens::list_item_height(),
+            render_offscreen: true,
         }
     }
 }
@@ -137,6 +139,17 @@ impl ListItem {
     #[inline]
     pub fn with_height(mut self, height: f32) -> Self {
         self.height = height;
+        self
+    }
+
+    /// Controls whether [`Self`] calls [`ListItemContent::ui`] when the item is not currently
+    /// visible.
+    ///
+    /// Skipping rendering can increase performances for long lists that are mostly out of view, but
+    /// this will prevent any side effects from [`ListItemContent::ui`] from occuring. For this
+    /// reason, this is an opt-in optimization.
+    pub fn render_offscreen(mut self, render_offscreen: bool) -> Self {
+        self.render_offscreen = render_offscreen;
         self
     }
 
@@ -274,6 +287,7 @@ impl ListItem {
             force_background,
             collapse_openness,
             height,
+            render_offscreen,
         } = self;
 
         let collapse_extra = if collapse_openness.is_some() {
@@ -328,6 +342,14 @@ impl ListItem {
         // could trigger `show_body_indented` (in `Self::show_hierarchical_with_children`) to
         // allocate past the available width.
         response.rect = rect;
+
+        let should_render = render_offscreen || ui.is_rect_visible(rect);
+        if !should_render {
+            return ListItemResponse {
+                response,
+                collapse_response: None,
+            };
+        }
 
         // override_hover should not affect the returned response
         let mut style_response = response.clone();

--- a/crates/viewer/re_ui/src/list_item/list_item.rs
+++ b/crates/viewer/re_ui/src/list_item/list_item.rs
@@ -146,8 +146,9 @@ impl ListItem {
     /// visible.
     ///
     /// Skipping rendering can increase performances for long lists that are mostly out of view, but
-    /// this will prevent any side effects from [`ListItemContent::ui`] from occuring. For this
+    /// this will prevent any side effects from [`ListItemContent::ui`] from occurring. For this
     /// reason, this is an opt-in optimization.
+    #[inline]
     pub fn render_offscreen(mut self, render_offscreen: bool) -> Self {
         self.render_offscreen = render_offscreen;
         self


### PR DESCRIPTION
### Related

- Part of #8233
- Fixes #8798
- Part of #8662 (or fixes it?)

### What

This PR adds an option to `ListItem` to disable rendering offscreen. In that case, `ListItem` skips some code and in particular does not call `ListItemContent::ui()`. The full sizing computation is still run, so it does not affect layout.

Both the blueprint tree and the time panel now opt in to this optimisation.

DNM: chaineded to blueprint tree refactor to minimise conflicts

### Benchmark

This optimisation is only measurable in "worst case" scenario, such as fully uncollapsed blueprint tree and streams tree in the air traffic data example. In this case, we shave about 13-15ms off the frame time (90% of which in the time panel) on a M4 Max.

Before/after screenshot (with the view hidden for better frame time stability): (61.8 vs. 47.4ms)

<img width="2023" alt="image" src="https://github.com/user-attachments/assets/c4f5557e-6db7-4f9f-b534-437caf6e650d" />


<img width="2023" alt="image" src="https://github.com/user-attachments/assets/93d36a44-ceda-443d-8c2a-c8529470769e" />


