### PR TITLE
Switch .vscode extension to dependi

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,8 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "charliermarsh.ruff",
+    "esbenp.prettier-vscode",
+    "fill-labs.dependi",
     "gaborv.flatbuffers",
     "github.vscode-github-actions",
     "josetr.cmake-language-support-vscode",
@@ -13,7 +15,6 @@
     "ms-vsliveshare.vsliveshare",
     "polymeilex.wgsl",
     "rust-lang.rust-analyzer",
-    "serayuzgur.crates",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",
     "vadimcn.vscode-lldb",
@@ -21,6 +22,5 @@
     "webfreak.debug",
     "xaver.clang-format", // C++ formatter
     "zxh404.vscode-proto3",
-    "esbenp.prettier-vscode"
   ]
 }


### PR DESCRIPTION
The `serayuzgur.crates` extension is deprecated and causes a warning in vs code.