### PR TITLE
Improve look of bar charts slightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecolor"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -1974,7 +1974,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2013,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2031,7 +2031,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2050,7 +2050,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "ahash",
  "egui",
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "dify",
  "eframe",
@@ -2195,7 +2195,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2330,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?branch=master#8eda32ec64c7b48c7b8f9195e3abc8c10efa8f00"
+source = "git+https://github.com/emilk/egui.git?branch=master#50294b5d9f51d4c599c243669c464f826ac51728"
 
 [[package]]
 name = "equivalent"

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -450,7 +450,7 @@ fn rgb8_histogram_ui(ui: &mut egui::Ui, rgb: &[u8]) -> egui::Response {
                     .enumerate()
                     .map(|(i, count)| {
                         Bar::new(i as _, count as _)
-                            .width(0.9)
+                            .width(1.0) // no gaps between bars
                             .fill(fill)
                             .vertical()
                             .stroke(egui::Stroke::NONE)

--- a/crates/viewer/re_view_bar_chart/src/view_class.rs
+++ b/crates/viewer/re_view_bar_chart/src/view_class.rs
@@ -169,15 +169,16 @@ Display a 1D tensor as a bar chart.
                 ) -> BarChart {
                     let color: egui::Color32 = color.0.into();
                     let fill = color.gamma_multiply(0.75).additive(); // make sure overlapping bars are obvious
+                    let stroke_color = fill.linear_multiply(0.5);
                     BarChart::new(
                         values
                             .enumerate()
                             .map(|(i, value)| {
                                 Bar::new(i as f64 + 0.5, value.into())
-                                    .width(0.95)
+                                    .width(1.0) // No gaps
                                     .name(format!("{ent_path} #{i}"))
                                     .fill(fill)
-                                    .stroke(egui::Stroke::NONE)
+                                    .stroke((1.0, stroke_color))
                             })
                             .collect(),
                     )


### PR DESCRIPTION
## What
Removes the gap between the bars. The gaps looked uneven because of pixel grid aliasing. Better to have no gaps (it is far less noticeable that some bars are a pixel wider/narrower than others since they are already so wide).

## Before/after
The comparison pictures are taken on a high-DPI display. The difference is much bigger on a low-DPI display.

### Before
<img width="1308" alt="Screenshot 2025-01-31 at 05 13 41" src="https://github.com/user-attachments/assets/32baa7ac-a6d7-4625-ab44-c7522daafb0f" />


### After
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/afbc137a-b84e-4e72-ae10-d5497e324b08" />
