### PR TITLE
Add `rerun rrd verify`

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/reflection.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/reflection.rs
@@ -147,6 +147,7 @@ fn generate_component_reflection(
                 docstring_md: #docstring_md,
                 custom_placeholder: #custom_placeholder,
                 datatype: #type_name::arrow_datatype(),
+                verify_arrow_array: #type_name::verify_arrow_array,
             }
         };
         quoted_pairs.push(quote! { (#quoted_name, #quoted_reflection) });

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -310,7 +310,7 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
                 return self.next();
             }
 
-            re_log::debug!("Reached end of stream, iterator complete");
+            re_log::trace!("Reached end of stream, iterator complete");
             return None;
         };
 

--- a/crates/store/re_log_encoding/src/decoder/streaming.rs
+++ b/crates/store/re_log_encoding/src/decoder/streaming.rs
@@ -209,7 +209,7 @@ impl<R: AsyncBufRead + Unpin> Stream for StreamingDecoder<R> {
                     continue;
                 }
 
-                re_log::debug!("Reached end of stream, iterator complete");
+                re_log::trace!("Reached end of stream, iterator complete");
                 return std::task::Poll::Ready(None);
             };
 

--- a/crates/store/re_log_encoding/src/lib.rs
+++ b/crates/store/re_log_encoding/src/lib.rs
@@ -123,7 +123,9 @@ pub enum OptionsError {
     UnknownCompression(u8),
 
     // TODO(jan): Remove this at some point, realistically 1-2 releases after 0.23
-    #[error("Attempted to use the removed MsgPack serializer, which is no longer supported")]
+    #[error(
+        "You are trying to load an old .rrd file that's not supported by this version of Rerun."
+    )]
     RemovedMsgPackSerializer,
 
     #[error("Unknown serializer: {0}")]

--- a/crates/store/re_types/src/reflection/mod.rs
+++ b/crates/store/re_types/src/reflection/mod.rs
@@ -39,6 +39,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The active tab in a tabbed container.",
                 custom_placeholder: Some(ActiveTab::default().to_arrow()?),
                 datatype: ActiveTab::arrow_datatype(),
+                verify_arrow_array: ActiveTab::verify_arrow_array,
             },
         ),
         (
@@ -47,6 +48,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether empty cells in a dataframe should be filled with a latest-at query.",
                 custom_placeholder: Some(ApplyLatestAt::default().to_arrow()?),
                 datatype: ApplyLatestAt::arrow_datatype(),
+                verify_arrow_array: ApplyLatestAt::verify_arrow_array,
             },
         ),
         (
@@ -55,6 +57,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether the viewport layout is determined automatically.",
                 custom_placeholder: Some(AutoLayout::default().to_arrow()?),
                 datatype: AutoLayout::arrow_datatype(),
+                verify_arrow_array: AutoLayout::verify_arrow_array,
             },
         ),
         (
@@ -63,6 +66,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether or not views should be created automatically.",
                 custom_placeholder: Some(AutoViews::default().to_arrow()?),
                 datatype: AutoViews::arrow_datatype(),
+                verify_arrow_array: AutoViews::verify_arrow_array,
             },
         ),
         (
@@ -71,6 +75,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The type of the background in a view.",
                 custom_placeholder: Some(BackgroundKind::default().to_arrow()?),
                 datatype: BackgroundKind::arrow_datatype(),
+                verify_arrow_array: BackgroundKind::verify_arrow_array,
             },
         ),
         (
@@ -79,6 +84,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The layout share of a column in the container.",
                 custom_placeholder: Some(ColumnShare::default().to_arrow()?),
                 datatype: ColumnShare::arrow_datatype(),
+                verify_arrow_array: ColumnShare::verify_arrow_array,
             },
         ),
         (
@@ -87,6 +93,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Describe a component column to be selected in the dataframe view.",
                 custom_placeholder: Some(ComponentColumnSelector::default().to_arrow()?),
                 datatype: ComponentColumnSelector::arrow_datatype(),
+                verify_arrow_array: ComponentColumnSelector::verify_arrow_array,
             },
         ),
         (
@@ -95,6 +102,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The kind of a blueprint container (tabs, grid, …).",
                 custom_placeholder: Some(ContainerKind::default().to_arrow()?),
                 datatype: ContainerKind::arrow_datatype(),
+                verify_arrow_array: ContainerKind::verify_arrow_array,
             },
         ),
         (
@@ -103,6 +111,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "One of four 2D corners, typically used to align objects.",
                 custom_placeholder: Some(Corner2D::default().to_arrow()?),
                 datatype: Corner2D::arrow_datatype(),
+                verify_arrow_array: Corner2D::verify_arrow_array,
             },
         ),
         (
@@ -111,6 +120,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether a procedure is enabled.",
                 custom_placeholder: Some(Enabled::default().to_arrow()?),
                 datatype: Enabled::arrow_datatype(),
+                verify_arrow_array: Enabled::verify_arrow_array,
             },
         ),
         (
@@ -119,6 +129,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Configuration for a filter-by-range feature of the dataframe view.",
                 custom_placeholder: Some(FilterByRange::default().to_arrow()?),
                 datatype: FilterByRange::arrow_datatype(),
+                verify_arrow_array: FilterByRange::verify_arrow_array,
             },
         ),
         (
@@ -127,6 +138,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Configuration for the filter is not null feature of the dataframe view.",
                 custom_placeholder: Some(FilterIsNotNull::default().to_arrow()?),
                 datatype: FilterIsNotNull::arrow_datatype(),
+                verify_arrow_array: FilterIsNotNull::verify_arrow_array,
             },
         ),
         (
@@ -135,6 +147,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The target distance between two nodes.\n\nThis is helpful to scale the layout, for example if long labels are involved.",
                 custom_placeholder: Some(ForceDistance::default().to_arrow()?),
                 datatype: ForceDistance::arrow_datatype(),
+                verify_arrow_array: ForceDistance::verify_arrow_array,
             },
         ),
         (
@@ -143,6 +156,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Specifies how often this force should be applied per iteration.\n\nIncreasing this parameter can lead to better results at the cost of longer computation time.",
                 custom_placeholder: Some(ForceIterations::default().to_arrow()?),
                 datatype: ForceIterations::arrow_datatype(),
+                verify_arrow_array: ForceIterations::verify_arrow_array,
             },
         ),
         (
@@ -151,6 +165,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The strength of a given force.\n\nAllows to assign different weights to the individual forces, prioritizing one over the other.",
                 custom_placeholder: Some(ForceStrength::default().to_arrow()?),
                 datatype: ForceStrength::arrow_datatype(),
+                verify_arrow_array: ForceStrength::verify_arrow_array,
             },
         ),
         (
@@ -159,6 +174,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "How many columns a grid container should have.",
                 custom_placeholder: Some(GridColumns::default().to_arrow()?),
                 datatype: GridColumns::arrow_datatype(),
+                verify_arrow_array: GridColumns::verify_arrow_array,
             },
         ),
         (
@@ -167,6 +183,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Space between grid lines of one line to the next in scene units.",
                 custom_placeholder: Some(GridSpacing::default().to_arrow()?),
                 datatype: GridSpacing::arrow_datatype(),
+                verify_arrow_array: GridSpacing::verify_arrow_array,
             },
         ),
         (
@@ -175,6 +192,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "All the contents in the container.",
                 custom_placeholder: Some(IncludedContent::default().to_arrow()?),
                 datatype: IncludedContent::arrow_datatype(),
+                verify_arrow_array: IncludedContent::verify_arrow_array,
             },
         ),
         (
@@ -183,6 +201,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether the entity can be interacted with.\n\nNon interactive components are still visible, but mouse interactions in the view are disabled.",
                 custom_placeholder: Some(Interactive::default().to_arrow()?),
                 datatype: Interactive::arrow_datatype(),
+                verify_arrow_array: Interactive::verify_arrow_array,
             },
         ),
         (
@@ -191,6 +210,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Indicate whether the range should be locked when zooming in on the data.\n\nDefault is `false`, i.e. zoom will change the visualized range.",
                 custom_placeholder: Some(LockRangeDuringZoom::default().to_arrow()?),
                 datatype: LockRangeDuringZoom::arrow_datatype(),
+                verify_arrow_array: LockRangeDuringZoom::verify_arrow_array,
             },
         ),
         (
@@ -199,6 +219,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Name of the map provider to be used in Map views.",
                 custom_placeholder: Some(MapProvider::default().to_arrow()?),
                 datatype: MapProvider::arrow_datatype(),
+                verify_arrow_array: MapProvider::verify_arrow_array,
             },
         ),
         (
@@ -207,6 +228,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Distance to the near clip plane used for `Spatial2DView`.",
                 custom_placeholder: Some(NearClipPlane::default().to_arrow()?),
                 datatype: NearClipPlane::arrow_datatype(),
+                verify_arrow_array: NearClipPlane::verify_arrow_array,
             },
         ),
         (
@@ -215,6 +237,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Tri-state for panel controls.",
                 custom_placeholder: Some(PanelState::default().to_arrow()?),
                 datatype: PanelState::arrow_datatype(),
+                verify_arrow_array: PanelState::verify_arrow_array,
             },
         ),
         (
@@ -223,6 +246,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "An individual query expression used to filter a set of [`datatypes.EntityPath`](https://rerun.io/docs/reference/types/datatypes/entity_path)s.\n\nEach expression is either an inclusion or an exclusion expression.\nInclusions start with an optional `+` and exclusions must start with a `-`.\n\nMultiple expressions are combined together as part of archetypes.ViewContents.\n\nThe `/**` suffix matches the whole subtree, i.e. self and any child, recursively\n(`/world/**` matches both `/world` and `/world/car/driver`).\nOther uses of `*` are not (yet) supported.",
                 custom_placeholder: Some(QueryExpression::default().to_arrow()?),
                 datatype: QueryExpression::arrow_datatype(),
+                verify_arrow_array: QueryExpression::verify_arrow_array,
             },
         ),
         (
@@ -231,6 +255,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The container that sits at the root of a viewport.",
                 custom_placeholder: Some(RootContainer::default().to_arrow()?),
                 datatype: RootContainer::arrow_datatype(),
+                verify_arrow_array: RootContainer::verify_arrow_array,
             },
         ),
         (
@@ -239,6 +264,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The layout share of a row in the container.",
                 custom_placeholder: Some(RowShare::default().to_arrow()?),
                 datatype: RowShare::arrow_datatype(),
+                verify_arrow_array: RowShare::verify_arrow_array,
             },
         ),
         (
@@ -247,6 +273,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Describe a component column to be selected in the dataframe view.",
                 custom_placeholder: Some(SelectedColumns::default().to_arrow()?),
                 datatype: SelectedColumns::arrow_datatype(),
+                verify_arrow_array: SelectedColumns::verify_arrow_array,
             },
         ),
         (
@@ -257,6 +284,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                     TensorDimensionIndexSlider::default().to_arrow()?,
                 ),
                 datatype: TensorDimensionIndexSlider::arrow_datatype(),
+                verify_arrow_array: TensorDimensionIndexSlider::verify_arrow_array,
             },
         ),
         (
@@ -265,6 +293,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A timeline identified by its name.",
                 custom_placeholder: Some(TimelineName::default().to_arrow()?),
                 datatype: TimelineName::arrow_datatype(),
+                verify_arrow_array: TimelineName::verify_arrow_array,
             },
         ),
         (
@@ -273,6 +302,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The class identifier of view, e.g. `\"2D\"`, `\"TextLog\"`, ….",
                 custom_placeholder: Some(ViewClass::default().to_arrow()?),
                 datatype: ViewClass::arrow_datatype(),
+                verify_arrow_array: ViewClass::verify_arrow_array,
             },
         ),
         (
@@ -281,6 +311,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Determines whether an image or texture should be scaled to fit the viewport.",
                 custom_placeholder: Some(ViewFit::default().to_arrow()?),
                 datatype: ViewFit::arrow_datatype(),
+                verify_arrow_array: ViewFit::verify_arrow_array,
             },
         ),
         (
@@ -289,6 +320,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether a view is maximized.",
                 custom_placeholder: Some(ViewMaximized::default().to_arrow()?),
                 datatype: ViewMaximized::arrow_datatype(),
+                verify_arrow_array: ViewMaximized::verify_arrow_array,
             },
         ),
         (
@@ -297,6 +329,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The origin of a view.",
                 custom_placeholder: Some(ViewOrigin::default().to_arrow()?),
                 datatype: ViewOrigin::arrow_datatype(),
+                verify_arrow_array: ViewOrigin::verify_arrow_array,
             },
         ),
         (
@@ -307,6 +340,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                     ViewerRecommendationHash::default().to_arrow()?,
                 ),
                 datatype: ViewerRecommendationHash::arrow_datatype(),
+                verify_arrow_array: ViewerRecommendationHash::verify_arrow_array,
             },
         ),
         (
@@ -315,6 +349,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The range of values on a given timeline that will be included in a view's query.\n\nRefer to `VisibleTimeRanges` archetype for more information.",
                 custom_placeholder: Some(VisibleTimeRange::default().to_arrow()?),
                 datatype: VisibleTimeRange::arrow_datatype(),
+                verify_arrow_array: VisibleTimeRange::verify_arrow_array,
             },
         ),
         (
@@ -323,6 +358,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Visual bounds in 2D space used for `Spatial2DView`.",
                 custom_placeholder: Some(VisualBounds2D::default().to_arrow()?),
                 datatype: VisualBounds2D::arrow_datatype(),
+                verify_arrow_array: VisualBounds2D::verify_arrow_array,
             },
         ),
         (
@@ -331,6 +367,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Override the visualizers for an entity.\n\nThis component is a stop-gap mechanism based on the current implementation details\nof the visualizer system. It is not intended to be a long-term solution, but provides\nenough utility to be useful in the short term.\n\nThe long-term solution is likely to be based off: <https://github.com/rerun-io/rerun/issues/6626>\n\nThis can only be used as part of blueprints. It will have no effect if used\nin a regular entity.",
                 custom_placeholder: Some(VisualizerOverrides::default().to_arrow()?),
                 datatype: VisualizerOverrides::arrow_datatype(),
+                verify_arrow_array: VisualizerOverrides::verify_arrow_array,
             },
         ),
         (
@@ -339,6 +376,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A zoom level determines how much of the world is visible on a map.",
                 custom_placeholder: Some(ZoomLevel::default().to_arrow()?),
                 datatype: ZoomLevel::arrow_datatype(),
+                verify_arrow_array: ZoomLevel::verify_arrow_array,
             },
         ),
         (
@@ -347,6 +385,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Policy for aggregation of multiple scalar plot values.\n\nThis is used for lines in plots when the X axis distance of individual points goes below a single pixel,\ni.e. a single pixel covers more than one tick worth of data. It can greatly improve performance\n(and readability) in such situations as it prevents overdraw.",
                 custom_placeholder: Some(AggregationPolicy::default().to_arrow()?),
                 datatype: AggregationPolicy::arrow_datatype(),
+                verify_arrow_array: AggregationPolicy::verify_arrow_array,
             },
         ),
         (
@@ -355,6 +394,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A color multiplier, usually applied to a whole entity, e.g. a mesh.",
                 custom_placeholder: Some(AlbedoFactor::default().to_arrow()?),
                 datatype: AlbedoFactor::arrow_datatype(),
+                verify_arrow_array: AlbedoFactor::verify_arrow_array,
             },
         ),
         (
@@ -363,6 +403,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The annotation context provides additional information on how to display entities.\n\nEntities can use [`datatypes.ClassId`](https://rerun.io/docs/reference/types/datatypes/class_id)s and [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id)s to provide annotations, and\nthe labels and colors will be looked up in the appropriate\nannotation context. We use the *first* annotation context we find in the\npath-hierarchy when searching up through the ancestors of a given entity\npath.",
                 custom_placeholder: Some(AnnotationContext::default().to_arrow()?),
                 datatype: AnnotationContext::arrow_datatype(),
+                verify_arrow_array: AnnotationContext::verify_arrow_array,
             },
         ),
         (
@@ -371,6 +412,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The length of an axis in local units of the space.",
                 custom_placeholder: Some(AxisLength::default().to_arrow()?),
                 datatype: AxisLength::arrow_datatype(),
+                verify_arrow_array: AxisLength::verify_arrow_array,
             },
         ),
         (
@@ -379,6 +421,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A binary blob of data.",
                 custom_placeholder: None,
                 datatype: Blob::arrow_datatype(),
+                verify_arrow_array: Blob::verify_arrow_array,
             },
         ),
         (
@@ -387,6 +430,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 16-bit ID representing a type of semantic class.",
                 custom_placeholder: Some(ClassId::default().to_arrow()?),
                 datatype: ClassId::arrow_datatype(),
+                verify_arrow_array: ClassId::verify_arrow_array,
             },
         ),
         (
@@ -395,6 +439,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Configures how a clear operation should behave - recursive or not.",
                 custom_placeholder: Some(ClearIsRecursive::default().to_arrow()?),
                 datatype: ClearIsRecursive::arrow_datatype(),
+                verify_arrow_array: ClearIsRecursive::verify_arrow_array,
             },
         ),
         (
@@ -403,6 +448,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.\n\nThe color is stored as a 32-bit integer, where the most significant\nbyte is `R` and the least significant byte is `A`.",
                 custom_placeholder: Some(Color::default().to_arrow()?),
                 datatype: Color::arrow_datatype(),
+                verify_arrow_array: Color::verify_arrow_array,
             },
         ),
         (
@@ -411,6 +457,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Colormap for mapping scalar values within a given range to a color.\n\nThis provides a number of popular pre-defined colormaps.\nIn the future, the Rerun Viewer will allow users to define their own colormaps,\nbut currently the Viewer is limited to the types defined here.",
                 custom_placeholder: Some(Colormap::default().to_arrow()?),
                 datatype: Colormap::arrow_datatype(),
+                verify_arrow_array: Colormap::verify_arrow_array,
             },
         ),
         (
@@ -419,6 +466,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The world->depth map scaling factor.\n\nThis measures how many depth map units are in a world unit.\nFor instance, if a depth map uses millimeters and the world uses meters,\nthis value would be `1000`.\n\nNote that the only effect on 2D views is the physical depth values shown when hovering the image.\nIn 3D views on the other hand, this affects where the points of the point cloud are placed.",
                 custom_placeholder: Some(DepthMeter::default().to_arrow()?),
                 datatype: DepthMeter::arrow_datatype(),
+                verify_arrow_array: DepthMeter::verify_arrow_array,
             },
         ),
         (
@@ -427,6 +475,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Draw order of 2D elements. Higher values are drawn on top of lower values.\n\nAn entity can have only a single draw order component.\nWithin an entity draw order is governed by the order of the components.\n\nDraw order for entities with the same draw order is generally undefined.",
                 custom_placeholder: Some(DrawOrder::default().to_arrow()?),
                 datatype: DrawOrder::arrow_datatype(),
+                verify_arrow_array: DrawOrder::verify_arrow_array,
             },
         ),
         (
@@ -435,6 +484,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A path to an entity, usually to reference some data that is part of the target entity.",
                 custom_placeholder: Some(EntityPath::default().to_arrow()?),
                 datatype: EntityPath::arrow_datatype(),
+                verify_arrow_array: EntityPath::verify_arrow_array,
             },
         ),
         (
@@ -443,6 +493,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "How a geometric shape is drawn and colored.",
                 custom_placeholder: Some(FillMode::default().to_arrow()?),
                 datatype: FillMode::arrow_datatype(),
+                verify_arrow_array: FillMode::verify_arrow_array,
             },
         ),
         (
@@ -451,6 +502,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "How much a primitive fills out the available space.\n\nUsed for instance to scale the points of the point cloud created from [`archetypes.DepthImage`](https://rerun.io/docs/reference/types/archetypes/depth_image) projection in 3D views.\nValid range is from 0 to max float although typically values above 1.0 are not useful.\n\nDefaults to 1.0.",
                 custom_placeholder: Some(FillRatio::default().to_arrow()?),
                 datatype: FillRatio::arrow_datatype(),
+                verify_arrow_array: FillRatio::verify_arrow_array,
             },
         ),
         (
@@ -459,6 +511,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A gamma correction value to be used with a scalar value or color.\n\nUsed to adjust the gamma of a color or scalar value between 0 and 1 before rendering.\n`new_value = old_value ^ gamma`\n\nValid range is from 0 (excluding) to max float.\nDefaults to 1.0 unless otherwise specified.",
                 custom_placeholder: Some(GammaCorrection::default().to_arrow()?),
                 datatype: GammaCorrection::arrow_datatype(),
+                verify_arrow_array: GammaCorrection::verify_arrow_array,
             },
         ),
         (
@@ -467,6 +520,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A geospatial line string expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees).",
                 custom_placeholder: Some(GeoLineString::default().to_arrow()?),
                 datatype: GeoLineString::arrow_datatype(),
+                verify_arrow_array: GeoLineString::verify_arrow_array,
             },
         ),
         (
@@ -475,6 +529,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "An edge in a graph connecting two nodes.",
                 custom_placeholder: Some(GraphEdge::default().to_arrow()?),
                 datatype: GraphEdge::arrow_datatype(),
+                verify_arrow_array: GraphEdge::verify_arrow_array,
             },
         ),
         (
@@ -483,6 +538,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A string-based ID representing a node in a graph.",
                 custom_placeholder: Some(GraphNode::default().to_arrow()?),
                 datatype: GraphNode::arrow_datatype(),
+                verify_arrow_array: GraphNode::verify_arrow_array,
             },
         ),
         (
@@ -491,6 +547,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Specifies if a graph has directed or undirected edges.",
                 custom_placeholder: Some(GraphType::default().to_arrow()?),
                 datatype: GraphType::arrow_datatype(),
+                verify_arrow_array: GraphType::verify_arrow_array,
             },
         ),
         (
@@ -499,6 +556,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Half-size (radius) of a 2D box.\n\nMeasured in its local coordinate system.\n\nThe box extends both in negative and positive direction along each axis.\nNegative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.",
                 custom_placeholder: Some(HalfSize2D::default().to_arrow()?),
                 datatype: HalfSize2D::arrow_datatype(),
+                verify_arrow_array: HalfSize2D::verify_arrow_array,
             },
         ),
         (
@@ -507,6 +565,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Half-size (radius) of a 3D box.\n\nMeasured in its local coordinate system.\n\nThe box extends both in negative and positive direction along each axis.\nNegative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.",
                 custom_placeholder: Some(HalfSize3D::default().to_arrow()?),
                 datatype: HalfSize3D::arrow_datatype(),
+                verify_arrow_array: HalfSize3D::verify_arrow_array,
             },
         ),
         (
@@ -515,6 +574,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A buffer that is known to store image data.\n\nTo interpret the contents of this buffer, see, [`components.ImageFormat`](https://rerun.io/docs/reference/types/components/image_format).",
                 custom_placeholder: None,
                 datatype: ImageBuffer::arrow_datatype(),
+                verify_arrow_array: ImageBuffer::verify_arrow_array,
             },
         ),
         (
@@ -523,6 +583,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).",
                 custom_placeholder: Some(ImageFormat::default().to_arrow()?),
                 datatype: ImageFormat::arrow_datatype(),
+                verify_arrow_array: ImageFormat::verify_arrow_array,
             },
         ),
         (
@@ -531,6 +592,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.\n\nThis is only used for visualization purposes, and does not affect the projection itself.",
                 custom_placeholder: Some(ImagePlaneDistance::default().to_arrow()?),
                 datatype: ImagePlaneDistance::arrow_datatype(),
+                verify_arrow_array: ImagePlaneDistance::verify_arrow_array,
             },
         ),
         (
@@ -539,6 +601,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 16-bit ID representing a type of semantic keypoint within a class.",
                 custom_placeholder: Some(KeypointId::default().to_arrow()?),
                 datatype: KeypointId::arrow_datatype(),
+                verify_arrow_array: KeypointId::verify_arrow_array,
             },
         ),
         (
@@ -547,6 +610,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A geospatial position expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees).",
                 custom_placeholder: Some(LatLon::default().to_arrow()?),
                 datatype: LatLon::arrow_datatype(),
+                verify_arrow_array: LatLon::verify_arrow_array,
             },
         ),
         (
@@ -555,6 +619,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Length, or one-dimensional size.\n\nMeasured in its local coordinate system; consult the archetype in use to determine which\naxis or part of the entity this is the length of.",
                 custom_placeholder: Some(Length::default().to_arrow()?),
                 datatype: Length::arrow_datatype(),
+                verify_arrow_array: Length::verify_arrow_array,
             },
         ),
         (
@@ -563,6 +628,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A line strip in 2D space.\n\nA line strip is a list of points connected by line segments. It can be used to draw\napproximations of smooth curves.\n\nThe points will be connected in order, like so:\n```text\n       2------3     5\n      /        \\   /\n0----1          \\ /\n                 4\n```",
                 custom_placeholder: Some(LineStrip2D::default().to_arrow()?),
                 datatype: LineStrip2D::arrow_datatype(),
+                verify_arrow_array: LineStrip2D::verify_arrow_array,
             },
         ),
         (
@@ -571,6 +637,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A line strip in 3D space.\n\nA line strip is a list of points connected by line segments. It can be used to draw\napproximations of smooth curves.\n\nThe points will be connected in order, like so:\n```text\n       2------3     5\n      /        \\   /\n0----1          \\ /\n                 4\n```",
                 custom_placeholder: Some(LineStrip3D::default().to_arrow()?),
                 datatype: LineStrip3D::arrow_datatype(),
+                verify_arrow_array: LineStrip3D::verify_arrow_array,
             },
         ),
         (
@@ -579,6 +646,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen.",
                 custom_placeholder: Some(MagnificationFilter::default().to_arrow()?),
                 datatype: MagnificationFilter::arrow_datatype(),
+                verify_arrow_array: MagnificationFilter::verify_arrow_array,
             },
         ),
         (
@@ -587,6 +655,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The visual appearance of a point in e.g. a 2D plot.",
                 custom_placeholder: Some(MarkerShape::default().to_arrow()?),
                 datatype: MarkerShape::arrow_datatype(),
+                verify_arrow_array: MarkerShape::verify_arrow_array,
             },
         ),
         (
@@ -595,6 +664,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Radius of a marker of a point in e.g. a 2D plot, measured in UI points.",
                 custom_placeholder: Some(MarkerSize::default().to_arrow()?),
                 datatype: MarkerSize::arrow_datatype(),
+                verify_arrow_array: MarkerSize::verify_arrow_array,
             },
         ),
         (
@@ -603,6 +673,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A standardized media type (RFC2046, formerly known as MIME types), encoded as a string.\n\nThe complete reference of officially registered media types is maintained by the IANA and can be\nconsulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.",
                 custom_placeholder: Some(MediaType::default().to_arrow()?),
                 datatype: MediaType::arrow_datatype(),
+                verify_arrow_array: MediaType::verify_arrow_array,
             },
         ),
         (
@@ -611,6 +682,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A display name, typically for an entity or a item like a plot series.",
                 custom_placeholder: Some(Name::default().to_arrow()?),
                 datatype: Name::arrow_datatype(),
+                verify_arrow_array: Name::verify_arrow_array,
             },
         ),
         (
@@ -619,6 +691,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Degree of transparency ranging from 0.0 (fully transparent) to 1.0 (fully opaque).\n\nThe final opacity value may be a result of multiplication with alpha values as specified by other color sources.\nUnless otherwise specified, the default value is 1.",
                 custom_placeholder: Some(Opacity::default().to_arrow()?),
                 datatype: Opacity::arrow_datatype(),
+                verify_arrow_array: Opacity::verify_arrow_array,
             },
         ),
         (
@@ -627,6 +700,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Camera projection, from image coordinates to view coordinates.\n\nChild from parent.\nImage coordinates from camera view coordinates.\n\nExample:\n```text\n1496.1     0.0  980.5\n   0.0  1496.1  744.5\n   0.0     0.0    1.0\n```",
                 custom_placeholder: Some(PinholeProjection::default().to_arrow()?),
                 datatype: PinholeProjection::arrow_datatype(),
+                verify_arrow_array: PinholeProjection::verify_arrow_array,
             },
         ),
         (
@@ -635,6 +709,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "An infinite 3D plane represented by a unit normal vector and a distance.\n\nAny point P on the plane fulfills the equation `dot(xyz, P) - d = 0`,\nwhere `xyz` is the plane's normal and `d` the distance of the plane from the origin.\nThis representation is also known as the Hesse normal form.\n\nNote: although the normal will be passed through to the\ndatastore as provided, when used in the Viewer, planes will always be normalized.\nI.e. the plane with xyz = (2, 0, 0), d = 1 is equivalent to xyz = (1, 0, 0), d = 0.5",
                 custom_placeholder: None,
                 datatype: Plane3D::arrow_datatype(),
+                verify_arrow_array: Plane3D::verify_arrow_array,
             },
         ),
         (
@@ -643,6 +718,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.\n\nIf normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the\nangle is zero in which case it is treated as an identity.",
                 custom_placeholder: Some(PoseRotationAxisAngle::default().to_arrow()?),
                 datatype: PoseRotationAxisAngle::arrow_datatype(),
+                verify_arrow_array: PoseRotationAxisAngle::verify_arrow_array,
             },
         ),
         (
@@ -651,6 +727,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 3D rotation expressed as a quaternion that doesn't propagate in the transform hierarchy.\n\nNote: although the x,y,z,w components of the quaternion will be passed through to the\ndatastore as provided, when used in the Viewer, quaternions will always be normalized.\nIf normalization fails the rotation is treated as an invalid transform.",
                 custom_placeholder: Some(PoseRotationQuat::default().to_arrow()?),
                 datatype: PoseRotationQuat::arrow_datatype(),
+                verify_arrow_array: PoseRotationQuat::verify_arrow_array,
             },
         ),
         (
@@ -659,6 +736,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 3D scale factor that doesn't propagate in the transform hierarchy.\n\nA scale of 1.0 means no scaling.\nA scale of 2.0 means doubling the size.\nEach component scales along the corresponding axis.",
                 custom_placeholder: Some(PoseScale3D::default().to_arrow()?),
                 datatype: PoseScale3D::arrow_datatype(),
+                verify_arrow_array: PoseScale3D::verify_arrow_array,
             },
         ),
         (
@@ -667,6 +745,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 3x3 transformation matrix Matrix that doesn't propagate in the transform hierarchy.\n\n3x3 matrixes are able to represent any affine transformation in 3D space,\ni.e. rotation, scaling, shearing, reflection etc.\n\nMatrices in Rerun are stored as flat list of coefficients in column-major order:\n```text\n            column 0       column 1       column 2\n       -------------------------------------------------\nrow 0 | flat_columns[0] flat_columns[3] flat_columns[6]\nrow 1 | flat_columns[1] flat_columns[4] flat_columns[7]\nrow 2 | flat_columns[2] flat_columns[5] flat_columns[8]\n```",
                 custom_placeholder: Some(PoseTransformMat3x3::default().to_arrow()?),
                 datatype: PoseTransformMat3x3::arrow_datatype(),
+                verify_arrow_array: PoseTransformMat3x3::verify_arrow_array,
             },
         ),
         (
@@ -675,6 +754,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A translation vector in 3D space that doesn't propagate in the transform hierarchy.",
                 custom_placeholder: Some(PoseTranslation3D::default().to_arrow()?),
                 datatype: PoseTranslation3D::arrow_datatype(),
+                verify_arrow_array: PoseTranslation3D::verify_arrow_array,
             },
         ),
         (
@@ -683,6 +763,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A position in 2D space.",
                 custom_placeholder: Some(Position2D::default().to_arrow()?),
                 datatype: Position2D::arrow_datatype(),
+                verify_arrow_array: Position2D::verify_arrow_array,
             },
         ),
         (
@@ -691,6 +772,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A position in 3D space.",
                 custom_placeholder: Some(Position3D::default().to_arrow()?),
                 datatype: Position3D::arrow_datatype(),
+                verify_arrow_array: Position3D::verify_arrow_array,
             },
         ),
         (
@@ -699,6 +781,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The radius of something, e.g. a point.\n\nInternally, positive values indicate scene units, whereas negative values\nare interpreted as UI points.\n\nUI points are independent of zooming in Views, but are sensitive to the application UI scaling.\nat 100% UI scaling, UI points are equal to pixels\nThe Viewer's UI scaling defaults to the OS scaling which typically is 100% for full HD screens and 200% for 4k screens.",
                 custom_placeholder: Some(Radius::default().to_arrow()?),
                 datatype: Radius::arrow_datatype(),
+                verify_arrow_array: Radius::verify_arrow_array,
             },
         ),
         (
@@ -707,6 +790,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 1D range, specifying a lower and upper bound.",
                 custom_placeholder: Some(Range1D::default().to_arrow()?),
                 datatype: Range1D::arrow_datatype(),
+                verify_arrow_array: Range1D::verify_arrow_array,
             },
         ),
         (
@@ -715,6 +799,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Pixel resolution width & height, e.g. of a camera sensor.\n\nTypically in integer units, but for some use cases floating point may be used.",
                 custom_placeholder: Some(Resolution::default().to_arrow()?),
                 datatype: Resolution::arrow_datatype(),
+                verify_arrow_array: Resolution::verify_arrow_array,
             },
         ),
         (
@@ -723,6 +808,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "3D rotation represented by a rotation around a given axis.\n\nIf normalization of the rotation axis fails the rotation is treated as an invalid transform, unless the\nangle is zero in which case it is treated as an identity.",
                 custom_placeholder: Some(RotationAxisAngle::default().to_arrow()?),
                 datatype: RotationAxisAngle::arrow_datatype(),
+                verify_arrow_array: RotationAxisAngle::verify_arrow_array,
             },
         ),
         (
@@ -731,6 +817,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 3D rotation expressed as a quaternion.\n\nNote: although the x,y,z,w components of the quaternion will be passed through to the\ndatastore as provided, when used in the Viewer, quaternions will always be normalized.\nIf normalization fails the rotation is treated as an invalid transform.",
                 custom_placeholder: Some(RotationQuat::default().to_arrow()?),
                 datatype: RotationQuat::arrow_datatype(),
+                verify_arrow_array: RotationQuat::verify_arrow_array,
             },
         ),
         (
@@ -739,6 +826,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A scalar value, encoded as a 64-bit floating point.\n\nUsed for time series plots.",
                 custom_placeholder: Some(Scalar::default().to_arrow()?),
                 datatype: Scalar::arrow_datatype(),
+                verify_arrow_array: Scalar::verify_arrow_array,
             },
         ),
         (
@@ -747,6 +835,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 3D scale factor.\n\nA scale of 1.0 means no scaling.\nA scale of 2.0 means doubling the size.\nEach component scales along the corresponding axis.",
                 custom_placeholder: Some(Scale3D::default().to_arrow()?),
                 datatype: Scale3D::arrow_datatype(),
+                verify_arrow_array: Scale3D::verify_arrow_array,
             },
         ),
         (
@@ -755,6 +844,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Like `Visible`, but for time series.\n\nTODO(#6889): This is a temporary workaround. Right now we can't use `Visible` since it would conflict with the entity-wide visibility state.",
                 custom_placeholder: None,
                 datatype: SeriesVisible::arrow_datatype(),
+                verify_arrow_array: SeriesVisible::verify_arrow_array,
             },
         ),
         (
@@ -763,6 +853,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether the entity's [`components.Text`](https://rerun.io/docs/reference/types/components/text) label is shown.\n\nThe main purpose of this component existing separately from the labels themselves\nis to be overridden when desired, to allow hiding and showing from the viewer and\nblueprints.",
                 custom_placeholder: None,
                 datatype: ShowLabels::arrow_datatype(),
+                verify_arrow_array: ShowLabels::verify_arrow_array,
             },
         ),
         (
@@ -771,6 +862,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The width of a stroke specified in UI points.",
                 custom_placeholder: Some(StrokeWidth::default().to_arrow()?),
                 datatype: StrokeWidth::arrow_datatype(),
+                verify_arrow_array: StrokeWidth::verify_arrow_array,
             },
         ),
         (
@@ -779,6 +871,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "An N-dimensional array of numbers.\n\nThe number of dimensions and their respective lengths is specified by the `shape` field.\nThe dimensions are ordered from outermost to innermost. For example, in the common case of\na 2D RGB Image, the shape would be `[height, width, channel]`.\n\nThese dimensions are combined with an index to look up values from the `buffer` field,\nwhich stores a contiguous array of typed values.",
                 custom_placeholder: Some(TensorData::default().to_arrow()?),
                 datatype: TensorData::arrow_datatype(),
+                verify_arrow_array: TensorData::verify_arrow_array,
             },
         ),
         (
@@ -789,6 +882,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                     TensorDimensionIndexSelection::default().to_arrow()?,
                 ),
                 datatype: TensorDimensionIndexSelection::arrow_datatype(),
+                verify_arrow_array: TensorDimensionIndexSelection::verify_arrow_array,
             },
         ),
         (
@@ -797,6 +891,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Specifies which dimension to use for height.",
                 custom_placeholder: Some(TensorHeightDimension::default().to_arrow()?),
                 datatype: TensorHeightDimension::arrow_datatype(),
+                verify_arrow_array: TensorHeightDimension::verify_arrow_array,
             },
         ),
         (
@@ -805,6 +900,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Specifies which dimension to use for width.",
                 custom_placeholder: Some(TensorWidthDimension::default().to_arrow()?),
                 datatype: TensorWidthDimension::arrow_datatype(),
+                verify_arrow_array: TensorWidthDimension::verify_arrow_array,
             },
         ),
         (
@@ -813,6 +909,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 2D texture UV coordinate.\n\nTexture coordinates specify a position on a 2D texture.\nA range from 0-1 covers the entire texture in the respective dimension.\nUnless configured otherwise, the texture repeats outside of this range.\nRerun uses top-left as the origin for UV coordinates.\n\n  0     U     1\n0 + --------- →\n  |           .\nV |           .\n  |           .\n1 ↓ . . . . . .\n\nThis is the same convention as in Vulkan/Metal/DX12/WebGPU, but (!) unlike OpenGL,\nwhich places the origin at the bottom-left.",
                 custom_placeholder: Some(Texcoord2D::default().to_arrow()?),
                 datatype: Texcoord2D::arrow_datatype(),
+                verify_arrow_array: Texcoord2D::verify_arrow_array,
             },
         ),
         (
@@ -821,6 +918,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A string of text, e.g. for labels and text documents.",
                 custom_placeholder: Some(Text::default().to_arrow()?),
                 datatype: Text::arrow_datatype(),
+                verify_arrow_array: Text::verify_arrow_array,
             },
         ),
         (
@@ -829,6 +927,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The severity level of a text log message.\n\nRecommended to be one of:\n* `\"CRITICAL\"`\n* `\"ERROR\"`\n* `\"WARN\"`\n* `\"INFO\"`\n* `\"DEBUG\"`\n* `\"TRACE\"`",
                 custom_placeholder: Some(TextLogLevel::default().to_arrow()?),
                 datatype: TextLogLevel::arrow_datatype(),
+                verify_arrow_array: TextLogLevel::verify_arrow_array,
             },
         ),
         (
@@ -837,6 +936,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A 3x3 transformation matrix Matrix.\n\n3x3 matrixes are able to represent any affine transformation in 3D space,\ni.e. rotation, scaling, shearing, reflection etc.\n\nMatrices in Rerun are stored as flat list of coefficients in column-major order:\n```text\n            column 0       column 1       column 2\n       -------------------------------------------------\nrow 0 | flat_columns[0] flat_columns[3] flat_columns[6]\nrow 1 | flat_columns[1] flat_columns[4] flat_columns[7]\nrow 2 | flat_columns[2] flat_columns[5] flat_columns[8]\n```",
                 custom_placeholder: Some(TransformMat3x3::default().to_arrow()?),
                 datatype: TransformMat3x3::arrow_datatype(),
+                verify_arrow_array: TransformMat3x3::verify_arrow_array,
             },
         ),
         (
@@ -845,6 +945,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Specifies relation a spatial transform describes.",
                 custom_placeholder: Some(TransformRelation::default().to_arrow()?),
                 datatype: TransformRelation::arrow_datatype(),
+                verify_arrow_array: TransformRelation::verify_arrow_array,
             },
         ),
         (
@@ -853,6 +954,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A translation vector in 3D space.",
                 custom_placeholder: Some(Translation3D::default().to_arrow()?),
                 datatype: Translation3D::arrow_datatype(),
+                verify_arrow_array: Translation3D::verify_arrow_array,
             },
         ),
         (
@@ -861,6 +963,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "The three indices of a triangle in a triangle mesh.",
                 custom_placeholder: Some(TriangleIndices::default().to_arrow()?),
                 datatype: TriangleIndices::arrow_datatype(),
+                verify_arrow_array: TriangleIndices::verify_arrow_array,
             },
         ),
         (
@@ -869,6 +972,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Range of expected or valid values, specifying a lower and upper bound.",
                 custom_placeholder: Some(ValueRange::default().to_arrow()?),
                 datatype: ValueRange::arrow_datatype(),
+                verify_arrow_array: ValueRange::verify_arrow_array,
             },
         ),
         (
@@ -877,6 +981,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A vector in 2D space.",
                 custom_placeholder: Some(Vector2D::default().to_arrow()?),
                 datatype: Vector2D::arrow_datatype(),
+                verify_arrow_array: Vector2D::verify_arrow_array,
             },
         ),
         (
@@ -885,6 +990,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "A vector in 3D space.",
                 custom_placeholder: Some(Vector3D::default().to_arrow()?),
                 datatype: Vector3D::arrow_datatype(),
+                verify_arrow_array: Vector3D::verify_arrow_array,
             },
         ),
         (
@@ -893,6 +999,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Timestamp inside a [`archetypes.AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video).",
                 custom_placeholder: Some(VideoTimestamp::default().to_arrow()?),
                 datatype: VideoTimestamp::arrow_datatype(),
+                verify_arrow_array: VideoTimestamp::verify_arrow_array,
             },
         ),
         (
@@ -901,6 +1008,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "How we interpret the coordinate system of an entity/space.\n\nFor instance: What is \"up\"? What does the Z axis mean?\n\nThe three coordinates are always ordered as [x, y, z].\n\nFor example [Right, Down, Forward] means that the X axis points to the right, the Y axis points\ndown, and the Z axis points forward.\n\n⚠ [Rerun does not yet support left-handed coordinate systems](https://github.com/rerun-io/rerun/issues/5032).\n\nThe following constants are used to represent the different directions:\n * Up = 1\n * Down = 2\n * Right = 3\n * Left = 4\n * Forward = 5\n * Back = 6",
                 custom_placeholder: Some(ViewCoordinates::default().to_arrow()?),
                 datatype: ViewCoordinates::arrow_datatype(),
+                verify_arrow_array: ViewCoordinates::verify_arrow_array,
             },
         ),
         (
@@ -909,6 +1017,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 docstring_md: "Whether the container, view, entity or instance is currently visible.",
                 custom_placeholder: Some(Visible::default().to_arrow()?),
                 datatype: Visible::arrow_datatype(),
+                verify_arrow_array: Visible::verify_arrow_array,
             },
         ),
     ];

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -75,6 +75,13 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
     ) -> crate::DeserializationResult<Vec<Option<Self>>> {
         Self::from_arrow(data).map(|v| v.into_iter().map(Some).collect())
     }
+
+    /// Verifies that the given Arrow array can be deserialized into a collection of [`Self`]s.
+    ///
+    /// Calls [`Self::from_arrow`] and returns an error if it fails.
+    fn verify_arrow_array(data: &dyn arrow::array::Array) -> crate::DeserializationResult<()> {
+        Self::from_arrow(data).map(|_| ())
+    }
 }
 
 /// A [`Component`] describes semantic data that can be used by any number of [`Archetype`]s.

--- a/crates/store/re_types_core/src/reflection.rs
+++ b/crates/store/re_types_core/src/reflection.rs
@@ -240,6 +240,9 @@ pub struct ComponentReflection {
 
     /// Datatype of the component.
     pub datatype: arrow::datatypes::DataType,
+
+    /// Checks that the given Arrow array can be deserialized into a collection of [`Self`]s.
+    pub verify_arrow_array: fn(&dyn arrow::array::Array) -> crate::DeserializationResult<()>,
 }
 
 /// Runtime reflection about archetypes.

--- a/crates/store/re_types_core/src/reflection.rs
+++ b/crates/store/re_types_core/src/reflection.rs
@@ -274,6 +274,10 @@ impl ArchetypeReflection {
     pub fn required_fields(&self) -> impl Iterator<Item = &ArchetypeFieldReflection> {
         self.fields.iter().filter(|field| field.is_required)
     }
+
+    pub fn get_field(&self, field_name: &str) -> Option<&ArchetypeFieldReflection> {
+        self.fields.iter().find(|field| field.name == field_name)
+    }
 }
 
 /// Additional information about an archetype's field.

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -104,7 +104,7 @@ impl FilterCommand {
                 Ok(size_bytes)
             });
 
-        for res in rx_decoder {
+        for (_source, res) in rx_decoder {
             let mut is_success = true;
 
             match res {

--- a/crates/top/rerun/src/commands/rrd/merge_compact.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_compact.rs
@@ -163,7 +163,7 @@ fn merge_and_compact(
 
     let mut entity_dbs: std::collections::HashMap<StoreId, EntityDb> = Default::default();
 
-    for res in rx {
+    for (_source, res) in rx {
         let mut is_success = true;
 
         match res {

--- a/crates/top/rerun/src/commands/rrd/mod.rs
+++ b/crates/top/rerun/src/commands/rrd/mod.rs
@@ -2,11 +2,13 @@ mod compare;
 mod filter;
 mod merge_compact;
 mod print;
+mod verify;
 
 use self::compare::CompareCommand;
 use self::filter::FilterCommand;
 use self::merge_compact::{CompactCommand, MergeCommand};
 use self::print::PrintCommand;
+use self::verify::VerifyCommand;
 
 // ---
 
@@ -28,6 +30,11 @@ pub enum RrdCommands {
     ///
     /// Example: `rerun rrd print /my/recordings/*.rrd`
     Print(PrintCommand),
+
+    /// Verify the that the .rrd file can be loaded and correctly interpreted.
+    ///
+    /// Can be used to ensure that the current Rerun version can load the data.
+    Verify(VerifyCommand),
 
     /// Compacts the contents of one or more .rrd/.rbl files/streams and writes the result standard output.
     ///
@@ -76,6 +83,7 @@ impl RrdCommands {
                     .with_context(|| format!("current directory {:?}", std::env::current_dir()))
             }
             Self::Print(print_command) => print_command.run(),
+            Self::Verify(verify_command) => verify_command.run(),
             Self::Compact(compact_command) => compact_command.run(),
             Self::Merge(merge_command) => merge_command.run(),
             Self::Filter(drop_command) => drop_command.run(),

--- a/crates/top/rerun/src/commands/rrd/print.rs
+++ b/crates/top/rerun/src/commands/rrd/print.rs
@@ -45,7 +45,7 @@ impl PrintCommand {
         let version_policy = re_log_encoding::VersionPolicy::Warn;
         let (rx, _) = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
 
-        for res in rx {
+        for (_source, res) in rx {
             let mut is_success = true;
 
             match res {

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -149,19 +149,19 @@ impl Verifier {
                     // Verify archetype field.
                     // We may want to have a flag to allow some of this?
                     let archetype_field_reflection = archetype_reflection
-                    .get_field(archetype_field_name)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Input column referred to the archetype field name {archetype_field_name:?} of {archetype_name:?}, which only has the fields: {:?}",
-                            archetype_reflection.fields.iter().map(|field| field.name)
-                        )
-                    })?;
+                        .get_field(archetype_field_name)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Input column referred to the archetype field name {archetype_field_name:?} of {archetype_name:?}, which only has the fields: {:?}",
+                                archetype_reflection.fields.iter().map(|field| field.name)
+                            )
+                        })?;
 
                     let expected_component_name = &archetype_field_reflection.component_name;
                     if component_name != expected_component_name {
                         return Err(anyhow::anyhow!(
-                        "Archetype field {archetype_field_name:?} of {archetype_name:?} has component {expected_component_name:?} in this version of Rerun, but the data column has component {component_name:?}"
-                    ));
+                            "Archetype field {archetype_field_name:?} of {archetype_name:?} has component {expected_component_name:?} in this version of Rerun, but the data column has component {component_name:?}"
+                        ));
                     }
                 }
             } else {

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -88,8 +88,9 @@ impl Verifier {
         for (component_descriptor, column) in chunk_batch.component_columns() {
             if let Err(err) = self.verify_component_column(component_descriptor, column) {
                 self.errors.insert(format!(
-                    "{source}: Failed to deserialize column {}: {err}",
-                    component_descriptor.component_name
+                    "{source}: Failed to deserialize column {}: {}",
+                    component_descriptor.component_name,
+                    re_error::format(err)
                 ));
             }
         }

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -72,8 +72,7 @@ impl Verifier {
         match re_sorbet::ChunkBatch::try_from(batch) {
             Ok(chunk_batch) => self.verify_chunk_batch(&chunk_batch),
             Err(err) => {
-                self.errors
-                    .insert(format!("Failed to parse batch: {err:?}"));
+                self.errors.insert(format!("Failed to parse batch: {err}"));
             }
         }
     }
@@ -88,7 +87,7 @@ impl Verifier {
 
             if let Err(err) = self.verify_component_column(component_name, column) {
                 self.errors.insert(format!(
-                    "Failed to deserialize column {component_name:?}: {err:?}"
+                    "Failed to deserialize column {component_name:?}: {err}"
                 ));
             }
         }

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -1,0 +1,85 @@
+use anyhow::Context as _;
+
+use arrow::array::AsArray;
+use re_log_types::LogMsg;
+use re_types::reflection::Reflection;
+
+use crate::commands::read_rrd_streams_from_file_or_stdin;
+
+// ---
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct VerifyCommand {
+    /// Paths to read from. Reads from standard input if none are specified.
+    path_to_input_rrds: Vec<String>,
+}
+
+impl VerifyCommand {
+    pub fn run(&self) -> anyhow::Result<()> {
+        let reflection = re_types::reflection::generate_reflection()?;
+
+        let Self { path_to_input_rrds } = self;
+
+        // TODO(cmc): might want to make this configurable at some point.
+        let version_policy = re_log_encoding::VersionPolicy::Warn;
+        let (rx, _) = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+
+        let mut log_msg_count = 0;
+        for res in rx {
+            verify_log_msg(&reflection, res?)?;
+            log_msg_count += 1;
+        }
+
+        eprintln!("{log_msg_count} chunks verified successfully.");
+
+        Ok(())
+    }
+}
+
+fn verify_log_msg(reflection: &Reflection, msg: LogMsg) -> anyhow::Result<()> {
+    match msg {
+        LogMsg::SetStoreInfo { .. } | LogMsg::BlueprintActivationCommand { .. } => {}
+
+        LogMsg::ArrowMsg(_store_id, arrow_msg) => {
+            verify_record_batch(reflection, &arrow_msg.batch)?;
+        }
+    }
+    Ok(())
+}
+
+fn verify_record_batch(
+    reflection: &Reflection,
+    batch: &arrow::array::RecordBatch,
+) -> anyhow::Result<()> {
+    let chunk_batch = re_sorbet::ChunkBatch::try_from(batch)?;
+
+    for (component_descriptor, column) in chunk_batch.component_columns() {
+        let component_name = component_descriptor.component_name;
+
+        if component_name.is_indicator_component() {
+            continue; // Lacks reflection
+        }
+
+        let component_reflection = reflection
+            .components
+            .get(&component_name)
+            .ok_or_else(|| anyhow::anyhow!("Unknown component: {component_name:?}"))?;
+
+        let list_array = column.as_list_opt::<i32>().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Expected list array, found {:?} (ComponentName: {component_name:?})",
+                column.data_type()
+            )
+        })?;
+
+        assert_eq!(column.len() + 1, list_array.offsets().len());
+
+        for i in 0..column.len() {
+            let cell = list_array.value(i);
+            (component_reflection.verify_arrow_array)(cell.as_ref())
+                .with_context(|| format!("ComponentName: {component_name:?}"))?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -25,14 +25,19 @@ impl VerifyCommand {
         let version_policy = re_log_encoding::VersionPolicy::Warn;
         let (rx, _) = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
 
-        let mut log_msg_count = 0;
+        let mut seen_files = std::collections::HashSet::new();
+
         for (source, res) in rx {
             verifier.verify_log_msg(&source.to_string(), res?);
-            log_msg_count += 1;
+            seen_files.insert(source);
         }
 
         if verifier.errors.is_empty() {
-            eprintln!("{log_msg_count} chunks verified successfully.");
+            if seen_files.len() == 1 {
+                eprintln!("1 file verified without error.");
+            } else {
+                eprintln!("{} files verified without error.", seen_files.len());
+            }
             Ok(())
         } else {
             for err in &verifier.errors {

--- a/crates/top/rerun/src/commands/stdio.rs
+++ b/crates/top/rerun/src/commands/stdio.rs
@@ -9,6 +9,7 @@ use re_log_types::LogMsg;
 
 // ---
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum InputSource {
     Stdin,
     File(PathBuf),


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/9110

### What
Add `rerun rrd verify some.rrd` which verifies that the current rerun version can load and understand the given .rrd file.

It goes through each component column in each record batch, find the corresponding component, and then tries to deserialize the arrow data within.
