### PR TITLE
Handle indicators, overrides & view states in view tests

### DIFF
--- a/crates/viewer/re_view_dataframe/tests/basic.rs
+++ b/crates/viewer/re_view_dataframe/tests/basic.rs
@@ -163,11 +163,6 @@ fn run_view_selection_panel_ui_and_save_snapshot(
     name: &str,
     size: egui::Vec2,
 ) {
-    let mut view_state = test_context
-        .view_class_registry
-        .get_class_or_log_error(DataframeView::identifier())
-        .new_state();
-
     let mut harness = test_context
         .setup_kittest_for_rendering()
         .with_size(size)
@@ -191,11 +186,14 @@ fn run_view_selection_panel_ui_and_save_snapshot(
                     ui.list_item_scope("test_harness", |ui| {
                         ui.spacing_mut().item_spacing = spacing;
 
+                        let mut view_states = test_context.view_states.lock();
+                        let view_state = view_states.get_mut_or_create(view_id, view_class);
+
                         view_class
                             .selection_ui(
                                 ctx,
                                 ui,
-                                &mut *view_state,
+                                view_state,
                                 &view_blueprint.space_origin,
                                 view_id,
                             )

--- a/crates/viewer/re_view_dataframe/tests/basic.rs
+++ b/crates/viewer/re_view_dataframe/tests/basic.rs
@@ -106,11 +106,6 @@ fn run_view_ui_and_save_snapshot(
     name: &str,
     size: egui::Vec2,
 ) {
-    let mut view_state = test_context
-        .view_class_registry
-        .get_class_or_log_error(DataframeView::identifier())
-        .new_state();
-
     let mut harness = test_context
         .setup_kittest_for_rendering()
         .with_size(size)
@@ -130,22 +125,19 @@ fn run_view_ui_and_save_snapshot(
                     )
                     .expect("we just created that view");
 
+                    let mut view_states = test_context.view_states.lock();
+                    let view_state = view_states.get_mut_or_create(view_id, view_class);
+
                     let (view_query, system_execution_output) =
                         re_viewport::execute_systems_for_view(
                             ctx,
                             &view_blueprint,
                             ctx.current_query().at(), // TODO(andreas): why is this even needed to be passed in?
-                            &*view_state,
+                            view_state,
                         );
 
                     view_class
-                        .ui(
-                            ctx,
-                            ui,
-                            &mut *view_state,
-                            &view_query,
-                            system_execution_output,
-                        )
+                        .ui(ctx, ui, view_state, &view_query, system_execution_output)
                         .expect("failed to run graph view ui");
                 });
 

--- a/crates/viewer/re_view_graph/tests/basic.rs
+++ b/crates/viewer/re_view_graph/tests/basic.rs
@@ -7,7 +7,7 @@ use egui::Vec2;
 use re_chunk_store::{Chunk, RowId};
 use re_entity_db::EntityPath;
 use re_types::{components, Component as _};
-use re_view_graph::{GraphView, GraphViewState};
+use re_view_graph::GraphView;
 use re_viewer_context::{test_context::TestContext, RecommendedView, ViewClass};
 use re_viewport_blueprint::test_context_ext::TestContextExt as _;
 use re_viewport_blueprint::ViewBlueprint;
@@ -134,8 +134,6 @@ fn run_graph_view_and_save_snapshot(test_context: &mut TestContext, name: &str, 
         view_id
     });
 
-    let mut view_state = GraphViewState::default();
-
     let mut harness = test_context
         .setup_kittest_for_rendering()
         .with_size(size)
@@ -153,21 +151,18 @@ fn run_graph_view_and_save_snapshot(test_context: &mut TestContext, name: &str, 
                 )
                 .expect("we just created that view");
 
+                let mut view_states = test_context.view_states.lock();
+                let view_state = view_states.get_mut_or_create(view_id, view_class);
+
                 let (view_query, system_execution_output) = re_viewport::execute_systems_for_view(
                     ctx,
                     &view_blueprint,
                     ctx.current_query().at(), // TODO(andreas): why is this even needed to be passed in?
-                    &view_state,
+                    view_state,
                 );
 
                 view_class
-                    .ui(
-                        ctx,
-                        ui,
-                        &mut view_state,
-                        &view_query,
-                        system_execution_output,
-                    )
+                    .ui(ctx, ui, view_state, &view_query, system_execution_output)
                     .expect("failed to run graph view ui");
             });
 

--- a/crates/viewer/re_view_spatial/tests/draw_order.rs
+++ b/crates/viewer/re_view_spatial/tests/draw_order.rs
@@ -176,11 +176,6 @@ fn run_view_ui_and_save_snapshot(
     name: &str,
     size: egui::Vec2,
 ) {
-    let mut view_state = test_context
-        .view_class_registry
-        .get_class_or_log_error(SpatialView2D::identifier())
-        .new_state();
-
     let mut harness = test_context
         .setup_kittest_for_rendering()
         .with_size(size)
@@ -200,22 +195,19 @@ fn run_view_ui_and_save_snapshot(
                     )
                     .expect("we just created that view");
 
+                    let mut view_states = test_context.view_states.lock();
+                    let view_state = view_states.get_mut_or_create(view_id, view_class);
+
                     let (view_query, system_execution_output) =
                         re_viewport::execute_systems_for_view(
                             ctx,
                             &view_blueprint,
                             ctx.current_query().at(), // TODO(andreas): why is this even needed to be passed in?
-                            &*view_state,
+                            view_state,
                         );
 
                     view_class
-                        .ui(
-                            ctx,
-                            ui,
-                            &mut *view_state,
-                            &view_query,
-                            system_execution_output,
-                        )
+                        .ui(ctx, ui, view_state, &view_query, system_execution_output)
                         .expect("failed to run graph view ui");
                 });
 

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -14,7 +14,7 @@ use re_types_core::reflection::Reflection;
 use crate::{
     blueprint_timeline, command_channel, ApplicationSelectionState, CommandReceiver, CommandSender,
     ComponentUiRegistry, DataQueryResult, ItemCollection, RecordingConfig, StoreContext,
-    SystemCommand, ViewClass, ViewClassRegistry, ViewId, ViewerContext,
+    SystemCommand, ViewClass, ViewClassRegistry, ViewId, ViewStates, ViewerContext,
 };
 
 pub trait HarnessExt {
@@ -77,6 +77,7 @@ pub struct TestContext {
     pub view_class_registry: ViewClassRegistry,
     pub selection_state: ApplicationSelectionState,
     pub recording_config: RecordingConfig,
+    pub view_states: Mutex<ViewStates>,
 
     // Populating this in `run` would pull in too many dependencies into the test harness for now.
     pub query_results: HashMap<ViewId, DataQueryResult>,
@@ -118,6 +119,7 @@ impl Default for TestContext {
             view_class_registry: Default::default(),
             selection_state: Default::default(),
             recording_config,
+            view_states: Default::default(),
             blueprint_query,
             query_results: Default::default(),
             component_ui_registry,
@@ -296,6 +298,9 @@ impl TestContext {
             hub: &Default::default(),
             should_enable_heuristics: false,
         };
+        let indicated_entities_per_visualizer = self
+            .view_class_registry
+            .indicated_entities_per_visualizer(&store_context.recording.store_id());
 
         let drag_and_drop_manager = crate::DragAndDropManager::new(ItemCollection::default());
 
@@ -316,7 +321,7 @@ impl TestContext {
             view_class_registry: &self.view_class_registry,
             store_context: &store_context,
             maybe_visualizable_entities_per_visualizer: &Default::default(),
-            indicated_entities_per_visualizer: &Default::default(),
+            indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
             query_results: &self.query_results,
             rec_cfg: &self.recording_config,
             blueprint_cfg: &Default::default(),

--- a/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
+++ b/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
@@ -28,7 +28,7 @@ impl std::ops::Deref for MaybeVisualizableEntities {
 ///
 /// In order to be a match the entity must have at some point in time on any timeline had any of
 /// the indicator components specified by the respective visualizer system.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub struct IndicatedEntities(pub IntSet<EntityPath>);
 
 impl std::ops::Deref for IndicatedEntities {

--- a/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
+++ b/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
@@ -63,6 +63,7 @@ impl TestContextExt for TestContext {
                         &self.recording_store.store_id(),
                     );
                 let mut query_results = HashMap::default();
+
                 self.run(egui_ctx, |ctx| {
                     viewport_blueprint.visit_contents(&mut |contents, _| {
                         if let Contents::View(view_id) = contents {
@@ -71,27 +72,47 @@ impl TestContextExt for TestContext {
                                 .expect("view is known to exist");
                             let class_identifier = view_blueprint.class_identifier();
 
-                            let data_query_result = {
-                                let visualizable_entities = ctx
-                                    .view_class_registry
-                                    .class(class_identifier)
-                                    .expect("The class must be registered beforehand")
-                                    .determine_visualizable_entities(
-                                        &maybe_visualizable_entities_per_visualizer,
-                                        ctx.recording(),
-                                        &ctx.view_class_registry
-                                            .new_visualizer_collection(class_identifier),
-                                        &view_blueprint.space_origin,
-                                    );
+                            let visualizable_entities = ctx
+                                .view_class_registry
+                                .class(class_identifier)
+                                .expect("The class must be registered beforehand")
+                                .determine_visualizable_entities(
+                                    &maybe_visualizable_entities_per_visualizer,
+                                    ctx.recording(),
+                                    &ctx.view_class_registry
+                                        .new_visualizer_collection(class_identifier),
+                                    &view_blueprint.space_origin,
+                                );
 
-                                view_blueprint.contents.execute_query(
-                                    ctx.store_context,
-                                    ctx.view_class_registry,
-                                    ctx.blueprint_query,
-                                    *view_id,
-                                    &visualizable_entities,
-                                )
-                            };
+                            let indicated_entities_per_visualizer = ctx
+                                .view_class_registry
+                                .indicated_entities_per_visualizer(&ctx.recording().store_id());
+
+                            let mut data_query_result = view_blueprint.contents.execute_query(
+                                ctx.store_context,
+                                ctx.view_class_registry,
+                                ctx.blueprint_query,
+                                *view_id,
+                                &visualizable_entities,
+                            );
+
+                            let resolver = view_blueprint.contents.build_resolver(
+                                ctx.view_class_registry,
+                                view_blueprint,
+                                &maybe_visualizable_entities_per_visualizer,
+                                &visualizable_entities,
+                                &indicated_entities_per_visualizer,
+                            );
+
+                            resolver.update_overrides(
+                                ctx.store_context.blueprint,
+                                ctx.blueprint_query,
+                                ctx.rec_cfg.time_ctrl.read().timeline(),
+                                ctx.view_class_registry,
+                                &mut data_query_result,
+                                &mut self.view_states.lock(),
+                            );
+
                             query_results.insert(*view_id, data_query_result);
                         }
 


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/8925

### What

Main problem was that we ignored indicators previously, meaning we didn't apply proper visualizer selection before.
As a sideeffect we now would also handle overrides and no longer build view states adhoc in tests

draft until https://github.com/rerun-io/rerun/pull/8916 lands (which can also use the changed view state access now)