### PR TITLE
Fix shader compiluation failure in Chrome 131

### DIFF
--- a/crates/viewer/re_renderer/shader/point_cloud.wgsl
+++ b/crates/viewer/re_renderer/shader/point_cloud.wgsl
@@ -131,9 +131,9 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 /// 2D primitives are always facing the camera - the difference to sphere_quad_coverage is that
 /// perspective projection is not taken into account.
 fn circle_quad_coverage(world_position: vec3f, radius: f32, circle_center: vec3f) -> f32 {
-    let distance = distance(circle_center, world_position);
-    let feathering_radius = fwidth(distance) * 0.5;
-    return smoothstep(radius + feathering_radius, radius - feathering_radius, distance);
+    let circle_distance = distance(circle_center, world_position);
+    let feathering_radius = fwidth(circle_distance) * 0.5;
+    return smoothstep(radius + feathering_radius, radius - feathering_radius, circle_distance);
 }
 
 fn coverage(world_position: vec3f, radius: f32, point_center: vec3f) -> f32 {


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

* Mentioned in #8377

### What

https://github.com/rerun-io/rerun/blob/af3312a21fb157b76dce2c509a1934ad252d1b67/crates/viewer/re_renderer/shader/point_cloud.wgsl#L134

The variable `distance` collide with internal function `distance()`, resulting in wgsl build error on macOS Chrome.

More information in #8377.

![Image](https://github.com/user-attachments/assets/a5932f43-0389-4994-b8f3-5fc2b7ada1fd)

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
