### PR TITLE
Copy description of selection (entity path, store id, etc.) via `cmd/ctrl + c`

### DIFF
--- a/crates/viewer/re_context_menu/src/actions/copy_entity_path.rs
+++ b/crates/viewer/re_context_menu/src/actions/copy_entity_path.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use re_viewer_context::Item;
 
 use crate::{ContextMenuAction, ContextMenuContext};

--- a/crates/viewer/re_context_menu/src/actions/copy_entity_path.rs
+++ b/crates/viewer/re_context_menu/src/actions/copy_entity_path.rs
@@ -30,24 +30,6 @@ impl ContextMenuAction for CopyEntityPathToClipboard {
     }
 
     fn process_selection(&self, ctx: &ContextMenuContext<'_>) {
-        let clipboard_text = ctx
-            .selection
-            .iter()
-            .filter_map(|(item, _)| match item {
-                Item::AppId(_)
-                | Item::DataSource(_)
-                | Item::StoreId(_)
-                | Item::Container(_)
-                | Item::View(_) => None,
-                Item::DataResult(_, instance_path) | Item::InstancePath(instance_path) => {
-                    Some(instance_path.entity_path.clone())
-                }
-                Item::ComponentPath(component_path) => Some(component_path.entity_path.clone()),
-            })
-            .map(|entity_path| entity_path.to_string())
-            .join("\n");
-
-        re_log::info!("Copied entity paths to clipboard:\n{}", &clipboard_text);
-        ctx.viewer_context.egui_ctx().copy_text(clipboard_text);
+        ctx.selection.copy_to_clipboard(ctx.egui_context());
     }
 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use egui::text_selection::LabelSelectionState;
 use itertools::Itertools as _;
 
 use re_build_info::CrateVersion;

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use egui::text_selection::LabelSelectionState;
 use itertools::Itertools as _;
 
 use re_build_info::CrateVersion;

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -1,7 +1,6 @@
 use ahash::HashMap;
 use egui::{text_selection::LabelSelectionState, NumExt as _, Ui};
 
-use itertools::Itertools as _;
 use re_chunk::TimelineName;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
@@ -12,7 +11,7 @@ use re_types::blueprint::components::PanelState;
 use re_ui::{ContextExt as _, DesignTokens};
 use re_viewer_context::{
     AppOptions, ApplicationSelectionState, BlueprintUndoState, CommandSender, ComponentUiRegistry,
-    DisplayMode, DragAndDropManager, GlobalContext, Item, PlayState, RecordingConfig, StoreContext,
+    DisplayMode, DragAndDropManager, GlobalContext, PlayState, RecordingConfig, StoreContext,
     StoreHub, SystemCommand, SystemCommandSender as _, ViewClassExt as _, ViewClassRegistry,
     ViewStates, ViewerContext,
 };
@@ -587,7 +586,7 @@ impl AppState {
             selection_state.clear_selection();
         }
 
-        // If there's no label selected, and the user triggers a copy command, copy a descripion of the current selection.
+        // If there's no label selected, and the user triggers a copy command, copy a description of the current selection.
         if !LabelSelectionState::load(ui.ctx()).has_selection()
             && ui.input(|input| input.events.iter().any(|e| e == &egui::Event::Copy))
         {

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -1,6 +1,7 @@
 use ahash::HashMap;
-use egui::{NumExt as _, Ui};
+use egui::{text_selection::LabelSelectionState, NumExt as _, Ui};
 
+use itertools::Itertools as _;
 use re_chunk::TimelineName;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
@@ -11,7 +12,7 @@ use re_types::blueprint::components::PanelState;
 use re_ui::{ContextExt as _, DesignTokens};
 use re_viewer_context::{
     AppOptions, ApplicationSelectionState, BlueprintUndoState, CommandSender, ComponentUiRegistry,
-    DisplayMode, DragAndDropManager, GlobalContext, PlayState, RecordingConfig, StoreContext,
+    DisplayMode, DragAndDropManager, GlobalContext, Item, PlayState, RecordingConfig, StoreContext,
     StoreHub, SystemCommand, SystemCommandSender as _, ViewClassExt as _, ViewClassRegistry,
     ViewStates, ViewerContext,
 };
@@ -584,6 +585,13 @@ impl AppState {
         // Deselect on ESC. Must happen after all other UI code to let them capture ESC if needed.
         if ui.input(|i| i.key_pressed(egui::Key::Escape)) && !is_any_popup_open {
             selection_state.clear_selection();
+        }
+
+        // If there's no label selected, and the user triggers a copy command, copy a descripion of the current selection.
+        if !LabelSelectionState::load(ui.ctx()).has_selection()
+            && ui.input(|input| input.events.iter().any(|e| e == &egui::Event::Copy))
+        {
+            selection_state.selected_items().copy_to_clipboard(ui.ctx());
         }
 
         // Reset the focused item.


### PR DESCRIPTION
### Related

* follow-up to https://github.com/rerun-io/rerun/pull/9137

### What


https://github.com/user-attachments/assets/6399a8f0-3e05-400b-8681-d194ab48d537



For various selections you can now press `ctrl+c` to copy what they're pointing to. This is most useful for entity paths but also allows to copy things like store ids.
The system automatically backs off if any text is selected anywhere in the viewer.