### PR TITLE
Make `SeriesLine` visualizer work with several scalars per time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "experimental_multi_scalar"
+version = "0.23.0-alpha.1+dev"
+dependencies = [
+ "rerun",
+]
+
+[[package]]
 name = "extend_viewer_ui"
 version = "0.23.0-alpha.1+dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "examples/rust/*",
   "rerun_py",
   "run_wasm",
+  "tests/rust/experimental_multi_scalar",
   "tests/rust/log_benchmark",
   "tests/rust/plot_dashboard_stress",
   "tests/rust/roundtrips/*",

--- a/crates/store/re_types/src/components/name_ext.rs
+++ b/crates/store/re_types/src/components/name_ext.rs
@@ -23,6 +23,12 @@ impl AsRef<str> for Name {
     }
 }
 
+impl std::fmt::Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 impl std::borrow::Borrow<str> for Name {
     #[inline]
     fn borrow(&self) -> &str {

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -228,14 +228,12 @@ impl SeriesLineSystem {
             // Keep in mind clears here.
             let num_series = all_scalar_chunks
                 .iter()
-                .next()
-                .and_then(|chunk| chunk.iter_slices::<f64>(Scalar::name()).next())
-                .map(|slice| slice.len())
+                .find_map(|chunk| {
+                    chunk
+                        .iter_slices::<f64>(Scalar::name())
+                        .find_map(|slice| (!slice.is_empty()).then_some(slice.len()))
+                })
                 .unwrap_or(1);
-            if num_series == 0 {
-                re_log::warn_once!("Empty scalar array found for {entity_path:?}");
-                return;
-            }
 
             // Allocate all points.
             {

--- a/docs/snippets/all/archetypes/scalar_simple.rs
+++ b/docs/snippets/all/archetypes/scalar_simple.rs
@@ -6,11 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log the data on a timeline called "step".
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log(
-            "scalar",
-            &rerun::Scalar::update_fields()
-                .with_many_scalar([(step as f64 / 10.0).sin(), (step as f64 / 10.0).cos()]),
-        )?;
+        rec.log("scalar", &rerun::Scalar::new((step as f64 / 10.0).sin()))?;
     }
 
     Ok(())

--- a/docs/snippets/all/archetypes/scalar_simple.rs
+++ b/docs/snippets/all/archetypes/scalar_simple.rs
@@ -6,7 +6,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log the data on a timeline called "step".
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log("scalar", &rerun::Scalar::new((step as f64 / 10.0).sin()))?;
+        rec.log(
+            "scalar",
+            &rerun::Scalar::update_fields()
+                .with_many_scalar([(step as f64 / 10.0).sin(), (step as f64 / 10.0).cos()]),
+        )?;
     }
 
     Ok(())

--- a/tests/rust/experimental_multi_scalar/Cargo.toml
+++ b/tests/rust/experimental_multi_scalar/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "experimental_multi_scalar"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rerun = { path = "../../../crates/top/rerun" }
+
+# TODO(#9005): Remove this "test" again. This should be a proper snippet.

--- a/tests/rust/experimental_multi_scalar/src/main.rs
+++ b/tests/rust/experimental_multi_scalar/src/main.rs
@@ -39,13 +39,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ])
                 .with_many_width([64.0 - step as f32, step as f32]),
         )?;
-        rec.log(
-            "multi_colored",
-            &rerun::Scalar::update_fields().with_many_scalar([
-                (step as f64 / 10.0).sin() + 2.0,
-                (step as f64 / 10.0).cos() + 2.0,
-            ]),
-        )?;
+
+        match step {
+            32..40 => {
+                // Partial gap.
+                rec.log(
+                    "multi_colored",
+                    &rerun::Scalar::update_fields()
+                        .with_many_scalar([(step as f64 / 10.0).sin() + 2.0]),
+                )?;
+            }
+
+            40 => {
+                // full gap
+                rec.log("multi_colored", &rerun::Clear::new(false))?;
+            }
+            41..60 => {}
+
+            _ => {
+                rec.log(
+                    "multi_colored",
+                    &rerun::Scalar::update_fields().with_many_scalar([
+                        (step as f64 / 10.0).sin() + 2.0,
+                        (step as f64 / 10.0).cos() + 2.0,
+                    ]),
+                )?;
+            }
+        }
     }
 
     Ok(())

--- a/tests/rust/experimental_multi_scalar/src/main.rs
+++ b/tests/rust/experimental_multi_scalar/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     rerun::Color::from_rgb(step * 4, 255 - step * 4, 0),
                     rerun::Color::from_rgb(0, step * 4, 255 - step * 4),
                 ])
-                .with_many_width([64.0 - step as f32, step as f32]),
+                .with_many_width([(64.0 - step as f32) * 0.5, step as f32 * 0.5]),
         )?;
 
         match step {
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // full gap
                 rec.log("multi_colored", &rerun::Clear::new(false))?;
             }
-            41..60 => {}
+            41..55 => {}
 
             _ => {
                 rec.log(

--- a/tests/rust/experimental_multi_scalar/src/main.rs
+++ b/tests/rust/experimental_multi_scalar/src/main.rs
@@ -3,6 +3,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
 
+    // Simple: Static color & stroke width.
+
     rec.log_static(
         "scalar",
         &rerun::SeriesLine::new()
@@ -10,6 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 rerun::Color::from_rgb(255, 0, 0),
                 rerun::Color::from_rgb(0, 0, 255),
             ])
+            .with_many_width([2.0, 4.0])
             .with_many_name(["sin", "cos"]),
     )?;
 
@@ -22,15 +25,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )?;
     }
 
+    // Complex: Color & stroke width changing over time.
+
     for step in 0..64 {
         rec.set_time_sequence("step", step);
 
         rec.log(
             "multi_colored",
-            &rerun::SeriesLine::new().with_many_color([
-                rerun::Color::from_rgb(step * 4, 255 - step * 4, 0),
-                rerun::Color::from_rgb(0, step * 4, 255 - step * 4),
-            ]),
+            &rerun::SeriesLine::new()
+                .with_many_color([
+                    rerun::Color::from_rgb(step * 4, 255 - step * 4, 0),
+                    rerun::Color::from_rgb(0, step * 4, 255 - step * 4),
+                ])
+                .with_many_width([64.0 - step as f32, step as f32]),
         )?;
         rec.log(
             "multi_colored",

--- a/tests/rust/experimental_multi_scalar/src/main.rs
+++ b/tests/rust/experimental_multi_scalar/src/main.rs
@@ -5,10 +5,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log_static(
         "scalar",
-        &rerun::SeriesLine::new().with_many_color([
-            rerun::Color::from_rgb(255, 0, 0),
-            rerun::Color::from_rgb(0, 0, 255),
-        ]),
+        &rerun::SeriesLine::new()
+            .with_many_color([
+                rerun::Color::from_rgb(255, 0, 0),
+                rerun::Color::from_rgb(0, 0, 255),
+            ])
+            .with_many_name(["sin", "cos"]),
     )?;
 
     for step in 0..64 {

--- a/tests/rust/experimental_multi_scalar/src/main.rs
+++ b/tests/rust/experimental_multi_scalar/src/main.rs
@@ -1,0 +1,43 @@
+//! Experimenting with multi-scalar logging.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_scalar").spawn()?;
+
+    rec.log_static(
+        "scalar",
+        &rerun::SeriesLine::new().with_many_color([
+            rerun::Color::from_rgb(255, 0, 0),
+            rerun::Color::from_rgb(0, 0, 255),
+        ]),
+    )?;
+
+    for step in 0..64 {
+        rec.set_time_sequence("step", step);
+        rec.log(
+            "scalar",
+            &rerun::Scalar::update_fields()
+                .with_many_scalar([(step as f64 / 10.0).sin(), (step as f64 / 10.0).cos()]),
+        )?;
+    }
+
+    for step in 0..64 {
+        rec.set_time_sequence("step", step);
+
+        rec.log(
+            "multi_colored",
+            &rerun::SeriesLine::new().with_many_color([
+                rerun::Color::from_rgb(step * 4, 255 - step * 4, 0),
+                rerun::Color::from_rgb(0, step * 4, 255 - step * 4),
+            ]),
+        )?;
+        rec.log(
+            "multi_colored",
+            &rerun::Scalar::update_fields().with_many_scalar([
+                (step as f64 / 10.0).sin() + 2.0,
+                (step as f64 / 10.0).cos() + 2.0,
+            ]),
+        )?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Related

* Fixes [#9019](https://github.com/rerun-io/rerun/issues/9019)

### What

![image](https://github.com/user-attachments/assets/1cb3cb59-667c-4216-97b5-910964e8be0d)

Try the example in the browser: 
https://rerun.io/viewer/pr/9033?url=https://static.rerun.io/rrd/0.22.0/multiplot_0a77742f7ddd55361c4b7bd9976caa1cc45f9c14.rrd


`SeriesLine` visualizer now operates _as-if_...
* scalars was a primary component (not new really actually) which is an array of arbitrary length on each timestamp
* colors, name and stroke-width are components that are splatted upon each scalar

**In other words: Single entity, multiple plots**

To test this out I added a manual "test" for now (to be removed again) which tests both static & varying color & widths as well as gaps.

In a follow-up I'll add automated tests for this.
This PR intentionally does NOT touch any APIs. Logging happens right now via the same generic APIs we use for column batches. That API didn't really make sense before here but works pretty much how one would expect, begging the question if this isn't already good enough 🤔 

Performance before/after was verified to be unchanged using
`cargo run --release --bin plot_dashboard_stress -- --num-plots 16 --num-series-per-plot 32`
(curiously it actually improved a lil bit from 30.1ms 29.6ms overall viewer time but that's probably just measurement fluctuation / background task activity)
![after](https://github.com/user-attachments/assets/08a347b3-f3f4-4398-80ad-db24f45057ab)
