### PR TITLE
rs-checks: print list of failed jobs at the end

### DIFF
--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -173,7 +173,10 @@ def main() -> None:
         sys.exit(0)
     else:
         print()
-        print(f"❌ {num_failures} checks / {len(results)} failed!")
+        print(f"❌ {num_failures} checks / {len(results)} failed:")
+        for result in results:
+            if not result.success:
+                print(f"  ❌ {result.command}")
         sys.exit(1)
 
 


### PR DESCRIPTION
If you have multiple failures, you will now see them all listed so you can start fixing them
![image](https://github.com/user-attachments/assets/d00dd5f9-b6f6-4aa0-b437-acffdae89ad2)
