### PR TITLE
Fix broken docs link on text view's help text

### DIFF
--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -57,7 +57,7 @@ impl ViewClass for TextView {
 
     fn help(&self, _egui_ctx: &egui::Context) -> Help<'_> {
         Help::new("Text log view")
-            .docs_link("https://rerun.io/docs/reference/types/views/text_log")
+            .docs_link("https://rerun.io/docs/reference/types/views/text_log_view")
             .markdown(
                 "TextLog entries over time.
 


### PR DESCRIPTION
We should add this to a patch release if we do one.