### PR TITLE
Python: untagged-resistant APIs

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2645,15 +2645,14 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
                     {init_args},
                 )
 
-            batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+            batches = inst.as_component_batches(include_indicators=False)
             if len(batches) == 0:
                 return ComponentColumnList([])
 
             lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
             columns = [batch.partition(lengths) for batch in batches]
 
-            indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-            indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+            indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
             return ComponentColumnList([indicator_column] + columns)
         "#

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -50,7 +50,6 @@ pub trait Archetype {
     /// Creates a [`ComponentBatch`] out of the associated [`Self::Indicator`] component.
     ///
     /// This allows for associating arbitrary indicator components with arbitrary data.
-    /// Check out the `manual_indicator` API example to see what's possible.
     fn indicator() -> SerializedComponentBatch;
 
     /// Returns all component descriptors that _must_ be provided by the user when constructing this archetype.

--- a/docs/content/howto/logging/custom-data.md
+++ b/docs/content/howto/logging/custom-data.md
@@ -37,7 +37,7 @@ class LabeledPoints:
     points: np.ndarray
     labels: List[str]
 
-    def as_component_batches(self) -> Iterable[rr.ComponentBatch]:
+    def as_component_batches(self) -> list[rr.ComponentBatch]:
         return rr.Points3D(positions=self.points,
                            labels=self.labels).as_component_batches()
 …

--- a/docs/snippets/all/descriptors/descr_custom_archetype.py
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any
 
 import numpy.typing as npt
 import rerun as rr  # pip install rerun-sdk
@@ -22,7 +22,7 @@ class CustomPoints3D(rr.AsComponents):
             archetype_field_name="colors",
         )
 
-    def as_component_batches(self) -> Iterable[rr.ComponentBatchLike]:
+    def as_component_batches(self) -> list[rr.DescribedComponentBatch]:
         return [self.positions, self.colors]
 
 

--- a/docs/snippets/all/tutorials/custom_data.py
+++ b/docs/snippets/all/tutorials/custom_data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from typing import Any, Iterable
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -35,7 +35,7 @@ class CustomPoints3D(rr.AsComponents):
             archetype_name="user.CustomPoints3D", archetype_field_name="confidences"
         )
 
-    def as_component_batches(self) -> Iterable[rr.ComponentBatchLike]:
+    def as_component_batches(self) -> list[rr.DescribedComponentBatch]:
         return (
             list(self.points3d.as_component_batches())  # The components from Points3D
             + [self.confidences]  # Custom confidence data

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -2,7 +2,6 @@
 
 # These snippets will be excluded from the snippet index, unconditionally.
 [snippets_ref.snippets.opt_out]
-"archetypes/manual_indicator" = []
 
 # These archetypes will ignore the associated snippets in the snippet index.
 [snippets_ref.archetypes.opt_out]

--- a/examples/python/openstreetmap_data/openstreetmap_data.py
+++ b/examples/python/openstreetmap_data/openstreetmap_data.py
@@ -81,7 +81,7 @@ def log_way(way: dict[str, Any]) -> None:
 def log_data(data: dict[str, Any]) -> None:
     try:
         copyright_text = data["osm3s"]["copyright"]
-        rr.log("copyright", [rr.components.Text(copyright_text)], static=True)
+        rr.log("copyright", rr.TextDocument(copyright_text), static=True)
     except KeyError:
         pass
 

--- a/examples/python/plots/plots.py
+++ b/examples/python/plots/plots.py
@@ -101,10 +101,7 @@ def log_classification() -> None:
         rr.log(
             "classification/samples",
             rr.Scalar(g_of_t),
-            [
-                rr.components.Color(color),
-                rr.components.MarkerSize(marker_size),
-            ],
+            rr.SeriesPoint(color=color, marker_size=marker_size),
         )
 
 

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -33,6 +33,7 @@ from . import (
     remote as remote,
 )
 from ._baseclasses import (
+    ComponentBatchLike as ComponentBatchLike,
     ComponentBatchMixin as ComponentBatchMixin,
     ComponentColumn as ComponentColumn,
     ComponentColumnList as ComponentColumnList,
@@ -45,7 +46,6 @@ from ._image_encoded import (
 )
 from ._log import (
     AsComponents as AsComponents,
-    ComponentBatchLike as ComponentBatchLike,
     IndicatorComponentBatch as IndicatorComponentBatch,
     escape_entity_path_part as escape_entity_path_part,
     log as log,

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -172,7 +172,7 @@ class ComponentBatchLike(Protocol):
 class AsComponents(Protocol):
     """Describes interface for interpreting an object as a bundle of Components."""
 
-    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+    def as_component_batches(self) -> list[DescribedComponentBatch]:
         """
         Returns an iterable of `ComponentBatchLike` objects.
 
@@ -204,24 +204,27 @@ class Archetype:
         return ".".join(cls.__module__.rsplit(".", 1)[:-1] + [cls.__name__])
 
     @classmethod
-    def indicator(cls) -> ComponentBatchLike:
+    def indicator(cls) -> DescribedComponentBatch:
         """
-        Creates a `ComponentBatchLike` out of the associated indicator component.
+        Creates a `DescribedComponentBatch` out of the associated indicator component.
 
         This allows for associating arbitrary indicator components with arbitrary data.
-        Check out the `manual_indicator` API example to see what's possible.
         """
         from ._log import IndicatorComponentBatch
 
-        return IndicatorComponentBatch(cls.archetype_name())
+        indicator = IndicatorComponentBatch(cls.archetype_name())
+        return DescribedComponentBatch(indicator, indicator.component_descriptor())
 
-    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+    def as_component_batches(self, *, include_indicators: bool = True) -> list[DescribedComponentBatch]:
         """
         Return all the component batches that make up the archetype.
 
         Part of the `AsComponents` logging interface.
         """
-        yield self.indicator()
+        if include_indicators:
+            batches = [self.indicator()]
+        else:
+            batches = []
 
         for fld in fields(type(self)):
             if "component" in fld.metadata:
@@ -232,7 +235,9 @@ class Archetype:
                         archetype_name=self.archetype_name(),
                         archetype_field_name=fld.name,
                     )
-                    yield DescribedComponentBatch(comp, descr)
+                    batches.append(DescribedComponentBatch(comp, descr))
+
+        return batches
 
     __repr__ = __str__
 

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable
 import pyarrow as pa
 import rerun_bindings as bindings
 
-from ._baseclasses import AsComponents, ComponentBatchLike, ComponentDescriptor
+from ._baseclasses import AsComponents, ComponentDescriptor, DescribedComponentBatch
 from .error_utils import _send_warning_or_raise, catch_and_log_exceptions
 from .recording_stream import RecordingStream
 
@@ -50,8 +50,8 @@ class IndicatorComponentBatch:
 @catch_and_log_exceptions()
 def log(
     entity_path: str | list[str],
-    entity: AsComponents | Iterable[ComponentBatchLike],
-    *extra: AsComponents | Iterable[ComponentBatchLike],
+    entity: AsComponents | Iterable[DescribedComponentBatch],
+    *extra: AsComponents | Iterable[DescribedComponentBatch],
     static: bool = False,
     recording: RecordingStream | None = None,
     strict: bool | None = None,
@@ -170,7 +170,7 @@ def log(
 @catch_and_log_exceptions()
 def log_components(
     entity_path: str | list[str],
-    components: Iterable[ComponentBatchLike],
+    components: Iterable[DescribedComponentBatch],
     *,
     static: bool = False,
     recording: RecordingStream | None = None,

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any
 
 import numpy as np
 import pyarrow as pa
 
 from rerun._baseclasses import ComponentDescriptor
 
-from ._baseclasses import ComponentColumn, ComponentColumnList
-from ._log import AsComponents, ComponentBatchLike
+from ._baseclasses import ComponentBatchLike, ComponentColumn, ComponentColumnList, DescribedComponentBatch
+from ._log import AsComponents
 from .error_utils import catch_and_log_exceptions
 
 ANY_VALUE_TYPE_REGISTRY: dict[ComponentDescriptor, Any] = {}
@@ -213,15 +213,15 @@ class AnyValues(AsComponents):
         """
         global ANY_VALUE_TYPE_REGISTRY
 
-        self.component_batches = []
+        self.component_batches = list([])
 
         with catch_and_log_exceptions(self.__class__.__name__):
             for name, value in kwargs.items():
                 batch = AnyBatchValue(name, value, drop_untyped_nones=drop_untyped_nones)
                 if batch.is_valid():
-                    self.component_batches.append(batch)
+                    self.component_batches.append(DescribedComponentBatch(batch, batch.descriptor))
 
-    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+    def as_component_batches(self) -> list[DescribedComponentBatch]:
         return self.component_batches
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -213,7 +213,7 @@ class AnyValues(AsComponents):
         """
         global ANY_VALUE_TYPE_REGISTRY
 
-        self.component_batches = list([])
+        self.component_batches = list()
 
         with catch_and_log_exceptions(self.__class__.__name__):
             for name, value in kwargs.items():

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -14,7 +14,6 @@ from .. import components
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -161,15 +160,14 @@ class AnnotationContext(Archetype):
                 context=context,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .arrows2d_ext import Arrows2DExt
@@ -224,15 +223,14 @@ class Arrows2D(Arrows2DExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .arrows3d_ext import Arrows3DExt
@@ -211,15 +210,14 @@ class Arrows3D(Arrows3DExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .asset3d_ext import Asset3DExt
@@ -182,15 +181,14 @@ class Asset3D(Asset3DExt, Archetype):
                 albedo_factor=albedo_factor,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .asset_video_ext import AssetVideoExt
@@ -216,15 +215,14 @@ class AssetVideo(AssetVideoExt, Archetype):
                 media_type=media_type,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .bar_chart_ext import BarChartExt
@@ -157,15 +156,14 @@ class BarChart(BarChartExt, Archetype):
                 color=color,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .boxes2d_ext import Boxes2DExt
@@ -209,15 +208,14 @@ class Boxes2D(Boxes2DExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .boxes3d_ext import Boxes3DExt
@@ -255,15 +254,14 @@ class Boxes3D(Boxes3DExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .capsules3d_ext import Capsules3DExt
@@ -254,15 +253,14 @@ class Capsules3D(Capsules3DExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .clear_ext import ClearExt
@@ -132,15 +131,14 @@ class Clear(ClearExt, Archetype):
                 is_recursive=is_recursive,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .depth_image_ext import DepthImageExt
@@ -252,15 +251,14 @@ class DepthImage(DepthImageExt, Archetype):
                 draw_order=draw_order,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .ellipsoids3d_ext import Ellipsoids3DExt
@@ -256,15 +255,14 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .encoded_image_ext import EncodedImageExt
@@ -177,15 +176,14 @@ class EncodedImage(EncodedImageExt, Archetype):
                 draw_order=draw_order,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .geo_line_strings_ext import GeoLineStringsExt
@@ -173,15 +172,14 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
                 colors=colors,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .geo_points_ext import GeoPointsExt
@@ -176,15 +175,14 @@ class GeoPoints(GeoPointsExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -169,15 +168,14 @@ class GraphEdges(Archetype):
                 graph_type=graph_type,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -221,15 +220,14 @@ class GraphNodes(Archetype):
                 radii=radii,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .image_ext import ImageExt
@@ -207,15 +206,14 @@ class Image(ImageExt, Archetype):
                 draw_order=draw_order,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -229,15 +228,14 @@ class InstancePoses3D(Archetype):
                 mat3x3=mat3x3,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -301,15 +300,14 @@ class LineStrips2D(Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -292,15 +291,14 @@ class LineStrips3D(Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .mesh3d_ext import Mesh3DExt
@@ -272,15 +271,14 @@ class Mesh3D(Mesh3DExt, Archetype):
                 class_ids=class_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .pinhole_ext import PinholeExt
@@ -252,15 +251,14 @@ class Pinhole(PinholeExt, Archetype):
                 image_plane_distance=image_plane_distance,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .points2d_ext import Points2DExt
@@ -279,15 +278,14 @@ class Points2D(Points2DExt, Archetype):
                 keypoint_ids=keypoint_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .points3d_ext import Points3DExt
@@ -302,15 +301,14 @@ class Points3D(Points3DExt, Archetype):
                 keypoint_ids=keypoint_ids,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -185,15 +184,14 @@ class Scalar(Archetype):
                 scalar=scalar,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .segmentation_image_ext import SegmentationImageExt
@@ -179,15 +178,14 @@ class SegmentationImage(SegmentationImageExt, Archetype):
                 draw_order=draw_order,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -219,15 +218,14 @@ class SeriesLine(Archetype):
                 aggregation_policy=aggregation_policy,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -225,15 +224,14 @@ class SeriesPoint(Archetype):
                 marker_size=marker_size,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .tensor_ext import TensorExt
@@ -165,15 +164,14 @@ class Tensor(TensorExt, Archetype):
                 value_range=value_range,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -217,15 +216,14 @@ class TextDocument(Archetype):
                 media_type=media_type,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 
@@ -186,15 +185,14 @@ class TextLog(Archetype):
                 color=color,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .transform3d_ext import Transform3DExt
@@ -280,15 +279,14 @@ class Transform3D(Transform3DExt, Archetype):
                 axis_length=axis_length,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -12,7 +12,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .video_frame_reference_ext import VideoFrameReferenceExt
@@ -232,15 +231,14 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
                 video_reference=video_reference,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -14,7 +14,6 @@ from .. import components, datatypes
 from .._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from ..error_utils import catch_and_log_exceptions
 from .view_coordinates_ext import ViewCoordinatesExt
@@ -163,15 +162,14 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
                 xyz=xyz,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates_ext.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Iterable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import numpy.typing as npt
 
 if TYPE_CHECKING:
-    from .._log import ComponentBatchLike
+    from .._baseclasses import DescribedComponentBatch
     from . import ViewCoordinates
 
 
@@ -30,7 +30,7 @@ class ViewCoordinatesExt:
         return coordinates
 
     # Implement the AsComponents protocol
-    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+    def as_component_batches(self) -> list[DescribedComponentBatch]:
         from ..archetypes import ViewCoordinates
         from ..components import ViewCoordinates as ViewCoordinatesComponent
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import itertools
-from typing import TYPE_CHECKING, Any, Iterable, Sequence, cast
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import pyarrow as pa
 
 from .keypoint_pair_ext import _keypoint_pair_converter
 
 if TYPE_CHECKING:
-    from .. import ComponentBatchLike
+    from .. import DescribedComponentBatch
     from . import (
         AnnotationInfo,
         AnnotationInfoLike,
@@ -65,7 +65,7 @@ class ClassDescriptionExt:
         )
 
     # Implement the AsComponents protocol
-    def as_component_batches(self) -> Iterable[ComponentBatchLike]:
+    def as_component_batches(self) -> list[DescribedComponentBatch]:
         from ..archetypes import AnnotationContext
         from . import ClassDescription
 

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -12,7 +12,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from rerun.error_utils import catch_and_log_exceptions
 
@@ -247,15 +246,14 @@ class AffixFuzzer1(Archetype):
                 fuzz1022=fuzz1022,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -12,7 +12,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from rerun.error_utils import catch_and_log_exceptions
 
@@ -226,15 +225,14 @@ class AffixFuzzer2(Archetype):
                 fuzz1122=fuzz1122,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -12,7 +12,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from rerun.error_utils import catch_and_log_exceptions
 
@@ -220,15 +219,14 @@ class AffixFuzzer3(Archetype):
                 fuzz2018=fuzz2018,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -12,7 +12,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
     ComponentColumnList,
-    DescribedComponentBatch,
 )
 from rerun.error_utils import catch_and_log_exceptions
 
@@ -220,15 +219,14 @@ class AffixFuzzer4(Archetype):
                 fuzz2118=fuzz2118,
             )
 
-        batches = [batch for batch in inst.as_component_batches() if isinstance(batch, DescribedComponentBatch)]
+        batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
         lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
         columns = [batch.partition(lengths) for batch in batches]
 
-        indicator_batch = DescribedComponentBatch(cls.indicator(), cls.indicator().component_descriptor())
-        indicator_column = indicator_batch.partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
 
         return ComponentColumnList([indicator_column] + columns)
 


### PR DESCRIPTION
It's pretty much just a matter of explicitly asking for `DescribedComponentBatch`es instead of `ComponentBatchLike`s in a couple of places.

The end result is that legacy code still works, but yields type errors.

* Fixes https://github.com/rerun-io/rerun/issues/8756