### PR TITLE
Fix non-final releases creating final-release git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       previous: ${{ steps.versioning.outputs.previous }}
       current: ${{ steps.versioning.outputs.current }}
       final: ${{ steps.versioning.outputs.final }}
-      git_tag: ${{ steps.versioning.outputs.tag }}
+      git_tag: ${{ steps.versioning.outputs.git_tag }}
       # will be set to `github.sha` if the pull request already exists
       # this is the last (and not merge) commit in the release branch
       release-commit: ${{ steps.commit.outputs.version_bump_commit_sha || github.sha }}
@@ -150,7 +150,7 @@ jobs:
             echo "Error: Version tag $git_tag already exists!"
             exit 1
           fi
-          echo "git_tag=$git_tag"       >> "$GITHUB_OUTPUT"
+          echo "git_tag=$git_tag" >> "$GITHUB_OUTPUT"
 
       - name: Update rerun_py & rerun_c version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       previous: ${{ steps.versioning.outputs.previous }}
       current: ${{ steps.versioning.outputs.current }}
       final: ${{ steps.versioning.outputs.final }}
+      git_tag: ${{ steps.versioning.outputs.tag }}
       # will be set to `github.sha` if the pull request already exists
       # this is the last (and not merge) commit in the release branch
       release-commit: ${{ steps.commit.outputs.version_bump_commit_sha || github.sha }}
@@ -136,6 +137,20 @@ jobs:
           echo "previous=$previous" >> "$GITHUB_OUTPUT"
           echo "current=$current"   >> "$GITHUB_OUTPUT"
           echo "final=$final"       >> "$GITHUB_OUTPUT"
+
+          # Pick what version we use for creating a github tag.
+          if [ ${{ inputs.release-type }} = "final" ]; then
+            git_tag=$final
+          else
+            git_tag=$current
+          fi
+
+          # Verify that it wasn't created yet.
+          if [ $(git tag -l "$git_tag") ]; then
+            echo "Error: Version tag $git_tag already exists!"
+            exit 1
+          fi
+          echo "git_tag=$git_tag"       >> "$GITHUB_OUTPUT"
 
       - name: Update rerun_py & rerun_c version
         run: |
@@ -345,7 +360,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
         run: |
-          version="${{ needs.version.outputs.final }}"
+          version="${{ needs.version.outputs.git_tag }}"
           commit="${{ needs.version.outputs.release-commit }}"
 
           if [ ${{ inputs.release-type }} = "final" ]; then


### PR DESCRIPTION
### Related

* follow-up to https://github.com/rerun-io/rerun/pull/8524/files

### What

0.22.0 GH release & branch was incorrectly created on the RC1 commit

This causes *all our release artifacts* (and thus cargo binstall) to point at RC1.
This is a bit of a problem as it messes with all sort of things. Luckily the main release artifact that people download from there is the C++ SDK which is close not not affected at all (it does have the RC1 version backed in there though as well, so it doesn't line up with e.g. python installed viewer)

This was triggered by a mistake in a PR right after 0.21 which caused us to create non-rc git tags on rc builds which then caused failures on the actual release. Those were missed, very likely because we had other spurious issues