### PR TITLE
Python: updated partial APIs naming

### DIFF
--- a/docs/snippets/all/archetypes/mesh3d_partial_updates.py
+++ b/docs/snippets/all/archetypes/mesh3d_partial_updates.py
@@ -22,4 +22,4 @@ rr.log(
 factors = np.abs(np.sin(np.arange(1, 300, dtype=np.float32) * 0.04))
 for i, factor in enumerate(factors):
     rr.set_time_sequence("frame", i)
-    rr.log("triangle", rr.Mesh3D.update_fields(vertex_positions=vertex_positions * factor))
+    rr.log("triangle", rr.Mesh3D.from_fields(vertex_positions=vertex_positions * factor))

--- a/docs/snippets/all/archetypes/points3d_partial_updates.py
+++ b/docs/snippets/all/archetypes/points3d_partial_updates.py
@@ -14,7 +14,7 @@ for i in range(0, 10):
     radii = [0.6 if n < i else 0.2 for n in range(0, 10)]
 
     rr.set_time_sequence("frame", i)
-    rr.log("points", rr.Points3D.update_fields(radii=radii, colors=colors))
+    rr.log("points", rr.Points3D.from_fields(radii=radii, colors=colors))
 
 rr.set_time_sequence("frame", 20)
-rr.log("points", rr.Points3D.update_fields(clear=True, positions=positions, radii=0.3))
+rr.log("points", rr.Points3D.from_fields(clear_unset=True, positions=positions, radii=0.3))

--- a/docs/snippets/all/archetypes/transform3d_partial_updates.py
+++ b/docs/snippets/all/archetypes/transform3d_partial_updates.py
@@ -23,7 +23,7 @@ for deg in range(46):
     rad = truncated_radians(deg * 4)
     rr.log(
         "box",
-        rr.Transform3D.update_fields(
+        rr.Transform3D.from_fields(
             # TODO(cmc): we should have access to all the fields of the extended constructor too.
             rotation_axis_angle=rr.RotationAxisAngle(axis=[0.0, 1.0, 0.0], radians=rad),
         ),
@@ -33,7 +33,7 @@ for deg in range(46):
 for t in range(51):
     rr.log(
         "box",
-        rr.Transform3D.update_fields(translation=[0, 0, t / 10.0]),
+        rr.Transform3D.from_fields(translation=[0, 0, t / 10.0]),
     )
 
 # Update only the rotation of the box.
@@ -41,7 +41,7 @@ for deg in range(46):
     rad = truncated_radians((deg + 45) * 4)
     rr.log(
         "box",
-        rr.Transform3D.update_fields(
+        rr.Transform3D.from_fields(
             # TODO(cmc): we should have access to all the fields of the extended constructor too.
             rotation_axis_angle=rr.RotationAxisAngle(axis=[0.0, 1.0, 0.0], radians=rad),
         ),
@@ -50,5 +50,5 @@ for deg in range(46):
 # Clear all of the box's attributes, and reset its axis length.
 rr.log(
     "box",
-    rr.Transform3D.update_fields(clear=True, axis_length=15),
+    rr.Transform3D.from_fields(clear_unset=True, axis_length=15),
 )

--- a/docs/snippets/all/tutorials/data_out.py
+++ b/docs/snippets/all/tutorials/data_out.py
@@ -38,7 +38,7 @@ rr.send_columns(
 
 # log a `Label` component to the face bounding box entity
 target_entity = "/video/detector/faces/0/bbox"
-rr.log(target_entity, rr.Boxes2D.update_fields(show_labels=True), static=True)
+rr.log(target_entity, rr.Boxes2D.from_fields(show_labels=True), static=True)
 rr.send_columns(
     target_entity,
     indexes=[rr.TimeSequenceColumn("frame_nr", df["frame_nr"])],

--- a/examples/python/air_traffic_data/air_traffic_data.py
+++ b/examples/python/air_traffic_data/air_traffic_data.py
@@ -318,12 +318,12 @@ class MeasurementBatchLogger:
             color = rr.components.Color.from_string(entity_path)
             rr.log(
                 entity_path,
-                rr.Points3D.update_fields(colors=color),
+                rr.Points3D.from_fields(colors=color),
                 # TODO(cmc): That would be UB right now (and doesn't matter as long as we are on the untagged index).
-                # rr.GeoPoints.update_fields(colors=color),
+                # rr.GeoPoints.from_fields(colors=color),
                 static=True,
             )
-            rr.log(entity_path + "/barometric_altitude", rr.SeriesLine.update_fields(color=color), static=True)
+            rr.log(entity_path + "/barometric_altitude", rr.SeriesLine.from_fields(color=color), static=True)
             self._position_indicators.add(icao_id)
 
         timestamps = rr.TimeSecondsColumn("unix_time", df["timestamp"].to_numpy())

--- a/examples/python/detect_and_track_objects/detect_and_track_objects.py
+++ b/examples/python/detect_and_track_objects/detect_and_track_objects.py
@@ -213,7 +213,7 @@ class Tracker:
                 ),
             )
         else:
-            rr.log(f"video/tracked/{self.tracking_id}", rr.Boxes2D.clear_fields())
+            rr.log(f"video/tracked/{self.tracking_id}", rr.Boxes2D.cleared())
 
     def update_with_detection(self, detection: Detection, bgr: cv2.typing.MatLike) -> None:
         self.num_recent_undetected_frames = 0

--- a/examples/python/drone_lidar/drone_lidar.py
+++ b/examples/python/drone_lidar/drone_lidar.py
@@ -119,7 +119,7 @@ def log_lidar_data() -> None:
     rr.log(
         "/lidar",
         # negative radii are interpreted in UI units (instead of scene units)
-        rr.Points3D.update_fields(colors=(128, 128, 255), radii=-0.1),
+        rr.Points3D.from_fields(colors=(128, 128, 255), radii=-0.1),
         static=True,
     )
 
@@ -137,7 +137,7 @@ def log_drone_trajectory() -> None:
 
     rr.log(
         "/drone",
-        rr.Points3D.update_fields(colors=(255, 0, 0), radii=0.5),
+        rr.Points3D.from_fields(colors=(255, 0, 0), radii=0.5),
         static=True,
     )
 

--- a/examples/python/incremental_logging/incremental_logging.py
+++ b/examples/python/incremental_logging/incremental_logging.py
@@ -23,7 +23,7 @@ It was logged with the following code:
 # Only log colors and radii once.
 # Logging as static would also work (i.e. `static=True`).
 rr.set_time_sequence("frame_nr", 0)
-rr.log("points", rr.Points3D.update_fields(colors=0xFF0000FF, radii=0.1))
+rr.log("points", rr.Points3D.from_fields(colors=0xFF0000FF, radii=0.1))
 
 rng = default_rng(12345)
 
@@ -32,7 +32,7 @@ rng = default_rng(12345)
 # They will automatically re-use the colors and radii logged at the beginning.
 for i in range(10):
     rr.set_time_sequence("frame_nr", i)
-    rr.log("points", rr.Points3D.update_fields(positions=rng.uniform(-5, 5, size=[10, 3])))
+    rr.log("points", rr.Points3D.from_fields(positions=rng.uniform(-5, 5, size=[10, 3])))
 ```
 
 Move the time cursor around, and notice how the colors and radii from frame 0 are still picked up by later frames, while the points themselves keep changing every frame.
@@ -47,7 +47,7 @@ rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), stat
 # Only log colors and radii once.
 # Logging as static would also work (i.e. `static=True`).
 rr.set_time_sequence("frame_nr", 0)
-rr.log("points", rr.Points3D.update_fields(colors=0xFF0000FF, radii=0.1))
+rr.log("points", rr.Points3D.from_fields(colors=0xFF0000FF, radii=0.1))
 
 rng = default_rng(12345)
 
@@ -56,6 +56,6 @@ rng = default_rng(12345)
 # They will automatically re-use the colors and radii logged at the beginning.
 for i in range(10):
     rr.set_time_sequence("frame_nr", i)
-    rr.log("points", rr.Points3D.update_fields(positions=rng.uniform(-5, 5, size=[10, 3])))
+    rr.log("points", rr.Points3D.from_fields(positions=rng.uniform(-5, 5, size=[10, 3])))
 
 rr.script_teardown(args)

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -96,10 +96,10 @@ class AnnotationContext(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         context: components.AnnotationContextLike | None = None,
     ) -> AnnotationContext:
         """
@@ -107,7 +107,7 @@ class AnnotationContext(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         context:
             List of class descriptions, mapping class indices to class names, colors etc.
@@ -120,7 +120,7 @@ class AnnotationContext(Archetype):
                 "context": context,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -130,13 +130,9 @@ class AnnotationContext(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> AnnotationContext:
+    def cleared(cls) -> AnnotationContext:
         """Clear all the fields of a `AnnotationContext`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            context=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -79,10 +79,10 @@ class Arrows2D(Arrows2DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         vectors: datatypes.Vec2DArrayLike | None = None,
         origins: datatypes.Vec2DArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
@@ -97,7 +97,7 @@ class Arrows2D(Arrows2DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         vectors:
             All the vectors for each arrow in the batch.
@@ -143,7 +143,7 @@ class Arrows2D(Arrows2DExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -153,20 +153,9 @@ class Arrows2D(Arrows2DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Arrows2D:
+    def cleared(cls) -> Arrows2D:
         """Clear all the fields of a `Arrows2D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            vectors=[],
-            origins=[],
-            radii=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            draw_order=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -78,10 +78,10 @@ class Arrows3D(Arrows3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         vectors: datatypes.Vec3DArrayLike | None = None,
         origins: datatypes.Vec3DArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
@@ -95,7 +95,7 @@ class Arrows3D(Arrows3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         vectors:
             All the vectors for each arrow in the batch.
@@ -136,7 +136,7 @@ class Arrows3D(Arrows3DExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -146,19 +146,9 @@ class Arrows3D(Arrows3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Arrows3D:
+    def cleared(cls) -> Arrows3D:
         """Clear all the fields of a `Arrows3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            vectors=[],
-            origins=[],
-            radii=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -77,10 +77,10 @@ class Asset3D(Asset3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         blob: datatypes.BlobLike | None = None,
         media_type: datatypes.Utf8Like | None = None,
         albedo_factor: datatypes.Rgba32Like | None = None,
@@ -90,7 +90,7 @@ class Asset3D(Asset3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         blob:
             The asset's bytes.
@@ -121,7 +121,7 @@ class Asset3D(Asset3DExt, Archetype):
                 "albedo_factor": albedo_factor,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -131,15 +131,9 @@ class Asset3D(Asset3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Asset3D:
+    def cleared(cls) -> Asset3D:
         """Clear all the fields of a `Asset3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            blob=[],
-            media_type=[],
-            albedo_factor=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -131,10 +131,10 @@ class AssetVideo(AssetVideoExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         blob: datatypes.BlobLike | None = None,
         media_type: datatypes.Utf8Like | None = None,
     ) -> AssetVideo:
@@ -143,7 +143,7 @@ class AssetVideo(AssetVideoExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         blob:
             The asset's bytes.
@@ -165,7 +165,7 @@ class AssetVideo(AssetVideoExt, Archetype):
                 "media_type": media_type,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -175,14 +175,9 @@ class AssetVideo(AssetVideoExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> AssetVideo:
+    def cleared(cls) -> AssetVideo:
         """Clear all the fields of a `AssetVideo`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            blob=[],
-            media_type=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -84,10 +84,10 @@ class BarChart(BarChartExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         values: datatypes.TensorDataLike | None = None,
         color: datatypes.Rgba32Like | None = None,
     ) -> BarChart:
@@ -96,7 +96,7 @@ class BarChart(BarChartExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         values:
             The values. Should always be a 1-dimensional tensor (i.e. a vector).
@@ -112,7 +112,7 @@ class BarChart(BarChartExt, Archetype):
                 "color": color,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -122,14 +122,9 @@ class BarChart(BarChartExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> BarChart:
+    def cleared(cls) -> BarChart:
         """Clear all the fields of a `BarChart`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            values=[],
-            color=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -70,10 +70,10 @@ class Boxes2D(Boxes2DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         half_sizes: datatypes.Vec2DArrayLike | None = None,
         centers: datatypes.Vec2DArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -88,7 +88,7 @@ class Boxes2D(Boxes2DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         half_sizes:
             All half-extents that make up the batch of boxes.
@@ -131,7 +131,7 @@ class Boxes2D(Boxes2DExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -141,20 +141,9 @@ class Boxes2D(Boxes2DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Boxes2D:
+    def cleared(cls) -> Boxes2D:
         """Clear all the fields of a `Boxes2D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            half_sizes=[],
-            centers=[],
-            colors=[],
-            radii=[],
-            labels=[],
-            show_labels=[],
-            draw_order=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -90,10 +90,10 @@ class Boxes3D(Boxes3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         half_sizes: datatypes.Vec3DArrayLike | None = None,
         centers: datatypes.Vec3DArrayLike | None = None,
         rotation_axis_angles: datatypes.RotationAxisAngleArrayLike | None = None,
@@ -110,7 +110,7 @@ class Boxes3D(Boxes3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         half_sizes:
             All half-extents that make up the batch of boxes.
@@ -164,7 +164,7 @@ class Boxes3D(Boxes3DExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -174,22 +174,9 @@ class Boxes3D(Boxes3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Boxes3D:
+    def cleared(cls) -> Boxes3D:
         """Clear all the fields of a `Boxes3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            half_sizes=[],
-            centers=[],
-            rotation_axis_angles=[],
-            quaternions=[],
-            colors=[],
-            radii=[],
-            fill_mode=[],
-            labels=[],
-            show_labels=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
@@ -103,10 +103,10 @@ class Capsules3D(Capsules3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         lengths: datatypes.Float32ArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
         translations: datatypes.Vec3DArrayLike | None = None,
@@ -122,7 +122,7 @@ class Capsules3D(Capsules3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         lengths:
             Lengths of the capsules, defined as the distance between the centers of the endcaps.
@@ -170,7 +170,7 @@ class Capsules3D(Capsules3DExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -180,21 +180,9 @@ class Capsules3D(Capsules3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Capsules3D:
+    def cleared(cls) -> Capsules3D:
         """Clear all the fields of a `Capsules3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            lengths=[],
-            radii=[],
-            translations=[],
-            rotation_axis_angles=[],
-            quaternions=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -83,10 +83,10 @@ class Clear(ClearExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         is_recursive: datatypes.BoolLike | None = None,
     ) -> Clear:
         """Update only some specific fields of a `Clear`."""
@@ -97,7 +97,7 @@ class Clear(ClearExt, Archetype):
                 "is_recursive": is_recursive,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -107,13 +107,9 @@ class Clear(ClearExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Clear:
+    def cleared(cls) -> Clear:
         """Clear all the fields of a `Clear`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            is_recursive=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -87,10 +87,10 @@ class DepthImage(DepthImageExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         buffer: datatypes.BlobLike | None = None,
         format: datatypes.ImageFormatLike | None = None,
         meter: datatypes.Float32Like | None = None,
@@ -104,7 +104,7 @@ class DepthImage(DepthImageExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         buffer:
             The raw depth image data.
@@ -161,7 +161,7 @@ class DepthImage(DepthImageExt, Archetype):
                 "draw_order": draw_order,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -171,19 +171,9 @@ class DepthImage(DepthImageExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> DepthImage:
+    def cleared(cls) -> DepthImage:
         """Clear all the fields of a `DepthImage`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            buffer=[],
-            format=[],
-            meter=[],
-            colormap=[],
-            depth_range=[],
-            point_fill_ratio=[],
-            draw_order=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
@@ -93,10 +93,10 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         half_sizes: datatypes.Vec3DArrayLike | None = None,
         centers: datatypes.Vec3DArrayLike | None = None,
         rotation_axis_angles: datatypes.RotationAxisAngleArrayLike | None = None,
@@ -113,7 +113,7 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         half_sizes:
             For each ellipsoid, half of its size on its three axes.
@@ -166,7 +166,7 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -176,22 +176,9 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Ellipsoids3D:
+    def cleared(cls) -> Ellipsoids3D:
         """Clear all the fields of a `Ellipsoids3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            half_sizes=[],
-            centers=[],
-            rotation_axis_angles=[],
-            quaternions=[],
-            colors=[],
-            line_radii=[],
-            fill_mode=[],
-            labels=[],
-            show_labels=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
@@ -66,10 +66,10 @@ class EncodedImage(EncodedImageExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         blob: datatypes.BlobLike | None = None,
         media_type: datatypes.Utf8Like | None = None,
         opacity: datatypes.Float32Like | None = None,
@@ -80,7 +80,7 @@ class EncodedImage(EncodedImageExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         blob:
             The encoded content of some image file, e.g. a PNG or JPEG.
@@ -113,7 +113,7 @@ class EncodedImage(EncodedImageExt, Archetype):
                 "draw_order": draw_order,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -123,16 +123,9 @@ class EncodedImage(EncodedImageExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> EncodedImage:
+    def cleared(cls) -> EncodedImage:
         """Clear all the fields of a `EncodedImage`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            blob=[],
-            media_type=[],
-            opacity=[],
-            draw_order=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -80,10 +80,10 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         line_strings: components.GeoLineStringArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -93,7 +93,7 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         line_strings:
             The line strings, expressed in [EPSG:4326](https://epsg.io/4326) coordinates (North/East-positive degrees).
@@ -118,7 +118,7 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
                 "colors": colors,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -128,15 +128,9 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> GeoLineStrings:
+    def cleared(cls) -> GeoLineStrings:
         """Clear all the fields of a `GeoLineStrings`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            line_strings=[],
-            radii=[],
-            colors=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
@@ -73,10 +73,10 @@ class GeoPoints(GeoPointsExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         positions: datatypes.DVec2DArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -87,7 +87,7 @@ class GeoPoints(GeoPointsExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         positions:
             The [EPSG:4326](https://epsg.io/4326) coordinates for the points (North/East-positive degrees).
@@ -116,7 +116,7 @@ class GeoPoints(GeoPointsExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -126,16 +126,9 @@ class GeoPoints(GeoPointsExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> GeoPoints:
+    def cleared(cls) -> GeoPoints:
         """Clear all the fields of a `GeoPoints`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            positions=[],
-            radii=[],
-            colors=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
@@ -92,10 +92,10 @@ class GraphEdges(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         edges: datatypes.Utf8PairArrayLike | None = None,
         graph_type: components.GraphTypeLike | None = None,
     ) -> GraphEdges:
@@ -104,7 +104,7 @@ class GraphEdges(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         edges:
             A list of node tuples.
@@ -122,7 +122,7 @@ class GraphEdges(Archetype):
                 "graph_type": graph_type,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -132,14 +132,9 @@ class GraphEdges(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> GraphEdges:
+    def cleared(cls) -> GraphEdges:
         """Clear all the fields of a `GraphEdges`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            edges=[],
-            graph_type=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
@@ -116,10 +116,10 @@ class GraphNodes(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         node_ids: datatypes.Utf8ArrayLike | None = None,
         positions: datatypes.Vec2DArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -132,7 +132,7 @@ class GraphNodes(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         node_ids:
             A list of node IDs.
@@ -160,7 +160,7 @@ class GraphNodes(Archetype):
                 "radii": radii,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -170,18 +170,9 @@ class GraphNodes(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> GraphNodes:
+    def cleared(cls) -> GraphNodes:
         """Clear all the fields of a `GraphNodes`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            node_ids=[],
-            positions=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            radii=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -110,10 +110,10 @@ class Image(ImageExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         buffer: datatypes.BlobLike | None = None,
         format: datatypes.ImageFormatLike | None = None,
         opacity: datatypes.Float32Like | None = None,
@@ -124,7 +124,7 @@ class Image(ImageExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         buffer:
             The raw image data.
@@ -150,7 +150,7 @@ class Image(ImageExt, Archetype):
                 "draw_order": draw_order,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -160,16 +160,9 @@ class Image(ImageExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Image:
+    def cleared(cls) -> Image:
         """Clear all the fields of a `Image`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            buffer=[],
-            format=[],
-            opacity=[],
-            draw_order=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -132,10 +132,10 @@ class InstancePoses3D(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         translations: datatypes.Vec3DArrayLike | None = None,
         rotation_axis_angles: datatypes.RotationAxisAngleArrayLike | None = None,
         quaternions: datatypes.QuaternionArrayLike | None = None,
@@ -147,7 +147,7 @@ class InstancePoses3D(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         translations:
             Translation vectors.
@@ -172,7 +172,7 @@ class InstancePoses3D(Archetype):
                 "mat3x3": mat3x3,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -182,17 +182,9 @@ class InstancePoses3D(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> InstancePoses3D:
+    def cleared(cls) -> InstancePoses3D:
         """Clear all the fields of a `InstancePoses3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            translations=[],
-            rotation_axis_angles=[],
-            quaternions=[],
-            scales=[],
-            mat3x3=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -174,10 +174,10 @@ class LineStrips2D(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         strips: components.LineStrip2DArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -191,7 +191,7 @@ class LineStrips2D(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         strips:
             All the actual 2D line strips that make up the batch.
@@ -229,7 +229,7 @@ class LineStrips2D(Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -239,19 +239,9 @@ class LineStrips2D(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> LineStrips2D:
+    def cleared(cls) -> LineStrips2D:
         """Clear all the fields of a `LineStrips2D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            strips=[],
-            radii=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            draw_order=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -177,10 +177,10 @@ class LineStrips3D(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         strips: components.LineStrip3DArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -193,7 +193,7 @@ class LineStrips3D(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         strips:
             All the actual 3D line strips that make up the batch.
@@ -226,7 +226,7 @@ class LineStrips3D(Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -236,18 +236,9 @@ class LineStrips3D(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> LineStrips3D:
+    def cleared(cls) -> LineStrips3D:
         """Clear all the fields of a `LineStrips3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            strips=[],
-            radii=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -125,10 +125,10 @@ class Mesh3D(Mesh3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         vertex_positions: datatypes.Vec3DArrayLike | None = None,
         triangle_indices: datatypes.UVec3DArrayLike | None = None,
         vertex_normals: datatypes.Vec3DArrayLike | None = None,
@@ -144,7 +144,7 @@ class Mesh3D(Mesh3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         vertex_positions:
             The positions of each vertex.
@@ -190,7 +190,7 @@ class Mesh3D(Mesh3DExt, Archetype):
                 "class_ids": class_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -200,21 +200,9 @@ class Mesh3D(Mesh3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Mesh3D:
+    def cleared(cls) -> Mesh3D:
         """Clear all the fields of a `Mesh3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            vertex_positions=[],
-            triangle_indices=[],
-            vertex_normals=[],
-            vertex_colors=[],
-            vertex_texcoords=[],
-            albedo_factor=[],
-            albedo_texture_buffer=[],
-            albedo_texture_format=[],
-            class_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -93,10 +93,10 @@ class Pinhole(PinholeExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         image_from_camera: datatypes.Mat3x3Like | None = None,
         resolution: datatypes.Vec2DLike | None = None,
         camera_xyz: datatypes.ViewCoordinatesLike | None = None,
@@ -107,7 +107,7 @@ class Pinhole(PinholeExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         image_from_camera:
             Camera projection, from image coordinates to view coordinates.
@@ -164,7 +164,7 @@ class Pinhole(PinholeExt, Archetype):
                 "image_plane_distance": image_plane_distance,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -174,16 +174,9 @@ class Pinhole(PinholeExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Pinhole:
+    def cleared(cls) -> Pinhole:
         """Clear all the fields of a `Pinhole`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            image_from_camera=[],
-            resolution=[],
-            camera_xyz=[],
-            image_plane_distance=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -124,10 +124,10 @@ class Points2D(Points2DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         positions: datatypes.Vec2DArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -142,7 +142,7 @@ class Points2D(Points2DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         positions:
             All the 2D positions at which the point cloud shows points.
@@ -193,7 +193,7 @@ class Points2D(Points2DExt, Archetype):
                 "keypoint_ids": keypoint_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -203,20 +203,9 @@ class Points2D(Points2DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Points2D:
+    def cleared(cls) -> Points2D:
         """Clear all the fields of a `Points2D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            positions=[],
-            radii=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            draw_order=[],
-            class_ids=[],
-            keypoint_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -159,10 +159,10 @@ class Points3D(Points3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         positions: datatypes.Vec3DArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
@@ -176,7 +176,7 @@ class Points3D(Points3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         positions:
             All the 3D positions at which the point cloud shows points.
@@ -222,7 +222,7 @@ class Points3D(Points3DExt, Archetype):
                 "keypoint_ids": keypoint_ids,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -232,19 +232,9 @@ class Points3D(Points3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Points3D:
+    def cleared(cls) -> Points3D:
         """Clear all the fields of a `Points3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            positions=[],
-            radii=[],
-            colors=[],
-            labels=[],
-            show_labels=[],
-            class_ids=[],
-            keypoint_ids=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -120,10 +120,10 @@ class Scalar(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         scalar: datatypes.Float64Like | None = None,
     ) -> Scalar:
         """
@@ -131,7 +131,7 @@ class Scalar(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         scalar:
             The scalar value to log.
@@ -144,7 +144,7 @@ class Scalar(Archetype):
                 "scalar": scalar,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -154,13 +154,9 @@ class Scalar(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Scalar:
+    def cleared(cls) -> Scalar:
         """Clear all the fields of a `Scalar`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            scalar=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -82,10 +82,10 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         buffer: datatypes.BlobLike | None = None,
         format: datatypes.ImageFormatLike | None = None,
         opacity: datatypes.Float32Like | None = None,
@@ -96,7 +96,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         buffer:
             The raw image data.
@@ -122,7 +122,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
                 "draw_order": draw_order,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -132,16 +132,9 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> SegmentationImage:
+    def cleared(cls) -> SegmentationImage:
         """Clear all the fields of a `SegmentationImage`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            buffer=[],
-            format=[],
-            opacity=[],
-            draw_order=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -118,10 +118,10 @@ class SeriesLine(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         color: datatypes.Rgba32Like | None = None,
         width: datatypes.Float32Like | None = None,
         name: datatypes.Utf8Like | None = None,
@@ -132,7 +132,7 @@ class SeriesLine(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         color:
             Color for the corresponding series.
@@ -160,7 +160,7 @@ class SeriesLine(Archetype):
                 "aggregation_policy": aggregation_policy,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -170,16 +170,9 @@ class SeriesLine(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> SeriesLine:
+    def cleared(cls) -> SeriesLine:
         """Clear all the fields of a `SeriesLine`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            color=[],
-            width=[],
-            name=[],
-            aggregation_policy=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -132,10 +132,10 @@ class SeriesPoint(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         color: datatypes.Rgba32Like | None = None,
         marker: components.MarkerShapeLike | None = None,
         name: datatypes.Utf8Like | None = None,
@@ -146,7 +146,7 @@ class SeriesPoint(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         color:
             Color for the corresponding series.
@@ -170,7 +170,7 @@ class SeriesPoint(Archetype):
                 "marker_size": marker_size,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -180,16 +180,9 @@ class SeriesPoint(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> SeriesPoint:
+    def cleared(cls) -> SeriesPoint:
         """Clear all the fields of a `SeriesPoint`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            color=[],
-            marker=[],
-            name=[],
-            marker_size=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -72,10 +72,10 @@ class Tensor(TensorExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         data: datatypes.TensorDataLike | None = None,
         value_range: datatypes.Range1DLike | None = None,
     ) -> Tensor:
@@ -84,7 +84,7 @@ class Tensor(TensorExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         data:
             The tensor data
@@ -110,7 +110,7 @@ class Tensor(TensorExt, Archetype):
                 "value_range": value_range,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -120,14 +120,9 @@ class Tensor(TensorExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Tensor:
+    def cleared(cls) -> Tensor:
         """Clear all the fields of a `Tensor`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            data=[],
-            value_range=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -132,10 +132,10 @@ class TextDocument(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         text: datatypes.Utf8Like | None = None,
         media_type: datatypes.Utf8Like | None = None,
     ) -> TextDocument:
@@ -144,7 +144,7 @@ class TextDocument(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         text:
             Contents of the text document.
@@ -166,7 +166,7 @@ class TextDocument(Archetype):
                 "media_type": media_type,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -176,14 +176,9 @@ class TextDocument(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> TextDocument:
+    def cleared(cls) -> TextDocument:
         """Clear all the fields of a `TextDocument`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            text=[],
-            media_type=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -101,10 +101,10 @@ class TextLog(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         text: datatypes.Utf8Like | None = None,
         level: datatypes.Utf8Like | None = None,
         color: datatypes.Rgba32Like | None = None,
@@ -114,7 +114,7 @@ class TextLog(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         text:
             The body of the message.
@@ -135,7 +135,7 @@ class TextLog(Archetype):
                 "color": color,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -145,15 +145,9 @@ class TextLog(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> TextLog:
+    def cleared(cls) -> TextLog:
         """Clear all the fields of a `TextLog`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            text=[],
-            level=[],
-            color=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -161,10 +161,10 @@ class Transform3D(Transform3DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         translation: datatypes.Vec3DLike | None = None,
         rotation_axis_angle: datatypes.RotationAxisAngleLike | None = None,
         quaternion: datatypes.QuaternionLike | None = None,
@@ -178,7 +178,7 @@ class Transform3D(Transform3DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         translation:
             Translation vector.
@@ -212,7 +212,7 @@ class Transform3D(Transform3DExt, Archetype):
                 "axis_length": axis_length,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -222,19 +222,9 @@ class Transform3D(Transform3DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Transform3D:
+    def cleared(cls) -> Transform3D:
         """Clear all the fields of a `Transform3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            translation=[],
-            rotation_axis_angle=[],
-            quaternion=[],
-            scale=[],
-            mat3x3=[],
-            relation=[],
-            axis_length=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -129,10 +129,10 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         timestamp: datatypes.VideoTimestampLike | None = None,
         video_reference: datatypes.EntityPathLike | None = None,
     ) -> VideoFrameReference:
@@ -141,7 +141,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         timestamp:
             References the closest video frame to this timestamp.
@@ -172,7 +172,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
                 "video_reference": video_reference,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -182,14 +182,9 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> VideoFrameReference:
+    def cleared(cls) -> VideoFrameReference:
         """Clear all the fields of a `VideoFrameReference`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            timestamp=[],
-            video_reference=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -98,10 +98,10 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         xyz: datatypes.ViewCoordinatesLike | None = None,
     ) -> ViewCoordinates:
         """
@@ -109,7 +109,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         xyz:
             The directions of the [x, y, z] axes.
@@ -122,7 +122,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
                 "xyz": xyz,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -132,13 +132,9 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ViewCoordinates:
+    def cleared(cls) -> ViewCoordinates:
         """Clear all the fields of a `ViewCoordinates`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            xyz=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/background.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/background.py
@@ -39,10 +39,10 @@ class Background(BackgroundExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         kind: blueprint_components.BackgroundKindLike | None = None,
         color: datatypes.Rgba32Like | None = None,
     ) -> Background:
@@ -51,7 +51,7 @@ class Background(BackgroundExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         kind:
             The type of the background.
@@ -67,7 +67,7 @@ class Background(BackgroundExt, Archetype):
                 "color": color,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -77,14 +77,9 @@ class Background(BackgroundExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> Background:
+    def cleared(cls) -> Background:
         """Clear all the fields of a `Background`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            kind=[],
-            color=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     kind: blueprint_components.BackgroundKindBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
@@ -111,10 +111,10 @@ class ContainerBlueprint(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         container_kind: blueprint_components.ContainerKindLike | None = None,
         display_name: datatypes.Utf8Like | None = None,
         contents: datatypes.EntityPathArrayLike | None = None,
@@ -129,7 +129,7 @@ class ContainerBlueprint(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         container_kind:
             The class of the view.
@@ -179,7 +179,7 @@ class ContainerBlueprint(Archetype):
                 "grid_columns": grid_columns,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -189,20 +189,9 @@ class ContainerBlueprint(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ContainerBlueprint:
+    def cleared(cls) -> ContainerBlueprint:
         """Clear all the fields of a `ContainerBlueprint`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            container_kind=[],
-            display_name=[],
-            contents=[],
-            col_shares=[],
-            row_shares=[],
-            active_tab=[],
-            visible=[],
-            grid_columns=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     container_kind: blueprint_components.ContainerKindBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/dataframe_query.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/dataframe_query.py
@@ -42,10 +42,10 @@ class DataframeQuery(DataframeQueryExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         timeline: datatypes.Utf8Like | None = None,
         filter_by_range: blueprint_datatypes.FilterByRangeLike | None = None,
         filter_is_not_null: blueprint_datatypes.FilterIsNotNullLike | None = None,
@@ -57,7 +57,7 @@ class DataframeQuery(DataframeQueryExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         timeline:
             The timeline for this query.
@@ -86,7 +86,7 @@ class DataframeQuery(DataframeQueryExt, Archetype):
                 "select": select,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -96,17 +96,9 @@ class DataframeQuery(DataframeQueryExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> DataframeQuery:
+    def cleared(cls) -> DataframeQuery:
         """Clear all the fields of a `DataframeQuery`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            timeline=[],
-            filter_by_range=[],
-            filter_is_not_null=[],
-            apply_latest_at=[],
-            select=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     timeline: blueprint_components.TimelineNameBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_center.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_center.py
@@ -61,10 +61,10 @@ class ForceCenter(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         enabled: datatypes.BoolLike | None = None,
         strength: datatypes.Float64Like | None = None,
     ) -> ForceCenter:
@@ -73,7 +73,7 @@ class ForceCenter(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         enabled:
             Whether the center force is enabled.
@@ -91,7 +91,7 @@ class ForceCenter(Archetype):
                 "strength": strength,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -101,14 +101,9 @@ class ForceCenter(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ForceCenter:
+    def cleared(cls) -> ForceCenter:
         """Clear all the fields of a `ForceCenter`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            enabled=[],
-            strength=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     enabled: blueprint_components.EnabledBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_collision_radius.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_collision_radius.py
@@ -70,10 +70,10 @@ class ForceCollisionRadius(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         enabled: datatypes.BoolLike | None = None,
         strength: datatypes.Float64Like | None = None,
         iterations: datatypes.UInt64Like | None = None,
@@ -83,7 +83,7 @@ class ForceCollisionRadius(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         enabled:
             Whether the collision force is enabled.
@@ -106,7 +106,7 @@ class ForceCollisionRadius(Archetype):
                 "iterations": iterations,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -116,15 +116,9 @@ class ForceCollisionRadius(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ForceCollisionRadius:
+    def cleared(cls) -> ForceCollisionRadius:
         """Clear all the fields of a `ForceCollisionRadius`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            enabled=[],
-            strength=[],
-            iterations=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     enabled: blueprint_components.EnabledBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_link.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_link.py
@@ -70,10 +70,10 @@ class ForceLink(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         enabled: datatypes.BoolLike | None = None,
         distance: datatypes.Float64Like | None = None,
         iterations: datatypes.UInt64Like | None = None,
@@ -83,7 +83,7 @@ class ForceLink(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         enabled:
             Whether the link force is enabled.
@@ -106,7 +106,7 @@ class ForceLink(Archetype):
                 "iterations": iterations,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -116,15 +116,9 @@ class ForceLink(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ForceLink:
+    def cleared(cls) -> ForceLink:
         """Clear all the fields of a `ForceLink`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            enabled=[],
-            distance=[],
-            iterations=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     enabled: blueprint_components.EnabledBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_many_body.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_many_body.py
@@ -68,10 +68,10 @@ class ForceManyBody(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         enabled: datatypes.BoolLike | None = None,
         strength: datatypes.Float64Like | None = None,
     ) -> ForceManyBody:
@@ -80,7 +80,7 @@ class ForceManyBody(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         enabled:
             Whether the many body force is enabled.
@@ -101,7 +101,7 @@ class ForceManyBody(Archetype):
                 "strength": strength,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -111,14 +111,9 @@ class ForceManyBody(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ForceManyBody:
+    def cleared(cls) -> ForceManyBody:
         """Clear all the fields of a `ForceManyBody`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            enabled=[],
-            strength=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     enabled: blueprint_components.EnabledBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_position.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/force_position.py
@@ -68,10 +68,10 @@ class ForcePosition(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         enabled: datatypes.BoolLike | None = None,
         strength: datatypes.Float64Like | None = None,
         position: datatypes.Vec2DLike | None = None,
@@ -81,7 +81,7 @@ class ForcePosition(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         enabled:
             Whether the position force is enabled.
@@ -102,7 +102,7 @@ class ForcePosition(Archetype):
                 "position": position,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -112,15 +112,9 @@ class ForcePosition(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ForcePosition:
+    def cleared(cls) -> ForcePosition:
         """Clear all the fields of a `ForcePosition`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            enabled=[],
-            strength=[],
-            position=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     enabled: blueprint_components.EnabledBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/line_grid3d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/line_grid3d.py
@@ -86,10 +86,10 @@ class LineGrid3D(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         visible: datatypes.BoolLike | None = None,
         spacing: datatypes.Float32Like | None = None,
         plane: datatypes.Plane3DLike | None = None,
@@ -101,7 +101,7 @@ class LineGrid3D(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         visible:
             Whether the grid is visible.
@@ -138,7 +138,7 @@ class LineGrid3D(Archetype):
                 "color": color,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -148,17 +148,9 @@ class LineGrid3D(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> LineGrid3D:
+    def cleared(cls) -> LineGrid3D:
         """Clear all the fields of a `LineGrid3D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            visible=[],
-            spacing=[],
-            plane=[],
-            stroke_width=[],
-            color=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     visible: blueprint_components.VisibleBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/map_background.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/map_background.py
@@ -55,10 +55,10 @@ class MapBackground(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         provider: blueprint_components.MapProviderLike | None = None,
     ) -> MapBackground:
         """
@@ -66,7 +66,7 @@ class MapBackground(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         provider:
             Map provider and style to use.
@@ -81,7 +81,7 @@ class MapBackground(Archetype):
                 "provider": provider,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -91,13 +91,9 @@ class MapBackground(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> MapBackground:
+    def cleared(cls) -> MapBackground:
         """Clear all the fields of a `MapBackground`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            provider=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     provider: blueprint_components.MapProviderBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/map_zoom.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/map_zoom.py
@@ -56,10 +56,10 @@ class MapZoom(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         zoom: datatypes.Float64Like | None = None,
     ) -> MapZoom:
         """
@@ -67,7 +67,7 @@ class MapZoom(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         zoom:
             Zoom level for the map.
@@ -82,7 +82,7 @@ class MapZoom(Archetype):
                 "zoom": zoom,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -92,13 +92,9 @@ class MapZoom(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> MapZoom:
+    def cleared(cls) -> MapZoom:
         """Clear all the fields of a `MapZoom`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            zoom=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     zoom: blueprint_components.ZoomLevelBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/near_clip_plane.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/near_clip_plane.py
@@ -56,10 +56,10 @@ class NearClipPlane(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         near_clip_plane: datatypes.Float32Like | None = None,
     ) -> NearClipPlane:
         """
@@ -67,7 +67,7 @@ class NearClipPlane(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         near_clip_plane:
             Controls the distance to the near clip plane in 3D scene units.
@@ -82,7 +82,7 @@ class NearClipPlane(Archetype):
                 "near_clip_plane": near_clip_plane,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -92,13 +92,9 @@ class NearClipPlane(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> NearClipPlane:
+    def cleared(cls) -> NearClipPlane:
         """Clear all the fields of a `NearClipPlane`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            near_clip_plane=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     near_clip_plane: blueprint_components.NearClipPlaneBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/panel_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/panel_blueprint.py
@@ -53,10 +53,10 @@ class PanelBlueprint(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         state: blueprint_components.PanelStateLike | None = None,
     ) -> PanelBlueprint:
         """
@@ -64,7 +64,7 @@ class PanelBlueprint(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         state:
             Current state of the panels.
@@ -77,7 +77,7 @@ class PanelBlueprint(Archetype):
                 "state": state,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -87,13 +87,9 @@ class PanelBlueprint(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> PanelBlueprint:
+    def cleared(cls) -> PanelBlueprint:
         """Clear all the fields of a `PanelBlueprint`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            state=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     state: blueprint_components.PanelStateBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
@@ -39,10 +39,10 @@ class PlotLegend(PlotLegendExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         corner: blueprint_components.Corner2DLike | None = None,
         visible: datatypes.BoolLike | None = None,
     ) -> PlotLegend:
@@ -51,7 +51,7 @@ class PlotLegend(PlotLegendExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         corner:
             To what corner the legend is aligned.
@@ -71,7 +71,7 @@ class PlotLegend(PlotLegendExt, Archetype):
                 "visible": visible,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -81,14 +81,9 @@ class PlotLegend(PlotLegendExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> PlotLegend:
+    def cleared(cls) -> PlotLegend:
         """Clear all the fields of a `PlotLegend`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            corner=[],
-            visible=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     corner: blueprint_components.Corner2DBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
@@ -59,10 +59,10 @@ class ScalarAxis(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         range: datatypes.Range1DLike | None = None,
         zoom_lock: datatypes.BoolLike | None = None,
     ) -> ScalarAxis:
@@ -71,7 +71,7 @@ class ScalarAxis(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         range:
             The range of the axis.
@@ -89,7 +89,7 @@ class ScalarAxis(Archetype):
                 "zoom_lock": zoom_lock,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -99,14 +99,9 @@ class ScalarAxis(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ScalarAxis:
+    def cleared(cls) -> ScalarAxis:
         """Clear all the fields of a `ScalarAxis`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            range=[],
-            zoom_lock=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     range: components.Range1DBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/tensor_scalar_mapping.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/tensor_scalar_mapping.py
@@ -73,10 +73,10 @@ class TensorScalarMapping(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         mag_filter: components.MagnificationFilterLike | None = None,
         colormap: components.ColormapLike | None = None,
         gamma: datatypes.Float32Like | None = None,
@@ -86,7 +86,7 @@ class TensorScalarMapping(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         mag_filter:
             Filter used when zooming in on the tensor.
@@ -113,7 +113,7 @@ class TensorScalarMapping(Archetype):
                 "gamma": gamma,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -123,15 +123,9 @@ class TensorScalarMapping(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> TensorScalarMapping:
+    def cleared(cls) -> TensorScalarMapping:
         """Clear all the fields of a `TensorScalarMapping`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            mag_filter=[],
-            colormap=[],
-            gamma=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     mag_filter: components.MagnificationFilterBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/tensor_slice_selection.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/tensor_slice_selection.py
@@ -80,10 +80,10 @@ class TensorSliceSelection(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         width: datatypes.TensorDimensionSelectionLike | None = None,
         height: datatypes.TensorDimensionSelectionLike | None = None,
         indices: datatypes.TensorDimensionIndexSelectionArrayLike | None = None,
@@ -94,7 +94,7 @@ class TensorSliceSelection(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         width:
             Which dimension to map to width.
@@ -126,7 +126,7 @@ class TensorSliceSelection(Archetype):
                 "slider": slider,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -136,16 +136,9 @@ class TensorSliceSelection(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> TensorSliceSelection:
+    def cleared(cls) -> TensorSliceSelection:
         """Clear all the fields of a `TensorSliceSelection`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            width=[],
-            height=[],
-            indices=[],
-            slider=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     width: components.TensorWidthDimensionBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/tensor_view_fit.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/tensor_view_fit.py
@@ -37,10 +37,10 @@ class TensorViewFit(TensorViewFitExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         scaling: blueprint_components.ViewFitLike | None = None,
     ) -> TensorViewFit:
         """
@@ -48,7 +48,7 @@ class TensorViewFit(TensorViewFitExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         scaling:
             How the image is scaled to fit the view.
@@ -61,7 +61,7 @@ class TensorViewFit(TensorViewFitExt, Archetype):
                 "scaling": scaling,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -71,13 +71,9 @@ class TensorViewFit(TensorViewFitExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> TensorViewFit:
+    def cleared(cls) -> TensorViewFit:
         """Clear all the fields of a `TensorViewFit`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            scaling=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     scaling: blueprint_components.ViewFitBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/view_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/view_blueprint.py
@@ -80,10 +80,10 @@ class ViewBlueprint(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         class_identifier: datatypes.Utf8Like | None = None,
         display_name: datatypes.Utf8Like | None = None,
         space_origin: datatypes.EntityPathLike | None = None,
@@ -94,7 +94,7 @@ class ViewBlueprint(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         class_identifier:
             The class of the view.
@@ -124,7 +124,7 @@ class ViewBlueprint(Archetype):
                 "visible": visible,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -134,16 +134,9 @@ class ViewBlueprint(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ViewBlueprint:
+    def cleared(cls) -> ViewBlueprint:
         """Clear all the fields of a `ViewBlueprint`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            class_identifier=[],
-            display_name=[],
-            space_origin=[],
-            visible=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     class_identifier: blueprint_components.ViewClassBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/view_contents.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/view_contents.py
@@ -95,10 +95,10 @@ class ViewContents(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         query: datatypes.Utf8ArrayLike | None = None,
     ) -> ViewContents:
         """
@@ -106,7 +106,7 @@ class ViewContents(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         query:
             The `QueryExpression` that populates the contents for the view.
@@ -121,7 +121,7 @@ class ViewContents(Archetype):
                 "query": query,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -131,13 +131,9 @@ class ViewContents(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ViewContents:
+    def cleared(cls) -> ViewContents:
         """Clear all the fields of a `ViewContents`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            query=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     query: blueprint_components.QueryExpressionBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
@@ -92,10 +92,10 @@ class ViewportBlueprint(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         root_container: datatypes.UuidLike | None = None,
         maximized: datatypes.UuidLike | None = None,
         auto_layout: datatypes.BoolLike | None = None,
@@ -107,7 +107,7 @@ class ViewportBlueprint(Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         root_container:
             The layout of the views
@@ -144,7 +144,7 @@ class ViewportBlueprint(Archetype):
                 "past_viewer_recommendations": past_viewer_recommendations,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -154,17 +154,9 @@ class ViewportBlueprint(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> ViewportBlueprint:
+    def cleared(cls) -> ViewportBlueprint:
         """Clear all the fields of a `ViewportBlueprint`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            root_container=[],
-            maximized=[],
-            auto_layout=[],
-            auto_views=[],
-            past_viewer_recommendations=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     root_container: blueprint_components.RootContainerBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
@@ -48,10 +48,10 @@ class VisibleTimeRanges(VisibleTimeRangesExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         ranges: datatypes.VisibleTimeRangeArrayLike | None = None,
     ) -> VisibleTimeRanges:
         """
@@ -59,7 +59,7 @@ class VisibleTimeRanges(VisibleTimeRangesExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         ranges:
             The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
@@ -74,7 +74,7 @@ class VisibleTimeRanges(VisibleTimeRangesExt, Archetype):
                 "ranges": ranges,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -84,13 +84,9 @@ class VisibleTimeRanges(VisibleTimeRangesExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> VisibleTimeRanges:
+    def cleared(cls) -> VisibleTimeRanges:
         """Clear all the fields of a `VisibleTimeRanges`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            ranges=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     ranges: blueprint_components.VisibleTimeRangeBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visual_bounds2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visual_bounds2d.py
@@ -46,10 +46,10 @@ class VisualBounds2D(VisualBounds2DExt, Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         range: datatypes.Range2DLike | None = None,
     ) -> VisualBounds2D:
         """
@@ -57,7 +57,7 @@ class VisualBounds2D(VisualBounds2DExt, Archetype):
 
         Parameters
         ----------
-        clear:
+        clear_unset:
             If true, all unspecified fields will be explicitly cleared.
         range:
             Controls the visible range of a 2D view.
@@ -72,7 +72,7 @@ class VisualBounds2D(VisualBounds2DExt, Archetype):
                 "range": range,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -82,13 +82,9 @@ class VisualBounds2D(VisualBounds2DExt, Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> VisualBounds2D:
+    def cleared(cls) -> VisualBounds2D:
         """Clear all the fields of a `VisualBounds2D`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            range=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     range: blueprint_components.VisualBounds2DBatch | None = field(
         metadata={"component": True},

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -114,10 +114,10 @@ class AffixFuzzer1(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         fuzz1001: datatypes.AffixFuzzer1Like | None = None,
         fuzz1002: datatypes.AffixFuzzer1Like | None = None,
         fuzz1003: datatypes.AffixFuzzer1Like | None = None,
@@ -170,7 +170,7 @@ class AffixFuzzer1(Archetype):
                 "fuzz1022": fuzz1022,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -180,34 +180,9 @@ class AffixFuzzer1(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> AffixFuzzer1:
+    def cleared(cls) -> AffixFuzzer1:
         """Clear all the fields of a `AffixFuzzer1`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            fuzz1001=[],
-            fuzz1002=[],
-            fuzz1003=[],
-            fuzz1004=[],
-            fuzz1005=[],
-            fuzz1006=[],
-            fuzz1007=[],
-            fuzz1008=[],
-            fuzz1009=[],
-            fuzz1010=[],
-            fuzz1011=[],
-            fuzz1012=[],
-            fuzz1013=[],
-            fuzz1014=[],
-            fuzz1015=[],
-            fuzz1016=[],
-            fuzz1017=[],
-            fuzz1018=[],
-            fuzz1019=[],
-            fuzz1020=[],
-            fuzz1021=[],
-            fuzz1022=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -105,10 +105,10 @@ class AffixFuzzer2(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         fuzz1101: datatypes.AffixFuzzer1ArrayLike | None = None,
         fuzz1102: datatypes.AffixFuzzer1ArrayLike | None = None,
         fuzz1103: datatypes.AffixFuzzer1ArrayLike | None = None,
@@ -155,7 +155,7 @@ class AffixFuzzer2(Archetype):
                 "fuzz1122": fuzz1122,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -165,31 +165,9 @@ class AffixFuzzer2(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> AffixFuzzer2:
+    def cleared(cls) -> AffixFuzzer2:
         """Clear all the fields of a `AffixFuzzer2`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            fuzz1101=[],
-            fuzz1102=[],
-            fuzz1103=[],
-            fuzz1104=[],
-            fuzz1105=[],
-            fuzz1106=[],
-            fuzz1107=[],
-            fuzz1108=[],
-            fuzz1109=[],
-            fuzz1110=[],
-            fuzz1111=[],
-            fuzz1112=[],
-            fuzz1113=[],
-            fuzz1114=[],
-            fuzz1115=[],
-            fuzz1116=[],
-            fuzz1117=[],
-            fuzz1118=[],
-            fuzz1122=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -103,10 +103,10 @@ class AffixFuzzer3(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         fuzz2001: datatypes.AffixFuzzer1Like | None = None,
         fuzz2002: datatypes.AffixFuzzer1Like | None = None,
         fuzz2003: datatypes.AffixFuzzer1Like | None = None,
@@ -151,7 +151,7 @@ class AffixFuzzer3(Archetype):
                 "fuzz2018": fuzz2018,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -161,30 +161,9 @@ class AffixFuzzer3(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> AffixFuzzer3:
+    def cleared(cls) -> AffixFuzzer3:
         """Clear all the fields of a `AffixFuzzer3`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            fuzz2001=[],
-            fuzz2002=[],
-            fuzz2003=[],
-            fuzz2004=[],
-            fuzz2005=[],
-            fuzz2006=[],
-            fuzz2007=[],
-            fuzz2008=[],
-            fuzz2009=[],
-            fuzz2010=[],
-            fuzz2011=[],
-            fuzz2012=[],
-            fuzz2013=[],
-            fuzz2014=[],
-            fuzz2015=[],
-            fuzz2016=[],
-            fuzz2017=[],
-            fuzz2018=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -103,10 +103,10 @@ class AffixFuzzer4(Archetype):
         return inst
 
     @classmethod
-    def update_fields(
+    def from_fields(
         cls,
         *,
-        clear: bool = False,
+        clear_unset: bool = False,
         fuzz2101: datatypes.AffixFuzzer1ArrayLike | None = None,
         fuzz2102: datatypes.AffixFuzzer1ArrayLike | None = None,
         fuzz2103: datatypes.AffixFuzzer1ArrayLike | None = None,
@@ -151,7 +151,7 @@ class AffixFuzzer4(Archetype):
                 "fuzz2118": fuzz2118,
             }
 
-            if clear:
+            if clear_unset:
                 kwargs = {k: v if v is not None else [] for k, v in kwargs.items()}  # type: ignore[misc]
 
             inst.__attrs_init__(**kwargs)
@@ -161,30 +161,9 @@ class AffixFuzzer4(Archetype):
         return inst
 
     @classmethod
-    def clear_fields(cls) -> AffixFuzzer4:
+    def cleared(cls) -> AffixFuzzer4:
         """Clear all the fields of a `AffixFuzzer4`."""
-        inst = cls.__new__(cls)
-        inst.__attrs_init__(
-            fuzz2101=[],
-            fuzz2102=[],
-            fuzz2103=[],
-            fuzz2104=[],
-            fuzz2105=[],
-            fuzz2106=[],
-            fuzz2107=[],
-            fuzz2108=[],
-            fuzz2109=[],
-            fuzz2110=[],
-            fuzz2111=[],
-            fuzz2112=[],
-            fuzz2113=[],
-            fuzz2114=[],
-            fuzz2115=[],
-            fuzz2116=[],
-            fuzz2117=[],
-            fuzz2118=[],
-        )
-        return inst
+        return cls.from_fields(clear_unset=True)
 
     @classmethod
     def columns(


### PR DESCRIPTION
* `update_fields(clear: bool, ...)` -> `from_fields(clear_unset: bool, ...)`
* `clear_fields()` -> `cleared()`
* `cleared()` is not implemented by forwarding to `from_fields(clear_unset=True)`

This does not cover implementing the constructors in terms of `from_fields()`. If that happens at all, this will be in one or more follow-ups.

---

* Part of https://github.com/rerun-io/rerun/issues/8822