### PR TITLE
Fix shader compilation further in Chrome 131

### DIFF
--- a/crates/viewer/re_renderer/shader/point_cloud.wgsl
+++ b/crates/viewer/re_renderer/shader/point_cloud.wgsl
@@ -147,8 +147,8 @@ fn coverage(world_position: vec3f, radius: f32, point_center: vec3f) -> f32 {
 
 @fragment
 fn fs_main(in: VertexOut) -> @location(0) vec4f {
-    let coverage = coverage(in.world_position, in.radius, in.point_center);
-    if coverage < 0.001 {
+    let cov = coverage(in.world_position, in.radius, in.point_center);
+    if cov < 0.001 {
         discard;
     }
 
@@ -159,13 +159,13 @@ fn fs_main(in: VertexOut) -> @location(0) vec4f {
     if has_any_flag(batch.flags, FLAG_ENABLE_SHADING) {
         shading = max(0.4, sqrt(1.2 - distance(in.point_center, in.world_position) / in.radius)); // quick and dirty coloring
     }
-    return vec4f(in.color.rgb * shading, coverage);
+    return vec4f(in.color.rgb * shading, cov);
 }
 
 @fragment
 fn fs_main_picking_layer(in: VertexOut) -> @location(0) vec4u {
-    let coverage = coverage(in.world_position, in.radius, in.point_center);
-    if coverage <= 0.5 {
+    let cov = coverage(in.world_position, in.radius, in.point_center);
+    if cov <= 0.5 {
         discard;
     }
     return vec4u(batch.picking_layer_object_id, in.picking_instance_id);
@@ -175,8 +175,8 @@ fn fs_main_picking_layer(in: VertexOut) -> @location(0) vec4u {
 fn fs_main_outline_mask(in: VertexOut) -> @location(0) vec2u {
     // Output is an integer target so we can't use coverage even though
     // the target is anti-aliased.
-    let coverage = coverage(in.world_position, in.radius, in.point_center);
-    if coverage <= 0.5 {
+    let cov = coverage(in.world_position, in.radius, in.point_center);
+    if cov <= 0.5 {
         discard;
     }
     return batch.outline_mask;


### PR DESCRIPTION
### Related

* Closes #8377
* Follow-up to  #9152

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

This pr is extension of #9152, further fixing the shader variable naming issue in Chome 131 version.

<img width="1021" alt="Image" src="https://github.com/user-attachments/assets/fab624cd-3d14-4bbc-8209-5a1cc1ccbd73" />

after fix:

<img width="1469" alt="Image" src="https://github.com/user-attachments/assets/3f08da34-919d-4efb-9104-137dd6fe2863" />


<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
