### PR TITLE
Infer column partition size from shape in `Scalar.columns()`

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2488,6 +2488,17 @@ fn quote_clear_methods(obj: &Object) -> String {
     ))
 }
 
+fn quote_kwargs(obj: &Object) -> String {
+    obj.fields
+        .iter()
+        .map(|field| {
+            let field_name = field.snake_case_name();
+            format!("'{field_name}': {field_name}")
+        })
+        .collect_vec()
+        .join(",\n")
+}
+
 fn quote_partial_update_methods(reporter: &Reporter, obj: &Object, objects: &Objects) -> String {
     let name = &obj.name;
 
@@ -2503,15 +2514,7 @@ fn quote_partial_update_methods(reporter: &Reporter, obj: &Object, objects: &Obj
         .join(",\n");
     let parameters = indent::indent_by(8, parameters);
 
-    let kwargs = obj
-        .fields
-        .iter()
-        .map(|field| {
-            let field_name = field.snake_case_name();
-            format!("'{field_name}': {field_name}")
-        })
-        .collect_vec()
-        .join(",\n");
+    let kwargs = quote_kwargs(obj);
     let kwargs = indent::indent_by(12, kwargs);
 
     let parameter_docs = compute_init_parameter_docs(reporter, obj, objects);
@@ -2562,27 +2565,6 @@ fn quote_partial_update_methods(reporter: &Reporter, obj: &Object, objects: &Obj
     ))
 }
 
-fn quote_columnar_partition_size(obj: &Object) -> String {
-    // If the obj is a Scalar, we can infer partition size from the array-like shape.
-    if obj.snake_case_name() == "scalar"
-        && obj.kind == ObjectKind::Archetype
-        && obj.fields.len() == 1
-        && !obj.fields[0].is_nullable
-    {
-        unindent(&format!(
-            r#"
-        shape = np.shape({}) # type: ignore[arg-type]
-        batch_length = shape[1] if len(shape) > 1 else 1
-        num_rows = shape[0] if len(shape) >= 1 else 1
-        lengths = num_rows * np.ones(batch_length)
-        "#,
-            obj.fields[0].snake_case_name()
-        ))
-    } else {
-        unindent("lengths = np.ones(len(batches[0]._batch.as_arrow_array()))")
-    }
-}
-
 fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) -> String {
     let parameters = obj
         .fields
@@ -2631,7 +2613,9 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
         }
     };
     let doc_block = indent::indent_by(12, quote_doc_lines(doc_string_lines));
-    let partition_size = indent::indent_by(12, quote_columnar_partition_size(obj));
+
+    let kwargs = quote_kwargs(obj);
+    let kwargs = indent::indent_by(12, kwargs);
 
     // NOTE: Calling `update_fields` is not an option: we need to be able to pass
     // plural data, even to singular fields (mono-components).
@@ -2654,11 +2638,29 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
             if len(batches) == 0:
                 return ComponentColumnList([])
 
-            {partition_size}
-            columns = [batch.partition(lengths) for batch in batches]
+            kwargs = {{
+                {kwargs}
+            }}
+            columns = []
+
+            for batch in batches:
+                arrow_array = batch.as_arrow_array()
+
+                # For primitive arrays, we infer partition size from the input shape.
+                if pa.types.is_primitive(arrow_array.type):
+                    param = kwargs[batch.component_descriptor().archetype_field_name] # type: ignore[arg-type]
+                    shape = np.shape(param)
+
+                    batch_length = shape[1] if len(shape) > 1 else 1
+                    num_rows = shape[0] if len(shape) >= 1 else 1
+                    lengths = batch_length * np.ones(num_rows)
+                else:
+                    # For non-primitive types, default to partitioning each element separately.
+                    lengths = np.ones(len(arrow_array))
+
+                columns.append(batch.partition(lengths))
 
             indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
             return ComponentColumnList([indicator_column] + columns)
         "#
     ))

--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2633,7 +2633,7 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
         }
     };
     let doc_block = indent::indent_by(12, quote_doc_lines(doc_string_lines));
-    let partion_size = indent::indent_by(12, quote_columnar_partition_size(obj));
+    let partition_size = indent::indent_by(12, quote_columnar_partition_size(obj));
 
     // NOTE: Calling `update_fields` is not an option: we need to be able to pass
     // plural data, even to singular fields (mono-components).
@@ -2656,7 +2656,7 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
             if len(batches) == 0:
                 return ComponentColumnList([])
 
-            {partion_size}
+            {partition_size}
             columns = [batch.partition(lengths) for batch in batches]
 
             indicator_column = cls.indicator().partition(np.zeros(len(lengths)))

--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2579,9 +2579,7 @@ fn quote_columnar_partition_size(obj: &Object) -> String {
             obj.fields[0].snake_case_name()
         ))
     } else {
-        unindent(&format!(
-            "lengths = np.ones(len(batches[0]._batch.as_arrow_array()))"
-        ))
+        unindent("lengths = np.ones(len(batches[0]._batch.as_arrow_array()))")
     }
 }
 

--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2648,19 +2648,19 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
 
                 # For primitive arrays, we infer partition size from the input shape.
                 if pa.types.is_primitive(arrow_array.type):
-                    param = kwargs[batch.component_descriptor().archetype_field_name] # type: ignore[arg-type]
-                    shape = np.shape(param)
+                    param = kwargs[batch.component_descriptor().archetype_field_name] # type: ignore[index]
+                    shape = np.shape(param)  # type: ignore[arg-type]
 
                     batch_length = shape[1] if len(shape) > 1 else 1
                     num_rows = shape[0] if len(shape) >= 1 else 1
-                    lengths = batch_length * np.ones(num_rows)
+                    sizes = batch_length * np.ones(num_rows)
                 else:
                     # For non-primitive types, default to partitioning each element separately.
-                    lengths = np.ones(len(arrow_array))
+                    sizes = np.ones(len(arrow_array))
 
-                columns.append(batch.partition(lengths))
+                columns.append(batch.partition(sizes))
 
-            indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+            indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
             return ComponentColumnList([indicator_column] + columns)
         "#
     ))

--- a/examples/python/plots/plots.py
+++ b/examples/python/plots/plots.py
@@ -89,7 +89,6 @@ def log_spiral() -> None:
 
     # want this in column major, and numpy is row-major by default
     scalars = np.array((x, y)).T
-
     rr.send_columns(
         "spiral", indexes=[rr.TimeSequenceColumn("frame_nr", times)], columns=[*rr.Scalar.columns(scalar=scalars)]
     )

--- a/examples/python/plots/plots.py
+++ b/examples/python/plots/plots.py
@@ -82,7 +82,7 @@ def log_trig() -> None:
 
 def log_spiral() -> None:
     times = np.arange(int(tau * 2 * 100.0))
-    theta = times / 100.
+    theta = times / 100.0
 
     x = theta * np.cos(theta)
     y = theta * np.sin(theta)
@@ -91,12 +91,9 @@ def log_spiral() -> None:
     scalars = np.array((x, y)).T
 
     rr.send_columns(
-        "spiral",
-         indexes=[rr.TimeSequenceColumn("frame_nr", times)],
-         columns=[
-             *rr.Scalar.columns(scalar=scalars)
-         ]
+        "spiral", indexes=[rr.TimeSequenceColumn("frame_nr", times)], columns=[*rr.Scalar.columns(scalar=scalars)]
     )
+
 
 def log_classification() -> None:
     for t in range(0, 1000, 2):
@@ -160,11 +157,9 @@ def main() -> None:
                 rrb.TimeSeriesView(
                     name="Spiral",
                     origin="/spiral",
-                    overrides={
-                        "spiral": [rr.components.NameBatch(["0.01t cos(0.01t)", "0.01t sin(0.01t)"])]
-                    }
+                    overrides={"spiral": [rr.components.NameBatch(["0.01t cos(0.01t)", "0.01t sin(0.01t)"])]},
                 ),
-                row_shares=[2, 1]
+                row_shares=[2, 1],
             ),
             rrb.TextDocumentView(name="Description", origin="/description"),
             column_shares=[3, 1],

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -173,19 +173,19 @@ class AnnotationContext(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     context: components.AnnotationContextBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components
@@ -164,11 +165,27 @@ class AnnotationContext(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"context": context}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     context: components.AnnotationContextBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -245,19 +245,19 @@ class Arrows2D(Arrows2DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     vectors: components.Vector2DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -227,11 +228,36 @@ class Arrows2D(Arrows2DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "vectors": vectors,
+            "origins": origins,
+            "radii": radii,
+            "colors": colors,
+            "labels": labels,
+            "show_labels": show_labels,
+            "draw_order": draw_order,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     vectors: components.Vector2DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -231,19 +231,19 @@ class Arrows3D(Arrows3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     vectors: components.Vector3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -214,11 +215,35 @@ class Arrows3D(Arrows3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "vectors": vectors,
+            "origins": origins,
+            "radii": radii,
+            "colors": colors,
+            "labels": labels,
+            "show_labels": show_labels,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     vectors: components.Vector3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -185,11 +186,27 @@ class Asset3D(Asset3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"blob": blob, "media_type": media_type, "albedo_factor": albedo_factor}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     blob: components.BlobBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -194,19 +194,19 @@ class Asset3D(Asset3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     blob: components.BlobBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -219,11 +220,27 @@ class AssetVideo(AssetVideoExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"blob": blob, "media_type": media_type}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     blob: components.BlobBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -228,19 +228,19 @@ class AssetVideo(AssetVideoExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     blob: components.BlobBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -160,11 +161,27 @@ class BarChart(BarChartExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"values": values, "color": color}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     values: components.TensorDataBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -169,19 +169,19 @@ class BarChart(BarChartExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     values: components.TensorDataBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -230,19 +230,19 @@ class Boxes2D(Boxes2DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     half_sizes: components.HalfSize2DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -258,11 +259,38 @@ class Boxes3D(Boxes3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "half_sizes": half_sizes,
+            "centers": centers,
+            "rotation_axis_angles": rotation_axis_angles,
+            "quaternions": quaternions,
+            "colors": colors,
+            "radii": radii,
+            "fill_mode": fill_mode,
+            "labels": labels,
+            "show_labels": show_labels,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     half_sizes: components.HalfSize3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -278,19 +278,19 @@ class Boxes3D(Boxes3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     half_sizes: components.HalfSize3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
@@ -276,19 +276,19 @@ class Capsules3D(Capsules3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     lengths: components.LengthBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -257,11 +258,37 @@ class Capsules3D(Capsules3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "lengths": lengths,
+            "radii": radii,
+            "translations": translations,
+            "rotation_axis_angles": rotation_axis_angles,
+            "quaternions": quaternions,
+            "colors": colors,
+            "labels": labels,
+            "show_labels": show_labels,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     lengths: components.LengthBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -135,11 +136,27 @@ class Clear(ClearExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"is_recursive": is_recursive}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     is_recursive: components.ClearIsRecursiveBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -144,19 +144,19 @@ class Clear(ClearExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     is_recursive: components.ClearIsRecursiveBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -255,11 +256,35 @@ class DepthImage(DepthImageExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "buffer": buffer,
+            "format": format,
+            "meter": meter,
+            "colormap": colormap,
+            "depth_range": depth_range,
+            "point_fill_ratio": point_fill_ratio,
+            "draw_order": draw_order,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     buffer: components.ImageBufferBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -272,19 +272,19 @@ class DepthImage(DepthImageExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     buffer: components.ImageBufferBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
@@ -279,19 +279,19 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     half_sizes: components.HalfSize3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -259,11 +260,38 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "half_sizes": half_sizes,
+            "centers": centers,
+            "rotation_axis_angles": rotation_axis_angles,
+            "quaternions": quaternions,
+            "colors": colors,
+            "line_radii": line_radii,
+            "fill_mode": fill_mode,
+            "labels": labels,
+            "show_labels": show_labels,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     half_sizes: components.HalfSize3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
@@ -189,19 +189,19 @@ class EncodedImage(EncodedImageExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     blob: components.BlobBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -180,11 +181,27 @@ class EncodedImage(EncodedImageExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"blob": blob, "media_type": media_type, "opacity": opacity, "draw_order": draw_order}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     blob: components.BlobBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -176,11 +177,27 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"line_strings": line_strings, "radii": radii, "colors": colors}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     line_strings: components.GeoLineStringBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -185,19 +185,19 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     line_strings: components.GeoLineStringBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -179,11 +180,27 @@ class GeoPoints(GeoPointsExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"positions": positions, "radii": radii, "colors": colors, "class_ids": class_ids}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     positions: components.LatLonBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
@@ -188,19 +188,19 @@ class GeoPoints(GeoPointsExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     positions: components.LatLonBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
@@ -181,19 +181,19 @@ class GraphEdges(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     edges: components.GraphEdgeBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -172,11 +173,27 @@ class GraphEdges(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"edges": edges, "graph_type": graph_type}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     edges: components.GraphEdgeBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
@@ -240,19 +240,19 @@ class GraphNodes(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     node_ids: components.GraphNodeBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -223,19 +223,19 @@ class Image(ImageExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     buffer: components.ImageBufferBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -214,11 +215,27 @@ class Image(ImageExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"buffer": buffer, "format": format, "opacity": opacity, "draw_order": draw_order}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     buffer: components.ImageBufferBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -232,11 +233,33 @@ class InstancePoses3D(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "translations": translations,
+            "rotation_axis_angles": rotation_axis_angles,
+            "quaternions": quaternions,
+            "scales": scales,
+            "mat3x3": mat3x3,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     translations: components.PoseTranslation3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -247,19 +247,19 @@ class InstancePoses3D(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     translations: components.PoseTranslation3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -321,19 +321,19 @@ class LineStrips2D(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     strips: components.LineStrip2DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -304,11 +305,35 @@ class LineStrips2D(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "strips": strips,
+            "radii": radii,
+            "colors": colors,
+            "labels": labels,
+            "show_labels": show_labels,
+            "draw_order": draw_order,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     strips: components.LineStrip2DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -311,19 +311,19 @@ class LineStrips3D(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     strips: components.LineStrip3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -295,11 +296,34 @@ class LineStrips3D(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "strips": strips,
+            "radii": radii,
+            "colors": colors,
+            "labels": labels,
+            "show_labels": show_labels,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     strips: components.LineStrip3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -294,19 +294,19 @@ class Mesh3D(Mesh3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     vertex_positions: components.Position3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -275,11 +276,37 @@ class Mesh3D(Mesh3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "vertex_positions": vertex_positions,
+            "triangle_indices": triangle_indices,
+            "vertex_normals": vertex_normals,
+            "vertex_colors": vertex_colors,
+            "vertex_texcoords": vertex_texcoords,
+            "albedo_factor": albedo_factor,
+            "albedo_texture_buffer": albedo_texture_buffer,
+            "albedo_texture_format": albedo_texture_format,
+            "class_ids": class_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     vertex_positions: components.Position3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -255,11 +256,32 @@ class Pinhole(PinholeExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "image_from_camera": image_from_camera,
+            "resolution": resolution,
+            "camera_xyz": camera_xyz,
+            "image_plane_distance": image_plane_distance,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     image_from_camera: components.PinholeProjectionBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -269,19 +269,19 @@ class Pinhole(PinholeExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     image_from_camera: components.PinholeProjectionBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -300,19 +300,19 @@ class Points2D(Points2DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     positions: components.Position2DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -282,11 +283,36 @@ class Points2D(Points2DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "positions": positions,
+            "radii": radii,
+            "colors": colors,
+            "labels": labels,
+            "show_labels": show_labels,
+            "draw_order": draw_order,
+            "class_ids": class_ids,
+            "keypoint_ids": keypoint_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     positions: components.Position2DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -346,19 +346,19 @@ class Points3D(Points3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     positions: components.Position3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -329,11 +330,35 @@ class Points3D(Points3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "positions": positions,
+            "radii": radii,
+            "colors": colors,
+            "labels": labels,
+            "show_labels": show_labels,
+            "class_ids": class_ids,
+            "keypoint_ids": keypoint_ids,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     positions: components.Position3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -198,19 +198,19 @@ class Scalar(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     scalar: components.ScalarBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -189,11 +189,11 @@ class Scalar(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        shape = np.shape(scalar) # type: ignore[arg-type]
+        shape = np.shape(scalar)  # type: ignore[arg-type]
         batch_length = shape[1] if len(shape) > 1 else 1
         num_rows = shape[0] if len(shape) >= 1 else 1
+        lengths = num_rows * np.ones(batch_length)
 
-        lengths = batch_length * np.ones(num_rows)
         columns = [batch.partition(lengths) for batch in batches]
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -189,7 +189,11 @@ class Scalar(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
+        shape = np.shape(scalar) # type: ignore[arg-type]
+        batch_length = shape[1] if len(shape) > 1 else 1
+        num_rows = shape[0] if len(shape) >= 1 else 1
+
+        lengths = batch_length * np.ones(num_rows)
         columns = [batch.partition(lengths) for batch in batches]
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -189,15 +190,27 @@ class Scalar(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        shape = np.shape(scalar)  # type: ignore[arg-type]
-        batch_length = shape[1] if len(shape) > 1 else 1
-        num_rows = shape[0] if len(shape) >= 1 else 1
-        lengths = num_rows * np.ones(batch_length)
+        kwargs = {"scalar": scalar}
+        columns = []
 
-        columns = [batch.partition(lengths) for batch in batches]
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     scalar: components.ScalarBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -191,19 +191,19 @@ class SegmentationImage(SegmentationImageExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     buffer: components.ImageBufferBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -182,11 +183,27 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"buffer": buffer, "format": format, "opacity": opacity, "draw_order": draw_order}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     buffer: components.ImageBufferBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -222,11 +223,27 @@ class SeriesLine(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"color": color, "width": width, "name": name, "aggregation_policy": aggregation_policy}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     color: components.ColorBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -231,19 +231,19 @@ class SeriesLine(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     color: components.ColorBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -228,11 +229,27 @@ class SeriesPoint(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"color": color, "marker": marker, "name": name, "marker_size": marker_size}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     color: components.ColorBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -237,19 +237,19 @@ class SeriesPoint(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     color: components.ColorBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -177,19 +177,19 @@ class Tensor(TensorExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     data: components.TensorDataBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -168,11 +169,27 @@ class Tensor(TensorExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"data": data, "value_range": value_range}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     data: components.TensorDataBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -220,11 +221,27 @@ class TextDocument(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"text": text, "media_type": media_type}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     text: components.TextBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -229,19 +229,19 @@ class TextDocument(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     text: components.TextBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -189,11 +190,27 @@ class TextLog(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"text": text, "level": level, "color": color}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     text: components.TextBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -198,19 +198,19 @@ class TextLog(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     text: components.TextBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -445,19 +445,19 @@ class Transform3D(Transform3DExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     translation: components.Translation3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -428,11 +429,35 @@ class Transform3D(Transform3DExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "translation": translation,
+            "rotation_axis_angle": rotation_axis_angle,
+            "quaternion": quaternion,
+            "scale": scale,
+            "mat3x3": mat3x3,
+            "relation": relation,
+            "axis_length": axis_length,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     translation: components.Translation3DBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -244,19 +244,19 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     timestamp: components.VideoTimestampBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -235,11 +236,27 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"timestamp": timestamp, "video_reference": video_reference}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     timestamp: components.VideoTimestampBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -175,19 +175,19 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     xyz: components.ViewCoordinatesBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 
 from .. import components, datatypes
@@ -166,11 +167,27 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {"xyz": xyz}
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     xyz: components.ViewCoordinatesBatch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -282,19 +282,19 @@ class AffixFuzzer1(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz1001: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
@@ -250,11 +251,50 @@ class AffixFuzzer1(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "fuzz1001": fuzz1001,
+            "fuzz1002": fuzz1002,
+            "fuzz1003": fuzz1003,
+            "fuzz1004": fuzz1004,
+            "fuzz1005": fuzz1005,
+            "fuzz1006": fuzz1006,
+            "fuzz1007": fuzz1007,
+            "fuzz1008": fuzz1008,
+            "fuzz1009": fuzz1009,
+            "fuzz1010": fuzz1010,
+            "fuzz1011": fuzz1011,
+            "fuzz1012": fuzz1012,
+            "fuzz1013": fuzz1013,
+            "fuzz1014": fuzz1014,
+            "fuzz1015": fuzz1015,
+            "fuzz1016": fuzz1016,
+            "fuzz1017": fuzz1017,
+            "fuzz1018": fuzz1018,
+            "fuzz1019": fuzz1019,
+            "fuzz1020": fuzz1020,
+            "fuzz1021": fuzz1021,
+            "fuzz1022": fuzz1022,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz1001: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
@@ -229,11 +230,47 @@ class AffixFuzzer2(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "fuzz1101": fuzz1101,
+            "fuzz1102": fuzz1102,
+            "fuzz1103": fuzz1103,
+            "fuzz1104": fuzz1104,
+            "fuzz1105": fuzz1105,
+            "fuzz1106": fuzz1106,
+            "fuzz1107": fuzz1107,
+            "fuzz1108": fuzz1108,
+            "fuzz1109": fuzz1109,
+            "fuzz1110": fuzz1110,
+            "fuzz1111": fuzz1111,
+            "fuzz1112": fuzz1112,
+            "fuzz1113": fuzz1113,
+            "fuzz1114": fuzz1114,
+            "fuzz1115": fuzz1115,
+            "fuzz1116": fuzz1116,
+            "fuzz1117": fuzz1117,
+            "fuzz1118": fuzz1118,
+            "fuzz1122": fuzz1122,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz1101: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -258,19 +258,19 @@ class AffixFuzzer2(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz1101: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
@@ -223,11 +224,46 @@ class AffixFuzzer3(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "fuzz2001": fuzz2001,
+            "fuzz2002": fuzz2002,
+            "fuzz2003": fuzz2003,
+            "fuzz2004": fuzz2004,
+            "fuzz2005": fuzz2005,
+            "fuzz2006": fuzz2006,
+            "fuzz2007": fuzz2007,
+            "fuzz2008": fuzz2008,
+            "fuzz2009": fuzz2009,
+            "fuzz2010": fuzz2010,
+            "fuzz2011": fuzz2011,
+            "fuzz2012": fuzz2012,
+            "fuzz2013": fuzz2013,
+            "fuzz2014": fuzz2014,
+            "fuzz2015": fuzz2015,
+            "fuzz2016": fuzz2016,
+            "fuzz2017": fuzz2017,
+            "fuzz2018": fuzz2018,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz2001: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -251,19 +251,19 @@ class AffixFuzzer3(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz2001: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -251,19 +251,19 @@ class AffixFuzzer4(Archetype):
 
             # For primitive arrays, we infer partition size from the input shape.
             if pa.types.is_primitive(arrow_array.type):
-                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
-                shape = np.shape(param)
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
+                shape = np.shape(param)  # type: ignore[arg-type]
 
                 batch_length = shape[1] if len(shape) > 1 else 1
                 num_rows = shape[0] if len(shape) >= 1 else 1
-                lengths = batch_length * np.ones(num_rows)
+                sizes = batch_length * np.ones(num_rows)
             else:
                 # For non-primitive types, default to partitioning each element separately.
-                lengths = np.ones(len(arrow_array))
+                sizes = np.ones(len(arrow_array))
 
-            columns.append(batch.partition(lengths))
+            columns.append(batch.partition(sizes))
 
-        indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
+        indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz2101: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     Archetype,
@@ -223,11 +224,46 @@ class AffixFuzzer4(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        lengths = np.ones(len(batches[0]._batch.as_arrow_array()))
-        columns = [batch.partition(lengths) for batch in batches]
+        kwargs = {
+            "fuzz2101": fuzz2101,
+            "fuzz2102": fuzz2102,
+            "fuzz2103": fuzz2103,
+            "fuzz2104": fuzz2104,
+            "fuzz2105": fuzz2105,
+            "fuzz2106": fuzz2106,
+            "fuzz2107": fuzz2107,
+            "fuzz2108": fuzz2108,
+            "fuzz2109": fuzz2109,
+            "fuzz2110": fuzz2110,
+            "fuzz2111": fuzz2111,
+            "fuzz2112": fuzz2112,
+            "fuzz2113": fuzz2113,
+            "fuzz2114": fuzz2114,
+            "fuzz2115": fuzz2115,
+            "fuzz2116": fuzz2116,
+            "fuzz2117": fuzz2117,
+            "fuzz2118": fuzz2118,
+        }
+        columns = []
+
+        for batch in batches:
+            arrow_array = batch.as_arrow_array()
+
+            # For primitive arrays, we infer partition size from the input shape.
+            if pa.types.is_primitive(arrow_array.type):
+                param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[arg-type]
+                shape = np.shape(param)
+
+                batch_length = shape[1] if len(shape) > 1 else 1
+                num_rows = shape[0] if len(shape) >= 1 else 1
+                lengths = batch_length * np.ones(num_rows)
+            else:
+                # For non-primitive types, default to partitioning each element separately.
+                lengths = np.ones(len(arrow_array))
+
+            columns.append(batch.partition(lengths))
 
         indicator_column = cls.indicator().partition(np.zeros(len(lengths)))
-
         return ComponentColumnList([indicator_column] + columns)
 
     fuzz2101: components.AffixFuzzer1Batch | None = field(

--- a/rerun_py/tests/unit/test_scalar.py
+++ b/rerun_py/tests/unit/test_scalar.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+from rerun.archetypes import Scalar
+from rerun.datatypes import Float64ArrayLike
+
+CASES: list[tuple[Float64ArrayLike, Float64ArrayLike]] = [
+    (
+        [],
+        [],
+    ),
+    (0.5, [[0.5]]),
+    (
+        [0.333],
+        [[0.333]],
+    ),
+    (
+        [0.111, 0.222, 0.333],
+        [[0.111], [0.222], [0.333]],
+    ),
+    (
+        [[0.111, 0.222], [0.333, 0.444]],
+        [[0.111, 0.222], [0.333, 0.444]],
+    ),
+    (np.array([1.1, 2.2, 3.3]), [[1.1], [2.2], [3.3]]),
+    (np.array([[1.1, 1.2], [2.1, 2.2]]), [[1.1, 1.2], [2.1, 2.2]]),
+    ((0.1, 0.2, 0.3), [[0.1], [0.2], [0.3]]),
+    (np.array([]), []),
+    (np.array([[0.5]]), [[0.5]]),
+    (np.ones((4321, 4)), np.ones((4321, 4)).tolist()),
+]
+
+
+def test_scalar_columns() -> None:
+    for input, expected in CASES:
+        data = [*Scalar.columns(scalar=input)]
+        assert data[1].as_arrow_array().to_pylist() == expected


### PR DESCRIPTION
### Related

Closes #9060

### What

We now infer partition size from array-like shape in `send_columns` when logging Scalar values. 

I've also added an Archimedes' spiral example (in Cartesian coordinates 😄) to plots to demonstrate this:

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/3016fa7a-af52-4a54-a674-6227c83d3966" />
