### PR TITLE
draft: correct unwanted eye (camera) movement upon firing shortcuts

### DIFF
--- a/crates/viewer/re_view_spatial/src/eye.rs
+++ b/crates/viewer/re_view_spatial/src/eye.rs
@@ -445,6 +445,12 @@ impl ViewEye {
             return false; // e.g. we're typing in a TextField
         }
 
+        // Navigation should not be activated if any modifiers is pressed
+        let modifiers_pressed = egui_ctx.input(|input| input.modifiers.any());
+        if modifiers_pressed {
+            return false;
+        }
+
         let mut did_interact = false;
         let mut requires_repaint = false;
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -702,6 +702,12 @@ impl App {
                 Some(re_log_types::StoreId::random(StoreKind::Recording))
             });
 
+        // Clear any shortcut input before firing up any UI components
+        egui_ctx.input_mut(|input| {
+            input.modifiers = Default::default();
+            input.keys_down = Default::default();
+        });
+
         match cmd {
             UICommand::SaveRecording => {
                 if let Err(err) = save_recording(self, store_context, None) {


### PR DESCRIPTION
### What

This PR addressed a UI glitch that eye could move slightly upon firing up a shortcut, e.g., ctrl + s. As shown in the video below, across all the platforms, due to the view still listening for any keyboard_navigation, there is a small backwards move before (at 0:03 in the video below) and after (0:05) the save dialog.

https://github.com/user-attachments/assets/c4f4e95e-2430-41f9-8d4d-50ed8f0e2b2a

Besides, there is also a platform-dependent issue: when testing in Ubuntu 22.04.5 LTS, after closed the save dialog, the egui input context still registered the ctrl modifier and "S" keys_pressed, causing the eye moved backwards as long as cursor hovers the view (0:14 and 0:19 in the video below).

https://github.com/user-attachments/assets/0f6698aa-08ae-4584-8fc5-4f35358ac9eb

