### PR TITLE
Treat zero-angle rotation as identity when axis is invalid

### DIFF
--- a/crates/store/re_types/definitions/rerun/components/rotation_axis_angle.fbs
+++ b/crates/store/re_types/definitions/rerun/components/rotation_axis_angle.fbs
@@ -2,7 +2,8 @@ namespace rerun.components;
 
 /// 3D rotation represented by a rotation around a given axis.
 ///
-/// If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+/// If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+/// angle is zero in which case it is treated as an identity.
 table RotationAxisAngle (
   "attr.rust.derive": "Default, Copy, PartialEq",
   "attr.rust.repr": "transparent"
@@ -12,7 +13,8 @@ table RotationAxisAngle (
 
 /// 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
 ///
-/// If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+/// If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+/// angle is zero in which case it is treated as an identity.
 table PoseRotationAxisAngle (
   "attr.rust.derive": "Default, Copy, PartialEq",
   "attr.rust.repr": "transparent"

--- a/crates/store/re_types/definitions/rerun/datatypes/rotation_axis_angle.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/rotation_axis_angle.fbs
@@ -10,7 +10,8 @@ table RotationAxisAngle (
   ///
   /// This is not required to be normalized.
   /// However, if normalization of the rotation axis fails (typically due to a zero vector)
-  /// the rotation is treated as an invalid transform.
+  /// the rotation is treated as an invalid transform, unless the angle is zero in which case
+  /// it is treated as an identity.
   axis: rerun.datatypes.Vec3D (order: 100);
 
   /// How much to rotate around the axis.

--- a/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
@@ -20,7 +20,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
 ///
-/// If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+/// If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+/// angle is zero in which case it is treated as an identity.
 #[derive(Clone, Debug, Default, Copy, PartialEq)]
 #[repr(transparent)]
 pub struct PoseRotationAxisAngle(pub crate::datatypes::RotationAxisAngle);

--- a/crates/store/re_types/src/components/pose_rotation_axis_angle_ext.rs
+++ b/crates/store/re_types/src/components/pose_rotation_axis_angle_ext.rs
@@ -19,9 +19,14 @@ impl TryFrom<PoseRotationAxisAngle> for glam::Affine3A {
 
     #[inline]
     fn try_from(val: PoseRotationAxisAngle) -> Result<Self, Self::Error> {
-        glam::Vec3::from(val.0.axis)
-            .try_normalize()
-            .map(|normalized| Self::from_axis_angle(normalized, val.0.angle.radians()))
-            .ok_or(())
+        // 0 degrees around any axis is an identity transform.
+        if val.angle.radians == 0. {
+            Ok(Self::IDENTITY)
+        } else {
+            glam::Vec3::from(val.0.axis)
+                .try_normalize()
+                .map(|normalized| Self::from_axis_angle(normalized, val.0.angle.radians()))
+                .ok_or(())
+        }
     }
 }

--- a/crates/store/re_types/src/components/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/rotation_axis_angle.rs
@@ -20,7 +20,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: 3D rotation represented by a rotation around a given axis.
 ///
-/// If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+/// If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+/// angle is zero in which case it is treated as an identity.
 #[derive(Clone, Debug, Default, Copy, PartialEq)]
 #[repr(transparent)]
 pub struct RotationAxisAngle(pub crate::datatypes::RotationAxisAngle);

--- a/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
@@ -25,7 +25,8 @@ pub struct RotationAxisAngle {
     ///
     /// This is not required to be normalized.
     /// However, if normalization of the rotation axis fails (typically due to a zero vector)
-    /// the rotation is treated as an invalid transform.
+    /// the rotation is treated as an invalid transform, unless the angle is zero in which case
+    /// it is treated as an identity.
     pub axis: crate::datatypes::Vec3D,
 
     /// How much to rotate around the axis.

--- a/crates/store/re_types/src/reflection/mod.rs
+++ b/crates/store/re_types/src/reflection/mod.rs
@@ -648,7 +648,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
         (
             <PoseRotationAxisAngle as Component>::name(),
             ComponentReflection {
-                docstring_md: "3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.\n\nIf normalization of the rotation axis fails the rotation is treated as an invalid transform.",
+                docstring_md: "3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.\n\nIf normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the\nangle is zero in which case it is treated as an identity.",
                 custom_placeholder: Some(PoseRotationAxisAngle::default().to_arrow()?),
                 datatype: PoseRotationAxisAngle::arrow_datatype(),
             },
@@ -736,7 +736,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
         (
             <RotationAxisAngle as Component>::name(),
             ComponentReflection {
-                docstring_md: "3D rotation represented by a rotation around a given axis.\n\nIf normalization of the rotation axis fails the rotation is treated as an invalid transform.",
+                docstring_md: "3D rotation represented by a rotation around a given axis.\n\nIf normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the\nangle is zero in which case it is treated as an identity.",
                 custom_placeholder: Some(RotationAxisAngle::default().to_arrow()?),
                 datatype: RotationAxisAngle::arrow_datatype(),
             },

--- a/docs/content/reference/types/components/pose_rotation_axis_angle.md
+++ b/docs/content/reference/types/components/pose_rotation_axis_angle.md
@@ -5,7 +5,8 @@ title: "PoseRotationAxisAngle"
 
 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
 
-If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+angle is zero in which case it is treated as an identity.
 
 ## Rerun datatype
 [`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)

--- a/docs/content/reference/types/components/rotation_axis_angle.md
+++ b/docs/content/reference/types/components/rotation_axis_angle.md
@@ -5,7 +5,8 @@ title: "RotationAxisAngle"
 
 3D rotation represented by a rotation around a given axis.
 
-If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+angle is zero in which case it is treated as an identity.
 
 ## Rerun datatype
 [`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -13,7 +13,8 @@ Axis to rotate around.
 
 This is not required to be normalized.
 However, if normalization of the rotation axis fails (typically due to a zero vector)
-the rotation is treated as an invalid transform.
+the rotation is treated as an invalid transform, unless the angle is zero in which case
+it is treated as an identity.
 
 #### `angle`
 Type: [`Angle`](../datatypes/angle.md)

--- a/rerun_cpp/src/rerun/components/pose_rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/components/pose_rotation_axis_angle.hpp
@@ -13,7 +13,8 @@
 namespace rerun::components {
     /// **Component**: 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
     ///
-    /// If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+    /// If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+    /// angle is zero in which case it is treated as an identity.
     struct PoseRotationAxisAngle {
         rerun::datatypes::RotationAxisAngle rotation;
 

--- a/rerun_cpp/src/rerun/components/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/components/rotation_axis_angle.hpp
@@ -13,7 +13,8 @@
 namespace rerun::components {
     /// **Component**: 3D rotation represented by a rotation around a given axis.
     ///
-    /// If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+    /// If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+    /// angle is zero in which case it is treated as an identity.
     struct RotationAxisAngle {
         rerun::datatypes::RotationAxisAngle rotation;
 

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -24,7 +24,8 @@ namespace rerun::datatypes {
         ///
         /// This is not required to be normalized.
         /// However, if normalization of the rotation axis fails (typically due to a zero vector)
-        /// the rotation is treated as an invalid transform.
+        /// the rotation is treated as an invalid transform, unless the angle is zero in which case
+        /// it is treated as an identity.
         rerun::datatypes::Vec3D axis;
 
         /// How much to rotate around the axis.

--- a/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
@@ -19,7 +19,8 @@ class PoseRotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
     """
     **Component**: 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
 
-    If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+    If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+    angle is zero in which case it is treated as an identity.
     """
 
     _BATCH_TYPE = None

--- a/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
@@ -19,7 +19,8 @@ class RotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
     """
     **Component**: 3D rotation represented by a rotation around a given axis.
 
-    If normalization of the rotation axis fails the rotation is treated as an invalid transform.
+    If normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the
+    angle is zero in which case it is treated as an identity.
     """
 
     _BATCH_TYPE = None

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
@@ -37,7 +37,8 @@ class RotationAxisAngle(RotationAxisAngleExt):
     #
     # This is not required to be normalized.
     # However, if normalization of the rotation axis fails (typically due to a zero vector)
-    # the rotation is treated as an invalid transform.
+    # the rotation is treated as an invalid transform, unless the angle is zero in which case
+    # it is treated as an identity.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### What

A rotation with a zero angle is always an identity transform, so we can treat it as such