### PR TITLE
Fix multi-value `Scalar` breaking legend disambiguation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7107,6 +7107,7 @@ dependencies = [
  "egui",
  "egui_plot",
  "itertools 0.13.0",
+ "nohash-hasher",
  "rayon",
  "re_chunk_store",
  "re_format",

--- a/crates/viewer/re_view_time_series/Cargo.toml
+++ b/crates/viewer/re_view_time_series/Cargo.toml
@@ -35,6 +35,7 @@ re_viewport_blueprint.workspace = true
 egui_plot.workspace = true
 egui.workspace = true
 itertools.workspace = true
+nohash-hasher.workspace = true
 rayon.workspace = true
 smallvec.workspace = true
 

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -480,7 +480,9 @@ impl ViewClass for TimeSeriesView {
             state.default_names_for_entities = EntityPath::short_names_with_disambiguation(
                 all_plot_series
                     .iter()
-                    .map(|series| series.instance_path.entity_path.clone()),
+                    .map(|series| series.instance_path.entity_path.clone())
+                    // `short_names_with_disambiguation` expects no duplicate entities
+                    .collect::<nohash_hasher::IntSet<_>>(),
             );
 
             if state.is_dragging_time_cursor {

--- a/crates/viewer/re_view_time_series/tests/snapshots/clear_series_points_and_line.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/clear_series_points_and_line.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:72ce04c1b6b734ada56e100837a522e6da7c8c8a32fc43783b6ea3e87842a448
-size 15370
+oid sha256:a36ae2d6b030384896bc556ef364e80540c7149123b02217e51cd2b2c3cf01f0
+size 14630

--- a/crates/viewer/re_view_time_series/tests/snapshots/clear_series_points_and_line_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/clear_series_points_and_line_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a98d2aab680cf01d29f758c75fd4fd31502eabb9d07bb882cb6635af11a0796e
-size 22748
+oid sha256:a642dc5272945069b52faf414e29f279edd290bf44124c9a25834c1d4c7d1746
+size 21196


### PR DESCRIPTION
### Related

* #7140
* #9033

### What

The recently introduced support for multi-value `Scalar` batch in the time-series view broke the way legend items are disambiguated, e.g. when several series share the same last entity part (see #7140). The reason for that is that now the same entity path might be passed multiple time to the utility that actually performs the disambiguation. This PR fixes this issue by ensuring that such duplication doesn't happen.

Before:
<img width="349" alt="image" src="https://github.com/user-attachments/assets/ac16545f-ab87-4edc-ac28-6ff3e9cba796" />


After:
<img width="123" alt="image" src="https://github.com/user-attachments/assets/73220e77-428c-410f-ad24-5432a30a829e" />
