### PR TITLE
Use `SorbetColumnDescriptors` in `re_dataframe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5870,6 +5870,7 @@ dependencies = [
  "re_types",
  "re_types_core",
  "similar-asserts",
+ "tap",
  "thiserror 1.0.65",
  "tinyvec",
  "web-time",
@@ -6578,6 +6579,7 @@ version = "0.23.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "itertools 0.13.0",
+ "nohash-hasher",
  "re_arrow_util",
  "re_format_arrow",
  "re_log",
@@ -8661,6 +8663,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"

--- a/crates/store/re_chunk_store/Cargo.toml
+++ b/crates/store/re_chunk_store/Cargo.toml
@@ -50,6 +50,7 @@ itertools.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true
 parking_lot = { workspace = true, features = ["arc_lock"] }
+tap.workspace = true
 thiserror.workspace = true
 web-time.workspace = true
 

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -1,11 +1,10 @@
 use std::collections::BTreeMap;
 
 use re_chunk::EntityPath;
-use re_chunk_store::{
-    ChunkStore, ChunkStoreConfig, ChunkStoreHandle, ColumnDescriptor, QueryExpression,
-};
+use re_chunk_store::{ChunkStore, ChunkStoreConfig, ChunkStoreHandle, QueryExpression};
 use re_log_types::{EntityPathFilter, StoreId};
 use re_query::{QueryCache, QueryCacheHandle, StorageEngine, StorageEngineLike};
+use re_sorbet::SorbetColumnDescriptors;
 
 use crate::QueryHandle;
 
@@ -71,7 +70,7 @@ impl<E: StorageEngineLike + Clone> QueryEngine<E> {
     /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
     /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
     #[inline]
-    pub fn schema(&self) -> Vec<ColumnDescriptor> {
+    pub fn schema(&self) -> SorbetColumnDescriptors {
         self.engine.with(|store, _cache| store.schema())
     }
 
@@ -81,7 +80,7 @@ impl<E: StorageEngineLike + Clone> QueryEngine<E> {
     /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
     /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
     #[inline]
-    pub fn schema_for_query(&self, query: &QueryExpression) -> Vec<ColumnDescriptor> {
+    pub fn schema_for_query(&self, query: &QueryExpression) -> SorbetColumnDescriptors {
         self.engine
             .with(|store, _cache| store.schema_for_query(query))
     }

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -174,7 +174,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
             .unwrap_or_else(|| Timeline::new_sequence(""));
 
         // 1. Compute the schema for the query.
-        let view_contents = store.schema_for_query(&self.query);
+        let view_contents = store.schema_for_query(&self.query).indices_and_components();
 
         // 2. Compute the schema of the selected contents.
         //
@@ -353,10 +353,6 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                 })
                 .collect_vec()
         };
-
-        for descr in &view_contents {
-            descr.sanity_check();
-        }
 
         for (_, descr) in &selected_contents {
             descr.sanity_check();

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -32,6 +32,7 @@ use re_chunk_store::{
 };
 use re_log_types::ResolvedTimeRange;
 use re_query::{QueryCache, StorageEngineLike};
+use re_sorbet::SorbetColumnDescriptors;
 use re_types_core::{components::ClearIsRecursive, ComponentDescriptor};
 
 // ---
@@ -76,7 +77,7 @@ struct QueryHandleState {
     /// Describes the columns that make up this view.
     ///
     /// See [`QueryExpression::view_contents`].
-    view_contents: Vec<ColumnDescriptor>,
+    view_contents: SorbetColumnDescriptors,
 
     /// Describes the columns specifically selected to be returned from this view.
     ///
@@ -174,7 +175,8 @@ impl<E: StorageEngineLike> QueryHandle<E> {
             .unwrap_or_else(|| Timeline::new_sequence(""));
 
         // 1. Compute the schema for the query.
-        let view_contents = store.schema_for_query(&self.query).indices_and_components();
+        let view_contents_schema = store.schema_for_query(&self.query);
+        let view_contents = view_contents_schema.indices_and_components();
 
         // 2. Compute the schema of the selected contents.
         //
@@ -359,7 +361,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
         }
 
         QueryHandleState {
-            view_contents,
+            view_contents: view_contents_schema,
             selected_contents,
             selected_static_values,
             filtered_index,
@@ -660,7 +662,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
     ///
     /// See [`QueryExpression::view_contents`].
     #[inline]
-    pub fn view_contents(&self) -> &[ColumnDescriptor] {
+    pub fn view_contents(&self) -> &SorbetColumnDescriptors {
         &self.init().view_contents
     }
 
@@ -1045,7 +1047,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
 
                 for (view_idx, streaming_state) in null_streaming_states {
                     let Some(ColumnDescriptor::Component(descr)) =
-                        state.view_contents.get(view_idx)
+                        state.view_contents.get_index_or_component(view_idx)
                     else {
                         continue;
                     };
@@ -1067,8 +1069,8 @@ impl<E: StorageEngineLike> QueryHandle<E> {
 
                     let results = cache.latest_at(
                         &query,
-                        &descr.entity_path,
-                        [ComponentDescriptor::from(descr)],
+                        &descr.entity_path.clone(),
+                        [ComponentDescriptor::from(descr.clone())],
                     );
 
                     *streaming_state = results
@@ -1178,7 +1180,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                         }
 
                         StreamingJoinState::Retrofilled(unit) => {
-                            let component_desc = state.view_contents.get(view_idx).and_then(|col| match col {
+                            let component_desc = state.view_contents.get_index_or_component(view_idx).and_then(|col| match col {
                                 ColumnDescriptor::Component(descr) => {
                                     descr.component_name.sanity_check();
                                     Some(re_types_core::ComponentDescriptor {

--- a/crates/store/re_sorbet/Cargo.toml
+++ b/crates/store/re_sorbet/Cargo.toml
@@ -30,6 +30,7 @@ re_types_core.workspace = true
 
 arrow.workspace = true
 itertools.workspace = true
+nohash-hasher.workspace = true
 thiserror.workspace = true
 
 # Keep this crate simple, with few dependencies.

--- a/crates/store/re_sorbet/src/chunk_schema.rs
+++ b/crates/store/re_sorbet/src/chunk_schema.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 
 use re_log_types::EntityPath;
@@ -24,8 +26,18 @@ pub struct ChunkSchema {
 }
 
 impl From<ChunkSchema> for SorbetSchema {
+    #[inline]
     fn from(value: ChunkSchema) -> Self {
         value.sorbet
+    }
+}
+
+impl Deref for ChunkSchema {
+    type Target = SorbetSchema;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.sorbet
     }
 }
 

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -169,6 +169,11 @@ impl ComponentColumnDescriptor {
     }
 
     #[inline]
+    pub fn is_static(&self) -> bool {
+        self.is_static
+    }
+
+    #[inline]
     pub fn matches(&self, entity_path: &EntityPath, component_name: &str) -> bool {
         &self.entity_path == entity_path && self.component_name.matches(component_name)
     }

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -53,6 +53,8 @@ impl SorbetColumnDescriptors {
 
     /// Returns all indices and then all components;
     /// skipping the `row_id` column.
+    ///
+    /// See also [`Self::get_index_or_component`].
     pub fn indices_and_components(&self) -> Vec<ColumnDescriptor> {
         itertools::chain!(
             self.indices.iter().cloned().map(ColumnDescriptor::Time),
@@ -62,6 +64,25 @@ impl SorbetColumnDescriptors {
                 .map(ColumnDescriptor::Component),
         )
         .collect()
+    }
+
+    /// Index the index- and component columns, ignoring the `row_id` column completely.
+    ///
+    /// That is, `get_index_or_component(0)` will return the first index column (if any; otherwise
+    /// the first component column).
+    ///
+    /// See also [`Self::indices_and_components`].
+    pub fn get_index_or_component(&self, index_ignoring_row_id: usize) -> Option<ColumnDescriptor> {
+        if index_ignoring_row_id < self.indices.len() {
+            Some(ColumnDescriptor::Time(
+                self.indices[index_ignoring_row_id].clone(),
+            ))
+        } else {
+            self.components
+                .get(index_ignoring_row_id - self.indices.len())
+                .cloned()
+                .map(ColumnDescriptor::Component)
+        }
     }
 
     pub fn arrow_fields(&self) -> Vec<ArrowField> {

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -106,6 +106,7 @@ impl SorbetColumnDescriptors {
 
     /// Keep only the component columns that satisfy the given predicate.
     #[must_use]
+    #[inline]
     pub fn filter_components(mut self, keep: impl Fn(&ComponentColumnDescriptor) -> bool) -> Self {
         self.components.retain(keep);
         self

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -1,10 +1,11 @@
 use arrow::datatypes::{Field as ArrowField, Fields as ArrowFields};
 
+use nohash_hasher::IntSet;
 use re_log_types::EntityPath;
 
 use crate::{
-    ColumnKind, ComponentColumnDescriptor, IndexColumnDescriptor, RowIdColumnDescriptor,
-    SorbetError,
+    ColumnDescriptor, ColumnKind, ComponentColumnDescriptor, IndexColumnDescriptor,
+    RowIdColumnDescriptor, SorbetError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,6 +22,15 @@ pub struct SorbetColumnDescriptors {
 }
 
 impl SorbetColumnDescriptors {
+    /// Debug-only sanity check.
+    #[inline]
+    #[track_caller]
+    pub fn sanity_check(&self) {
+        for component in &self.components {
+            component.sanity_check();
+        }
+    }
+
     /// Total number of columns in this chunk,
     /// including the row id column, the index columns,
     /// and the data columns.
@@ -31,6 +41,27 @@ impl SorbetColumnDescriptors {
             components,
         } = self;
         row_id.is_some() as usize + indices.len() + components.len()
+    }
+
+    /// All unique entity paths present in the view contents.
+    pub fn entity_paths(&self) -> IntSet<EntityPath> {
+        self.components
+            .iter()
+            .map(|col| col.entity_path.clone())
+            .collect()
+    }
+
+    /// Returns all indices and then all components;
+    /// skipping the `row_id` column.
+    pub fn indices_and_components(&self) -> Vec<ColumnDescriptor> {
+        itertools::chain!(
+            self.indices.iter().cloned().map(ColumnDescriptor::Time),
+            self.components
+                .iter()
+                .cloned()
+                .map(ColumnDescriptor::Component),
+        )
+        .collect()
     }
 
     pub fn arrow_fields(&self) -> Vec<ArrowField> {
@@ -50,6 +81,13 @@ impl SorbetColumnDescriptors {
                 .map(|column| column.to_arrow_field(crate::BatchType::Chunk)),
         );
         fields
+    }
+
+    /// Keep only the component columns that satisfy the given predicate.
+    #[must_use]
+    pub fn filter_components(mut self, keep: impl Fn(&ComponentColumnDescriptor) -> bool) -> Self {
+        self.components.retain(keep);
+        self
     }
 }
 

--- a/crates/store/re_sorbet/src/sorbet_schema.rs
+++ b/crates/store/re_sorbet/src/sorbet_schema.rs
@@ -89,6 +89,13 @@ impl SorbetSchema {
     }
 }
 
+impl From<SorbetSchema> for SorbetColumnDescriptors {
+    #[inline]
+    fn from(sorbet_schema: SorbetSchema) -> Self {
+        sorbet_schema.columns
+    }
+}
+
 impl From<&SorbetSchema> for ArrowSchema {
     fn from(sorbet_schema: &SorbetSchema) -> Self {
         Self {

--- a/crates/viewer/re_view_dataframe/src/view_class.rs
+++ b/crates/viewer/re_view_dataframe/src/view_class.rs
@@ -152,7 +152,9 @@ Configure in the selection panel:
             include_tombstone_columns: false,
         };
 
-        let view_columns = query_engine.schema_for_query(&dataframe_query);
+        let view_columns = query_engine
+            .schema_for_query(&dataframe_query)
+            .indices_and_components();
         dataframe_query.selection =
             view_query.apply_column_visibility_to_view_columns(ctx, &view_columns)?;
 

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -1277,7 +1277,7 @@ impl PyRecording {
     /// The schema describing all the columns available in the recording.
     fn schema(&self) -> PySchema {
         PySchema {
-            schema: self.store.read().schema(),
+            schema: self.store.read().schema().indices_and_components(),
         }
     }
 

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -292,22 +292,8 @@ impl PyStorageNodeClient {
             let chunk_schema = re_sorbet::ChunkSchema::try_from(&arrow_schema)
                 .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
-            let column_descriptors = itertools::chain!(
-                chunk_schema
-                    .index_columns()
-                    .iter()
-                    .cloned()
-                    .map(re_sorbet::ColumnDescriptor::Time),
-                chunk_schema
-                    .component_columns()
-                    .iter()
-                    .cloned()
-                    .map(re_sorbet::ColumnDescriptor::Component),
-            )
-            .collect();
-
             Ok(PySchema {
-                schema: column_descriptors,
+                schema: chunk_schema.columns.clone(),
             })
         })
     }


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/8744


### New
```rs
#[derive(Debug, Clone, PartialEq, Eq)]
pub struct SorbetColumnDescriptors {
    /// The primary row id column.
    /// If present, it is always the first column.
    pub row_id: Option<RowIdColumnDescriptor>,

    /// Index columns (timelines).
    pub indices: Vec<IndexColumnDescriptor>,

    /// The actual component data
    pub components: Vec<ComponentColumnDescriptor>,
}
```



### Old
`Vec<ColumnDescriptor>`

```rs
pub enum ColumnDescriptor {
    Time(IndexColumnDescriptor),
    Component(ComponentColumnDescriptor),
}
```

### Shortcomings
The existing code pretty much ignored the row_id column, and I didn't want to change too much, so I keep that indexing intact. At some point I hope to fold the `row_id` into the `indices` columns anyway.