### PR TITLE
Zero-length indicators on all codepaths in C++

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -1831,8 +1831,7 @@ fn archetype_serialize(type_ident: &Ident, obj: &Object, hpp_includes: &mut Incl
             #NEWLINE_TOKEN
             #(#push_batches)*
             {
-                auto indicator = #type_ident::IndicatorComponent();
-                auto result = ComponentBatch::from_loggable(indicator);
+                auto result = ComponentBatch::from_indicator<#type_ident>();
                 RR_RETURN_NOT_OK(result.error);
                 cells.emplace_back(std::move(result.value));
             }

--- a/docs/snippets/all/descriptors/descr_custom_archetype.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.cpp
@@ -38,8 +38,7 @@ struct rerun::AsComponents<CustomPoints3D> {
     static Result<std::vector<ComponentBatch>> serialize(const CustomPoints3D& archetype) {
         std::vector<rerun::ComponentBatch> batches;
 
-        CustomPoints3D::IndicatorComponent indicator;
-        batches.push_back(ComponentBatch::from_loggable(indicator).value_or_throw());
+        batches.push_back(ComponentBatch::from_indicator<CustomPoints3D>().value_or_throw());
 
         auto positions_descr = rerun::Loggable<CustomPosition3D>::Descriptor
                                    .or_with_archetype_name("user.CustomPoints3D")

--- a/docs/snippets/all/tutorials/custom_data.cpp
+++ b/docs/snippets/all/tutorials/custom_data.cpp
@@ -44,8 +44,7 @@ struct rerun::AsComponents<CustomPoints3D> {
         auto batches = AsComponents<rerun::Points3D>::serialize(archetype.points).value_or_throw();
 
         // Add a custom indicator component.
-        CustomPoints3D::IndicatorComponent indicator;
-        batches.push_back(ComponentBatch::from_loggable(indicator).value_or_throw());
+        batches.push_back(ComponentBatch::from_indicator<CustomPoints3D>().value_or_throw());
 
         // Add custom confidence components if present.
         if (archetype.confidences) {

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -50,8 +50,7 @@ namespace rerun {
             cells.push_back(archetype.context.value());
         }
         {
-            auto indicator = AnnotationContext::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<AnnotationContext>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
@@ -142,8 +142,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = Arrows2D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Arrows2D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -129,8 +129,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = Arrows3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Arrows3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -77,8 +77,7 @@ namespace rerun {
             cells.push_back(archetype.albedo_factor.value());
         }
         {
-            auto indicator = Asset3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Asset3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/asset_video.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.cpp
@@ -62,8 +62,7 @@ namespace rerun {
             cells.push_back(archetype.media_type.value());
         }
         {
-            auto indicator = AssetVideo::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<AssetVideo>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/asset_video_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video_ext.cpp
@@ -87,6 +87,9 @@ namespace rerun::archetypes {
             return std::vector<std::chrono::nanoseconds>();
         }
         auto blob_list_array = std::dynamic_pointer_cast<arrow::ListArray>(blob.value().array);
+        if (!blob_list_array) {
+            return Error(ErrorCode::InvalidArchetypeField, "Blob array is not a primitive array");
+        }
         auto blob_array =
             std::dynamic_pointer_cast<arrow::PrimitiveArray>(blob_list_array->values());
         if (!blob_array) {

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -62,8 +62,7 @@ namespace rerun {
             cells.push_back(archetype.color.value());
         }
         {
-            auto indicator = BarChart::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<BarChart>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -142,8 +142,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = Boxes2D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Boxes2D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -175,8 +175,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = Boxes3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Boxes3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.cpp
@@ -163,8 +163,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = Capsules3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Capsules3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -51,8 +51,7 @@ namespace rerun {
             cells.push_back(archetype.is_recursive.value());
         }
         {
-            auto indicator = Clear::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Clear>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -130,8 +130,7 @@ namespace rerun {
             cells.push_back(archetype.draw_order.value());
         }
         {
-            auto indicator = DepthImage::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<DepthImage>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.cpp
@@ -175,8 +175,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = Ellipsoids3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Ellipsoids3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/encoded_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/encoded_image.cpp
@@ -88,8 +88,7 @@ namespace rerun {
             cells.push_back(archetype.draw_order.value());
         }
         {
-            auto indicator = EncodedImage::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<EncodedImage>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.cpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.cpp
@@ -77,8 +77,7 @@ namespace rerun {
             cells.push_back(archetype.colors.value());
         }
         {
-            auto indicator = GeoLineStrings::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<GeoLineStrings>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/geo_points.cpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_points.cpp
@@ -87,8 +87,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = GeoPoints::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<GeoPoints>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.cpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.cpp
@@ -62,8 +62,7 @@ namespace rerun {
             cells.push_back(archetype.graph_type.value());
         }
         {
-            auto indicator = GraphEdges::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<GraphEdges>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.cpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.cpp
@@ -116,8 +116,7 @@ namespace rerun {
             cells.push_back(archetype.radii.value());
         }
         {
-            auto indicator = GraphNodes::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<GraphNodes>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -88,8 +88,7 @@ namespace rerun {
             cells.push_back(archetype.draw_order.value());
         }
         {
-            auto indicator = Image::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Image>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/instance_poses3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/instance_poses3d.cpp
@@ -110,8 +110,7 @@ namespace rerun {
             cells.push_back(archetype.mat3x3.value());
         }
         {
-            auto indicator = InstancePoses3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<InstancePoses3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -129,8 +129,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = LineStrips2D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<LineStrips2D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -116,8 +116,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = LineStrips3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<LineStrips3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -169,8 +169,7 @@ namespace rerun {
             cells.push_back(archetype.class_ids.value());
         }
         {
-            auto indicator = Mesh3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Mesh3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -95,8 +95,7 @@ namespace rerun {
             cells.push_back(archetype.image_plane_distance.value());
         }
         {
-            auto indicator = Pinhole::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Pinhole>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -144,8 +144,7 @@ namespace rerun {
             cells.push_back(archetype.keypoint_ids.value());
         }
         {
-            auto indicator = Points2D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Points2D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -131,8 +131,7 @@ namespace rerun {
             cells.push_back(archetype.keypoint_ids.value());
         }
         {
-            auto indicator = Points3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Points3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.cpp
@@ -49,8 +49,7 @@ namespace rerun {
             cells.push_back(archetype.scalar.value());
         }
         {
-            auto indicator = Scalar::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Scalar>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -88,8 +88,7 @@ namespace rerun {
             cells.push_back(archetype.draw_order.value());
         }
         {
-            auto indicator = SegmentationImage::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<SegmentationImage>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/series_line.cpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.cpp
@@ -91,8 +91,7 @@ namespace rerun {
             cells.push_back(archetype.aggregation_policy.value());
         }
         {
-            auto indicator = SeriesLine::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<SeriesLine>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/series_point.cpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.cpp
@@ -90,8 +90,7 @@ namespace rerun {
             cells.push_back(archetype.marker_size.value());
         }
         {
-            auto indicator = SeriesPoint::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<SeriesPoint>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -64,8 +64,7 @@ namespace rerun {
             cells.push_back(archetype.value_range.value());
         }
         {
-            auto indicator = Tensor::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Tensor>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -62,8 +62,7 @@ namespace rerun {
             cells.push_back(archetype.media_type.value());
         }
         {
-            auto indicator = TextDocument::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<TextDocument>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -75,8 +75,7 @@ namespace rerun {
             cells.push_back(archetype.color.value());
         }
         {
-            auto indicator = TextLog::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<TextLog>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -135,8 +135,7 @@ namespace rerun {
             cells.push_back(archetype.axis_length.value());
         }
         {
-            auto indicator = Transform3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Transform3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.cpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.cpp
@@ -64,8 +64,7 @@ namespace rerun {
             cells.push_back(archetype.video_reference.value());
         }
         {
-            auto indicator = VideoFrameReference::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<VideoFrameReference>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -49,8 +49,7 @@ namespace rerun {
             cells.push_back(archetype.xyz.value());
         }
         {
-            auto indicator = ViewCoordinates::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ViewCoordinates>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/background.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/background.cpp
@@ -63,8 +63,7 @@ namespace rerun {
             cells.push_back(archetype.color.value());
         }
         {
-            auto indicator = Background::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<Background>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.cpp
@@ -152,8 +152,7 @@ namespace rerun {
             cells.push_back(archetype.grid_columns.value());
         }
         {
-            auto indicator = ContainerBlueprint::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ContainerBlueprint>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.cpp
@@ -115,8 +115,7 @@ namespace rerun {
             cells.push_back(archetype.select.value());
         }
         {
-            auto indicator = DataframeQuery::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<DataframeQuery>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_center.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_center.cpp
@@ -63,8 +63,7 @@ namespace rerun {
             cells.push_back(archetype.strength.value());
         }
         {
-            auto indicator = ForceCenter::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ForceCenter>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.cpp
@@ -79,8 +79,7 @@ namespace rerun {
             cells.push_back(archetype.iterations.value());
         }
         {
-            auto indicator = ForceCollisionRadius::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ForceCollisionRadius>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_link.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_link.cpp
@@ -77,8 +77,7 @@ namespace rerun {
             cells.push_back(archetype.iterations.value());
         }
         {
-            auto indicator = ForceLink::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ForceLink>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.cpp
@@ -64,8 +64,7 @@ namespace rerun {
             cells.push_back(archetype.strength.value());
         }
         {
-            auto indicator = ForceManyBody::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ForceManyBody>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_position.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_position.cpp
@@ -77,8 +77,7 @@ namespace rerun {
             cells.push_back(archetype.position.value());
         }
         {
-            auto indicator = ForcePosition::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ForcePosition>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.cpp
@@ -105,8 +105,7 @@ namespace rerun {
             cells.push_back(archetype.color.value());
         }
         {
-            auto indicator = LineGrid3D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<LineGrid3D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_background.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_background.cpp
@@ -50,8 +50,7 @@ namespace rerun {
             cells.push_back(archetype.provider.value());
         }
         {
-            auto indicator = MapBackground::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<MapBackground>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.cpp
@@ -50,8 +50,7 @@ namespace rerun {
             cells.push_back(archetype.zoom.value());
         }
         {
-            auto indicator = MapZoom::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<MapZoom>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.cpp
@@ -54,8 +54,7 @@ namespace rerun {
             cells.push_back(archetype.near_clip_plane.value());
         }
         {
-            auto indicator = NearClipPlane::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<NearClipPlane>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.cpp
@@ -51,8 +51,7 @@ namespace rerun {
             cells.push_back(archetype.state.value());
         }
         {
-            auto indicator = PanelBlueprint::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<PanelBlueprint>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.cpp
@@ -64,8 +64,7 @@ namespace rerun {
             cells.push_back(archetype.visible.value());
         }
         {
-            auto indicator = PlotLegend::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<PlotLegend>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.cpp
@@ -64,8 +64,7 @@ namespace rerun {
             cells.push_back(archetype.zoom_lock.value());
         }
         {
-            auto indicator = ScalarAxis::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ScalarAxis>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.cpp
@@ -76,8 +76,7 @@ namespace rerun {
             cells.push_back(archetype.gamma.value());
         }
         {
-            auto indicator = TensorScalarMapping::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<TensorScalarMapping>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.cpp
@@ -97,8 +97,7 @@ namespace rerun {
             cells.push_back(archetype.slider.value());
         }
         {
-            auto indicator = TensorSliceSelection::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<TensorSliceSelection>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.cpp
@@ -51,8 +51,7 @@ namespace rerun {
             cells.push_back(archetype.scaling.value());
         }
         {
-            auto indicator = TensorViewFit::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<TensorViewFit>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.cpp
@@ -97,8 +97,7 @@ namespace rerun {
             cells.push_back(archetype.visible.value());
         }
         {
-            auto indicator = ViewBlueprint::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ViewBlueprint>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.cpp
@@ -51,8 +51,7 @@ namespace rerun {
             cells.push_back(archetype.query.value());
         }
         {
-            auto indicator = ViewContents::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ViewContents>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.cpp
@@ -113,8 +113,7 @@ namespace rerun {
             cells.push_back(archetype.past_viewer_recommendations.value());
         }
         {
-            auto indicator = ViewportBlueprint::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<ViewportBlueprint>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.cpp
@@ -51,8 +51,7 @@ namespace rerun {
             cells.push_back(archetype.ranges.value());
         }
         {
-            auto indicator = VisibleTimeRanges::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<VisibleTimeRanges>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.cpp
@@ -51,8 +51,7 @@ namespace rerun {
             cells.push_back(archetype.range.value());
         }
         {
-            auto indicator = VisualBounds2D::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<VisualBounds2D>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -40,8 +40,8 @@ namespace rerun {
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
         [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(const rerun::Collection<T>& components) {
+        )]] static Result<ComponentBatch>
+            from_loggable(const rerun::Collection<T>& components) {
             return from_loggable(components, Loggable<T>::Descriptor);
         }
 
@@ -96,8 +96,8 @@ namespace rerun {
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
         [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(const T& component) {
+        )]] static Result<ComponentBatch>
+            from_loggable(const T& component) {
             // Collection adapter will automatically borrow for single elements, but let's do this explicitly, avoiding the extra hoop.
             const auto collection = Collection<T>::borrow(&component, 1);
             return from_loggable(collection);
@@ -122,8 +122,8 @@ namespace rerun {
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
         [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(const std::optional<T>& component) {
+        )]] static Result<ComponentBatch>
+            from_loggable(const std::optional<T>& component) {
             if (component.has_value()) {
                 return from_loggable(component.value());
             } else {
@@ -154,10 +154,8 @@ namespace rerun {
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
         [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(
-            const std::optional<rerun::Collection<T>>& components
-        ) {
+        )]] static Result<ComponentBatch>
+            from_loggable(const std::optional<rerun::Collection<T>>& components) {
             if (components.has_value()) {
                 return from_loggable(components.value());
             } else {

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -29,12 +29,6 @@ namespace rerun {
         ComponentTypeHandle component_type;
 
       public:
-        ComponentBatch() = default;
-        ComponentBatch(ComponentBatch&& other) = default;
-        ComponentBatch(const ComponentBatch& other) = default;
-        ComponentBatch& operator=(ComponentBatch&& other) = default;
-        ComponentBatch& operator=(const ComponentBatch& other) = default;
-
         /// Creates a new empty component batch with a given descriptor.
         template <typename T>
         static Result<ComponentBatch> empty(const ComponentDescriptor& descriptor) {
@@ -45,6 +39,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(const rerun::Collection<T>& components) {
             return from_loggable(components, Loggable<T>::Descriptor);
         }
@@ -99,6 +95,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(const T& component) {
             // Collection adapter will automatically borrow for single elements, but let's do this explicitly, avoiding the extra hoop.
             const auto collection = Collection<T>::borrow(&component, 1);
@@ -123,6 +121,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(const std::optional<T>& component) {
             if (component.has_value()) {
                 return from_loggable(component.value());
@@ -153,6 +153,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(
             const std::optional<rerun::Collection<T>>& components
         ) {
@@ -178,6 +180,15 @@ namespace rerun {
             } else {
                 return from_loggable(Collection<T>(), descriptor);
             }
+        }
+
+        /// Creates a new component batch for an archetype indicator.
+        template <typename Archetype>
+        static Result<ComponentBatch> from_indicator() {
+            return ComponentBatch::from_loggable(
+                typename Archetype::IndicatorComponent(),
+                Loggable<typename Archetype::IndicatorComponent>::Descriptor
+            );
         }
 
         /// Size in the number of elements the underlying arrow array contains.

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -39,9 +39,7 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]] static Result<ComponentBatch>
-            from_loggable(const rerun::Collection<T>& components) {
+        static Result<ComponentBatch> from_loggable(const rerun::Collection<T>& components) {
             return from_loggable(components, Loggable<T>::Descriptor);
         }
 
@@ -95,9 +93,7 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]] static Result<ComponentBatch>
-            from_loggable(const T& component) {
+        static Result<ComponentBatch> from_loggable(const T& component) {
             // Collection adapter will automatically borrow for single elements, but let's do this explicitly, avoiding the extra hoop.
             const auto collection = Collection<T>::borrow(&component, 1);
             return from_loggable(collection);
@@ -121,9 +117,7 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]] static Result<ComponentBatch>
-            from_loggable(const std::optional<T>& component) {
+        static Result<ComponentBatch> from_loggable(const std::optional<T>& component) {
             if (component.has_value()) {
                 return from_loggable(component.value());
             } else {
@@ -153,9 +147,9 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]] static Result<ComponentBatch>
-            from_loggable(const std::optional<rerun::Collection<T>>& components) {
+        static Result<ComponentBatch> from_loggable(
+            const std::optional<rerun::Collection<T>>& components
+        ) {
             if (components.has_value()) {
                 return from_loggable(components.value());
             } else {

--- a/rerun_cpp/src/rerun/component_column.hpp
+++ b/rerun_cpp/src/rerun/component_column.hpp
@@ -33,6 +33,24 @@ namespace rerun {
         /// \param lengths The number of components in each run. for `rerun::RecordingStream::send_columns`,
         /// this specifies the number of components at each time point.
         /// The sum of the lengths must be equal to the number of components in the batch.
+        template <typename T>
+        [[deprecated(
+            "Use from_loggable_with_lengths(components, lengths, descriptor) (with explicit descriptor) instead"
+        )]]
+        static Result<ComponentColumn> from_loggable_with_lengths(
+            const Collection<T>& components, const Collection<uint32_t>& lengths
+        ) {
+            return from_loggable_with_lengths(components, lengths, Loggable<T>::Descriptor);
+        }
+
+        /// Creates a new component column from a collection of component instances.
+        ///
+        /// Automatically registers the component type the first time this type is encountered.
+        ///
+        /// \param components Continuous collection of components which is about to be partitioned.
+        /// \param lengths The number of components in each run. for `rerun::RecordingStream::send_columns`,
+        /// this specifies the number of components at each time point.
+        /// The sum of the lengths must be equal to the number of components in the batch.
         /// \param descriptor Descriptor of the component type for this column.
         template <typename T>
         static Result<ComponentColumn> from_loggable_with_lengths(
@@ -44,6 +62,21 @@ namespace rerun {
                 return component_batch_result.error;
             }
             return from_batch_with_lengths(component_batch_result.value, lengths);
+        }
+
+        /// Creates a new component column from a collection of component instances where each run has a length of one.
+        ///
+        /// When used with `rerun::RecordingStream::send_columns`, this is equivalent to `from_loggable(components, std::vector{1, 1, ...})`.
+        /// I.e. there's a single component for each time point.
+        ///
+        /// Automatically registers the component type the first time this type is encountered.
+        ///
+        /// \param components Continuous collection of components which is about to be partitioned into runs of length one.
+        template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
+        static Result<ComponentColumn> from_loggable(const Collection<T>& components) {
+            return from_loggable(components, Loggable<T>::Descriptor);
         }
 
         /// Creates a new component column from a collection of component instances where each run has a length of one.
@@ -70,8 +103,7 @@ namespace rerun {
         /// Creates a new component column with a given number of archetype indicators for a given archetype type.
         template <typename Archetype>
         static Result<ComponentColumn> from_indicators(uint32_t num_indicators) {
-            auto component_batch_result =
-                ComponentBatch::from_loggable(typename Archetype::IndicatorComponent());
+            auto component_batch_result = ComponentBatch::from_indicator<Archetype>();
             if (component_batch_result.is_err()) {
                 return component_batch_result.error;
             }

--- a/rerun_cpp/src/rerun/component_column.hpp
+++ b/rerun_cpp/src/rerun/component_column.hpp
@@ -36,10 +36,10 @@ namespace rerun {
         template <typename T>
         [[deprecated(
             "Use from_loggable_with_lengths(components, lengths, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentColumn> from_loggable_with_lengths(
-            const Collection<T>& components, const Collection<uint32_t>& lengths
-        ) {
+        )]] static Result<ComponentColumn>
+            from_loggable_with_lengths(
+                const Collection<T>& components, const Collection<uint32_t>& lengths
+            ) {
             return from_loggable_with_lengths(components, lengths, Loggable<T>::Descriptor);
         }
 
@@ -74,8 +74,8 @@ namespace rerun {
         /// \param components Continuous collection of components which is about to be partitioned into runs of length one.
         template <typename T>
         [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentColumn> from_loggable(const Collection<T>& components) {
+        )]] static Result<ComponentColumn>
+            from_loggable(const Collection<T>& components) {
             return from_loggable(components, Loggable<T>::Descriptor);
         }
 

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -322,8 +322,7 @@ namespace rerun {
             cells.push_back(archetype.fuzz1022.value());
         }
         {
-            auto indicator = AffixFuzzer1::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<AffixFuzzer1>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -283,8 +283,7 @@ namespace rerun {
             cells.push_back(archetype.fuzz1122.value());
         }
         {
-            auto indicator = AffixFuzzer2::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<AffixFuzzer2>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -270,8 +270,7 @@ namespace rerun {
             cells.push_back(archetype.fuzz2018.value());
         }
         {
-            auto indicator = AffixFuzzer3::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<AffixFuzzer3>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -270,8 +270,7 @@ namespace rerun {
             cells.push_back(archetype.fuzz2118.value());
         }
         {
-            auto indicator = AffixFuzzer4::IndicatorComponent();
-            auto result = ComponentBatch::from_loggable(indicator);
+            auto result = ComponentBatch::from_indicator<AffixFuzzer4>();
             RR_RETURN_NOT_OK(result.error);
             cells.emplace_back(std::move(result.value));
         }


### PR DESCRIPTION
This is just a cherry-pick of @Wumpf's work -- I actually didn't have to do anything more.

TODO:
* [x] Fix warnings on all compilers
* [x] Rebase order-agnostic comparison on top, and see if we're passing