### PR TITLE
Fix: `--serve-web` should consume data sources

### DIFF
--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -27,6 +27,8 @@ use tower_http::cors::CorsLayer;
 pub const DEFAULT_SERVER_PORT: u16 = 9876;
 pub const DEFAULT_MEMORY_LIMIT: MemoryLimit = MemoryLimit::UNLIMITED;
 
+// TODO(jan): Refactor `serve`/`spawn` variants into a builder?
+
 /// Start a Rerun server, listening on `addr`.
 ///
 /// A Rerun server is an in-memory implementation of a Storage Node.


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/9002

### What

Previously we would create a `RerunServer` from `rxs` before serving the Web Viewer. The gRPC server that's started by `--serve-web` will now consume `rxs` as well. It can still be sent additional data via `connect_grpc` in our SDKs, even after it consumes its initial data sources.

Tested with (from linked issue):
```
cargo run -p clock -- --save clock.rrd
pixi run --rerun-web clock.rrd
```
