### PR TITLE
Support unknown timeline in dataframe view

### DIFF
--- a/crates/viewer/re_view_dataframe/src/view_class.rs
+++ b/crates/viewer/re_view_dataframe/src/view_class.rs
@@ -4,8 +4,9 @@ use re_chunk_store::{ColumnDescriptor, SparseFillStrategy};
 use re_dataframe::QueryEngine;
 use re_log_types::EntityPath;
 use re_types_core::ViewClassIdentifier;
+use re_ui::UiExt;
 use re_viewer_context::{
-    SystemExecutionOutput, ViewClass, ViewClassRegistryError, ViewId, ViewQuery, ViewState,
+    Item, SystemExecutionOutput, ViewClass, ViewClassRegistryError, ViewId, ViewQuery, ViewState,
     ViewStateExt, ViewSystemExecutionError, ViewerContext,
 };
 
@@ -105,12 +106,7 @@ mode sets the default time range to _everything_. You can override this in the s
     ) -> Result<(), ViewSystemExecutionError> {
         let state = state.downcast_mut::<DataframeViewState>()?;
         let view_query = view_query::Query::from_blueprint(ctx, view_id);
-        let Some(view_columns) = &state.view_columns else {
-            // Shouldn't happen, except maybe on the first frame, which is too early
-            // for the user to click the menu anyway.
-            return Ok(());
-        };
-        view_query.selection_panel_ui(ctx, ui, view_id, view_columns)
+        view_query.selection_panel_ui(ctx, ui, view_id, state.view_columns.as_deref())
     }
 
     fn ui(
@@ -125,6 +121,14 @@ mode sets the default time range to _everything_. You can override this in the s
 
         let state = state.downcast_mut::<DataframeViewState>()?;
         let view_query = view_query::Query::from_blueprint(ctx, query.view_id);
+
+        // Make sure we know which timeline to query or display an error message.
+        let timeline = view_query.timeline(ctx)?;
+
+        let Some(timeline) = timeline else {
+            timeline_not_found_ui(ctx, ui, query.view_id);
+            return Ok(());
+        };
 
         let query_engine = QueryEngine {
             engine: ctx.recording().storage_engine_arc(),
@@ -143,7 +147,7 @@ mode sets the default time range to _everything_. You can override this in the s
 
         let mut dataframe_query = re_chunk_store::QueryExpression {
             view_contents: Some(view_contents),
-            filtered_index: Some(view_query.timeline(ctx)?),
+            filtered_index: Some(timeline),
             filtered_index_range: Some(view_query.filter_by_range()?),
             filtered_is_not_null: view_query.filter_is_not_null()?,
             sparse_fill_strategy,
@@ -175,6 +179,34 @@ mode sets the default time range to _everything_. You can override this in the s
 
         state.view_columns = Some(view_columns);
         Ok(())
+    }
+}
+
+fn timeline_not_found_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, view_id: ViewId) {
+    let full_view_rect = ui.available_rect_before_wrap();
+
+    egui::Frame::new()
+        .inner_margin(re_ui::DesignTokens::view_padding())
+        .show(ui, |ui| {
+            ui.warning_label("Unknown timeline");
+
+            ui.label(
+                "The timeline currently configured for this view does not exist in the current \
+                recording. Select another timeline in the view properties found in the selection \
+                panel.",
+            )
+        });
+
+    // select the view when clicked
+    if ui
+        .interact(
+            full_view_rect,
+            egui::Id::from("dataframe_view_empty").with(view_id),
+            egui::Sense::click(),
+        )
+        .clicked()
+    {
+        ctx.selection_state.set_selection(Item::View(view_id));
     }
 }
 

--- a/crates/viewer/re_view_dataframe/src/view_query/mod.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/mod.rs
@@ -33,17 +33,21 @@ impl Query {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         view_id: ViewId,
-        view_columns: &[ColumnDescriptor],
+        view_columns: Option<&[ColumnDescriptor]>,
     ) -> Result<(), ViewSystemExecutionError> {
+        ui.add_space(4.0);
+
+        let timeline_name = self.timeline_name(ctx)?;
+        self.timeline_ui(ctx, ui, timeline_name)?;
+
         let timeline = self.timeline(ctx)?;
 
-        self.timeline_ui(ctx, ui, &timeline)?;
         ui.separator();
-        self.filter_range_ui(ctx, ui, &timeline)?;
+        self.filter_range_ui(ctx, ui, timeline.as_ref())?;
         ui.separator();
-        self.filter_is_not_null_ui(ctx, ui, &timeline, view_id)?;
+        self.filter_is_not_null_ui(ctx, ui, timeline.as_ref(), view_id)?;
         ui.separator();
-        self.column_visibility_ui(ctx, ui, &timeline, view_columns)?;
+        self.column_visibility_ui(ctx, ui, timeline.as_ref(), view_columns)?;
         ui.separator();
         self.latest_at_ui(ctx, ui)?;
 

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -17,9 +17,8 @@ impl Query {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        timeline: &Timeline,
+        mut timeline_name: TimelineName,
     ) -> Result<(), ViewSystemExecutionError> {
-        let mut timeline_name = *timeline.name();
         egui::Grid::new("dataframe_view_query_ui_timeline")
             .num_columns(2)
             .spacing(egui::vec2(8.0, 10.0))
@@ -39,14 +38,21 @@ impl Query {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        timeline: &Timeline,
+        timeline: Option<&Timeline>,
     ) -> Result<(), ViewSystemExecutionError> {
-        let time_drag_value = if let Some(times) = ctx.recording().time_histogram(timeline) {
-            TimeDragValue::from_time_histogram(times)
-        } else {
-            debug_assert!(false, "This should never happen because `timeline` is guaranteed to be valid by `Self::timeline()`");
-            TimeDragValue::from_time_range(0..=0)
-        };
+        let time_drag_value_and_type = timeline.map(|timeline| {
+            let time_drag_value = if let Some(times) = ctx.recording().time_histogram(timeline) {
+                TimeDragValue::from_time_histogram(times)
+            } else {
+                debug_assert!(
+                    false,
+                    "This should never happen because `timeline` should exist if not `None`"
+                );
+                TimeDragValue::from_time_range(0..=0)
+            };
+
+            (time_drag_value, timeline.typ())
+        });
 
         ui.label("Filter rows by time range:");
         let range = self.filter_by_range()?;
@@ -63,18 +69,25 @@ impl Query {
                         reset_start = true;
                     })
                     .value_fn(|ui, _| {
-                        let response = time_boundary_ui(
-                            ui,
-                            &time_drag_value,
-                            None,
-                            timeline.typ(),
-                            ctx.app_options.time_zone,
-                            &mut start,
-                        );
+                        if let Some((time_drag_value, timeline_type)) = &time_drag_value_and_type {
+                            let response = time_boundary_ui(
+                                ui,
+                                time_drag_value,
+                                None,
+                                *timeline_type,
+                                ctx.app_options.time_zone,
+                                &mut start,
+                            );
 
-                        changed |= response.changed();
-                        should_display_time_range |=
-                            response.hovered() || response.dragged() || response.has_focus();
+                            changed |= response.changed();
+                            should_display_time_range |=
+                                response.hovered() || response.dragged() || response.has_focus();
+                        } else {
+                            ui.add_enabled(false, egui::Label::new("n/a"))
+                                .on_disabled_hover_text(
+                                    "Select an existing timeline to edit this property",
+                                );
+                        }
                     }),
             );
 
@@ -91,18 +104,25 @@ impl Query {
                         reset_to = true;
                     })
                     .value_fn(|ui, _| {
-                        let response = time_boundary_ui(
-                            ui,
-                            &time_drag_value,
-                            Some(start),
-                            timeline.typ(),
-                            ctx.app_options.time_zone,
-                            &mut end,
-                        );
+                        if let Some((time_drag_value, timeline_type)) = &time_drag_value_and_type {
+                            let response = time_boundary_ui(
+                                ui,
+                                time_drag_value,
+                                Some(start),
+                                *timeline_type,
+                                ctx.app_options.time_zone,
+                                &mut end,
+                            );
 
-                        changed |= response.changed();
-                        should_display_time_range |=
-                            response.hovered() || response.dragged() || response.has_focus();
+                            changed |= response.changed();
+                            should_display_time_range |=
+                                response.hovered() || response.dragged() || response.has_focus();
+                        } else {
+                            ui.add_enabled(false, egui::Label::new("n/a"))
+                                .on_disabled_hover_text(
+                                    "Select an existing timeline to edit this property",
+                                );
+                        }
                     }),
             );
 
@@ -118,7 +138,7 @@ impl Query {
 
         if should_display_time_range {
             let mut time_ctrl = ctx.rec_cfg.time_ctrl.write();
-            if time_ctrl.timeline() == timeline {
+            if Some(time_ctrl.timeline()) == timeline {
                 time_ctrl.highlighted_range = Some(ResolvedTimeRange::new(start, end));
             }
         }
@@ -130,7 +150,7 @@ impl Query {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        timeline: &Timeline,
+        timeline: Option<&Timeline>,
         view_id: ViewId,
     ) -> Result<(), ViewSystemExecutionError> {
         //
@@ -154,7 +174,37 @@ impl Query {
         // Filter active?
         //
 
-        ui.re_checkbox(&mut active, "Filter rows where column is not null:");
+        ui.add_enabled_ui(timeline.is_some(), |ui| {
+            ui.re_checkbox(&mut active, "Filter rows where column is not null:")
+                .on_disabled_hover_text("Select an existing timeline to edit this property");
+        });
+
+        //
+        // Fallback UI if timeline is not found
+        //
+
+        let Some(timeline) = timeline else {
+            ui.add_enabled_ui(false, |ui| {
+                ui.spacing_mut().item_spacing.y = 0.0;
+
+                ui.list_item_flat_noninteractive(
+                    list_item::PropertyContent::new("Entity")
+                        .value_text(filter_entity.unwrap_or_else(EntityPath::root).to_string()),
+                )
+                .on_disabled_hover_text("Select an existing timeline to edit this property");
+
+                ui.list_item_flat_noninteractive(
+                    list_item::PropertyContent::new("Component").value_text(
+                        filter_component
+                            .unwrap_or_else(|| ComponentName::from("-"))
+                            .short_name(),
+                    ),
+                )
+                .on_disabled_hover_text("Select an existing timeline to edit this property");
+            });
+
+            return Ok(());
+        };
 
         //
         // Filter entity
@@ -165,7 +215,7 @@ impl Query {
         let mut filter_entity = filter_entity
             .and_then(|entity| all_entities.contains(&entity).then_some(entity))
             .or_else(|| all_entities.iter().next().cloned())
-            .unwrap_or_else(|| EntityPath::from("/"));
+            .unwrap_or_else(EntityPath::root);
 
         //
         // Filter component
@@ -255,6 +305,21 @@ impl Query {
     }
 
     pub(super) fn column_visibility_ui(
+        &self,
+        ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        timeline: Option<&Timeline>,
+        view_columns: Option<&[ColumnDescriptor]>,
+    ) -> Result<(), ViewSystemExecutionError> {
+        if let (Some(timeline), Some(view_columns)) = (timeline, view_columns) {
+            self.column_visibility_ui_impl(ctx, ui, timeline, view_columns)
+        } else {
+            Self::column_visibility_ui_fallback(ui);
+            Ok(())
+        }
+    }
+
+    fn column_visibility_ui_impl(
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
@@ -388,6 +453,18 @@ impl Query {
         }
 
         Ok(())
+    }
+
+    fn column_visibility_ui_fallback(ui: &mut egui::Ui) {
+        ui.list_item_flat_noninteractive(list_item::PropertyContent::new("Columns").value_fn(
+            |ui, _| {
+                ui.add_enabled_ui(false, |ui| {
+                    ui.label("n/a").on_disabled_hover_text(
+                        "Select an existing timeline to edit this property",
+                    );
+                });
+            },
+        ));
     }
 
     pub(super) fn latest_at_ui(

--- a/crates/viewer/re_view_dataframe/tests/basic.rs
+++ b/crates/viewer/re_view_dataframe/tests/basic.rs
@@ -1,9 +1,10 @@
 use re_chunk_store::RowId;
 use re_log_types::{Timeline, TimelineName};
 use re_types::archetypes::Scalar;
+use re_ui::UiExt;
 use re_view_dataframe::DataframeView;
 use re_viewer_context::test_context::TestContext;
-use re_viewer_context::{RecommendedView, ViewClass};
+use re_viewer_context::{RecommendedView, ViewClass, ViewId};
 use re_viewport_blueprint::test_context_ext::TestContextExt;
 use re_viewport_blueprint::ViewBlueprint;
 
@@ -26,11 +27,42 @@ pub fn test_null_timeline() {
         )
     });
 
-    run_view_and_save_snapshot(
-        test_context,
-        timeline_a.name(),
+    let view_id = setup_blueprint(&mut test_context, timeline_a.name());
+    run_view_ui_and_save_snapshot(
+        &mut test_context,
+        view_id,
         "null_timeline",
         egui::vec2(300.0, 150.0),
+    );
+}
+
+#[test]
+pub fn test_unknown_timeline() {
+    let mut test_context = get_test_context();
+
+    let timeline = Timeline::new_sequence("existing_timeline");
+
+    test_context.log_entity("some_entity".into(), |builder| {
+        builder
+            .with_archetype(RowId::new(), [(timeline, 0)], &Scalar::new(10.0))
+            .with_archetype(RowId::new(), [(timeline, 1)], &Scalar::new(20.0))
+            .with_archetype(RowId::new(), [(timeline, 2)], &Scalar::new(30.0))
+    });
+
+    let view_id = setup_blueprint(&mut test_context, &TimelineName::from("unknown_timeline"));
+
+    run_view_ui_and_save_snapshot(
+        &mut test_context,
+        view_id,
+        "unknown_timeline_view_ui",
+        egui::vec2(300.0, 150.0),
+    );
+
+    run_view_selection_panel_ui_and_save_snapshot(
+        &mut test_context,
+        view_id,
+        "unknown_timeline_selection_panel_ui",
+        egui::vec2(300.0, 450.0),
     );
 }
 
@@ -48,14 +80,8 @@ fn get_test_context() -> TestContext {
     test_context
 }
 
-//TODO(ab): this utility could likely be generalized for all view tests
-fn run_view_and_save_snapshot(
-    mut test_context: TestContext,
-    timeline_name: &TimelineName,
-    name: &str,
-    size: egui::Vec2,
-) {
-    let view_id = test_context.setup_viewport_blueprint(|ctx, blueprint| {
+fn setup_blueprint(test_context: &mut TestContext, timeline_name: &TimelineName) -> ViewId {
+    test_context.setup_viewport_blueprint(|ctx, blueprint| {
         let view_blueprint = ViewBlueprint::new(
             re_view_dataframe::DataframeView::identifier(),
             RecommendedView::root(),
@@ -69,8 +95,15 @@ fn run_view_and_save_snapshot(
         query.save_timeline_name(ctx, timeline_name);
 
         view_id
-    });
+    })
+}
 
+fn run_view_ui_and_save_snapshot(
+    test_context: &mut TestContext,
+    view_id: ViewId,
+    name: &str,
+    size: egui::Vec2,
+) {
     let mut view_state = test_context
         .view_class_registry
         .get_class_or_log_error(DataframeView::identifier())
@@ -112,6 +145,60 @@ fn run_view_and_save_snapshot(
                             system_execution_output,
                         )
                         .expect("failed to run graph view ui");
+                });
+
+                test_context.handle_system_commands();
+            });
+        });
+
+    harness.run();
+    harness.snapshot(name);
+}
+
+fn run_view_selection_panel_ui_and_save_snapshot(
+    test_context: &mut TestContext,
+    view_id: ViewId,
+    name: &str,
+    size: egui::Vec2,
+) {
+    let mut view_state = test_context
+        .view_class_registry
+        .get_class_or_log_error(DataframeView::identifier())
+        .new_state();
+
+    let mut harness = test_context
+        .setup_kittest_for_rendering()
+        .with_size(size)
+        .build(|ctx| {
+            re_ui::apply_style_and_install_loaders(ctx);
+
+            egui::CentralPanel::default().show(ctx, |ui| {
+                test_context.run(ctx, |ctx| {
+                    let view_class = ctx
+                        .view_class_registry
+                        .get_class_or_log_error(DataframeView::identifier());
+
+                    let view_blueprint = ViewBlueprint::try_from_db(
+                        view_id,
+                        ctx.store_context.blueprint,
+                        ctx.blueprint_query,
+                    )
+                    .expect("we just created that view");
+
+                    let spacing = ui.spacing().item_spacing;
+                    ui.list_item_scope("test_harness", |ui| {
+                        ui.spacing_mut().item_spacing = spacing;
+
+                        view_class
+                            .selection_ui(
+                                ctx,
+                                ui,
+                                &mut *view_state,
+                                &view_blueprint.space_origin,
+                                view_id,
+                            )
+                            .expect("failed to run view selection panel ui");
+                    });
                 });
 
                 test_context.handle_system_commands();

--- a/crates/viewer/re_view_dataframe/tests/snapshots/unknown_timeline_selection_panel_ui.png
+++ b/crates/viewer/re_view_dataframe/tests/snapshots/unknown_timeline_selection_panel_ui.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8112b6db5675e5514807167caf7bb7bafaa948243861109f10978d95d532bfb
+size 27711

--- a/crates/viewer/re_view_dataframe/tests/snapshots/unknown_timeline_view_ui.png
+++ b/crates/viewer/re_view_dataframe/tests/snapshots/unknown_timeline_view_ui.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a2eb47275e2274e93f6d6a91e729b442d9d45a8bb8513bb99201d8bece8a6ff
+size 23211


### PR DESCRIPTION
### Related

- Fixes #8712 

### What

Initially, the dataframe view was built around the idea that the timeline it's configured for is always valid. It uphold this invariant, it would auto-switch to a known timeline in case the current on is unknown.

This was deeply flawed:
1) Recording has some stuff on timeline "X".
2) User configures a dataframe view with timeline "X"
3) New recording of the same app_id has _nothing_ on timeline "X" (e.g. because some event didn't happen in this run, or just because it takes time for data to be logged on "X")
==> dataframe would auto-switch to another timeline
==> 😤

With this PR, the dataframe now supports unknown timeline, at the cost of:
- displaying a warning in the view UI
- disabling most of the selection panel UI

Note: this PR does NOT introduce a way to specify a yet unknown timeline in the UI. You need to use the blueprint API for that, or set the timeline in a recording of your app id that has that timeline.

<img width="1345" alt="image" src="https://github.com/user-attachments/assets/568fa1e2-dafc-4fd4-9f96-1816b0347504" />
