### PR TITLE
`AsComponents::serialize` is now `AsComponents::as_batches` and returns `Collection<ComponentBatch>`

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -1818,9 +1818,8 @@ fn archetype_serialize(type_ident: &Ident, obj: &Object, hpp_includes: &mut Incl
         docs: "Serialize all set component batches.".into(),
         declaration: MethodDeclaration {
             is_static: true,
-            // TODO(andreas): Use a rerun::Collection here as well.
-            return_type: quote!(Result<std::vector<ComponentBatch>>),
-            name_and_parameters: quote!(serialize(const #quoted_scoped_archetypes::#type_ident& archetype)),
+            return_type: quote!(Result<Collection<ComponentBatch>>),
+            name_and_parameters: quote!(as_batches(const #quoted_scoped_archetypes::#type_ident& archetype)),
         },
         definition_body: quote! {
             using namespace #quoted_scoped_archetypes;
@@ -1837,7 +1836,7 @@ fn archetype_serialize(type_ident: &Ident, obj: &Object, hpp_includes: &mut Incl
             }
             #NEWLINE_TOKEN
             #NEWLINE_TOKEN
-            return cells;
+            return rerun::take_ownership(std::move(cells));
         },
         inline: false,
     }

--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -72,3 +72,22 @@ rec.send_columns("scalars", time_column,
 );
 ```
 All [example snippets](https://github.com/rerun-io/rerun/blob/0.22.0/docs/snippets/INDEX.md?speculative-link) have been updated accordingly.
+
+
+### C++ `AsComponents::serialize` is now called `AsComponents::as_batches` and returns `rerun::Collection<ComponentBatch>`
+
+The `AsComponents`'s `serialize` method has been renamed to `as_batches` and now returns a `rerun::Collection<ComponentBatch>` instead of a `std::vector<ComponentBatch>`.
+
+```cpp
+// Old
+template <>
+struct AsComponents<CustomArchetype> {
+    static Result<std::vector<ComponentBatch>> serialize(const CustomArchetype& archetype);
+};
+
+// New
+template <>
+struct AsComponents<CustomArchetype> {
+    static Result<rerun::Collection<ComponentBatch>> operator()(const CustomArchetype& archetype);
+};
+```

--- a/docs/snippets/all/descriptors/descr_custom_archetype.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.cpp
@@ -32,7 +32,7 @@ struct CustomPoints3D {
 
 template <>
 struct rerun::AsComponents<CustomPoints3D> {
-    static Result<std::vector<ComponentBatch>> serialize(const CustomPoints3D& archetype) {
+    static Result<rerun::Collection<ComponentBatch>> as_batches(const CustomPoints3D& archetype) {
         std::vector<rerun::ComponentBatch> batches;
 
         auto positions_descr = rerun::Loggable<CustomPosition3D>::Descriptor
@@ -51,7 +51,7 @@ struct rerun::AsComponents<CustomPoints3D> {
             );
         }
 
-        return batches;
+        return rerun::take_ownership(std::move(batches));
     }
 };
 

--- a/docs/snippets/all/tutorials/custom_data.cpp
+++ b/docs/snippets/all/tutorials/custom_data.cpp
@@ -37,8 +37,10 @@ struct CustomPoints3D {
 
 template <>
 struct rerun::AsComponents<CustomPoints3D> {
-    static Result<std::vector<ComponentBatch>> serialize(const CustomPoints3D& archetype) {
-        auto batches = AsComponents<rerun::Points3D>::serialize(archetype.points).value_or_throw();
+    static Result<rerun::Collection<ComponentBatch>> as_batches(const CustomPoints3D& archetype) {
+        auto batches = AsComponents<rerun::Points3D>::as_batches(archetype.points)
+                           .value_or_throw()
+                           .to_vector();
 
         // Add custom confidence components if present.
         if (archetype.confidences) {
@@ -50,7 +52,7 @@ struct rerun::AsComponents<CustomPoints3D> {
             );
         }
 
-        return batches;
+        return rerun::take_ownership(std::move(batches));
     }
 };
 

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.cpp
@@ -39,7 +39,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::AnnotationContext>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::AnnotationContext>::as_batches(
         const archetypes::AnnotationContext& archetype
     ) {
         using namespace archetypes;
@@ -55,6 +55,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -147,7 +147,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::AnnotationContext> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::AnnotationContext& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
@@ -110,7 +110,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Arrows2D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Arrows2D>::as_batches(
         const archetypes::Arrows2D& archetype
     ) {
         using namespace archetypes;
@@ -147,6 +147,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
@@ -266,6 +266,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Arrows2D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Arrows2D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Arrows2D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.cpp
@@ -100,7 +100,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Arrows3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Arrows3D>::as_batches(
         const archetypes::Arrows3D& archetype
     ) {
         using namespace archetypes;
@@ -134,6 +134,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -252,6 +252,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Arrows3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Arrows3D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Arrows3D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.cpp
@@ -60,7 +60,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Asset3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Asset3D>::as_batches(
         const archetypes::Asset3D& archetype
     ) {
         using namespace archetypes;
@@ -82,6 +82,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -234,6 +234,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Asset3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Asset3D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Asset3D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset_video.cpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.cpp
@@ -48,7 +48,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::AssetVideo>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::AssetVideo>::as_batches(
         const archetypes::AssetVideo& archetype
     ) {
         using namespace archetypes;
@@ -67,6 +67,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -262,7 +262,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::AssetVideo> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::AssetVideo& archetype
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::AssetVideo& archetype
         );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -48,7 +48,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::BarChart>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::BarChart>::as_batches(
         const archetypes::BarChart& archetype
     ) {
         using namespace archetypes;
@@ -67,6 +67,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -256,6 +256,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::BarChart> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::BarChart& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::BarChart& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.cpp
@@ -110,7 +110,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Boxes2D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Boxes2D>::as_batches(
         const archetypes::Boxes2D& archetype
     ) {
         using namespace archetypes;
@@ -147,6 +147,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -290,6 +290,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Boxes2D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Boxes2D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Boxes2D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.cpp
@@ -137,7 +137,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Boxes3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Boxes3D>::as_batches(
         const archetypes::Boxes3D& archetype
     ) {
         using namespace archetypes;
@@ -180,6 +180,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -364,6 +364,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Boxes3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Boxes3D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Boxes3D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.cpp
@@ -128,7 +128,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Capsules3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Capsules3D>::as_batches(
         const archetypes::Capsules3D& archetype
     ) {
         using namespace archetypes;
@@ -168,6 +168,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
@@ -327,7 +327,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Capsules3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Capsules3D& archetype
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Capsules3D& archetype
         );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.cpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.cpp
@@ -40,7 +40,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Clear>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Clear>::as_batches(
         const archetypes::Clear& archetype
     ) {
         using namespace archetypes;
@@ -56,6 +56,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -175,6 +175,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Clear> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Clear& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Clear& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.cpp
@@ -101,7 +101,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::DepthImage>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::DepthImage>::as_batches(
         const archetypes::DepthImage& archetype
     ) {
         using namespace archetypes;
@@ -135,6 +135,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -417,7 +417,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::DepthImage> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::DepthImage& archetype
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::DepthImage& archetype
         );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.cpp
@@ -137,7 +137,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Ellipsoids3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Ellipsoids3D>::as_batches(
         const archetypes::Ellipsoids3D& archetype
     ) {
         using namespace archetypes;
@@ -180,6 +180,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
@@ -377,7 +377,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Ellipsoids3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::Ellipsoids3D& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/encoded_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/encoded_image.cpp
@@ -68,7 +68,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::EncodedImage>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::EncodedImage>::as_batches(
         const archetypes::EncodedImage& archetype
     ) {
         using namespace archetypes;
@@ -93,6 +93,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
@@ -243,7 +243,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::EncodedImage> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::EncodedImage& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.cpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.cpp
@@ -60,7 +60,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::GeoLineStrings>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::GeoLineStrings>::as_batches(
         const archetypes::GeoLineStrings& archetype
     ) {
         using namespace archetypes;
@@ -82,6 +82,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
@@ -159,7 +159,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::GeoLineStrings> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::GeoLineStrings& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/geo_points.cpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_points.cpp
@@ -67,7 +67,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::GeoPoints>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::GeoPoints>::as_batches(
         const archetypes::GeoPoints& archetype
     ) {
         using namespace archetypes;
@@ -92,6 +92,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/geo_points.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_points.hpp
@@ -171,7 +171,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::GeoPoints> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::GeoPoints& archetype
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::GeoPoints& archetype
         );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.cpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.cpp
@@ -48,7 +48,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::GraphEdges>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::GraphEdges>::as_batches(
         const archetypes::GraphEdges& archetype
     ) {
         using namespace archetypes;
@@ -67,6 +67,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
@@ -146,7 +146,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::GraphEdges> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::GraphEdges& archetype
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::GraphEdges& archetype
         );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.cpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.cpp
@@ -90,7 +90,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::GraphNodes>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::GraphNodes>::as_batches(
         const archetypes::GraphNodes& archetype
     ) {
         using namespace archetypes;
@@ -121,6 +121,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
@@ -200,7 +200,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::GraphNodes> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::GraphNodes& archetype
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::GraphNodes& archetype
         );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image.cpp
@@ -68,7 +68,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Image>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Image>::as_batches(
         const archetypes::Image& archetype
     ) {
         using namespace archetypes;
@@ -93,6 +93,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -427,6 +427,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Image> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Image& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Image& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/instance_poses3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/instance_poses3d.cpp
@@ -87,7 +87,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::InstancePoses3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::InstancePoses3D>::as_batches(
         const archetypes::InstancePoses3D& archetype
     ) {
         using namespace archetypes;
@@ -115,6 +115,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
@@ -214,7 +214,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::InstancePoses3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::InstancePoses3D& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.cpp
@@ -100,7 +100,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::LineStrips2D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::LineStrips2D>::as_batches(
         const archetypes::LineStrips2D& archetype
     ) {
         using namespace archetypes;
@@ -134,6 +134,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -280,7 +280,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::LineStrips2D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::LineStrips2D& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.cpp
@@ -90,7 +90,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::LineStrips3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::LineStrips3D>::as_batches(
         const archetypes::LineStrips3D& archetype
     ) {
         using namespace archetypes;
@@ -121,6 +121,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -263,7 +263,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::LineStrips3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::LineStrips3D& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -134,7 +134,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Mesh3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Mesh3D>::as_batches(
         const archetypes::Mesh3D& archetype
     ) {
         using namespace archetypes;
@@ -174,6 +174,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -382,6 +382,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Mesh3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Mesh3D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Mesh3D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/pinhole.cpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.cpp
@@ -75,7 +75,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Pinhole>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Pinhole>::as_batches(
         const archetypes::Pinhole& archetype
     ) {
         using namespace archetypes;
@@ -100,6 +100,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -377,6 +377,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Pinhole> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Pinhole& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Pinhole& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.cpp
@@ -112,7 +112,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Points2D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Points2D>::as_batches(
         const archetypes::Points2D& archetype
     ) {
         using namespace archetypes;
@@ -149,6 +149,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -326,6 +326,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Points2D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Points2D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Points2D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.cpp
@@ -102,7 +102,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Points3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Points3D>::as_batches(
         const archetypes::Points3D& archetype
     ) {
         using namespace archetypes;
@@ -136,6 +136,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -332,6 +332,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Points3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Points3D& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Points3D& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/scalar.cpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.cpp
@@ -38,7 +38,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Scalar>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Scalar>::as_batches(
         const archetypes::Scalar& archetype
     ) {
         using namespace archetypes;
@@ -54,6 +54,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -157,6 +157,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Scalar> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Scalar& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Scalar& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.cpp
@@ -68,7 +68,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::SegmentationImage>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::SegmentationImage>::as_batches(
         const archetypes::SegmentationImage& archetype
     ) {
         using namespace archetypes;
@@ -93,6 +93,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -296,7 +296,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::SegmentationImage> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::SegmentationImage& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/series_line.cpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.cpp
@@ -71,7 +71,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::SeriesLine>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::SeriesLine>::as_batches(
         const archetypes::SeriesLine& archetype
     ) {
         using namespace archetypes;
@@ -96,6 +96,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -226,7 +226,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::SeriesLine> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::SeriesLine& archetype
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::SeriesLine& archetype
         );
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/series_point.cpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.cpp
@@ -70,7 +70,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::SeriesPoint>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::SeriesPoint>::as_batches(
         const archetypes::SeriesPoint& archetype
     ) {
         using namespace archetypes;
@@ -95,6 +95,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -222,7 +222,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::SeriesPoint> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::SeriesPoint& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/tensor.cpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.cpp
@@ -50,7 +50,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Tensor>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Tensor>::as_batches(
         const archetypes::Tensor& archetype
     ) {
         using namespace archetypes;
@@ -69,6 +69,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -208,6 +208,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Tensor> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::Tensor& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::Tensor& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.cpp
@@ -48,7 +48,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::TextDocument>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::TextDocument>::as_batches(
         const archetypes::TextDocument& archetype
     ) {
         using namespace archetypes;
@@ -67,6 +67,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -193,7 +193,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::TextDocument> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::TextDocument& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/text_log.cpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.cpp
@@ -58,7 +58,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::TextLog>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::TextLog>::as_batches(
         const archetypes::TextLog& archetype
     ) {
         using namespace archetypes;
@@ -80,6 +80,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -206,6 +206,6 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::TextLog> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(const archetypes::TextLog& archetype);
+        static Result<Collection<ComponentBatch>> as_batches(const archetypes::TextLog& archetype);
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.cpp
@@ -106,7 +106,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::Transform3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::Transform3D>::as_batches(
         const archetypes::Transform3D& archetype
     ) {
         using namespace archetypes;
@@ -140,6 +140,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -769,7 +769,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::Transform3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::Transform3D& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.cpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.cpp
@@ -50,7 +50,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::VideoFrameReference>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::VideoFrameReference>::as_batches(
         const archetypes::VideoFrameReference& archetype
     ) {
         using namespace archetypes;
@@ -69,6 +69,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -254,7 +254,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::VideoFrameReference> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::VideoFrameReference& archetype
         );
     };

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.cpp
@@ -38,7 +38,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::ViewCoordinates>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::ViewCoordinates>::as_batches(
         const archetypes::ViewCoordinates& archetype
     ) {
         using namespace archetypes;
@@ -54,6 +54,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -383,7 +383,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::ViewCoordinates> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::ViewCoordinates& archetype
         );
     };

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -6,7 +6,7 @@
 #include "loggable.hpp"
 
 namespace rerun {
-    /// The AsComponents trait is used to convert a type into a list of as_batchesd component.
+    /// The AsComponents trait is used to convert a type into a list of component batches.
     ///
     /// It is implemented for various built-in types as well as collections of components.
     /// You can build your own archetypes by implementing this trait.

--- a/rerun_cpp/src/rerun/as_components.hpp
+++ b/rerun_cpp/src/rerun/as_components.hpp
@@ -6,7 +6,7 @@
 #include "loggable.hpp"
 
 namespace rerun {
-    /// The AsComponents trait is used to convert a type into a list of serialized component.
+    /// The AsComponents trait is used to convert a type into a list of as_batchesd component.
     ///
     /// It is implemented for various built-in types as well as collections of components.
     /// You can build your own archetypes by implementing this trait.
@@ -26,11 +26,9 @@ namespace rerun {
             "You can add your own implementation by specializing AsComponents<T> for your type T."
         );
 
-        // TODO(andreas): List methods that the trait should implement.
+        /// Converts the type `T` into a collection of `ComponentBatch`s.
+        static Result<Collection<ComponentBatch>> as_batches(const T& archetype);
     };
-
-    // TODO(andreas): make these return collection?
-    // TODO(andreas): Now that we no longer rely on `Loggable` trait implementations here, `serialize` is a misnomer. Consider using `operator()` instead.
 
     // Documenting the builtin generic `AsComponents` impls is too much clutter for the doc class overview.
     /// \cond private
@@ -38,35 +36,35 @@ namespace rerun {
     /// `AsComponents` for a `Collection<ComponentBatch>`.
     template <>
     struct AsComponents<Collection<ComponentBatch>> {
-        static Result<std::vector<ComponentBatch>> serialize(Collection<ComponentBatch> components
+        static Result<Collection<ComponentBatch>> as_batches(Collection<ComponentBatch> components
         ) {
-            return Result<std::vector<ComponentBatch>>(std::move(components).to_vector());
+            return components;
         }
     };
 
     /// `AsComponents` for a single `ComponentBatch`.
     template <>
     struct AsComponents<ComponentBatch> {
-        static Result<std::vector<ComponentBatch>> serialize(ComponentBatch components) {
-            return Result<std::vector<ComponentBatch>>({std::move(components)});
+        static Result<Collection<ComponentBatch>> as_batches(ComponentBatch components) {
+            return rerun::take_ownership(std::move(components));
         }
     };
 
     /// `AsComponents` for a `Collection<ComponentBatch>` wrapped in a `Result`, forwarding errors for convenience.
     template <>
     struct AsComponents<Result<Collection<ComponentBatch>>> {
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             Result<Collection<ComponentBatch>> components
         ) {
             RR_RETURN_NOT_OK(components.error);
-            return Result<std::vector<ComponentBatch>>(std::move(components.value).to_vector());
+            return components.value;
         }
     };
 
     /// `AsComponents` for a `Collection<ComponentBatch>` individually wrapped in `Result`, forwarding errors for convenience.
     template <>
     struct AsComponents<Collection<Result<ComponentBatch>>> {
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             Collection<Result<ComponentBatch>> components
         ) {
             std::vector<ComponentBatch> result;
@@ -75,16 +73,16 @@ namespace rerun {
                 RR_RETURN_NOT_OK(component.error);
                 result.push_back(std::move(component.value));
             }
-            return Result<std::vector<ComponentBatch>>(std::move(result));
+            return rerun::take_ownership(std::move(result));
         }
     };
 
     /// `AsComponents` for a single `ComponentBatch` wrapped in a `Result`, forwarding errors for convenience.
     template <>
     struct AsComponents<Result<ComponentBatch>> {
-        static Result<std::vector<ComponentBatch>> serialize(Result<ComponentBatch> components) {
+        static Result<Collection<ComponentBatch>> as_batches(Result<ComponentBatch> components) {
             RR_RETURN_NOT_OK(components.error);
-            return Result<std::vector<ComponentBatch>>({std::move(components.value)});
+            return rerun::take_ownership(std::move(components.value));
         }
     };
 

--- a/rerun_cpp/src/rerun/blueprint/archetypes/background.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/background.cpp
@@ -49,7 +49,7 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<blueprint::archetypes::Background>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<blueprint::archetypes::Background>::as_batches(
         const blueprint::archetypes::Background& archetype
     ) {
         using namespace blueprint::archetypes;
@@ -68,6 +68,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/background.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/background.hpp
@@ -103,7 +103,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::Background> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::Background& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.cpp
@@ -119,8 +119,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::ContainerBlueprint>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::ContainerBlueprint>::as_batches(
             const blueprint::archetypes::ContainerBlueprint& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -157,6 +157,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.hpp
@@ -249,7 +249,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ContainerBlueprint> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ContainerBlueprint& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.cpp
@@ -91,8 +91,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::DataframeQuery>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::DataframeQuery>::as_batches(
             const blueprint::archetypes::DataframeQuery& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -120,6 +120,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.hpp
@@ -168,7 +168,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::DataframeQuery> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::DataframeQuery& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_center.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_center.cpp
@@ -49,7 +49,7 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<blueprint::archetypes::ForceCenter>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<blueprint::archetypes::ForceCenter>::as_batches(
         const blueprint::archetypes::ForceCenter& archetype
     ) {
         using namespace blueprint::archetypes;
@@ -68,6 +68,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_center.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_center.hpp
@@ -105,7 +105,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ForceCenter> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ForceCenter& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.cpp
@@ -61,8 +61,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::ForceCollisionRadius>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::ForceCollisionRadius>::as_batches(
             const blueprint::archetypes::ForceCollisionRadius& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -84,6 +84,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.hpp
@@ -131,7 +131,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ForceCollisionRadius> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ForceCollisionRadius& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_link.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_link.cpp
@@ -60,7 +60,7 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<blueprint::archetypes::ForceLink>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<blueprint::archetypes::ForceLink>::as_batches(
         const blueprint::archetypes::ForceLink& archetype
     ) {
         using namespace blueprint::archetypes;
@@ -82,6 +82,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_link.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_link.hpp
@@ -126,7 +126,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ForceLink> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ForceLink& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.cpp
@@ -49,8 +49,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::ForceManyBody>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::ForceManyBody>::as_batches(
             const blueprint::archetypes::ForceManyBody& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -69,6 +69,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.hpp
@@ -114,7 +114,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ForceManyBody> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ForceManyBody& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_position.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_position.cpp
@@ -59,8 +59,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::ForcePosition>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::ForcePosition>::as_batches(
             const blueprint::archetypes::ForcePosition& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -82,6 +82,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_position.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_position.hpp
@@ -122,7 +122,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ForcePosition> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ForcePosition& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.cpp
@@ -82,7 +82,7 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<blueprint::archetypes::LineGrid3D>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<blueprint::archetypes::LineGrid3D>::as_batches(
         const blueprint::archetypes::LineGrid3D& archetype
     ) {
         using namespace blueprint::archetypes;
@@ -110,6 +110,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.hpp
@@ -168,7 +168,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::LineGrid3D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::LineGrid3D& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_background.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_background.cpp
@@ -38,8 +38,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::MapBackground>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::MapBackground>::as_batches(
             const blueprint::archetypes::MapBackground& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -55,6 +55,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_background.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_background.hpp
@@ -94,7 +94,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::MapBackground> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::MapBackground& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.cpp
@@ -39,7 +39,7 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<blueprint::archetypes::MapZoom>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<blueprint::archetypes::MapZoom>::as_batches(
         const blueprint::archetypes::MapZoom& archetype
     ) {
         using namespace blueprint::archetypes;
@@ -55,6 +55,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.hpp
@@ -93,7 +93,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::MapZoom> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::MapZoom& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.cpp
@@ -42,8 +42,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::NearClipPlane>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::NearClipPlane>::as_batches(
             const blueprint::archetypes::NearClipPlane& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -59,6 +59,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.hpp
@@ -99,7 +99,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::NearClipPlane> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::NearClipPlane& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.cpp
@@ -39,8 +39,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::PanelBlueprint>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::PanelBlueprint>::as_batches(
             const blueprint::archetypes::PanelBlueprint& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -56,6 +56,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.hpp
@@ -85,7 +85,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::PanelBlueprint> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::PanelBlueprint& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.cpp
@@ -50,7 +50,7 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<blueprint::archetypes::PlotLegend>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<blueprint::archetypes::PlotLegend>::as_batches(
         const blueprint::archetypes::PlotLegend& archetype
     ) {
         using namespace blueprint::archetypes;
@@ -69,6 +69,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.hpp
@@ -108,7 +108,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::PlotLegend> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::PlotLegend& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.cpp
@@ -50,7 +50,7 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<blueprint::archetypes::ScalarAxis>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<blueprint::archetypes::ScalarAxis>::as_batches(
         const blueprint::archetypes::ScalarAxis& archetype
     ) {
         using namespace blueprint::archetypes;
@@ -69,6 +69,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.hpp
@@ -106,7 +106,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ScalarAxis> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ScalarAxis& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.cpp
@@ -58,8 +58,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::TensorScalarMapping>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::TensorScalarMapping>::as_batches(
             const blueprint::archetypes::TensorScalarMapping& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -81,6 +81,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.hpp
@@ -136,7 +136,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::TensorScalarMapping> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::TensorScalarMapping& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.cpp
@@ -76,8 +76,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::TensorSliceSelection>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::TensorSliceSelection>::as_batches(
             const blueprint::archetypes::TensorSliceSelection& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -102,6 +102,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.hpp
@@ -157,7 +157,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::TensorSliceSelection> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::TensorSliceSelection& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.cpp
@@ -39,8 +39,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::TensorViewFit>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::TensorViewFit>::as_batches(
             const blueprint::archetypes::TensorViewFit& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -56,6 +56,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.hpp
@@ -85,7 +85,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::TensorViewFit> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::TensorViewFit& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.cpp
@@ -76,8 +76,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::ViewBlueprint>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::ViewBlueprint>::as_batches(
             const blueprint::archetypes::ViewBlueprint& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -102,6 +102,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.hpp
@@ -160,7 +160,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ViewBlueprint> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ViewBlueprint& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.cpp
@@ -39,8 +39,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::ViewContents>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::ViewContents>::as_batches(
             const blueprint::archetypes::ViewContents& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -56,6 +56,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.hpp
@@ -132,7 +132,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ViewContents> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ViewContents& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.cpp
@@ -89,8 +89,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::ViewportBlueprint>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::ViewportBlueprint>::as_batches(
             const blueprint::archetypes::ViewportBlueprint& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -118,6 +118,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
@@ -190,7 +190,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::ViewportBlueprint> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::ViewportBlueprint& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.cpp
@@ -39,8 +39,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::VisibleTimeRanges>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::VisibleTimeRanges>::as_batches(
             const blueprint::archetypes::VisibleTimeRanges& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -56,6 +56,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
@@ -106,7 +106,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::VisibleTimeRanges> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::VisibleTimeRanges& archetype
         );
     };

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.cpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.cpp
@@ -39,8 +39,8 @@ namespace rerun::blueprint::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>>
-        AsComponents<blueprint::archetypes::VisualBounds2D>::serialize(
+    Result<Collection<ComponentBatch>>
+        AsComponents<blueprint::archetypes::VisualBounds2D>::as_batches(
             const blueprint::archetypes::VisualBounds2D& archetype
         ) {
         using namespace blueprint::archetypes;
@@ -56,6 +56,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.hpp
@@ -99,7 +99,7 @@ namespace rerun {
     template <>
     struct AsComponents<blueprint::archetypes::VisualBounds2D> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const blueprint::archetypes::VisualBounds2D& archetype
         );
     };

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -480,8 +480,8 @@ namespace rerun {
                         return;
                     }
 
-                    const Result<std::vector<ComponentBatch>> serialization_result =
-                        AsComponents<Ts>().serialize(as_components);
+                    const Result<Collection<ComponentBatch>> serialization_result =
+                        AsComponents<Ts>().as_batches(as_components);
                     if (serialization_result.is_err()) {
                         err = serialization_result.error;
                         return;
@@ -489,7 +489,7 @@ namespace rerun {
 
                     if (serialized_columns.empty()) {
                         // Fast path for the first batch (which is usually the only one!)
-                        serialized_columns = std::move(serialization_result.value);
+                        serialized_columns = std::move(serialization_result.value).to_vector();
                     } else {
                         serialized_columns.insert(
                             serialized_columns.end(),

--- a/rerun_cpp/tests/archetypes/archetype_test.hpp
+++ b/rerun_cpp/tests/archetypes/archetype_test.hpp
@@ -10,8 +10,8 @@
 template <typename T>
 void test_compare_archetype_serialization(const T& arch_a, const T& arch_b) {
     THEN("convert to component lists") {
-        auto arch_b_serialized_result = rerun::AsComponents<T>::serialize(arch_b);
-        auto arch_a_serialized_result = rerun::AsComponents<T>::serialize(arch_a);
+        auto arch_b_serialized_result = rerun::AsComponents<T>::as_batches(arch_b);
+        auto arch_a_serialized_result = rerun::AsComponents<T>::as_batches(arch_a);
 
         AND_THEN("serializing each list succeeds") {
             REQUIRE(arch_b_serialized_result.is_ok());

--- a/rerun_cpp/tests/archetypes/clear.cpp
+++ b/rerun_cpp/tests/archetypes/clear.cpp
@@ -11,7 +11,7 @@ SCENARIO("clear archetype can be serialized" TEST_TAG) {
         auto from_builder = Clear(true);
 
         THEN("serialization succeeds") {
-            CHECK(rerun::AsComponents<Clear>().serialize(from_builder).is_ok());
+            CHECK(rerun::AsComponents<Clear>().as_batches(from_builder).is_ok());
         }
     }
 }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.cpp
@@ -248,7 +248,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::AffixFuzzer1>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::AffixFuzzer1>::as_batches(
         const archetypes::AffixFuzzer1& archetype
     ) {
         using namespace archetypes;
@@ -327,6 +327,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -690,7 +690,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::AffixFuzzer1> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::AffixFuzzer1& archetype
         );
     };

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.cpp
@@ -218,7 +218,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::AffixFuzzer2>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::AffixFuzzer2>::as_batches(
         const archetypes::AffixFuzzer2& archetype
     ) {
         using namespace archetypes;
@@ -288,6 +288,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -414,7 +414,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::AffixFuzzer2> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::AffixFuzzer2& archetype
         );
     };

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.cpp
@@ -208,7 +208,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::AffixFuzzer3>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::AffixFuzzer3>::as_batches(
         const archetypes::AffixFuzzer3& archetype
     ) {
         using namespace archetypes;
@@ -275,6 +275,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -528,7 +528,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::AffixFuzzer3> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::AffixFuzzer3& archetype
         );
     };

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.cpp
@@ -208,7 +208,7 @@ namespace rerun::archetypes {
 
 namespace rerun {
 
-    Result<std::vector<ComponentBatch>> AsComponents<archetypes::AffixFuzzer4>::serialize(
+    Result<Collection<ComponentBatch>> AsComponents<archetypes::AffixFuzzer4>::as_batches(
         const archetypes::AffixFuzzer4& archetype
     ) {
         using namespace archetypes;
@@ -275,6 +275,6 @@ namespace rerun {
             cells.emplace_back(std::move(result.value));
         }
 
-        return cells;
+        return rerun::take_ownership(std::move(cells));
     }
 } // namespace rerun

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -339,7 +339,7 @@ namespace rerun {
     template <>
     struct AsComponents<archetypes::AffixFuzzer4> {
         /// Serialize all set component batches.
-        static Result<std::vector<ComponentBatch>> serialize(
+        static Result<Collection<ComponentBatch>> as_batches(
             const archetypes::AffixFuzzer4& archetype
         );
     };

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -44,7 +44,7 @@ struct BadArchetype {
 namespace rerun {
     template <>
     struct AsComponents<BadArchetype> {
-        static rerun::Result<std::vector<rerun::ComponentBatch>> serialize(const BadArchetype&) {
+        static rerun::Result<Collection<rerun::ComponentBatch>> as_batches(const BadArchetype&) {
             return Loggable<BadComponent>::error;
         }
     };


### PR DESCRIPTION
### What

See title. This is a breaking change for custom `AsComponents` implementations. But we had plenty of breaking changes in that area, so now it's the right time.

The rename `serialize` to `as_batches` is motivated by the fact that _previously_ we typically did to-arrow serializations in `AsComponents`. This is no longer the case and it's more of a collecting operation, just as we do in Rust's `AsComponents::as_serialized_batches` - since C++ only has `ComponentBatch` and no `SerializedComponentBatch` it follows that the method is just called `as_batches` now.

The change in return type fixes an old todo (no ticket) for using `rerun::Collection` for more flexibility in this area (pending improvements to `rerun::Collection`) and making our API handling more consistent in that regard.