### PR TITLE
Gijs/lerobot depth image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6699,6 +6699,7 @@ dependencies = [
  "similar-asserts",
  "smallvec",
  "thiserror 1.0.65",
+ "tiff",
  "uuid",
 ]
 

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -311,10 +311,9 @@ fn load_episode_depth_images(
     for idx in 0..image_bytes.len() {
         let img_buffer = image_bytes.value(idx);
         let depth_image = DepthImage::from_file_contents(img_buffer.to_owned());
-        let encoded_image = EncodedImage::from_file_contents(img_buffer.to_owned());
         let mut timepoint = TimePoint::default();
         timepoint.insert(*timeline, time_int);
-        chunk = chunk.with_archetype(row_id, timepoint, &encoded_image);
+        chunk = chunk.with_archetype(row_id, timepoint, &depth_image);
 
         row_id = row_id.next();
         time_int = time_int.inc();

--- a/crates/store/re_types/Cargo.toml
+++ b/crates/store/re_types/Cargo.toml
@@ -79,6 +79,7 @@ once_cell.workspace = true
 ply-rs.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
+tiff = { version = "0.9.1" }
 uuid = { workspace = true, features = ["serde", "v4", "js"] }
 
 # External (optional)

--- a/crates/store/re_types/src/archetypes/depth_image_ext.rs
+++ b/crates/store/re_types/src/archetypes/depth_image_ext.rs
@@ -79,20 +79,130 @@ impl DepthImage {
                         let dimensions = decoder.dimensions().expect("failed to get dimensions");
                         let img = decoder.read_image().expect("failed to read");
 
-                        let channel_type = match img {
-                            tiff::decoder::DecodingResult::U8(_) => ChannelDatatype::U8,
-                            tiff::decoder::DecodingResult::U16(_) => ChannelDatatype::U16,
-                            tiff::decoder::DecodingResult::U32(_) => ChannelDatatype::U32,
-                            tiff::decoder::DecodingResult::U64(_) => ChannelDatatype::U64,
-                            tiff::decoder::DecodingResult::F32(_) => ChannelDatatype::F32,
-                            tiff::decoder::DecodingResult::F64(_) => ChannelDatatype::F64,
-                            tiff::decoder::DecodingResult::I8(_) => ChannelDatatype::I8,
-                            tiff::decoder::DecodingResult::I16(_) => ChannelDatatype::I16,
-                            tiff::decoder::DecodingResult::I32(_) => ChannelDatatype::I32,
-                            tiff::decoder::DecodingResult::I64(_) => ChannelDatatype::I64,
+                        let img_buffer = match img {
+                            tiff::decoder::DecodingResult::U8(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::U8,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::U16(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::U16,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::U32(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::U32,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::U64(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::U64,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::F32(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::F32,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::F64(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::F64,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::I8(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::I8,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::I16(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::I16,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::I32(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::I32,
+                                )
+                            }
+                            tiff::decoder::DecodingResult::I64(data) => {
+                                Self::from_data_type_and_bytes(
+                                    ImageBuffer::from_elements(
+                                        &data,
+                                        dimensions.into(),
+                                        ColorModel::L,
+                                    )
+                                    .0,
+                                    dimensions.into(),
+                                    ChannelDatatype::I64,
+                                )
+                            }
                         };
 
-                        Self::from_data_type_and_bytes(img, dimensions.into(), channel_type)
+                        img_buffer
                     }
                     _ => panic!("eh"),
                 };

--- a/crates/store/re_types/src/components/image_buffer_ext.rs
+++ b/crates/store/re_types/src/components/image_buffer_ext.rs
@@ -1,14 +1,12 @@
 #[cfg(feature = "image")]
 use crate::{datatypes::ColorModel, image::ImageChannelType};
 
-#[cfg(feature = "image")]
 use super::{ImageBuffer, ImageFormat};
 
-#[cfg(feature = "image")]
 impl ImageBuffer {
     /// Utility method for constructing an image & format
     /// from a byte buffer given its resolution and using the data type of the given vector.
-    fn from_elements<T: ImageChannelType>(
+    pub fn from_elements<T: ImageChannelType>(
         elements: &[T],
         [width, height]: [u32; 2],
         color_model: ColorModel,
@@ -30,6 +28,7 @@ impl ImageBuffer {
     /// Construct an image buffer & image format from something that can be turned into a [`image::DynamicImage`].
     ///
     /// Requires the `image` feature.
+    #[cfg(feature = "image")]
     pub fn from_image(
         image: impl Into<image::DynamicImage>,
     ) -> Result<(Self, ImageFormat), crate::image::ImageConversionError> {
@@ -39,6 +38,7 @@ impl ImageBuffer {
     /// Construct an image buffer & image format from [`image::DynamicImage`].
     ///
     /// Requires the `image` feature.
+    #[cfg(feature = "image")]
     pub fn from_dynamic_image(
         image: image::DynamicImage,
     ) -> Result<(Self, ImageFormat), crate::image::ImageConversionError> {

--- a/crates/store/re_types/src/components/image_buffer_ext.rs
+++ b/crates/store/re_types/src/components/image_buffer_ext.rs
@@ -6,7 +6,7 @@ use super::{ImageBuffer, ImageFormat};
 impl ImageBuffer {
     /// Utility method for constructing an image & format
     /// from a byte buffer given its resolution and using the data type of the given vector.
-    pub fn from_elements<T: ImageChannelType>(
+    fn from_elements<T: ImageChannelType>(
         elements: &[T],
         [width, height]: [u32; 2],
         color_model: ColorModel,


### PR DESCRIPTION
### Related

Closes #8970

### What

When loading a Le Robot dataset, we now load any depth images into the viewer as depth images as well.

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/76db96a9-1e41-4cde-9486-f9f6618ae1e6" />

_Task 362 from_ [agibot-world/AgiBotWorld-Alpha](https://huggingface.co/datasets/agibot-world/AgiBotWorld-Alpha)