### PR TITLE
Fix `cpp` linking error on macOS due to missing `framework`s

### DIFF
--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -84,7 +84,7 @@ if(NOT TARGET rerun_c)
 endif()
 
 if(APPLE)
-    target_link_libraries(rerun_c INTERFACE "-framework CoreFoundation" "-framework IOKit")
+    target_link_libraries(rerun_c INTERFACE "-framework CoreFoundation" "-framework IOKit" "-framework CoreFoundation" "-framework Security")
 elseif(UNIX) # if(LINUX) # CMake 3.25
     target_link_libraries(rerun_c INTERFACE "-lm -ldl -pthread")
 elseif(WIN32)


### PR DESCRIPTION
### Related

* https://github.com/rerun-io/rerun/actions/runs/13260534162

### What

It looks like we were missing some macOS `framework`s that are required for linking with native certificates.
