### PR TITLE
Migrate vscode settings to native Ruff language server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,12 +58,7 @@
     "python.analysis.extraPaths": [
         "rerun_py/rerun_sdk"
     ],
-    "ruff.format.args": [
-        "--config=rerun_py/pyproject.toml"
-    ],
-    "ruff.lint.args": [
-        "--config=rerun_py/pyproject.toml"
-    ],
+    "ruff.configuration": "rerun_py/pyproject.toml",
     "prettier.requireConfig": true,
     "prettier.configPath": ".prettierrc.toml",
     "[proto3]": {


### PR DESCRIPTION
### What

This changes the .vscode/settings.json file to use the native Ruff server instead of the old `ruff-lsp` extension settings, since the language server is now stable and `ruff-lsp` is deprecated.

+ it gets rid of the annoying vscode pop up

<img width="488" alt="image" src="https://github.com/user-attachments/assets/43368275-f5a4-470a-bc09-1c96e0ac0489" />
