### PR TITLE
Move `ChunkId` (and `RowId`) from `re_chunk` to `re_types_core`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -158,4 +158,6 @@ extend-ignore-re = [
   "PNG.?",            # Workaround for https://github.com/crate-ci/typos/issues/967
 
   "_LEVL_", # USed in air_traffic_data.py
+
+  "thrEEone", # Used in a test
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5775,7 +5775,6 @@ dependencies = [
  "re_tracing",
  "re_tuid",
  "re_types_core",
- "serde",
  "similar-asserts",
  "tap",
  "thiserror 1.0.65",

--- a/crates/store/re_chunk/Cargo.toml
+++ b/crates/store/re_chunk/Cargo.toml
@@ -23,12 +23,7 @@ all-features = true
 default = []
 
 ## Enable (de)serialization using serde.
-serde = [
-  "dep:serde",
-  "re_log_types/serde",
-  "re_tuid/serde",
-  "re_types_core/serde",
-]
+serde = ["re_log_types/serde", "re_tuid/serde", "re_types_core/serde"]
 
 
 [dependencies]
@@ -58,9 +53,6 @@ rand = { workspace = true, features = ["std_rng"] }
 similar-asserts.workspace = true
 tap.workspace = true
 thiserror.workspace = true
-
-# Optional dependencies:
-serde = { workspace = true, optional = true, features = ["derive", "rc"] }
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/store/re_chunk/src/lib.rs
+++ b/crates/store/re_chunk/src/lib.rs
@@ -7,7 +7,6 @@
 mod builder;
 mod chunk;
 mod helpers;
-mod id;
 mod iter;
 mod latest_at;
 mod merge;
@@ -25,7 +24,6 @@ pub use self::chunk::{
     Chunk, ChunkComponents, ChunkError, ChunkResult, TimeColumn, TimeColumnError,
 };
 pub use self::helpers::{ChunkShared, UnitChunkShared};
-pub use self::id::{ChunkId, RowId};
 pub use self::iter::{
     ChunkComponentIter, ChunkComponentIterItem, ChunkComponentSlicer, ChunkIndicesIter,
 };
@@ -45,7 +43,7 @@ pub use arrow::array::Array as ArrowArray;
 #[doc(no_inline)]
 pub use re_log_types::{EntityPath, TimeInt, TimePoint, Timeline, TimelineName};
 #[doc(no_inline)]
-pub use re_types_core::{ArchetypeFieldName, ArchetypeName, ComponentName};
+pub use re_types_core::{ArchetypeFieldName, ArchetypeName, ChunkId, ComponentName, RowId};
 
 pub mod external {
     pub use arrow;

--- a/crates/store/re_types_core/src/id.rs
+++ b/crates/store/re_types_core/src/id.rs
@@ -1,8 +1,8 @@
-/// A unique ID for a [`crate::Chunk`].
+/// A unique ID for a `Chunk`.
 ///
 /// `Chunk`s are the atomic unit of ingestion, transport, storage, events and GC in Rerun.
 ///
-/// Internally, a [`crate::Chunk`] is made up of rows, which are themselves uniquely identified by
+/// Internally, a `Chunk` is made up of rows, which are themselves uniquely identified by
 /// their [`RowId`].
 ///
 /// There is no relationship whatsoever between a [`ChunkId`] and the [`RowId`]s within that chunk.
@@ -114,7 +114,7 @@ impl std::ops::DerefMut for ChunkId {
     }
 }
 
-re_types_core::delegate_arrow_tuid!(ChunkId as "rerun.controls.ChunkId");
+crate::delegate_arrow_tuid!(ChunkId as "rerun.controls.ChunkId");
 
 // ---
 
@@ -251,4 +251,4 @@ impl std::ops::DerefMut for RowId {
     }
 }
 
-re_types_core::delegate_arrow_tuid!(RowId as "rerun.controls.RowId");
+crate::delegate_arrow_tuid!(RowId as "rerun.controls.RowId");

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -27,6 +27,7 @@ mod arrow_string;
 pub mod arrow_zip_validity;
 mod as_components;
 mod component_descriptor;
+mod id;
 mod loggable;
 mod loggable_batch;
 pub mod reflection;
@@ -43,6 +44,7 @@ pub use self::{
     arrow_string::ArrowString,
     as_components::AsComponents,
     component_descriptor::ComponentDescriptor,
+    id::{ChunkId, RowId},
     loggable::{
         Component, ComponentName, ComponentNameSet, DatatypeName, Loggable,
         UnorderedComponentNameSet,

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -149,7 +149,7 @@ macro_rules! delegate_arrow_tuid {
 
             #[inline]
             fn to_arrow_opt<'a>(
-                values: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
+                _values: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
             ) -> $crate::SerializationResult<arrow::array::ArrayRef>
             where
                 Self: 'a,

--- a/crates/viewer/re_renderer/src/draw_phases/mod.rs
+++ b/crates/viewer/re_renderer/src/draw_phases/mod.rs
@@ -1,5 +1,5 @@
-// TODO(andreas): The concept of DrawPhase implementors is very much in progress!
-// Need to start to formalize this further and create implementors for all DrawPhases to build up our render graph.
+// TODO(andreas): The concept of DrawPhase implementers is very much in progress!
+// Need to start to formalize this further and create implementers for all DrawPhases to build up our render graph.
 
 mod outlines;
 pub use outlines::{OutlineConfig, OutlineMaskPreference, OutlineMaskProcessor};

--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -416,7 +416,7 @@ handle raw component collections which then would be serialized to arrow on the 
 #### `log`
 
 Under the hood we allow any type that implements the `AsComponents` trait.
-However, `AsComponents` is no longer implemented for collections of components / implementors of `Loggable`.
+However, `AsComponents` is no longer implemented for collections of components / implementers of `Loggable`.
 
 Instead, you're encouraged to use archetypes for cases where you'd previously use loose collections of components.
 This is made easier by the fact that archetypes can now be created without specifying required components.


### PR DESCRIPTION
This allows us to use them in `re_sorbet`

* Part of https://github.com/rerun-io/rerun/issues/8744
