### PR TITLE
Add command palette action for resetting to the default blueprint

### DIFF
--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -32,6 +32,7 @@ pub enum UICommand {
     OpenRerunDiscord,
 
     ResetViewer,
+    ClearActiveBlueprint,
     ClearActiveBlueprintAndEnableHeuristics,
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -137,9 +138,14 @@ impl UICommand {
                 "Reset the Viewer to how it looked the first time you ran it, forgetting all stored blueprints and UI state",
             ),
 
+            Self::ClearActiveBlueprint => (
+                "Reset to default blueprint",
+                "Clear active blueprint and use the default blueprint instead. If no default blueprint is set, this will use a heuristic blueprint."
+            ),
+
             Self::ClearActiveBlueprintAndEnableHeuristics => (
                 "Reset to heuristic blueprint",
-                "Re-populate viewport with automatically chosen views"
+                "Re-populate viewport with automatically chosen views using default visualizers"
             ),
 
             #[cfg(not(target_arch = "wasm32"))]
@@ -311,6 +317,7 @@ impl UICommand {
             Self::Quit => smallvec![cmd(Key::Q)],
 
             Self::ResetViewer => smallvec![ctrl_shift(Key::R)],
+            Self::ClearActiveBlueprint => smallvec![],
             Self::ClearActiveBlueprintAndEnableHeuristics => smallvec![],
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -860,6 +860,10 @@ impl App {
             }
 
             UICommand::ResetViewer => self.command_sender.send_system(SystemCommand::ResetViewer),
+            UICommand::ClearActiveBlueprint => {
+                self.command_sender
+                    .send_system(SystemCommand::ClearActiveBlueprint);
+            }
             UICommand::ClearActiveBlueprintAndEnableHeuristics => {
                 self.command_sender
                     .send_system(SystemCommand::ClearActiveBlueprintAndEnableHeuristics);

--- a/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
@@ -44,7 +44,7 @@ pub enum SystemCommand {
     /// To force using the heuristics, use [`Self::ClearActiveBlueprintAndEnableHeuristics`].
     ///
     /// UI note: because of the above ambiguity, controls for this command should only be enabled if
-    /// a default blueprint is set.
+    /// a default blueprint is set or the behavior is explicitly explained.
     ClearActiveBlueprint,
 
     /// Clear the active blueprint and enable heuristics.


### PR DESCRIPTION
### Related

* fixes https://github.com/rerun-io/rerun/issues/8677

### What

If no default blueprint is set, this resets to the heuristic blueprint.
There is actually a comment in the code warning against exposing this directly. But I think it's fine here - after all the default _is_ the heuristic if there's no default set 🤷 