### PR TITLE
Fix formatting in Python SDK LineStrip2D/3D

### DIFF
--- a/rerun_py/rerun_sdk/rerun/components/geo_line_string_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/geo_line_string_ext.py
@@ -74,7 +74,7 @@ class GeoLineStringExt:
                         else:
                             if isinstance(strip, np.ndarray) and (strip.ndim != 2 or strip.shape[1] != 2):
                                 raise ValueError(
-                                    "Expected a sequence of 2D vectors, instead got array with shape {strip.shape}."
+                                    f"Expected a sequence of 2D vectors, instead got array with shape {strip.shape}."
                                 )
                             return DVec2DBatch(strip)
 

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d_ext.py
@@ -67,7 +67,7 @@ class LineStrip2DExt:
                         else:
                             if isinstance(strip, np.ndarray) and (strip.ndim != 2 or strip.shape[1] != 2):
                                 raise ValueError(
-                                    "Expected a sequence of 2D vectors, instead got array with shape {strip.shape}."
+                                    f"Expected a sequence of 2D vectors, instead got array with shape {strip.shape}."
                                 )
                             return Vec2DBatch(strip)
 

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d_ext.py
@@ -67,7 +67,7 @@ class LineStrip3DExt:
                         else:
                             if isinstance(strip, np.ndarray) and (strip.ndim != 2 or strip.shape[1] != 3):
                                 raise ValueError(
-                                    "Expected a sequence of 3D vectors, instead got array with shape {strip.shape}."
+                                    f"Expected a sequence of 3D vectors, instead got array with shape {strip.shape}."
                                 )
                             return Vec3DBatch(strip)
 


### PR DESCRIPTION
Error message in Python SDK LineStrip2D/3D is missing f-string