### PR TITLE
Add link to Snap Store in Gettting Started

### DIFF
--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -41,7 +41,7 @@ There are many ways to install the viewer. Please pick whatever works best for y
 -   Via Cargo
     -   `cargo binstall rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
     -   `cargo install rerun-cli --locked` - build it from source (this requires Rust 1.81+)
--   Via Snap
+-   Via Snap (_community maintained_)
     -   `snap install rerun` - download the viewer from the [Store](https://snapcraft.io/rerun).
 -   Together with the Rerun [Python SDK](./quick-start/python.md):
     -   `pip3 install rerun-sdk` - download it via pip

--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -41,6 +41,8 @@ There are many ways to install the viewer. Please pick whatever works best for y
 -   Via Cargo
     -   `cargo binstall rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
     -   `cargo install rerun-cli --locked` - build it from source (this requires Rust 1.81+)
+-   Via Snap
+    -   `snap install rerun` - download the viewer from the [Store](https://snapcraft.io/rerun).
 -   Together with the Rerun [Python SDK](./quick-start/python.md):
     -   `pip3 install rerun-sdk` - download it via pip
     -   `conda install -c conda-forge rerun-sdk` - download via Conda


### PR DESCRIPTION
### Related

See https://github.com/rerun-io/rerun/pull/8589

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

Add instruction about the snap on the `Installing Rerun` doc page.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
