### PR TITLE
Clarify use of `std::move(*this)` & similar situations

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -191,7 +191,7 @@ class Rect {
 
     Rect with_color(Color color) && {
         _color = color;
-        return std::move(*this);
+        return std::move(*this); // `*this` is always an lvalue, so we have to move it to avoid a copy.
     }
 }
 ```

--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -599,6 +599,8 @@ impl QuotedObject {
                     definition_body: quote! {
                         #field_ident = ComponentBatch::from_loggable(#parameter_ident, #descriptor).value_or_throw();
                         #NEWLINE_TOKEN
+                        // `*this` is *always* an lvalue, so we have to move it.
+                        // https://stackoverflow.com/a/25334892
                         return std::move(*this);
                     },
                     inline: true,
@@ -627,6 +629,8 @@ impl QuotedObject {
                     definition_body: quote! {
                         #field_ident = ComponentBatch::from_loggable(#parameter_ident, #descriptor).value_or_throw();
                         #NEWLINE_TOKEN
+                        // `*this` is *always* an lvalue, so we have to move it.
+                        // https://stackoverflow.com/a/25334892
                         return std::move(*this);
                     },
                     inline: true,

--- a/docs/snippets/all/howto/any_batch_value_send_columns.cpp
+++ b/docs/snippets/all/howto/any_batch_value_send_columns.cpp
@@ -38,7 +38,7 @@ arrow::Status run_main() {
 
     rec.send_columns(
         "/",
-        rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+        rerun::TimeColumn::from_sequence("step", std::move(times)),
         one_per_timestamp.partitioned().value_or_throw(),
         ten_per_timestamp.partitioned(std::vector<uint32_t>(STEPS, 10)).value_or_throw()
     );

--- a/docs/snippets/all/howto/any_values_send_columns.cpp
+++ b/docs/snippets/all/howto/any_values_send_columns.cpp
@@ -36,7 +36,7 @@ arrow::Status run_main() {
 
     rec.send_columns(
         "/",
-        rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+        rerun::TimeColumn::from_sequence("step", std::move(times)),
         sin.partitioned().value_or_throw(),
         cos.partitioned().value_or_throw()
     );

--- a/rerun_cpp/src/rerun/collection.hpp
+++ b/rerun_cpp/src/rerun/collection.hpp
@@ -389,6 +389,7 @@ namespace rerun {
                 }
 
                 case CollectionOwnership::VectorOwned: {
+                    // Ensure move constructor is called, so `storage.vector_owned` is in a valid state.
                     return std::move(storage.vector_owned);
                 }
 

--- a/rerun_cpp/src/rerun/result.hpp
+++ b/rerun_cpp/src/rerun/result.hpp
@@ -60,6 +60,7 @@ namespace rerun {
         /// @see error::value_or_exit
         T value_or_throw() && {
             error.throw_on_failure();
+            // Do an explicit move in order to guarantee that we give up ownership of `value`.
             return std::move(value);
         }
 
@@ -74,6 +75,7 @@ namespace rerun {
         /// @see error::value_or_throw
         T value_or_exit() && {
             error.exit_on_failure();
+            // Do an explicit move in order to guarantee that we give up ownership of `value`.
             return std::move(value);
         }
 


### PR DESCRIPTION
Originally I wanted to remove superfluous `std::move` which can prevent return value optimization (see https://stackoverflow.com/questions/14856344/when-should-stdmove-be-used-on-a-function-return-value or https://developers.redhat.com/blog/2019/04/12/understanding-when-not-to-stdmove-in-c) buuuut I ended up backpadelling and documenting why we need `std::move` in these places anyways: `return *this` would cause a copy since `*this` is never a temporary

(C++23 (!!) will allow handling this better, with `Deducing this` which then allows perfect forwarding of `this`, see for instance https://stackoverflow.com/questions/73043766/return-type-for-this-in-a-builder-class-method-lvalue-vs-rvalue-refence)