### PR TITLE
Set default log level to `warn` now that notification center is in place

### DIFF
--- a/crates/utils/re_log/src/lib.rs
+++ b/crates/utils/re_log/src/lib.rs
@@ -95,7 +95,7 @@ pub fn default_log_filter() -> String {
         if cfg!(debug_assertions) {
             "debug".to_owned()
         } else {
-            "info".to_owned()
+            "warn".to_owned()
         }
     });
 


### PR DESCRIPTION
### Related

Closes #7815 

### What

Set the default log level to `warn`, now that we have the notification center.
