### PR TITLE
add catalog entry property to remaining APIs

### DIFF
--- a/crates/store/re_protos/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_protos/proto/rerun/v0/remote_store.proto
@@ -404,7 +404,10 @@ message ScanParametersOrderClause {
 // ---------------- GetRecordingSchema ------------------
 
 message GetRecordingSchemaRequest {
-    rerun.common.v0.RecordingId recording_id = 1;
+    // which catalog entry do we want to fetch the schema from
+    CatalogEntry entry = 1;
+    // recording id from which we're want to fetch the schema
+    rerun.common.v0.RecordingId recording_id = 2;
 }
 
 message GetRecordingSchemaResponse {
@@ -446,6 +449,9 @@ message UnregisterAllRecordingsResponse {}
 // ---------------- UpdateCatalog  -----------------
 
 message UpdateCatalogRequest {
+    // which catalog entry do we want to update
+    CatalogEntry entry = 1;
+    // Properties that we want to update
     DataframePart metadata = 2;
 }
 
@@ -454,8 +460,10 @@ message UpdateCatalogResponse {}
 // ---------------- Query -----------------
 
 message QueryRequest {
+    // which catalog entry do we want to query
+    CatalogEntry entry = 1;
     // unique identifier of the recording
-    rerun.common.v0.RecordingId recording_id = 1;
+    rerun.common.v0.RecordingId recording_id = 2;
     // query to execute
     rerun.common.v0.Query query = 3;
 }
@@ -463,11 +471,13 @@ message QueryRequest {
 // ----------------- QueryCatalog -----------------
 
 message QueryCatalogRequest {
+    // which catalog entry do we want to query
+    CatalogEntry entry = 1;
     // Column projection - define which columns should be returned.
     // Providing it is optional, if not provided, all columns should be returned
-    ColumnProjection column_projection = 1;
+    ColumnProjection column_projection = 2;
     // Filter specific recordings that match the criteria (selection)
-    CatalogFilter filter = 2;
+    CatalogFilter filter = 3;
 }
 
 message ColumnProjection {

--- a/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
@@ -746,7 +746,11 @@ impl ::prost::Name for ScanParametersOrderClause {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetRecordingSchemaRequest {
+    /// which catalog entry do we want to fetch the schema from
     #[prost(message, optional, tag = "1")]
+    pub entry: ::core::option::Option<CatalogEntry>,
+    /// recording id from which we're want to fetch the schema
+    #[prost(message, optional, tag = "2")]
     pub recording_id: ::core::option::Option<super::super::common::v0::RecordingId>,
 }
 impl ::prost::Name for GetRecordingSchemaRequest {
@@ -864,6 +868,10 @@ impl ::prost::Name for UnregisterAllRecordingsResponse {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCatalogRequest {
+    /// which catalog entry do we want to update
+    #[prost(message, optional, tag = "1")]
+    pub entry: ::core::option::Option<CatalogEntry>,
+    /// Properties that we want to update
     #[prost(message, optional, tag = "2")]
     pub metadata: ::core::option::Option<DataframePart>,
 }
@@ -891,8 +899,11 @@ impl ::prost::Name for UpdateCatalogResponse {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryRequest {
-    /// unique identifier of the recording
+    /// which catalog entry do we want to query
     #[prost(message, optional, tag = "1")]
+    pub entry: ::core::option::Option<CatalogEntry>,
+    /// unique identifier of the recording
+    #[prost(message, optional, tag = "2")]
     pub recording_id: ::core::option::Option<super::super::common::v0::RecordingId>,
     /// query to execute
     #[prost(message, optional, tag = "3")]
@@ -910,12 +921,15 @@ impl ::prost::Name for QueryRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryCatalogRequest {
+    /// which catalog entry do we want to query
+    #[prost(message, optional, tag = "1")]
+    pub entry: ::core::option::Option<CatalogEntry>,
     /// Column projection - define which columns should be returned.
     /// Providing it is optional, if not provided, all columns should be returned
-    #[prost(message, optional, tag = "1")]
+    #[prost(message, optional, tag = "2")]
     pub column_projection: ::core::option::Option<ColumnProjection>,
     /// Filter specific recordings that match the criteria (selection)
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, optional, tag = "3")]
     pub filter: ::core::option::Option<CatalogFilter>,
 }
 impl ::prost::Name for QueryCatalogRequest {


### PR DESCRIPTION

### What

In order to get rid of "default collection" concept from the ReDap server, making remaining APIs catalog entry aware.  There's plenty of renaming of actual calls ahead of us, but this is unrelated effort, for now the goal is to make everything specific collection aware. 