### PR TITLE
Introduce a `LogMsg` that keeps track of its origins in bytes

### DIFF
--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -1,6 +1,7 @@
 //! Decoding [`LogMsg`]:es from `.rrd` files/streams.
 
 pub mod stream;
+
 #[cfg(feature = "decoder")]
 pub mod streaming;
 


### PR DESCRIPTION
This introduces `StreamingLogMsg` (which is a terrible name, holy), which encapsulates a `LogMsg` and tells you exactly where, in terms of byte, you can find that data in the underlying storage.