### PR TITLE
Do not generate debug symbols by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,9 +349,16 @@ zip = { version = "0.6", default-features = false } # We're stuck on 0.6 because
 # ---------------------------------------------------------------------------------
 [profile]
 
+## Dev
+
 # Our dev profile has some optimizations turned on, as well as debug assertions.
 [profile.dev]
 opt-level = 1 # Make debug builds run faster
+# See <https://github.com/rerun-io/rerun/pull/9094> for a thorough explanation of why.
+# This does not affect cfg(debug_assertions).
+# Use the `debugging` profile (see below) if you need debug symbols.
+debug = false
+
 [profile.dev.package.re_video]
 opt-level = 2 # Speed up CPU-side chroma-upsampling (TODO(#7298): move to GPU)
 
@@ -360,30 +367,38 @@ opt-level = 2 # Speed up CPU-side chroma-upsampling (TODO(#7298): move to GPU)
 # egui has a feature where if you hold down all modifiers keys on your keyboard and hover any UI widget,
 # you will see the backtrace to that widget, and we don't want to break that feature in dev builds.
 
-[profile.dev.build-override]
-debug = true # enable debug symbols for build scripts when building in dev (codegen backtraces!)
-
 # Optimize all dependencies even in debug builds (does not affect workspace packages):
 [profile.dev.package."*"]
 opt-level = 2
 
+
+## Release
 
 [profile.release]
 # debug = true # good for profilers
 panic = "abort" # This leads to better optimizations and smaller binaries (and is the default in Wasm anyways).
 
 
-[profile.bench]
-debug = true
+## Bench
 
+[profile.bench]
+debug = false
+
+
+## Debugging
 
 # Set up a `debugging` profile that turns of optimization of the workspace and select packages.
 # Note that the profile name `debug` is reserved.
 [profile.debugging]
 inherits = "dev"
 opt-level = 0
+debug = true
+
 [profile.debugging.package.egui]
 opt-level = 0 # we often debug egui via Rerun
+
+[profile.debugging.build-override]
+debug = true # enable debug symbols for build scripts
 
 
 # ---------------------------------------------------------------------------------


### PR DESCRIPTION
My hot take of the day is that always-on debug symbols, in a language that generate this many and such complex symbols, is the wrong default (especially in a world where the tooling around these symbols leaves _a lot_ to be desired).

As the timings below show, we spend a non-negligible chunk of our days computing and dumping these symbols to disk, which is both time and space consuming (hello 400GB+ target/ folders).

This PR turns it all around: the `dev` profile will not generate debug symbols anymore, while the `debugging` profile will.

## Timings

```
touch crates/store/re_chunk_store/src/query.rs  ; cargo build -p rerun-cli --all-features --timings
```

Full debug build with debug symbols (3m 02s):
https://storage.googleapis.com/rerun-builds/timings/full_with_debug.html

Incremental debug build with debug symbols (Best of 3: 6.86s):
https://storage.googleapis.com/rerun-builds/timings/incremental_with_debug.html


Full debug build without debug symbols (1m 50s):
https://storage.googleapis.com/rerun-builds/timings/full_without_debug.html

Incremental debug build without debug symbols (Best of 3: 5.33s):
https://storage.googleapis.com/rerun-builds/timings/incremental_without_debug.html

## Summary

* Full: 39.6% speedup
* Incremental: 22.3% speedup

Note that the "full build" timing is in fact not specific to full builds: anytime the aggregated set of feature flags change (i.e.: always), all code affected by these flags, including dependencies, will have to be rebuilt (which is how we end up with 400GB+ target folders in the first place).
For that reason, incremental builds often behave more like something in-between incremental and full builds (so around 30% improvement).

## Aside: backtraces

This is what a crash looks like without debug symbols:
```
thread 'main' panicked at 'index out of bounds: the len is 3 but the index is 4'
re_chunk_store/src/query.rs:707
stack backtrace:
   6: core::panicking::panic_fmt
   7: core::panicking::panic_bounds_check
   8: re_chunk_store::query::<impl re_chunk_store::store::ChunkStore>::latest_at
   9: re_chunk_store::query::<impl re_chunk_store::store::ChunkStore>::latest_at_relevant_chunks
  10: re_query::latest_at::LatestAtCache::latest_at
  11: re_query::latest_at::<impl re_query::cache::QueryCache>::latest_at
  12: re_viewer::app_blueprint::load_panel_state
  13: re_viewer::app_blueprint::AppBlueprint::new
  14: <re_viewer::app::App as eframe::epi::App>::update
  15: egui::context::Context::run
  16: eframe::native::epi_integration::EpiIntegration::update
  17: <eframe::native::wgpu_integration::WgpuWinitApp as eframe::native::winit_integration::WinitApp>::run_ui_and_paint
  18: eframe::native::event_loop_context::with_event_loop_context
  19: <eframe::native::run::WinitAppWrapper<T> as winit::application::ApplicationHandler<eframe::native::winit_integration::UserEvent>>::window_event
  20: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
  21: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::pump_events
  22: winit::platform_impl::linux::wayland::event_loop::EventLoop<T>::run_on_demand
  23: eframe::native::run::run_wgpu
  24: eframe::run_native
```

## Aside: `cfg(debug_assertions)`

This is not affected by `debug = false` as far as I can tell.
