### PR TITLE
Make `IndexColumnDescriptor` members private

### DIFF
--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -165,7 +165,7 @@ impl Chunk {
                 let times =
                     TimeColumn::read_array(&as_array_ref(column.clone())).map_err(|err| {
                         ChunkError::Malformed {
-                            reason: format!("Bad time column '{}': {err}", schema.name()),
+                            reason: format!("Bad time column '{}': {err}", schema.column_name()),
                         }
                     })?;
 
@@ -175,7 +175,7 @@ impl Chunk {
                     return Err(ChunkError::Malformed {
                         reason: format!(
                             "time column '{}' was specified more than once",
-                            schema.name(),
+                            timeline.name()
                         ),
                     });
                 }

--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -63,11 +63,11 @@ impl Chunk {
                     } = info;
 
                     let array = info.times_array();
-                    let schema = re_sorbet::IndexColumnDescriptor {
-                        timeline: *timeline,
-                        datatype: array.data_type().clone(),
-                        is_sorted: *is_sorted,
-                    };
+
+                    debug_assert_eq!(&timeline.datatype(), array.data_type());
+
+                    let schema =
+                        re_sorbet::IndexColumnDescriptor::from_timeline(*timeline, *is_sorted);
 
                     (schema, into_arrow_ref(array))
                 })
@@ -170,7 +170,7 @@ impl Chunk {
                     })?;
 
                 let time_column =
-                    TimeColumn::new(schema.is_sorted.then_some(true), timeline, times);
+                    TimeColumn::new(schema.is_sorted().then_some(true), timeline, times);
                 if timelines.insert(timeline, time_column).is_some() {
                     return Err(ChunkError::Malformed {
                         reason: format!(

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -70,7 +70,7 @@ impl From<IndexColumnDescriptor> for TimeColumnSelector {
     #[inline]
     fn from(desc: IndexColumnDescriptor) -> Self {
         Self {
-            timeline: *desc.name(),
+            timeline: *desc.timeline().name(),
         }
     }
 }

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -66,6 +66,40 @@ pub struct TimeColumnSelector {
     pub timeline: TimelineName,
 }
 
+impl From<TimelineName> for TimeColumnSelector {
+    #[inline]
+    fn from(timeline: TimelineName) -> Self {
+        Self { timeline }
+    }
+}
+
+impl From<Timeline> for TimeColumnSelector {
+    #[inline]
+    fn from(timeline: Timeline) -> Self {
+        Self {
+            timeline: *timeline.name(),
+        }
+    }
+}
+
+impl From<&str> for TimeColumnSelector {
+    #[inline]
+    fn from(timeline: &str) -> Self {
+        Self {
+            timeline: timeline.into(),
+        }
+    }
+}
+
+impl From<String> for TimeColumnSelector {
+    #[inline]
+    fn from(timeline: String) -> Self {
+        Self {
+            timeline: timeline.into(),
+        }
+    }
+}
+
 impl From<IndexColumnDescriptor> for TimeColumnSelector {
     #[inline]
     fn from(desc: IndexColumnDescriptor) -> Self {

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -70,7 +70,7 @@ impl From<IndexColumnDescriptor> for TimeColumnSelector {
     #[inline]
     fn from(desc: IndexColumnDescriptor) -> Self {
         Self {
-            timeline: *desc.timeline.name(),
+            timeline: *desc.name(),
         }
     }
 }

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -1831,15 +1831,9 @@ mod tests {
             let query = QueryExpression {
                 filtered_index: Some(filtered_index),
                 selection: Some(vec![
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: "ATimeColumnThatDoesntExist".into(),
-                    }),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from("ATimeColumnThatDoesntExist")),
                 ]),
                 ..Default::default()
             };
@@ -1906,36 +1900,16 @@ mod tests {
                 selection: Some(vec![
                     // NOTE: This will force a crash if the selected indexes vs. view indexes are
                     // improperly handled.
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
                     //
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),
@@ -1988,15 +1962,9 @@ mod tests {
                     .collect(),
                 ),
                 selection: Some(vec![
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *filtered_index.name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *Timeline::log_time().name(),
-                    }),
-                    ColumnSelector::Time(TimeColumnSelector {
-                        timeline: *Timeline::log_tick().name(),
-                    }),
+                    ColumnSelector::Time(TimeColumnSelector::from(*filtered_index.name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*Timeline::log_time().name())),
+                    ColumnSelector::Time(TimeColumnSelector::from(*Timeline::log_tick().name())),
                     //
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -1204,7 +1204,9 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                 ColumnDescriptor::Time(descr) => {
                     max_value_per_index.get(&descr.timeline()).map_or_else(
                         || arrow::array::new_null_array(&column.arrow_datatype(), 1),
-                        |(_time, time_sliced)| descr.typ().make_arrow_array(time_sliced.clone()),
+                        |(_time, time_sliced)| {
+                            descr.timeline().typ().make_arrow_array(time_sliced.clone())
+                        },
                     )
                 }
 

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -393,7 +393,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                             ColumnDescriptor::Time(view_descr) => Some((idx, view_descr)),
                             ColumnDescriptor::Component(_) => None,
                         })
-                        .find(|(_idx, view_descr)| *view_descr.name() == *selected_timeline)
+                        .find(|(_idx, view_descr)| *view_descr.timeline().name() == *selected_timeline)
                         .map_or_else(
                             || {
                                 (

--- a/crates/store/re_sorbet/src/column_descriptor.rs
+++ b/crates/store/re_sorbet/src/column_descriptor.rs
@@ -57,7 +57,7 @@ impl ColumnDescriptor {
     #[inline]
     pub fn short_name(&self) -> String {
         match self {
-            Self::Time(descr) => descr.name().to_string(),
+            Self::Time(descr) => descr.column_name().to_owned(),
             Self::Component(descr) => descr.component_name.short_name().to_owned(),
         }
     }

--- a/crates/store/re_sorbet/src/column_descriptor.rs
+++ b/crates/store/re_sorbet/src/column_descriptor.rs
@@ -57,7 +57,7 @@ impl ColumnDescriptor {
     #[inline]
     pub fn short_name(&self) -> String {
         match self {
-            Self::Time(descr) => descr.timeline.name().to_string(),
+            Self::Time(descr) => descr.name().to_string(),
             Self::Component(descr) => descr.component_name.short_name().to_owned(),
         }
     }
@@ -73,7 +73,7 @@ impl ColumnDescriptor {
     #[inline]
     pub fn arrow_datatype(&self) -> ArrowDatatype {
         match self {
-            Self::Time(descr) => descr.datatype.clone(),
+            Self::Time(descr) => descr.datatype().clone(),
             Self::Component(descr) => descr.returned_datatype(),
         }
     }
@@ -134,14 +134,10 @@ fn test_schema_over_ipc() {
     #![expect(clippy::disallowed_methods)] // Schema::new
 
     let original_columns = [
-        ColumnDescriptor::Time(IndexColumnDescriptor {
-            timeline: re_log_types::Timeline::log_time(),
-            datatype: arrow::datatypes::DataType::Timestamp(
-                arrow::datatypes::TimeUnit::Nanosecond,
-                None,
-            ),
-            is_sorted: true,
-        }),
+        ColumnDescriptor::Time(IndexColumnDescriptor::from_timeline(
+            re_log_types::Timeline::log_time(),
+            true,
+        )),
         ColumnDescriptor::Component(ComponentColumnDescriptor {
             entity_path: re_log_types::EntityPath::from("/some/path"),
             archetype_name: Some("archetype".to_owned().into()),

--- a/crates/store/re_sorbet/src/column_descriptor_ref.rs
+++ b/crates/store/re_sorbet/src/column_descriptor_ref.rs
@@ -15,7 +15,7 @@ impl ColumnDescriptorRef<'_> {
     pub fn name(&self) -> String {
         match self {
             Self::RowId(descr) => descr.name().to_owned(),
-            Self::Time(descr) => descr.name().to_string(),
+            Self::Time(descr) => descr.column_name().to_owned(),
             Self::Component(descr) => descr.component_name.short_name().to_owned(),
         }
     }

--- a/crates/store/re_sorbet/src/column_descriptor_ref.rs
+++ b/crates/store/re_sorbet/src/column_descriptor_ref.rs
@@ -15,7 +15,7 @@ impl ColumnDescriptorRef<'_> {
     pub fn name(&self) -> String {
         match self {
             Self::RowId(descr) => descr.name().to_owned(),
-            Self::Time(descr) => descr.timeline.name().to_string(),
+            Self::Time(descr) => descr.name().to_string(),
             Self::Component(descr) => descr.component_name.short_name().to_owned(),
         }
     }

--- a/crates/store/re_sorbet/src/index_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/index_column_descriptor.rs
@@ -72,7 +72,7 @@ impl IndexColumnDescriptor {
     }
 
     #[inline]
-    pub fn name(&self) -> &TimelineName {
+    pub fn column_name(&self) -> &str {
         self.timeline.name()
     }
 

--- a/crates/store/re_sorbet/src/index_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/index_column_descriptor.rs
@@ -77,11 +77,6 @@ impl IndexColumnDescriptor {
     }
 
     #[inline]
-    pub fn typ(&self) -> re_log_types::TimeType {
-        self.timeline.typ()
-    }
-
-    #[inline]
     pub fn datatype(&self) -> &ArrowDatatype {
         &self.datatype
     }

--- a/crates/store/re_sorbet/src/index_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/index_column_descriptor.rs
@@ -14,15 +14,15 @@ pub struct UnsupportedTimeType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IndexColumnDescriptor {
     /// The timeline this column is associated with.
-    pub timeline: Timeline,
+    timeline: Timeline,
 
     /// The Arrow datatype of the column.
-    pub datatype: ArrowDatatype,
+    datatype: ArrowDatatype,
 
     /// Are the indices in this column sorted?
     ///
     /// `false` means either "unsorted" or "unknown".
-    pub is_sorted: bool,
+    is_sorted: bool,
 }
 
 impl PartialOrd for IndexColumnDescriptor {
@@ -58,6 +58,15 @@ impl IndexColumnDescriptor {
     }
 
     #[inline]
+    pub fn from_timeline(timeline: Timeline, is_sorted: bool) -> Self {
+        Self {
+            timeline,
+            datatype: timeline.datatype(),
+            is_sorted,
+        }
+    }
+
+    #[inline]
     pub fn timeline(&self) -> Timeline {
         self.timeline
     }
@@ -75,6 +84,14 @@ impl IndexColumnDescriptor {
     #[inline]
     pub fn datatype(&self) -> &ArrowDatatype {
         &self.datatype
+    }
+
+    /// Are the indices in this column sorted?
+    ///
+    /// `false` means either "unsorted" or "unknown".
+    #[inline]
+    pub fn is_sorted(&self) -> bool {
+        self.is_sorted
     }
 
     #[inline]

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -213,5 +213,5 @@ impl FilterCommand {
 fn is_field_timeline_of(field: &ArrowField, dropped_timelines: &HashSet<String>) -> bool {
     re_sorbet::IndexColumnDescriptor::try_from(field)
         .ok()
-        .is_some_and(|schema| dropped_timelines.contains(schema.name().as_str()))
+        .is_some_and(|schema| dropped_timelines.contains(schema.column_name()))
 }

--- a/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
@@ -287,7 +287,7 @@ impl egui_table::TableDelegate for DataframeTableDelegate<'_> {
                         match column {
                             ColumnDescriptor::Time(desc) => (desc.timeline() != filtered_index)
                                 .then(|| HideColumnAction::HideTimeColumn {
-                                    timeline_name: *desc.name(),
+                                    timeline_name: *desc.timeline().name(),
                                 }),
 
                             ColumnDescriptor::Component(desc) => {

--- a/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
@@ -213,8 +213,8 @@ impl Query {
             .filter(|column| match column {
                 ColumnDescriptor::Time(desc) => {
                     // we always include the query timeline column because we need it for the dataframe ui
-                    desc.name() == &query_timeline_name
-                        || selected_time_columns.contains(desc.name())
+                    desc.timeline().name() == &query_timeline_name
+                        || selected_time_columns.contains(desc.timeline().name())
                 }
 
                 ColumnDescriptor::Component(desc) => {

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -379,7 +379,7 @@ impl Query {
 
                 // The query timeline is always active because it's necessary for the dataframe ui
                 // (for tooltips).
-                let is_query_timeline = time_column_descriptor.name() == timeline.name();
+                let is_query_timeline = time_column_descriptor.timeline() == *timeline;
                 let is_enabled = !is_query_timeline;
                 let mut is_visible =
                     is_query_timeline || selected_columns.contains(&column_selector);

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -76,7 +76,7 @@ struct PyIndexColumnDescriptor(IndexColumnDescriptor);
 #[pymethods]
 impl PyIndexColumnDescriptor {
     fn __repr__(&self) -> String {
-        format!("Index(timeline:{})", self.0.name())
+        format!("Index(timeline:{})", self.0.column_name())
     }
 
     /// The name of the index.
@@ -84,7 +84,7 @@ impl PyIndexColumnDescriptor {
     /// This property is read-only.
     #[getter]
     fn name(&self) -> &str {
-        self.0.name()
+        self.0.column_name()
     }
 
     /// Part of generic ColumnDescriptor interface: always False for Index.

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -121,9 +121,7 @@ impl PyIndexColumnSelector {
     #[new]
     #[pyo3(text_signature = "(self, index)")]
     fn new(index: &str) -> Self {
-        Self(TimeColumnSelector {
-            timeline: index.into(),
-        })
+        Self(TimeColumnSelector::from(index))
     }
 
     fn __repr__(&self) -> String {
@@ -284,9 +282,7 @@ impl AnyColumn {
         match self {
             Self::Name(name) => {
                 if !name.contains(':') && !name.contains('/') {
-                    Ok(ColumnSelector::Time(TimeColumnSelector {
-                        timeline: name.into(),
-                    }))
+                    Ok(ColumnSelector::Time(TimeColumnSelector::from(name)))
                 } else {
                     let component_path =
                         re_log_types::ComponentPath::from_str(&name).map_err(|err| {
@@ -1340,9 +1336,7 @@ impl PyRecording {
         let borrowed_self = slf.borrow();
 
         // Look up the type of the timeline
-        let selector = TimeColumnSelector {
-            timeline: index.into(),
-        };
+        let selector = TimeColumnSelector::from(index);
 
         let timeline = borrowed_self.store.read().resolve_time_selector(&selector);
 


### PR DESCRIPTION
### Related
* Sibling PR: https://github.com/rerun-io/dataplatform/pull/259
* Part of https://github.com/rerun-io/rerun/issues/8744
* Part of https://github.com/rerun-io/rerun/issues/9082

### What
A few steps on the road to unifying timelines and RowId


### TODO
* [x] dataplatform PR