### PR TITLE
Ignore RUSTSEC about unmaintained crate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ all-features = true
 version = 2
 ignore = [
   "RUSTSEC-2024-0384", # Waiting for https://github.com/console-rs/indicatif/pull/666
+  "RUSTSEC-2024-0436", # https://rustsec.org/advisories/RUSTSEC-2024-0436 - paste is unmaintained - https://github.com/dtolnay/paste
 ]
 
 


### PR DESCRIPTION
[`paste`](https://crates.io/crates/paste) is unmaintained.
Not much we can do about it right now:
* https://rustsec.org/advisories/RUSTSEC-2024-0436
* https://github.com/dtolnay/paste