### PR TITLE
Remove ALPN from gRPC connection

### DIFF
--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -75,17 +75,32 @@ pub async fn channel(origin: Origin) -> Result<tonic_web_wasm_client::Client, Co
 
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn channel(origin: Origin) -> Result<tonic::transport::Channel, ConnectionError> {
+    use std::net::Ipv4Addr;
+
     use tonic::transport::Endpoint;
 
     let http_url = origin.as_url();
 
     match Endpoint::new(http_url)?
-        .tls_config(tonic::transport::ClientTlsConfig::new().with_enabled_roots())?
+        .tls_config(
+            tonic::transport::ClientTlsConfig::new()
+                .with_enabled_roots()
+                .assume_http2(true),
+        )?
         .connect()
         .await
     {
         Ok(channel) => Ok(channel),
         Err(original_error) => {
+            if ![
+                url::Host::Domain("localhost".to_owned()),
+                url::Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)),
+            ]
+            .contains(&origin.host)
+            {
+                return Err(ConnectionError::Tonic(original_error));
+            }
+
             // If we can't establish a connection, we probe if the server is
             // expecting unencrypted traffic. If that is the case, we return
             // a more meaningful error message.


### PR DESCRIPTION
### What

This PR does two things:

* Establishes gRPC connection using `assume_http2` to prevent `tonic` from using ALPN, which fails with the current setup of Redap.
* Only probes local servers for unsecured connections.

### How to Test

Connect to a dataplatform over the internet with the native viewer.