### PR TITLE
Fix link in text log view help text

### DIFF
--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -57,7 +57,7 @@ impl ViewClass for TextView {
 
     fn help(&self, _egui_ctx: &egui::Context) -> Help<'_> {
         Help::new("Text log view")
-            .docs_link("https://rerun.io/docs/reference/types/views/text_log")
+            .docs_link("https://rerun.io/docs/reference/types/views/text_log_view")
             .markdown(
                 "TextLog entries over time.
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -111,6 +111,7 @@ exclude = [
   'file://foo',
   'http://foo.com/',
   'https://link.to',
+  'https://rerun.rs',
   'https://static.rerun.io/my_screenshot/',
   'https://your-hosted-asset-url.com/widget.js',
   'file:///path/to/file',


### PR DESCRIPTION
An incorrect link made it to the new view help introduced in #8947.

Also fixed another link related CI issue.