### PR TITLE
Fix action button showing up for recording in app id tooltip

### DIFF
--- a/crates/viewer/re_data_ui/src/app_id.rs
+++ b/crates/viewer/re_data_ui/src/app_id.rs
@@ -50,7 +50,7 @@ impl crate::DataUi for ApplicationId {
                 ui.add_space(8.0);
                 ui.strong("Loaded recordings for this app");
                 for entity_db in recordings {
-                    entity_db_button_ui(ctx, ui, entity_db, true);
+                    entity_db_button_ui(ctx, ui, entity_db, ui_layout, true);
                 }
             });
         }

--- a/crates/viewer/re_data_ui/src/app_id.rs
+++ b/crates/viewer/re_data_ui/src/app_id.rs
@@ -19,10 +19,12 @@ impl crate::DataUi for ApplicationId {
             .num_columns(2)
             .show(ui, |ui| {
                 ui.label("Application ID");
-                ui.label(self.to_string());
+
+                let mut label = self.to_string();
                 if self == &ctx.store_context.app_id {
-                    ui.label("(active)");
+                    label.push_str(" (active)");
                 }
+                UiLayout::List.label(ui, label);
                 ui.end_row();
             });
 

--- a/crates/viewer/re_data_ui/src/data_source.rs
+++ b/crates/viewer/re_data_ui/src/data_source.rs
@@ -56,7 +56,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
                 ui.add_space(8.0);
                 ui.strong("Recordings from this data source");
                 for entity_db in recordings {
-                    entity_db_button_ui(ctx, ui, entity_db, true);
+                    entity_db_button_ui(ctx, ui, entity_db, ui_layout, true);
                 }
             }
 
@@ -64,7 +64,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
                 ui.add_space(8.0);
                 ui.strong("Blueprints from this data source");
                 for entity_db in blueprints {
-                    entity_db_button_ui(ctx, ui, entity_db, true);
+                    entity_db_button_ui(ctx, ui, entity_db, ui_layout, true);
                 }
             }
         });

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -49,7 +49,7 @@ impl crate::DataUi for EntityDb {
 
                 if let Some(cloned_from) = cloned_from {
                     ui.grid_left_hand_label("Clone of");
-                    crate::item_ui::store_id_button_ui(ctx, ui, cloned_from);
+                    crate::item_ui::store_id_button_ui(ctx, ui, cloned_from, ui_layout);
                     ui.end_row();
                 }
 

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -711,11 +711,12 @@ pub fn store_id_button_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     store_id: &re_log_types::StoreId,
+    ui_layout: UiLayout,
 ) {
     if let Some(entity_db) = ctx.store_context.bundle.get(store_id) {
-        entity_db_button_ui(ctx, ui, entity_db, true);
+        entity_db_button_ui(ctx, ui, entity_db, ui_layout, true);
     } else {
-        ui.label(store_id.to_string());
+        ui_layout.label(ui, store_id.to_string());
     }
 }
 
@@ -729,6 +730,7 @@ pub fn entity_db_button_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     entity_db: &re_entity_db::EntityDb,
+    ui_layout: UiLayout,
     include_app_id: bool,
 ) {
     use re_byte_size::SizeBytes as _;
@@ -761,17 +763,18 @@ pub fn entity_db_button_ui(
         re_log_types::StoreKind::Blueprint => &icons::BLUEPRINT,
     };
 
-    let item_content = list_item::LabelContent::new(title)
-        .with_icon_fn(|ui, rect, visuals| {
-            // Color icon based on whether this is the active recording or not:
-            let color = if ctx.store_context.is_active(&store_id) {
-                visuals.fg_stroke.color
-            } else {
-                ui.visuals().widgets.noninteractive.fg_stroke.color
-            };
-            icon.as_image().tint(color).paint_at(ui, rect);
-        })
-        .with_buttons(|ui| {
+    let mut item_content = list_item::LabelContent::new(title).with_icon_fn(|ui, rect, visuals| {
+        // Color icon based on whether this is the active recording or not:
+        let color = if ctx.store_context.is_active(&store_id) {
+            visuals.fg_stroke.color
+        } else {
+            ui.visuals().widgets.noninteractive.fg_stroke.color
+        };
+        icon.as_image().tint(color).paint_at(ui, rect);
+    });
+
+    if ui_layout.is_selection_panel() {
+        item_content = item_content.with_buttons(|ui| {
             // Close-button:
             let resp = ui
                 .small_icon_button(&icons::REMOVE)
@@ -789,6 +792,7 @@ pub fn entity_db_button_ui(
             }
             resp
         });
+    }
 
     let mut list_item = ui
         .list_item()

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -212,7 +212,13 @@ fn app_and_its_recordings_ui(
                 } else {
                     for entity_db in entity_dbs {
                         let include_app_id = false; // we already show it in the parent
-                        entity_db_button_ui(ctx, ui, entity_db, include_app_id);
+                        entity_db_button_ui(
+                            ctx,
+                            ui,
+                            entity_db,
+                            UiLayout::SelectionPanel,
+                            include_app_id,
+                        );
                     }
                 }
             })


### PR DESCRIPTION
### Related

- Fixes #8902 

### What

The app id tooltip no longer has action buttons on recordings in its tooltip:

<img width="389" alt="image" src="https://github.com/user-attachments/assets/10bd60d3-1b32-4ffa-8c5c-b941cd8f6248" />

The button is still there in the selection panel though, which now truncates properly:

<img width="344" alt="image" src="https://github.com/user-attachments/assets/bc6cd394-e19d-47d6-9ca4-e579e58c73ae" />

