### PR TITLE
Remove indicators from custom data examples

### DIFF
--- a/docs/snippets/all/descriptors/descr_custom_archetype.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.cpp
@@ -26,9 +26,6 @@ struct rerun::Loggable<CustomPosition3D> {
 
 /// A custom archetype that extends Rerun's builtin `rerun::Points3D` archetype with a custom component.
 struct CustomPoints3D {
-    static constexpr const char IndicatorComponentName[] = "user.CustomPoints3DIndicator";
-    using IndicatorComponent = rerun::components::IndicatorComponent<IndicatorComponentName>;
-
     rerun::Collection<CustomPosition3D> positions;
     std::optional<rerun::Collection<rerun::Color>> colors;
 };
@@ -37,8 +34,6 @@ template <>
 struct rerun::AsComponents<CustomPoints3D> {
     static Result<std::vector<ComponentBatch>> serialize(const CustomPoints3D& archetype) {
         std::vector<rerun::ComponentBatch> batches;
-
-        batches.push_back(ComponentBatch::from_indicator<CustomPoints3D>().value_or_throw());
 
         auto positions_descr = rerun::Loggable<CustomPosition3D>::Descriptor
                                    .or_with_archetype_name("user.CustomPoints3D")

--- a/docs/snippets/all/descriptors/descr_custom_archetype.py
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.py
@@ -23,7 +23,7 @@ class CustomPoints3D(rr.AsComponents):
         )
 
     def as_component_batches(self) -> Iterable[rr.ComponentBatchLike]:
-        return [rr.IndicatorComponentBatch("user.CustomPoints3D"), self.positions, self.colors]
+        return [self.positions, self.colors]
 
 
 rr.init("rerun_example_descriptors_custom_archetype")

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -6,10 +6,6 @@ struct CustomPoints3D {
 }
 
 impl CustomPoints3D {
-    fn indicator() -> rerun::NamedIndicatorComponent {
-        rerun::NamedIndicatorComponent("user.CustomPoints3DIndicator".into())
-    }
-
     fn overridden_position_descriptor() -> ComponentDescriptor {
         ComponentDescriptor {
             archetype_name: Some("user.CustomPoints3D".into()),
@@ -28,7 +24,6 @@ impl CustomPoints3D {
 impl rerun::AsComponents for CustomPoints3D {
     fn as_serialized_batches(&self) -> Vec<rerun::SerializedComponentBatch> {
         [
-            Self::indicator().serialized(),
             self.positions.serialized().map(|positions| {
                 positions.with_descriptor_override(Self::overridden_position_descriptor())
             }),
@@ -105,11 +100,6 @@ fn check_tags(rec: &rerun::RecordingStream) {
         descriptors.sort();
 
         let expected = vec![
-            ComponentDescriptor {
-                archetype_name: None,
-                archetype_field_name: None,
-                component_name: "user.CustomPoints3DIndicator".into(),
-            },
             ComponentDescriptor {
                 archetype_name: Some("user.CustomPoints3D".into()),
                 archetype_field_name: Some("colors".into()),

--- a/docs/snippets/all/tutorials/custom_data.cpp
+++ b/docs/snippets/all/tutorials/custom_data.cpp
@@ -29,9 +29,6 @@ struct rerun::Loggable<Confidence> {
 
 /// A custom archetype that extends Rerun's builtin `rerun::Points3D` archetype with a custom component.
 struct CustomPoints3D {
-    static constexpr const char IndicatorComponentName[] = "user.CustomPoints3DIndicator";
-    using IndicatorComponent = rerun::components::IndicatorComponent<IndicatorComponentName>;
-
     rerun::Points3D points;
     // Using a rerun::Collection is not strictly necessary, you could also use an std::vector for example,
     // but useful for avoiding allocations since `rerun::Collection` can borrow data from other containers.
@@ -42,9 +39,6 @@ template <>
 struct rerun::AsComponents<CustomPoints3D> {
     static Result<std::vector<ComponentBatch>> serialize(const CustomPoints3D& archetype) {
         auto batches = AsComponents<rerun::Points3D>::serialize(archetype.points).value_or_throw();
-
-        // Add a custom indicator component.
-        batches.push_back(ComponentBatch::from_indicator<CustomPoints3D>().value_or_throw());
 
         // Add custom confidence components if present.
         if (archetype.confidences) {

--- a/docs/snippets/all/tutorials/custom_data.py
+++ b/docs/snippets/all/tutorials/custom_data.py
@@ -38,7 +38,6 @@ class CustomPoints3D(rr.AsComponents):
     def as_component_batches(self) -> Iterable[rr.ComponentBatchLike]:
         return (
             list(self.points3d.as_component_batches())  # The components from Points3D
-            + [rr.IndicatorComponentBatch("user.CustomPoints3D")]  # Our custom indicator
             + [self.confidences]  # Custom confidence data
         )
 

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -19,22 +19,19 @@ struct CustomPoints3D {
 
 impl rerun::AsComponents for CustomPoints3D {
     fn as_serialized_batches(&self) -> Vec<SerializedComponentBatch> {
-        let indicator = rerun::NamedIndicatorComponent("user.CustomPoints3DIndicator".into());
         self.points3d
             .as_serialized_batches()
             .into_iter()
             .chain(
-                [
-                    indicator.serialized(),
-                    self.confidences
-                        .as_ref()
-                        .and_then(|batch| batch.serialized())
-                        .map(|batch|
+                [self
+                    .confidences
+                    .as_ref()
+                    .and_then(|batch| batch.serialized())
+                    .map(|batch|
                             // Optionally override the descriptor with extra information.
                             batch
                                 .or_with_archetype_name(|| "user.CustomPoints3D".into())
-                                .or_with_archetype_field_name(|| "confidences".into())),
-                ]
+                                .or_with_archetype_field_name(|| "confidences".into()))]
                 .into_iter()
                 .flatten(),
             )


### PR DESCRIPTION
This is just confusing users for no value: A) they're deprecated and B) only the builtin indicators have any effect on the viewer anyhow.