### PR TITLE
Fix links to `nyu_depth_v2`

### DIFF
--- a/examples/python/rgbd/README.md
+++ b/examples/python/rgbd/README.md
@@ -7,7 +7,7 @@ channel = "release"
 build_args = ["--frames=300"]
 -->
 
-Visualizes an example recording from [the NYUD dataset](https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html) with RGB and Depth channels.
+Visualizes an example recording from [the NYUD dataset](https://cs.nyu.edu/~fergus/datasets/nyu_depth_v2.html) with RGB and Depth channels.
 
 <picture data-inline-viewer="examples/rgbd">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/rgbd/4109d29ed52fa0a8f980fcdd0e9673360c76879f/480w.png">
@@ -18,9 +18,11 @@ Visualizes an example recording from [the NYUD dataset](https://cs.nyu.edu/~silb
 </picture>
 
 ## Used Rerun types
+
 [`Image`](https://www.rerun.io/docs/reference/types/archetypes/image), [`Pinhole`](https://www.rerun.io/docs/reference/types/archetypes/pinhole), [`DepthImage`](https://www.rerun.io/docs/reference/types/archetypes/depth_image)
 
 ## Background
+
 The dataset, known as the NYU Depth V2 dataset, consists of synchronized pairs of RGB and depth frames recorded by the Microsoft Kinect in various indoor scenes.
 This example visualizes one scene of this dataset, and offers a rich source of data for object recognition, scene understanding, depth estimation, and more.
 
@@ -33,12 +35,14 @@ The visualizations in this example were created with the following Rerun code:
 All data logged using Rerun in the following sections is connected to a specific time.
 Rerun assigns a timestamp to each piece of logged data, and these timestamps are associated with a [`timeline`](https://www.rerun.io/docs/concepts/timelines).
 
- ```python
+```python
 rr.set_time_seconds("time", time.timestamp())
- ```
+```
 
 ### Image
+
 The example image is logged as [`Image`](https://www.rerun.io/docs/reference/types/archetypes/image) to the `world/camera/image/rgb` entity.
+
 ```python
 rr.log("world/camera/image/rgb", rr.Image(img_rgb).compress(jpeg_quality=95))
 ```
@@ -64,26 +68,36 @@ rr.log("world/camera/image/depth", rr.DepthImage(img_depth, meter=DEPTH_IMAGE_SC
 ```
 
 ## Run the code
+
 To run this example, make sure you have the Rerun repository checked out and the latest SDK installed:
+
 ```bash
 pip install --upgrade rerun-sdk  # install the latest Rerun SDK
 git clone git@github.com:rerun-io/rerun.git  # Clone the repository
 cd rerun
 git checkout latest  # Check out the commit matching the latest SDK release
 ```
+
 Install the necessary libraries specified in the requirements file:
+
 ```bash
 pip install -e examples/python/rgbd
 ```
+
 To experiment with the provided example, simply execute the main Python script:
+
 ```bash
 python -m rgbd # run the example
 ```
+
 You can specify the recording:
+
 ```bash
 python -m rgbd --recording {cafe,basements,studies,office_kitchens,playroooms}
 ```
+
 If you wish to customize it, explore additional features, or save it use the CLI with the `--help` option for guidance:
+
 ```bash
 python -m rgbd --help
 ```

--- a/examples/python/rgbd/rgbd.py
+++ b/examples/python/rgbd/rgbd.py
@@ -2,7 +2,7 @@
 """
 Example using an example depth dataset from NYU.
 
-https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html
+https://cs.nyu.edu/~fergus/datasets/nyu_depth_v2.html
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ The full source code for this example is available [on GitHub](https://github.co
 DEPTH_IMAGE_SCALING: Final = 1e4
 DATASET_DIR: Final = Path(os.path.dirname(__file__)) / "dataset"
 DATASET_URL_BASE: Final = "https://static.rerun.io/rgbd_dataset"
-DATASET_URL_BASE_ALTERNATE: Final = "http://horatio.cs.nyu.edu/mit/silberman/nyu_depth_v2"
+DATASET_URL_BASE_ALTERNATE: Final = "https://cs.nyu.edu/~fergus/datasets/nyu_depth_v2.html"
 AVAILABLE_RECORDINGS: Final = ["cafe", "basements", "studies", "office_kitchens", "playroooms"]
 
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -146,7 +146,6 @@ exclude = [
   'https://github.com/google/mediapipe/issues/5188',      # For some reason that link has always failed.
 
   # Temporarily down or not accessible.
-  'https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html',       # Nyud links are down every now and then.
   'https://eigen.tuxfamily.org/',                                   # Website down https://gitlab.com/libeigen/eigen/-/issues/2804
   'https://github.com/rerun-io/rerun/releases/download/prerelease', # Pre-release downloads may go down while a pre-release updates or pre-release CI partially breaks.
 


### PR DESCRIPTION
### Related

* https://github.com/rerun-io/rerun/actions/runs/13389293499/job/37393122973

### What

Unifies all links to a single destination—using the last author might give us a bit more stability too.