### PR TITLE
Fix inconsistencies in plot highlights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,8 +2166,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1794c66fb727dac28dffed2e4b548e5118d1cccc331d368a35411d68725dde71"
+source = "git+https://github.com/emilk/egui_plot.git?branch=legend-reporting-hover#d47bb2a63882768d32c5d77237d50fc147ae065f"
 dependencies = [
  "ahash",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.31.0"
-source = "git+https://github.com/emilk/egui_plot.git?branch=legend-reporting-hover#d47bb2a63882768d32c5d77237d50fc147ae065f"
+source = "git+https://github.com/emilk/egui_plot.git?branch=main#99303b45554581163f022a8cf0b1a40e6fd3d333"
 dependencies = [
  "ahash",
  "egui",
@@ -3930,7 +3930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -592,7 +592,7 @@ significant_drop_tightening = "allow" # An update of parking_lot made this trigg
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-# egui_plot = { git = "https://github.com/emilk/egui_plot.git", branch = "main" }
+egui_plot = { git = "https://github.com/emilk/egui_plot.git", branch = "legend-reporting-hover" }
 # egui_plot = { path = "../../egui_plot/egui_plot" }
 
 # egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", branch = "emilk/update-egui" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -592,7 +592,7 @@ significant_drop_tightening = "allow" # An update of parking_lot made this trigg
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-egui_plot = { git = "https://github.com/emilk/egui_plot.git", branch = "legend-reporting-hover" }
+egui_plot = { git = "https://github.com/emilk/egui_plot.git", branch = "main" } # 2025-02-18 - legend hover reports as hovered items
 # egui_plot = { path = "../../egui_plot/egui_plot" }
 
 # egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", branch = "emilk/update-egui" }

--- a/crates/viewer/re_view_time_series/src/lib.rs
+++ b/crates/viewer/re_view_time_series/src/lib.rs
@@ -11,8 +11,9 @@ mod point_visualizer_system;
 mod util;
 mod view_class;
 
-use re_log_types::EntityPath;
 use re_types::components::{AggregationPolicy, MarkerShape};
+use re_viewer_context::external::re_entity_db::InstancePath;
+
 pub use view_class::TimeSeriesView;
 
 /// Computes a deterministic, globally unique ID for the plot based on the ID of the view
@@ -83,7 +84,7 @@ pub struct PlotSeries {
 
     pub kind: PlotSeriesKind,
     pub points: Vec<(i64, f64)>,
-    pub entity_path: EntityPath,
+    pub instance_path: InstancePath,
 
     /// Earliest time an entity was recorded at on the current timeline.
     pub min_time: i64,

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -11,6 +11,7 @@ use re_types::{
     Archetype as _, Component, Loggable,
 };
 use re_view::{clamped_or_nothing, range_with_blueprint_resolved_data};
+use re_viewer_context::external::re_entity_db::InstancePath;
 use re_viewer_context::{
     auto_color_egui, auto_color_for_entity_path, IdentifiedViewSystem, QueryContext,
     TypedComponentFallbackProvider, ViewContext, ViewQuery, ViewStateExt as _,
@@ -534,9 +535,22 @@ impl SeriesLineSystem {
             }
 
             debug_assert_eq!(points_per_series.len(), series_names.len());
-            for (points, label) in points_per_series.into_iter().zip(series_names.into_iter()) {
+            for (instance, (points, label)) in points_per_series
+                .into_iter()
+                .zip(series_names.into_iter())
+                .enumerate()
+            {
+                let instance_path = if num_series == 1 {
+                    InstancePath::entity_all(data_result.entity_path.clone())
+                } else {
+                    InstancePath::instance(
+                        data_result.entity_path.clone(),
+                        (instance as u64).into(),
+                    )
+                };
+
                 points_to_series(
-                    &data_result.entity_path,
+                    instance_path,
                     time_per_pixel,
                     points,
                     ctx.recording_engine().store(),

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -8,9 +8,9 @@ use re_types::{
 };
 use re_view::range_with_blueprint_resolved_data;
 use re_viewer_context::{
-    auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, TypedComponentFallbackProvider,
-    ViewContext, ViewQuery, ViewStateExt as _, ViewSystemExecutionError, VisualizerQueryInfo,
-    VisualizerSystem,
+    auto_color_for_entity_path, external::re_entity_db::InstancePath, IdentifiedViewSystem,
+    QueryContext, TypedComponentFallbackProvider, ViewContext, ViewQuery, ViewStateExt as _,
+    ViewSystemExecutionError, VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
@@ -472,7 +472,7 @@ impl SeriesPointSystem {
 
             // Now convert the `PlotPoints` into `Vec<PlotSeries>`
             points_to_series(
-                &data_result.entity_path,
+                InstancePath::entity_all(data_result.entity_path.clone()),
                 time_per_pixel,
                 points,
                 ctx.recording_engine().store(),

--- a/crates/viewer/re_view_time_series/src/util.rs
+++ b/crates/viewer/re_view_time_series/src/util.rs
@@ -1,9 +1,9 @@
-use re_log_types::{EntityPath, ResolvedTimeRange};
+use re_log_types::ResolvedTimeRange;
 use re_types::{
     components::AggregationPolicy,
     datatypes::{TimeRange, TimeRangeBoundary},
 };
-use re_viewer_context::{ViewQuery, ViewerContext};
+use re_viewer_context::{external::re_entity_db::InstancePath, ViewQuery, ViewerContext};
 
 use crate::{
     aggregation::{AverageAggregator, MinMaxAggregator},
@@ -82,7 +82,7 @@ pub fn determine_time_range(
 // we notice a change in attributes, we need a new series.
 #[allow(clippy::too_many_arguments)]
 pub fn points_to_series(
-    entity_path: &EntityPath,
+    instance_path: InstancePath,
     time_per_pixel: f64,
     points: Vec<PlotPoint>,
     store: &re_chunk_store::ChunkStore,
@@ -91,14 +91,14 @@ pub fn points_to_series(
     aggregator: AggregationPolicy,
     all_series: &mut Vec<PlotSeries>,
 ) {
-    re_tracing::profile_scope!("secondary", &entity_path.to_string());
+    re_tracing::profile_scope!("secondary", &instance_path.to_string());
     if points.is_empty() {
         return;
     }
 
     let (aggregation_factor, points) = apply_aggregation(aggregator, time_per_pixel, points, query);
     let min_time = store
-        .entity_min_time(&query.timeline, entity_path)
+        .entity_min_time(&query.timeline, &instance_path.entity_path)
         .map_or(points.first().map_or(0, |p| p.time), |time| time.as_i64());
 
     if points.len() == 1 {
@@ -114,7 +114,7 @@ pub fn points_to_series(
             radius_ui: points[0].attrs.radius_ui,
             kind,
             points: vec![(points[0].time, points[0].value)],
-            entity_path: entity_path.clone(),
+            instance_path,
             aggregator,
             aggregation_factor,
             min_time,
@@ -123,7 +123,7 @@ pub fn points_to_series(
         add_series_runs(
             series_label,
             points,
-            entity_path,
+            instance_path,
             aggregator,
             aggregation_factor,
             min_time,
@@ -203,7 +203,7 @@ pub fn apply_aggregation(
 fn add_series_runs(
     series_label: String,
     points: Vec<PlotPoint>,
-    entity_path: &EntityPath,
+    instance_path: InstancePath,
     aggregator: AggregationPolicy,
     aggregation_factor: f64,
     min_time: i64,
@@ -219,7 +219,7 @@ fn add_series_runs(
         radius_ui: attrs.radius_ui,
         points: Vec::with_capacity(num_points),
         kind: attrs.kind,
-        entity_path: entity_path.clone(),
+        instance_path: instance_path.clone(),
         aggregator,
         aggregation_factor,
         min_time,
@@ -243,7 +243,7 @@ fn add_series_runs(
                     radius_ui: attrs.radius_ui,
                     kind: attrs.kind,
                     points: Vec::with_capacity(num_points - i),
-                    entity_path: entity_path.clone(),
+                    instance_path: instance_path.clone(),
                     aggregator,
                     aggregation_factor,
                     min_time,

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -94,6 +94,11 @@ impl InteractionHighlight {
             hover: self.hover.max(other.hover),
         }
     }
+
+    /// Returns true if either selection or hover is active.
+    pub fn any(&self) -> bool {
+        self.selection != SelectionHighlight::None || self.hover != HoverHighlight::None
+    }
 }
 
 /// An ordered collection of [`Item`] and optional associated context objects.


### PR DESCRIPTION
### Related

* To fully work needs https://github.com/emilk/egui_plot/pull/81

### What

Noticed these issues while looking into solving
* https://github.com/rerun-io/rerun/issues/4974

I noticed that syncing of highlights is also all over the place. Seemed related enough to sort it out right away!



https://github.com/user-attachments/assets/57ad14f9-a586-4ca9-bb19-b2a2116ebbc7


Drawback is that for some already large markers this may be a bit too noisy:


https://github.com/user-attachments/assets/74c8d3c5-31ee-4bca-8463-4b8659715fa2

But I believe it's the right tradeoff!



Internally it also moves over to `InstancePath` over `EntityPath` for plot association in order to handle multi-scalar cases without surprises.