### PR TITLE
Rerun CMake dependency now automatically ensures C++17 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,11 +129,6 @@ if(MSVC)
     add_compile_options("/MP")
 endif()
 
-# Arrow requires a C++17 compliant compiler.
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
-endif()
-
 # Signal to all our build scripts that we're inside the Rerun repository.
 set(RERUN_REPOSITORY YES)
 

--- a/docs/content/getting-started/data-in/cpp.md
+++ b/docs/content/getting-started/data-in/cpp.md
@@ -59,12 +59,11 @@ FetchContent_Declare(rerun_sdk URL
     https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
-# Rerun requires at least C++17, but it should be compatible with newer versions.
-set_property(TARGET example_dna PROPERTY CXX_STANDARD 17)
-
 # Link against rerun_sdk.
 target_link_libraries(example_dna PRIVATE rerun_sdk)
 ```
+
+Note that Rerun requires at least C++17. Depending on the sdk will automatically ensure that C++17 or newer is enabled.
 
 ## Includes
 

--- a/docs/content/getting-started/quick-start/cpp.md
+++ b/docs/content/getting-started/quick-start/cpp.md
@@ -36,13 +36,7 @@ all Rerun C++ sources and headers, as well as CMake build instructions for them.
 By default this will in turn download & build [Apache Arrow](https://arrow.apache.org/)'s C++ library which is required to build the Rerun C++.
 See [Install arrow-cpp](https://ref.rerun.io/docs/cpp/stable/md__2home_2runner_2work_2rerun_2rerun_2rerun__cpp_2arrow__cpp__install.html) to learn more about this step and how to use an existing install.
 
-Currently, Rerun SDK works with C++17 or newer, so you need to add this property to your target:
-
-```cmake
-set_property(TARGET example_minimal PROPERTY CXX_STANDARD 17)
-```
-
-And finally, make sure you link with `rerun_sdk`:
+Finally, make sure you link with `rerun_sdk`:
 
 ```cmake
 target_link_libraries(example_minimal PRIVATE rerun_sdk)
@@ -62,12 +56,11 @@ FetchContent_Declare(rerun_sdk URL
     https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
-# Rerun requires at least C++17, but it should be compatible with newer versions.
-set_property(TARGET example_minimal PROPERTY CXX_STANDARD 17)
-
 # Link against rerun_sdk.
 target_link_libraries(example_minimal PRIVATE rerun_sdk)
 ```
+
+Note that Rerun requires at least C++17. Depending on the sdk will automatically ensure that C++17 or newer is enabled.
 
 ## Logging some data
 

--- a/examples/cpp/clock/CMakeLists.txt
+++ b/examples/cpp/clock/CMakeLists.txt
@@ -18,9 +18,6 @@ else()
     include(FetchContent)
     FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
     FetchContent_MakeAvailable(rerun_sdk)
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_clock PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/custom_collection_adapter/CMakeLists.txt
+++ b/examples/cpp/custom_collection_adapter/CMakeLists.txt
@@ -18,9 +18,6 @@ else()
     include(FetchContent)
     FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
     FetchContent_MakeAvailable(rerun_sdk)
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_custom_collection_adapter PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/dna/CMakeLists.txt
+++ b/examples/cpp/dna/CMakeLists.txt
@@ -18,9 +18,6 @@ else()
     include(FetchContent)
     FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
     FetchContent_MakeAvailable(rerun_sdk)
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_dna PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/external_data_loader/CMakeLists.txt
+++ b/examples/cpp/external_data_loader/CMakeLists.txt
@@ -23,9 +23,6 @@ else()
         FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
         FetchContent_MakeAvailable(rerun_sdk)
     endif()
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET rerun-loader-cpp-file PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/incremental_logging/CMakeLists.txt
+++ b/examples/cpp/incremental_logging/CMakeLists.txt
@@ -18,9 +18,6 @@ else()
     include(FetchContent)
     FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
     FetchContent_MakeAvailable(rerun_sdk)
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_incremental_logging PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/log_file/CMakeLists.txt
+++ b/examples/cpp/log_file/CMakeLists.txt
@@ -23,9 +23,6 @@ else()
         FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
         FetchContent_MakeAvailable(rerun_sdk)
     endif()
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_log_file PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/minimal/CMakeLists.txt
+++ b/examples/cpp/minimal/CMakeLists.txt
@@ -23,9 +23,6 @@ else()
         FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
         FetchContent_MakeAvailable(rerun_sdk)
     endif()
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_minimal PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/shared_recording/CMakeLists.txt
+++ b/examples/cpp/shared_recording/CMakeLists.txt
@@ -23,9 +23,6 @@ else()
         FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
         FetchContent_MakeAvailable(rerun_sdk)
     endif()
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_shared_recording PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/spawn_viewer/CMakeLists.txt
+++ b/examples/cpp/spawn_viewer/CMakeLists.txt
@@ -18,9 +18,6 @@ else()
     include(FetchContent)
     FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
     FetchContent_MakeAvailable(rerun_sdk)
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_spawn_viewer PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/examples/cpp/stdio/CMakeLists.txt
+++ b/examples/cpp/stdio/CMakeLists.txt
@@ -23,9 +23,6 @@ else()
         FetchContent_Declare(rerun_sdk URL ${RERUN_CPP_URL})
         FetchContent_MakeAvailable(rerun_sdk)
     endif()
-
-    # Rerun requires at least C++17, but it should be compatible with newer versions.
-    set_property(TARGET example_stdio PROPERTY CXX_STANDARD 17)
 endif()
 
 # Link against rerun_sdk.

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(rerun_sdk PUBLIC
 )
 
 # Rerun needs at least C++17.
-set_target_properties(rerun_sdk PROPERTIES CXX_STANDARD 17)
+target_compile_features(rerun_sdk PUBLIC cxx_std_17)
 
 # Do multithreaded compiling on MSVC.
 if(MSVC)


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/7883

### What

By setting the C++17 as a public target property in CMake, all targets depending on Rerun will automatically use _at least_ C++17

Tested this against the OpenCV example and it works like a charm:
* don't set C++ standard explicitly -> picks C++17 automatically
* `set(CMAKE_CXX_STANDARD 20)`: compiles everything with C++20
* `set(CMAKE_CXX_STANDARD 14)` / `target_compile_features(my_target PRIVATE cxx_std_14)`: unfortunately silently still uses C++17. Not sure if we can do something about this, seems to be how this ecosystem works?