### PR TITLE
Fix setting visible time range from overrides

### DIFF
--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -44,12 +44,10 @@ pub fn visible_time_range_ui_for_data_result(
     ui: &mut Ui,
     data_result: &re_viewer_context::DataResult,
 ) {
-    // TODO(#8557): Almost certainly this is wrong and should be regular override path.
-    let override_path = data_result.recursive_override_path();
     let query_range = data_result.property_overrides.query_range.clone();
 
     let is_view = false;
-    visible_time_range_ui(ctx, ui, query_range, override_path, is_view);
+    visible_time_range_ui(ctx, ui, query_range, data_result.override_path(), is_view);
 }
 
 /// Draws ui for a visible time range from a given override path and a resulting query range.

--- a/crates/viewer/re_viewer_context/src/view/view_query.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_query.rs
@@ -49,7 +49,6 @@ pub struct PropertyOverrides {
     /// for properties that apply recursively.
     ///
     /// Recursive overrides are currently only used for visibility.
-    // TODO(#8557): Plus some confusion around time ranges.
     pub recursive_override_path: EntityPath,
 
     /// `EntityPath` in the Blueprint store where updated overrides should be written back

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -560,7 +560,7 @@ impl DataQueryPropertyResolver<'_> {
                 use re_types::Component as _;
                 let latest_at_results = blueprint.latest_at(
                     blueprint_query,
-                    &recursive_override_path,
+                    &individual_override_path,
                     std::iter::once(blueprint_components::VisibleTimeRange::name()),
                 );
                 let visible_time_ranges =


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/8557

### What

Overrides from blueprint do what they're supposed to again (now? not sure if this ever worked correctly :/)
![image](https://github.com/user-attachments/assets/d576f778-60e0-424a-8da5-359a0ede6b1d)



Todo:
* [ ] port `rerun\tests\python\release_checklist\check_time_range_individual_overrides.py` to a screenshot test and test this
    * @teh-cmc didn't you already start this one and didn't finish it because of the bug fixed here?