### PR TITLE
Add hint for missing web viewer when building `re_web_viewer_server`

### DIFF
--- a/crates/viewer/re_web_viewer_server/build.rs
+++ b/crates/viewer/re_web_viewer_server/build.rs
@@ -1,4 +1,14 @@
+use std::path::Path;
+
 fn main() {
     // https://blog.rust-lang.org/2024/05/06/check-cfg.html
     println!("cargo::rustc-check-cfg=cfg(disable_web_viewer_server)");
+
+    let viewer_js_path = Path::new("./web_viewer/re_viewer.js");
+    let viewer_wasm_path = Path::new("./web_viewer/re_viewer_bg.wasm");
+
+    assert!(
+        viewer_js_path.exists() && viewer_wasm_path.exists(),
+        "Web viewer not found, run `pixi run rerun-build-web` to build it!"
+    );
 }


### PR DESCRIPTION
### What

Tell the user to build the web viewer when building `re_web_viewer_server`, and the required files do not exist.

Could perhaps use the `cargo::error=` directive, which is now respected in 1.84?

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
