### PR TITLE
Add `RecordingStream::set_index`

### DIFF
--- a/crates/store/re_log_types/src/index/index_cell.rs
+++ b/crates/store/re_log_types/src/index/index_cell.rs
@@ -101,12 +101,16 @@ impl From<IndexCell> for i64 {
     }
 }
 
+// ------------------------------------------------------------------
+
 impl From<std::time::Duration> for IndexCell {
     /// Saturating cast from [`std::time::Duration`].
     fn from(time: std::time::Duration) -> Self {
         Self::from_duration_nanos(NonMinI64::saturating_from_u128(time.as_nanos()))
     }
 }
+
+// ------------------------------------------------------------------
 
 impl TryFrom<std::time::SystemTime> for IndexCell {
     type Error = OutOfRange;

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -65,7 +65,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     let radii = [0.05, 0.01, 0.2, 0.1, 0.3];
 ///
 ///     for (time, positions, color, radius) in itertools::izip!(10..15, positions, colors, radii) {
-///         rec.set_time_seconds("time", time);
+///         rec.set_duration_seconds("time", time);
 ///
 ///         let point_cloud = rerun::Points3D::new(positions)
 ///             .with_colors([color])

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -81,7 +81,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     // TODO(#5521): log two views as in the python example
 ///
-///     rec.set_time_seconds("sim_time", 0.0);
+///     rec.set_duration_seconds("sim_time", 0.0);
 ///
 ///     // Planetary motion is typically in the XY plane.
 ///     rec.log_static("/", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP())?;
@@ -129,7 +129,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     // Movement via transforms.
 ///     for i in 0..(6 * 120) {
 ///         let time = i as f32 / 120.0;
-///         rec.set_time_seconds("sim_time", time);
+///         rec.set_duration_seconds("sim_time", time);
 ///         let r_moon = time * 5.0;
 ///         let r_planet = time * 2.0;
 ///

--- a/crates/top/rerun_c/src/lib.rs
+++ b/crates/top/rerun_c/src/lib.rs
@@ -23,8 +23,8 @@ use re_sdk::{
     external::{nohash_hasher::IntMap, re_log_types::TimelineName},
     log::{Chunk, ChunkId, PendingRow, TimeColumn},
     time::TimeType,
-    ComponentDescriptor, EntityPath, RecordingStream, RecordingStreamBuilder, StoreKind, TimePoint,
-    Timeline,
+    ComponentDescriptor, EntityPath, IndexCell, RecordingStream, RecordingStreamBuilder, StoreKind,
+    TimePoint, Timeline,
 };
 
 use component_type_registry::COMPONENT_TYPES;
@@ -690,11 +690,12 @@ fn rr_recording_stream_set_index_impl(
 ) -> Result<(), CError> {
     let timeline = timeline_name.as_str("timeline_name")?;
     let stream = recording_stream(stream)?;
-    match time_type {
-        CTimeType::Sequence => stream.set_time_sequence(timeline, value),
+    let time_type = match time_type {
+        CTimeType::Sequence => TimeType::Sequence,
         // TODO(#8635): do different things for Duration and Timestamp
-        CTimeType::Duration | CTimeType::Timestamp => stream.set_time_nanos(timeline, value),
-    }
+        CTimeType::Duration | CTimeType::Timestamp => TimeType::Time,
+    };
+    stream.set_index(timeline, IndexCell::new(time_type, value));
     Ok(())
 }
 

--- a/docs/snippets/all/archetypes/points3d_row_updates.rs
+++ b/docs/snippets/all/archetypes/points3d_row_updates.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let radii = [0.05, 0.01, 0.2, 0.1, 0.3];
 
     for (time, positions, color, radius) in itertools::izip!(10..15, positions, colors, radii) {
-        rec.set_time_seconds("time", time);
+        rec.set_duration_seconds("time", time);
 
         let point_cloud = rerun::Points3D::new(positions)
             .with_colors([color])

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.rs
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // TODO(#5521): log two views as in the python example
 
-    rec.set_time_seconds("sim_time", 0.0);
+    rec.set_duration_seconds("sim_time", 0.0);
 
     // Planetary motion is typically in the XY plane.
     rec.log_static("/", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP())?;
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Movement via transforms.
     for i in 0..(6 * 120) {
         let time = i as f32 / 120.0;
-        rec.set_time_seconds("sim_time", time);
+        rec.set_duration_seconds("sim_time", time);
         let r_moon = time * 5.0;
         let r_planet = time * 2.0;
 

--- a/docs/snippets/all/concepts/different_data_per_timeline.rs
+++ b/docs/snippets/all/concepts/different_data_per_timeline.rs
@@ -5,12 +5,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rerun::RecordingStreamBuilder::new("rerun_example_different_data_per_timeline").spawn()?;
 
     rec.set_time_sequence("blue timeline", 0);
-    rec.set_time_seconds("red timeline", 0.0);
+    rec.set_duration_seconds("red timeline", 0.0);
     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
 
     // Log a red color on one timeline.
     rec.reset_time(); // Clears all set timeline info.
-    rec.set_time_seconds("red timeline", 1.0);
+    rec.set_duration_seconds("red timeline", 1.0);
     rec.log(
         "points",
         &rerun::Points2D::update_fields().with_colors([0xFF0000FF]),

--- a/docs/snippets/all/concepts/indices.rs
+++ b/docs/snippets/all/concepts/indices.rs
@@ -4,8 +4,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_different_indices").spawn()?;
 
     rec.set_time_sequence("frame_nr", 42);
-    rec.set_time_seconds("elapsed", 12.0);
-    rec.set_time_seconds("time", 1_741_017_564); // Seconds since unix epoch
+    rec.set_duration_seconds("elapsed", 12.0);
+    rec.set_timestamp_seconds_since_epoch("time", 1_741_017_564.0);
     rec.set_time_nanos("precise_time", 1_741_017_564_987_654_321_i64); // Nanos since unix epoch
 
     // All following logged data will be timestamped with the above times:

--- a/docs/snippets/all/concepts/indices.rs
+++ b/docs/snippets/all/concepts/indices.rs
@@ -6,7 +6,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rec.set_time_sequence("frame_nr", 42);
     rec.set_duration_seconds("elapsed", 12.0);
     rec.set_timestamp_seconds_since_epoch("time", 1_741_017_564.0);
-    rec.set_time_nanos("precise_time", 1_741_017_564_987_654_321_i64); // Nanos since unix epoch
+    rec.set_index(
+        "precise_time",
+        std::time::SystemTime::UNIX_EPOCH
+            + std::time::Duration::from_nanos(1_741_017_564_987_654_321),
+    );
 
     // All following logged data will be timestamped with the above times:
     rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;

--- a/docs/snippets/all/tutorials/timelines_example.rs
+++ b/docs/snippets/all/tutorials/timelines_example.rs
@@ -1,6 +1,6 @@
 for frame in read_sensor_frames() {
     rec.set_time_sequence("frame_idx", frame.idx);
-    rec.set_time_seconds("sensor_time", frame.timestamp);
+    rec.set_timestamp_seconds_since_epoch("sensor_time", frame.timestamp);
 
     rec.log("sensor/points", rerun::Points3D::new(&frame.points))?;
 }

--- a/examples/rust/clock/src/main.rs
+++ b/examples/rust/clock/src/main.rs
@@ -67,7 +67,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
         let pos = tip(angle * TAU, length);
         let color = color(angle, blue);
 
-        rec.set_time_seconds("sim_time", step as f64);
+        rec.set_duration_seconds("sim_time", step as f64);
 
         rec.log(
             format!("world/{name}_pt"),

--- a/examples/rust/dna/src/main.rs
+++ b/examples/rust/dna/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (points1, colors1) = color_spiral(NUM_POINTS, 2.0, 0.02, 0.0, 0.1);
     let (points2, colors2) = color_spiral(NUM_POINTS, 2.0, 0.02, TAU * 0.5, 0.1);
 
-    rec.set_time_seconds("stable_time", 0f64);
+    rec.set_duration_seconds("stable_time", 0f64);
 
     rec.log_static(
         "dna/structure/left",
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for i in 0..400 {
         let time = i as f32 * 0.01;
 
-        rec.set_time_seconds("stable_time", time as f64);
+        rec.set_duration_seconds("stable_time", time as f64);
 
         let times = offsets.iter().map(|offset| time + offset).collect_vec();
         let (beads, colors): (Vec<_>, Vec<_>) = points_interleaved

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -94,16 +94,14 @@ def set_index(
         )
     elif timedelta is not None:
         nanos = to_nanos(timedelta)
-        # TODO(#8635): call a function that is specific to time-deltas
-        bindings.set_time_nanos(
+        bindings.set_time_duration_nanos(
             timeline,
             nanos,
             recording=recording.to_native() if recording is not None else None,
         )
     elif datetime is not None:
         nanos = to_nanos_since_epoch(datetime)
-        # TODO(#8635): call a function that is specific to absolute times
-        bindings.set_time_nanos(
+        bindings.set_time_timestamp_nanos_since_epoch(
             timeline,
             nanos,
             recording=recording.to_native() if recording is not None else None,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -17,8 +17,8 @@ use pyo3::{
 use re_log::ResultExt as _;
 use re_log_types::LogMsg;
 use re_log_types::{BlueprintActivationCommand, EntityPathPart, StoreKind};
-use re_sdk::external::re_log_encoding::encoder::encode_ref_as_bytes_local;
 use re_sdk::sink::CallbackSink;
+use re_sdk::{external::re_log_encoding::encoder::encode_ref_as_bytes_local, IndexCell};
 use re_sdk::{
     sink::{BinaryStreamStorage, MemorySinkStorage},
     time::TimePoint,
@@ -158,8 +158,8 @@ fn rerun_bindings(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // time
     m.add_function(wrap_pyfunction!(set_time_sequence, m)?)?;
-    m.add_function(wrap_pyfunction!(set_time_seconds, m)?)?;
-    m.add_function(wrap_pyfunction!(set_time_nanos, m)?)?;
+    m.add_function(wrap_pyfunction!(set_time_duration_nanos, m)?)?;
+    m.add_function(wrap_pyfunction!(set_time_timestamp_nanos_since_epoch, m)?)?;
     m.add_function(wrap_pyfunction!(disable_timeline, m)?)?;
     m.add_function(wrap_pyfunction!(reset_time, m)?)?;
 
@@ -1059,27 +1059,29 @@ fn set_time_sequence(timeline: &str, sequence: i64, recording: Option<&PyRecordi
     let Some(recording) = get_data_recording(recording) else {
         return;
     };
-    recording.set_time_sequence(timeline, sequence);
+    recording.set_index(timeline, IndexCell::from_sequence(sequence));
 }
 
-// TODO(#8635): distinguish between absolute and relative time
-#[pyfunction]
-#[pyo3(signature = (timeline, seconds, recording=None))]
-fn set_time_seconds(timeline: &str, seconds: f64, recording: Option<&PyRecordingStream>) {
-    let Some(recording) = get_data_recording(recording) else {
-        return;
-    };
-    recording.set_time_seconds(timeline, seconds);
-}
-
-// TODO(#8635): distinguish between absolute and relative time
 #[pyfunction]
 #[pyo3(signature = (timeline, nanos, recording=None))]
-fn set_time_nanos(timeline: &str, nanos: i64, recording: Option<&PyRecordingStream>) {
+fn set_time_duration_nanos(timeline: &str, nanos: i64, recording: Option<&PyRecordingStream>) {
     let Some(recording) = get_data_recording(recording) else {
         return;
     };
-    recording.set_time_nanos(timeline, nanos);
+    recording.set_index(timeline, IndexCell::from_duration_nanos(nanos));
+}
+
+#[pyfunction]
+#[pyo3(signature = (timeline, nanos, recording=None))]
+fn set_time_timestamp_nanos_since_epoch(
+    timeline: &str,
+    nanos: i64,
+    recording: Option<&PyRecordingStream>,
+) {
+    let Some(recording) = get_data_recording(recording) else {
+        return;
+    };
+    recording.set_index(timeline, IndexCell::from_timestamp_nanos_since_epoch(nanos));
 }
 
 #[pyfunction]

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -136,7 +136,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
     #[allow(clippy::unchecked_duration_subtraction)]
     for offset in offsets {
         if args.temporal_batch_size.is_none() {
-            rec.set_time_seconds("sim_time", sim_times[offset]);
+            rec.set_duration_seconds("sim_time", sim_times[offset]);
         }
 
         // Log

--- a/tests/rust/test_api/src/main.rs
+++ b/tests/rust/test_api/src/main.rs
@@ -27,7 +27,7 @@ use rerun::{
 fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
     use rerun::{archetypes::Boxes3D, components::Color};
 
-    rec.set_time_seconds("sim_time", 0f64);
+    rec.set_duration_seconds("sim_time", 0f64);
     rec.log(
         "bbox_test/bbox",
         &Boxes3D::from_half_sizes([(1.0, 0.5, 0.25)])
@@ -41,7 +41,7 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
             .with_radii([0.005])
             .with_labels(["box/t0"]),
     )?;
-    rec.set_time_seconds("sim_time", 1f64);
+    rec.set_duration_seconds("sim_time", 1f64);
 
     rec.log(
         "bbox_test/bbox",
@@ -63,7 +63,7 @@ fn test_bbox(rec: &RecordingStream) -> anyhow::Result<()> {
 fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
     use rerun::archetypes::Boxes2D;
 
-    rec.set_time_seconds("sim_time", 1f64);
+    rec.set_duration_seconds("sim_time", 1f64);
     rec.log(
         "null_test/rect/0",
         &Boxes2D::from_mins_and_sizes([(5.0, 5.0)], [(4.0, 4.0)])
@@ -77,19 +77,19 @@ fn test_log_cleared(rec: &RecordingStream) -> anyhow::Result<()> {
             .with_labels(["Rect2"]),
     )?;
 
-    rec.set_time_seconds("sim_time", 2f64);
+    rec.set_duration_seconds("sim_time", 2f64);
     rec.log("null_test/rect/0", &Clear::flat())?;
 
-    rec.set_time_seconds("sim_time", 3f64);
+    rec.set_duration_seconds("sim_time", 3f64);
     rec.log("null_test/rect", &Clear::recursive())?;
 
-    rec.set_time_seconds("sim_time", 4f64);
+    rec.set_duration_seconds("sim_time", 4f64);
     rec.log(
         "null_test/rect/0",
         &Boxes2D::from_mins_and_sizes([(5.0, 5.0)], [(4.0, 4.0)]),
     )?;
 
-    rec.set_time_seconds("sim_time", 5f64);
+    rec.set_duration_seconds("sim_time", 5f64);
     rec.log(
         "null_test/rect/1",
         &Boxes2D::from_mins_and_sizes([(10.0, 5.0)], [(4.0, 4.0)]),
@@ -104,7 +104,7 @@ fn test_3d_points(rec: &RecordingStream) -> anyhow::Result<()> {
         components::{Color, Position3D, Radius, Text},
     };
 
-    rec.set_time_seconds("sim_time", 1f64);
+    rec.set_duration_seconds("sim_time", 1f64);
 
     rec.log(
         "3d_points/single_point_unlabeled",
@@ -164,7 +164,7 @@ fn test_rects(rec: &RecordingStream) -> anyhow::Result<()> {
     };
 
     // Add an image
-    rec.set_time_seconds("sim_time", 1f64);
+    rec.set_duration_seconds("sim_time", 1f64);
     let img = Array::<u8, _>::from_elem((1024, 1024, 3, 1).f(), 128);
     rec.log(
         "rects_test/img",
@@ -179,7 +179,7 @@ fn test_rects(rec: &RecordingStream) -> anyhow::Result<()> {
         .map(|c| Color::from_rgb(c[0], c[1], c[2]))
         .collect_vec();
 
-    rec.set_time_seconds("sim_time", 2f64);
+    rec.set_duration_seconds("sim_time", 2f64);
     rec.log(
         "rects_test/rects",
         &Boxes2D::from_mins_and_sizes(
@@ -190,7 +190,7 @@ fn test_rects(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
 
     // Clear the rectangles by logging an empty set
-    rec.set_time_seconds("sim_time", 3f64);
+    rec.set_duration_seconds("sim_time", 3f64);
     rec.log("rects_test/rects", &Boxes2D::clear_fields())?;
 
     Ok(())
@@ -222,7 +222,7 @@ fn test_segmentation(rec: &RecordingStream) -> anyhow::Result<()> {
     segmentation_img.slice_mut(s![80..100, 60..80]).fill(42);
     segmentation_img.slice_mut(s![20..50, 90..110]).fill(99);
 
-    rec.set_time_seconds("sim_time", 1f64);
+    rec.set_duration_seconds("sim_time", 1f64);
 
     rec.log(
         "seg_test/img",
@@ -260,7 +260,7 @@ fn test_segmentation(rec: &RecordingStream) -> anyhow::Result<()> {
         "no rects, default colored points, a single point has a label",
     )?;
 
-    rec.set_time_seconds("sim_time", 2f64);
+    rec.set_duration_seconds("sim_time", 2f64);
 
     rec.log(
         "seg_test",
@@ -272,7 +272,7 @@ fn test_segmentation(rec: &RecordingStream) -> anyhow::Result<()> {
             bottom right clusters have labels",
     )?;
 
-    rec.set_time_seconds("sim_time", 3f64);
+    rec.set_duration_seconds("sim_time", 3f64);
 
     // Log an updated segmentation map with specific colors
     rec.log(
@@ -285,7 +285,7 @@ fn test_segmentation(rec: &RecordingStream) -> anyhow::Result<()> {
     )?;
     log_info(rec, "points/rects with user specified colors")?;
 
-    rec.set_time_seconds("sim_time", 4f64);
+    rec.set_duration_seconds("sim_time", 4f64);
 
     // Log with a mixture of set and unset colors / labels
     rec.log(
@@ -312,7 +312,7 @@ fn test_text_logs(rec: &RecordingStream) -> anyhow::Result<()> {
     // TODO(cmc): the python SDK has some magic that glues the standard logger directly into rerun
     // logs; we're gonna need something similar for rust (e.g. `tracing` backend).
 
-    rec.set_time_seconds("sim_time", 0f64);
+    rec.set_duration_seconds("sim_time", 0f64);
 
     rec.log(
         "logs",
@@ -352,7 +352,7 @@ fn test_transforms_3d(rec: &RecordingStream) -> anyhow::Result<()> {
     log_coordinate_space(rec, "transforms3d/sun/planet")?;
     log_coordinate_space(rec, "transforms3d/sun/planet/moon")?;
 
-    rec.set_time_seconds("sim_time", 0f64);
+    rec.set_duration_seconds("sim_time", 0f64);
 
     // All are in the center of their own space:
     fn log_point(
@@ -415,7 +415,7 @@ fn test_transforms_3d(rec: &RecordingStream) -> anyhow::Result<()> {
     for i in 0..6 * 120 {
         let time = i as f32 / 120.0;
 
-        rec.set_time_seconds("sim_time", time as f64);
+        rec.set_duration_seconds("sim_time", time as f64);
 
         rec.log(
             "transforms3d/sun/planet",


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/8635

### What
Introduce a new API for setting timeline values.

`rec.set_index(timeline_name, rerun::IndexCell)` 

#### Deprecated: `rec.set_time_seconds` and `rec.set_time_nanos`
Use one of these instead:
* `rec.set_duration_seconds`
* `rec.set_timestamp_seconds_since_epoch`
* `rec.set_index` with `std::time::Duration`
* `rec.set_index` with `std::time::SystemTime`

### TODO
* [ ] Migration guide
* [ ] Full check