### PR TITLE
Filter entities in the UI (part 7): Refactor and optimize `re_time_panel` and add more tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6570,6 +6570,7 @@ dependencies = [
  "re_viewer_context",
  "re_viewport_blueprint",
  "serde",
+ "smallvec",
  "vec1",
 ]
 

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -185,8 +185,7 @@ pub fn instance_path_icon(
         if db
             .storage_engine()
             .store()
-            .all_components_on_timeline(timeline, &instance_path.entity_path)
-            .is_some()
+            .entity_has_data_on_timeline(timeline, &instance_path.entity_path)
         {
             &icons::ENTITY
         } else {

--- a/crates/viewer/re_time_panel/Cargo.toml
+++ b/crates/viewer/re_time_panel/Cargo.toml
@@ -38,6 +38,7 @@ itertools.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true
 serde.workspace = true
+smallvec.workspace = true
 vec1.workspace = true
 
 [dev-dependencies]

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -3,7 +3,6 @@
 //! The data density is the number of data points per unit of time.
 //! We collect this into a histogram, blur it, and then paint it.
 
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use egui::emath::Rangef;
@@ -211,7 +210,6 @@ impl DensityGraph {
         y_range: Rangef,
         painter: &egui::Painter,
         full_color: Color32,
-        hovered_x_range: RangeInclusive<f32>,
     ) {
         re_tracing::profile_function!();
 
@@ -270,11 +268,8 @@ impl DensityGraph {
                 let inner_radius =
                     (max_radius * normalized_density).at_least(MIN_RADIUS) - feather_radius;
 
-                let inner_color = if hovered_x_range.contains(&x) {
-                    Color32::WHITE
-                } else {
-                    full_color.gamma_multiply(lerp(0.5..=1.0, normalized_density))
-                };
+                let inner_color = full_color.gamma_multiply(lerp(0.5..=1.0, normalized_density));
+
                 (inner_radius, inner_color)
             };
             let outer_radius = inner_radius + feather_radius;
@@ -417,8 +412,6 @@ pub fn data_density_graph_ui(
         row_rect.y_range(),
         time_area_painter,
         graph_color(ctx, &item.to_item(), ui),
-        // TODO(jprochazk): completely remove `hovered_x_range` and associated code from painter
-        0f32..=0f32,
     );
 
     if tooltips_enabled {

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -853,15 +853,6 @@ impl TimePanel {
                         &component_name,
                     );
 
-                let num_static_messages =
-                    store.num_static_events_for_component(entity_path, component_name);
-                let num_temporal_messages = store.num_temporal_events_for_component_on_timeline(
-                    time_ctrl.timeline(),
-                    entity_path,
-                    component_name,
-                );
-                let total_num_messages = num_static_messages + num_temporal_messages;
-
                 let response = ui
                     .list_item()
                     .render_offscreen(false)
@@ -894,6 +885,16 @@ impl TimePanel {
                 let response_rect = response.rect;
 
                 response.on_hover_ui(|ui| {
+                    let num_static_messages =
+                        store.num_static_events_for_component(entity_path, component_name);
+                    let num_temporal_messages = store
+                        .num_temporal_events_for_component_on_timeline(
+                            time_ctrl.timeline(),
+                            entity_path,
+                            component_name,
+                        );
+                    let total_num_messages = num_static_messages + num_temporal_messages;
+
                     if total_num_messages == 0 {
                         ui.label(ui.ctx().warning_text(format!(
                             "No event logged on timeline {:?}",

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -704,7 +704,6 @@ impl TimePanel {
                     entity_data.highlight_sections.iter().cloned(),
                     None,
                 ))
-                //TODO: this is slow
                 .with_icon(guess_instance_path_icon(
                     ctx,
                     &InstancePath::from(entity_path.clone()),

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -9,6 +9,7 @@
 mod data_density_graph;
 mod paint_ticks;
 mod recursive_chunks_per_timeline_subscriber;
+mod streams_tree_data;
 mod time_axis;
 mod time_control_ui;
 mod time_ranges_ui;
@@ -88,7 +89,7 @@ impl TimePanelItem {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 enum TimePanelSource {
     #[default]
     Recording,
@@ -606,6 +607,14 @@ impl TimePanel {
         ui: &mut egui::Ui,
     ) {
         re_tracing::profile_function!();
+
+        let entity_tree_data = crate::streams_tree_data::StreamsTreeData::from_source_and_filter(
+            ctx,
+            self.source,
+            &self.filter_state.filter(),
+        );
+
+        dbg!(entity_tree_data);
 
         egui::ScrollArea::vertical()
             .auto_shrink([false; 2])

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -3,9 +3,6 @@
 //! This crate provides a panel that shows all entities in the store and allows control of time and
 //! timelines, as well as all necessary ui elements that make it up.
 
-// TODO(#6330): remove unwrap()
-#![expect(clippy::unwrap_used)]
-
 mod data_density_graph;
 mod paint_ticks;
 mod recursive_chunks_per_timeline_subscriber;
@@ -25,12 +22,13 @@ use re_context_menu::{
 };
 use re_data_ui::DataUi as _;
 use re_data_ui::{item_ui::guess_instance_path_icon, sorted_component_list_for_ui};
-use re_entity_db::{EntityDb, EntityTree, InstancePath};
+use re_entity_db::{EntityDb, InstancePath};
 use re_log_types::{
     external::re_types_core::ComponentName, ApplicationId, ComponentPath, EntityPath,
     ResolvedTimeRange, TimeInt, TimeReal, TimeType,
 };
 use re_types::blueprint::components::PanelState;
+use re_ui::filter_widget::format_matching_text;
 use re_ui::{filter_widget, list_item, ContextExt as _, DesignTokens, UiExt as _};
 use re_viewer_context::{
     CollapseScope, HoverHighlight, Item, ItemContext, RecordingConfig, TimeControl, TimeView,
@@ -38,6 +36,7 @@ use re_viewer_context::{
 };
 use re_viewport_blueprint::ViewportBlueprint;
 
+use crate::streams_tree_data::EntityData;
 use recursive_chunks_per_timeline_subscriber::PathRecursiveChunksPerTimelineStoreSubscriber;
 use time_axis::TimelineAxis;
 use time_control_ui::TimeControlUi;
@@ -608,14 +607,6 @@ impl TimePanel {
     ) {
         re_tracing::profile_function!();
 
-        let entity_tree_data = crate::streams_tree_data::StreamsTreeData::from_source_and_filter(
-            ctx,
-            self.source,
-            &self.filter_state.filter(),
-        );
-
-        dbg!(entity_tree_data);
-
         egui::ScrollArea::vertical()
             .auto_shrink([false; 2])
             // We turn off `drag_to_scroll` so that the `ScrollArea` don't steal input from
@@ -629,44 +620,33 @@ impl TimePanel {
                     ui.scroll_with_delta(Vec2::Y * time_area_response.drag_delta().y);
                 }
 
-                // Show "/" on top only for recording streams, because the `/` entity in blueprint
-                // is always empty, so it's just lost space. This works around an issue where the
-                // selection/hover state of the `/` entity is wrongly synchronized between both
-                // stores, due to `Item::*` not tracking stores for entity paths.
-                let show_root = self.source == TimePanelSource::Recording;
-
                 let filter_matcher = self.filter_state.filter();
 
-                if show_root {
-                    self.show_tree(
+                let entity_tree_data =
+                    crate::streams_tree_data::StreamsTreeData::from_source_and_filter(
                         ctx,
-                        viewport_blueprint,
-                        entity_db,
-                        time_ctrl,
-                        time_area_response,
-                        time_area_painter,
-                        entity_db.tree(),
+                        self.source,
                         &filter_matcher,
-                        ui,
                     );
-                } else {
-                    self.show_children(
+
+                for child in &entity_tree_data.children {
+                    self.show_entity(
                         ctx,
                         viewport_blueprint,
                         entity_db,
                         time_ctrl,
                         time_area_response,
                         time_area_painter,
-                        entity_db.tree(),
-                        &filter_matcher,
+                        child,
                         ui,
                     );
                 }
             });
     }
 
+    /// Display the list item for an entity.
     #[expect(clippy::too_many_arguments)]
-    fn show_tree(
+    fn show_entity(
         &mut self,
         ctx: &ViewerContext<'_>,
         viewport_blueprint: &ViewportBlueprint,
@@ -674,68 +654,11 @@ impl TimePanel {
         time_ctrl: &mut TimeControl,
         time_area_response: &egui::Response,
         time_area_painter: &egui::Painter,
-        tree: &EntityTree,
-        filter_matcher: &filter_widget::FilterMatcher,
+        entity_data: &EntityData,
         ui: &mut egui::Ui,
     ) {
-        // We traverse and display this tree only if it contains a matching entity part.
-        'early_exit: {
-            if filter_matcher.matches_nothing() {
-                return;
-            }
-
-            // Filter is inactive or otherwise whitelisting everything.
-            if filter_matcher.matches_everything() {
-                break 'early_exit;
-            }
-
-            // The current path is a match.
-            if tree
-                .path
-                .iter()
-                .any(|entity_part| filter_matcher.matches(&entity_part.ui_string()))
-            {
-                break 'early_exit;
-            }
-
-            // Our subtree contains a match.
-            if tree
-                .find_first_child_recursive(|entity_path| {
-                    entity_path
-                        .last()
-                        .is_some_and(|entity_part| filter_matcher.matches(&entity_part.ui_string()))
-                })
-                .is_some()
-            {
-                break 'early_exit;
-            }
-
-            // No match to be found, so nothing to display.
-            return;
-        }
-
-        let db = match self.source {
-            TimePanelSource::Recording => ctx.recording(),
-            TimePanelSource::Blueprint => ctx.store_context.blueprint,
-        };
-
-        // The last part of the path component
-        let last_path_part = tree.path.last();
-        let text = if let Some(last_path_part) = last_path_part {
-            let part_text = if tree.is_leaf() {
-                last_path_part.ui_string()
-            } else {
-                format!("{}/", last_path_part.ui_string()) // show we have children with a /
-            };
-
-            filter_matcher
-                .matches_formatted(ui.ctx(), &part_text)
-                .unwrap_or_else(|| part_text.into())
-        } else {
-            "/".into()
-        };
-
-        let item = TimePanelItem::entity_path(tree.path.clone());
+        let entity_path = &entity_data.entity_path;
+        let item = TimePanelItem::entity_path(entity_path.clone());
         let is_selected = ctx.selection().contains_item(&item.to_item());
         let is_item_hovered = ctx
             .selection_state()
@@ -744,24 +667,22 @@ impl TimePanel {
 
         let collapse_scope = self.collapse_scope();
 
-        // expand if children is focused
+        // Expand if one of the children is focused
         let focused_entity_path = ctx
             .focused_item
             .as_ref()
             .and_then(|item| item.entity_path());
 
-        if focused_entity_path.is_some_and(|entity_path| entity_path.is_descendant_of(&tree.path)) {
+        if focused_entity_path.is_some_and(|entity_path| entity_path.is_descendant_of(entity_path))
+        {
             collapse_scope
-                .entity(tree.path.clone())
+                .entity(entity_path.clone())
                 .set_open(ui.ctx(), true);
         }
 
         // Globally unique id that is dependent on the "nature" of the tree (recording or blueprint,
         // in a filter session or not)
-        let id = collapse_scope.entity(tree.path.clone()).into();
-
-        let is_short_path = tree.path.len() <= 1 && !tree.is_leaf();
-        let default_open = self.filter_state.is_active() || is_short_path;
+        let id = collapse_scope.entity(entity_path.clone()).into();
 
         let list_item::ShowCollapsingResponse {
             item_response: response,
@@ -776,23 +697,28 @@ impl TimePanel {
             .show_hierarchical_with_children(
                 ui,
                 id,
-                default_open,
-                list_item::LabelContent::new(text)
-                    .with_icon(guess_instance_path_icon(
-                        ctx,
-                        &InstancePath::from(tree.path.clone()),
-                    ))
-                    .truncate(false),
+                entity_data.default_open,
+                list_item::LabelContent::new(format_matching_text(
+                    ctx.egui_ctx,
+                    &entity_data.label,
+                    entity_data.highlight_sections.iter().cloned(),
+                    None,
+                ))
+                //TODO: this is slow
+                .with_icon(guess_instance_path_icon(
+                    ctx,
+                    &InstancePath::from(entity_path.clone()),
+                ))
+                .truncate(false),
                 |ui| {
-                    self.show_children(
+                    self.show_entity_contents(
                         ctx,
                         viewport_blueprint,
                         entity_db,
                         time_ctrl,
                         time_area_response,
                         time_area_painter,
-                        tree,
-                        filter_matcher,
+                        entity_data,
                         ui,
                     );
                 },
@@ -804,13 +730,13 @@ impl TimePanel {
                 ui,
                 ctx,
                 &time_ctrl.current_query(),
-                db,
-                &tree.path,
+                entity_db,
+                entity_path,
                 include_subtree,
             );
         });
 
-        if Some(&tree.path) == focused_entity_path {
+        if Some(entity_path) == focused_entity_path {
             // Scroll only if the entity isn't already visible. This is important because that's what
             // happens when double-clicking an entity _in the blueprint tree_. In such case, it would be
             // annoying to induce a scroll motion.
@@ -851,7 +777,7 @@ impl TimePanel {
         let tree_has_data_in_current_timeline = entity_db.subtree_has_data_on_timeline(
             &entity_db.storage_engine(),
             time_ctrl.timeline(),
-            &tree.path,
+            entity_path,
         );
         if is_visible && tree_has_data_in_current_timeline {
             let row_rect =
@@ -865,7 +791,7 @@ impl TimePanel {
                     &mut self.data_density_graph_painter,
                     ctx,
                     time_ctrl,
-                    db,
+                    entity_db,
                     time_area_painter,
                     ui,
                     &self.time_ranges_ui,
@@ -877,8 +803,9 @@ impl TimePanel {
         }
     }
 
+    /// Display the contents of an entity, i.e. its sub-entities and its components.
     #[expect(clippy::too_many_arguments)]
-    fn show_children(
+    fn show_entity_contents(
         &mut self,
         ctx: &ViewerContext<'_>,
         viewport_blueprint: &ViewportBlueprint,
@@ -886,12 +813,11 @@ impl TimePanel {
         time_ctrl: &mut TimeControl,
         time_area_response: &egui::Response,
         time_area_painter: &egui::Painter,
-        tree: &EntityTree,
-        filter_matcher: &filter_widget::FilterMatcher,
+        entity_data: &EntityData,
         ui: &mut egui::Ui,
     ) {
-        for child in tree.children.values() {
-            self.show_tree(
+        for child in &entity_data.children {
+            self.show_entity(
                 ctx,
                 viewport_blueprint,
                 entity_db,
@@ -899,20 +825,20 @@ impl TimePanel {
                 time_area_response,
                 time_area_painter,
                 child,
-                filter_matcher,
                 ui,
             );
         }
 
+        let entity_path = &entity_data.entity_path;
         let engine = entity_db.storage_engine();
         let store = engine.store();
 
         // If this is an entity:
-        if let Some(components) = store.all_components_for_entity(&tree.path) {
+        if let Some(components) = store.all_components_for_entity(entity_path) {
             for component_name in sorted_component_list_for_ui(components.iter()) {
-                let is_static = store.entity_has_static_component(&tree.path, &component_name);
+                let is_static = store.entity_has_static_component(entity_path, &component_name);
 
-                let component_path = ComponentPath::new(tree.path.clone(), component_name);
+                let component_path = ComponentPath::new(entity_path.clone(), component_name);
                 let short_component_name = component_path.component_name.short_name();
                 let item = TimePanelItem::component_path(component_path.clone());
                 let timeline = time_ctrl.timeline();
@@ -920,15 +846,15 @@ impl TimePanel {
                 let component_has_data_in_current_timeline = store
                     .entity_has_component_on_timeline(
                         time_ctrl.timeline(),
-                        &tree.path,
+                        entity_path,
                         &component_name,
                     );
 
                 let num_static_messages =
-                    store.num_static_events_for_component(&tree.path, component_name);
+                    store.num_static_events_for_component(entity_path, component_name);
                 let num_temporal_messages = store.num_temporal_events_for_component_on_timeline(
                     time_ctrl.timeline(),
-                    &tree.path,
+                    entity_path,
                     component_name,
                 );
                 let total_num_messages = num_static_messages + num_temporal_messages;

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -762,6 +762,10 @@ impl TimePanel {
         let response_rect = response.rect;
         self.next_col_right = self.next_col_right.max(response_rect.right());
 
+        //
+        // Display the data density graph only if it is visible.
+        //
+
         // From the left of the label, all the way to the right-most of the time panel
         let full_width_rect = Rect::from_x_y_ranges(
             response_rect.left()..=ui.max_rect().right(),
@@ -769,35 +773,35 @@ impl TimePanel {
         );
 
         let is_visible = ui.is_rect_visible(full_width_rect);
-
-        // ----------------------------------------------
-
-        // show the data in the time area:
-        let tree_has_data_in_current_timeline = entity_db.subtree_has_data_on_timeline(
-            &entity_db.storage_engine(),
-            time_ctrl.timeline(),
-            entity_path,
-        );
-        if is_visible && tree_has_data_in_current_timeline {
-            let row_rect =
-                Rect::from_x_y_ranges(time_area_response.rect.x_range(), response_rect.y_range());
-
-            highlight_timeline_row(ui, ctx, time_area_painter, &item.to_item(), &row_rect);
-
-            // show the density graph only if that item is closed
-            if is_closed {
-                data_density_graph::data_density_graph_ui(
-                    &mut self.data_density_graph_painter,
-                    ctx,
-                    time_ctrl,
-                    entity_db,
-                    time_area_painter,
-                    ui,
-                    &self.time_ranges_ui,
-                    row_rect,
-                    &item,
-                    true,
+        if is_visible {
+            let tree_has_data_in_current_timeline = entity_db.subtree_has_data_on_timeline(
+                &entity_db.storage_engine(),
+                time_ctrl.timeline(),
+                entity_path,
+            );
+            if tree_has_data_in_current_timeline {
+                let row_rect = Rect::from_x_y_ranges(
+                    time_area_response.rect.x_range(),
+                    response_rect.y_range(),
                 );
+
+                highlight_timeline_row(ui, ctx, time_area_painter, &item.to_item(), &row_rect);
+
+                // show the density graph only if that item is closed
+                if is_closed {
+                    data_density_graph::data_density_graph_ui(
+                        &mut self.data_density_graph_painter,
+                        ctx,
+                        time_ctrl,
+                        entity_db,
+                        time_area_painter,
+                        ui,
+                        &self.time_ranges_ui,
+                        row_rect,
+                        &item,
+                        true,
+                    );
+                }
             }
         }
     }

--- a/crates/viewer/re_time_panel/src/streams_tree_data.rs
+++ b/crates/viewer/re_time_panel/src/streams_tree_data.rs
@@ -1,0 +1,152 @@
+use std::ops::Range;
+
+use itertools::Itertools as _;
+use smallvec::SmallVec;
+
+use re_entity_db::EntityTree;
+use re_log_types::EntityPath;
+use re_ui::filter_widget::FilterMatcher;
+use re_viewer_context::ViewerContext;
+
+use crate::TimePanelSource;
+
+#[derive(Debug)]
+pub struct StreamsTreeData {
+    pub children: Vec<EntityData>,
+}
+
+impl StreamsTreeData {
+    pub fn from_source_and_filter(
+        ctx: &ViewerContext<'_>,
+        source: TimePanelSource,
+        filter_matcher: &FilterMatcher,
+    ) -> Self {
+        re_tracing::profile_function!();
+
+        let db = match source {
+            TimePanelSource::Recording => ctx.recording(),
+            TimePanelSource::Blueprint => ctx.blueprint_db(),
+        };
+
+        let root_data = EntityData::from_entity_tree_and_filter(db.tree(), filter_matcher, false);
+
+        // We show "/" on top only for recording streams, because the `/` entity in blueprint
+        // is always empty, so it's just lost space. This works around an issue where the
+        // selection/hover state of the `/` entity is wrongly synchronized between both
+        // stores, due to `Item::*` not tracking stores for entity paths.
+
+        Self {
+            children: match source {
+                TimePanelSource::Recording => root_data
+                    .map(|entity_part_data| vec![entity_part_data])
+                    .unwrap_or_default(),
+                TimePanelSource::Blueprint => root_data
+                    .map(|entity_part_data| entity_part_data.children)
+                    .unwrap_or_default(),
+            },
+        }
+    }
+}
+
+// ---
+
+#[derive(Debug)]
+pub struct EntityData {
+    pub entity_path: EntityPath,
+
+    pub label: String,
+    pub highlight_sections: SmallVec<[Range<usize>; 1]>,
+
+    pub default_open: bool,
+
+    pub children: Vec<EntityData>,
+}
+
+impl EntityData {
+    pub fn from_entity_tree_and_filter(
+        entity_tree: &EntityTree,
+        filter_matcher: &FilterMatcher,
+        mut is_already_a_match: bool,
+    ) -> Option<Self> {
+        // Early out
+        if filter_matcher.matches_nothing() {
+            return None;
+        }
+
+        let mut label = entity_tree
+            .path
+            .last()
+            .map(|entity_part| entity_part.ui_string())
+            .unwrap_or("/".to_owned());
+
+        //
+        // Filtering
+        //
+
+        let (entity_part_matches, highlight_sections) = if filter_matcher.matches_everything() {
+            // fast path (filter is inactive)
+            (true, SmallVec::new())
+        } else if let Some(entity_part) = entity_tree.path.last() {
+            // Nominal case of matching the hierarchy.
+            if let Some(match_sections) = filter_matcher.find_matches(&entity_part.ui_string()) {
+                (true, match_sections.collect())
+            } else {
+                (false, SmallVec::new())
+            }
+        } else {
+            // we are the root, it can never match anything
+            (false, SmallVec::new())
+        };
+
+        // We want to keep entire branches if a single of its node matches. So we must propagate the
+        // "matched" state so we can make the right call when we reach leaf nodes.
+        is_already_a_match |= entity_part_matches;
+
+        //
+        // Recurse
+        //
+
+        if entity_tree.children.is_empty() {
+            // Discard a leaf item unless it is already a match.
+            is_already_a_match.then(|| {
+                // Leaf items are always collapsed by default, even when the filter is active.
+                let default_open = false;
+
+                Self {
+                    entity_path: entity_tree.path.clone(),
+                    label,
+                    highlight_sections,
+                    default_open,
+                    children: vec![],
+                }
+            })
+        } else {
+            let children = entity_tree
+                .children
+                .values()
+                .filter_map(|sub_tree| {
+                    Self::from_entity_tree_and_filter(sub_tree, filter_matcher, is_already_a_match)
+                })
+                .collect_vec();
+
+            (is_already_a_match || !children.is_empty()).then(|| {
+                // Only top-level non-leaf entities are expanded by default, unless the filter is
+                // active.
+                let default_open = filter_matcher.is_active() || entity_tree.path.len() <= 1;
+                Self {
+                    entity_path: entity_tree.path.clone(),
+                    label: if children.is_empty() || entity_tree.path.is_root() {
+                        label
+                    } else {
+                        // Indicate that we have children
+                        label.push('/');
+                        label
+                    },
+                    highlight_sections,
+                    default_open,
+                    children,
+                }
+            })
+        }
+    }
+}

--- a/crates/viewer/re_time_panel/src/time_axis.rs
+++ b/crates/viewer/re_time_panel/src/time_axis.rs
@@ -1,3 +1,6 @@
+// TODO(#6330): remove unwrap()
+#![expect(clippy::unwrap_used)]
+
 use re_entity_db::TimeHistogram;
 use re_log_types::{ResolvedTimeRange, TimeInt, TimeType};
 

--- a/crates/viewer/re_time_panel/tests/snapshots/time_panel_filter_test_active_query.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/time_panel_filter_test_active_query.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17c40bafbc465fe68335737b608569126c437c29319b42d49e7b38e87f027ee1
-size 27073
+oid sha256:7de7ddd6c3b874dd17ae124dd89b2ba396360fb8e9ad96102ec3571c56da158d
+size 21810

--- a/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_a_0.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f25d6bba58b9aeab6bc25d55ff2d7d5d7a72892c038257624650eabba7d774a
+size 144221

--- a/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_a_5.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_a_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4398719c591105cdbcd9eb904acdc487e2630a6b19a7ecf522a681c1f555469
+size 144429

--- a/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_a_9223372036854775807.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_a_9223372036854775807.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20a045edfc9294e5ac7a483f7d47177c3721865906eb37a6aa1e2cdd4e668e1a
+size 144551

--- a/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_b_0.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_b_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee17ecdc118609f31ff0285acdfa49061ccdf7dd403e14c364532750470f699
+size 142735

--- a/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_b_5.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_b_5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba32eb0898dfd66fbd3a287fd21405772258a705427ee7f4678b6adb1bbf6a7a
+size 142918

--- a/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_b_9223372036854775807.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/various_entity_kinds_timeline_b_9223372036854775807.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f56e3ef65134aa7785ef9d88101bdf0e66f7258d86bfc80b764c47cb17e10a8
+size 143213

--- a/crates/viewer/re_time_panel/tests/time_panel_tests.rs
+++ b/crates/viewer/re_time_panel/tests/time_panel_tests.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use egui::Vec2;
 
-use re_chunk_store::{Chunk, LatestAtQuery, RowId};
+use re_chunk_store::{LatestAtQuery, RowId};
+use re_log_types::build_frame_nr;
 use re_log_types::example_components::MyPoint;
 use re_log_types::external::re_types_core::Component;
-use re_log_types::{build_frame_nr, EntityPath};
 use re_time_panel::TimePanel;
 use re_viewer_context::blueprint_timeline;
 use re_viewer_context::test_context::TestContext;
@@ -18,19 +16,17 @@ pub fn time_panel_two_sections_should_match_snapshot() {
 
     let points1 = MyPoint::from_iter(0..1);
     for i in 0..2 {
-        let entity_path = EntityPath::from(format!("/entity/{i}"));
-        let mut builder = Chunk::builder(entity_path.clone());
-        for frame in [10, 11, 12, 15, 18, 100, 102, 104].map(|frame| frame + i) {
-            builder = builder.with_sparse_component_batches(
-                RowId::new(),
-                [build_frame_nr(frame)],
-                [(MyPoint::descriptor(), Some(&points1 as _))],
-            );
-        }
-        test_context
-            .recording_store
-            .add_chunk(&Arc::new(builder.build().unwrap()))
-            .unwrap();
+        test_context.log_entity(format!("/entity/{i}").into(), |mut builder| {
+            for frame in [10, 11, 12, 15, 18, 100, 102, 104].map(|frame| frame + i) {
+                builder = builder.with_sparse_component_batches(
+                    RowId::new(),
+                    [build_frame_nr(frame)],
+                    [(MyPoint::descriptor(), Some(&points1 as _))],
+                );
+            }
+
+            builder
+        });
     }
 
     run_time_panel_and_save_snapshot(
@@ -55,86 +51,23 @@ pub fn time_panel_dense_data_should_match_snapshot() {
         rng_seed.wrapping_mul(0x2545_f491_4f6c_dd1d)
     };
 
-    let entity_path = EntityPath::from("/entity");
-    let mut builder = Chunk::builder(entity_path.clone());
-    for frame in 0..1_000 {
-        if rng() & 0b1 == 0 {
-            continue;
+    test_context.log_entity("/entity".into(), |mut builder| {
+        for frame in 0..1_000 {
+            if rng() & 0b1 == 0 {
+                continue;
+            }
+
+            builder = builder.with_sparse_component_batches(
+                RowId::new(),
+                [build_frame_nr(frame)],
+                [(MyPoint::descriptor(), Some(&points1 as _))],
+            );
         }
 
-        builder = builder.with_sparse_component_batches(
-            RowId::new(),
-            [build_frame_nr(frame)],
-            [(MyPoint::descriptor(), Some(&points1 as _))],
-        );
-    }
-    test_context
-        .recording_store
-        .add_chunk(&Arc::new(builder.build().unwrap()))
-        .unwrap();
+        builder
+    });
 
     run_time_panel_and_save_snapshot(test_context, TimePanel::default(), "time_panel_dense_data");
-}
-
-#[test]
-pub fn time_panel_filter_test_inactive_should_match_snapshot() {
-    run_time_panel_filter_tests(false, "", "time_panel_filter_test_inactive");
-}
-
-#[test]
-pub fn time_panel_filter_test_active_no_query_should_match_snapshot() {
-    run_time_panel_filter_tests(true, "", "time_panel_filter_test_active_no_query");
-}
-
-#[test]
-pub fn time_panel_filter_test_active_query_should_match_snapshot() {
-    run_time_panel_filter_tests(true, "ath", "time_panel_filter_test_active_query");
-}
-
-#[allow(clippy::unwrap_used)]
-pub fn run_time_panel_filter_tests(filter_active: bool, query: &str, snapshot_name: &str) {
-    TimePanel::ensure_registered_subscribers();
-    let mut test_context = TestContext::default();
-
-    let points1 = MyPoint::from_iter(0..1);
-    for i in 0..2 {
-        let entity_path = EntityPath::from(format!("/entity/{i}"));
-        let mut builder = Chunk::builder(entity_path.clone());
-
-        builder = builder.with_sparse_component_batches(
-            RowId::new(),
-            [build_frame_nr(1)],
-            [(MyPoint::descriptor(), Some(&points1 as _))],
-        );
-
-        test_context
-            .recording_store
-            .add_chunk(&Arc::new(builder.build().unwrap()))
-            .unwrap();
-    }
-
-    for i in 0..2 {
-        let entity_path = EntityPath::from(format!("/path/{i}"));
-        let mut builder = Chunk::builder(entity_path.clone());
-
-        builder = builder.with_sparse_component_batches(
-            RowId::new(),
-            [build_frame_nr(1)],
-            [(MyPoint::descriptor(), Some(&points1 as _))],
-        );
-
-        test_context
-            .recording_store
-            .add_chunk(&Arc::new(builder.build().unwrap()))
-            .unwrap();
-    }
-
-    let mut time_panel = TimePanel::default();
-    if filter_active {
-        time_panel.activate_filter(query);
-    }
-
-    run_time_panel_and_save_snapshot(test_context, time_panel, snapshot_name);
 }
 
 fn run_time_panel_and_save_snapshot(
@@ -142,7 +75,6 @@ fn run_time_panel_and_save_snapshot(
     mut time_panel: TimePanel,
     snapshot_name: &str,
 ) {
-    //TODO(ab): this contains a lot of boilerplate which should be provided by helpers
     let mut harness = test_context
         .setup_kittest_for_rendering()
         .with_size(Vec2::new(700.0, 300.0))
@@ -171,4 +103,59 @@ fn run_time_panel_and_save_snapshot(
 
     harness.run();
     harness.snapshot(snapshot_name);
+}
+
+// ---
+
+#[test]
+pub fn time_panel_filter_test_inactive_should_match_snapshot() {
+    run_time_panel_filter_tests(false, "", "time_panel_filter_test_inactive");
+}
+
+#[test]
+pub fn time_panel_filter_test_active_no_query_should_match_snapshot() {
+    run_time_panel_filter_tests(true, "", "time_panel_filter_test_active_no_query");
+}
+
+#[test]
+pub fn time_panel_filter_test_active_query_should_match_snapshot() {
+    run_time_panel_filter_tests(true, "ath", "time_panel_filter_test_active_query");
+}
+
+#[allow(clippy::unwrap_used)]
+pub fn run_time_panel_filter_tests(filter_active: bool, query: &str, snapshot_name: &str) {
+    TimePanel::ensure_registered_subscribers();
+    let mut test_context = TestContext::default();
+
+    let points1 = MyPoint::from_iter(0..1);
+    for i in 0..2 {
+        test_context.log_entity(format!("/entity/{i}").into(), |mut builder| {
+            builder = builder.with_sparse_component_batches(
+                RowId::new(),
+                [build_frame_nr(1)],
+                [(MyPoint::descriptor(), Some(&points1 as _))],
+            );
+
+            builder
+        });
+    }
+
+    for i in 0..2 {
+        test_context.log_entity(format!("/path/{i}").into(), |mut builder| {
+            builder = builder.with_sparse_component_batches(
+                RowId::new(),
+                [build_frame_nr(1)],
+                [(MyPoint::descriptor(), Some(&points1 as _))],
+            );
+
+            builder
+        });
+    }
+
+    let mut time_panel = TimePanel::default();
+    if filter_active {
+        time_panel.activate_filter(query);
+    }
+
+    run_time_panel_and_save_snapshot(test_context, time_panel, snapshot_name);
 }

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -162,8 +162,6 @@ impl ViewerContext<'_> {
         interacted_items: impl Into<ItemCollection>,
         draggable: bool,
     ) {
-        re_tracing::profile_function!();
-
         let interacted_items = interacted_items.into().into_mono_instance_path_items(self);
         let selection_state = self.selection_state();
 


### PR DESCRIPTION
### Related

### Related

- Part of #8586
- Part of a series of PR:
  - #8645
  - #8652
  - #8654
  - #8672
  - #8706
  - #8728
  - #8795
  - #8863
  - ...

### What

This PR refactors the streams tree code in a similar way as what was done in the blueprint tree in #8795. In addition, it makes it significantly faster.

I've decided *against* listing all components in the data structure and instead keep that at the (on-demand) UI level. The reason for that is that `store.all_components_for_entity()` can be rather expensive as the number of entities grows.

**Note**: This PR does not introduce shift-click range selection (that will be in a follow up PR). Because of the design decision above, it will be slightly more tricky (but worth it perf-wise).

#### Visual changes

Only visual/behavioural change introduced in this PR is that leaf entities are now collapsed by default when the entity filter is active (we're searching for entities, not components, so we don't need to see them).

#### Performance

Like the previous PR, we are now parsing the entire entity tree regardless of whether we're going to use/display it or not. With air traffic data, that's 0.3ms only.

As for the optimisations, it's hard to keep track of everything. But frame time for air traffic data with no view and uncollapsed time panel went from ~44ms (0.21) to ~26ms (this PR).
