### PR TITLE
Bump `transform_clamping`'s acceptable error rate to 0.007

### DIFF
--- a/crates/viewer/re_view_spatial/tests/transform_clamping.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_clamping.rs
@@ -259,7 +259,7 @@ fn run_view_ui_and_save_snapshot(
             harness.run_steps(10);
 
             // TODO(#8924): To account for platform-specific AA.
-            let broken_percent_threshold = 0.003;
+            let broken_percent_threshold = 0.007;
             let num_pixels = (size.x * size.y).ceil() as u64;
 
             use re_viewer_context::test_context::HarnessExt as _;


### PR DESCRIPTION
CI fails on macOS due to AA otherwise.