### PR TITLE
Fix python Windows unicode issues (maybe)

### DIFF
--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -117,7 +117,7 @@ jobs:
             name: "windows"
 
     # Note: we can't use `matrix.os` here because its evaluated before the matrix stuff.
-    # if: ${{ inputs.CHANNEL == 'main' || inputs.CHANNEL == 'nightly' }}
+    if: ${{ inputs.CHANNEL == 'main' || inputs.CHANNEL == 'nightly' }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -160,5 +160,5 @@ jobs:
         run: pixi run cargo test --all-targets --all-features
 
       - name: Rust all checks & tests
-        # if: ${{ inputs.CHANNEL == 'nightly' }}
+        if: ${{ inputs.CHANNEL == 'nightly' }}
         run: pixi run rs-check

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -117,7 +117,7 @@ jobs:
             name: "windows"
 
     # Note: we can't use `matrix.os` here because its evaluated before the matrix stuff.
-    if: ${{ inputs.CHANNEL == 'main' || inputs.CHANNEL == 'nightly' }}
+    # if: ${{ inputs.CHANNEL == 'main' || inputs.CHANNEL == 'nightly' }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -160,5 +160,5 @@ jobs:
         run: pixi run cargo test --all-targets --all-features
 
       - name: Rust all checks & tests
-        if: ${{ inputs.CHANNEL == 'nightly' }}
+        # if: ${{ inputs.CHANNEL == 'nightly' }}
         run: pixi run rs-check

--- a/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
+++ b/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
@@ -45,7 +45,7 @@ impl std::ops::Deref for IndicatedEntities {
 ///
 /// It gets invalidated whenever any properties of the respective view instance
 /// change, e.g. its origin.
-/// TODO(andreas): Unclear if any of the view's configuring blueprint entities are included in this!
+/// TODO(andreas): Unclear if any of the view's configuring blueprint entities are included in this.
 ///
 /// This is a subset of [`MaybeVisualizableEntities`] and may differs on a per view instance base!
 #[derive(Default, Clone, Debug)]

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -68,9 +68,9 @@ def run_cargo(cargo_cmd: str, cargo_args: str, clippy_conf: str | None = None) -
     success = result.returncode == 0
 
     if success:
-        print("✅")
+        print("✅".encode("utf-8"))
     else:
-        print("❌")
+        print("❌".encode("utf-8"))
         # Print output right away, so the user can start fixing it while waiting for the rest of the checks to run:
         env_var_string = " ".join([f'{env_var}="{value}"' for env_var, value in additional_env_vars.items()])
         print(

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -68,9 +68,9 @@ def run_cargo(cargo_cmd: str, cargo_args: str, clippy_conf: str | None = None) -
     success = result.returncode == 0
 
     if success:
-        print("✅".encode("utf-8"))
+        print("✅")
     else:
-        print("❌".encode("utf-8"))
+        print("❌")
         # Print output right away, so the user can start fixing it while waiting for the rest of the checks to run:
         env_var_string = " ".join([f'{env_var}="{value}"' for env_var, value in additional_env_vars.items()])
         print(
@@ -92,6 +92,9 @@ def package_name_from_cargo_toml(cargo_toml_path: str) -> str:
 
 
 def main() -> None:
+    # Ensure we can print unicode characters. Has been historically an issue on Windows CI.
+    sys.stdout.reconfigure(encoding='utf-8')
+
     checks = [
         ("base_checks", base_checks),
         ("sdk_variations", sdk_variations),

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -93,7 +93,7 @@ def package_name_from_cargo_toml(cargo_toml_path: str) -> str:
 
 def main() -> None:
     # Ensure we can print unicode characters. Has been historically an issue on Windows CI.
-    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stdout.reconfigure(encoding="utf-8")
 
     checks = [
         ("base_checks", base_checks),


### PR DESCRIPTION
Fixes nightly ci. Maybe. This works just fine on my machine and any unicode printing issue should have been fixed long ago, see https://peps.python.org/pep-0528/