### PR TITLE
Show user strings with quotes around them

### DIFF
--- a/crates/viewer/re_ui/tests/snapshots/arrow_ui.png
+++ b/crates/viewer/re_ui/tests/snapshots/arrow_ui.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ddd1280aa011dd42b4f4e47252acf35817ecf7326ce97ce29aeb5216b1b21f3
-size 45306
+oid sha256:6ca1f36cbef3e4841769ba151f90b22e83d588d7a8fb8305f5a4c2c1326bb6dd
+size 55624


### PR DESCRIPTION
I think what feels wrong to me about the current formatting is that we use monospace and format almost everything as if it was code (e.g. use `[]` for lists, and add `.0` suffixes to floats to distinguish them from integers). But strings are a weird exception.

So I think we should EITHER use a _proportional_ font without quotes, or go all in on make it feel like code (merge this PR).

### Before
<img width="456" alt="image" src="https://github.com/user-attachments/assets/ed461fa8-cd7a-407f-9431-182268941f91" />

### After
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/fd424d1f-59c2-4b83-a0fd-9d1aec991e92" />

### Counter-proposal
Proportional font without `[]`:
![image](https://github.com/user-attachments/assets/0a65b8ea-9841-4de6-8e39-48c4454b34d6)
