### PR TITLE
Include a python API for routing time control commands to the notebook instance

### DIFF
--- a/rerun_notebook/src/js/widget.ts
+++ b/rerun_notebook/src/js/widget.ts
@@ -43,6 +43,8 @@ class ViewerWidget {
 
     model.on("msg:custom", this.on_custom_message);
 
+    model.on("change:_time_ctrl", (_, [timeline, time, play]) => this.on_time_ctrl(null, timeline, time, play));
+
     this.viewer.on("ready", () => {
       this.channel = this.viewer.open_channel("temp");
 
@@ -122,6 +124,33 @@ class ViewerWidget {
       console.log("unknown message type", msg, buffers);
     }
   };
+
+  on_time_ctrl = (_: unknown, timeline: string | null, time: number | null, play: boolean) => {
+    let recording_id = this.viewer.get_active_recording_id();
+    if (recording_id === null) {
+      return;
+    }
+
+    let active_timeline = this.viewer.get_active_timeline(recording_id);
+
+    if (timeline === null) {
+      timeline = active_timeline;
+    }
+
+    if (timeline === null) {
+      return;
+    }
+
+    if (timeline !== active_timeline) {
+      this.viewer.set_active_timeline(recording_id, timeline);
+    }
+
+    this.viewer.set_playing(recording_id, play);
+
+    if (time !== null) {
+      this.viewer.set_current_time(recording_id, timeline, time);
+    }
+  }
 }
 
 const render: Render<WidgetModel> = ({ model, el }) => {

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -68,6 +68,13 @@ class Viewer(anywidget.AnyWidget):
     _ready = False
     _data_queue: list[bytes]
 
+    _time_ctrl = traitlets.Tuple(
+        traitlets.Unicode(allow_none=True),
+        traitlets.Int(allow_none=True),
+        traitlets.Bool(),
+        allow_none=True,
+    ).tag(sync=True)
+
     def __init__(
         self,
         *,
@@ -122,3 +129,6 @@ If not, consider setting `RERUN_NOTEBOOK_ASSET`. Consult https://pypi.org/projec
                     return
                 poll(1)
                 time.sleep(0.1)
+
+    def set_time_ctrl(self, timeline: str | None, time: int | None, play: bool) -> None:
+        self._time_ctrl = (timeline, time, play)

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -151,6 +151,46 @@ class Viewer:
     def _repr_keys(self):  # type: ignore[no-untyped-def]
         return self._viewer._repr_keys()
 
+    def set_time_ctrl(
+        self,
+        *,
+        sequence: int | None = None,
+        nanoseconds: int | None = None,
+        seconds: float | None = None,
+        timeline: str | None = None,
+        play: bool = False,
+    ) -> None:
+        """
+        Set the time control for the viewer.
+
+        Parameters
+        ----------
+        sequence: int
+            The sequence number to set the viewer to.
+        seconds: float
+            The time in seconds to set the viewer to.
+        nanoseconds: int
+            The time in nanoseconds to set the viewer to.
+        play: bool
+            Whether to start playing from the the specified time point. Defaults to paused.
+        timeline : str
+            The name of the timeline to switch to. If not provided, time will remain on the current timeline.
+
+        """
+        if sum([sequence is not None, nanoseconds is not None, seconds is not None]) > 1:
+            raise ValueError("At most one of sequence, nanoseconds, or seconds may be provided")
+
+        if sequence is not None:
+            time = sequence
+        elif nanoseconds is not None:
+            time = nanoseconds
+        elif seconds is not None:
+            time = int(seconds * 1e9)
+        else:
+            time = None
+
+        self._viewer.set_time_ctrl(timeline, time, play)
+
 
 def notebook_show(
     *,

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -172,7 +172,7 @@ class Viewer:
         nanoseconds: int
             The time in nanoseconds to set the viewer to.
         play: bool
-            Whether to start playing from the the specified time point. Defaults to paused.
+            Whether to start playing from the specified time point. Defaults to paused.
         timeline : str
             The name of the timeline to switch to. If not provided, time will remain on the current timeline.
 


### PR DESCRIPTION
### Related
- https://github.com/rerun-io/rerun/pull/8673

### What

The linked PR added support for using javascript to update the time controls. Routing this into python when working in the context of a notebook unlocks lots of interesting interactive behavior.

This does not yet expose the reverse of generating python callback events based on rerun time cursor changes, but that would be an obvious next step.