### PR TITLE
Fix rounding issue in snippet comparision

### DIFF
--- a/docs/snippets/all/archetypes/arrows3d_simple.cpp
+++ b/docs/snippets/all/archetypes/arrows3d_simple.cpp
@@ -19,7 +19,7 @@ int main() {
         origins.push_back({0, 0, 0});
 
         float angle = TAU * static_cast<float>(i) * 0.01f;
-        float length = log2f(static_cast<float>(i + 1));
+        float length = static_cast<float>(log2(i + 1));
         vectors.push_back({length * sinf(angle), 0.0, length * cosf(angle)});
 
         uint8_t c = static_cast<uint8_t>(round(angle / TAU * 255.0f));


### PR DESCRIPTION
Fix issue showing up in  https://github.com/rerun-io/rerun/actions/runs/13045039452/job/36395250023

Tested locally on Windows & Mac to pass now (`pixi run -e py python .\docs\snippets\compare_snippet_output.py archetypes/arrows3d_simple`)