### PR TITLE
Fix default handling of URIs without an endpoint

### DIFF
--- a/crates/store/re_grpc_client/src/redap/address.rs
+++ b/crates/store/re_grpc_client/src/redap/address.rs
@@ -228,7 +228,7 @@ impl TryFrom<&str> for RedapAddress {
                 origin,
                 recording_id: (*recording_id).to_owned(),
             }),
-            ["catalog"] | [] => Ok(Self::Catalog { origin }),
+            ["catalog" | ""] | [] => Ok(Self::Catalog { origin }),
             [unknown, ..] => Err(ConnectionError::UnexpectedEndpoint(format!("{unknown}/"))),
         }
     }
@@ -341,7 +341,28 @@ mod tests {
 
         assert!(matches!(
             address.unwrap_err(),
-            super::ConnectionError::UnexpectedEndpoint { .. }
+            super::ConnectionError::UnexpectedEndpoint(unknown) if &unknown == "redap/"
         ));
+    }
+
+    #[test]
+    fn test_catalog_default() {
+        let url = "rerun://localhost:51234";
+        let address: Result<RedapAddress, _> = url.try_into();
+
+        let expected = RedapAddress::Catalog {
+            origin: Origin {
+                scheme: Scheme::Rerun,
+                host: url::Host::Domain("localhost".to_string()),
+                port: 51234,
+            },
+        };
+
+        assert_eq!(address.unwrap(), expected);
+
+        let url = "rerun://localhost:51234/";
+        let address: Result<RedapAddress, _> = url.try_into();
+
+        assert_eq!(address.unwrap(), expected);
     }
 }


### PR DESCRIPTION
### What

Previously, `rerun://localhost:51234` and `rerun://localhost:51234/` didn't forward to `catalog/` because of an error in the parsing logic.

Added test cases.
