### PR TITLE
fix re_blueprint_tree standalone all features build

### DIFF
--- a/crates/viewer/re_blueprint_tree/Cargo.toml
+++ b/crates/viewer/re_blueprint_tree/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 
 [features]
 default = []
-testing = ["dep:serde"]
+testing = ["dep:serde", "smallvec/serde", "re_viewer_context/testing"]
 
 
 [dependencies]


### PR DESCRIPTION
make `cargo check --all-features -p re_blueprint_tree` work again