### PR TITLE
Fix memory leaks when closing recordings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ icd.json
 
 .pixi/*
 justfile
+
+# heaptrack files
+*.zst


### PR DESCRIPTION
All the lazily registered subscribers need to know about this.

* Fixes #8858 

## Test

Load 50 DNA recordings into a viewer, then close them all.

### Results

Before:
![image](https://github.com/user-attachments/assets/53f50622-b7de-4eb5-bd9d-09e0b7fe262d)

After:
![image](https://github.com/user-attachments/assets/94e3b800-f657-43e5-af19-d2c69b9ccc75)

