### PR TITLE
Low-hanging optimizations of the time panel

### DIFF
--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -185,8 +185,7 @@ pub fn instance_path_icon(
         if db
             .storage_engine()
             .store()
-            .all_components_on_timeline(timeline, &instance_path.entity_path)
-            .is_some()
+            .entity_has_data_on_timeline(timeline, &instance_path.entity_path)
         {
             &icons::ENTITY
         } else {

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -833,36 +833,38 @@ impl TimePanel {
             response_rect.y_range(),
         );
 
-        let is_visible = ui.is_rect_visible(full_width_rect);
-
         // ----------------------------------------------
 
-        // show the data in the time area:
-        let tree_has_data_in_current_timeline = entity_db.subtree_has_data_on_timeline(
-            &entity_db.storage_engine(),
-            time_ctrl.timeline(),
-            &tree.path,
-        );
-        if is_visible && tree_has_data_in_current_timeline {
-            let row_rect =
-                Rect::from_x_y_ranges(time_area_response.rect.x_range(), response_rect.y_range());
-
-            highlight_timeline_row(ui, ctx, time_area_painter, &item.to_item(), &row_rect);
-
-            // show the density graph only if that item is closed
-            if is_closed {
-                data_density_graph::data_density_graph_ui(
-                    &mut self.data_density_graph_painter,
-                    ctx,
-                    time_ctrl,
-                    db,
-                    time_area_painter,
-                    ui,
-                    &self.time_ranges_ui,
-                    row_rect,
-                    &item,
-                    true,
+        let is_visible = ui.is_rect_visible(full_width_rect);
+        if is_visible {
+            let tree_has_data_in_current_timeline = entity_db.subtree_has_data_on_timeline(
+                &entity_db.storage_engine(),
+                time_ctrl.timeline(),
+                &tree.path,
+            );
+            if tree_has_data_in_current_timeline {
+                let row_rect = Rect::from_x_y_ranges(
+                    time_area_response.rect.x_range(),
+                    response_rect.y_range(),
                 );
+
+                highlight_timeline_row(ui, ctx, time_area_painter, &item.to_item(), &row_rect);
+
+                // show the density graph only if that item is closed
+                if is_closed {
+                    data_density_graph::data_density_graph_ui(
+                        &mut self.data_density_graph_painter,
+                        ctx,
+                        time_ctrl,
+                        db,
+                        time_area_painter,
+                        ui,
+                        &self.time_ranges_ui,
+                        row_rect,
+                        &item,
+                        true,
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
### Related

* Part of #8233

### What

Two small optimisations which, together, account for 2ms in a worse case scenario.

Benchmark: air traffic data, no views, uncollapsed time panel

![image](https://github.com/user-attachments/assets/aa63e689-aac1-44cf-bc92-08a2287fa964)


Result:

![image](https://github.com/user-attachments/assets/6082c678-dddc-447a-8409-702e7bc512e4)


