### PR TITLE
Install cargo-deny `0.17` instead of latest

### DIFF
--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -194,7 +194,7 @@ def cargo_deny(results: list[Result]) -> None:
     # Note: running just `cargo deny check` without a `--target` can result in
     # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
     # Installing is quite quick if it's already installed.
-    results.append(run_cargo("install", "--locked cargo-deny"))
+    results.append(run_cargo("install", "--locked cargo-deny@^0.17"))
     results.append(
         run_cargo("deny", "--all-features --exclude-dev --log-level error --target aarch64-apple-darwin check")
     )


### PR DESCRIPTION
https://github.com/rerun-io/rerun/actions/runs/13494146032/job/37697608053?pr=9042

`0.18+` requires Rust `1.85`, and it's a bit too early for us to update to that