### PR TITLE
Add `with_many_` variants for C++ archetype mono fields & port remaining snippets

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -609,11 +609,11 @@ impl QuotedObject {
             if !obj_field.typ.is_plural() && !is_blueprint_type(obj) {
                 let method_ident_many = format_ident!("with_many_{}", obj_field.name);
                 let docstring_many = unindent::unindent(&format!("\
-                This method makes it possible to pack multiple `{field_type} in a single component batch.
+                This method makes it possible to pack multiple `{}` in a single component batch.
 
                 This only makes sense when used in conjunction with `columns`. `{method_ident}` should
                 be used when logging a single row's worth of data.
-                "));
+                ", obj_field.name));
 
                 methods.push(Method {
                     docs: docstring_many.into(),

--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -43,7 +43,7 @@ However, it is still possible to do so with the `TensorData` component.
 
 Previously, `RecordingStream::send_column` accepted raw component collections.
 
-This is no longer the case and only `rerun::ComponentColumn` and anything else from from which
+This is no longer the case and only `rerun::ComponentColumn` and anything else from which
 a `Collection<ComponentColumn>` can be constructed is accepted.
 The preferred way to create `rerun::ComponentColumn`s is to use the new `columns` method on archetypes.
 
@@ -53,4 +53,4 @@ rec.send_columns("scalars", time_column,
     rerun::Scalar().with_many_scalar(scalar_data).columns()
 );
 ```
-All [example snippets](https://rerun.io/docs/snippets/all) have been updated accordingly.
+All [example snippets](https://github.com/rerun-io/rerun/blob/0.22.0/docs/snippets/INDEX.md?speculative-link) have been updated accordingly.

--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -38,3 +38,19 @@ Instead, there's now methods with the same name, i.e. `ViewCoordinates::RUB()`.
 As part of the switch to "eager archetype serialization" (serialization of archetype components now occurs at time of archetype instantiation rather than logging), we can no longer offer exposing the `Tensor` **archetype** as `ndarray::ArrayView` directly.
 
 However, it is still possible to do so with the `TensorData` component.
+
+### C++ `RecordingStream::send_column` no longer takes raw component collections
+
+Previously, `RecordingStream::send_column` accepted raw component collections.
+
+This is no longer the case and only `rerun::ComponentColumn` and anything else from from which
+a `Collection<ComponentColumn>` can be constructed is accepted.
+The preferred way to create `rerun::ComponentColumn`s is to use the new `columns` method on archetypes.
+
+For instance in order to send a column of scalars, you can now do this.
+```cpp
+rec.send_columns("scalars", time_column,
+    rerun::Scalar().with_many_scalar(scalar_data).columns()
+);
+```
+All [example snippets](https://rerun.io/docs/snippets/all) have been updated accordingly.

--- a/docs/snippets/all/archetypes/image_send_columns.cpp
+++ b/docs/snippets/all/archetypes/image_send_columns.cpp
@@ -45,6 +45,6 @@ int main() {
     rec.send_columns(
         "images",
         rerun::TimeColumn::from_sequence_points("step", std::move(times)),
-        rerun::borrow(image_data)
+        rerun::Image().with_many_buffer(std::move(image_data)).columns()
     );
 }

--- a/docs/snippets/all/archetypes/points3d_send_columns.cpp
+++ b/docs/snippets/all/archetypes/points3d_send_columns.cpp
@@ -30,10 +30,8 @@ int main() {
     auto time_column = rerun::TimeColumn::from_times("time", std::move(times));
 
     // Partition our data as expected across the 5 timesteps.
-    auto position =
-        rerun::Points3D::update_fields().with_positions(positions).columns({2, 4, 4, 3, 4});
-    auto color_and_radius =
-        rerun::Points3D::update_fields().with_colors(colors).with_radii(radii).columns();
+    auto position = rerun::Points3D().with_positions(positions).columns({2, 4, 4, 3, 4});
+    auto color_and_radius = rerun::Points3D().with_colors(colors).with_radii(radii).columns();
 
     rec.send_columns("points", time_column, position, color_and_radius);
 }

--- a/docs/snippets/all/archetypes/points3d_send_columns.cpp
+++ b/docs/snippets/all/archetypes/points3d_send_columns.cpp
@@ -35,5 +35,5 @@ int main() {
     auto color_and_radius =
         rerun::Points3D::update_fields().with_colors(colors).with_radii(radii).columns();
 
-    rec.send_columns2("points", time_column, position, color_and_radius);
+    rec.send_columns("points", time_column, position, color_and_radius);
 }

--- a/docs/snippets/all/archetypes/scalar_send_columns.cpp
+++ b/docs/snippets/all/archetypes/scalar_send_columns.cpp
@@ -19,7 +19,7 @@ int main() {
     std::iota(times.begin(), times.end(), 0);
 
     // Serialize to columns and send.
-    rec.send_columns2(
+    rec.send_columns(
         "scalars",
         rerun::TimeColumn::from_sequence_points("step", std::move(times)),
         rerun::Scalar().with_many_scalar(std::move(scalar_data)).columns()

--- a/docs/snippets/all/archetypes/scalar_send_columns.cpp
+++ b/docs/snippets/all/archetypes/scalar_send_columns.cpp
@@ -18,10 +18,10 @@ int main() {
     std::vector<int64_t> times(64);
     std::iota(times.begin(), times.end(), 0);
 
-    // Convert to rerun time / scalars
-    auto time_column = rerun::TimeColumn::from_sequence_points("step", std::move(times));
-    auto scalar_data_collection =
-        rerun::Collection<rerun::components::Scalar>(std::move(scalar_data));
-
-    rec.send_columns("scalars", time_column, scalar_data_collection);
+    // Serialize to columns and send.
+    rec.send_columns2(
+        "scalars",
+        rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+        rerun::Scalar().with_many_scalar(std::move(scalar_data)).columns()
+    );
 }

--- a/docs/snippets/all/archetypes/video_auto_frames.cpp
+++ b/docs/snippets/all/archetypes/video_auto_frames.cpp
@@ -42,9 +42,6 @@ int main(int argc, char* argv[]) {
     rec.send_columns(
         "video",
         time_column,
-        {
-            video_frame_reference_indicators.value_or_throw(),
-            rerun::ComponentColumn::from_loggable(rerun::borrow(video_timestamps)).value_or_throw(),
-        }
+        rerun::VideoFrameReference().with_many_timestamp(rerun::borrow(video_timestamps)).columns()
     );
 }

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -244,9 +244,6 @@ quick_start = [ # These examples don't have exactly the same implementation.
 "archetypes/scalar_multiple_plots" = [ # trigonometric functions have slightly different outcomes
   "cpp",
 ]
-"archetypes/scalar_send_columns" = [
-  "cpp", # TODO(#8754): needs tagged columnar APIs
-]
 "archetypes/tensor_simple" = [ # TODO(#3206): examples use different RNGs
   "cpp",
   "py",

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -108,6 +108,17 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AnnotationContext in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_context` should
+        /// be used when logging a single row's worth of data.
+        AnnotationContext with_many_context(
+            const Collection<rerun::components::AnnotationContext>& _context
+        ) && {
+            context = ComponentBatch::from_loggable(_context, Descriptor_context).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Partitions the component data into multiple sub-batches.
         ///
         /// Specifically, this transforms the existing `ComponentBatch` data into `ComponentColumn`s

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -108,7 +108,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AnnotationContext in a single component batch.
+        /// This method makes it possible to pack multiple `context` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_context` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
@@ -198,10 +198,32 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Arrows2D with_many_show_labels(const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         Arrows2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        Arrows2D with_many_draw_order(const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
@@ -198,7 +198,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.
@@ -218,7 +218,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -204,6 +204,17 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Arrows3D with_many_show_labels(const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional class Ids for the points.
         ///
         /// The `components::ClassId` provides colors and labels if not specified explicitly.

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -204,7 +204,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -148,6 +148,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Blob in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_blob` should
+        /// be used when logging a single row's worth of data.
+        Asset3D with_many_blob(const Collection<rerun::components::Blob>& _blob) && {
+            blob = ComponentBatch::from_loggable(_blob, Descriptor_blob).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The Media Type of the asset.
         ///
         /// Supported values:
@@ -164,11 +173,34 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
+        /// be used when logging a single row's worth of data.
+        Asset3D with_many_media_type(const Collection<rerun::components::MediaType>& _media_type
+        ) && {
+            media_type =
+                ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
+            return std::move(*this);
+        }
+
         /// A color multiplier applied to the whole asset.
         ///
         /// For mesh who already have `albedo_factor` in materials,
         /// it will be overwritten by actual `albedo_factor` of `archetypes::Asset3D` (if specified).
         Asset3D with_albedo_factor(const rerun::components::AlbedoFactor& _albedo_factor) && {
+            albedo_factor = ComponentBatch::from_loggable(_albedo_factor, Descriptor_albedo_factor)
+                                .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AlbedoFactor in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_albedo_factor` should
+        /// be used when logging a single row's worth of data.
+        Asset3D with_many_albedo_factor(
+            const Collection<rerun::components::AlbedoFactor>& _albedo_factor
+        ) && {
             albedo_factor = ComponentBatch::from_loggable(_albedo_factor, Descriptor_albedo_factor)
                                 .value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -148,7 +148,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Blob in a single component batch.
+        /// This method makes it possible to pack multiple `blob` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_blob` should
         /// be used when logging a single row's worth of data.
@@ -173,7 +173,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        /// This method makes it possible to pack multiple `media_type` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
         /// be used when logging a single row's worth of data.
@@ -194,7 +194,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AlbedoFactor in a single component batch.
+        /// This method makes it possible to pack multiple `albedo_factor` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_albedo_factor` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -75,10 +75,7 @@ namespace rerun::archetypes {
     ///     rec.send_columns(
     ///         "video",
     ///         time_column,
-    ///         {
-    ///             video_frame_reference_indicators.value_or_throw(),
-    ///             rerun::ComponentColumn::from_loggable(rerun::borrow(video_timestamps)).value_or_throw(),
-    ///         }
+    ///         rerun::VideoFrameReference().with_many_timestamp(rerun::borrow(video_timestamps)).columns()
     ///     );
     /// }
     /// ```

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -201,7 +201,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Blob in a single component batch.
+        /// This method makes it possible to pack multiple `blob` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_blob` should
         /// be used when logging a single row's worth of data.
@@ -223,7 +223,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        /// This method makes it possible to pack multiple `media_type` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -204,6 +204,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Blob in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_blob` should
+        /// be used when logging a single row's worth of data.
+        AssetVideo with_many_blob(const Collection<rerun::components::Blob>& _blob) && {
+            blob = ComponentBatch::from_loggable(_blob, Descriptor_blob).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The Media Type of the asset.
         ///
         /// Supported values:
@@ -212,6 +221,17 @@ namespace rerun::archetypes {
         /// If omitted, the viewer will try to guess from the data blob.
         /// If it cannot guess, it won't be able to render the asset.
         AssetVideo with_media_type(const rerun::components::MediaType& _media_type) && {
+            media_type =
+                ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
+        /// be used when logging a single row's worth of data.
+        AssetVideo with_many_media_type(const Collection<rerun::components::MediaType>& _media_type
+        ) && {
             media_type =
                 ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -204,8 +204,26 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: TensorData in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_values` should
+        /// be used when logging a single row's worth of data.
+        BarChart with_many_values(const Collection<rerun::components::TensorData>& _values) && {
+            values = ComponentBatch::from_loggable(_values, Descriptor_values).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The color of the bar chart
         BarChart with_color(const rerun::components::Color& _color) && {
+            color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_color` should
+        /// be used when logging a single row's worth of data.
+        BarChart with_many_color(const Collection<rerun::components::Color>& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
             return std::move(*this);
         }

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -204,7 +204,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: TensorData in a single component batch.
+        /// This method makes it possible to pack multiple `values` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_values` should
         /// be used when logging a single row's worth of data.
@@ -219,7 +219,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        /// This method makes it possible to pack multiple `color` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_color` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -220,7 +220,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.
@@ -242,7 +242,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -220,12 +220,34 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Boxes2D with_many_show_labels(const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         ///
         /// The default for 2D boxes is 10.0.
         Boxes2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        Boxes2D with_many_draw_order(const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -290,7 +290,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: FillMode in a single component batch.
+        /// This method makes it possible to pack multiple `fill_mode` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fill_mode` should
         /// be used when logging a single row's worth of data.
@@ -316,7 +316,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -290,6 +290,16 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: FillMode in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fill_mode` should
+        /// be used when logging a single row's worth of data.
+        Boxes3D with_many_fill_mode(const Collection<rerun::components::FillMode>& _fill_mode) && {
+            fill_mode =
+                ComponentBatch::from_loggable(_fill_mode, Descriptor_fill_mode).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional text labels for the boxes.
         ///
         /// If there's a single label present, it will be placed at the center of the entity.
@@ -301,6 +311,17 @@ namespace rerun::archetypes {
 
         /// Optional choice of whether the text labels should be shown by default.
         Boxes3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Boxes3D with_many_show_labels(const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
@@ -278,7 +278,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
@@ -278,6 +278,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Capsules3D with_many_show_labels(
+            const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional class ID for the ellipsoids.
         ///
         /// The class ID provides colors and labels if not specified explicitly.

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -135,6 +135,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ClearIsRecursive in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_is_recursive` should
+        /// be used when logging a single row's worth of data.
+        Clear with_many_is_recursive(
+            const Collection<rerun::components::ClearIsRecursive>& _is_recursive
+        ) && {
+            is_recursive = ComponentBatch::from_loggable(_is_recursive, Descriptor_is_recursive)
+                               .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Partitions the component data into multiple sub-batches.
         ///
         /// Specifically, this transforms the existing `ComponentBatch` data into `ComponentColumn`s

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -135,7 +135,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ClearIsRecursive in a single component batch.
+        /// This method makes it possible to pack multiple `is_recursive` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_is_recursive` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -249,7 +249,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        /// This method makes it possible to pack multiple `buffer` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_buffer` should
         /// be used when logging a single row's worth of data.
@@ -264,7 +264,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        /// This method makes it possible to pack multiple `format` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_format` should
         /// be used when logging a single row's worth of data.
@@ -285,7 +285,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DepthMeter in a single component batch.
+        /// This method makes it possible to pack multiple `meter` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_meter` should
         /// be used when logging a single row's worth of data.
@@ -303,7 +303,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Colormap in a single component batch.
+        /// This method makes it possible to pack multiple `colormap` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_colormap` should
         /// be used when logging a single row's worth of data.
@@ -330,7 +330,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ValueRange in a single component batch.
+        /// This method makes it possible to pack multiple `depth_range` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_depth_range` should
         /// be used when logging a single row's worth of data.
@@ -356,7 +356,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: FillRatio in a single component batch.
+        /// This method makes it possible to pack multiple `point_fill_ratio` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_point_fill_ratio` should
         /// be used when logging a single row's worth of data.
@@ -378,7 +378,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -249,8 +249,26 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_buffer` should
+        /// be used when logging a single row's worth of data.
+        DepthImage with_many_buffer(const Collection<rerun::components::ImageBuffer>& _buffer) && {
+            buffer = ComponentBatch::from_loggable(_buffer, Descriptor_buffer).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The format of the image.
         DepthImage with_format(const rerun::components::ImageFormat& _format) && {
+            format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_format` should
+        /// be used when logging a single row's worth of data.
+        DepthImage with_many_format(const Collection<rerun::components::ImageFormat>& _format) && {
             format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
             return std::move(*this);
         }
@@ -267,10 +285,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: DepthMeter in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_meter` should
+        /// be used when logging a single row's worth of data.
+        DepthImage with_many_meter(const Collection<rerun::components::DepthMeter>& _meter) && {
+            meter = ComponentBatch::from_loggable(_meter, Descriptor_meter).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Colormap to use for rendering the depth image.
         ///
         /// If not set, the depth image will be rendered using the Turbo colormap.
         DepthImage with_colormap(const rerun::components::Colormap& _colormap) && {
+            colormap =
+                ComponentBatch::from_loggable(_colormap, Descriptor_colormap).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: Colormap in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_colormap` should
+        /// be used when logging a single row's worth of data.
+        DepthImage with_many_colormap(const Collection<rerun::components::Colormap>& _colormap) && {
             colormap =
                 ComponentBatch::from_loggable(_colormap, Descriptor_colormap).value_or_throw();
             return std::move(*this);
@@ -293,6 +330,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ValueRange in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_depth_range` should
+        /// be used when logging a single row's worth of data.
+        DepthImage with_many_depth_range(
+            const Collection<rerun::components::ValueRange>& _depth_range
+        ) && {
+            depth_range = ComponentBatch::from_loggable(_depth_range, Descriptor_depth_range)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Scale the radii of the points in the point cloud generated from this image.
         ///
         /// A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
@@ -307,10 +356,34 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: FillRatio in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_point_fill_ratio` should
+        /// be used when logging a single row's worth of data.
+        DepthImage with_many_point_fill_ratio(
+            const Collection<rerun::components::FillRatio>& _point_fill_ratio
+        ) && {
+            point_fill_ratio =
+                ComponentBatch::from_loggable(_point_fill_ratio, Descriptor_point_fill_ratio)
+                    .value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         DepthImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        DepthImage with_many_draw_order(const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
@@ -304,7 +304,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: FillMode in a single component batch.
+        /// This method makes it possible to pack multiple `fill_mode` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fill_mode` should
         /// be used when logging a single row's worth of data.
@@ -328,7 +328,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
@@ -304,6 +304,17 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: FillMode in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fill_mode` should
+        /// be used when logging a single row's worth of data.
+        Ellipsoids3D with_many_fill_mode(const Collection<rerun::components::FillMode>& _fill_mode
+        ) && {
+            fill_mode =
+                ComponentBatch::from_loggable(_fill_mode, Descriptor_fill_mode).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional text labels for the ellipsoids.
         Ellipsoids3D with_labels(const Collection<rerun::components::Text>& _labels) && {
             labels = ComponentBatch::from_loggable(_labels, Descriptor_labels).value_or_throw();
@@ -312,6 +323,18 @@ namespace rerun::archetypes {
 
         /// Optional choice of whether the text labels should be shown by default.
         Ellipsoids3D with_show_labels(const rerun::components::ShowLabels& _show_labels) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Ellipsoids3D with_many_show_labels(
+            const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
             show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
                               .value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
@@ -142,6 +142,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Blob in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_blob` should
+        /// be used when logging a single row's worth of data.
+        EncodedImage with_many_blob(const Collection<rerun::components::Blob>& _blob) && {
+            blob = ComponentBatch::from_loggable(_blob, Descriptor_blob).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The Media Type of the asset.
         ///
         /// Supported values:
@@ -156,6 +165,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
+        /// be used when logging a single row's worth of data.
+        EncodedImage with_many_media_type(
+            const Collection<rerun::components::MediaType>& _media_type
+        ) && {
+            media_type =
+                ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Opacity of the image, useful for layering several images.
         ///
         /// Defaults to 1.0 (fully opaque).
@@ -164,10 +185,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Opacity in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_opacity` should
+        /// be used when logging a single row's worth of data.
+        EncodedImage with_many_opacity(const Collection<rerun::components::Opacity>& _opacity) && {
+            opacity = ComponentBatch::from_loggable(_opacity, Descriptor_opacity).value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         EncodedImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        EncodedImage with_many_draw_order(
+            const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
@@ -142,7 +142,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Blob in a single component batch.
+        /// This method makes it possible to pack multiple `blob` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_blob` should
         /// be used when logging a single row's worth of data.
@@ -165,7 +165,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        /// This method makes it possible to pack multiple `media_type` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
         /// be used when logging a single row's worth of data.
@@ -185,7 +185,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Opacity in a single component batch.
+        /// This method makes it possible to pack multiple `opacity` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_opacity` should
         /// be used when logging a single row's worth of data.
@@ -203,7 +203,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
@@ -107,7 +107,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: GraphType in a single component batch.
+        /// This method makes it possible to pack multiple `graph_type` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_graph_type` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
@@ -107,6 +107,17 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: GraphType in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_graph_type` should
+        /// be used when logging a single row's worth of data.
+        GraphEdges with_many_graph_type(const Collection<rerun::components::GraphType>& _graph_type
+        ) && {
+            graph_type =
+                ComponentBatch::from_loggable(_graph_type, Descriptor_graph_type).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Partitions the component data into multiple sub-batches.
         ///
         /// Specifically, this transforms the existing `ComponentBatch` data into `ComponentColumn`s

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
@@ -154,7 +154,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
@@ -154,6 +154,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        GraphNodes with_many_show_labels(
+            const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional radii for nodes.
         GraphNodes with_radii(const Collection<rerun::components::Radius>& _radii) && {
             radii = ComponentBatch::from_loggable(_radii, Descriptor_radii).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -339,8 +339,26 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_buffer` should
+        /// be used when logging a single row's worth of data.
+        Image with_many_buffer(const Collection<rerun::components::ImageBuffer>& _buffer) && {
+            buffer = ComponentBatch::from_loggable(_buffer, Descriptor_buffer).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The format of the image.
         Image with_format(const rerun::components::ImageFormat& _format) && {
+            format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_format` should
+        /// be used when logging a single row's worth of data.
+        Image with_many_format(const Collection<rerun::components::ImageFormat>& _format) && {
             format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
             return std::move(*this);
         }
@@ -353,10 +371,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Opacity in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_opacity` should
+        /// be used when logging a single row's worth of data.
+        Image with_many_opacity(const Collection<rerun::components::Opacity>& _opacity) && {
+            opacity = ComponentBatch::from_loggable(_opacity, Descriptor_opacity).value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         Image with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        Image with_many_draw_order(const Collection<rerun::components::DrawOrder>& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -339,7 +339,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        /// This method makes it possible to pack multiple `buffer` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_buffer` should
         /// be used when logging a single row's worth of data.
@@ -354,7 +354,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        /// This method makes it possible to pack multiple `format` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_format` should
         /// be used when logging a single row's worth of data.
@@ -371,7 +371,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Opacity in a single component batch.
+        /// This method makes it possible to pack multiple `opacity` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_opacity` should
         /// be used when logging a single row's worth of data.
@@ -389,7 +389,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -210,10 +210,34 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        LineStrips2D with_many_show_labels(
+            const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order of each line strip.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         LineStrips2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        LineStrips2D with_many_draw_order(
+            const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -210,7 +210,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.
@@ -231,7 +231,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -214,6 +214,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        LineStrips3D with_many_show_labels(
+            const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional `components::ClassId`s for the lines.
         ///
         /// The `components::ClassId` provides colors and labels if not specified explicitly.

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -214,7 +214,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -274,7 +274,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AlbedoFactor in a single component batch.
+        /// This method makes it possible to pack multiple `albedo_factor` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_albedo_factor` should
         /// be used when logging a single row's worth of data.
@@ -303,7 +303,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        /// This method makes it possible to pack multiple `albedo_texture_buffer` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_albedo_texture_buffer` should
         /// be used when logging a single row's worth of data.
@@ -330,7 +330,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        /// This method makes it possible to pack multiple `albedo_texture_format` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_albedo_texture_format` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -274,6 +274,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AlbedoFactor in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_albedo_factor` should
+        /// be used when logging a single row's worth of data.
+        Mesh3D with_many_albedo_factor(
+            const Collection<rerun::components::AlbedoFactor>& _albedo_factor
+        ) && {
+            albedo_factor = ComponentBatch::from_loggable(_albedo_factor, Descriptor_albedo_factor)
+                                .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional albedo texture.
         ///
         /// Used with the `components::Texcoord2D` of the mesh.
@@ -291,9 +303,39 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_albedo_texture_buffer` should
+        /// be used when logging a single row's worth of data.
+        Mesh3D with_many_albedo_texture_buffer(
+            const Collection<rerun::components::ImageBuffer>& _albedo_texture_buffer
+        ) && {
+            albedo_texture_buffer = ComponentBatch::from_loggable(
+                                        _albedo_texture_buffer,
+                                        Descriptor_albedo_texture_buffer
+            )
+                                        .value_or_throw();
+            return std::move(*this);
+        }
+
         /// The format of the `albedo_texture_buffer`, if any.
         Mesh3D with_albedo_texture_format(
             const rerun::components::ImageFormat& _albedo_texture_format
+        ) && {
+            albedo_texture_format = ComponentBatch::from_loggable(
+                                        _albedo_texture_format,
+                                        Descriptor_albedo_texture_format
+            )
+                                        .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_albedo_texture_format` should
+        /// be used when logging a single row's worth of data.
+        Mesh3D with_many_albedo_texture_format(
+            const Collection<rerun::components::ImageFormat>& _albedo_texture_format
         ) && {
             albedo_texture_format = ComponentBatch::from_loggable(
                                         _albedo_texture_format,

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -237,6 +237,19 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: PinholeProjection in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_image_from_camera` should
+        /// be used when logging a single row's worth of data.
+        Pinhole with_many_image_from_camera(
+            const Collection<rerun::components::PinholeProjection>& _image_from_camera
+        ) && {
+            image_from_camera =
+                ComponentBatch::from_loggable(_image_from_camera, Descriptor_image_from_camera)
+                    .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Pixel resolution (usually integers) of child image space. Width and height.
         ///
         /// Example:
@@ -246,6 +259,17 @@ namespace rerun::archetypes {
         ///
         /// `image_from_camera` project onto the space spanned by `(0,0)` and `resolution - 1`.
         Pinhole with_resolution(const rerun::components::Resolution& _resolution) && {
+            resolution =
+                ComponentBatch::from_loggable(_resolution, Descriptor_resolution).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: Resolution in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_resolution` should
+        /// be used when logging a single row's worth of data.
+        Pinhole with_many_resolution(const Collection<rerun::components::Resolution>& _resolution
+        ) && {
             resolution =
                 ComponentBatch::from_loggable(_resolution, Descriptor_resolution).value_or_throw();
             return std::move(*this);
@@ -284,11 +308,38 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ViewCoordinates in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_camera_xyz` should
+        /// be used when logging a single row's worth of data.
+        Pinhole with_many_camera_xyz(
+            const Collection<rerun::components::ViewCoordinates>& _camera_xyz
+        ) && {
+            camera_xyz =
+                ComponentBatch::from_loggable(_camera_xyz, Descriptor_camera_xyz).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.
         ///
         /// This is only used for visualization purposes, and does not affect the projection itself.
         Pinhole with_image_plane_distance(
             const rerun::components::ImagePlaneDistance& _image_plane_distance
+        ) && {
+            image_plane_distance = ComponentBatch::from_loggable(
+                                       _image_plane_distance,
+                                       Descriptor_image_plane_distance
+            )
+                                       .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ImagePlaneDistance in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_image_plane_distance` should
+        /// be used when logging a single row's worth of data.
+        Pinhole with_many_image_plane_distance(
+            const Collection<rerun::components::ImagePlaneDistance>& _image_plane_distance
         ) && {
             image_plane_distance = ComponentBatch::from_loggable(
                                        _image_plane_distance,

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -237,7 +237,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: PinholeProjection in a single component batch.
+        /// This method makes it possible to pack multiple `image_from_camera` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_image_from_camera` should
         /// be used when logging a single row's worth of data.
@@ -264,7 +264,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Resolution in a single component batch.
+        /// This method makes it possible to pack multiple `resolution` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_resolution` should
         /// be used when logging a single row's worth of data.
@@ -308,7 +308,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ViewCoordinates in a single component batch.
+        /// This method makes it possible to pack multiple `camera_xyz` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_camera_xyz` should
         /// be used when logging a single row's worth of data.
@@ -334,7 +334,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImagePlaneDistance in a single component batch.
+        /// This method makes it possible to pack multiple `image_plane_distance` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_image_plane_distance` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -243,10 +243,32 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Points2D with_many_show_labels(const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         Points2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        Points2D with_many_draw_order(const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -243,7 +243,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.
@@ -263,7 +263,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -134,10 +134,8 @@ namespace rerun::archetypes {
     ///     auto time_column = rerun::TimeColumn::from_times("time", std::move(times));
     ///
     ///     // Partition our data as expected across the 5 timesteps.
-    ///     auto position =
-    ///         rerun::Points3D::update_fields().with_positions(positions).columns({2, 4, 4, 3, 4});
-    ///     auto color_and_radius =
-    ///         rerun::Points3D::update_fields().with_colors(colors).with_radii(radii).columns();
+    ///     auto position = rerun::Points3D().with_positions(positions).columns({2, 4, 4, 3, 4});
+    ///     auto color_and_radius = rerun::Points3D().with_colors(colors).with_radii(radii).columns();
     ///
     ///     rec.send_columns("points", time_column, position, color_and_radius);
     /// }

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -271,6 +271,17 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
+        /// be used when logging a single row's worth of data.
+        Points3D with_many_show_labels(const Collection<rerun::components::ShowLabels>& _show_labels
+        ) && {
+            show_labels = ComponentBatch::from_loggable(_show_labels, Descriptor_show_labels)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional class Ids for the points.
         ///
         /// The `components::ClassId` provides colors and labels if not specified explicitly.

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -139,7 +139,7 @@ namespace rerun::archetypes {
     ///     auto color_and_radius =
     ///         rerun::Points3D::update_fields().with_colors(colors).with_radii(radii).columns();
     ///
-    ///     rec.send_columns2("points", time_column, position, color_and_radius);
+    ///     rec.send_columns("points", time_column, position, color_and_radius);
     /// }
     /// ```
     struct Points3D {

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -269,7 +269,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ShowLabels in a single component batch.
+        /// This method makes it possible to pack multiple `show_labels` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_show_labels` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -70,12 +70,12 @@ namespace rerun::archetypes {
     ///     std::vector<int64_t> times(64);
     ///     std::iota(times.begin(), times.end(), 0);
     ///
-    ///     // Convert to rerun time / scalars
-    ///     auto time_column = rerun::TimeColumn::from_sequence_points("step", std::move(times));
-    ///     auto scalar_data_collection =
-    ///         rerun::Collection<rerun::components::Scalar>(std::move(scalar_data));
-    ///
-    ///     rec.send_columns("scalars", time_column, scalar_data_collection);
+    ///     // Serialize to columns and send.
+    ///     rec.send_columns2(
+    ///         "scalars",
+    ///         rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+    ///         rerun::Scalar().with_many_scalar(std::move(scalar_data)).columns()
+    ///     );
     /// }
     /// ```
     struct Scalar {

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -120,7 +120,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Scalar in a single component batch.
+        /// This method makes it possible to pack multiple `scalar` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_scalar` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -71,7 +71,7 @@ namespace rerun::archetypes {
     ///     std::iota(times.begin(), times.end(), 0);
     ///
     ///     // Serialize to columns and send.
-    ///     rec.send_columns2(
+    ///     rec.send_columns(
     ///         "scalars",
     ///         rerun::TimeColumn::from_sequence_points("step", std::move(times)),
     ///         rerun::Scalar().with_many_scalar(std::move(scalar_data)).columns()

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -120,6 +120,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Scalar in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_scalar` should
+        /// be used when logging a single row's worth of data.
+        Scalar with_many_scalar(const Collection<rerun::components::Scalar>& _scalar) && {
+            scalar = ComponentBatch::from_loggable(_scalar, Descriptor_scalar).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Partitions the component data into multiple sub-batches.
         ///
         /// Specifically, this transforms the existing `ComponentBatch` data into `ComponentColumn`s

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -203,7 +203,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        /// This method makes it possible to pack multiple `buffer` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_buffer` should
         /// be used when logging a single row's worth of data.
@@ -219,7 +219,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        /// This method makes it possible to pack multiple `format` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_format` should
         /// be used when logging a single row's worth of data.
@@ -237,7 +237,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Opacity in a single component batch.
+        /// This method makes it possible to pack multiple `opacity` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_opacity` should
         /// be used when logging a single row's worth of data.
@@ -256,7 +256,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -203,8 +203,28 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageBuffer in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_buffer` should
+        /// be used when logging a single row's worth of data.
+        SegmentationImage with_many_buffer(const Collection<rerun::components::ImageBuffer>& _buffer
+        ) && {
+            buffer = ComponentBatch::from_loggable(_buffer, Descriptor_buffer).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The format of the image.
         SegmentationImage with_format(const rerun::components::ImageFormat& _format) && {
+            format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ImageFormat in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_format` should
+        /// be used when logging a single row's worth of data.
+        SegmentationImage with_many_format(const Collection<rerun::components::ImageFormat>& _format
+        ) && {
             format = ComponentBatch::from_loggable(_format, Descriptor_format).value_or_throw();
             return std::move(*this);
         }
@@ -217,10 +237,32 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Opacity in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_opacity` should
+        /// be used when logging a single row's worth of data.
+        SegmentationImage with_many_opacity(const Collection<rerun::components::Opacity>& _opacity
+        ) && {
+            opacity = ComponentBatch::from_loggable(_opacity, Descriptor_opacity).value_or_throw();
+            return std::move(*this);
+        }
+
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
         SegmentationImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: DrawOrder in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        SegmentationImage with_many_draw_order(
+            const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -130,8 +130,26 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_color` should
+        /// be used when logging a single row's worth of data.
+        SeriesLine with_many_color(const Collection<rerun::components::Color>& _color) && {
+            color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Stroke width for the corresponding series.
         SeriesLine with_width(const rerun::components::StrokeWidth& _width) && {
+            width = ComponentBatch::from_loggable(_width, Descriptor_width).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: StrokeWidth in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_width` should
+        /// be used when logging a single row's worth of data.
+        SeriesLine with_many_width(const Collection<rerun::components::StrokeWidth>& _width) && {
             width = ComponentBatch::from_loggable(_width, Descriptor_width).value_or_throw();
             return std::move(*this);
         }
@@ -144,6 +162,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Name in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_name` should
+        /// be used when logging a single row's worth of data.
+        SeriesLine with_many_name(const Collection<rerun::components::Name>& _name) && {
+            name = ComponentBatch::from_loggable(_name, Descriptor_name).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Configures the zoom-dependent scalar aggregation.
         ///
         /// This is done only if steps on the X axis go below a single pixel,
@@ -151,6 +178,19 @@ namespace rerun::archetypes {
         /// (and readability) in such situations as it prevents overdraw.
         SeriesLine with_aggregation_policy(
             const rerun::components::AggregationPolicy& _aggregation_policy
+        ) && {
+            aggregation_policy =
+                ComponentBatch::from_loggable(_aggregation_policy, Descriptor_aggregation_policy)
+                    .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AggregationPolicy in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_aggregation_policy` should
+        /// be used when logging a single row's worth of data.
+        SeriesLine with_many_aggregation_policy(
+            const Collection<rerun::components::AggregationPolicy>& _aggregation_policy
         ) && {
             aggregation_policy =
                 ComponentBatch::from_loggable(_aggregation_policy, Descriptor_aggregation_policy)

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -130,7 +130,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        /// This method makes it possible to pack multiple `color` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_color` should
         /// be used when logging a single row's worth of data.
@@ -145,7 +145,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: StrokeWidth in a single component batch.
+        /// This method makes it possible to pack multiple `width` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_width` should
         /// be used when logging a single row's worth of data.
@@ -162,7 +162,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Name in a single component batch.
+        /// This method makes it possible to pack multiple `name` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_name` should
         /// be used when logging a single row's worth of data.
@@ -185,7 +185,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AggregationPolicy in a single component batch.
+        /// This method makes it possible to pack multiple `aggregation_policy` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_aggregation_policy` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -134,8 +134,26 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_color` should
+        /// be used when logging a single row's worth of data.
+        SeriesPoint with_many_color(const Collection<rerun::components::Color>& _color) && {
+            color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
+            return std::move(*this);
+        }
+
         /// What shape to use to represent the point
         SeriesPoint with_marker(const rerun::components::MarkerShape& _marker) && {
+            marker = ComponentBatch::from_loggable(_marker, Descriptor_marker).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: MarkerShape in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_marker` should
+        /// be used when logging a single row's worth of data.
+        SeriesPoint with_many_marker(const Collection<rerun::components::MarkerShape>& _marker) && {
             marker = ComponentBatch::from_loggable(_marker, Descriptor_marker).value_or_throw();
             return std::move(*this);
         }
@@ -148,8 +166,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Name in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_name` should
+        /// be used when logging a single row's worth of data.
+        SeriesPoint with_many_name(const Collection<rerun::components::Name>& _name) && {
+            name = ComponentBatch::from_loggable(_name, Descriptor_name).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Size of the marker.
         SeriesPoint with_marker_size(const rerun::components::MarkerSize& _marker_size) && {
+            marker_size = ComponentBatch::from_loggable(_marker_size, Descriptor_marker_size)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: MarkerSize in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_marker_size` should
+        /// be used when logging a single row's worth of data.
+        SeriesPoint with_many_marker_size(
+            const Collection<rerun::components::MarkerSize>& _marker_size
+        ) && {
             marker_size = ComponentBatch::from_loggable(_marker_size, Descriptor_marker_size)
                               .value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -134,7 +134,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        /// This method makes it possible to pack multiple `color` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_color` should
         /// be used when logging a single row's worth of data.
@@ -149,7 +149,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: MarkerShape in a single component batch.
+        /// This method makes it possible to pack multiple `marker` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_marker` should
         /// be used when logging a single row's worth of data.
@@ -166,7 +166,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Name in a single component batch.
+        /// This method makes it possible to pack multiple `name` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_name` should
         /// be used when logging a single row's worth of data.
@@ -182,7 +182,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: MarkerSize in a single component batch.
+        /// This method makes it possible to pack multiple `marker_size` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_marker_size` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -143,7 +143,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: TensorData in a single component batch.
+        /// This method makes it possible to pack multiple `data` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_data` should
         /// be used when logging a single row's worth of data.
@@ -169,7 +169,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ValueRange in a single component batch.
+        /// This method makes it possible to pack multiple `value_range` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_value_range` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -143,6 +143,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: TensorData in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_data` should
+        /// be used when logging a single row's worth of data.
+        Tensor with_many_data(const Collection<rerun::components::TensorData>& _data) && {
+            data = ComponentBatch::from_loggable(_data, Descriptor_data).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The expected range of values.
         ///
         /// This is typically the expected range of valid values.
@@ -155,6 +164,17 @@ namespace rerun::archetypes {
         /// E.g. if all values are positive, some bigger than 1.0 and all smaller than 255.0,
         /// the Viewer will guess that the data likely came from an 8bit image, thus assuming a range of 0-255.
         Tensor with_value_range(const rerun::components::ValueRange& _value_range) && {
+            value_range = ComponentBatch::from_loggable(_value_range, Descriptor_value_range)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: ValueRange in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_value_range` should
+        /// be used when logging a single row's worth of data.
+        Tensor with_many_value_range(const Collection<rerun::components::ValueRange>& _value_range
+        ) && {
             value_range = ComponentBatch::from_loggable(_value_range, Descriptor_value_range)
                               .value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -131,7 +131,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Text in a single component batch.
+        /// This method makes it possible to pack multiple `text` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_text` should
         /// be used when logging a single row's worth of data.
@@ -153,7 +153,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        /// This method makes it possible to pack multiple `media_type` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -131,6 +131,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Text in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_text` should
+        /// be used when logging a single row's worth of data.
+        TextDocument with_many_text(const Collection<rerun::components::Text>& _text) && {
+            text = ComponentBatch::from_loggable(_text, Descriptor_text).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The Media Type of the text.
         ///
         /// For instance:
@@ -139,6 +148,18 @@ namespace rerun::archetypes {
         ///
         /// If omitted, `text/plain` is assumed.
         TextDocument with_media_type(const rerun::components::MediaType& _media_type) && {
+            media_type =
+                ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: MediaType in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_media_type` should
+        /// be used when logging a single row's worth of data.
+        TextDocument with_many_media_type(
+            const Collection<rerun::components::MediaType>& _media_type
+        ) && {
             media_type =
                 ComponentBatch::from_loggable(_media_type, Descriptor_media_type).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -137,7 +137,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Text in a single component batch.
+        /// This method makes it possible to pack multiple `text` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_text` should
         /// be used when logging a single row's worth of data.
@@ -154,7 +154,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: TextLogLevel in a single component batch.
+        /// This method makes it possible to pack multiple `level` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_level` should
         /// be used when logging a single row's worth of data.
@@ -169,7 +169,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        /// This method makes it possible to pack multiple `color` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_color` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -137,6 +137,15 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Text in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_text` should
+        /// be used when logging a single row's worth of data.
+        TextLog with_many_text(const Collection<rerun::components::Text>& _text) && {
+            text = ComponentBatch::from_loggable(_text, Descriptor_text).value_or_throw();
+            return std::move(*this);
+        }
+
         /// The verbosity level of the message.
         ///
         /// This can be used to filter the log messages in the Rerun Viewer.
@@ -145,8 +154,26 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: TextLogLevel in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_level` should
+        /// be used when logging a single row's worth of data.
+        TextLog with_many_level(const Collection<rerun::components::TextLogLevel>& _level) && {
+            level = ComponentBatch::from_loggable(_level, Descriptor_level).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional color to use for the log line in the Rerun Viewer.
         TextLog with_color(const rerun::components::Color& _color) && {
+            color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: Color in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_color` should
+        /// be used when logging a single row's worth of data.
+        TextLog with_many_color(const Collection<rerun::components::Color>& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
             return std::move(*this);
         }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -615,7 +615,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Translation3D in a single component batch.
+        /// This method makes it possible to pack multiple `translation` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_translation` should
         /// be used when logging a single row's worth of data.
@@ -637,7 +637,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: RotationAxisAngle in a single component batch.
+        /// This method makes it possible to pack multiple `rotation_axis_angle` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_rotation_axis_angle` should
         /// be used when logging a single row's worth of data.
@@ -657,7 +657,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: RotationQuat in a single component batch.
+        /// This method makes it possible to pack multiple `quaternion` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_quaternion` should
         /// be used when logging a single row's worth of data.
@@ -675,7 +675,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: Scale3D in a single component batch.
+        /// This method makes it possible to pack multiple `scale` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_scale` should
         /// be used when logging a single row's worth of data.
@@ -690,7 +690,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: TransformMat3x3 in a single component batch.
+        /// This method makes it possible to pack multiple `mat3x3` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_mat3x3` should
         /// be used when logging a single row's worth of data.
@@ -707,7 +707,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: TransformRelation in a single component batch.
+        /// This method makes it possible to pack multiple `relation` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_relation` should
         /// be used when logging a single row's worth of data.
@@ -729,7 +729,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AxisLength in a single component batch.
+        /// This method makes it possible to pack multiple `axis_length` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_axis_length` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -615,9 +615,34 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Translation3D in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_translation` should
+        /// be used when logging a single row's worth of data.
+        Transform3D with_many_translation(
+            const Collection<rerun::components::Translation3D>& _translation
+        ) && {
+            translation = ComponentBatch::from_loggable(_translation, Descriptor_translation)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
         /// Rotation via axis + angle.
         Transform3D with_rotation_axis_angle(
             const rerun::components::RotationAxisAngle& _rotation_axis_angle
+        ) && {
+            rotation_axis_angle =
+                ComponentBatch::from_loggable(_rotation_axis_angle, Descriptor_rotation_axis_angle)
+                    .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: RotationAxisAngle in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_rotation_axis_angle` should
+        /// be used when logging a single row's worth of data.
+        Transform3D with_many_rotation_axis_angle(
+            const Collection<rerun::components::RotationAxisAngle>& _rotation_axis_angle
         ) && {
             rotation_axis_angle =
                 ComponentBatch::from_loggable(_rotation_axis_angle, Descriptor_rotation_axis_angle)
@@ -632,14 +657,45 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: RotationQuat in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_quaternion` should
+        /// be used when logging a single row's worth of data.
+        Transform3D with_many_quaternion(
+            const Collection<rerun::components::RotationQuat>& _quaternion
+        ) && {
+            quaternion =
+                ComponentBatch::from_loggable(_quaternion, Descriptor_quaternion).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Scaling factor.
         Transform3D with_scale(const rerun::components::Scale3D& _scale) && {
             scale = ComponentBatch::from_loggable(_scale, Descriptor_scale).value_or_throw();
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: Scale3D in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_scale` should
+        /// be used when logging a single row's worth of data.
+        Transform3D with_many_scale(const Collection<rerun::components::Scale3D>& _scale) && {
+            scale = ComponentBatch::from_loggable(_scale, Descriptor_scale).value_or_throw();
+            return std::move(*this);
+        }
+
         /// 3x3 transformation matrix.
         Transform3D with_mat3x3(const rerun::components::TransformMat3x3& _mat3x3) && {
+            mat3x3 = ComponentBatch::from_loggable(_mat3x3, Descriptor_mat3x3).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: TransformMat3x3 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_mat3x3` should
+        /// be used when logging a single row's worth of data.
+        Transform3D with_many_mat3x3(const Collection<rerun::components::TransformMat3x3>& _mat3x3
+        ) && {
             mat3x3 = ComponentBatch::from_loggable(_mat3x3, Descriptor_mat3x3).value_or_throw();
             return std::move(*this);
         }
@@ -651,11 +707,35 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: TransformRelation in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_relation` should
+        /// be used when logging a single row's worth of data.
+        Transform3D with_many_relation(
+            const Collection<rerun::components::TransformRelation>& _relation
+        ) && {
+            relation =
+                ComponentBatch::from_loggable(_relation, Descriptor_relation).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Visual length of the 3 axes.
         ///
         /// The length is interpreted in the local coordinate system of the transform.
         /// If the transform is scaled, the axes will be scaled accordingly.
         Transform3D with_axis_length(const rerun::components::AxisLength& _axis_length) && {
+            axis_length = ComponentBatch::from_loggable(_axis_length, Descriptor_axis_length)
+                              .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AxisLength in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_axis_length` should
+        /// be used when logging a single row's worth of data.
+        Transform3D with_many_axis_length(
+            const Collection<rerun::components::AxisLength>& _axis_length
+        ) && {
             axis_length = ComponentBatch::from_loggable(_axis_length, Descriptor_axis_length)
                               .value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -71,10 +71,7 @@ namespace rerun::archetypes {
     ///     rec.send_columns(
     ///         "video",
     ///         time_column,
-    ///         {
-    ///             video_frame_reference_indicators.value_or_throw(),
-    ///             rerun::ComponentColumn::from_loggable(rerun::borrow(video_timestamps)).value_or_throw(),
-    ///         }
+    ///         rerun::VideoFrameReference().with_many_timestamp(rerun::borrow(video_timestamps)).columns()
     ///     );
     /// }
     /// ```

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -183,7 +183,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: VideoTimestamp in a single component batch.
+        /// This method makes it possible to pack multiple `timestamp` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_timestamp` should
         /// be used when logging a single row's worth of data.
@@ -213,7 +213,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: EntityPath in a single component batch.
+        /// This method makes it possible to pack multiple `video_reference` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_video_reference` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -186,6 +186,18 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: VideoTimestamp in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_timestamp` should
+        /// be used when logging a single row's worth of data.
+        VideoFrameReference with_many_timestamp(
+            const Collection<rerun::components::VideoTimestamp>& _timestamp
+        ) && {
+            timestamp =
+                ComponentBatch::from_loggable(_timestamp, Descriptor_timestamp).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Optional reference to an entity with a `archetypes::AssetVideo`.
         ///
         /// If none is specified, the video is assumed to be at the same entity.
@@ -197,6 +209,19 @@ namespace rerun::archetypes {
         /// keep the video reference active.
         VideoFrameReference with_video_reference(
             const rerun::components::EntityPath& _video_reference
+        ) && {
+            video_reference =
+                ComponentBatch::from_loggable(_video_reference, Descriptor_video_reference)
+                    .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: EntityPath in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_video_reference` should
+        /// be used when logging a single row's worth of data.
+        VideoFrameReference with_many_video_reference(
+            const Collection<rerun::components::EntityPath>& _video_reference
         ) && {
             video_reference =
                 ComponentBatch::from_loggable(_video_reference, Descriptor_video_reference)

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -345,6 +345,16 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: ViewCoordinates in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_xyz` should
+        /// be used when logging a single row's worth of data.
+        ViewCoordinates with_many_xyz(const Collection<rerun::components::ViewCoordinates>& _xyz
+        ) && {
+            xyz = ComponentBatch::from_loggable(_xyz, Descriptor_xyz).value_or_throw();
+            return std::move(*this);
+        }
+
         /// Partitions the component data into multiple sub-batches.
         ///
         /// Specifically, this transforms the existing `ComponentBatch` data into `ComponentColumn`s

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -345,7 +345,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: ViewCoordinates in a single component batch.
+        /// This method makes it possible to pack multiple `xyz` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_xyz` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -719,7 +719,7 @@ namespace rerun {
             return try_send_columns(
                 entity_path,
                 std::move(time_columns),
-                // Need to create collection explicitely, otherwise this becomes a recursive call.
+                // Need to create collection explicitly, otherwise this becomes a recursive call.
                 Collection<ComponentColumn>(std::move(flat_column_list))
             );
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -281,7 +281,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer1 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1001` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1001(const Collection<rerun::components::AffixFuzzer1>& _fuzz1001
+        ) && {
+            fuzz1001 =
+                ComponentBatch::from_loggable(_fuzz1001, Descriptor_fuzz1001).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1002(const rerun::components::AffixFuzzer2& _fuzz1002) && {
+            fuzz1002 =
+                ComponentBatch::from_loggable(_fuzz1002, Descriptor_fuzz1002).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer2 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1002` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1002(const Collection<rerun::components::AffixFuzzer2>& _fuzz1002
+        ) && {
             fuzz1002 =
                 ComponentBatch::from_loggable(_fuzz1002, Descriptor_fuzz1002).value_or_throw();
             return std::move(*this);
@@ -293,7 +315,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer3 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1003` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1003(const Collection<rerun::components::AffixFuzzer3>& _fuzz1003
+        ) && {
+            fuzz1003 =
+                ComponentBatch::from_loggable(_fuzz1003, Descriptor_fuzz1003).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1004(const rerun::components::AffixFuzzer4& _fuzz1004) && {
+            fuzz1004 =
+                ComponentBatch::from_loggable(_fuzz1004, Descriptor_fuzz1004).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer4 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1004` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1004(const Collection<rerun::components::AffixFuzzer4>& _fuzz1004
+        ) && {
             fuzz1004 =
                 ComponentBatch::from_loggable(_fuzz1004, Descriptor_fuzz1004).value_or_throw();
             return std::move(*this);
@@ -305,7 +349,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer5 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1005` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1005(const Collection<rerun::components::AffixFuzzer5>& _fuzz1005
+        ) && {
+            fuzz1005 =
+                ComponentBatch::from_loggable(_fuzz1005, Descriptor_fuzz1005).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1006(const rerun::components::AffixFuzzer6& _fuzz1006) && {
+            fuzz1006 =
+                ComponentBatch::from_loggable(_fuzz1006, Descriptor_fuzz1006).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer6 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1006` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1006(const Collection<rerun::components::AffixFuzzer6>& _fuzz1006
+        ) && {
             fuzz1006 =
                 ComponentBatch::from_loggable(_fuzz1006, Descriptor_fuzz1006).value_or_throw();
             return std::move(*this);
@@ -317,7 +383,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer7 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1007` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1007(const Collection<rerun::components::AffixFuzzer7>& _fuzz1007
+        ) && {
+            fuzz1007 =
+                ComponentBatch::from_loggable(_fuzz1007, Descriptor_fuzz1007).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1008(const rerun::components::AffixFuzzer8& _fuzz1008) && {
+            fuzz1008 =
+                ComponentBatch::from_loggable(_fuzz1008, Descriptor_fuzz1008).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer8 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1008` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1008(const Collection<rerun::components::AffixFuzzer8>& _fuzz1008
+        ) && {
             fuzz1008 =
                 ComponentBatch::from_loggable(_fuzz1008, Descriptor_fuzz1008).value_or_throw();
             return std::move(*this);
@@ -329,7 +417,30 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer9 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1009` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1009(const Collection<rerun::components::AffixFuzzer9>& _fuzz1009
+        ) && {
+            fuzz1009 =
+                ComponentBatch::from_loggable(_fuzz1009, Descriptor_fuzz1009).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1010(const rerun::components::AffixFuzzer10& _fuzz1010) && {
+            fuzz1010 =
+                ComponentBatch::from_loggable(_fuzz1010, Descriptor_fuzz1010).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer10 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1010` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1010(
+            const Collection<rerun::components::AffixFuzzer10>& _fuzz1010
+        ) && {
             fuzz1010 =
                 ComponentBatch::from_loggable(_fuzz1010, Descriptor_fuzz1010).value_or_throw();
             return std::move(*this);
@@ -341,7 +452,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer11 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1011` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1011(
+            const Collection<rerun::components::AffixFuzzer11>& _fuzz1011
+        ) && {
+            fuzz1011 =
+                ComponentBatch::from_loggable(_fuzz1011, Descriptor_fuzz1011).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1012(const rerun::components::AffixFuzzer12& _fuzz1012) && {
+            fuzz1012 =
+                ComponentBatch::from_loggable(_fuzz1012, Descriptor_fuzz1012).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer12 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1012` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1012(
+            const Collection<rerun::components::AffixFuzzer12>& _fuzz1012
+        ) && {
             fuzz1012 =
                 ComponentBatch::from_loggable(_fuzz1012, Descriptor_fuzz1012).value_or_throw();
             return std::move(*this);
@@ -353,7 +488,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer13 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1013` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1013(
+            const Collection<rerun::components::AffixFuzzer13>& _fuzz1013
+        ) && {
+            fuzz1013 =
+                ComponentBatch::from_loggable(_fuzz1013, Descriptor_fuzz1013).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1014(const rerun::components::AffixFuzzer14& _fuzz1014) && {
+            fuzz1014 =
+                ComponentBatch::from_loggable(_fuzz1014, Descriptor_fuzz1014).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer14 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1014` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1014(
+            const Collection<rerun::components::AffixFuzzer14>& _fuzz1014
+        ) && {
             fuzz1014 =
                 ComponentBatch::from_loggable(_fuzz1014, Descriptor_fuzz1014).value_or_throw();
             return std::move(*this);
@@ -365,7 +524,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer15 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1015` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1015(
+            const Collection<rerun::components::AffixFuzzer15>& _fuzz1015
+        ) && {
+            fuzz1015 =
+                ComponentBatch::from_loggable(_fuzz1015, Descriptor_fuzz1015).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1016(const rerun::components::AffixFuzzer16& _fuzz1016) && {
+            fuzz1016 =
+                ComponentBatch::from_loggable(_fuzz1016, Descriptor_fuzz1016).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer16 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1016` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1016(
+            const Collection<rerun::components::AffixFuzzer16>& _fuzz1016
+        ) && {
             fuzz1016 =
                 ComponentBatch::from_loggable(_fuzz1016, Descriptor_fuzz1016).value_or_throw();
             return std::move(*this);
@@ -377,7 +560,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer17 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1017` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1017(
+            const Collection<rerun::components::AffixFuzzer17>& _fuzz1017
+        ) && {
+            fuzz1017 =
+                ComponentBatch::from_loggable(_fuzz1017, Descriptor_fuzz1017).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1018(const rerun::components::AffixFuzzer18& _fuzz1018) && {
+            fuzz1018 =
+                ComponentBatch::from_loggable(_fuzz1018, Descriptor_fuzz1018).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer18 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1018` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1018(
+            const Collection<rerun::components::AffixFuzzer18>& _fuzz1018
+        ) && {
             fuzz1018 =
                 ComponentBatch::from_loggable(_fuzz1018, Descriptor_fuzz1018).value_or_throw();
             return std::move(*this);
@@ -389,7 +596,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer19 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1019` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1019(
+            const Collection<rerun::components::AffixFuzzer19>& _fuzz1019
+        ) && {
+            fuzz1019 =
+                ComponentBatch::from_loggable(_fuzz1019, Descriptor_fuzz1019).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1020(const rerun::components::AffixFuzzer20& _fuzz1020) && {
+            fuzz1020 =
+                ComponentBatch::from_loggable(_fuzz1020, Descriptor_fuzz1020).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer20 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1020` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1020(
+            const Collection<rerun::components::AffixFuzzer20>& _fuzz1020
+        ) && {
             fuzz1020 =
                 ComponentBatch::from_loggable(_fuzz1020, Descriptor_fuzz1020).value_or_throw();
             return std::move(*this);
@@ -401,7 +632,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer21 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1021` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1021(
+            const Collection<rerun::components::AffixFuzzer21>& _fuzz1021
+        ) && {
+            fuzz1021 =
+                ComponentBatch::from_loggable(_fuzz1021, Descriptor_fuzz1021).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer1 with_fuzz1022(const rerun::components::AffixFuzzer22& _fuzz1022) && {
+            fuzz1022 =
+                ComponentBatch::from_loggable(_fuzz1022, Descriptor_fuzz1022).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer22 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz1022` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer1 with_many_fuzz1022(
+            const Collection<rerun::components::AffixFuzzer22>& _fuzz1022
+        ) && {
             fuzz1022 =
                 ComponentBatch::from_loggable(_fuzz1022, Descriptor_fuzz1022).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -281,7 +281,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer1 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1001` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1001` should
         /// be used when logging a single row's worth of data.
@@ -298,7 +298,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer2 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1002` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1002` should
         /// be used when logging a single row's worth of data.
@@ -315,7 +315,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer3 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1003` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1003` should
         /// be used when logging a single row's worth of data.
@@ -332,7 +332,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer4 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1004` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1004` should
         /// be used when logging a single row's worth of data.
@@ -349,7 +349,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer5 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1005` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1005` should
         /// be used when logging a single row's worth of data.
@@ -366,7 +366,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer6 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1006` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1006` should
         /// be used when logging a single row's worth of data.
@@ -383,7 +383,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer7 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1007` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1007` should
         /// be used when logging a single row's worth of data.
@@ -400,7 +400,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer8 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1008` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1008` should
         /// be used when logging a single row's worth of data.
@@ -417,7 +417,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer9 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1009` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1009` should
         /// be used when logging a single row's worth of data.
@@ -434,7 +434,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer10 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1010` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1010` should
         /// be used when logging a single row's worth of data.
@@ -452,7 +452,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer11 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1011` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1011` should
         /// be used when logging a single row's worth of data.
@@ -470,7 +470,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer12 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1012` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1012` should
         /// be used when logging a single row's worth of data.
@@ -488,7 +488,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer13 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1013` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1013` should
         /// be used when logging a single row's worth of data.
@@ -506,7 +506,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer14 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1014` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1014` should
         /// be used when logging a single row's worth of data.
@@ -524,7 +524,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer15 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1015` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1015` should
         /// be used when logging a single row's worth of data.
@@ -542,7 +542,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer16 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1016` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1016` should
         /// be used when logging a single row's worth of data.
@@ -560,7 +560,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer17 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1017` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1017` should
         /// be used when logging a single row's worth of data.
@@ -578,7 +578,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer18 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1018` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1018` should
         /// be used when logging a single row's worth of data.
@@ -596,7 +596,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer19 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1019` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1019` should
         /// be used when logging a single row's worth of data.
@@ -614,7 +614,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer20 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1020` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1020` should
         /// be used when logging a single row's worth of data.
@@ -632,7 +632,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer21 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1021` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1021` should
         /// be used when logging a single row's worth of data.
@@ -650,7 +650,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer22 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz1022` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz1022` should
         /// be used when logging a single row's worth of data.

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -191,7 +191,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer1 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2001` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2001(const Collection<rerun::components::AffixFuzzer1>& _fuzz2001
+        ) && {
+            fuzz2001 =
+                ComponentBatch::from_loggable(_fuzz2001, Descriptor_fuzz2001).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2002(const rerun::components::AffixFuzzer2& _fuzz2002) && {
+            fuzz2002 =
+                ComponentBatch::from_loggable(_fuzz2002, Descriptor_fuzz2002).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer2 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2002` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2002(const Collection<rerun::components::AffixFuzzer2>& _fuzz2002
+        ) && {
             fuzz2002 =
                 ComponentBatch::from_loggable(_fuzz2002, Descriptor_fuzz2002).value_or_throw();
             return std::move(*this);
@@ -203,7 +225,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer3 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2003` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2003(const Collection<rerun::components::AffixFuzzer3>& _fuzz2003
+        ) && {
+            fuzz2003 =
+                ComponentBatch::from_loggable(_fuzz2003, Descriptor_fuzz2003).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2004(const rerun::components::AffixFuzzer4& _fuzz2004) && {
+            fuzz2004 =
+                ComponentBatch::from_loggable(_fuzz2004, Descriptor_fuzz2004).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer4 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2004` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2004(const Collection<rerun::components::AffixFuzzer4>& _fuzz2004
+        ) && {
             fuzz2004 =
                 ComponentBatch::from_loggable(_fuzz2004, Descriptor_fuzz2004).value_or_throw();
             return std::move(*this);
@@ -215,7 +259,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer5 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2005` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2005(const Collection<rerun::components::AffixFuzzer5>& _fuzz2005
+        ) && {
+            fuzz2005 =
+                ComponentBatch::from_loggable(_fuzz2005, Descriptor_fuzz2005).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2006(const rerun::components::AffixFuzzer6& _fuzz2006) && {
+            fuzz2006 =
+                ComponentBatch::from_loggable(_fuzz2006, Descriptor_fuzz2006).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer6 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2006` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2006(const Collection<rerun::components::AffixFuzzer6>& _fuzz2006
+        ) && {
             fuzz2006 =
                 ComponentBatch::from_loggable(_fuzz2006, Descriptor_fuzz2006).value_or_throw();
             return std::move(*this);
@@ -227,7 +293,29 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer7 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2007` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2007(const Collection<rerun::components::AffixFuzzer7>& _fuzz2007
+        ) && {
+            fuzz2007 =
+                ComponentBatch::from_loggable(_fuzz2007, Descriptor_fuzz2007).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2008(const rerun::components::AffixFuzzer8& _fuzz2008) && {
+            fuzz2008 =
+                ComponentBatch::from_loggable(_fuzz2008, Descriptor_fuzz2008).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer8 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2008` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2008(const Collection<rerun::components::AffixFuzzer8>& _fuzz2008
+        ) && {
             fuzz2008 =
                 ComponentBatch::from_loggable(_fuzz2008, Descriptor_fuzz2008).value_or_throw();
             return std::move(*this);
@@ -239,7 +327,30 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer9 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2009` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2009(const Collection<rerun::components::AffixFuzzer9>& _fuzz2009
+        ) && {
+            fuzz2009 =
+                ComponentBatch::from_loggable(_fuzz2009, Descriptor_fuzz2009).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2010(const rerun::components::AffixFuzzer10& _fuzz2010) && {
+            fuzz2010 =
+                ComponentBatch::from_loggable(_fuzz2010, Descriptor_fuzz2010).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer10 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2010` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2010(
+            const Collection<rerun::components::AffixFuzzer10>& _fuzz2010
+        ) && {
             fuzz2010 =
                 ComponentBatch::from_loggable(_fuzz2010, Descriptor_fuzz2010).value_or_throw();
             return std::move(*this);
@@ -251,7 +362,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer11 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2011` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2011(
+            const Collection<rerun::components::AffixFuzzer11>& _fuzz2011
+        ) && {
+            fuzz2011 =
+                ComponentBatch::from_loggable(_fuzz2011, Descriptor_fuzz2011).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2012(const rerun::components::AffixFuzzer12& _fuzz2012) && {
+            fuzz2012 =
+                ComponentBatch::from_loggable(_fuzz2012, Descriptor_fuzz2012).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer12 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2012` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2012(
+            const Collection<rerun::components::AffixFuzzer12>& _fuzz2012
+        ) && {
             fuzz2012 =
                 ComponentBatch::from_loggable(_fuzz2012, Descriptor_fuzz2012).value_or_throw();
             return std::move(*this);
@@ -263,7 +398,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer13 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2013` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2013(
+            const Collection<rerun::components::AffixFuzzer13>& _fuzz2013
+        ) && {
+            fuzz2013 =
+                ComponentBatch::from_loggable(_fuzz2013, Descriptor_fuzz2013).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2014(const rerun::components::AffixFuzzer14& _fuzz2014) && {
+            fuzz2014 =
+                ComponentBatch::from_loggable(_fuzz2014, Descriptor_fuzz2014).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer14 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2014` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2014(
+            const Collection<rerun::components::AffixFuzzer14>& _fuzz2014
+        ) && {
             fuzz2014 =
                 ComponentBatch::from_loggable(_fuzz2014, Descriptor_fuzz2014).value_or_throw();
             return std::move(*this);
@@ -275,7 +434,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer15 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2015` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2015(
+            const Collection<rerun::components::AffixFuzzer15>& _fuzz2015
+        ) && {
+            fuzz2015 =
+                ComponentBatch::from_loggable(_fuzz2015, Descriptor_fuzz2015).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2016(const rerun::components::AffixFuzzer16& _fuzz2016) && {
+            fuzz2016 =
+                ComponentBatch::from_loggable(_fuzz2016, Descriptor_fuzz2016).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer16 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2016` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2016(
+            const Collection<rerun::components::AffixFuzzer16>& _fuzz2016
+        ) && {
             fuzz2016 =
                 ComponentBatch::from_loggable(_fuzz2016, Descriptor_fuzz2016).value_or_throw();
             return std::move(*this);
@@ -287,7 +470,31 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer17 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2017` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2017(
+            const Collection<rerun::components::AffixFuzzer17>& _fuzz2017
+        ) && {
+            fuzz2017 =
+                ComponentBatch::from_loggable(_fuzz2017, Descriptor_fuzz2017).value_or_throw();
+            return std::move(*this);
+        }
+
         AffixFuzzer3 with_fuzz2018(const rerun::components::AffixFuzzer18& _fuzz2018) && {
+            fuzz2018 =
+                ComponentBatch::from_loggable(_fuzz2018, Descriptor_fuzz2018).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer18 in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fuzz2018` should
+        /// be used when logging a single row's worth of data.
+        AffixFuzzer3 with_many_fuzz2018(
+            const Collection<rerun::components::AffixFuzzer18>& _fuzz2018
+        ) && {
             fuzz2018 =
                 ComponentBatch::from_loggable(_fuzz2018, Descriptor_fuzz2018).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -191,7 +191,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer1 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2001` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2001` should
         /// be used when logging a single row's worth of data.
@@ -208,7 +208,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer2 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2002` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2002` should
         /// be used when logging a single row's worth of data.
@@ -225,7 +225,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer3 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2003` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2003` should
         /// be used when logging a single row's worth of data.
@@ -242,7 +242,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer4 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2004` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2004` should
         /// be used when logging a single row's worth of data.
@@ -259,7 +259,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer5 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2005` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2005` should
         /// be used when logging a single row's worth of data.
@@ -276,7 +276,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer6 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2006` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2006` should
         /// be used when logging a single row's worth of data.
@@ -293,7 +293,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer7 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2007` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2007` should
         /// be used when logging a single row's worth of data.
@@ -310,7 +310,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer8 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2008` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2008` should
         /// be used when logging a single row's worth of data.
@@ -327,7 +327,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer9 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2009` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2009` should
         /// be used when logging a single row's worth of data.
@@ -344,7 +344,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer10 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2010` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2010` should
         /// be used when logging a single row's worth of data.
@@ -362,7 +362,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer11 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2011` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2011` should
         /// be used when logging a single row's worth of data.
@@ -380,7 +380,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer12 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2012` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2012` should
         /// be used when logging a single row's worth of data.
@@ -398,7 +398,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer13 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2013` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2013` should
         /// be used when logging a single row's worth of data.
@@ -416,7 +416,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer14 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2014` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2014` should
         /// be used when logging a single row's worth of data.
@@ -434,7 +434,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer15 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2015` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2015` should
         /// be used when logging a single row's worth of data.
@@ -452,7 +452,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer16 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2016` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2016` should
         /// be used when logging a single row's worth of data.
@@ -470,7 +470,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer17 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2017` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2017` should
         /// be used when logging a single row's worth of data.
@@ -488,7 +488,7 @@ namespace rerun::archetypes {
             return std::move(*this);
         }
 
-        /// This method makes it possible to pack multiple `rerun:: components:: AffixFuzzer18 in a single component batch.
+        /// This method makes it possible to pack multiple `fuzz2018` in a single component batch.
         ///
         /// This only makes sense when used in conjunction with `columns`. `with_fuzz2018` should
         /// be used when logging a single row's worth of data.

--- a/tests/cpp/plot_dashboard_stress/main.cpp
+++ b/tests/cpp/plot_dashboard_stress/main.cpp
@@ -189,10 +189,12 @@ int main(int argc, char** argv) {
                     rec.send_columns(
                         path,
                         *time_column,
-                        rerun::Collection<rerun::components::Scalar>::borrow(
-                            series_values.data() + time_step,
-                            *temporal_batch_size
-                        )
+                        rerun::Scalar::update_fields()
+                            .with_many_scalar(rerun::borrow(
+                                series_values.data() + time_step,
+                                *temporal_batch_size
+                            ))
+                            .columns()
                     );
                 } else {
                     rec.log(path, rerun::Scalar(series_values[time_step]));


### PR DESCRIPTION
### Related

* builds upon https://github.com/rerun-io/rerun/pull/8828
* conflicts with https://github.com/rerun-io/rerun/pull/8833
    * scalar workaround shouldn't be necessary anymore 
* Fixes https://github.com/rerun-io/rerun/issues/8754 

### What

Allows for this:
```cpp
    rec.send_columns(
        "scalars",
        rerun::TimeColumn::from_sequence_points("step", std::move(times)),
        rerun::Scalar().with_many_scalar(std::move(scalar_data)).columns()
    );
```