### PR TITLE
Remove container/view IDs from insta snapshots

### DIFF
--- a/crates/viewer/re_blueprint_tree/src/data.rs
+++ b/crates/viewer/re_blueprint_tree/src/data.rs
@@ -28,7 +28,7 @@ use crate::data_result_node_or_path::DataResultNodeOrPath;
 
 /// Top-level blueprint tree structure.
 #[derive(Debug, Default)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub struct BlueprintTreeData {
     pub root_container: Option<ContainerData>,
 }
@@ -71,7 +71,7 @@ impl BlueprintTreeData {
 
 /// Data for either a container or a view (both of which possible child of a container).
 #[derive(Debug)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub enum ContentsData {
     Container(ContainerData),
     View(ViewData),
@@ -91,8 +91,9 @@ impl ContentsData {
 
 /// Data related to a single container and its children.
 #[derive(Debug)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub struct ContainerData {
+    #[cfg_attr(feature = "testing", serde(skip))]
     pub id: ContainerId,
     pub name: ContentsName,
     pub kind: egui_tiles::ContainerKind,
@@ -178,8 +179,9 @@ impl ContainerData {
 
 /// Data related to a single view and its content.
 #[derive(Debug)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub struct ViewData {
+    #[cfg_attr(feature = "testing", serde(skip))]
     pub id: ViewId,
 
     pub class_identifier: ViewClassIdentifier,
@@ -326,7 +328,7 @@ impl ViewData {
 
 /// The various kind of things that may be represented in a data result tree.
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub enum DataResultKind {
     /// This is a regular entity part of a data result (or the tree that contains it).
     EntityPart,
@@ -341,12 +343,13 @@ pub enum DataResultKind {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub struct DataResultData {
     pub kind: DataResultKind,
     pub entity_path: EntityPath,
     pub visible: bool,
 
+    #[cfg_attr(feature = "testing", serde(skip))]
     pub view_id: ViewId,
 
     /// Label that should be used for display.

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/empty.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/empty.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EmptyOriginPlaceholder
           entity_path: []
           visible: false
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/multiple_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/multiple_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -25,8 +21,6 @@ root_container:
             - center
             - way
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: way
           highlight_sections: []
           default_open: false
@@ -38,8 +32,6 @@ root_container:
               - to
               - right
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: right
             highlight_sections: []
             default_open: false
@@ -50,8 +42,6 @@ root_container:
               - to
               - the
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: the
             highlight_sections: []
             default_open: false
@@ -63,8 +53,6 @@ root_container:
                   - the
                   - void
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: void
                 highlight_sections: []
                 default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/non_root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/non_root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections: []
           default_open: true
@@ -37,8 +31,6 @@ root_container:
                 - to
                 - left
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: left
               highlight_sections: []
               default_open: false
@@ -49,8 +41,6 @@ root_container:
                 - to
                 - right
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: right
               highlight_sections: []
               default_open: false
@@ -61,8 +51,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections: []
               default_open: false
@@ -74,8 +62,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections: []
           default_open: true
@@ -37,8 +31,6 @@ root_container:
                 - to
                 - left
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: left
               highlight_sections: []
               default_open: false
@@ -49,8 +41,6 @@ root_container:
                 - to
                 - right
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: right
               highlight_sections: []
               default_open: false
@@ -61,8 +51,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections: []
               default_open: false
@@ -74,8 +62,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: false
@@ -84,8 +70,6 @@ root_container:
           - kind: EntityPart
             entity_path: []
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: / (root)
             highlight_sections: []
             default_open: false
@@ -94,8 +78,6 @@ root_container:
                 entity_path:
                   - center
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: center
                 highlight_sections: []
                 default_open: false
@@ -105,8 +87,6 @@ root_container:
                       - center
                       - way
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: way
                     highlight_sections: []
                     default_open: false
@@ -115,8 +95,6 @@ root_container:
                 entity_path:
                   - path
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: path
                 highlight_sections: []
                 default_open: false
@@ -126,8 +104,6 @@ root_container:
                       - path
                       - onto
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: onto
                     highlight_sections: []
                     default_open: false
@@ -138,8 +114,6 @@ root_container:
                           - onto
                           - their
                         visible: true
-                        view_id:
-                          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                         label: their
                         highlight_sections: []
                         default_open: false
@@ -151,8 +125,6 @@ root_container:
                               - their
                               - coils
                             visible: true
-                            view_id:
-                              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                             label: coils
                             highlight_sections: []
                             default_open: false
@@ -162,8 +134,6 @@ root_container:
                       - path
                       - to
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: to
                     highlight_sections: []
                     default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - center
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: center
               highlight_sections: []
               default_open: false
@@ -44,8 +36,6 @@ root_container:
                     - center
                     - way
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: way
                   highlight_sections: []
                   default_open: false
@@ -54,8 +44,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections: []
               default_open: true
@@ -65,8 +53,6 @@ root_container:
                     - path
                     - onto
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: onto
                   highlight_sections: []
                   default_open: false
@@ -77,8 +63,6 @@ root_container:
                         - onto
                         - their
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: their
                       highlight_sections: []
                       default_open: false
@@ -90,8 +74,6 @@ root_container:
                             - their
                             - coils
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: coils
                           highlight_sections: []
                           default_open: false
@@ -101,8 +83,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections: []
                   default_open: true
@@ -113,8 +93,6 @@ root_container:
                         - to
                         - left
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: left
                       highlight_sections: []
                       default_open: false
@@ -125,8 +103,6 @@ root_container:
                         - to
                         - right
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: right
                       highlight_sections: []
                       default_open: false
@@ -137,8 +113,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections: []
                       default_open: false
@@ -150,8 +124,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections: []
                           default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/single_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/single_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -25,8 +21,6 @@ root_container:
             - center
             - way
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: way
           highlight_sections: []
           default_open: false
@@ -37,8 +31,6 @@ root_container:
               - path
               - to
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: to
             highlight_sections: []
             default_open: false
@@ -49,8 +41,6 @@ root_container:
                   - to
                   - left
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: left
                 highlight_sections: []
                 default_open: false
@@ -61,8 +51,6 @@ root_container:
                   - to
                   - right
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: right
                 highlight_sections: []
                 default_open: false
@@ -73,8 +61,6 @@ root_container:
                   - to
                   - the
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: the
                 highlight_sections: []
                 default_open: false
@@ -86,8 +72,6 @@ root_container:
                       - the
                       - void
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: void
                     highlight_sections: []
                     default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/unknown_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/no-query/unknown_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: wrong/path
@@ -25,8 +21,6 @@ root_container:
             - wrong
             - path
           visible: false
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: path
           highlight_sections: []
           default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_path_to,_rig/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_path_to,_rig/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections:
                 - start: 0
@@ -46,8 +38,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections:
                     - start: 0
@@ -60,8 +50,6 @@ root_container:
                         - to
                         - right
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: right
                       highlight_sections:
                         - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_path_to_th/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_path_to_th/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections:
                 - start: 0
@@ -46,8 +38,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections:
                     - start: 0
@@ -60,8 +50,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections:
                         - start: 0
@@ -75,8 +63,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections: []
                           default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/non_root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/non_root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -54,8 +46,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -54,8 +46,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections: []
               default_open: true
@@ -44,8 +36,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections:
                     - start: 0
@@ -58,8 +48,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections:
                         - start: 0
@@ -73,8 +61,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections: []
                           default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/single_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-_to_the_/single_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -26,8 +22,6 @@ root_container:
               - path
               - to
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: to
             highlight_sections:
               - start: 0
@@ -40,8 +34,6 @@ root_container:
                   - to
                   - the
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: the
                 highlight_sections:
                   - start: 0
@@ -55,8 +47,6 @@ root_container:
                       - the
                       - void
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: void
                     highlight_sections: []
                     default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,left/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,left/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections:
                 - start: 1
@@ -46,8 +38,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections: []
                   default_open: true
@@ -58,8 +48,6 @@ root_container:
                         - to
                         - left
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: left
                       highlight_sections:
                         - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,t/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,t/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -24,8 +20,6 @@ root_container:
           - kind: EntityPart
             entity_path: []
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: / (root)
             highlight_sections: []
             default_open: true
@@ -34,8 +28,6 @@ root_container:
                 entity_path:
                   - path
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: path
                 highlight_sections:
                   - start: 1
@@ -47,8 +39,6 @@ root_container:
                       - path
                       - onto
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: onto
                     highlight_sections:
                       - start: 2
@@ -61,8 +51,6 @@ root_container:
                           - onto
                           - their
                         visible: true
-                        view_id:
-                          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                         label: their
                         highlight_sections:
                           - start: 0
@@ -76,8 +64,6 @@ root_container:
                               - their
                               - coils
                             visible: true
-                            view_id:
-                              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                             label: coils
                             highlight_sections: []
                             default_open: true
@@ -87,8 +73,6 @@ root_container:
                       - path
                       - to
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: to
                     highlight_sections: []
                     default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,t/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,t/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections:
                 - start: 1
@@ -46,8 +38,6 @@ root_container:
                     - path
                     - onto
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: onto
                   highlight_sections:
                     - start: 2
@@ -60,8 +50,6 @@ root_container:
                         - onto
                         - their
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: their
                       highlight_sections:
                         - start: 0
@@ -75,8 +63,6 @@ root_container:
                             - their
                             - coils
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: coils
                           highlight_sections: []
                           default_open: true
@@ -86,8 +72,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections:
                     - start: 0
@@ -100,8 +84,6 @@ root_container:
                         - to
                         - left
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: left
                       highlight_sections:
                         - start: 3
@@ -114,8 +96,6 @@ root_container:
                         - to
                         - right
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: right
                       highlight_sections:
                         - start: 4
@@ -128,8 +108,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections:
                         - start: 0
@@ -143,8 +121,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections: []
                           default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,t/unknown_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-ath,t/unknown_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: wrong/path
@@ -25,8 +21,6 @@ root_container:
             - wrong
             - path
           visible: false
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: path
           highlight_sections:
             - start: 1

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-path/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-path/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -24,8 +20,6 @@ root_container:
           - kind: EntityPart
             entity_path: []
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: / (root)
             highlight_sections: []
             default_open: true
@@ -34,8 +28,6 @@ root_container:
                 entity_path:
                   - path
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: path
                 highlight_sections:
                   - start: 0
@@ -47,8 +39,6 @@ root_container:
                       - path
                       - onto
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: onto
                     highlight_sections: []
                     default_open: true
@@ -59,8 +49,6 @@ root_container:
                           - onto
                           - their
                         visible: true
-                        view_id:
-                          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                         label: their
                         highlight_sections: []
                         default_open: true
@@ -72,8 +60,6 @@ root_container:
                               - their
                               - coils
                             visible: true
-                            view_id:
-                              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                             label: coils
                             highlight_sections: []
                             default_open: true
@@ -83,8 +69,6 @@ root_container:
                       - path
                       - to
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: to
                     highlight_sections: []
                     default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-path/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-path/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections:
                 - start: 0
@@ -46,8 +38,6 @@ root_container:
                     - path
                     - onto
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: onto
                   highlight_sections: []
                   default_open: true
@@ -58,8 +48,6 @@ root_container:
                         - onto
                         - their
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: their
                       highlight_sections: []
                       default_open: true
@@ -71,8 +59,6 @@ root_container:
                             - their
                             - coils
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: coils
                           highlight_sections: []
                           default_open: true
@@ -82,8 +68,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections: []
                   default_open: true
@@ -94,8 +78,6 @@ root_container:
                         - to
                         - left
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: left
                       highlight_sections: []
                       default_open: true
@@ -106,8 +88,6 @@ root_container:
                         - to
                         - right
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: right
                       highlight_sections: []
                       default_open: true
@@ -118,8 +98,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections: []
                       default_open: true
@@ -131,8 +109,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections: []
                           default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-path/unknown_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-path/unknown_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: wrong/path
@@ -25,8 +21,6 @@ root_container:
             - wrong
             - path
           visible: false
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: path
           highlight_sections:
             - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/multiple_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/multiple_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -27,8 +23,6 @@ root_container:
               - to
               - right
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: right
             highlight_sections:
               - start: 4
@@ -41,8 +35,6 @@ root_container:
               - to
               - the
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: the
             highlight_sections:
               - start: 0
@@ -56,8 +48,6 @@ root_container:
                   - the
                   - void
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: void
                 highlight_sections: []
                 default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/non_root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/non_root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - left
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: left
               highlight_sections:
                 - start: 3
@@ -53,8 +45,6 @@ root_container:
                 - to
                 - right
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: right
               highlight_sections:
                 - start: 4
@@ -67,8 +57,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -82,8 +70,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - left
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: left
               highlight_sections:
                 - start: 3
@@ -53,8 +45,6 @@ root_container:
                 - to
                 - right
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: right
               highlight_sections:
                 - start: 4
@@ -67,8 +57,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -82,8 +70,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: true
@@ -92,8 +78,6 @@ root_container:
           - kind: EntityPart
             entity_path: []
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: / (root)
             highlight_sections: []
             default_open: true
@@ -102,8 +86,6 @@ root_container:
                 entity_path:
                   - center
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: center
                 highlight_sections:
                   - start: 3
@@ -115,8 +97,6 @@ root_container:
                       - center
                       - way
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: way
                     highlight_sections: []
                     default_open: true
@@ -125,8 +105,6 @@ root_container:
                 entity_path:
                   - path
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: path
                 highlight_sections:
                   - start: 2
@@ -138,8 +116,6 @@ root_container:
                       - path
                       - onto
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: onto
                     highlight_sections:
                       - start: 2
@@ -152,8 +128,6 @@ root_container:
                           - onto
                           - their
                         visible: true
-                        view_id:
-                          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                         label: their
                         highlight_sections:
                           - start: 0
@@ -167,8 +141,6 @@ root_container:
                               - their
                               - coils
                             visible: true
-                            view_id:
-                              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                             label: coils
                             highlight_sections: []
                             default_open: true
@@ -178,8 +150,6 @@ root_container:
                       - path
                       - to
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: to
                     highlight_sections: []
                     default_open: false

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - center
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: center
               highlight_sections:
                 - start: 3
@@ -46,8 +38,6 @@ root_container:
                     - center
                     - way
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: way
                   highlight_sections: []
                   default_open: true
@@ -56,8 +46,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections:
                 - start: 2
@@ -69,8 +57,6 @@ root_container:
                     - path
                     - onto
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: onto
                   highlight_sections:
                     - start: 2
@@ -83,8 +69,6 @@ root_container:
                         - onto
                         - their
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: their
                       highlight_sections:
                         - start: 0
@@ -98,8 +82,6 @@ root_container:
                             - their
                             - coils
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: coils
                           highlight_sections: []
                           default_open: true
@@ -109,8 +91,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections:
                     - start: 0
@@ -123,8 +103,6 @@ root_container:
                         - to
                         - left
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: left
                       highlight_sections:
                         - start: 3
@@ -137,8 +115,6 @@ root_container:
                         - to
                         - right
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: right
                       highlight_sections:
                         - start: 4
@@ -151,8 +127,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections:
                         - start: 0
@@ -166,8 +140,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections: []
                           default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/single_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/single_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -26,8 +22,6 @@ root_container:
               - path
               - to
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: to
             highlight_sections:
               - start: 0
@@ -40,8 +34,6 @@ root_container:
                   - to
                   - left
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: left
                 highlight_sections:
                   - start: 3
@@ -54,8 +46,6 @@ root_container:
                   - to
                   - right
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: right
                 highlight_sections:
                   - start: 4
@@ -68,8 +58,6 @@ root_container:
                   - to
                   - the
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: the
                 highlight_sections:
                   - start: 0
@@ -83,8 +71,6 @@ root_container:
                       - the
                       - void
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: void
                     highlight_sections: []
                     default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/unknown_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-t/unknown_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: wrong/path
@@ -25,8 +21,6 @@ root_container:
             - wrong
             - path
           visible: false
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: path
           highlight_sections:
             - start: 2

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/non_root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/non_root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -54,8 +46,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections:
                     - start: 1

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -54,8 +46,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections:
                     - start: 1

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections: []
               default_open: true
@@ -44,8 +36,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections:
                     - start: 0
@@ -58,8 +48,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections:
                         - start: 0
@@ -73,8 +61,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections:
                             - start: 1

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/single_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the,oid/single_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -26,8 +22,6 @@ root_container:
               - path
               - to
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: to
             highlight_sections:
               - start: 0
@@ -40,8 +34,6 @@ root_container:
                   - to
                   - the
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: the
                 highlight_sections:
                   - start: 0
@@ -55,8 +47,6 @@ root_container:
                       - the
                       - void
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: void
                     highlight_sections:
                       - start: 1

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/non_root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/non_root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -54,8 +46,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections:
             - start: 0
@@ -39,8 +33,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections:
                 - start: 0
@@ -54,8 +46,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections: []
                   default_open: true
@@ -64,8 +54,6 @@ root_container:
           - kind: EntityPart
             entity_path: []
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: / (root)
             highlight_sections: []
             default_open: true
@@ -74,8 +62,6 @@ root_container:
                 entity_path:
                   - path
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: path
                 highlight_sections: []
                 default_open: true
@@ -85,8 +71,6 @@ root_container:
                       - path
                       - onto
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: onto
                     highlight_sections:
                       - start: 2
@@ -99,8 +83,6 @@ root_container:
                           - onto
                           - their
                         visible: true
-                        view_id:
-                          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                         label: their
                         highlight_sections:
                           - start: 0
@@ -114,8 +96,6 @@ root_container:
                               - their
                               - coils
                             visible: true
-                            view_id:
-                              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                             label: coils
                             highlight_sections: []
                             default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections: []
               default_open: true
@@ -44,8 +36,6 @@ root_container:
                     - path
                     - onto
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: onto
                   highlight_sections:
                     - start: 2
@@ -58,8 +48,6 @@ root_container:
                         - onto
                         - their
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: their
                       highlight_sections:
                         - start: 0
@@ -73,8 +61,6 @@ root_container:
                             - their
                             - coils
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: coils
                           highlight_sections: []
                           default_open: true
@@ -84,8 +70,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections:
                     - start: 0
@@ -98,8 +82,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections:
                         - start: 0
@@ -113,8 +95,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections: []
                           default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/single_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-to_the/single_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -26,8 +22,6 @@ root_container:
               - path
               - to
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: to
             highlight_sections:
               - start: 0
@@ -40,8 +34,6 @@ root_container:
                   - to
                   - the
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: the
                 highlight_sections:
                   - start: 0
@@ -55,8 +47,6 @@ root_container:
                       - the
                       - void
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: void
                     highlight_sections: []
                     default_open: true

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/multiple_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/multiple_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -27,8 +23,6 @@ root_container:
               - to
               - the
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: the
             highlight_sections: []
             default_open: true
@@ -40,8 +34,6 @@ root_container:
                   - the
                   - void
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: void
                 highlight_sections:
                   - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/non_root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/non_root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections: []
           default_open: true
@@ -37,8 +31,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections: []
               default_open: true
@@ -50,8 +42,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections:
                     - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/proj_with_placeholder.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: path/to
@@ -25,8 +21,6 @@ root_container:
             - path
             - to
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: to
           highlight_sections: []
           default_open: true
@@ -37,8 +31,6 @@ root_container:
                 - to
                 - the
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: the
               highlight_sections: []
               default_open: true
@@ -50,8 +42,6 @@ root_container:
                     - the
                     - void
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: void
                   highlight_sections:
                     - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/root_origin.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: /
@@ -23,8 +19,6 @@ root_container:
           kind: EntityPart
           entity_path: []
           visible: true
-          view_id:
-            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
           label: / (root)
           highlight_sections: []
           default_open: true
@@ -33,8 +27,6 @@ root_container:
               entity_path:
                 - path
               visible: true
-              view_id:
-                id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
               label: path
               highlight_sections: []
               default_open: true
@@ -44,8 +36,6 @@ root_container:
                     - path
                     - to
                   visible: true
-                  view_id:
-                    id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                   label: to
                   highlight_sections: []
                   default_open: true
@@ -56,8 +46,6 @@ root_container:
                         - to
                         - the
                       visible: true
-                      view_id:
-                        id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                       label: the
                       highlight_sections: []
                       default_open: true
@@ -69,8 +57,6 @@ root_container:
                             - the
                             - void
                           visible: true
-                          view_id:
-                            id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                           label: void
                           highlight_sections:
                             - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/single_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-void/single_proj.snap
@@ -3,8 +3,6 @@ source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
 expression: blueprint_tree_data
 ---
 root_container:
-  id:
-    id: "<container-id>"
   name:
     Placeholder: Grid
   kind: Grid
@@ -12,8 +10,6 @@ root_container:
   default_open: true
   children:
     - View:
-        id:
-          id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
         class_identifier: 3D
         name:
           Placeholder: center/way
@@ -26,8 +22,6 @@ root_container:
               - path
               - to
             visible: true
-            view_id:
-              id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
             label: to
             highlight_sections: []
             default_open: true
@@ -38,8 +32,6 @@ root_container:
                   - to
                   - the
                 visible: true
-                view_id:
-                  id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                 label: the
                 highlight_sections: []
                 default_open: true
@@ -51,8 +43,6 @@ root_container:
                       - the
                       - void
                     visible: true
-                    view_id:
-                      id: 0864e1b8-cec4-1b82-5b17-b9d628b8f4fe
                     label: void
                     highlight_sections:
                       - start: 0

--- a/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
@@ -260,9 +260,7 @@ fn test_all_insta_test_cases() {
             ));
 
             settings.bind(|| {
-                insta::assert_yaml_snapshot!(test_case.name, blueprint_tree_data, {
-                    ".root_container.id.id" => "<container-id>"
-                });
+                insta::assert_yaml_snapshot!(test_case.name, blueprint_tree_data);
             });
         }
     }

--- a/crates/viewer/re_time_panel/src/streams_tree_data.rs
+++ b/crates/viewer/re_time_panel/src/streams_tree_data.rs
@@ -14,7 +14,7 @@ use re_viewer_context::{CollapseScope, Item, ViewerContext, VisitorControlFlow};
 use crate::time_panel::TimePanelSource;
 
 #[derive(Debug)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub struct StreamsTreeData {
     pub children: Vec<EntityData>,
 }
@@ -87,7 +87,7 @@ impl StreamsTreeData {
 // ---
 
 #[derive(Debug)]
-#[cfg_attr(feature = "testing", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "testing", derive(serde::Serialize))]
 pub struct EntityData {
     pub entity_path: EntityPath,
 

--- a/crates/viewer/re_view_graph/tests/snapshots/coincident_nodes.png
+++ b/crates/viewer/re_view_graph/tests/snapshots/coincident_nodes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:177dfc40ce059ed36109d783e0a5862378042d0f365147107940014d3b14b4d3
-size 870
+oid sha256:3df570c849be18e65333bfe3bc7085ee96b0f88d4633e539d71da6b1f5254bbd
+size 590

--- a/crates/viewer/re_view_graph/tests/snapshots/coincident_nodes.png
+++ b/crates/viewer/re_view_graph/tests/snapshots/coincident_nodes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3df570c849be18e65333bfe3bc7085ee96b0f88d4633e539d71da6b1f5254bbd
-size 590
+oid sha256:177dfc40ce059ed36109d783e0a5862378042d0f365147107940014d3b14b4d3
+size 870

--- a/crates/viewer/re_view_graph/tests/snapshots/self_and_multi_edges.png
+++ b/crates/viewer/re_view_graph/tests/snapshots/self_and_multi_edges.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9b940c98d6b60c6ef21a718c060360bbe54bd9b897045f3fe1f582cab688045
-size 4377
+oid sha256:b02fc0df02c613dfb41a8ec712d7ab1648c1ce0fe324f1d992e2a24e4fdb553f
+size 20082

--- a/crates/viewer/re_view_graph/tests/snapshots/self_and_multi_edges.png
+++ b/crates/viewer/re_view_graph/tests/snapshots/self_and_multi_edges.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b02fc0df02c613dfb41a8ec712d7ab1648c1ce0fe324f1d992e2a24e4fdb553f
-size 20082
+oid sha256:b9b940c98d6b60c6ef21a718c060360bbe54bd9b897045f3fe1f582cab688045
+size 4377

--- a/crates/viewer/re_view_spatial/tests/snapshots/draw_order.png
+++ b/crates/viewer/re_view_spatial/tests/snapshots/draw_order.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ef4a975b15c46fe74db22eddae77d03236208a220d79a75ff0f246941c32fa7a
-size 56662
+oid sha256:87ea91508e4c3aa00f53fe06c69c6c4b820eafa11384bb0f7b38490b0794c417
+size 56660

--- a/crates/viewer/re_view_spatial/tests/snapshots/draw_order.png
+++ b/crates/viewer/re_view_spatial/tests/snapshots/draw_order.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87ea91508e4c3aa00f53fe06c69c6c4b820eafa11384bb0f7b38490b0794c417
-size 56660
+oid sha256:ef4a975b15c46fe74db22eddae77d03236208a220d79a75ff0f246941c32fa7a
+size 56662


### PR DESCRIPTION
Although these ID are supposed to be deterministic, they are in practice not for reasons that are beyond me. Best eradicate them entirely from insta snapshot.

To that end, I lost lots of time trying to use insta's redaction, before realising I could just slap a  `serde(skip)` in the data structures.

I also removed the `Deserialize` trait since that's not needed for insta.

