### PR TITLE
Remove `redap` feature

### DIFF
--- a/crates/store/re_data_source/Cargo.toml
+++ b/crates/store/re_data_source/Cargo.toml
@@ -18,12 +18,11 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
-
 [features]
 default = ["grpc"]
 
 ## Enable the gRPC Rerun Data Platform data source.
-grpc = ["re_grpc_client/redap"]
+grpc = []
 
 
 [dependencies]

--- a/crates/store/re_grpc_client/Cargo.toml
+++ b/crates/store/re_grpc_client/Cargo.toml
@@ -18,12 +18,6 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
-
-[features]
-default = ["redap"]
-
-redap = []
-
 [dependencies]
 re_arrow_util.workspace = true
 re_chunk.workspace = true

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod message_proxy;
 pub use message_proxy::MessageProxyUrl;
 
-#[cfg(feature = "redap")]
 pub mod redap;
 
 /// Wrapper with a nicer error message
@@ -41,7 +40,6 @@ pub enum StreamError {
     #[error(transparent)]
     Transport(#[from] tonic::transport::Error),
 
-    #[cfg(feature = "redap")]
     #[error(transparent)]
     ConnectionError(#[from] redap::ConnectionError),
 

--- a/crates/top/re_sdk/Cargo.toml
+++ b/crates/top/re_sdk/Cargo.toml
@@ -46,7 +46,7 @@ web_viewer = [
   "dep:webbrowser",
 ]
 
-grpc = ["re_grpc_client/redap"]
+grpc = []
 
 
 [dependencies]

--- a/crates/viewer/re_component_ui/Cargo.toml
+++ b/crates/viewer/re_component_ui/Cargo.toml
@@ -40,6 +40,7 @@ egui.workspace = true
 
 [dev-dependencies]
 re_viewer_context = { workspace = true, features = ["testing"] }
+re_data_source = { workspace = true, features = ["grpc"] }
 
 egui_kittest.workspace = true
 itertools.workspace = true

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -41,7 +41,7 @@ analytics = ["dep:re_analytics"]
 map_view = ["dep:re_view_map"]
 
 ## Enable the gRPC Rerun Data Platform data source.
-grpc = ["re_data_source/grpc", "re_grpc_client/redap"]
+grpc = ["re_data_source/grpc"]
 
 
 [dependencies]

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -42,7 +42,6 @@ remote = [
   "dep:tokio-stream",
   "dep:tonic",
   "dep:url",
-  "re_grpc_client/redap",
   "re_sdk/grpc",
 ]
 


### PR DESCRIPTION
### What

`redap::Origin` and Redap functionality will become ubiquitous in the viewer, so an additional feature gate will complicate things by a lot (as seen by recent CI failures).