### PR TITLE
Check dataset version when loading LeRobot dataset

### DIFF
--- a/crates/store/re_data_loader/src/lerobot.rs
+++ b/crates/store/re_data_loader/src/lerobot.rs
@@ -20,8 +20,13 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-/// Check whether the provided path contains a Le Robot dataset.
+/// Check whether the provided path contains a `LeRobot` dataset.
 pub fn is_lerobot_dataset(path: impl AsRef<Path>) -> bool {
+    is_v1_lerobot_dataset(path.as_ref()) || is_v2_lerobot_dataset(path.as_ref())
+}
+
+/// Check whether the provided path contains a v2 `LeRobot` dataset.
+pub fn is_v2_lerobot_dataset(path: impl AsRef<Path>) -> bool {
     let path = path.as_ref();
 
     if !path.is_dir() {
@@ -29,6 +34,21 @@ pub fn is_lerobot_dataset(path: impl AsRef<Path>) -> bool {
     }
 
     ["meta", "data"].iter().all(|subdir| {
+        let subpath = path.join(subdir);
+
+        subpath.is_dir()
+    })
+}
+
+/// Check whether the provided path contains a v1 `LeRobot` dataset.
+pub fn is_v1_lerobot_dataset(path: impl AsRef<Path>) -> bool {
+    let path = path.as_ref();
+
+    if !path.is_dir() {
+        return false;
+    }
+
+    ["meta_data", "data"].iter().all(|subdir| {
         let subpath = path.join(subdir);
 
         subpath.is_dir()

--- a/crates/store/re_data_loader/src/lerobot.rs
+++ b/crates/store/re_data_loader/src/lerobot.rs
@@ -33,11 +33,9 @@ pub fn is_v2_lerobot_dataset(path: impl AsRef<Path>) -> bool {
         return false;
     }
 
-    ["meta", "data"].iter().all(|subdir| {
-        let subpath = path.join(subdir);
-
-        subpath.is_dir()
-    })
+    // v2 `LeRobot` datasets store the metadata in a `meta` directory,
+    // instead of the `meta_data` directory used in v1 datasets.
+    has_sub_directories(&["meta_data", "data"], path)
 }
 
 /// Check whether the provided path contains a v1 `LeRobot` dataset.
@@ -48,8 +46,14 @@ pub fn is_v1_lerobot_dataset(path: impl AsRef<Path>) -> bool {
         return false;
     }
 
-    ["meta_data", "data"].iter().all(|subdir| {
-        let subpath = path.join(subdir);
+    // v1 `LeRobot` datasets stored the metadata in a `meta_data` directory,
+    // instead of the `meta` directory used in v2 datasets.
+    has_sub_directories(&["meta_data", "data"], path)
+}
+
+fn has_sub_directories(directories: &[&str], path: impl AsRef<Path>) -> bool {
+    directories.iter().all(|subdir| {
+        let subpath = path.as_ref().join(subdir);
 
         subpath.is_dir()
     })

--- a/crates/store/re_data_loader/src/lerobot.rs
+++ b/crates/store/re_data_loader/src/lerobot.rs
@@ -35,7 +35,7 @@ pub fn is_v2_lerobot_dataset(path: impl AsRef<Path>) -> bool {
 
     // v2 `LeRobot` datasets store the metadata in a `meta` directory,
     // instead of the `meta_data` directory used in v1 datasets.
-    has_sub_directories(&["meta_data", "data"], path)
+    has_sub_directories(&["meta", "data"], path)
 }
 
 /// Check whether the provided path contains a v1 `LeRobot` dataset.
@@ -55,7 +55,11 @@ fn has_sub_directories(directories: &[&str], path: impl AsRef<Path>) -> bool {
     directories.iter().all(|subdir| {
         let subpath = path.as_ref().join(subdir);
 
+        // check that the sub directory exists and is not empty
         subpath.is_dir()
+            && subpath
+                .read_dir()
+                .is_ok_and(|mut contents| contents.next().is_some())
     })
 }
 

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -21,13 +21,20 @@ use re_types::archetypes::{
 use re_types::components::{Scalar, VideoTimestamp};
 use re_types::{Archetype, Component, ComponentBatch};
 
-use crate::lerobot::{is_lerobot_dataset, DType, EpisodeIndex, Feature, LeRobotDataset, TaskIndex};
+use crate::lerobot::{
+    is_lerobot_dataset, is_v1_lerobot_dataset, DType, EpisodeIndex, Feature, LeRobotDataset,
+    TaskIndex,
+};
 use crate::load_file::prepare_store_info;
 use crate::{DataLoader, DataLoaderError, LoadedData};
 
 /// Columns in the `LeRobot` dataset schema that we do not visualize in the viewer, and thus ignore.
 const LEROBOT_DATASET_IGNORED_COLUMNS: &[&str] =
     &["episode_index", "index", "frame_index", "timestamp"];
+
+/// Only supports `LeRobot` datasets that are in a supported version format.
+/// Datasets from unsupported versions won't load.
+const LEROBOT_DATASET_SUPPORTED_VERSIONS: &[&str] = &["v2.0", "v2.1"];
 
 /// A [`DataLoader`] for `LeRobot` datasets.
 ///
@@ -49,12 +56,28 @@ impl DataLoader for LeRobotDatasetLoader {
             return Err(DataLoaderError::Incompatible(filepath));
         }
 
+        if is_v1_lerobot_dataset(&filepath) {
+            re_log::warn!("LeRobot 'v1.x' dataset format is unsupported.");
+            return Ok(());
+        }
+
         let dataset = LeRobotDataset::load_from_directory(&filepath)
             .map_err(|err| anyhow!("Loading LeRobot dataset failed: {err}"))?;
+
+        if !LEROBOT_DATASET_SUPPORTED_VERSIONS
+            .contains(&dataset.metadata.info.codebase_version.as_str())
+        {
+            re_log::warn!(
+                "LeRobot '{}' dataset format is unsupported.",
+                dataset.metadata.info.codebase_version
+            );
+            return Ok(());
+        }
+
         let application_id = settings
             .application_id
             .clone()
-            .unwrap_or(ApplicationId(format!("{filepath:?}")));
+            .unwrap_or(ApplicationId(filepath.display().to_string()));
 
         // NOTE(1): `spawn` is fine, this whole function is native-only.
         // NOTE(2): this must spawned on a dedicated thread to avoid a deadlock!

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -57,7 +57,7 @@ impl DataLoader for LeRobotDatasetLoader {
         }
 
         if is_v1_lerobot_dataset(&filepath) {
-            re_log::warn!("LeRobot 'v1.x' dataset format is unsupported.");
+            re_log::error!("LeRobot 'v1.x' dataset format is unsupported.");
             return Ok(());
         }
 
@@ -67,7 +67,7 @@ impl DataLoader for LeRobotDatasetLoader {
         if !LEROBOT_DATASET_SUPPORTED_VERSIONS
             .contains(&dataset.metadata.info.codebase_version.as_str())
         {
-            re_log::warn!(
+            re_log::error!(
                 "LeRobot '{}' dataset format is unsupported.",
                 dataset.metadata.info.codebase_version
             );


### PR DESCRIPTION
### Related

* Closes #9177

### What

The loader now explicitly validates the dataset version, preventing unexpected behavior or silent failures due to unsupported dataset versions.
