### PR TITLE
Switch from `cargo-machete` to `cargo-shear`

### DIFF
--- a/.github/workflows/cargo_shear.yml
+++ b/.github/workflows/cargo_shear.yml
@@ -16,5 +16,5 @@ jobs:
 
       - name: Shear
         run: |
-          cargo install cargo-shear@1.1.10 --locked
+          cargo +stable install cargo-shear@1.1.11 --locked
           cargo shear

--- a/.github/workflows/cargo_shear.yml
+++ b/.github/workflows/cargo_shear.yml
@@ -1,4 +1,4 @@
-name: Cargo Machete
+name: Cargo Shear
 
 on:
   push:
@@ -8,13 +8,13 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  cargo-machete:
+  cargo-shear:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Machete
+      - name: Shear
         run: |
-          cargo install cargo-machete@0.7.0 --locked
-          cargo machete
+          cargo install cargo-shear@1.1.10 --locked
+          cargo shear

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5882,12 +5882,10 @@ dependencies = [
  "anyhow",
  "arrow",
  "bytemuck",
- "criterion",
  "crossbeam",
  "document-features",
  "half",
  "itertools 0.14.0",
- "mimalloc",
  "nohash-hasher",
  "rand",
  "re_arrow_util",
@@ -5912,12 +5910,10 @@ dependencies = [
  "ahash",
  "anyhow",
  "arrow",
- "criterion",
  "document-features",
  "indent",
  "insta",
  "itertools 0.14.0",
- "mimalloc",
  "nohash-hasher",
  "once_cell",
  "parking_lot",
@@ -5937,7 +5933,6 @@ dependencies = [
  "similar-asserts",
  "tap",
  "thiserror 1.0.65",
- "tinyvec",
  "web-time",
 ]
 
@@ -6030,7 +6025,6 @@ dependencies = [
  "rayon",
  "re_arrow_util",
  "re_build_info",
- "re_build_tools",
  "re_chunk",
  "re_crash_handler",
  "re_log",
@@ -6041,7 +6035,6 @@ dependencies = [
  "re_types",
  "serde",
  "serde_json",
- "tempfile",
  "thiserror 1.0.65",
  "uuid",
  "walkdir",
@@ -6078,7 +6071,6 @@ dependencies = [
  "egui",
  "egui_extras",
  "egui_plot",
- "image",
  "itertools 0.14.0",
  "nohash-hasher",
  "re_byte_size",
@@ -6125,7 +6117,6 @@ dependencies = [
  "similar-asserts",
  "tokio",
  "tokio-stream",
- "unindent",
 ]
 
 [[package]]
@@ -6161,14 +6152,11 @@ version = "0.23.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
- "criterion",
  "document-features",
  "emath",
  "itertools 0.14.0",
- "mimalloc",
  "nohash-hasher",
  "parking_lot",
- "rand",
  "re_build_info",
  "re_byte_size",
  "re_chunk",
@@ -6312,7 +6300,6 @@ dependencies = [
  "re_smart_channel",
  "re_tracing",
  "re_types",
- "serde_test",
  "similar-asserts",
  "thiserror 1.0.65",
  "tokio",
@@ -6422,7 +6409,6 @@ dependencies = [
  "re_tuid",
  "thiserror 1.0.65",
  "tonic",
- "tonic-web-wasm-client",
 ]
 
 [[package]]
@@ -6517,7 +6503,6 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio-stream",
  "tonic",
- "tonic-web-wasm-client",
  "url",
 ]
 
@@ -6605,18 +6590,14 @@ dependencies = [
  "document-features",
  "itertools 0.14.0",
  "libc",
- "ndarray",
- "ndarray-rand",
  "nohash-hasher",
  "once_cell",
  "parking_lot",
  "percent-encoding",
- "rand",
  "re_build_info",
  "re_build_tools",
  "re_byte_size",
  "re_chunk",
- "re_chunk_store",
  "re_data_loader",
  "re_grpc_client",
  "re_grpc_server",
@@ -7066,13 +7047,11 @@ dependencies = [
  "arrow",
  "bitflags 2.8.0",
  "bytemuck",
- "criterion",
  "egui",
  "glam",
  "hexasphere",
  "image",
  "itertools 0.14.0",
- "mimalloc",
  "ndarray",
  "nohash-hasher",
  "once_cell",
@@ -8293,15 +8272,6 @@ name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_test"
-version = "1.0.177"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,22 @@ repository = "https://github.com/rerun-io/rerun"
 rust-version = "1.84"
 version = "0.23.0-alpha.1+dev"
 
+[workspace.metadata.cargo-shear]
+ignored = [
+  # rerun crates
+  "rerun_c",
+  "re_dev_tools",
+  "rerun-cli",
+  "re_types_builder",
+  "re_protos_builder",
+  "re_renderer_examples",
+
+  # used for specific targets or features
+  "wayland-sys",
+  "home",
+  "profiling",
+]
+
 [workspace.dependencies]
 # When using alpha-release, always use exact version, e.g. `version = "=0.x.y-alpha.z"
 # This is because we treat alpha-releases as incompatible, but semver doesn't.
@@ -119,7 +135,6 @@ re_viewport_blueprint = { path = "crates/viewer/re_viewport_blueprint", version 
 re_web_viewer_server = { path = "crates/viewer/re_web_viewer_server", version = "=0.23.0-alpha.1", default-features = false }
 
 # Rerun crates in other repos:
-ewebsock = "0.8.0"
 re_math = "0.20.0"
 
 # If this package fails to build, install `nasm` locally, or build through `pixi`.
@@ -158,14 +173,12 @@ argh = "0.1.12"
 array-init = "2.1"
 arrow = { version = "54.1", default-features = false }
 arrow2 = { package = "re_arrow2", version = "0.19.0", features = ["arrow"] }
-async-executor = "1.0"
 async-stream = "0.3"
 backtrace = "0.3"
 base64 = "0.22"
 bincode = "1.3"
 bit-vec = "0.8"
 bitflags = { version = "2.4", features = ["bytemuck"] }
-blackbox = "0.2.0"
 bytemuck = { version = "1.18", features = ["extern_crate_alloc"] }
 bytes = "1.0"
 camino = "1.1"
@@ -196,8 +209,6 @@ fixed = { version = "1.28", default-features = false }
 fjadra = "0.2.1"
 flatbuffers = "24.12.23"
 futures = "0.3"
-futures-channel = "0.3"
-futures-util = { version = "0.3", default-features = false }
 getrandom = "0.2"
 glam = { version = "0.28", features = ["debug-glam-assert"] }
 glob = "0.3"
@@ -245,7 +256,6 @@ percent-encoding = "2.3"
 pico-args = "0.5"
 ply-rs = { version = "0.1", default-features = false }
 poll-promise = "0.3"
-polling = "3.7.3"
 pollster = "0.4"
 prettyplease = "0.2"
 proc-macro2 = { version = "1.0", default-features = false }
@@ -275,7 +285,6 @@ seq-macro = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1", default-features = false, features = ["std"] }
-serde_test = "1"
 serde-wasm-bindgen = "0.6.5"
 serde_yaml = { version = "0.9.21", default-features = false }
 sha2 = "0.10"
@@ -298,7 +307,6 @@ time = { version = "0.3.36", default-features = false, features = [
 ] }
 tiny_http = { version = "0.12", default-features = false }
 tinystl = { version = "0.0.3", default-features = false }
-tinyvec = { version = "1.6", features = ["alloc", "rustc_1_55"] }
 tobj = "4.0"
 tokio = { version = "1.40.0", default-features = false }
 tokio-stream = "0.1.16"
@@ -310,7 +318,6 @@ tonic-web = "0.12"
 tonic-web-wasm-client = "0.6"
 tower-http = "0.5"
 tracing = { version = "0.1", default-features = false }
-tungstenite = { version = "0.24", default-features = false }
 type-map = "0.5"
 typenum = "1.15"
 unindent = "0.2"
@@ -351,7 +358,6 @@ wgpu = { version = "24.0", default-features = false, features = [
   "fragile-send-sync-non-atomic-wasm",
 ] }
 xshell = "0.2.7"
-zip = { version = "0.6", default-features = false } # We're stuck on 0.6 because https://crates.io/crates/protoc-prebuilt is still using 0.6
 
 
 # ---------------------------------------------------------------------------------

--- a/crates/store/re_chunk/Cargo.toml
+++ b/crates/store/re_chunk/Cargo.toml
@@ -61,6 +61,4 @@ crossbeam.workspace = true
 
 [dev-dependencies]
 re_log = { workspace = true, features = ["setup"] }
-criterion.workspace = true
-mimalloc.workspace = true
 similar-asserts.workspace = true

--- a/crates/store/re_chunk_store/Cargo.toml
+++ b/crates/store/re_chunk_store/Cargo.toml
@@ -60,9 +60,6 @@ re_format.workspace = true
 re_types = { workspace = true, features = ["testing"] }
 
 anyhow.workspace = true
-criterion.workspace = true
 insta.workspace = true
-mimalloc.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
 similar-asserts.workspace = true
-tinyvec.workspace = true

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -56,7 +56,3 @@ re_crash_handler.workspace = true
 
 [dev-dependencies]
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
-tempfile.workspace = true
-
-[build-dependencies]
-re_build_tools.workspace = true

--- a/crates/store/re_dataframe/Cargo.toml
+++ b/crates/store/re_dataframe/Cargo.toml
@@ -53,4 +53,3 @@ insta.workspace = true
 similar-asserts.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tokio-stream.workspace = true
-unindent.workspace = true

--- a/crates/store/re_entity_db/Cargo.toml
+++ b/crates/store/re_entity_db/Cargo.toml
@@ -55,9 +55,6 @@ web-time.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
 
 anyhow.workspace = true
-criterion.workspace = true
-mimalloc.workspace = true
-rand.workspace = true
 similar-asserts.workspace = true
 
 [lib]

--- a/crates/store/re_log_encoding/Cargo.toml
+++ b/crates/store/re_log_encoding/Cargo.toml
@@ -85,7 +85,6 @@ re_types.workspace = true
 
 criterion.workspace = true
 mimalloc.workspace = true
-serde_test.workspace = true
 similar-asserts.workspace = true
 
 [lib]

--- a/crates/store/re_log_types/Cargo.toml
+++ b/crates/store/re_log_types/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
-[package.metadata.cargo-machete]
+[package.metadata.cargo-shear]
 ignored = [
   "num-traits", # Needed for `num-derive`'s macros to work.
   "half",       # Needed so that `fixed` is pinned at the right version.

--- a/crates/store/re_protos/Cargo.toml
+++ b/crates/store/re_protos/Cargo.toml
@@ -39,7 +39,6 @@ tonic = { workspace = true, default-features = false, features = [
   "codegen",
   "prost",
 ] }
-tonic-web-wasm-client.workspace = true
 
 [lints]
 workspace = true

--- a/crates/store/re_types/Cargo.toml
+++ b/crates/store/re_types/Cargo.toml
@@ -115,5 +115,5 @@ rayon.workspace = true
 # `machete` is not a fan of `build-dependencies`.
 
 
-[package.metadata.cargo-machete]
+[package.metadata.cargo-shear]
 ignored = ["rayon", "re_build_tools", "re_types_builder"]

--- a/crates/store/re_types_core/Cargo.toml
+++ b/crates/store/re_types_core/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
-[package.metadata.cargo-machete]
+[package.metadata.cargo-shear]
 ignored = [
   "serde", # Needed to make `ComponentName` (an interned string) serializable.
 ]

--- a/crates/top/re_sdk/Cargo.toml
+++ b/crates/top/re_sdk/Cargo.toml
@@ -85,11 +85,6 @@ webbrowser = { workspace = true, optional = true }
 libc.workspace = true
 
 [dev-dependencies]
-re_chunk_store.workspace = true
-
-ndarray-rand.workspace = true
-ndarray.workspace = true
-rand.workspace = true
 similar-asserts.workspace = true
 
 

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 all-features = true
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
-
 [features]
 default = [
   "analytics",
@@ -173,6 +172,6 @@ unindent = { workspace = true, optional = true }
 re_build_tools.workspace = true
 
 
-[package.metadata.cargo-machete]
+[package.metadata.cargo-shear]
 # We only depend on re_video so we can enable extra features for it
-ignored = ["re_video"]
+ignored = ["re_video", "puffin"]

--- a/crates/utils/re_log/Cargo.toml
+++ b/crates/utils/re_log/Cargo.toml
@@ -18,6 +18,9 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[package.metadata.cargo-shear]
+ignored = ["js-sys", "env_filter"]
+
 
 [features]
 default = []

--- a/crates/utils/re_tracing/Cargo.toml
+++ b/crates/utils/re_tracing/Cargo.toml
@@ -19,6 +19,10 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[package.metadata.cargo-shear]
+# Work-around for https://github.com/Smithay/wayland-rs/issues/767
+ignored = ["wayland-sys"]
+
 
 [features]
 default = []

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -43,7 +43,6 @@ bytemuck.workspace = true
 egui_extras.workspace = true
 egui_plot.workspace = true
 egui.workspace = true
-image.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
 rexif.workspace = true

--- a/crates/viewer/re_redap_browser/Cargo.toml
+++ b/crates/viewer/re_redap_browser/Cargo.toml
@@ -53,5 +53,4 @@ tonic = { workspace = true, default-features = false, features = ["transport"] }
 
 # Web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tonic-web-wasm-client.workspace = true
 tonic = { workspace = true, default-features = false }

--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -26,8 +26,13 @@ workspace = true
 all-features = true
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
-[package.metadata.cargo-machete]
-ignored = ["profiling"] # Needed to hook up wgpu, see below at dependency setup.
+[package.metadata.cargo-shear]
+ignored = [
+  "profiling",    # Needed to hook up wgpu, see below at dependency setup.
+  "js-sys",       # Needed for wasm builds
+  "getrandom",
+  "wasm-bindgen",
+]
 
 
 [features]

--- a/crates/viewer/re_view_spatial/Cargo.toml
+++ b/crates/viewer/re_view_spatial/Cargo.toml
@@ -69,8 +69,6 @@ re_viewer_context = { workspace = true, features = ["testing"] }
 re_viewport.workspace = true
 re_viewport_blueprint = { workspace = true, features = ["testing"] }
 
-criterion.workspace = true
-mimalloc.workspace = true
 ndarray.workspace = true
 
 [lib]

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -26,6 +26,8 @@ workspace = true
 all-features = true
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
+[package.metadata.cargo-shear]
+ignored = ["strum"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -18,6 +18,9 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[package.metadata.cargo-shear]
+ignored = ["home"]
+
 [features]
 ## Enable for testing utilities.
 testing = ["dep:pollster", "dep:egui_kittest"]

--- a/docs/snippets/Cargo.toml
+++ b/docs/snippets/Cargo.toml
@@ -28,7 +28,7 @@ itertools.workspace = true
 rust-format.workspace = true
 
 
-[package.metadata.cargo-machete]
+[package.metadata.cargo-shear]
 # false positives because they aren't used until codegen is run:
 ignored = [
   "itertools",


### PR DESCRIPTION
### What

Replaces `cargo-machete` with [cargo-shear](https://github.com/Boshen/cargo-shear) in our CI, as `cargo-machete` had a lot of false negatives.

