### PR TITLE
Fix `insta` crate leaking into regular (non-testing) builds

### DIFF
--- a/crates/store/re_dataframe/Cargo.toml
+++ b/crates/store/re_dataframe/Cargo.toml
@@ -41,7 +41,6 @@ re_types_core.workspace = true
 # External dependencies:
 anyhow.workspace = true
 arrow.workspace = true
-insta.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
 rayon.workspace = true
@@ -50,6 +49,7 @@ rayon.workspace = true
 # Rerun dependencies:
 re_types.workspace = true
 # External dependencies:
+insta.workspace = true
 similar-asserts.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tokio-stream.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -37,37 +37,36 @@ ignore = [
 multiple-versions = "deny"
 wildcards = "allow" # We use them for examples
 deny = [
-  { name = "cgmath" },      # We use glam
-  { name = "cmake" },       # Never again
-  { name = "derive_more" }, # Is very slow to compile; see https://github.com/rerun-io/rerun/issues/1316
-  { name = "egui_glow" },   # We use wgpu
-  { name = "openssl-sys" }, # We prefer rustls
-  { name = "openssl" },     # We prefer rustls
+  { name = "cgmath", reason = "We use glam" },
+  { name = "cmake", reason = "Never again" },
+  { name = "criterion", reason = "Only allowed as a dev-dependency for testing." },
+  { name = "derive_more", reason = "Is very slow to compile; see https://github.com/rerun-io/rerun/issues/1316" },
+  { name = "egui_glow", reason = "We use wgpu" },
+  { name = "insta", reason = "Only allowed as a dev-dependency for testing." },
+  { name = "openssl-sys", reason = "We prefer rustls" },
+  { name = "openssl", reason = "We prefer rustls" },
+
+  # We have to allow egui_kittest since we use it behind a `testing` feature flag, rather than just as a dev-dependency.
+  #{ name = "egui_kittest", reason = "Only allowed as a dev-dependency for testing." },
 ]
 skip = [
   { name = "accesskit_consumer" }, # Duplicate as when used as dev dependency - eframe & egui_kittest are on different versions.
-  { name = "ahash" },              # Popular crate + fast release schedule = lots of crates still using old versions
   { name = "base64" },             # Too popular
   { name = "cargo_metadata" },     # Older version used by ply-rs. It's small, and it's build-time only!
-  { name = "cfg_aliases" },        # Tiny macro-only crate. wgpu/naga is using an old version
   { name = "hashbrown" },          # Old version used by polar-rs
-  { name = "memoffset" },          # Small crate
+  { name = "heck" },               # clap and snafu use different versions.
   { name = "ordered-float" },      # Old version being used by parquet, but super small!
   { name = "pollster" },           # rfd is still on 0.3
-  { name = "prettyplease" },       # Old version being used by prost
   { name = "pulldown-cmark" },     # Build-dependency via `ply-rs` (!). TODO(emilk): use a better crate for .ply parsing
   { name = "redox_syscall" },      # Plenty of versions in the wild
 ]
 skip-tree = [
-  { name = "cargo-run-wasm" }, # Dev-tool
-  { name = "criterion" },      # dev-dependency
-  { name = "quick-xml" },      # Old version via rfd
-  { name = "tower" },          # tonic depends on 0.4.3, but also transitively (axum) on 0.5.1
-  { name = "walkers" },        # TODO(#7876): suppress that when `walkers` is updated
-  { name = "windows" },        # Latest sysinfo uses 0.57 max, latest wgpu uses 0.58. See also https://github.com/GuillaumeGomez/sysinfo/pull/1338.
-  { name = "zbus" },           # Old version via rfd
+  { name = "quick-xml" }, # Old version via rfd
+  { name = "tower" },     # tonic depends on 0.4.3, but also transitively (axum) on 0.5.1
+  { name = "walkers" },   # TODO(#7876): suppress that when `walkers` is updated
+  { name = "windows" },   # Latest sysinfo uses 0.57 max, latest wgpu uses 0.58. See also https://github.com/GuillaumeGomez/sysinfo/pull/1338.
+  { name = "zbus" },      # Old version via rfd
 ]
-
 
 [licenses]
 version = 2

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -195,17 +195,17 @@ def cargo_deny(results: list[Result]) -> None:
     # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
     # Installing is quite quick if it's already installed.
     results.append(run_cargo("install", "--locked cargo-deny"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target aarch64-apple-darwin check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-gnu check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-msvc check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target i686-unknown-linux-gnu check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target wasm32-unknown-unknown check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target x86_64-apple-darwin check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target x86_64-pc-windows-gnu check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target x86_64-pc-windows-msvc check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-linux-gnu check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-linux-musl check"))
-    results.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-redox check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target aarch64-apple-darwin check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-pc-windows-gnu check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-pc-windows-msvc check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-unknown-linux-gnu check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target wasm32-unknown-unknown check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-apple-darwin check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-pc-windows-gnu check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-pc-windows-msvc check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-linux-gnu check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-linux-musl check"))
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-redox check"))
 
 
 def wasm(results: list[Result]) -> None:

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -195,17 +195,39 @@ def cargo_deny(results: list[Result]) -> None:
     # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
     # Installing is quite quick if it's already installed.
     results.append(run_cargo("install", "--locked cargo-deny"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target aarch64-apple-darwin check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-pc-windows-gnu check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-pc-windows-msvc check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-unknown-linux-gnu check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target wasm32-unknown-unknown check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-apple-darwin check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-pc-windows-gnu check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-pc-windows-msvc check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-linux-gnu check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-linux-musl check"))
-    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-redox check"))
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target aarch64-apple-darwin check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-pc-windows-gnu check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-pc-windows-msvc check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target i686-unknown-linux-gnu check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target wasm32-unknown-unknown check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-apple-darwin check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-pc-windows-gnu check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-pc-windows-msvc check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-linux-gnu check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-linux-musl check")
+    )
+    results.append(
+        run_cargo("deny", "--all-features --exclude-dev --log-level error --target x86_64-unknown-redox check")
+    )
 
 
 def wasm(results: list[Result]) -> None:


### PR DESCRIPTION
this meant that even minimal Rust applications building with our SDK dragged in this dependency, adding unnecessary 1.5 cpu seconds on my M1.

To solve this problem "once and for all" we now execute `cargo deny` always with `--exclude-dev`, meaning it no longer checks for any dev dependencies. This way we can flag pure testing crates like insta and criterion as forbidden.
(Note that licenses were already ignored  for dev dependencies, see https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html#the-include-dev-field-optional)

Plus some general updates to our `deny.toml`