### PR TITLE
Require descriptors to be provided on all log calls in C++ (either explicitely or implicitely via archetype)

### DIFF
--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -39,11 +39,29 @@ As part of the switch to "eager archetype serialization" (serialization of arche
 
 However, it is still possible to do so with the `TensorData` component.
 
-### C++ `RecordingStream::send_column` no longer takes raw component collections
+### C++ `RecordingStream::log`/`send_column` no longer takes raw component collections
 
-Previously, `RecordingStream::send_column` accepted raw component collections.
+Previously, both `RecordingStream::log` and `RecordingStream::send_column` were able to
+handle raw component collections which then would be serialized to arrow on the fly.
 
-This is no longer the case and only `rerun::ComponentColumn` and anything else from which
+#### `log`
+
+Under the hood we allow any type that implements the `AsComponents` trait.
+However, `AsComponents` is no longer implemented for collections of components / implementors of `Loggable`.
+
+Instead, you're encouraged to use archetypes for cases where you'd previously use loose collections of components.
+This is made easier by the fact that archetypes can now be created without specifying required components.
+For example, colors of a point cloud can be logged without position data:
+
+```cpp
+rec.log("points", rerun::Points3D().with_colors(colors));
+```
+
+Custom implementations of `AsComponents` still work as before.
+
+#### `send_column`
+
+Only `rerun::ComponentColumn` and anything else from which
 a `Collection<ComponentColumn>` can be constructed is accepted.
 The preferred way to create `rerun::ComponentColumn`s is to use the new `columns` method on archetypes.
 

--- a/docs/snippets/all/concepts/different_data_per_timeline.cpp
+++ b/docs/snippets/all/concepts/different_data_per_timeline.cpp
@@ -13,12 +13,12 @@ int main() {
     // Log a red color on one timeline.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_seconds("red timeline", 1.0);
-    rec.log("points", std::array{rerun::components::Color(0xFF0000FF)});
+    rec.log("points", rerun::Points2D::update_fields().with_colors(rerun::Color(0xFF0000FF)));
 
     // And a blue color on the other.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_sequence("blue timeline", 1);
-    rec.log("points", std::array{rerun::components::Color(0x0000FFFF)});
+    rec.log("points", rerun::Points2D::update_fields().with_colors(rerun::Color(0x0000FFFF)));
 
     // TODO(#5521): log VisualBounds2D
 }

--- a/docs/snippets/all/descriptors/descr_builtin_component.cpp
+++ b/docs/snippets/all/descriptors/descr_builtin_component.cpp
@@ -4,8 +4,13 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_descriptors_builtin_component");
     rec.spawn().exit_on_failure();
 
-    rerun::Position3D positions[1] = {{1.0f, 2.0f, 3.0f}};
-    rec.log_static("data", positions);
+    rec.log_static(
+        "data",
+        rerun::ComponentBatch::from_loggable<rerun::Position3D>(
+            {1.0f, 2.0f, 3.0f},
+            rerun::Loggable<rerun::Position3D>::Descriptor
+        )
+    );
 
     // The tags are indirectly checked by the Rust version (have a look over there for more info).
 }

--- a/docs/snippets/all/descriptors/descr_custom_component.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_component.cpp
@@ -28,11 +28,10 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_descriptors_custom_component");
     rec.spawn().exit_on_failure();
 
-    CustomPosition3D positions[1] = {{rerun::components::Position3D{1.0f, 2.0f, 3.0f}}};
     rec.log_static(
         "data",
-        rerun::ComponentBatch::from_loggable(
-            positions,
+        rerun::ComponentBatch::from_loggable<rerun::components::Position3D>(
+            {1.0f, 2.0f, 3.0f},
             rerun::Loggable<CustomPosition3D>::Descriptor
         )
     );

--- a/docs/snippets/all/descriptors/descr_custom_component.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_component.cpp
@@ -29,7 +29,13 @@ int main() {
     rec.spawn().exit_on_failure();
 
     CustomPosition3D positions[1] = {{rerun::components::Position3D{1.0f, 2.0f, 3.0f}}};
-    rec.log_static("data", positions);
+    rec.log_static(
+        "data",
+        rerun::ComponentBatch::from_loggable(
+            positions,
+            rerun::Loggable<CustomPosition3D>::Descriptor
+        )
+    );
 
     // The tags are indirectly checked by the Rust version (have a look over there for more info).
 }

--- a/examples/cpp/incremental_logging/main.cpp
+++ b/examples/cpp/incremental_logging/main.cpp
@@ -49,14 +49,10 @@ int main() {
         rerun::TextDocument(README).with_media_type(rerun::components::MediaType::markdown())
     );
 
-    rerun::Collection<rerun::Color> colors = rerun::Color(255, 0, 0);
-    rerun::Collection<rerun::Radius> radii = rerun::Radius(0.1f);
-
     // Only log colors and radii once.
-    rec.set_time_sequence("frame_nr", 0);
-    rec.log("points", colors, radii);
     // Logging statically with `RecordingStream::log_static` would also work.
-    // rec.log_static("points", colors, radii);
+    rec.set_time_sequence("frame_nr", 0);
+    rec.log("points", rerun::Points3D().with_colors(rerun::Color(255, 0, 0)).with_radii(0.1f));
 
     std::default_random_engine gen;
     std::uniform_real_distribution<float> dist_pos(-5.0f, 5.0f);
@@ -71,6 +67,6 @@ int main() {
         std::generate(points.begin(), points.end(), [&] {
             return rerun::Position3D(dist_pos(gen), dist_pos(gen), dist_pos(gen));
         });
-        rec.log("points", rerun::Points3D(points));
+        rec.log("points", rerun::Points3D::update_fields().with_positions(points));
     }
 }

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -22,8 +22,7 @@ namespace rerun {
         static_assert(
             NoAsComponentsFor<T>::value,
             "AsComponents is not implemented for this type. "
-            "It is implemented for all built-in archetypes as well as std::vector, std::array, and "
-            "c-arrays of components. "
+            "It is implemented for all built-in archetypes as well as invidiual & collections of `rerun::ComponentBatch`."
             "You can add your own implementation by specializing AsComponents<T> for your type T."
         );
 
@@ -34,8 +33,48 @@ namespace rerun {
     /// \cond private
 
     /// `AsComponents` for a Collection of types implementing the `rerun::Loggable` trait.
+
+    /// `AsComponents` for a `Collection<ComponentBatch>`.
+    template <>
+    struct AsComponents<Collection<ComponentBatch>> {
+        static Result<std::vector<ComponentBatch>> serialize(Collection<ComponentBatch> components
+        ) {
+            return Result<std::vector<ComponentBatch>>(std::move(components).to_vector());
+        }
+    };
+
+    /// `AsComponents` for a single `ComponentBatch`.
+    template <>
+    struct AsComponents<ComponentBatch> {
+        static Result<std::vector<ComponentBatch>> serialize(ComponentBatch components) {
+            return Result<std::vector<ComponentBatch>>({std::move(components)});
+        }
+    };
+
+    /// `AsComponents` for a `Collection<ComponentBatch>` wrapped in a `Result`.
+    template <>
+    struct AsComponents<Result<Collection<ComponentBatch>>> {
+        static Result<std::vector<ComponentBatch>> serialize(
+            Result<Collection<ComponentBatch>> components
+        ) {
+            RR_RETURN_NOT_OK(components.error);
+            return Result<std::vector<ComponentBatch>>(std::move(components.value).to_vector());
+        }
+    };
+
+    /// `AsComponents` for a single `ComponentBatch` wrapped in a `Result`.
+    template <>
+    struct AsComponents<Result<ComponentBatch>> {
+        static Result<std::vector<ComponentBatch>> serialize(Result<ComponentBatch> components) {
+            RR_RETURN_NOT_OK(components.error);
+            return Result<std::vector<ComponentBatch>>({std::move(components.value)});
+        }
+    };
+
     template <typename TComponent>
-    struct AsComponents<Collection<TComponent>> {
+    [[deprecated(
+        "Direct serialization of component collections is deprecated. Either use archetype constructors or construct `ComponentBatch` with explicit descriptors."
+    )]] struct AsComponents<Collection<TComponent>> {
         static_assert(
             is_loggable<TComponent>, "The given type does not implement the rerun::Loggable trait."
         );
@@ -52,7 +91,9 @@ namespace rerun {
 
     /// `AsComponents` for a `std::vector` of types implementing the `rerun::Loggable` trait.
     template <typename TComponent>
-    struct AsComponents<std::vector<TComponent>> {
+    [[deprecated(
+        "Direct serialization of component collections is deprecated. Either use archetype constructors or construct `ComponentBatch` with explicit descriptors."
+    )]] struct AsComponents<std::vector<TComponent>> {
         static Result<std::vector<ComponentBatch>> serialize(
             const std::vector<TComponent>& components
         ) {
@@ -62,7 +103,9 @@ namespace rerun {
 
     /// AsComponents for `std::initializer_list`
     template <typename TComponent>
-    struct AsComponents<std::initializer_list<TComponent>> {
+    [[deprecated(
+        "Direct serialization of component collections is deprecated. Either use archetype constructors or construct `ComponentBatch` with explicit descriptors."
+    )]] struct AsComponents<std::initializer_list<TComponent>> {
         static Result<std::vector<ComponentBatch>> serialize(
             std::initializer_list<TComponent> components
         ) {
@@ -72,7 +115,9 @@ namespace rerun {
 
     /// `AsComponents` for an `std::array` of types implementing the `rerun::Loggable` trait.
     template <typename TComponent, size_t NumInstances>
-    struct AsComponents<std::array<TComponent, NumInstances>> {
+    [[deprecated(
+        "Direct serialization of component collections is deprecated. Either use archetype constructors or construct `ComponentBatch` with explicit descriptors."
+    )]] struct AsComponents<std::array<TComponent, NumInstances>> {
         static Result<std::vector<ComponentBatch>> serialize(
             const std::array<TComponent, NumInstances>& components
         ) {
@@ -82,7 +127,9 @@ namespace rerun {
 
     /// `AsComponents` for an c-array of types implementing the `rerun::Loggable` trait.
     template <typename TComponent, size_t NumInstances>
-    struct AsComponents<TComponent[NumInstances]> {
+    [[deprecated(
+        "Direct serialization of component collections is deprecated. Either use archetype constructors or construct `ComponentBatch` with explicit descriptors."
+    )]] struct AsComponents<TComponent[NumInstances]> {
         static Result<std::vector<ComponentBatch>> serialize(const TComponent (&components
         )[NumInstances]) {
             return AsComponents<Collection<TComponent>>::serialize(components);
@@ -91,7 +138,9 @@ namespace rerun {
 
     /// `AsComponents` for single indicator components.
     template <const char ComponentName[]>
-    struct AsComponents<components::IndicatorComponent<ComponentName>> {
+    [[deprecated(
+        "Direct serialization of component collections is deprecated. Either use archetype constructors or construct `ComponentBatch` with explicit descriptors."
+    )]] struct AsComponents<components::IndicatorComponent<ComponentName>> {
         static Result<std::vector<ComponentBatch>> serialize(
             const components::IndicatorComponent<ComponentName>& indicator
         ) {

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -51,7 +51,7 @@ namespace rerun {
         }
     };
 
-    /// `AsComponents` for a `Collection<ComponentBatch>` wrapped in a `Result`.
+    /// `AsComponents` for a `Collection<ComponentBatch>` wrapped in a `Result`, forwarding errors for convenience.
     template <>
     struct AsComponents<Result<Collection<ComponentBatch>>> {
         static Result<std::vector<ComponentBatch>> serialize(
@@ -62,7 +62,7 @@ namespace rerun {
         }
     };
 
-    /// `AsComponents` for a single `ComponentBatch` wrapped in a `Result`.
+    /// `AsComponents` for a single `ComponentBatch` wrapped in a `Result`, forwarding errors for convenience.
     template <>
     struct AsComponents<Result<ComponentBatch>> {
         static Result<std::vector<ComponentBatch>> serialize(Result<ComponentBatch> components) {

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -29,12 +29,11 @@ namespace rerun {
         // TODO(andreas): List methods that the trait should implement.
     };
 
-    // TODO: make these return collection?
+    // TODO(andreas): make these return collection?
+    // TODO(andreas): Now that we no longer rely on `Loggable` trait implementations here, `serialize` is a misnomer. Consider using `operator()` instead.
 
     // Documenting the builtin generic `AsComponents` impls is too much clutter for the doc class overview.
     /// \cond private
-
-    /// `AsComponents` for a Collection of types implementing the `rerun::Loggable` trait.
 
     /// `AsComponents` for a `Collection<ComponentBatch>`.
     template <>

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -39,6 +39,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(const rerun::Collection<T>& components) {
             return from_loggable(components, Loggable<T>::Descriptor);
         }
@@ -93,6 +95,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(const T& component) {
             // Collection adapter will automatically borrow for single elements, but let's do this explicitly, avoiding the extra hoop.
             const auto collection = Collection<T>::borrow(&component, 1);
@@ -117,6 +121,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(const std::optional<T>& component) {
             if (component.has_value()) {
                 return from_loggable(component.value());
@@ -147,6 +153,8 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
+        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
+        )]]
         static Result<ComponentBatch> from_loggable(
             const std::optional<rerun::Collection<T>>& components
         ) {

--- a/rerun_cpp/src/rerun/component_batch.hpp
+++ b/rerun_cpp/src/rerun/component_batch.hpp
@@ -39,16 +39,6 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(const rerun::Collection<T>& components) {
-            return from_loggable(components, Loggable<T>::Descriptor);
-        }
-
-        /// Creates a new component batch from a collection of component instances.
-        ///
-        /// Automatically registers the component type the first time this type is encountered.
-        template <typename T>
         static Result<ComponentBatch> from_loggable(
             const rerun::Collection<T>& components, const ComponentDescriptor& descriptor
         ) {
@@ -95,40 +85,12 @@ namespace rerun {
         ///
         /// Automatically registers the component type the first time this type is encountered.
         template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(const T& component) {
-            // Collection adapter will automatically borrow for single elements, but let's do this explicitly, avoiding the extra hoop.
-            const auto collection = Collection<T>::borrow(&component, 1);
-            return from_loggable(collection);
-        }
-
-        /// Creates a new component batch from a single component instance.
-        ///
-        /// Automatically registers the component type the first time this type is encountered.
-        template <typename T>
         static Result<ComponentBatch> from_loggable(
             const T& component, const ComponentDescriptor& descriptor
         ) {
             // Collection adapter will automatically borrow for single elements, but let's do this explicitly, avoiding the extra hoop.
             const auto collection = Collection<T>::borrow(&component, 1);
             return from_loggable(collection, descriptor);
-        }
-
-        /// Creates a new data cell from a single optional component instance.
-        ///
-        /// None is represented as a data cell with 0 instances.
-        ///
-        /// Automatically registers the component type the first time this type is encountered.
-        template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(const std::optional<T>& component) {
-            if (component.has_value()) {
-                return from_loggable(component.value());
-            } else {
-                return from_loggable(Collection<T>());
-            }
         }
 
         /// Creates a new data cell from a single optional component instance.
@@ -144,24 +106,6 @@ namespace rerun {
                 return from_loggable(component.value(), descriptor);
             } else {
                 return from_loggable(Collection<T>(), descriptor);
-            }
-        }
-
-        /// Creates a new data cell from an optional collection of component instances.
-        ///
-        /// None is represented as a data cell with 0 instances.
-        ///
-        /// Automatically registers the component type the first time this type is encountered.
-        template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]]
-        static Result<ComponentBatch> from_loggable(
-            const std::optional<rerun::Collection<T>>& components
-        ) {
-            if (components.has_value()) {
-                return from_loggable(components.value());
-            } else {
-                return from_loggable(Collection<T>());
             }
         }
 

--- a/rerun_cpp/src/rerun/component_column.hpp
+++ b/rerun_cpp/src/rerun/component_column.hpp
@@ -55,7 +55,7 @@ namespace rerun {
         template <typename T>
         static Result<ComponentColumn> from_loggable_with_lengths(
             const Collection<T>& components, const Collection<uint32_t>& lengths,
-            const ComponentDescriptor& descriptor = Loggable<T>::Descriptor
+            const ComponentDescriptor& descriptor
         ) {
             auto component_batch_result = ComponentBatch::from_loggable(components, descriptor);
             if (component_batch_result.is_err()) {
@@ -90,8 +90,7 @@ namespace rerun {
         /// \param descriptor Descriptor of the component type for this column.
         template <typename T>
         static Result<ComponentColumn> from_loggable(
-            const Collection<T>& components,
-            const ComponentDescriptor& descriptor = Loggable<T>::Descriptor
+            const Collection<T>& components, const ComponentDescriptor& descriptor
         ) {
             return ComponentColumn::from_loggable_with_lengths(
                 components,

--- a/rerun_cpp/src/rerun/component_column.hpp
+++ b/rerun_cpp/src/rerun/component_column.hpp
@@ -33,24 +33,6 @@ namespace rerun {
         /// \param lengths The number of components in each run. for `rerun::RecordingStream::send_columns`,
         /// this specifies the number of components at each time point.
         /// The sum of the lengths must be equal to the number of components in the batch.
-        template <typename T>
-        [[deprecated(
-            "Use from_loggable_with_lengths(components, lengths, descriptor) (with explicit descriptor) instead"
-        )]] static Result<ComponentColumn>
-            from_loggable_with_lengths(
-                const Collection<T>& components, const Collection<uint32_t>& lengths
-            ) {
-            return from_loggable_with_lengths(components, lengths, Loggable<T>::Descriptor);
-        }
-
-        /// Creates a new component column from a collection of component instances.
-        ///
-        /// Automatically registers the component type the first time this type is encountered.
-        ///
-        /// \param components Continuous collection of components which is about to be partitioned.
-        /// \param lengths The number of components in each run. for `rerun::RecordingStream::send_columns`,
-        /// this specifies the number of components at each time point.
-        /// The sum of the lengths must be equal to the number of components in the batch.
         /// \param descriptor Descriptor of the component type for this column.
         template <typename T>
         static Result<ComponentColumn> from_loggable_with_lengths(
@@ -62,21 +44,6 @@ namespace rerun {
                 return component_batch_result.error;
             }
             return from_batch_with_lengths(component_batch_result.value, lengths);
-        }
-
-        /// Creates a new component column from a collection of component instances where each run has a length of one.
-        ///
-        /// When used with `rerun::RecordingStream::send_columns`, this is equivalent to `from_loggable(components, std::vector{1, 1, ...})`.
-        /// I.e. there's a single component for each time point.
-        ///
-        /// Automatically registers the component type the first time this type is encountered.
-        ///
-        /// \param components Continuous collection of components which is about to be partitioned into runs of length one.
-        template <typename T>
-        [[deprecated("Use from_loggable(components, descriptor) (with explicit descriptor) instead"
-        )]] static Result<ComponentColumn>
-            from_loggable(const Collection<T>& components) {
-            return from_loggable(components, Loggable<T>::Descriptor);
         }
 
         /// Creates a new component column from a collection of component instances where each run has a length of one.

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -338,7 +338,7 @@ namespace rerun {
         /// ```
         ///
         /// The `log` function can flexibly accept an arbitrary number of additional objects which will
-        /// be merged into the first entity so long as they don't expose conflicting components, for instance:
+        /// be merged into the first entity, for instance:
         /// ```
         /// // Log three points with arrows sticking out of them:
         /// rec.log(
@@ -349,19 +349,20 @@ namespace rerun {
         /// );
         /// ```
         ///
-        /// Any failures that may occur during serialization are handled with `Error::handle`.
+        /// Any failures that may are handled with `Error::handle`.
         ///
         /// \param entity_path Path to the entity in the space hierarchy.
-        /// \param archetypes_or_collections Any type for which the `AsComponents<T>` trait is implemented.
-        /// This is the case for any archetype or `std::vector`/`std::array`/C-array of components implements.
+        /// \param as_components Any type for which the `AsComponents<T>` trait is implemented.
+        /// This is the case for any archetype as well as individual or collection of `ComponentBatch`.
+        /// You can implement `AsComponents` for your own types as well
         ///
         /// @see try_log, log_static, try_log_with_static
         template <typename... Ts>
-        void log(std::string_view entity_path, const Ts&... archetypes_or_collections) const {
+        void log(std::string_view entity_path, const Ts&... as_components) const {
             if (!is_enabled()) {
                 return;
             }
-            try_log_with_static(entity_path, false, archetypes_or_collections...).handle();
+            try_log_with_static(entity_path, false, as_components...).handle();
         }
 
         /// Logs one or more archetype and/or component batches as static data.
@@ -373,61 +374,62 @@ namespace rerun {
         /// Failures are handled with `Error::handle`.
         ///
         /// \param entity_path Path to the entity in the space hierarchy.
-        /// \param archetypes_or_collections Any type for which the `AsComponents<T>` trait is implemented.
-        /// This is the case for any archetype or `std::vector`/`std::array`/C-array of components implements.
+        /// \param as_components Any type for which the `AsComponents<T>` trait is implemented.
+        /// This is the case for any archetype as well as individual or collection of `ComponentBatch`.
+        /// You can implement `AsComponents` for your own types as well
         ///
         /// @see log, try_log_static, try_log_with_static
         template <typename... Ts>
-        void log_static(std::string_view entity_path, const Ts&... archetypes_or_collections)
-            const {
+        void log_static(std::string_view entity_path, const Ts&... as_components) const {
             if (!is_enabled()) {
                 return;
             }
-            try_log_with_static(entity_path, true, archetypes_or_collections...).handle();
+            try_log_with_static(entity_path, true, as_components...).handle();
         }
 
         /// Logs one or more archetype and/or component batches.
         ///
         /// See `log` for more information.
-        /// Unlike `log` this method returns an error if an error occurs during serialization or logging.
+        /// Unlike `log` this method returns an error if an error occurs.
         ///
         /// \param entity_path Path to the entity in the space hierarchy.
-        /// \param archetypes_or_collections Any type for which the `AsComponents<T>` trait is implemented.
-        /// This is the case for any archetype or `std::vector`/`std::array`/C-array of components implements.
+        /// \param as_components Any type for which the `AsComponents<T>` trait is implemented.
+        /// This is the case for any archetype as well as individual or collection of `ComponentBatch`.
+        /// You can implement `AsComponents` for your own types as well
         ///
         /// @see log, try_log_static, try_log_with_static
         template <typename... Ts>
-        Error try_log(std::string_view entity_path, const Ts&... archetypes_or_collections) const {
+        Error try_log(std::string_view entity_path, const Ts&... as_components) const {
             if (!is_enabled()) {
                 return Error::ok();
             }
-            return try_log_with_static(entity_path, false, archetypes_or_collections...);
+            return try_log_with_static(entity_path, false, as_components...);
         }
 
         /// Logs one or more archetype and/or component batches as static data, returning an error.
         ///
         /// See `log`/`log_static` for more information.
-        /// Unlike `log_static` this method returns if an error occurs during serialization or logging.
+        /// Unlike `log_static` this method returns if an error occurs.
         ///
         /// \param entity_path Path to the entity in the space hierarchy.
-        /// \param archetypes_or_collections Any type for which the `AsComponents<T>` trait is implemented.
-        /// This is the case for any archetype or `std::vector`/`std::array`/C-array of components implements.
-        /// \returns An error if an error occurs during serialization or logging.
+        /// \param as_components Any type for which the `AsComponents<T>` trait is implemented.
+        /// This is the case for any archetype as well as individual or collection of `ComponentBatch`.
+        /// You can implement `AsComponents` for your own types as well
+        /// \returns An error if an error occurs during evaluation of `AsComponents` or logging.
         ///
         /// @see log_static, try_log, try_log_with_static
         template <typename... Ts>
-        Error try_log_static(std::string_view entity_path, const Ts&... archetypes_or_collections)
-            const {
+        Error try_log_static(std::string_view entity_path, const Ts&... as_components) const {
             if (!is_enabled()) {
                 return Error::ok();
             }
-            return try_log_with_static(entity_path, true, archetypes_or_collections...);
+            return try_log_with_static(entity_path, true, as_components...);
         }
 
         /// Logs one or more archetype and/or component batches optionally static, returning an error.
         ///
         /// See `log`/`log_static` for more information.
-        /// Returns an error if an error occurs during serialization or logging.
+        /// Returns an error if an error occurs during evaluation of `AsComponents` or logging.
         ///
         /// \param entity_path Path to the entity in the space hierarchy.
         /// \param static_ If true, the logged components will be static.
@@ -435,21 +437,21 @@ namespace rerun {
         /// any temporal data of the same type.
         /// Otherwise, the data will be timestamped automatically with `log_time` and `log_tick`.
         /// Additional timelines set by `set_time_sequence` or `set_time` will also be included.
-        /// \param archetypes_or_collections Any type for which the `AsComponents<T>` trait is implemented.
-        /// This is the case for any archetype or `std::vector`/`std::array`/C-array of components implements.
+        /// \param as_components Any type for which the `AsComponents<T>` trait is implemented.
+        /// This is the case for any archetype as well as individual or collection of `ComponentBatch`.
+        /// You can implement `AsComponents` for your own types as well
         ///
         /// @see log, try_log, log_static, try_log_static
         template <typename... Ts>
-        void log_with_static(
-            std::string_view entity_path, bool static_, const Ts&... archetypes_or_collections
-        ) const {
-            try_log_with_static(entity_path, static_, archetypes_or_collections...).handle();
+        void log_with_static(std::string_view entity_path, bool static_, const Ts&... as_components)
+            const {
+            try_log_with_static(entity_path, static_, as_components...).handle();
         }
 
         /// Logs one or more archetype and/or component batches optionally static, returning an error.
         ///
         /// See `log`/`log_static` for more information.
-        /// Returns an error if an error occurs during serialization or logging.
+        /// Returns an error if an error occurs during evaluation of `AsComponents` or logging.
         ///
         /// \param entity_path Path to the entity in the space hierarchy.
         /// \param static_ If true, the logged components will be static.
@@ -457,14 +459,15 @@ namespace rerun {
         /// any temporal data of the same type.
         /// Otherwise, the data will be timestamped automatically with `log_time` and `log_tick`.
         /// Additional timelines set by `set_time_sequence` or `set_time` will also be included.
-        /// \param archetypes_or_collections Any type for which the `AsComponents<T>` trait is implemented.
-        /// This is the case for any archetype or `std::vector`/`std::array`/C-array of components implements.
-        /// \returns An error if an error occurs during serialization or logging.
+        /// \param as_components Any type for which the `AsComponents<T>` trait is implemented.
+        /// This is the case for any archetype as well as individual or collection of `ComponentBatch`.
+        /// You can implement `AsComponents` for your own types as well
+        /// \returns An error if an error occurs during evaluation of `AsComponents` or logging.
         ///
         /// @see log, try_log, log_static, try_log_static
         template <typename... Ts>
         Error try_log_with_static(
-            std::string_view entity_path, bool static_, const Ts&... archetypes_or_collections
+            std::string_view entity_path, bool static_, const Ts&... as_components
         ) const {
             if (!is_enabled()) {
                 return Error::ok();
@@ -478,7 +481,7 @@ namespace rerun {
                     }
 
                     const Result<std::vector<ComponentBatch>> serialization_result =
-                        AsComponents<Ts>().serialize(archetypes_or_collections);
+                        AsComponents<Ts>().serialize(as_components);
                     if (serialization_result.is_err()) {
                         err = serialization_result.error;
                         return;

--- a/rerun_cpp/tests/log_empty.cpp
+++ b/rerun_cpp/tests/log_empty.cpp
@@ -15,7 +15,14 @@ SCENARIO("Log empty data", TEST_TAG) {
             stream.log("empty", rerun::Points3D(std::vector<rerun::Position3D>{}));
         });
     }
-    SECTION("Using an empty component vector") {
-        check_logged_error([&] { stream.log("empty", std::vector<rerun::Position3D>{}); });
+    SECTION("Using an empty component batch") {
+        check_logged_error([&] {
+            stream.log(
+                "empty",
+                rerun::ComponentBatch::empty<rerun::Position3D>(
+                    rerun::Loggable<rerun::Position3D>::Descriptor
+                )
+            );
+        });
     }
 }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -191,8 +191,7 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     THEN("collection of component batch results can be logged") {
                         rerun::Collection<rerun::Result<rerun::ComponentBatch>> batches = {
                             batch0,
-                            batch1
-                        };
+                            batch1};
                         stream.log("log_archetype-splat", batches);
                         stream.log_static("log_archetype-splat", batches);
                     }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -146,119 +146,56 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
             WHEN("creating a new stream") {
                 rerun::RecordingStream stream("test", std::string_view(), kind);
 
-                // We can make single components work, but this would make error messages a lot
-                // worse since we'd have to implement the base `AsComponents` template for this.
-                //
-                // THEN("single components can be logged") {
-                //     stream.log(
-                //         "single-components",
-                //         rerun::Position2D{1.0, 2.0},
-                //         rerun::Color(0x00FF00FF)
-                //     );
-                // }
-
-                THEN("components as c-array can be logged") {
-                    rerun::Position2D c_style_array[2] = {
-                        rerun::Vec2D{1.0, 2.0},
-                        rerun::Vec2D{4.0, 5.0},
-                    };
-
-                    stream.log("as-carray", c_style_array);
-                    stream.log_static("as-carray", c_style_array);
+                GIVEN("component batches") {
+                    auto batch0 = rerun::ComponentBatch::from_loggable<rerun::Position2D>(
+                                      {{1.0, 2.0}, {4.0, 5.0}},
+                                      rerun::Loggable<rerun::Position2D>::Descriptor
+                    )
+                                      .value_or_throw();
+                    auto batch1 = rerun::ComponentBatch::from_loggable<rerun::Color>(
+                                      {rerun::Color(0xFF0000FF)},
+                                      rerun::Loggable<rerun::Color>::Descriptor
+                    )
+                                      .value_or_throw();
+                    THEN("single component batch can be logged") {
+                        stream.log("log_archetype-splat", batch0);
+                        stream.log_static("log_archetype-splat", batch0);
+                    }
+                    THEN("component batches can be listed out") {
+                        stream.log("log_archetype-splat", batch0, batch1);
+                        stream.log_static("log_archetype-splat", batch0, batch1);
+                    }
+                    THEN("a collection of component batches can be logged") {
+                        rerun::Collection<rerun::ComponentBatch> batches = {batch0, batch1};
+                        stream.log("log_archetype-splat", batches);
+                        stream.log_static("log_archetype-splat", batches);
+                    }
                 }
-                THEN("components as std::initializer_list can be logged") {
-                    const auto c_style_array = {
-                        rerun::components::Position2D{1.0, 2.0},
-                        rerun::components::Position2D{4.0, 5.0},
-                    };
-                    stream.log("as-initializer-list", c_style_array);
-                    stream.log_static("as-initializer-list", c_style_array);
-                }
-                THEN("components as std::array can be logged") {
-                    stream.log(
-                        "as-array",
-                        std::array<rerun::Position2D, 2>{
-                            rerun::Vec2D{1.0, 2.0},
-                            rerun::Vec2D{4.0, 5.0},
-                        }
+                GIVEN("component batches wrapped in `rerun::Result`") {
+                    auto batch0 = rerun::ComponentBatch::from_loggable<rerun::Position2D>(
+                        {{1.0, 2.0}, {4.0, 5.0}},
+                        rerun::Loggable<rerun::Position2D>::Descriptor
                     );
-                    stream.log_static(
-                        "as-array",
-                        std::array<rerun::Position2D, 2>{
-                            rerun::Vec2D{1.0, 2.0},
-                            rerun::Vec2D{4.0, 5.0},
-                        }
+                    auto batch1 = rerun::ComponentBatch::from_loggable<rerun::Color>(
+                        {rerun::Color(0xFF0000FF)},
+                        rerun::Loggable<rerun::Color>::Descriptor
                     );
-                }
-                THEN("components as std::vector can be logged") {
-                    stream.log(
-                        "as-vector",
-                        std::vector<rerun::Position2D>{
-                            rerun::Vec2D{1.0, 2.0},
-                            rerun::Vec2D{4.0, 5.0},
-                        }
-                    );
-                    stream.log_static(
-                        "as-vector",
-                        std::vector<rerun::Position2D>{
-                            rerun::Vec2D{1.0, 2.0},
-                            rerun::Vec2D{4.0, 5.0},
-                        }
-                    );
-                }
-                THEN("several components with a mix of vector, array and c-array can be logged") {
-                    rerun::Text c_style_array[3] = {
-                        rerun::Text("hello"),
-                        rerun::Text("friend"),
-                        rerun::Text("yo"),
-                    };
-                    stream.log(
-                        "as-mix",
-                        std::vector{
-                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
-                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
-                            rerun::Position2D(rerun::Vec2D{5.0, 5.0}),
-                        },
-                        std::array{
-                            rerun::Color(0xFF0000FF),
-                            rerun::Color(0x00FF00FF),
-                            rerun::Color(0x0000FFFF),
-                        },
-                        c_style_array
-                    );
-                    stream.log_static(
-                        "as-mix",
-                        std::vector{
-                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
-                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
-                            rerun::Position2D(rerun::Vec2D{5.0, 5.0}),
-                        },
-                        std::array{
-                            rerun::Color(0xFF0000FF),
-                            rerun::Color(0x00FF00FF),
-                            rerun::Color(0x0000FFFF),
-                        },
-                        c_style_array
-                    );
-                }
-
-                THEN("components with splatting some of them can be logged") {
-                    stream.log(
-                        "log-splat",
-                        std::vector{
-                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
-                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
-                        },
-                        std::array{rerun::Color(0xFF0000FF)}
-                    );
-                    stream.log_static(
-                        "log-splat",
-                        std::vector{
-                            rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
-                            rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
-                        },
-                        std::array{rerun::Color(0xFF0000FF)}
-                    );
+                    THEN("single component batch can be logged") {
+                        stream.log("log_archetype-splat", batch0);
+                        stream.log_static("log_archetype-splat", batch0);
+                    }
+                    THEN("component batches can be listed out") {
+                        stream.log("log_archetype-splat", batch0, batch1);
+                        stream.log_static("log_archetype-splat", batch0, batch1);
+                    }
+                    THEN("collection of component batch results can be logged") {
+                        rerun::Collection<rerun::Result<rerun::ComponentBatch>> batches = {
+                            batch0,
+                            batch1
+                        };
+                        stream.log("log_archetype-splat", batches);
+                        stream.log_static("log_archetype-splat", batches);
+                    }
                 }
 
                 THEN("an archetype can be logged") {
@@ -269,6 +206,22 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     );
                     stream.log_static(
                         "log_archetype-splat",
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
+                    );
+                }
+                THEN("several archetypes can be logged") {
+                    stream.log(
+                        "log_archetype-splat",
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF)),
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
+                    );
+                    stream.log_static(
+                        "log_archetype-splat",
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF)),
                         rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
                         ).with_colors(rerun::Color(0xFF0000FF))
                     );
@@ -326,23 +279,6 @@ SCENARIO("RecordingStream can log to file", TEST_TAG) {
                     WHEN("saving that one to a different file " << test_rrd1) {
                         REQUIRE(stream1->save(test_rrd1).is_ok());
 
-                        WHEN("logging a component to the second stream") {
-                            check_logged_error([&] {
-                                stream1->log(
-                                    "as-array",
-                                    std::array<rerun::Position2D, 2>{
-                                        rerun::Vec2D{1.0, 2.0},
-                                        rerun::Vec2D{4.0, 5.0},
-                                    }
-                                );
-                            });
-
-                            THEN("after destruction, the second stream produced a bigger file") {
-                                stream0.reset();
-                                stream1.reset();
-                                CHECK(fs::file_size(test_rrd0) < fs::file_size(test_rrd1));
-                            }
-                        }
                         WHEN("logging an archetype to the second stream") {
                             check_logged_error([&] {
                                 stream1->log(
@@ -389,22 +325,6 @@ void test_logging_to_connection(const char* address, const rerun::RecordingStrea
         THEN("save call with zero timeout returns no error") {
             REQUIRE(stream.connect_tcp(address, 0.0f).is_ok());
 
-            WHEN("logging a component and then flushing") {
-                check_logged_error([&] {
-                    stream.log(
-                        "as-array",
-                        std::array<rerun::Position2D, 2>{
-                            rerun::Vec2D{1.0, 2.0},
-                            rerun::Vec2D{4.0, 5.0},
-                        }
-                    );
-                });
-                stream.flush_blocking();
-
-                THEN("does not crash") {
-                    // No easy way to see if it got sent.
-                }
-            }
             WHEN("logging an archetype and then flushing") {
                 check_logged_error([&] {
                     stream.log(
@@ -483,41 +403,25 @@ SCENARIO("Recording stream handles serialization failure during logging graceful
         const char* path = "valid";
         auto& expected_error = rerun::Loggable<BadComponent>::error;
 
-        AND_GIVEN("an component that fails serialization") {
+        AND_GIVEN("an component batch result that failed serialization") {
             const auto component = BadComponent();
 
             expected_error.code =
                 GENERATE(rerun::ErrorCode::Unknown, rerun::ErrorCode::ArrowStatusCode_TypeError);
 
-            THEN("calling log with an array logs the serialization error") {
+            auto batch_result = rerun::ComponentBatch::from_loggable(
+                component,
+                rerun::Loggable<BadComponent>::Descriptor
+            );
+
+            THEN("calling log with that batch logs the serialization error") {
+                check_logged_error([&] { stream.log(path, batch_result); }, expected_error.code);
+            }
+            THEN("calling log with a collection wrapping that batch logs the serialization error") {
                 check_logged_error(
-                    [&] {
-                        stream.log(path, std::array{component, component});
-                    },
+                    [&] { stream.log(path, rerun::Collection{batch_result}); },
                     expected_error.code
                 );
-            }
-            THEN("calling log with a vector logs the serialization error") {
-                check_logged_error(
-                    [&] {
-                        stream.log(path, std::vector{component, component});
-                    },
-                    expected_error.code
-                );
-            }
-            THEN("calling log with a c array logs the serialization error") {
-                const BadComponent components[] = {component, component};
-                check_logged_error([&] { stream.log(path, components); }, expected_error.code);
-            }
-            THEN("calling try_log with an array forwards the serialization error") {
-                CHECK(stream.try_log(path, std::array{component, component}) == expected_error);
-            }
-            THEN("calling try_log with a vector forwards the serialization error") {
-                CHECK(stream.try_log(path, std::vector{component, component}) == expected_error);
-            }
-            THEN("calling try_log with a c array forwards the serialization error") {
-                const BadComponent components[] = {component, component};
-                CHECK(stream.try_log(path, components) == expected_error);
             }
         }
         AND_GIVEN("an archetype that fails serialization") {
@@ -568,88 +472,6 @@ SCENARIO("RecordingStream can set time without errors", TEST_TAG) {
         check_logged_error([&] { stream.set_time_sequence("exists!", 123); });
         check_logged_error([&] { stream.disable_timeline("exists"); });
     }
-}
-
-// Regression test for https://github.com/rerun-io/cpp-example-opencv-eigen/issues/25
-SCENARIO("Deprecated log_static still works", TEST_TAG) {
-    rerun::RecordingStream stream("test");
-
-    // Disable deprecation warnings for this test since this is testing deprecated functionality.
-    RR_PUSH_WARNINGS
-    RR_DISABLE_DEPRECATION_WARNING
-
-    GIVEN("a new RecordingStream and valid entity paths") {
-        THEN("components as std::initializer_list can be logged") {
-            const auto c_style_array = {
-                rerun::components::Position2D{1.0, 2.0},
-                rerun::components::Position2D{4.0, 5.0},
-            };
-            stream.log_static("as-initializer-list", c_style_array);
-        }
-
-        THEN("components as std::array can be logged") {
-            stream.log_static(
-                "as-array",
-                std::array<rerun::Position2D, 2>{
-                    rerun::Vec2D{1.0, 2.0},
-                    rerun::Vec2D{4.0, 5.0},
-                }
-            );
-        }
-
-        THEN("components as std::vector can be logged") {
-            stream.log_static(
-                "as-vector",
-                std::vector<rerun::Position2D>{
-                    rerun::Vec2D{1.0, 2.0},
-                    rerun::Vec2D{4.0, 5.0},
-                }
-            );
-        }
-
-        THEN("several components with a mix of vector, array and c-array can be logged") {
-            rerun::Text c_style_array[3] = {
-                rerun::Text("hello"),
-                rerun::Text("friend"),
-                rerun::Text("yo"),
-            };
-            stream.log_static(
-                "as-mix",
-                std::vector{
-                    rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
-                    rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
-                    rerun::Position2D(rerun::Vec2D{5.0, 5.0}),
-                },
-                std::array{
-                    rerun::Color(0xFF0000FF),
-                    rerun::Color(0x00FF00FF),
-                    rerun::Color(0x0000FFFF),
-                },
-                c_style_array
-            );
-        }
-
-        THEN("components with splatting some of them can be logged") {
-            stream.log_static(
-                "log-splat",
-                std::vector{
-                    rerun::Position2D(rerun::Vec2D{0.0, 0.0}),
-                    rerun::Position2D(rerun::Vec2D{1.0, 3.0}),
-                },
-                std::array{rerun::Color(0xFF0000FF)}
-            );
-        }
-
-        THEN("an archetype can be logged") {
-            stream.log_static(
-                "log_archetype-splat",
-                rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
-                ).with_colors(rerun::Color(0xFF0000FF))
-            );
-        }
-    }
-
-    RR_POP_WARNINGS // For `RR_DISABLE_DEPRECATION_WARNING`.
 }
 
 SCENARIO("Global RecordingStream doesn't cause crashes", TEST_TAG) {


### PR DESCRIPTION
### Related

* fixes https://github.com/rerun-io/rerun/issues/8758

### What

Followed the Rust example and opted out of deprecating this, instead making it a breaking change.
Iterated on the migration guide & adjusted snippets.

* [x] pass main ci