### PR TITLE
Update test and snippets using `new_recording()` to _actually_ use the stateless API

### DIFF
--- a/docs/snippets/all/concepts/explicit_recording.py
+++ b/docs/snippets/all/concepts/explicit_recording.py
@@ -6,7 +6,7 @@ import rerun as rr
 
 rec = rr.new_recording("rerun_example_explicit_recording")
 
-rr.log("points", rr.Points3D([[0, 0, 0], [1, 1, 1]]), recording=rec)
+rec.log("points", rr.Points3D([[0, 0, 0], [1, 1, 1]]))
 
 dir = os.path.dirname(os.path.abspath(__file__))
-rr.log_file_from_path(os.path.join(dir, "../../../../tests/assets/cube.glb"), recording=rec)
+rec.log_file_from_path(os.path.join(dir, "../../../../tests/assets/cube.glb"))

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -17,9 +17,9 @@ def test_load_recording() -> None:
         rrd = tmpdir + "/tmp.rrd"
 
         with rr.new_recording("rerun_example_test_recording") as rec:
-            rr.save(rrd, recording=rec)
-            rr.set_index("my_index", sequence=1, recording=rec)
-            rr.log("log", rr.TextLog("Hello"), recording=rec)
+            rec.save(rrd)
+            rec.set_index("my_index", sequence=1)
+            rec.log("log", rr.TextLog("Hello"))
 
         recording = rr.dataframe.load_recording(rrd)
         assert recording is not None
@@ -50,12 +50,12 @@ class TestDataframe:
             rrd = tmpdir + "/tmp.rrd"
 
             with rr.new_recording(APP_ID, recording_id=RECORDING_ID) as rec:
-                rr.save(rrd, recording=rec)
-                rr.set_index("my_index", sequence=1, recording=rec)
-                rr.log("points", rr.Points3D([[1, 2, 3], [4, 5, 6], [7, 8, 9]], radii=[]), recording=rec)
-                rr.set_index("my_index", sequence=7, recording=rec)
-                rr.log("points", rr.Points3D([[10, 11, 12]], colors=[[255, 0, 0]]), recording=rec)
-                rr.log("static_text", rr.TextLog("Hello"), static=True, recording=rec)
+                rec.save(rrd)
+                rec.set_index("my_index", sequence=1)
+                rec.log("points", rr.Points3D([[1, 2, 3], [4, 5, 6], [7, 8, 9]], radii=[]))
+                rec.set_index("my_index", sequence=7)
+                rec.log("points", rr.Points3D([[10, 11, 12]], colors=[[255, 0, 0]]))
+                rec.log("static_text", rr.TextLog("Hello"), static=True)
 
             self.recording = rr.dataframe.load_recording(rrd)
 
@@ -389,7 +389,7 @@ class TestDataframe:
             rrd = tmpdir + "/tmp.rrd"
 
             with rr.new_recording("rerun_example_test_recording") as rec:
-                rr.save(rrd, recording=rec)
+                rec.save(rrd)
                 rr.dataframe.send_dataframe(df, rec=rec)
 
             round_trip_recording = rr.dataframe.load_recording(rrd)

--- a/tests/python/gil_stress/main.py
+++ b/tests/python/gil_stress/main.py
@@ -15,38 +15,38 @@ import rerun as rr
 rec = rr.new_recording(application_id="test")
 
 rec = rr.new_recording(application_id="test")
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 rec = rr.new_recording(application_id="test", make_default=True)
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 rec = rr.new_recording(application_id="test", make_thread_default=True)
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 rec = rr.new_recording(application_id="test")  # this works
 rr.set_global_data_recording(rec)
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 rec = rr.new_recording(application_id="test")  # this works
 rr.set_thread_local_data_recording(rec)
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 rec = rr.new_recording(application_id="test", spawn=True)
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 rec = rr.new_recording(application_id="test")
 rr.connect_grpc(recording=rec)
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 rec = rr.new_recording(application_id="test")
 rr.memory_recording(recording=rec)
-rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+rec.log("test", rr.Points3D([1, 2, 3]))
 
 for _ in range(3):
     rec = rr.new_recording(application_id="test", make_default=False, make_thread_default=False)
     mem = rec.memory_recording()
-    rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+    rec.log("test", rr.Points3D([1, 2, 3]))
 
 for _ in range(3):
     rec = rr.new_recording(application_id="test", make_default=False, make_thread_default=False)
-    rr.log("test", rr.Points3D([1, 2, 3]), recording=rec)
+    rec.log("test", rr.Points3D([1, 2, 3]))


### PR DESCRIPTION
### Related

- Follow up to #9182

### What

Some (too little imo) existing snippets and test explicitly create a recording stream but didn't use its API, relying on the `recording=rec` shenanigans. This PR fixes this.