### PR TITLE
Fix handling null timestamps in the dataframe

### DIFF
--- a/crates/viewer/re_view_dataframe/src/view_class.rs
+++ b/crates/viewer/re_view_dataframe/src/view_class.rs
@@ -1,9 +1,5 @@
 use std::any::Any;
 
-use crate::{
-    dataframe_ui::dataframe_ui, expanded_rows::ExpandedRowsCache, view_query,
-    visualizer_system::EmptySystem,
-};
 use re_chunk_store::{ColumnDescriptor, SparseFillStrategy};
 use re_dataframe::QueryEngine;
 use re_log_types::EntityPath;
@@ -11,6 +7,11 @@ use re_types_core::ViewClassIdentifier;
 use re_viewer_context::{
     SystemExecutionOutput, ViewClass, ViewClassRegistryError, ViewId, ViewQuery, ViewState,
     ViewStateExt, ViewSystemExecutionError, ViewerContext,
+};
+
+use crate::{
+    dataframe_ui::dataframe_ui, expanded_rows::ExpandedRowsCache, view_query,
+    visualizer_system::EmptySystem,
 };
 
 #[derive(Default)]


### PR DESCRIPTION
### Related

- Closes #8893 

### What

Since #8639, the dataframe view would break with a timeline that contains null, which can easily happen with code as the repro in #8893. Previously, the dataframe was quite possibly displaying garbage instead of null timestamps.

This PR now properly handles nulls in timelines.