### PR TITLE
Fix handling clears in transform cache

### DIFF
--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -596,7 +596,7 @@ fn transforms_at<'a>(
 ) -> TransformsAtEntity<'a> {
     // This is called very frequently, don't put a profile scope here.
 
-    let Some(entity_transforms) = transforms_for_timeline.entity_transforms(&entity_path) else {
+    let Some(entity_transforms) = transforms_for_timeline.entity_transforms(entity_path) else {
         return TransformsAtEntity::default();
     };
 

--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -596,8 +596,7 @@ fn transforms_at<'a>(
 ) -> TransformsAtEntity<'a> {
     // This is called very frequently, don't put a profile scope here.
 
-    let Some(entity_transforms) = transforms_for_timeline.entity_transforms(entity_path.hash())
-    else {
+    let Some(entity_transforms) = transforms_for_timeline.entity_transforms(&entity_path) else {
         return TransformsAtEntity::default();
     };
 


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/8857

### What

Testing:
* unit test
* revy breakout looks again as before https://rerun.io/viewer/pr/8872?url=https%3A%2F%2Fstatic.rerun.io%2Frrd%2F0.20.0%2Frevy_breakout_3572dc5d61f77dc4fc9675a85c74035a6ee4b020.rrd


as before, most of this is added test code. Some clutter in the diff because I split `add_chunk` into `add_non_static_chunk` and `add_static_chunk` to make it easier to reason. Also this unfortunately rippled into minor interface change since I had to go with `EntityPath` in one spot where I used `EntityPathHash` before