### PR TITLE
Add general `re_sorbet::SorbetSchema`

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -56,7 +56,7 @@ pub enum ChunkError {
     MismatchedChunkSchemaError(#[from] re_sorbet::MismatchedChunkSchemaError),
 
     #[error(transparent)]
-    InvalidChunkSchema(#[from] re_sorbet::InvalidChunkSchema),
+    InvalidChunkSchema(#[from] re_sorbet::InvalidSorbetSchema),
 }
 
 pub type ChunkResult<T> = Result<T, ChunkError>;

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -56,7 +56,7 @@ pub enum ChunkError {
     MismatchedChunkSchemaError(#[from] re_sorbet::MismatchedChunkSchemaError),
 
     #[error(transparent)]
-    InvalidSorbetSchema(#[from] re_sorbet::InvalidSorbetSchema),
+    InvalidSorbetSchema(#[from] re_sorbet::SorbetError),
 }
 
 pub type ChunkResult<T> = Result<T, ChunkError>;

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -56,7 +56,7 @@ pub enum ChunkError {
     MismatchedChunkSchemaError(#[from] re_sorbet::MismatchedChunkSchemaError),
 
     #[error(transparent)]
-    InvalidChunkSchema(#[from] re_sorbet::InvalidSorbetSchema),
+    InvalidSorbetSchema(#[from] re_sorbet::InvalidSorbetSchema),
 }
 
 pub type ChunkResult<T> = Result<T, ChunkError>;

--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -193,7 +193,7 @@ impl Chunk {
         let components = {
             let mut components = ChunkComponents::default();
 
-            for (schema, column) in batch.data_columns() {
+            for (schema, column) in batch.component_columns() {
                 let column = column
                     .downcast_array_ref::<ArrowListArray>()
                     .ok_or_else(|| ChunkError::Malformed {

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -57,7 +57,7 @@ pub enum StreamError {
     InvalidUri(String),
 
     #[error(transparent)]
-    InvalidChunkSchema(#[from] re_sorbet::InvalidSorbetSchema),
+    InvalidSorbetSchema(#[from] re_sorbet::InvalidSorbetSchema),
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -57,7 +57,7 @@ pub enum StreamError {
     InvalidUri(String),
 
     #[error(transparent)]
-    InvalidSorbetSchema(#[from] re_sorbet::InvalidSorbetSchema),
+    InvalidSorbetSchema(#[from] re_sorbet::SorbetError),
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -57,7 +57,7 @@ pub enum StreamError {
     InvalidUri(String),
 
     #[error(transparent)]
-    InvalidChunkSchema(#[from] re_sorbet::InvalidChunkSchema),
+    InvalidChunkSchema(#[from] re_sorbet::InvalidSorbetSchema),
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -335,8 +335,8 @@ async fn stream_catalog_async(
             let mut metadata = record_batch.schema_ref().metadata.clone();
 
             for (key, value) in [
-                re_sorbet::ChunkSchema::chunk_id_metadata(&ChunkId::new()),
-                re_sorbet::ChunkSchema::entity_path_metadata(&entity_path),
+                re_sorbet::SorbetSchema::chunk_id_metadata(&ChunkId::new()),
+                re_sorbet::SorbetSchema::entity_path_metadata(&entity_path),
             ] {
                 metadata.entry(key).or_insert(value);
             }

--- a/crates/store/re_sorbet/src/chunk_batch.rs
+++ b/crates/store/re_sorbet/src/chunk_batch.rs
@@ -75,14 +75,14 @@ impl ChunkBatch {
             }
         }
 
-        if data_arrays.len() != schema.data_columns().len() {
+        if data_arrays.len() != schema.component_columns().len() {
             return Err(MismatchedChunkSchemaError::custom(format!(
-                "Schema had {} data columns, but got {}",
-                schema.data_columns().len(),
+                "Schema had {} component columns, but got {}",
+                schema.component_columns().len(),
                 data_arrays.len()
             )));
         }
-        for (schema, array) in itertools::izip!(schema.data_columns(), &data_arrays) {
+        for (schema, array) in itertools::izip!(schema.component_columns(), &data_arrays) {
             WrongDatatypeError::compare_expected_actual(&schema.store_datatype, array.data_type())?;
             if array.len() != row_count {
                 return Err(MismatchedChunkSchemaError::custom(format!(
@@ -171,11 +171,11 @@ impl ChunkBatch {
     }
 
     /// The columns of the indices (timelines).
-    pub fn data_columns(
+    pub fn component_columns(
         &self,
     ) -> impl Iterator<Item = (&ComponentColumnDescriptor, &ArrowArrayRef)> {
         itertools::izip!(
-            self.schema.data_columns(),
+            self.schema.component_columns(),
             self.batch
                 .columns()
                 .iter()

--- a/crates/store/re_sorbet/src/chunk_batch.rs
+++ b/crates/store/re_sorbet/src/chunk_batch.rs
@@ -9,10 +9,7 @@ use arrow::{
 use re_log_types::EntityPath;
 use re_types_core::ChunkId;
 
-use crate::{
-    ArrowBatchMetadata, ChunkSchema, ComponentColumnDescriptor, IndexColumnDescriptor,
-    RowIdColumnDescriptor, SorbetBatch, SorbetError, WrongDatatypeError,
-};
+use crate::{ChunkSchema, RowIdColumnDescriptor, SorbetBatch, SorbetError, WrongDatatypeError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum MismatchedChunkSchemaError {
@@ -76,28 +73,12 @@ impl ChunkBatch {
         self.schema.entity_path()
     }
 
-    /// The heap size of this chunk in bytes, if known.
-    #[inline]
-    pub fn heap_size_bytes(&self) -> Option<u64> {
-        self.schema.heap_size_bytes()
-    }
-
-    /// Are we sorted by the row id column?
-    #[inline]
-    pub fn is_sorted(&self) -> bool {
-        self.schema.is_sorted()
-    }
-
     #[inline]
     pub fn fields(&self) -> &ArrowFields {
         &self.schema_ref().fields
     }
 
-    #[inline]
-    pub fn arrow_bacth_metadata(&self) -> &ArrowBatchMetadata {
-        &self.schema_ref().metadata
-    }
-
+    /// The [`RowId`] column.
     pub fn row_id_column(&self) -> (&RowIdColumnDescriptor, &ArrowStructArray) {
         // The first column is always the row IDs.
         (
@@ -106,18 +87,6 @@ impl ChunkBatch {
                 .as_struct_opt()
                 .expect("Row IDs should be encoded as struct"),
         )
-    }
-
-    /// The columns of the indices (timelines).
-    pub fn index_columns(&self) -> impl Iterator<Item = (&IndexColumnDescriptor, &ArrowArrayRef)> {
-        self.sorbet_batch.index_columns()
-    }
-
-    /// The columns of the indices (timelines).
-    pub fn component_columns(
-        &self,
-    ) -> impl Iterator<Item = (&ComponentColumnDescriptor, &ArrowArrayRef)> {
-        self.sorbet_batch.component_columns()
     }
 }
 
@@ -168,6 +137,7 @@ impl TryFrom<&ArrowRecordBatch> for ChunkBatch {
         Self::try_from(SorbetBatch::try_from(batch)?)
     }
 }
+
 impl TryFrom<SorbetBatch> for ChunkBatch {
     type Error = SorbetError;
 

--- a/crates/store/re_sorbet/src/chunk_batch.rs
+++ b/crates/store/re_sorbet/src/chunk_batch.rs
@@ -78,7 +78,7 @@ impl ChunkBatch {
         &self.schema_ref().fields
     }
 
-    /// The [`RowId`] column.
+    /// The `RowId` column.
     pub fn row_id_column(&self) -> (&RowIdColumnDescriptor, &ArrowStructArray) {
         // The first column is always the row IDs.
         (

--- a/crates/store/re_sorbet/src/chunk_schema.rs
+++ b/crates/store/re_sorbet/src/chunk_schema.rs
@@ -107,7 +107,7 @@ impl ChunkSchema {
     }
 
     #[inline]
-    pub fn data_columns(&self) -> &[ComponentColumnDescriptor] {
+    pub fn component_columns(&self) -> &[ComponentColumnDescriptor] {
         &self.sorbet.columns.components
     }
 

--- a/crates/store/re_sorbet/src/column_descriptor.rs
+++ b/crates/store/re_sorbet/src/column_descriptor.rs
@@ -118,7 +118,7 @@ impl ColumnDescriptor {
             "index" | "time" => Ok(Self::Time(IndexColumnDescriptor::try_from(field)?)),
 
             "data" => Ok(Self::Component(
-                ComponentColumnDescriptor::try_from_arrow_field(chunk_entity_path, field)?,
+                ComponentColumnDescriptor::from_arrow_field(chunk_entity_path, field),
             )),
 
             _ => Err(ColumnError::UnsupportedColumnKind {

--- a/crates/store/re_sorbet/src/column_kind.rs
+++ b/crates/store/re_sorbet/src/column_kind.rs
@@ -1,0 +1,28 @@
+use arrow::datatypes::Field as ArrowField;
+
+use crate::{InvalidSorbetSchema, MetadataExt as _};
+
+/// The type of column in a sorbet batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ColumnKind {
+    RowId,
+    Index,
+    Component,
+}
+
+impl TryFrom<&ArrowField> for ColumnKind {
+    type Error = InvalidSorbetSchema;
+
+    fn try_from(fields: &ArrowField) -> Result<Self, Self::Error> {
+        let kind = fields.get_or_err("rerun.kind")?;
+        match kind {
+            "control" | "row_id" => Ok(Self::RowId),
+            "index" | "time" => Ok(Self::Index),
+            "component" | "data" => Ok(Self::Component),
+
+            _ => Err(InvalidSorbetSchema::custom(format!(
+                "Unknown column kind: {kind}"
+            ))),
+        }
+    }
+}

--- a/crates/store/re_sorbet/src/column_kind.rs
+++ b/crates/store/re_sorbet/src/column_kind.rs
@@ -1,6 +1,6 @@
 use arrow::datatypes::Field as ArrowField;
 
-use crate::{InvalidSorbetSchema, MetadataExt as _};
+use crate::{MetadataExt as _, SorbetError};
 
 /// The type of column in a sorbet batch.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -11,7 +11,7 @@ pub enum ColumnKind {
 }
 
 impl TryFrom<&ArrowField> for ColumnKind {
-    type Error = InvalidSorbetSchema;
+    type Error = SorbetError;
 
     fn try_from(fields: &ArrowField) -> Result<Self, Self::Error> {
         let kind = fields.get_or_err("rerun.kind")?;
@@ -20,9 +20,7 @@ impl TryFrom<&ArrowField> for ColumnKind {
             "index" | "time" => Ok(Self::Index),
             "component" | "data" => Ok(Self::Component),
 
-            _ => Err(InvalidSorbetSchema::custom(format!(
-                "Unknown column kind: {kind}"
-            ))),
+            _ => Err(SorbetError::custom(format!("Unknown column kind: {kind}"))),
         }
     }
 }

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -20,12 +20,20 @@ pub struct ComponentColumnDescriptor {
     /// we introduce mono-type optimization, this might be a native type instead.
     pub store_datatype: ArrowDatatype,
 
+    /// Semantic name associated with this data.
+    ///
+    /// This is fully implied by `archetype_name` and `archetype_field`, but
+    /// included for semantic convenience.
+    ///
+    /// Example: `rerun.components.Position3D`.
+    pub component_name: ComponentName,
+
     /// The path of the entity.
     ///
     /// If this column is part of a chunk batch,
     /// this is the same for all columns in the batch,
     /// and will also be set in the schema for the whole chunk.
-    pub entity_path: EntityPath,
+    pub entity_path: EntityPath, // TODO(#8744): make optional for sorbet batches
 
     /// Optional name of the `Archetype` associated with this data.
     ///
@@ -40,14 +48,6 @@ pub struct ComponentColumnDescriptor {
     ///
     /// Example: `positions`.
     pub archetype_field_name: Option<ArchetypeFieldName>,
-
-    /// Semantic name associated with this data.
-    ///
-    /// This is fully implied by `archetype_name` and `archetype_field`, but
-    /// included for semantic convenience.
-    ///
-    /// Example: `rerun.components.Position3D`.
-    pub component_name: ComponentName,
 
     /// Whether this column represents static data.
     pub is_static: bool,

--- a/crates/store/re_sorbet/src/error.rs
+++ b/crates/store/re_sorbet/src/error.rs
@@ -1,0 +1,30 @@
+use arrow::error::ArrowError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SorbetError {
+    #[error(transparent)]
+    MissingMetadataKey(#[from] crate::MissingMetadataKey),
+
+    #[error(transparent)]
+    MissingFieldMetadata(#[from] crate::MissingFieldMetadata),
+
+    #[error(transparent)]
+    UnsupportedTimeType(#[from] crate::UnsupportedTimeType),
+
+    #[error(transparent)]
+    WrongDatatypeError(#[from] crate::WrongDatatypeError),
+
+    #[error(transparent)]
+    ArrowError(#[from] ArrowError),
+
+    #[error("Bad chunk schema: {reason}")]
+    Custom { reason: String },
+}
+
+impl SorbetError {
+    pub fn custom(reason: impl Into<String>) -> Self {
+        Self::Custom {
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -2,11 +2,18 @@
 //!
 //! Handles the structure of arrow record batches and their meta data for different use cases for Rerun.
 //!
-//! An arrow record batch that follows a specific schema is called a `SorbetBatch`.
+//! An arrow record batch that follows a specific schema is called a [`SorbetBatch`].
 //!
-//! Some `SorbetBatch`es has even more constrained requirements, such as [`ChunkBatch`] and `DataframeBatch`.
-//! * Every [`ChunkBatch`] is a `SorbetBatch`.
-//! * Every `DataframeBatch` is a `SorbetBatch`.
+//! Some [`SorbetBatch`]es has even more constrained requirements, such as [`ChunkBatch`] and `DataframeBatch`.
+//! * Every [`ChunkBatch`] is a [`SorbetBatch`].
+//! * Every `DataframeBatch` is a [`SorbetBatch`].
+//!
+//! NOTE: `DataframeBatch` has not yet been implemented.
+//!
+//! Each batch type has a matching schema type:
+//! * [`SorbetBatch`] has a [`SorbetSchema`]
+//! * [`ChunkBatch`] has a [`ChunkSchema`]
+//! * `DataframeBatch` will have a `DataframeSchema`
 
 mod chunk_batch;
 mod chunk_schema;
@@ -17,6 +24,7 @@ mod index_column_descriptor;
 mod ipc;
 mod metadata;
 mod row_id_column_descriptor;
+mod sorbet_batch;
 mod sorbet_columns;
 mod sorbet_schema;
 
@@ -33,10 +41,12 @@ pub use self::{
         MissingMetadataKey,
     },
     row_id_column_descriptor::{RowIdColumnDescriptor, WrongDatatypeError},
+    sorbet_batch::SorbetBatch,
     sorbet_columns::SorbetColumnDescriptors,
     sorbet_schema::{InvalidSorbetSchema, SorbetSchema},
 };
 
+/// The type of [`SorbetBatch`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BatchType {
     /// Data for one entity

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -20,6 +20,7 @@ mod chunk_schema;
 mod column_descriptor;
 mod column_kind;
 mod component_column_descriptor;
+mod error;
 mod index_column_descriptor;
 mod ipc;
 mod metadata;
@@ -34,6 +35,7 @@ pub use self::{
     column_descriptor::{ColumnDescriptor, ColumnError},
     column_kind::ColumnKind,
     component_column_descriptor::ComponentColumnDescriptor,
+    error::SorbetError,
     index_column_descriptor::{IndexColumnDescriptor, UnsupportedTimeType},
     ipc::{ipc_from_schema, schema_from_ipc},
     metadata::{
@@ -43,7 +45,7 @@ pub use self::{
     row_id_column_descriptor::{RowIdColumnDescriptor, WrongDatatypeError},
     sorbet_batch::SorbetBatch,
     sorbet_columns::SorbetColumnDescriptors,
-    sorbet_schema::{InvalidSorbetSchema, SorbetSchema},
+    sorbet_schema::SorbetSchema,
 };
 
 /// The type of [`SorbetBatch`].

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -4,33 +4,9 @@
 //!
 //! An arrow record batch that follows a specific schema is called a `SorbetBatch`.
 //!
-//! Some `SorbetBatch`es has even more constrained requirements, such as `ChunkBatch` and `DataframeBatch`.
-//! * Every `ChunkBatch` is a `SorbetBatch`.
+//! Some `SorbetBatch`es has even more constrained requirements, such as [`ChunkBatch`] and `DataframeBatch`.
+//! * Every [`ChunkBatch`] is a `SorbetBatch`.
 //! * Every `DataframeBatch` is a `SorbetBatch`.
-//!
-//!
-//! and that schema is defined in [`ChunkSchema`].
-//! If a record batch matches the schema, it can be converted to a [`ChunkBatch`].
-
-/*
-Sorbet record batch phylogenetic tree.
-* Every ChunkBatch is a SorbetBatch.
-* Every DataframeBatch is a SorbetBatch.
-
-SorbetBatch superset:
-    Optional RowId
-    0-N IndexColumns
-    0-N ComponentColumns
-
-    ChunkBatch specialization:
-        Always has row ids
-        Always is of a single entity
-        Each `ComponentColumns` is a `ListArray`
-
-    DataframeBatch specialization:
-        Always has row ids
-        Each component column may have a different entity
-*/
 
 mod chunk_batch;
 mod chunk_schema;
@@ -58,7 +34,7 @@ pub use self::{
     },
     row_id_column_descriptor::{RowIdColumnDescriptor, WrongDatatypeError},
     sorbet_columns::SorbetColumnDescriptors,
-    sorbet_schema::{ColumnKind, InvalidSorbetSchema, SorbetColumnDescriptors, SorbetSchema},
+    sorbet_schema::{InvalidSorbetSchema, SorbetSchema},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -35,17 +35,20 @@ SorbetBatch superset:
 mod chunk_batch;
 mod chunk_schema;
 mod column_descriptor;
+mod column_kind;
 mod component_column_descriptor;
 mod index_column_descriptor;
 mod ipc;
 mod metadata;
 mod row_id_column_descriptor;
+mod sorbet_columns;
 mod sorbet_schema;
 
 pub use self::{
     chunk_batch::{ChunkBatch, MismatchedChunkSchemaError},
     chunk_schema::ChunkSchema,
     column_descriptor::{ColumnDescriptor, ColumnError},
+    column_kind::ColumnKind,
     component_column_descriptor::ComponentColumnDescriptor,
     index_column_descriptor::{IndexColumnDescriptor, UnsupportedTimeType},
     ipc::{ipc_from_schema, schema_from_ipc},
@@ -54,6 +57,7 @@ pub use self::{
         MissingMetadataKey,
     },
     row_id_column_descriptor::{RowIdColumnDescriptor, WrongDatatypeError},
+    sorbet_columns::SorbetColumnDescriptors,
     sorbet_schema::{ColumnKind, InvalidSorbetSchema, SorbetColumnDescriptors, SorbetSchema},
 };
 

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -2,9 +2,35 @@
 //!
 //! Handles the structure of arrow record batches and their meta data for different use cases for Rerun.
 //!
-//! An arrow record batch needs to follow a specific schema to be compatible with Rerun,
+//! An arrow record batch that follows a specific schema is called a `SorbetBatch`.
+//!
+//! Some `SorbetBatch`es has even more constrained requirements, such as `ChunkBatch` and `DataframeBatch`.
+//! * Every `ChunkBatch` is a `SorbetBatch`.
+//! * Every `DataframeBatch` is a `SorbetBatch`.
+//!
+//!
 //! and that schema is defined in [`ChunkSchema`].
 //! If a record batch matches the schema, it can be converted to a [`ChunkBatch`].
+
+/*
+Sorbet record batch phylogenetic tree.
+* Every ChunkBatch is a SorbetBatch.
+* Every DataframeBatch is a SorbetBatch.
+
+SorbetBatch superset:
+    Optional RowId
+    0-N IndexColumns
+    0-N ComponentColumns
+
+    ChunkBatch specialization:
+        Always has row ids
+        Always is of a single entity
+        Each `ComponentColumns` is a `ListArray`
+
+    DataframeBatch specialization:
+        Always has row ids
+        Each component column may have a different entity
+*/
 
 mod chunk_batch;
 mod chunk_schema;
@@ -14,10 +40,11 @@ mod index_column_descriptor;
 mod ipc;
 mod metadata;
 mod row_id_column_descriptor;
+mod sorbet_schema;
 
 pub use self::{
     chunk_batch::{ChunkBatch, MismatchedChunkSchemaError},
-    chunk_schema::{ChunkSchema, InvalidChunkSchema},
+    chunk_schema::ChunkSchema,
     column_descriptor::{ColumnDescriptor, ColumnError},
     component_column_descriptor::ComponentColumnDescriptor,
     index_column_descriptor::{IndexColumnDescriptor, UnsupportedTimeType},
@@ -27,6 +54,7 @@ pub use self::{
         MissingMetadataKey,
     },
     row_id_column_descriptor::{RowIdColumnDescriptor, WrongDatatypeError},
+    sorbet_schema::{ColumnKind, InvalidSorbetSchema, SorbetColumnDescriptors, SorbetSchema},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/store/re_sorbet/src/sorbet_batch.rs
+++ b/crates/store/re_sorbet/src/sorbet_batch.rs
@@ -1,0 +1,226 @@
+use arrow::{
+    array::{
+        Array as ArrowArray, ArrayRef as ArrowArrayRef, AsArray, ListArray as ArrowListArray,
+        RecordBatch as ArrowRecordBatch, RecordBatchOptions, StructArray as ArrowStructArray,
+    },
+    datatypes::{FieldRef as ArrowFieldRef, Fields as ArrowFields, Schema as ArrowSchema},
+    error::ArrowError,
+};
+
+use re_arrow_util::{into_arrow_ref, ArrowArrayDowncastRef};
+use re_log_types::EntityPath;
+use re_types_core::ChunkId;
+
+use crate::{
+    ArrowBatchMetadata, ComponentColumnDescriptor, IndexColumnDescriptor, InvalidSorbetSchema,
+    RowIdColumnDescriptor, SorbetSchema,
+};
+
+/// Any rerun-compatible [`ArrowRecordBatch`].
+///
+/// This is a wrapper around a [`SorbetSchema`] and a [`ArrowRecordBatch`].
+#[derive(Debug, Clone)]
+pub struct SorbetBatch {
+    schema: SorbetSchema,
+    batch: ArrowRecordBatch,
+}
+
+impl SorbetBatch {
+    pub fn try_new(
+        schema: SorbetSchema,
+        row_ids: Option<ArrowArrayRef>,
+        index_arrays: Vec<ArrowArrayRef>,
+        data_arrays: Vec<ArrowArrayRef>,
+    ) -> Result<Self, ArrowError> {
+        let arrow_columns = itertools::chain!(row_ids, index_arrays, data_arrays).collect();
+
+        let batch = ArrowRecordBatch::try_new(
+            std::sync::Arc::new(ArrowSchema::from(&schema)),
+            arrow_columns,
+        )?;
+
+        Ok(Self { schema, batch })
+    }
+}
+
+impl SorbetBatch {
+    /// The parsed rerun schema of this chunk.
+    #[inline]
+    pub fn chunk_schema(&self) -> &SorbetSchema {
+        &self.schema
+    }
+
+    /// The globally unique ID of this chunk.
+    #[inline]
+    pub fn chunk_id(&self) -> Option<ChunkId> {
+        self.schema.chunk_id
+    }
+
+    /// Which entity is this chunk for?
+    #[inline]
+    pub fn entity_path(&self) -> Option<&EntityPath> {
+        self.schema.entity_path.as_ref()
+    }
+
+    /// The heap size of this chunk in bytes, if known.
+    #[inline]
+    pub fn heap_size_bytes(&self) -> Option<u64> {
+        self.schema.heap_size_bytes
+    }
+
+    /// Are we sorted by the row id column?
+    #[inline]
+    pub fn is_sorted(&self) -> bool {
+        self.schema.is_sorted
+    }
+
+    #[inline]
+    pub fn fields(&self) -> &ArrowFields {
+        &self.schema_ref().fields
+    }
+
+    #[inline]
+    pub fn arrow_bacth_metadata(&self) -> &ArrowBatchMetadata {
+        &self.batch.schema_ref().metadata
+    }
+
+    pub fn row_id_column(&self) -> Option<(&RowIdColumnDescriptor, &ArrowStructArray)> {
+        self.schema.columns.row_id.as_ref().map(|row_id_desc| {
+            (
+                row_id_desc,
+                self.batch.columns()[0]
+                    .as_struct_opt()
+                    .expect("Row IDs should be encoded as struct"),
+            )
+        })
+    }
+
+    /// The columns of the indices (timelines).
+    pub fn index_columns(&self) -> impl Iterator<Item = (&IndexColumnDescriptor, &ArrowArrayRef)> {
+        itertools::izip!(
+            &self.schema.columns.indices,
+            self.batch.columns().iter().skip(1) // skip row IDs
+        )
+    }
+
+    /// The columns of the indices (timelines).
+    pub fn component_columns(
+        &self,
+    ) -> impl Iterator<Item = (&ComponentColumnDescriptor, &ArrowArrayRef)> {
+        itertools::izip!(
+            &self.schema.columns.components,
+            self.batch
+                .columns()
+                .iter()
+                .skip(1 + self.schema.columns.indices.len()) // skip row IDs and indices
+        )
+    }
+}
+
+impl std::fmt::Display for SorbetBatch {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        re_format_arrow::format_record_batch_with_width(self, f.width()).fmt(f)
+    }
+}
+
+impl AsRef<ArrowRecordBatch> for SorbetBatch {
+    #[inline]
+    fn as_ref(&self) -> &ArrowRecordBatch {
+        &self.batch
+    }
+}
+
+impl std::ops::Deref for SorbetBatch {
+    type Target = ArrowRecordBatch;
+
+    #[inline]
+    fn deref(&self) -> &ArrowRecordBatch {
+        &self.batch
+    }
+}
+
+impl From<SorbetBatch> for ArrowRecordBatch {
+    #[inline]
+    fn from(chunk: SorbetBatch) -> Self {
+        chunk.batch
+    }
+}
+
+impl From<&SorbetBatch> for ArrowRecordBatch {
+    #[inline]
+    fn from(chunk: &SorbetBatch) -> Self {
+        chunk.batch.clone()
+    }
+}
+
+impl TryFrom<&ArrowRecordBatch> for SorbetBatch {
+    type Error = InvalidSorbetSchema;
+
+    /// Will automatically wrap data columns in `ListArrays` if they are not already.
+    fn try_from(batch: &ArrowRecordBatch) -> Result<Self, Self::Error> {
+        re_tracing::profile_function!();
+
+        let batch = make_all_data_columns_list_arrays(batch);
+
+        let sorbet_schema = SorbetSchema::try_from(batch.schema_ref().as_ref())?;
+
+        for (field, column) in
+            itertools::izip!(sorbet_schema.columns.arrow_fields(), batch.columns())
+        {
+            debug_assert_eq!(field.data_type(), column.data_type());
+        }
+
+        // Extend with any metadata that might have been missing:
+        let mut arrow_schema = ArrowSchema::clone(batch.schema_ref().as_ref());
+        arrow_schema
+            .metadata
+            .extend(sorbet_schema.arrow_batch_metadata());
+
+        let batch = ArrowRecordBatch::try_new_with_options(
+            arrow_schema.into(),
+            batch.columns().to_vec(),
+            &RecordBatchOptions::default().with_row_count(Some(batch.num_rows())),
+        )
+        .expect("Can't fail");
+
+        Ok(Self {
+            schema: sorbet_schema,
+            batch,
+        })
+    }
+}
+
+/// Make sure all data columns are `ListArrays`.
+fn make_all_data_columns_list_arrays(batch: &ArrowRecordBatch) -> ArrowRecordBatch {
+    re_tracing::profile_function!();
+
+    let num_columns = batch.num_columns();
+    let mut fields: Vec<ArrowFieldRef> = Vec::with_capacity(num_columns);
+    let mut columns: Vec<ArrowArrayRef> = Vec::with_capacity(num_columns);
+
+    for (field, array) in itertools::izip!(batch.schema().fields(), batch.columns()) {
+        let is_list_array = array.downcast_array_ref::<ArrowListArray>().is_some();
+        let is_data_column = field
+            .metadata()
+            .get("rerun.kind")
+            .is_some_and(|kind| kind == "data");
+        if is_data_column && !is_list_array {
+            let (field, array) = re_arrow_util::wrap_in_list_array(field, array.clone());
+            fields.push(field.into());
+            columns.push(into_arrow_ref(array));
+        } else {
+            fields.push(field.clone());
+            columns.push(array.clone());
+        }
+    }
+
+    let schema = ArrowSchema::new_with_metadata(fields, batch.schema().metadata.clone());
+
+    ArrowRecordBatch::try_new_with_options(
+        schema.into(),
+        columns,
+        &RecordBatchOptions::default().with_row_count(Some(batch.num_rows())),
+    )
+    .expect("Can't fail")
+}

--- a/crates/store/re_sorbet/src/sorbet_batch.rs
+++ b/crates/store/re_sorbet/src/sorbet_batch.rs
@@ -66,10 +66,11 @@ impl SorbetBatch {
     }
 
     #[inline]
-    pub fn arrow_bacth_metadata(&self) -> &ArrowBatchMetadata {
+    pub fn arrow_batch_metadata(&self) -> &ArrowBatchMetadata {
         &self.batch.schema_ref().metadata
     }
 
+    /// The [`RowId`] column, if any.
     pub fn row_id_column(&self) -> Option<(&RowIdColumnDescriptor, &ArrowStructArray)> {
         self.schema.columns.row_id.as_ref().map(|row_id_desc| {
             (
@@ -90,17 +91,18 @@ impl SorbetBatch {
         )
     }
 
-    /// The columns of the indices (timelines).
+    /// The columns of the components.
     pub fn component_columns(
         &self,
     ) -> impl Iterator<Item = (&ComponentColumnDescriptor, &ArrowArrayRef)> {
         let num_row_id_columns = self.schema.columns.row_id.is_some() as usize;
+        let num_index_columns = self.schema.columns.indices.len();
         itertools::izip!(
             &self.schema.columns.components,
             self.batch
                 .columns()
                 .iter()
-                .skip(num_row_id_columns + self.schema.columns.indices.len())
+                .skip(num_row_id_columns + num_index_columns)
         )
     }
 }

--- a/crates/store/re_sorbet/src/sorbet_batch.rs
+++ b/crates/store/re_sorbet/src/sorbet_batch.rs
@@ -70,7 +70,7 @@ impl SorbetBatch {
         &self.batch.schema_ref().metadata
     }
 
-    /// The [`RowId`] column, if any.
+    /// The `RowId` column, if any.
     pub fn row_id_column(&self) -> Option<(&RowIdColumnDescriptor, &ArrowStructArray)> {
         self.schema.columns.row_id.as_ref().map(|row_id_desc| {
             (

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -54,7 +54,7 @@ impl SorbetColumnDescriptors {
 }
 
 impl SorbetColumnDescriptors {
-    fn try_from_arrow_fields(
+    pub fn try_from_arrow_fields(
         chunk_entity_path: Option<&EntityPath>,
         fields: &ArrowFields,
     ) -> Result<Self, InvalidSorbetSchema> {

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -1,0 +1,110 @@
+use arrow::datatypes::{Field as ArrowField, Fields as ArrowFields};
+
+use re_log_types::EntityPath;
+
+use crate::{
+    ColumnKind, ComponentColumnDescriptor, IndexColumnDescriptor, InvalidSorbetSchema,
+    RowIdColumnDescriptor,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SorbetColumnDescriptors {
+    /// The primary row id column.
+    /// If present, it is always the first column.
+    pub row_id: Option<RowIdColumnDescriptor>,
+
+    /// Index columns (timelines).
+    pub indices: Vec<IndexColumnDescriptor>,
+
+    /// The actual component data
+    pub components: Vec<ComponentColumnDescriptor>,
+}
+
+impl SorbetColumnDescriptors {
+    /// Total number of columns in this chunk,
+    /// including the row id column, the index columns,
+    /// and the data columns.
+    pub fn num_columns(&self) -> usize {
+        let Self {
+            row_id,
+            indices,
+            components,
+        } = self;
+        row_id.is_some() as usize + indices.len() + components.len()
+    }
+
+    pub fn arrow_fields(&self) -> Vec<ArrowField> {
+        let Self {
+            row_id,
+            indices,
+            components,
+        } = self;
+        let mut fields: Vec<ArrowField> = Vec::with_capacity(self.num_columns());
+        if let Some(row_id) = row_id {
+            fields.push(row_id.to_arrow_field());
+        }
+        fields.extend(indices.iter().map(|column| column.to_arrow_field()));
+        fields.extend(
+            components
+                .iter()
+                .map(|column| column.to_arrow_field(crate::BatchType::Chunk)),
+        );
+        fields
+    }
+}
+
+impl SorbetColumnDescriptors {
+    fn try_from_arrow_fields(
+        chunk_entity_path: Option<&EntityPath>,
+        fields: &ArrowFields,
+    ) -> Result<Self, InvalidSorbetSchema> {
+        let mut row_ids = Vec::new();
+        let mut indices = Vec::new();
+        let mut components = Vec::new();
+
+        for field in fields {
+            let field = field.as_ref();
+            let column_kind = ColumnKind::try_from(field)?;
+            match column_kind {
+                ColumnKind::RowId => {
+                    if indices.is_empty() && components.is_empty() {
+                        row_ids.push(RowIdColumnDescriptor::try_from(field)?);
+                    } else {
+                        return Err(InvalidSorbetSchema::custom(
+                            "RowId column must be the first column",
+                        ));
+                    }
+                }
+
+                ColumnKind::Index => {
+                    if components.is_empty() {
+                        indices.push(IndexColumnDescriptor::try_from(field)?);
+                    } else {
+                        return Err(InvalidSorbetSchema::custom(
+                            "Index columns must come before any data columns",
+                        ));
+                    }
+                }
+
+                ColumnKind::Component => {
+                    components.push(ComponentColumnDescriptor::from_arrow_field(
+                        chunk_entity_path,
+                        field,
+                    ));
+                }
+            }
+        }
+
+        if row_ids.len() > 1 {
+            return Err(InvalidSorbetSchema::custom(
+                "Multiple row_id columns are not supported",
+            ));
+        }
+
+        Ok(Self {
+            row_id: row_ids.pop(),
+            indices,
+            components,
+        })
+    }
+}

--- a/crates/store/re_sorbet/src/sorbet_schema.rs
+++ b/crates/store/re_sorbet/src/sorbet_schema.rs
@@ -1,12 +1,9 @@
-use arrow::datatypes::{Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema};
+use arrow::datatypes::Schema as ArrowSchema;
 
 use re_log_types::EntityPath;
 use re_types_core::ChunkId;
 
-use crate::{
-    ArrowBatchMetadata, ColumnError, ComponentColumnDescriptor, IndexColumnDescriptor,
-    MetadataExt as _, RowIdColumnDescriptor,
-};
+use crate::{ArrowBatchMetadata, ColumnError, MetadataExt as _, SorbetColumnDescriptors};
 
 #[derive(thiserror::Error, Debug)]
 pub enum InvalidSorbetSchema {
@@ -40,135 +37,6 @@ impl InvalidSorbetSchema {
         Self::Custom {
             reason: reason.into(),
         }
-    }
-}
-
-// ----------------------------------------------------------------------------
-
-pub enum ColumnKind {
-    RowId,
-    Index,
-    Component,
-}
-
-impl TryFrom<&ArrowField> for ColumnKind {
-    type Error = InvalidSorbetSchema;
-
-    fn try_from(fields: &ArrowField) -> Result<Self, Self::Error> {
-        let kind = fields.get_or_err("rerun.kind")?;
-        match kind {
-            "control" | "row_id" => Ok(Self::RowId),
-            "index" | "time" => Ok(Self::Index),
-            "component" | "data" => Ok(Self::Component),
-
-            _ => Err(InvalidSorbetSchema::custom(format!(
-                "Unknown column kind: {kind}"
-            ))),
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SorbetColumnDescriptors {
-    /// The primary row id column.
-    /// If present, it is always the first column.
-    pub row_id: Option<RowIdColumnDescriptor>,
-
-    /// Index columns (timelines).
-    pub indices: Vec<IndexColumnDescriptor>,
-
-    /// The actual component data
-    pub components: Vec<ComponentColumnDescriptor>,
-}
-
-impl SorbetColumnDescriptors {
-    /// Total number of columns in this chunk,
-    /// including the row id column, the index columns,
-    /// and the data columns.
-    pub fn num_columns(&self) -> usize {
-        let Self {
-            row_id,
-            indices,
-            components,
-        } = self;
-        row_id.is_some() as usize + indices.len() + components.len()
-    }
-
-    pub fn arrow_fields(&self) -> Vec<ArrowField> {
-        let Self {
-            row_id,
-            indices,
-            components,
-        } = self;
-        let mut fields: Vec<ArrowField> = Vec::with_capacity(self.num_columns());
-        if let Some(row_id) = row_id {
-            fields.push(row_id.to_arrow_field());
-        }
-        fields.extend(indices.iter().map(|column| column.to_arrow_field()));
-        fields.extend(
-            components
-                .iter()
-                .map(|column| column.to_arrow_field(crate::BatchType::Chunk)),
-        );
-        fields
-    }
-}
-
-impl SorbetColumnDescriptors {
-    fn try_from_arrow_fields(
-        chunk_entity_path: Option<&EntityPath>,
-        fields: &ArrowFields,
-    ) -> Result<Self, InvalidSorbetSchema> {
-        let mut row_ids = Vec::new();
-        let mut indices = Vec::new();
-        let mut components = Vec::new();
-
-        for field in fields {
-            let field = field.as_ref();
-            let column_kind = ColumnKind::try_from(field)?;
-            match column_kind {
-                ColumnKind::RowId => {
-                    if indices.is_empty() && components.is_empty() {
-                        row_ids.push(RowIdColumnDescriptor::try_from(field)?);
-                    } else {
-                        return Err(InvalidSorbetSchema::custom(
-                            "RowId column must be the first column",
-                        ));
-                    }
-                }
-
-                ColumnKind::Index => {
-                    if components.is_empty() {
-                        indices.push(IndexColumnDescriptor::try_from(field)?);
-                    } else {
-                        return Err(InvalidSorbetSchema::custom(
-                            "Index columns must come before any data columns",
-                        ));
-                    }
-                }
-
-                ColumnKind::Component => {
-                    components.push(ComponentColumnDescriptor::from_arrow_field(
-                        chunk_entity_path,
-                        field,
-                    ));
-                }
-            }
-        }
-
-        if row_ids.len() > 1 {
-            return Err(InvalidSorbetSchema::custom(
-                "Multiple row_id columns are not supported",
-            ));
-        }
-
-        Ok(Self {
-            row_id: row_ids.pop(),
-            indices,
-            components,
-        })
     }
 }
 

--- a/crates/store/re_sorbet/src/sorbet_schema.rs
+++ b/crates/store/re_sorbet/src/sorbet_schema.rs
@@ -124,6 +124,15 @@ impl SorbetSchema {
     }
 }
 
+impl From<&SorbetSchema> for ArrowSchema {
+    fn from(sorbet_schema: &SorbetSchema) -> Self {
+        Self {
+            metadata: sorbet_schema.arrow_batch_metadata(),
+            fields: sorbet_schema.columns.arrow_fields().into(),
+        }
+    }
+}
+
 impl TryFrom<&ArrowSchema> for SorbetSchema {
     type Error = InvalidSorbetSchema;
 

--- a/crates/store/re_sorbet/src/sorbet_schema.rs
+++ b/crates/store/re_sorbet/src/sorbet_schema.rs
@@ -1,0 +1,313 @@
+use arrow::datatypes::{Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema};
+
+use re_log_types::EntityPath;
+use re_types_core::ChunkId;
+
+use crate::{
+    ArrowBatchMetadata, ColumnError, ComponentColumnDescriptor, IndexColumnDescriptor,
+    MetadataExt as _, RowIdColumnDescriptor,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum InvalidSorbetSchema {
+    #[error(transparent)]
+    MissingMetadataKey(#[from] crate::MissingMetadataKey),
+
+    #[error(transparent)]
+    MissingFieldMetadata(#[from] crate::MissingFieldMetadata),
+
+    #[error(transparent)]
+    UnsupportedTimeType(#[from] crate::UnsupportedTimeType),
+
+    #[error(transparent)]
+    WrongDatatypeError(#[from] crate::WrongDatatypeError),
+
+    #[error("Bad column '{field_name}': {error}")]
+    BadColumn {
+        field_name: String,
+        error: ColumnError,
+    },
+
+    #[error("Bad chunk schema: {reason}")]
+    Custom { reason: String },
+
+    #[error("The data columns were not the last columns. Index columns must come before any data columns.")]
+    UnorderedIndexAndDataColumns,
+}
+
+impl InvalidSorbetSchema {
+    pub fn custom(reason: impl Into<String>) -> Self {
+        Self::Custom {
+            reason: reason.into(),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+pub enum ColumnKind {
+    RowId,
+    Index,
+    Component,
+}
+
+impl TryFrom<&ArrowField> for ColumnKind {
+    type Error = InvalidSorbetSchema;
+
+    fn try_from(fields: &ArrowField) -> Result<Self, Self::Error> {
+        let kind = fields.get_or_err("rerun.kind")?;
+        match kind {
+            "control" | "row_id" => Ok(Self::RowId),
+            "index" | "time" => Ok(Self::Index),
+            "component" | "data" => Ok(Self::Component),
+
+            _ => Err(InvalidSorbetSchema::custom(format!(
+                "Unknown column kind: {kind}"
+            ))),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SorbetColumnDescriptors {
+    /// The primary row id column.
+    /// If present, it is always the first column.
+    pub row_id: Option<RowIdColumnDescriptor>,
+
+    /// Index columns (timelines).
+    pub indices: Vec<IndexColumnDescriptor>,
+
+    /// The actual component data
+    pub components: Vec<ComponentColumnDescriptor>,
+}
+
+impl SorbetColumnDescriptors {
+    /// Total number of columns in this chunk,
+    /// including the row id column, the index columns,
+    /// and the data columns.
+    pub fn num_columns(&self) -> usize {
+        let Self {
+            row_id,
+            indices,
+            components,
+        } = self;
+        row_id.is_some() as usize + indices.len() + components.len()
+    }
+
+    pub fn arrow_fields(&self) -> Vec<ArrowField> {
+        let Self {
+            row_id,
+            indices,
+            components,
+        } = self;
+        let mut fields: Vec<ArrowField> = Vec::with_capacity(self.num_columns());
+        if let Some(row_id) = row_id {
+            fields.push(row_id.to_arrow_field());
+        }
+        fields.extend(indices.iter().map(|column| column.to_arrow_field()));
+        fields.extend(
+            components
+                .iter()
+                .map(|column| column.to_arrow_field(crate::BatchType::Chunk)),
+        );
+        fields
+    }
+}
+
+impl SorbetColumnDescriptors {
+    fn try_from_arrow_fields(
+        chunk_entity_path: Option<&EntityPath>,
+        fields: &ArrowFields,
+    ) -> Result<Self, InvalidSorbetSchema> {
+        let mut row_ids = Vec::new();
+        let mut indices = Vec::new();
+        let mut components = Vec::new();
+
+        for field in fields {
+            let field = field.as_ref();
+            let column_kind = ColumnKind::try_from(field)?;
+            match column_kind {
+                ColumnKind::RowId => {
+                    if indices.is_empty() && components.is_empty() {
+                        row_ids.push(RowIdColumnDescriptor::try_from(field)?);
+                    } else {
+                        return Err(InvalidSorbetSchema::custom(
+                            "RowId column must be the first column",
+                        ));
+                    }
+                }
+
+                ColumnKind::Index => {
+                    if components.is_empty() {
+                        indices.push(IndexColumnDescriptor::try_from(field)?);
+                    } else {
+                        return Err(InvalidSorbetSchema::custom(
+                            "Index columns must come before any data columns",
+                        ));
+                    }
+                }
+
+                ColumnKind::Component => {
+                    components.push(ComponentColumnDescriptor::try_from_arrow_field(
+                        chunk_entity_path,
+                        field,
+                    )?);
+                }
+            }
+        }
+
+        if row_ids.len() > 1 {
+            return Err(InvalidSorbetSchema::custom(
+                "Multiple row_id columns are not supported",
+            ));
+        }
+
+        Ok(Self {
+            row_id: row_ids.pop(),
+            indices,
+            components,
+        })
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+/// The parsed schema of a `SorbetBatch`.
+///
+/// This does NOT contain custom arrow metadata.
+/// It only contains the metadata used by Rerun.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SorbetSchema {
+    pub columns: SorbetColumnDescriptors,
+
+    /// The globally unique ID of this chunk,
+    /// if this is a chunk.
+    pub chunk_id: Option<ChunkId>,
+
+    /// Which entity is this chunk for?
+    pub entity_path: Option<EntityPath>,
+
+    /// The heap size of this batch in bytes, if known.
+    pub heap_size_bytes: Option<u64>,
+
+    /// Are we sorted by the row id column?
+    pub is_sorted: bool, // TODO(emilk): move to `RowIdColumnDescriptor`.
+}
+
+/// ## Metadata keys for the record batch metadata
+impl SorbetSchema {
+    /// The key used to identify the version of the Rerun schema.
+    const METADATA_KEY_VERSION: &'static str = "rerun.version";
+
+    /// The version of the Rerun schema.
+    const METADATA_VERSION: &'static str = "1";
+}
+
+impl SorbetSchema {
+    #[inline]
+    pub fn with_heap_size_bytes(mut self, heap_size_bytes: u64) -> Self {
+        self.heap_size_bytes = Some(heap_size_bytes);
+        self
+    }
+
+    #[inline]
+    pub fn with_sorted(mut self, sorted_by_row_id: bool) -> Self {
+        self.is_sorted = sorted_by_row_id;
+        self
+    }
+
+    pub fn chunk_id_metadata(chunk_id: &ChunkId) -> (String, String) {
+        ("rerun.id".to_owned(), format!("{:X}", chunk_id.as_u128()))
+    }
+
+    pub fn entity_path_metadata(entity_path: &EntityPath) -> (String, String) {
+        ("rerun.entity_path".to_owned(), entity_path.to_string())
+    }
+
+    pub fn arrow_batch_metadata(&self) -> ArrowBatchMetadata {
+        let Self {
+            columns: _,
+            chunk_id,
+            entity_path,
+            heap_size_bytes,
+            is_sorted,
+        } = self;
+
+        [
+            Some((
+                Self::METADATA_KEY_VERSION.to_owned(),
+                Self::METADATA_VERSION.to_owned(),
+            )),
+            chunk_id.as_ref().map(Self::chunk_id_metadata),
+            entity_path.as_ref().map(Self::entity_path_metadata),
+            heap_size_bytes.as_ref().map(|heap_size_bytes| {
+                (
+                    "rerun.heap_size_bytes".to_owned(),
+                    heap_size_bytes.to_string(),
+                )
+            }),
+            is_sorted.then(|| ("rerun.is_sorted".to_owned(), "true".to_owned())),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+}
+
+impl TryFrom<&ArrowSchema> for SorbetSchema {
+    type Error = InvalidSorbetSchema;
+
+    fn try_from(arrow_schema: &ArrowSchema) -> Result<Self, Self::Error> {
+        let ArrowSchema { metadata, fields } = arrow_schema;
+
+        let entity_path = metadata
+            .get("rerun.entity_path")
+            .map(|s| EntityPath::parse_forgiving(s));
+
+        let columns = SorbetColumnDescriptors::try_from_arrow_fields(entity_path.as_ref(), fields)?;
+
+        let chunk_id = if let Some(chunk_id_str) = metadata.get("rerun.id") {
+            Some(chunk_id_str.parse().map_err(|err| {
+                InvalidSorbetSchema::custom(format!(
+                    "Failed to deserialize chunk id {chunk_id_str:?}: {err}"
+                ))
+            })?)
+        } else {
+            None
+        };
+
+        let sorted_by_row_id = metadata.get_bool("rerun.is_sorted");
+        let heap_size_bytes = if let Some(heap_size_bytes) = metadata.get("rerun.heap_size_bytes") {
+            heap_size_bytes
+                .parse()
+                .map_err(|err| {
+                    re_log::warn_once!(
+                        "Failed to parse heap_size_bytes {heap_size_bytes:?} in chunk: {err}"
+                    );
+                })
+                .ok()
+        } else {
+            None
+        };
+
+        // Verify version
+        if let Some(batch_version) = metadata.get(Self::METADATA_KEY_VERSION) {
+            if batch_version != Self::METADATA_VERSION {
+                re_log::warn_once!(
+                    "Sorbet batch version mismatch. Expected {:?}, got {batch_version:?}",
+                    Self::METADATA_VERSION
+                );
+            }
+        }
+
+        Ok(Self {
+            columns,
+            chunk_id,
+            entity_path,
+            heap_size_bytes,
+            is_sorted: sorted_by_row_id,
+        })
+    }
+}

--- a/crates/store/re_sorbet/src/sorbet_schema.rs
+++ b/crates/store/re_sorbet/src/sorbet_schema.rs
@@ -150,10 +150,10 @@ impl SorbetColumnDescriptors {
                 }
 
                 ColumnKind::Component => {
-                    components.push(ComponentColumnDescriptor::try_from_arrow_field(
+                    components.push(ComponentColumnDescriptor::from_arrow_field(
                         chunk_entity_path,
                         field,
-                    )?);
+                    ));
                 }
             }
         }

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -114,7 +114,7 @@ impl FilterCommand {
                             match re_sorbet::ChunkSchema::try_from(msg.batch.schema_ref().as_ref())
                             {
                                 Ok(schema) => {
-                                    if !dropped_entity_paths.contains(&schema.entity_path) {
+                                    if !dropped_entity_paths.contains(schema.entity_path()) {
                                         None
                                     } else {
                                         let (fields, columns): (Vec<_>, Vec<_>) = itertools::izip!(

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -294,12 +294,14 @@ impl PyStorageNodeClient {
 
             let column_descriptors = itertools::chain!(
                 chunk_schema
-                    .index_columns
-                    .into_iter()
+                    .index_columns()
+                    .iter()
+                    .cloned()
                     .map(re_sorbet::ColumnDescriptor::Time),
                 chunk_schema
-                    .data_columns
-                    .into_iter()
+                    .data_columns()
+                    .iter()
+                    .cloned()
                     .map(re_sorbet::ColumnDescriptor::Component),
             )
             .collect();

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -299,7 +299,7 @@ impl PyStorageNodeClient {
                     .cloned()
                     .map(re_sorbet::ColumnDescriptor::Time),
                 chunk_schema
-                    .data_columns()
+                    .component_columns()
                     .iter()
                     .cloned()
                     .map(re_sorbet::ColumnDescriptor::Component),


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/8744

### What
Expand `re_sorbet` with `SorbetSchema` and `SorbetBatch` - a superset of the existing `ChunkSchema` and `ChunkBatch`.

### How
I'm using a pretty ~ugly~ interesting approach of "fake inheritance":

Define `A` -> `B` as:
* `struct A` contains a `B`
* `impl Deref<Target=B> for A` (upcasting)
* `impl TryFrom<B> for A` (“downcasting”)
* `impl From<A> for B` (“object slicing”)

Using this notation:
* `ChunkSchema` -> `SorbetSchema`
* `ChunkBatch` -> `SorbetBatch` -> `arrow::RecordBatch`

This means the `ChunkBatch` can be used as `SorbetBatch` but also as an `arrow::RecordBatch`.

Note that there is no dynamic dispatch involved at all.