### PR TITLE
Improve `image_column_updates` python example

### DIFF
--- a/docs/snippets/all/archetypes/image_column_updates.py
+++ b/docs/snippets/all/archetypes/image_column_updates.py
@@ -29,8 +29,7 @@ rr.send_columns(
     indexes=[rr.TimeSequenceColumn("step", times)],
     # Reshape the images so `Image` can tell that this is several blobs.
     #
-    # Note that the `Image` consumes arrays of bytes, so if you have a different channel
-    # datatype than `U8`, you need to make sure that the data is converted to arrays of bytes
-    # before passing it to `Image`.
-    columns=rr.Image.columns(buffer=images.reshape(len(times), -1)),
+    # Note that the `Image` consumes arrays of bytes, so we should ensure that we take a
+    # uint8 view of it. This way, this also works when working with datatypes other than `U8`.
+    columns=rr.Image.columns(buffer=images.view(np.uint8).reshape(len(times), -1)),
 )


### PR DESCRIPTION
Came up on Discord https://discord.com/channels/1062300748202921994/1075873257124810852/1341072804790927513

If you don't know how to deal with e.g. 16bit images it's really hard to get it right and what to look for. This shows how it's done! :)

Future work: should we handle this directly like this on the image buffer serialization?