### PR TITLE
Deprecate C++ `TimeColumn::from_sequence_points` in favor of `TimeColumn::from_sequence`

### DIFF
--- a/docs/snippets/all/archetypes/image_send_columns.cpp
+++ b/docs/snippets/all/archetypes/image_send_columns.cpp
@@ -44,7 +44,7 @@ int main() {
     // Send all images at once.
     rec.send_columns(
         "images",
-        rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+        rerun::TimeColumn::from_sequence("step", std::move(times)),
         rerun::Image().with_many_buffer(std::move(image_data)).columns()
     );
 }

--- a/docs/snippets/all/archetypes/scalar_send_columns.cpp
+++ b/docs/snippets/all/archetypes/scalar_send_columns.cpp
@@ -21,7 +21,7 @@ int main() {
     // Serialize to columns and send.
     rec.send_columns(
         "scalars",
-        rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+        rerun::TimeColumn::from_sequence("step", std::move(times)),
         rerun::Scalar().with_many_scalar(std::move(scalar_data)).columns()
     );
 }

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -73,7 +73,7 @@ namespace rerun::archetypes {
     ///     // Serialize to columns and send.
     ///     rec.send_columns(
     ///         "scalars",
-    ///         rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+    ///         rerun::TimeColumn::from_sequence("step", std::move(times)),
     ///         rerun::Scalar().with_many_scalar(std::move(scalar_data)).columns()
     ///     );
     /// }

--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -71,8 +71,7 @@ namespace rerun {
         /// Already sorted time points may perform better.
         ///
         /// \deprecated Use `from_sequence` instead.
-        [[deprecated("Use `from_sequence` instead.")]]
-        static TimeColumn from_sequence_points(
+        [[deprecated("Use `from_sequence` instead.")]] static TimeColumn from_sequence_points(
             std::string timeline_name, Collection<int64_t> sequence_points,
             SortingStatus sorting_status = SortingStatus::Unknown
         ) {

--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -69,7 +69,28 @@ namespace rerun {
         /// Make sure the sorting status is correctly specified.
         /// \param sorting_status The sorting status of the sequence points.
         /// Already sorted time points may perform better.
+        ///
+        /// \deprecated Use `from_sequence` instead.
+        [[deprecated("Use `from_sequence` instead.")]]
         static TimeColumn from_sequence_points(
+            std::string timeline_name, Collection<int64_t> sequence_points,
+            SortingStatus sorting_status = SortingStatus::Unknown
+        ) {
+            return TimeColumn(
+                Timeline(std::move(timeline_name), TimeType::Sequence),
+                std::move(sequence_points),
+                sorting_status
+            );
+        }
+
+        /// Creates a time column from an array of sequence points.
+        ///
+        /// \param timeline_name The name of the timeline this column belongs to.
+        /// \param sequence_points The sequence points.
+        /// Make sure the sorting status is correctly specified.
+        /// \param sorting_status The sorting status of the sequence points.
+        /// Already sorted time points may perform better.
+        static TimeColumn from_sequence(
             std::string timeline_name, Collection<int64_t> sequence_points,
             SortingStatus sorting_status = SortingStatus::Unknown
         ) {


### PR DESCRIPTION
Equivalent in the other SDKs:
* Rust: `TimeColumn::new_sequence`
* Python: `rerun.TimeSequenceColumn`

`from_sequence_points` was called that way to make clear it's about time points, but figuring now that overall this is more in the way than helpful.