### PR TITLE
Document default-log level change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Check the [🧳 Migration guide](https://rerun.io/docs/reference/migration/migra
 - Make rust `Tensor` archetype eager serialized [#8801](https://github.com/rerun-io/rerun/pull/8801)
 - Rust: remove legacy `send_columns` and update everything left [#8804](https://github.com/rerun-io/rerun/pull/8804)
 - `ComponentBatch` doesn't implement `AsComponents` anymore [#8820](https://github.com/rerun-io/rerun/pull/8820)
+- Set default log level in `re_log` to `warn` [#8918](https://github.com/rerun-io/rerun/pull/8918)
 
 #### 🪳 Bug fixes
 - Fix WSL support, update troubleshooting guide [#8610](https://github.com/rerun-io/rerun/pull/8610)

--- a/crates/utils/re_log/src/lib.rs
+++ b/crates/utils/re_log/src/lib.rs
@@ -86,7 +86,7 @@ const CRATES_AT_INFO_LEVEL: &[&str] = &[
     "winit",
 ];
 
-/// Get `RUST_LOG` environment variable or `info`, if not set.
+/// Get `RUST_LOG` environment variable or `warn`, if not set.
 ///
 /// Also sets some other log levels on crates that are too loud.
 #[cfg(not(target_arch = "wasm32"))]

--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -410,6 +410,11 @@ As part of the switch to "eager archetype serialization" (serialization of arche
 
 However, it is still possible to do so with the `TensorData` component.
 
+### Default log level changed to `warn` in `re_log`
+
+With the addition of the notification center, the default log level in `re_log` is now set to `warn`.
+
+Logs at the `info` level will appear in the notification center.
 
 
 ## C++ API changes


### PR DESCRIPTION
### Related

Closes #8979

### What

This documents the change to the default log level that landed in `0.22` / #8918 