### PR TITLE
gRPC spec update: Add support for fetching temporal range of recordings

### DIFF
--- a/crates/store/re_protos/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_protos/proto/rerun/v0/remote_store.proto
@@ -11,6 +11,9 @@ service StorageNode {
 
     rpc CreateIndex(CreateIndexRequest) returns (CreateIndexResponse) {}
 
+    rpc GetChunkIds(GetChunkIdsRequest) returns (stream GetChunkIdsResponse) {}
+    rpc GetChunks(GetChunksRequest) returns (stream rerun.common.v0.RerunChunk) {}
+
     // The response to `SearchIndex` a RecordBatch with 3 columns:
     // - 'resource_id' column with the id of the resource
     // - timepoint column with the values representing the points in time
@@ -43,6 +46,31 @@ message DataframePart {
 
     // Data payload is Arrow IPC encoded RecordBatch
     bytes payload = 1000;
+}
+
+// ---------------- GetChunkIds ------------------
+
+message GetChunkIdsRequest {
+    // recording id from which we're want to fetch the chunk ids
+    rerun.common.v0.RecordingId recording_id = 1;
+    // timeline for which we specify the time range
+    rerun.common.v0.IndexColumnSelector time_index = 2;
+    // time range for which we want to fetch the chunk ids
+    rerun.common.v0.TimeRange time_range = 3;
+}
+
+message GetChunkIdsResponse {
+    // a batch of chunk ids for chunks that are within the specified time range
+    repeated rerun.common.v0.Tuid chunk_ids = 1;
+}
+
+// ---------------- GetChunk ---------------------
+
+message GetChunksRequest {
+    // recording id from which we're want to fetch the chunk ids
+    rerun.common.v0.RecordingId recording_id = 1;
+    // batch of chunk ids for which we want to stream back chunks
+    repeated rerun.common.v0.Tuid chunk_ids = 2;
 }
 
 // ---------------- CreateIndex ------------------

--- a/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
@@ -19,6 +19,62 @@ impl ::prost::Name for DataframePart {
         "/rerun.remote_store.v0.DataframePart".into()
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetChunkIdsRequest {
+    /// recording id from which we're want to fetch the chunk ids
+    #[prost(message, optional, tag = "1")]
+    pub recording_id: ::core::option::Option<super::super::common::v0::RecordingId>,
+    /// timeline for which we specify the time range
+    #[prost(message, optional, tag = "2")]
+    pub time_index: ::core::option::Option<super::super::common::v0::IndexColumnSelector>,
+    /// time range for which we want to fetch the chunk ids
+    #[prost(message, optional, tag = "3")]
+    pub time_range: ::core::option::Option<super::super::common::v0::TimeRange>,
+}
+impl ::prost::Name for GetChunkIdsRequest {
+    const NAME: &'static str = "GetChunkIdsRequest";
+    const PACKAGE: &'static str = "rerun.remote_store.v0";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.remote_store.v0.GetChunkIdsRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.remote_store.v0.GetChunkIdsRequest".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetChunkIdsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub chunk_ids: ::prost::alloc::vec::Vec<super::super::common::v0::Tuid>,
+}
+impl ::prost::Name for GetChunkIdsResponse {
+    const NAME: &'static str = "GetChunkIdsResponse";
+    const PACKAGE: &'static str = "rerun.remote_store.v0";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.remote_store.v0.GetChunkIdsResponse".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.remote_store.v0.GetChunkIdsResponse".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetChunksRequest {
+    /// recording id from which we're want to fetch the chunk ids
+    #[prost(message, optional, tag = "1")]
+    pub recording_id: ::core::option::Option<super::super::common::v0::RecordingId>,
+    /// batch of chunk ids for which we want to stream back chunks
+    #[prost(message, repeated, tag = "2")]
+    pub chunk_ids: ::prost::alloc::vec::Vec<super::super::common::v0::Tuid>,
+}
+impl ::prost::Name for GetChunksRequest {
+    const NAME: &'static str = "GetChunksRequest";
+    const PACKAGE: &'static str = "rerun.remote_store.v0";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.remote_store.v0.GetChunksRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.remote_store.v0.GetChunksRequest".into()
+    }
+}
 /// used to define which column we want to index
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IndexColumn {
@@ -800,6 +856,48 @@ pub mod storage_node_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn get_chunk_ids(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetChunkIdsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::GetChunkIdsResponse>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.remote_store.v0.StorageNode/GetChunkIds",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.remote_store.v0.StorageNode",
+                "GetChunkIds",
+            ));
+            self.inner.server_streaming(req, path, codec).await
+        }
+        pub async fn get_chunks(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetChunksRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::super::super::common::v0::RerunChunk>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.remote_store.v0.StorageNode/GetChunks",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.remote_store.v0.StorageNode",
+                "GetChunks",
+            ));
+            self.inner.server_streaming(req, path, codec).await
+        }
         /// The response to `SearchIndex` a RecordBatch with 3 columns:
         /// - 'resource_id' column with the id of the resource
         /// - timepoint column with the values representing the points in time
@@ -989,6 +1087,27 @@ pub mod storage_node_server {
             &self,
             request: tonic::Request<super::CreateIndexRequest>,
         ) -> std::result::Result<tonic::Response<super::CreateIndexResponse>, tonic::Status>;
+        /// Server streaming response type for the GetChunkIds method.
+        type GetChunkIdsStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::GetChunkIdsResponse, tonic::Status>,
+            > + std::marker::Send
+            + 'static;
+        async fn get_chunk_ids(
+            &self,
+            request: tonic::Request<super::GetChunkIdsRequest>,
+        ) -> std::result::Result<tonic::Response<Self::GetChunkIdsStream>, tonic::Status>;
+        /// Server streaming response type for the GetChunks method.
+        type GetChunksStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    super::super::super::common::v0::RerunChunk,
+                    tonic::Status,
+                >,
+            > + std::marker::Send
+            + 'static;
+        async fn get_chunks(
+            &self,
+            request: tonic::Request<super::GetChunksRequest>,
+        ) -> std::result::Result<tonic::Response<Self::GetChunksStream>, tonic::Status>;
         /// Server streaming response type for the SearchIndex method.
         type SearchIndexStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::DataframePart, tonic::Status>,
@@ -1233,6 +1352,94 @@ pub mod storage_node_server {
                                 max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.remote_store.v0.StorageNode/GetChunkIds" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetChunkIdsSvc<T: StorageNode>(pub Arc<T>);
+                    impl<T: StorageNode>
+                        tonic::server::ServerStreamingService<super::GetChunkIdsRequest>
+                        for GetChunkIdsSvc<T>
+                    {
+                        type Response = super::GetChunkIdsResponse;
+                        type ResponseStream = T::GetChunkIdsStream;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetChunkIdsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as StorageNode>::get_chunk_ids(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetChunkIdsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.remote_store.v0.StorageNode/GetChunks" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetChunksSvc<T: StorageNode>(pub Arc<T>);
+                    impl<T: StorageNode>
+                        tonic::server::ServerStreamingService<super::GetChunksRequest>
+                        for GetChunksSvc<T>
+                    {
+                        type Response = super::super::super::common::v0::RerunChunk;
+                        type ResponseStream = T::GetChunksStream;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetChunksRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as StorageNode>::get_chunks(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetChunksSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)


### PR DESCRIPTION
### What

Adding support for fetching chunks that belong to specific range of the recording. This consists of the 2 APIs calls:
* fetching chunk ids for a given range
* fetching chunks for the given chunk ids (which we might want to leverage separately in the future)

As there is a limitation for the client side gRPC streaming on the web (see [here](https://github.com/rerun-io/rerun/issues/8877#issuecomment-2652986044)), we've decided to send a batch of chunk ids to the server. To make the APIs somewhat symmetrical, the 1st API call will stream batches of chunk ids. 

Closes
* https://github.com/rerun-io/rerun/issues/8877