### PR TITLE
Remove `grpc` as a feature flag (always have it enabled)

### DIFF
--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Setup software rasterizer
         run: pixi run python ./scripts/ci/setup_software_rasterizer.py
 
-      - name: Run tests (`cargo test --all-targets --all-features`)
+      - name: Rust tests
         if: ${{ inputs.CHANNEL == 'main' }}
         run: pixi run rs-check --only tests
 

--- a/crates/store/re_data_source/Cargo.toml
+++ b/crates/store/re_data_source/Cargo.toml
@@ -19,10 +19,7 @@ workspace = true
 all-features = true
 
 [features]
-default = ["grpc"]
-
-## Enable the gRPC Rerun Data Platform data source.
-grpc = []
+default = []
 
 
 [dependencies]

--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -30,7 +30,6 @@ pub enum DataSource {
 
     /// A file or a metadata catalog on a Rerun Data Platform server,
     /// over `rerun://` gRPC interface.
-    #[cfg(feature = "grpc")]
     RerunGrpcUrl { url: String },
 
     /// A stream of messages over gRPC, relayed from the SDK.
@@ -98,7 +97,6 @@ impl DataSource {
 
         let path = std::path::Path::new(&uri).to_path_buf();
 
-        #[cfg(feature = "grpc")]
         if uri.starts_with("rerun://")
             || uri.starts_with("rerun+http://")
             || uri.starts_with("rerun+https://")
@@ -145,7 +143,6 @@ impl DataSource {
             Self::FileContents(_, file_contents) => Some(file_contents.name.clone()),
             #[cfg(not(target_arch = "wasm32"))]
             Self::Stdin => None,
-            #[cfg(feature = "grpc")]
             Self::RerunGrpcUrl { .. } => None, // TODO(jleibs): This needs to come from the server.
             Self::MessageProxy { .. } => None,
         }
@@ -252,7 +249,6 @@ impl DataSource {
                 Ok(StreamSource::LogMessages(rx))
             }
 
-            #[cfg(feature = "grpc")]
             Self::RerunGrpcUrl { url } => {
                 use re_grpc_client::redap::RedapAddress;
 

--- a/crates/top/re_sdk/Cargo.toml
+++ b/crates/top/re_sdk/Cargo.toml
@@ -46,8 +46,6 @@ web_viewer = [
   "dep:webbrowser",
 ]
 
-grpc = []
-
 
 [dependencies]
 re_build_info.workspace = true

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -58,7 +58,7 @@ default = ["native_viewer", "web_viewer", "map_view"]
 
 ## The features we enable when we build the pre-built binaries during our releases.
 ## This may enable features that require extra build tools that not everyone has.
-release = ["default", "grpc", "nasm"]
+release = ["default", "nasm"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
@@ -71,9 +71,6 @@ native_viewer = ["rerun/native_viewer"]
 ## Support the map view.
 ## This adds a lot of extra dependencies.
 map_view = ["rerun/map_view"]
-
-## Enable the gRPC Rerun Data Platform data source.
-grpc = ["rerun/grpc"]
 
 ## Support serving a web viewer over HTTP.
 ##

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -88,9 +88,6 @@ native_viewer = ["dep:re_viewer"]
 ## This adds a lot of extra dependencies.
 map_view = ["re_viewer?/map_view"]
 
-## Enable the gRPC Rerun Data Platform data source.
-grpc = ["re_viewer?/grpc", "re_sdk?/grpc"]
-
 ## Add support for the [`run()`] function, which acts like a main-function for a CLI,
 ## acting the same as [the `rerun` binary](https://crates.io/crates/rerun-cli).
 run = [

--- a/crates/viewer/re_component_ui/Cargo.toml
+++ b/crates/viewer/re_component_ui/Cargo.toml
@@ -40,7 +40,7 @@ egui.workspace = true
 
 [dev-dependencies]
 re_viewer_context = { workspace = true, features = ["testing"] }
-re_data_source = { workspace = true, features = ["grpc"] }
+re_data_source.workspace = true
 
 egui_kittest.workspace = true
 itertools.workspace = true

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -40,9 +40,6 @@ analytics = ["dep:re_analytics"]
 ## Enable the map view
 map_view = ["dep:re_view_map"]
 
-## Enable the gRPC Rerun Data Platform data source.
-grpc = ["re_data_source/grpc"]
-
 
 [dependencies]
 # Internal:

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -142,14 +142,10 @@ pub fn url_to_receiver(
             ),
         ),
 
-        #[cfg(feature = "grpc")]
         EndpointCategory::RerunGrpc(url) => {
             re_grpc_client::redap::stream_from_redap(url, Some(ui_waker)).map_err(|err| err.into())
         }
-        #[cfg(not(feature = "grpc"))]
-        EndpointCategory::RerunGrpc(_url) => {
-            anyhow::bail!("Missing 'grpc' feature flag");
-        }
+
         EndpointCategory::WebEventListener(url) => {
             // Process an rrd when it's posted via `window.postMessage`
             let (tx, rx) = re_smart_channel::smart_channel(

--- a/pixi.toml
+++ b/pixi.toml
@@ -136,18 +136,18 @@ man = "cargo --quiet run --package rerun-cli --all-features -- man > docs/conten
 # Compile and run the rerun viewer.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun = "cargo run --package rerun-cli --no-default-features --features grpc,map_view,nasm,native_viewer --"
+rerun = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer --"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build = "cargo build --package rerun-cli --no-default-features --features grpc,map_view,nasm,native_viewer"
+rerun-build = "cargo build --package rerun-cli --no-default-features --features map_view,nasm,native_viewer"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features grpc,map_view,nasm,native_viewer"
+rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features map_view,nasm,native_viewer"
 
 # Compile and run the rerun viewer with --release.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-release = "cargo run --package rerun-cli --no-default-features --features grpc,map_view,nasm,native_viewer --release --"
+rerun-release = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer --release --"
 
 # Compile `rerun-cli` with the same feature set as we build for releases.
 rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features release --", depends-on = [
@@ -173,13 +173,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --debug"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -187,7 +187,7 @@ rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run --q
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features --features web_viewer,map_view,grpc --release -- --web-viewer", depends-on = [
+rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features --features map_view,web_viewer --release -- --web-viewer", depends-on = [
   "rerun-build-web-release",
 ] }
 
@@ -195,7 +195,7 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --release -g"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run --quiet -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,map_view --release -g"
 
 rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/ci/rust_checks.py", depends-on = [
   "rerun-build-web", # The checks require the web viewer wasm to be around.

--- a/rerun_js/web-viewer/build-wasm.mjs
+++ b/rerun_js/web-viewer/build-wasm.mjs
@@ -32,7 +32,7 @@ function buildWebViewer(mode) {
       modeFlags,
       "--target no-modules-base",
       "--no-default-features",
-      "--features grpc,map_view", // no `analytics`
+      "--features map_view", // no `analytics`
       "-o rerun_js/web-viewer",
     ].join(" "),
   );

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -42,7 +42,6 @@ remote = [
   "dep:tokio-stream",
   "dep:tonic",
   "dep:url",
-  "re_sdk/grpc",
 ]
 
 ## Support serving a web viewer over HTTP with `serve()`.


### PR DESCRIPTION
Let's keep it simple.

If we ever need to build something without gRPC, we can ad back the feature flag again. But likely, YAGNI