### PR TITLE
Remove check for inner nullability of component columns

### DIFF
--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -71,7 +71,7 @@ pub fn stream_from_redap(
                 recording_id,
             } => {
                 if let Err(err) = stream_recording_async(tx, origin, recording_id, on_msg).await {
-                    re_log::warn!(
+                    re_log::error!(
                         "Error while streaming {url}: {}",
                         re_error::format_ref(&err)
                     );
@@ -79,7 +79,7 @@ pub fn stream_from_redap(
             }
             RedapAddress::Catalog { origin } => {
                 if let Err(err) = stream_catalog_async(tx, origin, on_msg).await {
-                    re_log::warn!(
+                    re_log::error!(
                         "Error while streaming {url}: {}",
                         re_error::format_ref(&err)
                     );


### PR DESCRIPTION
### Related
* https://github.com/rerun-io/rerun/pull/8998
* #6819

### What
`pixi run rerun rerun://redap.rerun.io/catalog` failed with `Detected malformed Chunk: The outer array in chunked component batch must be a sparse list, got List(Field { name: "item", data_type: Utf8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} })`.

The cause was a check in the `Chunk::sanity_check` requiring _inner mutability_, i.e. allowing a single component to be null in a list. The intention of the check was to check for _outer_ nullability, i.e. that any cell in the column can be `null` (or a dense list).

In other words, we want to support `Vec<Option<Vec<T>>`, but NOT require `Vec<Option<Vec<Option<T>>>`.

Why did this trigger now? Because we now allow sending component columns as "mono components", i.e. as `Vec<T>` and that is then automatically changed to `Vec<Vec<T>>`, but wether or not it has interior nullability depends on if the source data had it.