### PR TITLE
Load lerobot dataset on separate IO thread

### DIFF
--- a/crates/store/re_data_loader/src/lerobot.rs
+++ b/crates/store/re_data_loader/src/lerobot.rs
@@ -177,6 +177,11 @@ impl LeRobotDataset {
 
         Ok(Cow::Owned(contents))
     }
+
+    /// Retrieve the task using the provided task index.
+    pub fn task_by_index(&self, task: TaskIndex) -> Option<&LeRobotDatasetTask> {
+        self.metadata.tasks.get(task.0)
+    }
 }
 
 /// Metadata for a `LeRobot` dataset.
@@ -365,6 +370,7 @@ pub enum DType {
     Float32,
     Float64,
     Int64,
+    String,
 }
 
 /// Name metadata for a feature in the `LeRobot` dataset.

--- a/crates/store/re_data_loader/src/lerobot.rs
+++ b/crates/store/re_data_loader/src/lerobot.rs
@@ -177,11 +177,6 @@ impl LeRobotDataset {
 
         Ok(Cow::Owned(contents))
     }
-
-    /// Retrieve the task using the provided task index.
-    pub fn task_by_index(&self, task: TaskIndex) -> Option<&LeRobotDatasetTask> {
-        self.metadata.tasks.get(task.0)
-    }
 }
 
 /// Metadata for a `LeRobot` dataset.
@@ -370,7 +365,6 @@ pub enum DType {
     Float32,
     Float64,
     Int64,
-    String,
 }
 
 /// Name metadata for a feature in the `LeRobot` dataset.

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -14,13 +14,11 @@ use re_chunk::{
 };
 
 use re_log_types::StoreId;
-use re_types::archetypes::{AssetVideo, EncodedImage, TextDocument, VideoFrameReference};
+use re_types::archetypes::{AssetVideo, EncodedImage, VideoFrameReference};
 use re_types::components::{Scalar, VideoTimestamp};
 use re_types::{Archetype, Component, ComponentBatch};
 
-use crate::lerobot::{
-    is_le_robot_dataset, DType, EpisodeIndex, Feature, LeRobotDataset, TaskIndex,
-};
+use crate::lerobot::{is_le_robot_dataset, DType, EpisodeIndex, Feature, LeRobotDataset};
 use crate::{DataLoader, DataLoaderError, LoadedData};
 
 /// Columns in the `LeRobot` dataset schema that we do not visualize in the viewer, and thus ignore.
@@ -160,12 +158,7 @@ fn load_episode(
                 )?);
             }
             DType::Image => chunks.extend(log_episode_images(feature_key, &timeline, &data)?),
-            DType::Int64 if feature_key == "task_index" => {
-                // special case int64 task_index columns
-                // this always refers to the task description in the dataset metadata.
-                chunks.extend(log_episode_task(dataset, &timeline, &data)?);
-            }
-            DType::Int64 | DType::Bool | DType::String => {
+            DType::Int64 | DType::Bool => {
                 re_log::warn_once!(
                     "Loading LeRobot feature ({}) of dtype `{:?}` into Rerun is not yet implemented",
                     feature_key,
@@ -179,42 +172,6 @@ fn load_episode(
     }
 
     Ok(chunks)
-}
-
-fn log_episode_task(
-    dataset: &LeRobotDataset,
-    timeline: &Timeline,
-    data: &RecordBatch,
-) -> Result<impl ExactSizeIterator<Item = Chunk>, DataLoaderError> {
-    let task_indices = data
-        .column_by_name("task_index")
-        .and_then(|c| c.downcast_array_ref::<Int64Array>())
-        .with_context(|| "Failed to get task_index field from dataset!")?;
-
-    let mut chunk = Chunk::builder("task".into());
-    let mut row_id = RowId::new();
-    let mut time_int = TimeInt::ZERO;
-
-    for task_index in task_indices {
-        let Some(task) = task_index
-            .and_then(|i| usize::try_from(i).ok())
-            .and_then(|i| dataset.task_by_index(TaskIndex(i)))
-        else {
-            // if there is no valid task for the current frame index, we skip it.
-            time_int = time_int.inc();
-            continue;
-        };
-
-        let mut timepoint = TimePoint::default();
-        timepoint.insert(*timeline, time_int);
-        let text = TextDocument::new(task.task.clone());
-        chunk = chunk.with_archetype(row_id, timepoint, &text);
-
-        row_id = row_id.next();
-        time_int = time_int.inc();
-    }
-
-    Ok(std::iter::once(chunk.build()?))
 }
 
 fn log_episode_images(

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -149,7 +149,7 @@ fn load_episode(
     {
         match feature.dtype {
             DType::Video => {
-                chunks.extend(log_episode_video(
+                chunks.extend(load_episode_video(
                     dataset,
                     feature_key,
                     episode,
@@ -157,7 +157,7 @@ fn load_episode(
                     time_column.clone(),
                 )?);
             }
-            DType::Image => chunks.extend(log_episode_images(feature_key, &timeline, &data)?),
+            DType::Image => chunks.extend(load_episode_images(feature_key, &timeline, &data)?),
             DType::Int64 | DType::Bool => {
                 re_log::warn_once!(
                     "Loading LeRobot feature ({}) of dtype `{:?}` into Rerun is not yet implemented",
@@ -174,7 +174,7 @@ fn load_episode(
     Ok(chunks)
 }
 
-fn log_episode_images(
+fn load_episode_images(
     observation: &str,
     timeline: &Timeline,
     data: &RecordBatch,
@@ -206,7 +206,7 @@ fn log_episode_images(
     })?))
 }
 
-fn log_episode_video(
+fn load_episode_video(
     dataset: &LeRobotDataset,
     observation: &str,
     episode: EpisodeIndex,

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -14,21 +14,18 @@ use re_chunk::{
 };
 
 use re_log_types::StoreId;
-use re_types::archetypes::{AssetVideo, EncodedImage, VideoFrameReference};
+use re_types::archetypes::{AssetVideo, EncodedImage, TextDocument, VideoFrameReference};
 use re_types::components::{Scalar, VideoTimestamp};
 use re_types::{Archetype, Component, ComponentBatch};
 
-use crate::lerobot::{is_le_robot_dataset, DType, EpisodeIndex, Feature, LeRobotDataset};
+use crate::lerobot::{
+    is_le_robot_dataset, DType, EpisodeIndex, Feature, LeRobotDataset, TaskIndex,
+};
 use crate::{DataLoader, DataLoaderError, LoadedData};
 
 /// Columns in the `LeRobot` dataset schema that we do not visualize in the viewer, and thus ignore.
-const LEROBOT_DATASET_IGNORED_COLUMNS: &[&str] = &[
-    "episode_index",
-    "task_index",
-    "index",
-    "frame_index",
-    "timestamp",
-];
+const LEROBOT_DATASET_IGNORED_COLUMNS: &[&str] =
+    &["episode_index", "index", "frame_index", "timestamp"];
 
 /// A [`DataLoader`] for `LeRobot` datasets.
 ///
@@ -157,7 +154,12 @@ fn load_episode(
                 )?);
             }
             DType::Image => chunks.extend(log_episode_images(feature_key, &timeline, &data)?),
-            DType::Int64 | DType::Bool => {
+            DType::Int64 if feature_key == "task_index" => {
+                // special case int64 task_index columns
+                // this always refers to the task description in the dataset metadata.
+                chunks.extend(log_episode_task(dataset, &timeline, &data)?);
+            }
+            DType::Int64 | DType::Bool | DType::String => {
                 re_log::warn_once!(
                     "Loading LeRobot feature ({}) of dtype `{:?}` into Rerun is not yet implemented",
                     feature_key,
@@ -171,6 +173,42 @@ fn load_episode(
     }
 
     Ok(chunks)
+}
+
+fn log_episode_task(
+    dataset: &LeRobotDataset,
+    timeline: &Timeline,
+    data: &RecordBatch,
+) -> Result<impl ExactSizeIterator<Item = Chunk>, DataLoaderError> {
+    let task_indices = data
+        .column_by_name("task_index")
+        .and_then(|c| c.downcast_array_ref::<Int64Array>())
+        .with_context(|| "Failed to get task_index field from dataset!")?;
+
+    let mut chunk = Chunk::builder("task".into());
+    let mut row_id = RowId::new();
+    let mut time_int = TimeInt::ZERO;
+
+    for task_index in task_indices {
+        let Some(task) = task_index
+            .and_then(|i| usize::try_from(i).ok())
+            .and_then(|i| dataset.task_by_index(TaskIndex(i)))
+        else {
+            // if there is no valid task for the current frame index, we skip it.
+            time_int = time_int.inc();
+            continue;
+        };
+
+        let mut timepoint = TimePoint::default();
+        timepoint.insert(*timeline, time_int);
+        let text = TextDocument::new(task.task.clone());
+        chunk = chunk.with_archetype(row_id, timepoint, &text);
+
+        row_id = row_id.next();
+        time_int = time_int.inc();
+    }
+
+    Ok(std::iter::once(chunk.build()?))
 }
 
 fn log_episode_images(

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -71,7 +71,7 @@ impl crate::DataLoader for RrdLoader {
                             );
                         }
                     })
-                    .with_context(|| format!("Failed to open spawn IO thread for {filepath:?}"))?;
+                    .with_context(|| format!("Failed to spawn IO thread for {filepath:?}"))?;
             }
 
             "rrd" => {
@@ -95,7 +95,7 @@ impl crate::DataLoader for RrdLoader {
                             );
                         }
                     })
-                    .with_context(|| format!("Failed to open spawn IO thread for {filepath:?}"))?;
+                    .with_context(|| format!("Failed to spawn IO thread for {filepath:?}"))?;
             }
             _ => unreachable!(),
         }


### PR DESCRIPTION
### What

This runs the LeRobot dataset loader on a separate IO thread to avoid blocking the ui.
