### PR TITLE
Fix time series marker sizes not being able to vary over time

### DIFF
--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -377,7 +377,7 @@ impl SeriesPointSystem {
                             itertools::izip!(
                                 chunk
                                     .iter_component_indices(&query.timeline(), &MarkerSize::name()),
-                                chunk.iter_slices::<f32>(Color::name())
+                                chunk.iter_slices::<f32>(MarkerSize::name())
                             )
                         });
 


### PR DESCRIPTION
Small bug I found while adding tests.

With this fix, you can change the size of a point in a point series over time

![image](https://github.com/user-attachments/assets/fa4843ac-22a0-4974-8639-2a8608d380b3)