### PR TITLE
Refactor time code, and change formatting of time ranges in URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -706,7 +706,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -763,7 +763,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1081,7 +1081,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1364,7 +1364,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1813,7 +1813,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1824,7 +1824,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1916,7 +1916,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2268,7 +2268,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2289,7 +2289,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2300,7 +2300,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2321,7 +2321,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2561,7 +2561,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2663,7 +2663,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2829,7 +2829,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3487,7 +3487,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3725,6 +3725,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c163c633eb184a4ad2a5e7a5dacf12a58c830d717a7963563d4eceb4ced079f"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc3e0019b0f5f43038cf46471b1312136f29e36f54436c6042c8f155fec8789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3930,7 +3971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4161,7 +4202,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4471,7 +4512,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -4534,7 +4575,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5038,7 +5079,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5085,7 +5126,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5232,15 +5273,15 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a7d5beecc52a491b54d6dd05c7a45ba1801666a5baad9fdbfc6fef8d2d206c"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
@@ -5273,7 +5314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5287,9 +5328,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -5311,7 +5352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5341,7 +5382,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.99",
  "tempfile",
 ]
 
@@ -5355,7 +5396,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5476,7 +5517,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5489,7 +5530,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -5563,9 +5604,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -6279,6 +6320,7 @@ dependencies = [
  "fixed",
  "half",
  "itertools 0.13.0",
+ "jiff",
  "mimalloc",
  "natord",
  "nohash-hasher",
@@ -6769,7 +6811,7 @@ dependencies = [
  "re_tracing",
  "rust-format",
  "serde",
- "syn 2.0.87",
+ "syn 2.0.99",
  "tempfile",
  "toml",
  "unindent",
@@ -8201,7 +8243,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8224,7 +8266,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8598,7 +8640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8636,9 +8678,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8668,7 +8710,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8845,7 +8887,7 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -8856,7 +8898,7 @@ checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9056,7 +9098,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9184,7 +9226,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9314,7 +9356,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9609,7 +9651,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -9649,7 +9691,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -9717,7 +9759,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10172,7 +10214,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10183,7 +10225,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10632,7 +10674,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -10692,7 +10734,7 @@ checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
  "zbus-lockstep",
  "zbus_xml",
  "zvariant",
@@ -10707,7 +10749,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
  "zvariant_utils",
 ]
 
@@ -10753,7 +10795,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10773,7 +10815,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
  "synstructure",
 ]
 
@@ -10802,7 +10844,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -10855,7 +10897,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
  "zvariant_utils",
 ]
 
@@ -10867,5 +10909,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.99",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6341,7 +6341,6 @@ dependencies = [
  "similar-asserts",
  "static_assertions",
  "thiserror 1.0.65",
- "time",
  "typenum",
  "uuid",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,6 +292,7 @@ tempfile = "3.0"
 thiserror = "1.0"
 tiff = "0.9.1"
 time = { version = "0.3.36", default-features = false, features = [
+  # TODO(emilk): stop using `time`, and replace all uses with `jiff`
   "wasm-bindgen",
 ] }
 tiny_http = { version = "0.12", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,6 +211,7 @@ indicatif = "0.17.7" # Progress bar
 infer = "0.16" # infer MIME type by checking the magic number signaturefer MIME type by checking the magic number signature
 insta = "1.23"
 itertools = "0.13"
+jiff = "0.2.3"
 js-sys = "0.3"
 jsonwebtoken = { version = "9", default-features = false }
 libc = "0.2"

--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -1031,7 +1031,7 @@ mod tests {
     fn simple() -> anyhow::Result<()> {
         let batcher = ChunkBatcher::new(ChunkBatcherConfig::NEVER)?;
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
 
         let timepoint1 = TimePoint::default().with(timeline1, 42);
         let timepoint2 = TimePoint::default().with(timeline1, 43);
@@ -1140,7 +1140,7 @@ mod tests {
     fn simple_but_hashes_might_not_match() -> anyhow::Result<()> {
         let batcher = ChunkBatcher::new(ChunkBatcherConfig::NEVER)?;
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
 
         let timepoint1 = TimePoint::default().with(timeline1, 42);
         let timepoint2 = TimePoint::default().with(timeline1, 43);
@@ -1323,7 +1323,7 @@ mod tests {
     fn different_entities() -> anyhow::Result<()> {
         let batcher = ChunkBatcher::new(ChunkBatcherConfig::NEVER)?;
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
 
         let timepoint1 = TimePoint::default().with(timeline1, 42);
         let timepoint2 = TimePoint::default().with(timeline1, 43);
@@ -1426,7 +1426,7 @@ mod tests {
     fn different_timelines() -> anyhow::Result<()> {
         let batcher = ChunkBatcher::new(ChunkBatcherConfig::NEVER)?;
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
         let timeline2 = Timeline::new_sequence("frame_nr");
 
         let timepoint1 = TimePoint::default().with(timeline1, 42);
@@ -1539,7 +1539,7 @@ mod tests {
     fn different_datatypes() -> anyhow::Result<()> {
         let batcher = ChunkBatcher::new(ChunkBatcherConfig::NEVER)?;
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
 
         let timepoint1 = TimePoint::default().with(timeline1, 42);
         let timepoint2 = TimePoint::default().with(timeline1, 43);
@@ -1646,8 +1646,8 @@ mod tests {
             ..ChunkBatcherConfig::NEVER
         })?;
 
-        let timeline1 = Timeline::new_temporal("log_time");
-        let timeline2 = Timeline::new_temporal("frame_nr");
+        let timeline1 = Timeline::new_duration("log_time");
+        let timeline2 = Timeline::new_duration("frame_nr");
 
         let timepoint1 = TimePoint::default()
             .with(timeline2, 1000)
@@ -1750,8 +1750,8 @@ mod tests {
             ..ChunkBatcherConfig::NEVER
         })?;
 
-        let timeline1 = Timeline::new_temporal("log_time");
-        let timeline2 = Timeline::new_temporal("frame_nr");
+        let timeline1 = Timeline::new_duration("log_time");
+        let timeline2 = Timeline::new_duration("frame_nr");
 
         let timepoint1 = TimePoint::default()
             .with(timeline2, 1000)

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -14,7 +14,7 @@ use nohash_hasher::IntMap;
 use re_arrow_util::ArrowArrayDowncastRef as _;
 use re_byte_size::SizeBytes as _;
 use re_log_types::{
-    EntityPath, NonMinI64, ResolvedTimeRange, Time, TimeInt, TimePoint, Timeline, TimelineName,
+    EntityPath, NonMinI64, ResolvedTimeRange, TimeInt, TimePoint, TimeType, Timeline, TimelineName,
 };
 use re_types_core::{
     ComponentDescriptor, ComponentName, DeserializationError, Loggable as _, SerializationError,
@@ -936,61 +936,132 @@ impl TimeColumn {
         )
     }
 
-    /// Creates a new [`TimeColumn`] of sequence type.
-    pub fn new_seconds(
+    /// Creates a new [`TimeColumn`] of duration type, in seconds.
+    pub fn new_duration_seconds(
         name: impl Into<re_log_types::TimelineName>,
-        times: impl IntoIterator<Item = impl Into<f64>>,
+        seconds: impl IntoIterator<Item = impl Into<f64>>,
     ) -> Self {
-        let time_vec = times.into_iter().map(|t| {
-            let t = t.into();
-            let time = Time::from_seconds_since_epoch(t);
-            TimeInt::try_from(time)
-                .unwrap_or_else(|_| {
-                    re_log::error!(
-                illegal_value = t,
-                new_value = TimeInt::MIN.as_i64(),
-                "TimeColumn::new_seconds() called with illegal value - clamped to minimum legal value"
-            );
-                    TimeInt::MIN
-                })
-                .as_i64()
+        let time_vec = seconds.into_iter().map(|seconds| {
+            let seconds = seconds.into();
+            let nanos = (1e9 * seconds).round();
+            let clamped = NonMinI64::saturating_from_i64(nanos as i64);
+            if clamped.get() as f64 != nanos {
+                re_log::warn!(
+                    illegal_value = nanos,
+                    new_value = clamped.get(),
+                    "TimeColumn::new_duration_seconds() called with out-of-range value. Clamped to valid range."
+                );
+            }
+            clamped.get()
         }).collect_vec();
 
         Self::new(
             None,
-            Timeline::new_temporal(name.into()),
+            Timeline::new(name, TimeType::Time),
             ArrowScalarBuffer::from(time_vec),
         )
     }
 
-    /// Creates a new [`TimeColumn`] of nanoseconds type.
-    pub fn new_nanos(
+    /// Creates a new [`TimeColumn`] of duration type, in seconds.
+    pub fn new_timestamp_seconds_since_epoch(
         name: impl Into<re_log_types::TimelineName>,
-        times: impl IntoIterator<Item = impl Into<i64>>,
+        seconds: impl IntoIterator<Item = impl Into<f64>>,
     ) -> Self {
-        let time_vec = times
+        let time_vec = seconds.into_iter().map(|seconds| {
+            let seconds = seconds.into();
+            let nanos = (1e9 * seconds).round();
+            let clamped = NonMinI64::saturating_from_i64(nanos as i64);
+            if clamped.get() as f64 != nanos {
+                re_log::warn!(
+                    illegal_value = nanos,
+                    new_value = clamped.get(),
+                    "TimeColumn::new_timestamp_seconds_since_epoch() called with out-of-range value. Clamped to valid range."
+                );
+            }
+            clamped.get()
+        }).collect_vec();
+
+        Self::new(
+            None,
+            Timeline::new(name, TimeType::Time),
+            ArrowScalarBuffer::from(time_vec),
+        )
+    }
+
+    /// Creates a new [`TimeColumn`] of duration type, in seconds.
+    #[deprecated = "Use `TimeColumn::new_duration_seconds` or `new_timestamp_seconds_since_epoch` instead"]
+    pub fn new_seconds(
+        name: impl Into<re_log_types::TimelineName>,
+        seconds: impl IntoIterator<Item = impl Into<f64>>,
+    ) -> Self {
+        Self::new_duration_seconds(name, seconds)
+    }
+
+    /// Creates a new [`TimeColumn`] measuring duration in nanoseconds.
+    pub fn new_duration_nanos(
+        name: impl Into<re_log_types::TimelineName>,
+        nanos: impl IntoIterator<Item = impl Into<i64>>,
+    ) -> Self {
+        let time_vec = nanos
             .into_iter()
-            .map(|t| {
-                let t = t.into();
-                let time = Time::from_ns_since_epoch(t);
-                TimeInt::try_from(time)
-                    .unwrap_or_else(|_| {
+            .map(|nanos| {
+                let nanos = nanos.into();
+                NonMinI64::new(nanos)
+                    .unwrap_or_else(|| {
                         re_log::error!(
-                illegal_value = t,
-                new_value = TimeInt::MIN.as_i64(),
-                "TimeColumn::new_nanos() called with illegal value - clamped to minimum legal value"
-            );
-                        TimeInt::MIN
+                            illegal_value = nanos,
+                            new_value = TimeInt::MIN.as_i64(),
+                            "TimeColumn::new_duration_nanos() called with illegal value - clamped to minimum legal value"
+                        );
+                        NonMinI64::MIN
                     })
-                    .as_i64()
+                    .get()
             })
             .collect_vec();
 
         Self::new(
             None,
-            Timeline::new_temporal(name.into()),
+            Timeline::new(name, TimeType::Time),
             ArrowScalarBuffer::from(time_vec),
         )
+    }
+
+    /// Creates a new [`TimeColumn`] of timestamps, as nanoseconds since unix epoch.
+    pub fn new_timestamp_nanos_since_epoch(
+        name: impl Into<re_log_types::TimelineName>,
+        nanos: impl IntoIterator<Item = impl Into<i64>>,
+    ) -> Self {
+        let time_vec = nanos
+            .into_iter()
+            .map(|nanos| {
+                let nanos = nanos.into();
+                NonMinI64::new(nanos)
+                    .unwrap_or_else(|| {
+                        re_log::error!(
+                            illegal_value = nanos,
+                            new_value = TimeInt::MIN.as_i64(),
+                            "TimeColumn::new_timestamp_nanos_since_epoch() called with illegal value - clamped to minimum legal value"
+                        );
+                        NonMinI64::MIN
+                    })
+                    .get()
+            })
+            .collect_vec();
+
+        Self::new(
+            None,
+            Timeline::new(name, TimeType::Time),
+            ArrowScalarBuffer::from(time_vec),
+        )
+    }
+
+    /// Creates a new [`TimeColumn`] of nanoseconds type.
+    #[deprecated = "Use `TimeColumn::new_duration_nanos` or `new_timestamp_nanos_since_epoch` instead"]
+    pub fn new_nanos(
+        name: impl Into<re_log_types::TimelineName>,
+        nanos: impl IntoIterator<Item = impl Into<i64>>,
+    ) -> Self {
+        Self::new_duration_nanos(name, nanos)
     }
 
     /// Parse the given [`ArrowArray`] as a time column.

--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -323,7 +323,7 @@ mod tests {
     fn sort() -> anyhow::Result<()> {
         let entity_path: EntityPath = "a/b/c".into();
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
         let timeline2 = Timeline::new_sequence("frame_nr");
 
         let points1 = vec![
@@ -418,7 +418,7 @@ mod tests {
     fn sort_time() -> anyhow::Result<()> {
         let entity_path: EntityPath = "a/b/c".into();
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
         let timeline2 = Timeline::new_sequence("frame_nr");
 
         let chunk_id = ChunkId::new();

--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -283,7 +283,7 @@ mod tests {
     fn roundtrip() -> anyhow::Result<()> {
         let entity_path = EntityPath::parse_forgiving("a/b/c");
 
-        let timeline1 = Timeline::new_temporal("log_time");
+        let timeline1 = Timeline::new_duration("log_time");
         let timelines1: IntMap<_, _> = std::iter::once((
             *timeline1.name(),
             TimeColumn::new(Some(true), timeline1, vec![42, 43, 44, 45].into()),

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -481,7 +481,10 @@ impl ChunkStore {
         let timeline = timelines
             .get(&selector.timeline)
             .copied()
-            .unwrap_or_else(|| Timeline::new_temporal(selector.timeline));
+            .unwrap_or_else(|| {
+                re_log::warn_once!("Unknown timeline {selector:?}; assuming sequence timeline.");
+                Timeline::new_sequence(selector.timeline)
+            });
 
         IndexColumnDescriptor::from(timeline)
     }

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -294,7 +294,7 @@ mod tests {
         let mut view = GlobalCounts::default();
 
         let timeline_frame = Timeline::new_sequence("frame");
-        let timeline_other = Timeline::new_temporal("other");
+        let timeline_other = Timeline::new_duration("other");
         let timeline_yet_another = Timeline::new_sequence("yet_another");
 
         let row_id1 = RowId::new();

--- a/crates/store/re_chunk_store/src/subscribers.rs
+++ b/crates/store/re_chunk_store/src/subscribers.rs
@@ -376,7 +376,7 @@ mod tests {
         let view_handle = ChunkStore::register_subscriber(Box::new(view));
 
         let timeline_frame = Timeline::new_sequence("frame");
-        let timeline_other = Timeline::new_temporal("other");
+        let timeline_other = Timeline::new_duration("other");
         let timeline_yet_another = Timeline::new_sequence("yet_another");
 
         let chunk = Chunk::builder("entity_a".into())

--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -183,7 +183,7 @@ fn load_video(
 ) -> Result<impl ExactSizeIterator<Item = Chunk>, DataLoaderError> {
     re_tracing::profile_function!();
 
-    let video_timeline = re_log_types::Timeline::new_temporal("video");
+    let video_timeline = re_log_types::Timeline::new_duration("video");
     timepoint.insert_index(
         *video_timeline.name(),
         re_log_types::IndexCell::ZERO_DURATION,

--- a/crates/store/re_log_types/Cargo.toml
+++ b/crates/store/re_log_types/Cargo.toml
@@ -74,12 +74,6 @@ num-derive.workspace = true
 num-traits.workspace = true
 static_assertions.workspace = true
 thiserror.workspace = true
-time = { workspace = true, features = [
-  "formatting",
-  "local-offset",
-  "macros",
-  "parsing",
-] }
 typenum.workspace = true
 uuid = { workspace = true, features = ["serde", "v4", "js"] }
 web-time.workspace = true

--- a/crates/store/re_log_types/Cargo.toml
+++ b/crates/store/re_log_types/Cargo.toml
@@ -67,6 +67,7 @@ fixed = { workspace = true, default-features = false }
 # we keep it as a direct dependency to ensure it stays pinned to the right version
 half.workspace = true
 itertools.workspace = true
+jiff.workspace = true
 natord.workspace = true
 nohash-hasher.workspace = true
 num-derive.workspace = true

--- a/crates/store/re_log_types/src/index/duration.rs
+++ b/crates/store/re_log_types/src/index/duration.rs
@@ -197,7 +197,7 @@ impl std::fmt::Display for Duration {
 impl From<Duration> for super::TimeInt {
     #[inline]
     fn from(duration: Duration) -> Self {
-        super::TimeInt::saturated_nonstatic_i64(duration.as_nanos())
+        Self::saturated_nonstatic_i64(duration.as_nanos())
     }
 }
 

--- a/crates/store/re_log_types/src/index/duration.rs
+++ b/crates/store/re_log_types/src/index/duration.rs
@@ -194,6 +194,13 @@ impl std::fmt::Display for Duration {
     }
 }
 
+impl From<Duration> for super::TimeInt {
+    #[inline]
+    fn from(duration: Duration) -> Self {
+        super::TimeInt::saturated_nonstatic_i64(duration.as_nanos())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::Duration;

--- a/crates/store/re_log_types/src/index/duration.rs
+++ b/crates/store/re_log_types/src/index/duration.rs
@@ -120,6 +120,40 @@ impl Duration {
 
         Ok(())
     }
+
+    /// Useful when showing dates/times on a timeline and you want it compact.
+    ///
+    /// When a duration is less than a second, we only show the time from the last whole second.
+    pub fn format_subsecond_as_relative(self) -> String {
+        let ns = self.as_nanos();
+
+        let fractional_ns = ns % 1_000_000_000;
+        let is_whole_second = fractional_ns == 0;
+
+        if is_whole_second {
+            self.to_string()
+        } else {
+            // We are in the sub-second resolution.
+            // Showing the full time (HH:MM:SS.XXX or 3h 2m 6s …) becomes too long,
+            // so instead we switch to showing the time as milliseconds since the last whole second:
+            let ms = fractional_ns as f64 * 1e-6;
+            if fractional_ns % 1_000_000 == 0 {
+                format!("{ms:+.0} ms")
+            } else if fractional_ns % 100_000 == 0 {
+                format!("{ms:+.1} ms")
+            } else if fractional_ns % 10_000 == 0 {
+                format!("{ms:+.2} ms")
+            } else if fractional_ns % 1_000 == 0 {
+                format!("{ms:+.3} ms")
+            } else if fractional_ns % 100 == 0 {
+                format!("{ms:+.4} ms")
+            } else if fractional_ns % 10 == 0 {
+                format!("{ms:+.5} ms")
+            } else {
+                format!("{ms:+.6} ms")
+            }
+        }
+    }
 }
 
 impl From<std::time::Duration> for Duration {

--- a/crates/store/re_log_types/src/index/duration.rs
+++ b/crates/store/re_log_types/src/index/duration.rs
@@ -12,12 +12,12 @@ impl Duration {
     const SEC_PER_DAY: i64 = 24 * Self::SEC_PER_HOUR;
 
     #[inline]
-    pub fn from_nanos(nanos: i64) -> Self {
+    pub const fn from_nanos(nanos: i64) -> Self {
         Self(nanos)
     }
 
     #[inline]
-    pub fn from_millis(millis: i64) -> Self {
+    pub const fn from_millis(millis: i64) -> Self {
         Self(millis * Self::NANOS_PER_MILLI)
     }
 
@@ -79,6 +79,21 @@ impl Duration {
         }
 
         None
+    }
+
+    /// Format as seconds, approximately.
+    pub fn format_seconds(self) -> String {
+        let nanos = self.as_nanos();
+        let secs = nanos as f64 * 1e-9;
+
+        let is_whole_second = nanos % 1_000_000_000 == 0;
+
+        let secs = re_format::FloatFormatOptions::DEFAULT_f64
+            .with_always_sign(true)
+            .with_decimals(if is_whole_second { 0 } else { 3 })
+            .with_strip_trailing_zeros(false)
+            .format(secs);
+        format!("{secs}s")
     }
 
     pub fn exact_format(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/store/re_log_types/src/index/duration.rs
+++ b/crates/store/re_log_types/src/index/duration.rs
@@ -22,8 +22,9 @@ impl Duration {
     }
 
     #[inline]
-    pub fn from_secs(secs: f32) -> Self {
-        Self::from_nanos((secs * Self::NANOS_PER_SEC as f32).round() as _)
+    pub fn from_secs(secs: impl Into<f64>) -> Self {
+        let secs = secs.into();
+        Self::from_nanos((secs * Self::NANOS_PER_SEC as f64).round() as _)
     }
 
     #[inline]
@@ -39,6 +40,45 @@ impl Duration {
     #[inline]
     pub fn as_secs_f64(&self) -> f64 {
         self.0 as f64 * 1e-9
+    }
+
+    /// Try to parse a duration from a string
+    pub fn parse(s: &str) -> Option<Self> {
+        // Try parsing as a simple relative time with unit suffix (e.g. "1.234s", "1.234ms")
+        let suffixes = [("s", 1e9), ("ms", 1e6), ("us", 1e3), ("ns", 1.0)];
+        for (suffix, to_ns) in suffixes {
+            if let Some(s) = s.strip_suffix(suffix) {
+                if let Ok(value) = s.parse::<f64>() {
+                    return Some(Self::from_nanos((value * to_ns).round() as i64));
+                }
+            }
+        }
+
+        // Parse a few common ntime formats:
+        let time_formats = [
+            // Just time with milliseconds
+            "[hour]:[minute]:[second].[subsecond]",
+            // Just time
+            "[hour]:[minute]:[second]",
+        ];
+        for format in time_formats {
+            let format = time::format_description::parse_borrowed::<2>(format)
+                .expect("Invalid format string");
+
+            if let Ok(time) = time::Time::parse(s, &format).map(|t| {
+                let (h, m, s, ns) = t.as_hms_nano();
+                Self::from_nanos(
+                    ns as i64
+                        + s as i64 * time::convert::Nanosecond::per(time::convert::Second) as i64
+                        + m as i64 * time::convert::Nanosecond::per(time::convert::Minute) as i64
+                        + h as i64 * time::convert::Nanosecond::per(time::convert::Hour) as i64,
+                )
+            }) {
+                return Some(time);
+            }
+        }
+
+        None
     }
 
     pub fn exact_format(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -127,8 +167,53 @@ impl std::ops::Neg for Duration {
     }
 }
 
+impl std::fmt::Debug for Duration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.exact_format(f)
+    }
+}
+
 impl std::fmt::Display for Duration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.exact_format(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Duration;
+
+    #[test]
+    fn parse_duration() {
+        assert_eq!(Duration::parse("42s"), Some(Duration::from_secs(42.0)));
+        assert_eq!(
+            Duration::parse("42.123s"),
+            Some(Duration::from_secs(42.123))
+        );
+        assert_eq!(Duration::parse("42ms"), Some(Duration::from_secs(0.042)));
+        assert_eq!(Duration::parse("42us"), Some(Duration::from_secs(0.000042)));
+        assert_eq!(
+            Duration::parse("42ns"),
+            Some(Duration::from_secs(0.000000042))
+        );
+
+        // Hour format.
+        assert_eq!(
+            Duration::parse("22:35:42"),
+            Some(Duration::from_secs(22 * 60 * 60 + 35 * 60 + 42))
+        );
+
+        // Hout format with fractional seconds.
+        assert_eq!(
+            Duration::parse("00:00:42.069"),
+            Some(Duration::from_nanos(42_069_000_000))
+        );
+
+        // Test invalid formats
+        assert_eq!(Duration::parse("invalid"), None);
+        assert_eq!(Duration::parse("123"), None); // lacks unit
+        assert_eq!(Duration::parse("25:00:00"), None); // Invalid hour
+        assert_eq!(Duration::parse("00:60:00"), None); // Invalid minute
+        assert_eq!(Duration::parse("00:00:60"), None); // Invalid second
     }
 }

--- a/crates/store/re_log_types/src/index/index_cell.rs
+++ b/crates/store/re_log_types/src/index/index_cell.rs
@@ -1,4 +1,6 @@
-use crate::{NonMinI64, TimeInt, TimeType};
+use std::str::FromStr;
+
+use crate::{NonMinI64, Time, TimeInt, TimeType};
 
 pub struct OutOfRange;
 
@@ -152,5 +154,68 @@ impl TryFrom<web_time::SystemTime> for IndexCell {
         let nanos_since_epoch = duration_since_epoch.as_nanos();
         let nanos_since_epoch = i64::try_from(nanos_since_epoch).map_err(|_ignored| OutOfRange)?;
         Ok(Self::from_timestamp_nanos_since_epoch(nanos_since_epoch))
+    }
+}
+
+// ------------------------------------------------------------------
+
+impl std::fmt::Display for IndexCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.typ {
+            TimeType::Sequence => write!(f, "#{}", self.value),
+            TimeType::Time => Time::from_ns_since_epoch(self.value.get())
+                .format(crate::TimeZone::Utc)
+                .fmt(f),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Invalid IndexCell: {0}")]
+pub struct InvalidIndexCell(String);
+
+impl FromStr for IndexCell {
+    type Err = InvalidIndexCell;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(s) = s.strip_prefix('#') {
+            let int = NonMinI64::from_str(s).map_err(|err| {
+                InvalidIndexCell(format!("Invalid sequence index: '#{s}': {err}"))
+            })?;
+            Ok(Self::new(TimeType::Sequence, int))
+        } else if let Ok(duration) = s.parse::<super::Duration>() {
+            Ok(Self::from(duration))
+        } else if let Ok(timestamp) = s.parse::<super::Timestamp>() {
+            Ok(Self::from(timestamp))
+        } else {
+            Err(InvalidIndexCell(format!(
+                "Expected a #sequence, duration, or RFC3339 timestamp, but got '{s}'"
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_iso_format_and_parse() {
+        assert_eq!(
+            "#1234".parse::<IndexCell>().unwrap(),
+            IndexCell::from_sequence(1234)
+        );
+
+        assert_eq!(
+            "10.134567s".parse::<IndexCell>().unwrap(),
+            IndexCell::from_duration_nanos(10_134_567_000)
+        );
+
+        assert_eq!(
+            "2022-01-01T00:00:03.123456789Z"
+                .parse::<IndexCell>()
+                .unwrap(),
+            IndexCell::from_timestamp_nanos_since_epoch(1_640_995_203_123_456_789)
+        );
     }
 }

--- a/crates/store/re_log_types/src/index/index_cell.rs
+++ b/crates/store/re_log_types/src/index/index_cell.rs
@@ -110,6 +110,20 @@ impl From<std::time::Duration> for IndexCell {
     }
 }
 
+impl From<super::Duration> for IndexCell {
+    #[inline]
+    fn from(duration: super::Duration) -> Self {
+        Self::from_duration_nanos(duration.as_nanos())
+    }
+}
+
+impl From<super::Timestamp> for IndexCell {
+    #[inline]
+    fn from(timestamp: super::Timestamp) -> Self {
+        Self::from_timestamp_nanos_since_epoch(timestamp.ns_since_epoch())
+    }
+}
+
 // ------------------------------------------------------------------
 
 impl TryFrom<std::time::SystemTime> for IndexCell {

--- a/crates/store/re_log_types/src/index/index_cell.rs
+++ b/crates/store/re_log_types/src/index/index_cell.rs
@@ -165,7 +165,7 @@ impl std::fmt::Display for IndexCell {
             // NOTE: we avoid special characters here so we can put these formats in an URI
             TimeType::Sequence => self.value.fmt(f),
             TimeType::Time => Time::from_ns_since_epoch(self.value.get())
-                .format(crate::TimeZone::Utc)
+                .format(crate::TimestampFormat::Utc)
                 .fmt(f),
         }
     }

--- a/crates/store/re_log_types/src/index/mod.rs
+++ b/crates/store/re_log_types/src/index/mod.rs
@@ -9,6 +9,7 @@ mod time_int;
 mod time_point;
 mod time_real;
 mod time_type;
+mod time_zone;
 mod timeline;
 
 pub use self::{
@@ -16,10 +17,11 @@ pub use self::{
     index_cell::IndexCell,
     non_min_i64::{NonMinI64, TryFromIntError},
     resolved_time_range::{ResolvedTimeRange, ResolvedTimeRangeF},
-    time::{Time, TimeZone},
+    time::Time,
     time_int::TimeInt,
     time_point::TimePoint,
     time_real::TimeReal,
     time_type::TimeType,
+    time_zone::TimeZone,
     timeline::{Timeline, TimelineName},
 };

--- a/crates/store/re_log_types/src/index/mod.rs
+++ b/crates/store/re_log_types/src/index/mod.rs
@@ -9,9 +9,9 @@ mod time_int;
 mod time_point;
 mod time_real;
 mod time_type;
-mod time_zone;
 mod timeline;
 mod timestamp;
+mod timestamp_format;
 
 pub use self::{
     duration::Duration,
@@ -23,7 +23,7 @@ pub use self::{
     time_point::TimePoint,
     time_real::TimeReal,
     time_type::TimeType,
-    time_zone::TimeZone,
     timeline::{Timeline, TimelineName},
     timestamp::Timestamp,
+    timestamp_format::TimestampFormat,
 };

--- a/crates/store/re_log_types/src/index/mod.rs
+++ b/crates/store/re_log_types/src/index/mod.rs
@@ -11,6 +11,7 @@ mod time_real;
 mod time_type;
 mod time_zone;
 mod timeline;
+mod timestamp;
 
 pub use self::{
     duration::Duration,
@@ -24,4 +25,5 @@ pub use self::{
     time_type::TimeType,
     time_zone::TimeZone,
     timeline::{Timeline, TimelineName},
+    timestamp::Timestamp,
 };

--- a/crates/store/re_log_types/src/index/non_min_i64.rs
+++ b/crates/store/re_log_types/src/index/non_min_i64.rs
@@ -208,6 +208,24 @@ impl<'de> serde::Deserialize<'de> for NonMinI64 {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+#[error("Failed to parse NonMinI64: {0}")]
+pub enum ParseNonMinI64Error {
+    Std(#[from] std::num::ParseIntError),
+
+    #[error("out-of-range")]
+    OutOfRange,
+}
+
+impl std::str::FromStr for NonMinI64 {
+    type Err = ParseNonMinI64Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let int = i64::from_str(s)?;
+        Self::new(int).ok_or(ParseNonMinI64Error::OutOfRange)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/store/re_log_types/src/index/non_min_i64.rs
+++ b/crates/store/re_log_types/src/index/non_min_i64.rs
@@ -213,8 +213,8 @@ impl<'de> serde::Deserialize<'de> for NonMinI64 {
 pub enum ParseNonMinI64Error {
     Std(#[from] std::num::ParseIntError),
 
-    #[error("out-of-range")]
-    OutOfRange,
+    #[error("Value is equal to minimum i64. Every i64 integer *except* the lowest representable number of a signed 64 bit number is valid.")]
+    InvalidValue,
 }
 
 impl std::str::FromStr for NonMinI64 {
@@ -222,7 +222,7 @@ impl std::str::FromStr for NonMinI64 {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let int = i64::from_str(s)?;
-        Self::new(int).ok_or(ParseNonMinI64Error::OutOfRange)
+        Self::new(int).ok_or(ParseNonMinI64Error::InvalidValue)
     }
 }
 

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -127,7 +127,7 @@ impl Time {
 
     /// Best effort parsing of a string into a [`Time`] from a human readable string.
     pub fn parse(s: &str, time_zone_for_timestamps: TimeZone) -> Option<Self> {
-        if let Some(duration) = Duration::parse(s) {
+        if let Ok(duration) = s.parse::<Duration>() {
             return Some(Self::from_ns_since_epoch(duration.as_nanos()));
         }
 
@@ -567,8 +567,5 @@ mod tests {
         assert_eq!(Time::parse("invalid", TimeZone::Utc), None);
         assert_eq!(Time::parse("2022-13-28", TimeZone::Utc), None); // Invalid month
         assert_eq!(Time::parse("2022-02-29", TimeZone::Utc), None); // Invalid day (not leap year)
-        assert_eq!(Time::parse("25:00:00", TimeZone::Utc), None); // Invalid hour
-        assert_eq!(Time::parse("00:60:00", TimeZone::Utc), None); // Invalid minute
-        assert_eq!(Time::parse("00:00:60", TimeZone::Utc), None); // Invalid second
     }
 }

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -3,21 +3,7 @@ use re_log::ResultExt as _;
 use std::ops::RangeInclusive;
 use time::{format_description::FormatItem, OffsetDateTime, UtcOffset};
 
-use super::Duration;
-
-/// How to display a [`Time`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum TimeZone {
-    /// Convert to local timezone and display as such.
-    Local,
-
-    /// Display as UTC.
-    Utc,
-
-    /// Show as seconds since unix epoch
-    UnixEpoch,
-}
+use super::{Duration, TimeZone};
 
 /// A date-time represented as nanoseconds since unix epoch
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
-use re_log::ResultExt as _;
 use std::ops::RangeInclusive;
 use time::{format_description::FormatItem, OffsetDateTime, UtcOffset};
 
-use super::{Duration, TimeZone, Timestamp};
+use re_log::ResultExt as _;
+
+use crate::{Duration, TimeZone, Timestamp};
 
 /// Either a [`Timestamp`] or a [`Duration`].
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -241,7 +241,7 @@ mod tests {
     }
 
     fn parse_datetime(s: &str) -> Time {
-        crate::Time::parse(s, TimestampFormat::Utc).unwrap().into()
+        crate::Time::parse(s, TimestampFormat::Utc).unwrap()
     }
 
     #[test]

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -89,6 +89,18 @@ impl Time {
         r.ok_or_log_error().unwrap_or_default()
     }
 
+    /// RFC3339
+    pub fn format_iso(&self) -> String {
+        let nanos_since_epoch = self.nanos_since_epoch();
+
+        if self.is_absolute_date() {
+            super::Timestamp::from_ns_since_epoch(nanos_since_epoch).format_iso()
+        } else {
+            // Relative time
+            Duration::from_nanos(nanos_since_epoch).format_seconds()
+        }
+    }
+
     /// Human-readable formatting
     pub fn format(&self, time_zone_for_timestamps: TimeZone) -> String {
         let nanos_since_epoch = self.nanos_since_epoch();

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -188,20 +188,11 @@ impl TryFrom<web_time::SystemTime> for Time {
     }
 }
 
-impl TryFrom<time::OffsetDateTime> for Time {
-    type Error = core::num::TryFromIntError;
-
-    fn try_from(datetime: time::OffsetDateTime) -> Result<Self, Self::Error> {
-        i64::try_from(datetime.unix_timestamp_nanos()).map(Self::from_ns_since_epoch)
-    }
-}
-
 // ---------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use time::macros::datetime;
 
     #[test]
     fn test_formatting_short_times() {
@@ -249,9 +240,13 @@ mod tests {
         );
     }
 
+    fn parse_datetime(s: &str) -> Time {
+        crate::Time::parse(s, TimestampFormat::Utc).unwrap().into()
+    }
+
     #[test]
     fn test_formatting_whole_second_for_datetime() {
-        let datetime = Time::try_from(datetime!(2022-02-28 22:35:42 UTC)).unwrap();
+        let datetime = parse_datetime("2022-02-28 22:35:42Z");
         assert_eq!(
             &datetime.format(TimestampFormat::Utc),
             "2022-02-28 22:35:42Z"
@@ -260,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_formatting_whole_millisecond_for_datetime() {
-        let datetime = Time::try_from(datetime!(2022-02-28 22:35:42.069 UTC)).unwrap();
+        let datetime = parse_datetime("2022-02-28 22:35:42.069Z");
         assert_eq!(
             &datetime.format(TimestampFormat::Utc),
             "2022-02-28 22:35:42.069Z"
@@ -269,7 +264,7 @@ mod tests {
 
     #[test]
     fn test_formatting_many_digits_for_datetime() {
-        let datetime = Time::try_from(datetime!(2022-02-28 22:35:42.069_042_7 UTC)).unwrap();
+        let datetime = parse_datetime("2022-02-28 22:35:42.0690427Z");
         assert_eq!(
             &datetime.format(TimestampFormat::Utc),
             "2022-02-28 22:35:42.069042Z"
@@ -311,13 +306,13 @@ mod tests {
             // Hour format.
             assert_eq!(
                 Time::parse("22:35:42", format),
-                Some(Time::try_from(datetime!(1970-01-01 22:35:42 UTC)).unwrap())
+                Some(parse_datetime("1970-01-01 22:35:42Z"))
             );
 
             // Hour format with fractional seconds.
             assert_eq!(
                 Time::parse("22:35:42.069", format),
-                Some(Time::try_from(datetime!(1970-01-01 22:35:42.069 UTC)).unwrap())
+                Some(parse_datetime("1970-01-01 22:35:42.069Z"))
             );
         }
 
@@ -326,25 +321,25 @@ mod tests {
         // Full date and time
         assert_eq!(
             Time::parse("1954-04-11 22:35:42", TimestampFormat::Utc),
-            Some(Time::try_from(datetime!(1954-04-11 22:35:42 UTC)).unwrap())
+            Some(parse_datetime("1954-04-11 22:35:42Z"))
         );
         // Full date and time with milliseconds
         assert_eq!(
             Time::parse("1954-04-11 22:35:42.069", TimestampFormat::Utc),
-            Some(Time::try_from(datetime!(1954-04-11 22:35:42.069 UTC)).unwrap())
+            Some(parse_datetime("1954-04-11 22:35:42.069Z"))
         );
-        // Timezone setting doesn't matter if UTC is enabled.
+        // Timezone setting doesn't matter ifZ is enabled.
         for format in all_formats {
             // Full date and time with Z suffix
             assert_eq!(
                 Time::parse("1954-04-11 22:35:42Z", format),
-                Some(Time::try_from(datetime!(1954-04-11 22:35:42 UTC)).unwrap())
+                Some(parse_datetime("1954-04-11 22:35:42Z"))
             );
 
             // Full date and time with milliseconds with Z suffix
             assert_eq!(
                 Time::parse("1954-04-11 22:35:42.069Z", format),
-                Some(Time::try_from(datetime!(1954-04-11 22:35:42.069 UTC)).unwrap())
+                Some(parse_datetime("1954-04-11 22:35:42.069Z"))
             );
         }
 

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -42,7 +42,7 @@ impl Time {
         20 <= years_since_epoch && years_since_epoch <= 150
     }
 
-    /// RFC3339
+    /// Formats the time as specified by ISO standard [`RFC3339`](https://www.rfc-editor.org/rfc/rfc3339.html).
     pub fn format_iso(&self) -> String {
         let nanos_since_epoch = self.nanos_since_epoch();
 

--- a/crates/store/re_log_types/src/index/time.rs
+++ b/crates/store/re_log_types/src/index/time.rs
@@ -139,16 +139,7 @@ impl Time {
             Self::time_string(datetime, &parsed_format, time_zone_for_timestamps)
         } else {
             // Relative time
-            let secs = nanos_since_epoch as f64 * 1e-9;
-
-            let is_whole_second = nanos_since_epoch % 1_000_000_000 == 0;
-
-            let secs = re_format::FloatFormatOptions::DEFAULT_f64
-                .with_always_sign(true)
-                .with_decimals(if is_whole_second { 0 } else { 3 })
-                .with_strip_trailing_zeros(false)
-                .format(secs);
-            format!("{secs}s")
+            Duration::from_nanos(nanos_since_epoch).format_seconds()
         }
     }
 
@@ -522,7 +513,7 @@ mod tests {
                 Some(Time::try_from(datetime!(1970-01-01 22:35:42 UTC)).unwrap())
             );
 
-            // Hout format with fractional seconds.
+            // Hour format with fractional seconds.
             assert_eq!(
                 Time::parse("22:35:42.069", time_zone),
                 Some(Time::try_from(datetime!(1970-01-01 22:35:42.069 UTC)).unwrap())

--- a/crates/store/re_log_types/src/index/time_int.rs
+++ b/crates/store/re_log_types/src/index/time_int.rs
@@ -180,6 +180,15 @@ impl TryFrom<Time> for TimeInt {
     }
 }
 
+impl TryFrom<TimeInt> for NonMinI64 {
+    type Error = TryFromIntError;
+
+    #[inline]
+    fn try_from(t: TimeInt) -> Result<Self, Self::Error> {
+        Self::new(t.as_i64()).ok_or(TryFromIntError)
+    }
+}
+
 impl From<TimeInt> for Time {
     #[inline]
     fn from(int: TimeInt) -> Self {

--- a/crates/store/re_log_types/src/index/time_type.rs
+++ b/crates/store/re_log_types/src/index/time_type.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::DataType as ArrowDataType;
 
-use crate::{ResolvedTimeRange, Time, TimeZone};
+use crate::{ResolvedTimeRange, Time, TimestampFormat};
 
 use super::TimeInt;
 
@@ -36,7 +36,7 @@ impl TimeType {
     }
 
     pub fn format_sequence(time_int: TimeInt) -> String {
-        Self::Sequence.format(time_int, TimeZone::Utc)
+        Self::Sequence.format(time_int, TimestampFormat::Utc)
     }
 
     pub fn parse_sequence(s: &str) -> Option<TimeInt> {
@@ -52,7 +52,7 @@ impl TimeType {
     }
 
     /// Parses a human-readable time string into a [`TimeInt`].
-    pub fn parse_time(&self, s: &str, time_zone_for_timestamps: TimeZone) -> Option<TimeInt> {
+    pub fn parse_time(&self, s: &str, timestamp_format: TimestampFormat) -> Option<TimeInt> {
         match s.to_lowercase().as_str() {
             "<static>" | "static" => Some(TimeInt::STATIC),
             "−∞" | "-inf" | "-infinity" => Some(TimeInt::MIN),
@@ -65,7 +65,7 @@ impl TimeType {
                             TimeInt::try_from(int).ok()
                         } else {
                             // Otherwise, try to make sense of the time string depending on the timezone setting.
-                            TimeInt::try_from(Time::parse(s, time_zone_for_timestamps)?).ok()
+                            TimeInt::try_from(Time::parse(s, timestamp_format)?).ok()
                         }
                     }
                     Self::Sequence => {
@@ -83,7 +83,7 @@ impl TimeType {
     pub fn format(
         &self,
         time_int: impl Into<TimeInt>,
-        time_zone_for_timestamps: TimeZone,
+        timestamp_format: TimestampFormat,
     ) -> String {
         let time_int = time_int.into();
         match time_int {
@@ -91,7 +91,7 @@ impl TimeType {
             TimeInt::MIN => "−∞".into(),
             TimeInt::MAX => "+∞".into(),
             _ => match self {
-                Self::Time => Time::from(time_int).format(time_zone_for_timestamps),
+                Self::Time => Time::from(time_int).format(timestamp_format),
                 Self::Sequence => format!("#{}", re_format::format_int(time_int.as_i64())),
             },
         }
@@ -99,25 +99,25 @@ impl TimeType {
 
     #[inline]
     pub fn format_utc(&self, time_int: TimeInt) -> String {
-        self.format(time_int, TimeZone::Utc)
+        self.format(time_int, TimestampFormat::Utc)
     }
 
     #[inline]
     pub fn format_range(
         &self,
         time_range: ResolvedTimeRange,
-        time_zone_for_timestamps: TimeZone,
+        timestamp_format: TimestampFormat,
     ) -> String {
         format!(
             "{}..={}",
-            self.format(time_range.min(), time_zone_for_timestamps),
-            self.format(time_range.max(), time_zone_for_timestamps)
+            self.format(time_range.min(), timestamp_format),
+            self.format(time_range.max(), timestamp_format)
         )
     }
 
     #[inline]
     pub fn format_range_utc(&self, time_range: ResolvedTimeRange) -> String {
-        self.format_range(time_range, TimeZone::Utc)
+        self.format_range(time_range, TimestampFormat::Utc)
     }
 
     /// Returns the appropriate arrow datatype to represent this timeline.

--- a/crates/store/re_log_types/src/index/time_type.rs
+++ b/crates/store/re_log_types/src/index/time_type.rs
@@ -60,9 +60,9 @@ impl TimeType {
             _ => {
                 match self {
                     Self::Time => {
-                        if s.chars().all(|c| c.is_ascii_digit()) {
+                        if let Some(int) = re_format::parse_i64(s) {
                             // If it's just numbers, interpret it as a raw time int.
-                            TimeInt::try_from(re_format::parse_i64(s)?).ok()
+                            TimeInt::try_from(int).ok()
                         } else {
                             // Otherwise, try to make sense of the time string depending on the timezone setting.
                             TimeInt::try_from(Time::parse(s, time_zone_for_timestamps)?).ok()

--- a/crates/store/re_log_types/src/index/time_zone.rs
+++ b/crates/store/re_log_types/src/index/time_zone.rs
@@ -1,0 +1,13 @@
+/// How to display a [`Time`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum TimeZone {
+    /// Convert to local timezone and display as such.
+    Local,
+
+    /// Display as UTC.
+    Utc,
+
+    /// Show as seconds since unix epoch
+    UnixEpoch,
+}

--- a/crates/store/re_log_types/src/index/time_zone.rs
+++ b/crates/store/re_log_types/src/index/time_zone.rs
@@ -1,4 +1,4 @@
-/// How to display a [`Time`].
+/// How to display a [`crate::Timestamp`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum TimeZone {

--- a/crates/store/re_log_types/src/index/timeline.rs
+++ b/crates/store/re_log_types/src/index/timeline.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{ResolvedTimeRange, TimeType, TimeZone};
+use crate::{ResolvedTimeRange, TimeType, TimestampFormat};
 
 re_string_interner::declare_new_type!(
     /// The name of a timeline. Often something like `"log_time"` or `"frame_nr"`.
@@ -123,15 +123,15 @@ impl Timeline {
     pub fn format_time_range(
         &self,
         time_range: &ResolvedTimeRange,
-        time_zone_for_timestamps: TimeZone,
+        timestamp_format: TimestampFormat,
     ) -> String {
-        self.typ.format_range(*time_range, time_zone_for_timestamps)
+        self.typ.format_range(*time_range, timestamp_format)
     }
 
     /// Returns a formatted string of `time_range` on this `Timeline`.
     #[inline]
     pub fn format_time_range_utc(&self, time_range: &ResolvedTimeRange) -> String {
-        self.format_time_range(time_range, TimeZone::Utc)
+        self.format_time_range(time_range, TimestampFormat::Utc)
     }
 
     /// Returns the appropriate arrow datatype to represent this timeline.

--- a/crates/store/re_log_types/src/index/timeline.rs
+++ b/crates/store/re_log_types/src/index/timeline.rs
@@ -82,7 +82,10 @@ impl Timeline {
         }
     }
 
-    #[deprecated(note = "Use `Timeline::new_duration` or `new_timestamp` instead")]
+    #[deprecated(
+        since = "0.23.0",
+        note = "Use `Timeline::new_duration` or `new_timestamp` instead"
+    )]
     #[inline]
     pub fn new_temporal(name: impl Into<TimelineName>) -> Self {
         Self::new_duration(name)

--- a/crates/store/re_log_types/src/index/timeline.rs
+++ b/crates/store/re_log_types/src/index/timeline.rs
@@ -47,12 +47,11 @@ pub struct Timeline {
 }
 
 impl Timeline {
-    /// For absolute or relative time.
     #[inline]
-    pub fn new_temporal(name: impl Into<TimelineName>) -> Self {
+    pub fn new(name: impl Into<TimelineName>, typ: TimeType) -> Self {
         Self {
             name: name.into(),
-            typ: TimeType::Time,
+            typ,
         }
     }
 
@@ -65,12 +64,28 @@ impl Timeline {
         }
     }
 
+    /// For relative times (e.g. seconds since start).
     #[inline]
-    pub fn new(name: impl Into<TimelineName>, typ: TimeType) -> Self {
+    pub fn new_duration(name: impl Into<TimelineName>) -> Self {
         Self {
             name: name.into(),
-            typ,
+            typ: TimeType::Time,
         }
+    }
+
+    /// For absolute timestamps.
+    #[inline]
+    pub fn new_timestamp(name: impl Into<TimelineName>) -> Self {
+        Self {
+            name: name.into(),
+            typ: TimeType::Time,
+        }
+    }
+
+    #[deprecated(note = "Use `Timeline::new_duration` or `new_timestamp` instead")]
+    #[inline]
+    pub fn new_temporal(name: impl Into<TimelineName>) -> Self {
+        Self::new_duration(name)
     }
 
     #[inline]

--- a/crates/store/re_log_types/src/index/timestamp.rs
+++ b/crates/store/re_log_types/src/index/timestamp.rs
@@ -62,11 +62,11 @@ impl TryFrom<web_time::SystemTime> for Timestamp {
 }
 
 // ------------------------------------------
-// Joff converters
+// `jiff` converters
 
 impl Timestamp {
     pub fn to_jiff_zoned(self, timestamp_format: TimestampFormat) -> jiff::Zoned {
-        jiff::Timestamp::from(self).to_zoned(timestamp_format.to_jiff_tz())
+        jiff::Timestamp::from(self).to_zoned(timestamp_format.to_jiff_time_zone())
     }
 }
 
@@ -110,7 +110,7 @@ impl std::fmt::Debug for Timestamp {
 }
 
 impl Timestamp {
-    /// RFC3339
+    /// Formats the time as specified by ISO standard [`RFC3339`](https://www.rfc-editor.org/rfc/rfc3339.html).
     pub fn format_iso(self) -> String {
         jiff::Timestamp::from(self).to_string()
     }
@@ -145,7 +145,7 @@ impl Timestamp {
             }
 
             TimestampFormat::LocalTimezone | TimestampFormat::Utc => {
-                let tz = timestamp_format.to_jiff_tz();
+                let tz = timestamp_format.to_jiff_time_zone();
                 let zoned = timestamp.to_zoned(tz.clone());
 
                 let is_today = zoned.date() == jiff::Timestamp::now().to_zoned(tz).date();
@@ -217,7 +217,7 @@ impl Timestamp {
             Some(Self::from(zoned))
         } else if let Ok(date_time) = jiff::civil::DateTime::from_str(s) {
             date_time
-                .to_zoned(timestamp_format.to_jiff_tz())
+                .to_zoned(timestamp_format.to_jiff_time_zone())
                 .ok()
                 .map(|zoned| zoned.into())
         } else if timestamp_format == TimestampFormat::UnixEpoch {

--- a/crates/store/re_log_types/src/index/timestamp.rs
+++ b/crates/store/re_log_types/src/index/timestamp.rs
@@ -153,7 +153,7 @@ impl Timestamp {
 
     /// Parse a timestamp,
     ///
-    /// If it is missing a timezone specifier, the the given timezone is assumed.
+    /// If it is missing a timezone specifier, the given timezone is assumed.
     pub fn parse_with_format(s: &str, timestamp_format: TimestampFormat) -> Option<Self> {
         if let Ok(utc) = Self::from_str(s) {
             // It has a `Z` suffix

--- a/crates/store/re_log_types/src/index/timestamp_format.rs
+++ b/crates/store/re_log_types/src/index/timestamp_format.rs
@@ -11,3 +11,21 @@ pub enum TimestampFormat {
     /// Show as seconds since unix epoch
     UnixEpoch,
 }
+
+impl TimestampFormat {
+    pub fn to_jiff_tz(self) -> jiff::tz::TimeZone {
+        use jiff::tz::TimeZone;
+
+        match self {
+            Self::UnixEpoch | Self::Utc => TimeZone::UTC,
+
+            Self::LocalTimezone => match TimeZone::try_system() {
+                Ok(tz) => tz,
+                Err(err) => {
+                    re_log::warn_once!("Failed to detect system/local time zone: {err}");
+                    TimeZone::UTC
+                }
+            },
+        }
+    }
+}

--- a/crates/store/re_log_types/src/index/timestamp_format.rs
+++ b/crates/store/re_log_types/src/index/timestamp_format.rs
@@ -13,7 +13,7 @@ pub enum TimestampFormat {
 }
 
 impl TimestampFormat {
-    pub fn to_jiff_tz(self) -> jiff::tz::TimeZone {
+    pub fn to_jiff_time_zone(self) -> jiff::tz::TimeZone {
         use jiff::tz::TimeZone;
 
         match self {

--- a/crates/store/re_log_types/src/index/timestamp_format.rs
+++ b/crates/store/re_log_types/src/index/timestamp_format.rs
@@ -1,9 +1,9 @@
 /// How to display a [`crate::Timestamp`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum TimeZone {
+pub enum TimestampFormat {
     /// Convert to local timezone and display as such.
-    Local,
+    LocalTimezone,
 
     /// Display as UTC.
     Utc,

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -38,7 +38,7 @@ pub use self::{
     arrow_msg::{ArrowMsg, ArrowRecordBatchReleaseCallback},
     index::{
         Duration, IndexCell, NonMinI64, ResolvedTimeRange, ResolvedTimeRangeF, Time, TimeInt,
-        TimePoint, TimeReal, TimeType, TimestampFormat, Timeline, TimelineName, Timestamp,
+        TimePoint, TimeReal, TimeType, Timeline, TimelineName, Timestamp, TimestampFormat,
         TryFromIntError,
     },
     instance::Instance,

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -38,7 +38,7 @@ pub use self::{
     arrow_msg::{ArrowMsg, ArrowRecordBatchReleaseCallback},
     index::{
         Duration, IndexCell, NonMinI64, ResolvedTimeRange, ResolvedTimeRangeF, Time, TimeInt,
-        TimePoint, TimeReal, TimeType, TimeZone, Timeline, TimelineName, Timestamp,
+        TimePoint, TimeReal, TimeType, TimestampFormat, Timeline, TimelineName, Timestamp,
         TryFromIntError,
     },
     instance::Instance,

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -38,7 +38,8 @@ pub use self::{
     arrow_msg::{ArrowMsg, ArrowRecordBatchReleaseCallback},
     index::{
         Duration, IndexCell, NonMinI64, ResolvedTimeRange, ResolvedTimeRangeF, Time, TimeInt,
-        TimePoint, TimeReal, TimeType, TimeZone, Timeline, TimelineName, TryFromIntError,
+        TimePoint, TimeReal, TimeType, TimeZone, Timeline, TimelineName, Timestamp,
+        TryFromIntError,
     },
     instance::Instance,
     path::*,

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -54,7 +54,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .copied()
 ///         .map(rerun::components::VideoTimestamp::from_nanoseconds)
 ///         .collect::<Vec<_>>();
-///     let time_column = rerun::TimeColumn::new_nanos(
+///     let time_column = rerun::TimeColumn::new_duration_nanos(
 ///         "video_time",
 ///         // Note timeline values don't have to be the same as the video timestamps.
 ///         frame_timestamps_ns,

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -93,7 +93,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     let rec =
 ///         rerun::RecordingStreamBuilder::new("rerun_example_points3d_column_updates").spawn()?;
 ///
-///     let times = rerun::TimeColumn::new_seconds("time", 10..15);
+///     let times = rerun::TimeColumn::new_duration_seconds("time", 10..15);
 ///
 ///     // Prepare a point cloud that evolves over 5 timesteps, changing the number of points in the process.
 ///     #[rustfmt::skip]

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -52,7 +52,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         .copied()
 ///         .map(rerun::components::VideoTimestamp::from_nanoseconds)
 ///         .collect::<Vec<_>>();
-///     let time_column = rerun::TimeColumn::new_nanos(
+///     let time_column = rerun::TimeColumn::new_duration_nanos(
 ///         "video_time",
 ///         // Note timeline values don't have to be the same as the video timestamps.
 ///         frame_timestamps_ns,

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -954,11 +954,11 @@ impl RecordingStream {
     ///
     /// Unlike the regular `log` API, which is row-oriented, this API lets you submit the data
     /// in a columnar form. The lengths of all of the [`TimeColumn`] and the component columns
-    /// must match. All data that occurs at the same index across the different time and components
+    /// must match. All data that occurs at the same index across the different index/time and components
     /// arrays will act as a single logical row.
     ///
-    /// Note that this API ignores any stateful time set on the log stream via the
-    /// [`Self::set_timepoint`]/[`Self::set_time_nanos`]/etc. APIs.
+    /// Note that this API ignores any stateful index/time set on the log stream via the
+    /// [`Self::set_index`]/[`Self::set_timepoint`]/[`Self::set_time_nanos`]/etc. APIs.
     /// Furthermore, this will _not_ inject the default timelines `log_tick` and `log_time` timeline columns.
     pub fn send_columns(
         &self,
@@ -2019,13 +2019,14 @@ impl RecordingStream {
     /// Set the current time of the recording, for the current calling thread.
     ///
     /// Used for all subsequent logging performed from this same thread, until the next call
-    /// to one of the time setting methods.
+    /// to one of the index/time setting methods.
     ///
     /// There is no requirement of monotonicity. You can move the time backwards if you like.
     ///
     /// See also:
     /// - [`Self::set_index`]
     /// - [`Self::set_time_sequence`]
+    /// - [`Self::set_duration_seconds`]
     /// - [`Self::disable_timeline`]
     /// - [`Self::reset_time`]
     pub fn set_timepoint(&self, timepoint: impl Into<TimePoint>) {
@@ -2044,7 +2045,7 @@ impl RecordingStream {
     /// Set the current value of one of the timelines.
     ///
     /// Used for all subsequent logging performed from this same thread, until the next call
-    /// to one of the time setting methods.
+    /// to one of the index/time setting methods.
     ///
     /// There is no requirement of monotonicity. You can move the time backwards if you like.
     ///
@@ -2060,6 +2061,7 @@ impl RecordingStream {
     /// See also:
     /// - [`Self::set_timepoint`]
     /// - [`Self::set_time_sequence`]
+    /// - [`Self::set_duration_seconds`]
     /// - [`Self::disable_timeline`]
     /// - [`Self::reset_time`]
     pub fn set_index(&self, timeline: impl Into<TimelineName>, value: impl TryInto<IndexCell>) {
@@ -2084,7 +2086,7 @@ impl RecordingStream {
     /// Short for `set_index(timeline, rerun::IndexCell::from_sequence(sequence))`.
     ///
     /// Used for all subsequent logging performed from this same thread, until the next call
-    /// to one of the time setting methods.
+    /// to one of the index/time setting methods.
     ///
     /// For example: `rec.set_time_sequence("frame_nr", frame_nr)`.
     /// You can remove a timeline again using `rec.disable_timeline("frame_nr")`.
@@ -2092,9 +2094,9 @@ impl RecordingStream {
     /// There is no requirement of monotonicity. You can move the time backwards if you like.
     ///
     /// See also:
+    /// - [`Self::set_index`]
     /// - [`Self::set_timepoint`]
-    /// - [`Self::set_time_seconds`]
-    /// - [`Self::set_time_nanos`]
+    /// - [`Self::set_duration_seconds`]
     /// - [`Self::disable_timeline`]
     /// - [`Self::reset_time`]
     #[inline]
@@ -2102,7 +2104,25 @@ impl RecordingStream {
         self.set_index(timeline, IndexCell::from_sequence(sequence.into()));
     }
 
-    /// Short for `set_index(timeline, std::time::Duration::from_secs_f64(secs))`.
+    /// Set the current time of the recording, for the current calling thread.
+    ///
+    /// Short for `set_index(timeline, std::time::Duration::from_secs_f64(secs))`..
+    ///
+    /// Used for all subsequent logging performed from this same thread, until the next call
+    /// to one of the index/time setting methods.
+    ///
+    /// For example: `rec.set_duration_seconds("time_since_start", time_offset)`.
+    /// You can remove a timeline again using `rec.disable_timeline("time_since_start")`.
+    ///
+    /// There is no requirement of monotonicity. You can move the time backwards if you like.
+    ///
+    /// See also:
+    /// - [`Self::set_index`]
+    /// - [`Self::set_timepoint`]
+    /// - [`Self::set_timestamp_seconds_since_epoch`]
+    /// - [`Self::set_time_sequence`]
+    /// - [`Self::disable_timeline`]
+    /// - [`Self::reset_time`]
     #[inline]
     pub fn set_duration_seconds(&self, timeline: impl Into<TimelineName>, secs: impl Into<f64>) {
         self.set_index(timeline, std::time::Duration::from_secs_f64(secs.into()));
@@ -2111,6 +2131,22 @@ impl RecordingStream {
     /// Set a timestamp as seconds since Unix epoch (1970-01-01 00:00:00 UTC).
     ///
     /// Short for `self.set_index(timeline, rerun::IndexCell::from_timestamp_seconds_since_epoch(secs))`.
+    ///
+    /// Used for all subsequent logging performed from this same thread, until the next call
+    /// to one of the index/time setting methods.
+    ///
+    /// For example: `rec.set_duration_seconds("time_since_start", time_offset)`.
+    /// You can remove a timeline again using `rec.disable_timeline("time_since_start")`.
+    ///
+    /// There is no requirement of monotonicity. You can move the time backwards if you like.
+    ///
+    /// See also:
+    /// - [`Self::set_index`]
+    /// - [`Self::set_timepoint`]
+    /// - [`Self::set_duration_seconds`]
+    /// - [`Self::set_time_sequence`]
+    /// - [`Self::disable_timeline`]
+    /// - [`Self::reset_time`]
     #[inline]
     pub fn set_timestamp_seconds_since_epoch(
         &self,
@@ -2126,7 +2162,7 @@ impl RecordingStream {
     /// Set the current time of the recording, for the current calling thread.
     ///
     /// Used for all subsequent logging performed from this same thread, until the next call
-    /// to one of the time setting methods.
+    /// to one of the index/time setting methods.
     ///
     /// For example: `rec.set_time_seconds("sim_time", sim_time_secs)`.
     /// You can remove a timeline again using `rec.disable_timeline("sim_time")`.
@@ -2151,7 +2187,7 @@ impl RecordingStream {
     /// Set the current time of the recording, for the current calling thread.
     ///
     /// Used for all subsequent logging performed from this same thread, until the next call
-    /// to one of the time setting methods.
+    /// to one of the index/time setting methods.
     ///
     /// For example: `rec.set_time_nanos("sim_time", sim_time_nanos)`.
     /// You can remove a timeline again using `rec.disable_timeline("sim_time")`.
@@ -2205,7 +2241,7 @@ impl RecordingStream {
     /// Clears out the current time of the recording, for the current calling thread.
     ///
     /// Used for all subsequent logging performed from this same thread, until the next call
-    /// to one of the time setting methods.
+    /// to one of the index/time setting methods.
     ///
     /// For example: `rec.reset_time()`.
     ///

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -2140,6 +2140,7 @@ impl RecordingStream {
     /// - [`Self::disable_timeline`]
     /// - [`Self::reset_time`]
     #[deprecated(
+        since = "0.23.0",
         note = "Use either `set_duration_seconds` or `set_timestamp_seconds_since_epoch` instead"
     )]
     #[inline]
@@ -2164,6 +2165,7 @@ impl RecordingStream {
     /// - [`Self::disable_timeline`]
     /// - [`Self::reset_time`]
     #[deprecated(
+        since = "0.23.0",
         note = "Use `set_index` with either `rerun::IndexCell::from_duration_nanos` or `rerun::IndexCell::from_timestamp_nanos_since_epoch`, or with `std::time::Duration` or `std::time::SystemTime`."
     )]
     #[inline]

--- a/crates/utils/re_uri/src/error.rs
+++ b/crates/utils/re_uri/src/error.rs
@@ -6,8 +6,8 @@ pub enum Error {
     #[error("invalid or missing scheme (expected `rerun(+http|+https)://`)")]
     InvalidScheme,
 
-    #[error("invalid time range (expected `TIMELINE@(\\d+)s?..(\\d+)s?`)")]
-    InvalidTimeRange,
+    #[error("invalid time range (expected `TIMELINE@time..time`): {0}")]
+    InvalidTimeRange(String),
 
     #[error("unexpected endpoint: {0}")]
     UnexpectedEndpoint(String),

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(
             time_range,
             Some(TimeRange {
-                timeline: re_log_types::Timeline::new_temporal("timeline"),
+                timeline: re_log_types::Timeline::new_duration("timeline"),
                 range: re_log_types::ResolvedTimeRangeF::new(
                     re_log_types::TimeReal::from_seconds(10.0),
                     re_log_types::TimeReal::from_seconds(20.0)
@@ -446,7 +446,7 @@ mod tests {
             assert_eq!(
                 time_range,
                 Some(TimeRange {
-                    timeline: re_log_types::Timeline::new_temporal("timeline"),
+                    timeline: re_log_types::Timeline::new_duration("timeline"),
                     range: re_log_types::ResolvedTimeRangeF::new(
                         re_log_types::TimeReal::from_seconds(10.0),
                         re_log_types::TimeReal::from_seconds(20.0)

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -87,7 +87,7 @@ impl TryFrom<&str> for TimeRange {
 
         if min.typ() != max.typ() {
             return Err(Error::InvalidTimeRange(
-                "min/max had differing types".to_owned(),
+                format!("min/max had differing types. Min was identified as {}, whereas max was identified as {}", min.typ(), max.typ()),
             ));
         }
 

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -411,7 +411,10 @@ mod tests {
 
     #[test]
     fn test_recording_url_time_range_temporal() {
-        for url in ["rerun://127.0.0.1:1234/recording/12345?time_range=timeline@10s..20s"] {
+        for url in [
+            "rerun://127.0.0.1:1234/recording/12345?time_range=timeline@1.23s..72s",
+            "rerun://127.0.0.1:1234/recording/12345?time_range=timeline@1230ms..1m12s",
+        ] {
             let address: RedapUri = url.try_into().unwrap();
 
             let RedapUri::Recording(RecordingEndpoint {
@@ -432,8 +435,8 @@ mod tests {
                 Some(TimeRange {
                     timeline: re_log_types::Timeline::new_duration("timeline"),
                     range: re_log_types::ResolvedTimeRangeF::new(
-                        re_log_types::TimeReal::from_seconds(10.0),
-                        re_log_types::TimeReal::from_seconds(20.0)
+                        re_log_types::TimeReal::from_seconds(1.23),
+                        re_log_types::TimeReal::from_seconds(72.0)
                     )
                 })
             );

--- a/crates/viewer/re_chunk_store_ui/src/chunk_list_mode.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_list_mode.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use re_chunk_store::external::re_chunk::ComponentName;
 use re_chunk_store::ChunkStore;
-use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, TimeZone, Timeline};
+use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, Timeline, TimestampFormat};
 use re_ui::UiExt as _;
 use re_viewer_context::TimeDragValue;
 
@@ -32,7 +32,7 @@ impl ChunkListMode {
         &mut self,
         ui: &mut egui::Ui,
         chunk_store: &ChunkStore,
-        time_zone: TimeZone,
+        format: TimestampFormat,
     ) -> Option<()> {
         let all_timelines = chunk_store.timelines();
         let all_entities = chunk_store.all_entities_sorted();
@@ -168,23 +168,16 @@ impl ChunkListMode {
             match query {
                 ChunkListQueryMode::LatestAt(time) => {
                     ui.label("at:");
-                    time_drag_value.drag_value_ui(ui, time_typ, time, true, None, time_zone);
+                    time_drag_value.drag_value_ui(ui, time_typ, time, true, None, format);
                 }
                 ChunkListQueryMode::Range(range) => {
                     let (mut min, mut max) = (range.min(), range.max());
 
                     ui.label("from:");
-                    time_drag_value.drag_value_ui(ui, time_typ, &mut min, true, None, time_zone);
+                    time_drag_value.drag_value_ui(ui, time_typ, &mut min, true, None, format);
 
                     ui.label("to:");
-                    time_drag_value.drag_value_ui(
-                        ui,
-                        time_typ,
-                        &mut max,
-                        true,
-                        Some(min),
-                        time_zone,
-                    );
+                    time_drag_value.drag_value_ui(ui, time_typ, &mut max, true, Some(min), format);
 
                     range.set_min(min);
                     range.set_max(max);

--- a/crates/viewer/re_chunk_store_ui/src/chunk_list_mode.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_list_mode.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use re_chunk_store::external::re_chunk::ComponentName;
 use re_chunk_store::ChunkStore;
-use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, TimeType, TimeZone, Timeline};
+use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, TimeZone, Timeline};
 use re_ui::UiExt as _;
 use re_viewer_context::TimeDragValue;
 
@@ -168,37 +168,24 @@ impl ChunkListMode {
             match query {
                 ChunkListQueryMode::LatestAt(time) => {
                     ui.label("at:");
-                    match time_typ {
-                        TimeType::Time => {
-                            time_drag_value.temporal_drag_value_ui(ui, time, true, None, time_zone);
-                        }
-                        TimeType::Sequence => {
-                            time_drag_value.sequence_drag_value_ui(ui, time, true, None);
-                        }
-                    };
+                    time_drag_value.drag_value_ui(ui, time_typ, time, true, None, time_zone);
                 }
                 ChunkListQueryMode::Range(range) => {
                     let (mut min, mut max) = (range.min(), range.max());
+
                     ui.label("from:");
-                    match time_typ {
-                        TimeType::Time => {
-                            time_drag_value
-                                .temporal_drag_value_ui(ui, &mut min, true, None, time_zone);
-                            ui.label("to:");
-                            time_drag_value.temporal_drag_value_ui(
-                                ui,
-                                &mut max,
-                                true,
-                                Some(min),
-                                time_zone,
-                            );
-                        }
-                        TimeType::Sequence => {
-                            time_drag_value.sequence_drag_value_ui(ui, &mut min, true, None);
-                            ui.label("to:");
-                            time_drag_value.sequence_drag_value_ui(ui, &mut max, true, Some(min));
-                        }
-                    };
+                    time_drag_value.drag_value_ui(ui, time_typ, &mut min, true, None, time_zone);
+
+                    ui.label("to:");
+                    time_drag_value.drag_value_ui(
+                        ui,
+                        time_typ,
+                        &mut max,
+                        true,
+                        Some(min),
+                        time_zone,
+                    );
+
                     range.set_min(min);
                     range.set_max(max);
                 }

--- a/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
@@ -7,7 +7,7 @@ use itertools::Itertools as _;
 
 use re_byte_size::SizeBytes;
 use re_chunk_store::Chunk;
-use re_log_types::{TimeZone, Timeline};
+use re_log_types::{Timeline, TimestampFormat};
 use re_types::datatypes::TimeInt;
 use re_ui::{list_item, UiExt as _};
 
@@ -48,7 +48,7 @@ impl ChunkUi {
     }
 
     // Return `true` if the user wants to exit the chunk viewer.
-    pub(crate) fn ui(&mut self, ui: &mut egui::Ui, time_zone: TimeZone) -> bool {
+    pub(crate) fn ui(&mut self, ui: &mut egui::Ui, timestamp_format: TimestampFormat) -> bool {
         let should_exit = self.chunk_info_ui(ui);
 
         //
@@ -137,7 +137,7 @@ impl ChunkUi {
                     ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
 
                     let time = TimeInt::from(time_column.times_raw()[row_index]);
-                    ui.label(time_column.timeline().typ().format(time, time_zone));
+                    ui.label(time_column.timeline().typ().format(time, timestamp_format));
                 });
             }
 

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -93,7 +93,7 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
                 }
             } else {
                 let typ = db.timeline_type(&query.timeline());
-                let formatted_time = typ.format(time, ctx.app_options().time_zone);
+                let formatted_time = typ.format(time, ctx.app_options().timestamp_format);
                 ui.horizontal(|ui| {
                     ui.add(re_ui::icons::COMPONENT_TEMPORAL.as_image());
                     ui.label(format!("Temporal component at {formatted_time}"));

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -75,7 +75,7 @@ impl crate::DataUi for EntityDb {
                 ui.end_row();
 
                 ui.grid_left_hand_label("Created");
-                ui.label(started.format(ctx.app_options().time_zone));
+                ui.label(started.format(ctx.app_options().timestamp_format));
                 ui.end_row();
             }
 
@@ -85,7 +85,7 @@ impl crate::DataUi for EntityDb {
                 {
                     let time = re_log_types::Time::from_ns_since_epoch(nanos_since_epoch);
                     ui.grid_left_hand_label("Modified");
-                    ui.label(time.format(ctx.app_options().time_zone));
+                    ui.label(time.format(ctx.app_options().timestamp_format));
                     ui.end_row();
                 }
             }

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -76,7 +76,7 @@ impl DataUi for InstancePath {
                 format!(
                     "Nothing logged at {} = {}",
                     query.timeline(),
-                    typ.format(query.at(), ctx.app_options().time_zone),
+                    typ.format(query.at(), ctx.app_options().timestamp_format),
                 ),
             );
             return;

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -543,7 +543,10 @@ pub fn time_button(
 
     let typ = ctx.recording().timeline_type(timeline_name);
 
-    let response = ui.selectable_label(is_selected, typ.format(value, ctx.app_options().timestamp_format));
+    let response = ui.selectable_label(
+        is_selected,
+        typ.format(value, ctx.app_options().timestamp_format),
+    );
     if response.clicked() {
         let timeline = Timeline::new(*timeline_name, typ);
         ctx.rec_cfg
@@ -746,8 +749,10 @@ pub fn entity_db_button_ui(
     let creation_time = entity_db
         .store_info()
         .and_then(|info| {
-            info.started
-                .format_time_custom("[hour]:[minute]:[second]", ctx.app_options().timestamp_format)
+            info.started.format_time_custom(
+                "[hour]:[minute]:[second]",
+                ctx.app_options().timestamp_format,
+            )
         })
         .unwrap_or("<unknown time>".to_owned());
 

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -543,7 +543,7 @@ pub fn time_button(
 
     let typ = ctx.recording().timeline_type(timeline_name);
 
-    let response = ui.selectable_label(is_selected, typ.format(value, ctx.app_options().time_zone));
+    let response = ui.selectable_label(is_selected, typ.format(value, ctx.app_options().timestamp_format));
     if response.clicked() {
         let timeline = Timeline::new(*timeline_name, typ);
         ctx.rec_cfg
@@ -747,7 +747,7 @@ pub fn entity_db_button_ui(
         .store_info()
         .and_then(|info| {
             info.started
-                .format_time_custom("[hour]:[minute]:[second]", ctx.app_options().time_zone)
+                .format_time_custom("[hour]:[minute]:[second]", ctx.app_options().timestamp_format)
         })
         .unwrap_or("<unknown time>".to_owned());
 

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -748,11 +748,11 @@ pub fn entity_db_button_ui(
 
     let creation_time = entity_db
         .store_info()
-        .and_then(|info| {
-            info.started.format_time_custom(
-                "[hour]:[minute]:[second]",
-                ctx.app_options().timestamp_format,
-            )
+        .map(|info| {
+            re_log_types::Timestamp::from(info.started)
+                .to_jiff_zoned(ctx.app_options().timestamp_format)
+                .strftime("%H:%M:%S")
+                .to_string()
         })
         .unwrap_or("<unknown time>".to_owned());
 

--- a/crates/viewer/re_selection_panel/src/item_title.rs
+++ b/crates/viewer/re_selection_panel/src/item_title.rs
@@ -77,14 +77,10 @@ impl ItemTitle {
 
         let title = if let Some(entity_db) = ctx.store_context.bundle.get(store_id) {
             if let Some(info) = entity_db.store_info() {
-                let time = info
-                    .started
-                    .format_time_custom(
-                        "[hour]:[minute]:[second]",
-                        ctx.app_options().timestamp_format,
-                    )
-                    .unwrap_or("<unknown time>".to_owned());
-
+                let time = re_log_types::Timestamp::from(info.started)
+                    .to_jiff_zoned(ctx.app_options().timestamp_format)
+                    .strftime("%H:%M:%S")
+                    .to_string();
                 format!("{} - {}", info.application_id, time)
             } else {
                 id_str.clone()

--- a/crates/viewer/re_selection_panel/src/item_title.rs
+++ b/crates/viewer/re_selection_panel/src/item_title.rs
@@ -79,7 +79,7 @@ impl ItemTitle {
             if let Some(info) = entity_db.store_info() {
                 let time = info
                     .started
-                    .format_time_custom("[hour]:[minute]:[second]", ctx.app_options().time_zone)
+                    .format_time_custom("[hour]:[minute]:[second]", ctx.app_options().timestamp_format)
                     .unwrap_or("<unknown time>".to_owned());
 
                 format!("{} - {}", info.application_id, time)

--- a/crates/viewer/re_selection_panel/src/item_title.rs
+++ b/crates/viewer/re_selection_panel/src/item_title.rs
@@ -79,7 +79,10 @@ impl ItemTitle {
             if let Some(info) = entity_db.store_info() {
                 let time = info
                     .started
-                    .format_time_custom("[hour]:[minute]:[second]", ctx.app_options().timestamp_format)
+                    .format_time_custom(
+                        "[hour]:[minute]:[second]",
+                        ctx.app_options().timestamp_format,
+                    )
                     .unwrap_or("<unknown time>".to_owned());
 
                 format!("{} - {}", info.application_id, time)

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -228,7 +228,7 @@ Notes:
                     }
                     QueryRange::LatestAt => {
                         let current_time =
-                            time_type.format(current_time, ctx.app_options().time_zone);
+                            time_type.format(current_time, ctx.app_options().timestamp_format);
                         ui.label(format!("Latest-at query at: {current_time}"))
                             .on_hover_text("Uses the latest known value for each component.");
                     }
@@ -324,7 +324,7 @@ fn show_visual_time_range(
     } else if resolved_range.start == TimeRangeBoundary::AT_CURSOR
         && resolved_range.end == TimeRangeBoundary::AT_CURSOR
     {
-        let current_time = time_type.format(current_time, ctx.app_options().time_zone);
+        let current_time = time_type.format(current_time, ctx.app_options().timestamp_format);
         match time_type {
             TimeType::Time => {
                 ui.label(format!("At current time: {current_time}"))
@@ -356,8 +356,8 @@ fn current_range_ui(
     time_range: &TimeRange,
 ) {
     let absolute_range = ResolvedTimeRange::from_relative_time_range(time_range, current_time);
-    let from_formatted = time_type.format(absolute_range.min(), ctx.app_options().time_zone);
-    let to_formatted = time_type.format(absolute_range.max(), ctx.app_options().time_zone);
+    let from_formatted = time_type.format(absolute_range.min(), ctx.app_options().timestamp_format);
+    let to_formatted = time_type.format(absolute_range.max(), ctx.app_options().timestamp_format);
 
     ui.label(format!("{from_formatted} to {to_formatted}"))
         .on_hover_text("Showing data in this range (inclusive).");
@@ -423,7 +423,7 @@ fn resolved_visible_history_boundary_ui(
             }
         }
         TimeRangeBoundary::Absolute(time) => {
-            label += &format!(" {}", time_type.format(*time, ctx.app_options().time_zone));
+            label += &format!(" {}", time_type.format(*time, ctx.app_options().timestamp_format));
         }
         TimeRangeBoundary::Infinite => {}
     }
@@ -542,7 +542,7 @@ fn visible_history_boundary_ui(
                             &mut edit_value,
                             false,
                             low_bound_override,
-                            ctx.app_options().time_zone,
+                            ctx.app_options().timestamp_format,
                         )
 
                         .on_hover_text(match time_type {
@@ -569,7 +569,7 @@ fn visible_history_boundary_ui(
                         &mut edit_value,
                         true,
                         low_bound_override,
-                        ctx.app_options().time_zone,
+                        ctx.app_options().timestamp_format,
                     );
 
                     if let Some(base_time_resp) = base_time_resp {

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -423,7 +423,10 @@ fn resolved_visible_history_boundary_ui(
             }
         }
         TimeRangeBoundary::Absolute(time) => {
-            label += &format!(" {}", time_type.format(*time, ctx.app_options().timestamp_format));
+            label += &format!(
+                " {}",
+                time_type.format(*time, ctx.app_options().timestamp_format)
+            );
         }
         TimeRangeBoundary::Infinite => {}
     }

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -534,33 +534,24 @@ fn visible_history_boundary_ui(
             };
 
             let mut edit_value = (*value).into();
-            let response = match time_type {
-                TimeType::Time => Some(
+            let response =
                     time_drag_value
-                        .temporal_drag_value_ui(
+                        .drag_value_ui(
                             ui,
+                            time_type,
                             &mut edit_value,
                             false,
                             low_bound_override,
                             ctx.app_options().time_zone,
                         )
-                        .0
-                        .on_hover_text(
-                            "Time duration before/after the current time to use as time range \
-                                boundary",
-                        ),
-                ),
-                TimeType::Sequence => Some(
-                    time_drag_value
-                        .sequence_drag_value_ui(ui, &mut edit_value, false, low_bound_override)
-                        .on_hover_text(
-                            "Number of frames before/after the current time to use a time \
-                        range boundary",
-                        ),
-                ),
-            };
+
+                        .on_hover_text(match time_type {
+                            TimeType::Time => "Time duration before/after the current time to use as time range boundary",
+                            TimeType::Sequence => "Number of frames before/after the current time to use a time range boundary",
+                        })
+                    ;
             *value = edit_value.into();
-            response
+            Some(response)
         }
         TimeRangeBoundary::Absolute(value) => {
             // see note above
@@ -585,16 +576,14 @@ fn visible_history_boundary_ui(
                         base_time_resp.on_hover_text("Base time used to set time range boundaries");
                     }
 
-                    Some(drag_resp.on_hover_text("Absolute time to use as time range boundary"))
+                    drag_resp.on_hover_text("Absolute time to use as time range boundary")
                 }
-                TimeType::Sequence => Some(
-                    time_drag_value
-                        .sequence_drag_value_ui(ui, &mut edit_value, true, low_bound_override)
-                        .on_hover_text("Absolute frame number to use as time range boundary"),
-                ),
+                TimeType::Sequence => time_drag_value
+                    .sequence_drag_value_ui(ui, &mut edit_value, true, low_bound_override)
+                    .on_hover_text("Absolute frame number to use as time range boundary"),
             };
             *value = edit_value.into();
-            response
+            Some(response)
         }
         TimeRangeBoundary::Infinite => None,
     };

--- a/crates/viewer/re_time_panel/src/paint_ticks.rs
+++ b/crates/viewer/re_time_panel/src/paint_ticks.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use egui::{lerp, pos2, remap_clamp, Align2, Color32, Rect, Rgba, Shape, Stroke};
 
 use re_format::next_grid_tick_magnitude_ns;
-use re_log_types::{ResolvedTimeRangeF, Time, TimeReal, TimeType, TimeZone};
+use re_log_types::{ResolvedTimeRangeF, Time, TimeReal, TimeType, TimestampFormat};
 
 use super::time_ranges_ui::TimeRangesUi;
 
@@ -13,7 +13,7 @@ pub fn paint_time_ranges_and_ticks(
     time_area_painter: &egui::Painter,
     line_y_range: RangeInclusive<f32>,
     time_type: TimeType,
-    time_zone_for_timestamps: TimeZone,
+    timestamp_format: TimestampFormat,
 ) {
     let clip_rect = ui.clip_rect();
     let clip_left = clip_rect.left() as f64;
@@ -52,7 +52,7 @@ pub fn paint_time_ranges_and_ticks(
                 &rect,
                 time_type,
                 &time_range,
-                time_zone_for_timestamps,
+                timestamp_format,
             ));
     }
 }
@@ -62,7 +62,7 @@ fn paint_time_range_ticks(
     rect: &Rect,
     time_type: TimeType,
     time_range: &ResolvedTimeRangeF,
-    time_zone_for_timestamps: TimeZone,
+    timestamp_format: TimestampFormat,
 ) -> Vec<Shape> {
     let font_id = egui::TextStyle::Small.resolve(ui.style());
 
@@ -76,7 +76,7 @@ fn paint_time_range_ticks(
                 &ui.clip_rect(),
                 time_range, // ns
                 next_grid_tick_magnitude_ns,
-                |ns| Time::from_ns_since_epoch(ns).format_time_compact(time_zone_for_timestamps),
+                |ns| Time::from_ns_since_epoch(ns).format_time_compact(timestamp_format),
             )
         }
 

--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -501,7 +501,7 @@ impl TimePanel {
             &time_area_painter,
             timeline_rect.top()..=timeline_rect.bottom(),
             time_ctrl.time_type(),
-            ctx.app_options().time_zone,
+            ctx.app_options().timestamp_format,
         );
         paint_time_ranges_gaps(
             &self.time_ranges_ui,
@@ -1283,7 +1283,7 @@ impl TimePanel {
             let mut time_str = self
                 .time_edit_string
                 .clone()
-                .unwrap_or_else(|| time_type.format(time_int, ctx.app_options().time_zone));
+                .unwrap_or_else(|| time_type.format(time_int, ctx.app_options().timestamp_format));
 
             ui.style_mut().spacing.text_edit_width = 200.0;
 
@@ -1292,7 +1292,7 @@ impl TimePanel {
                 self.time_edit_string = Some(time_str.clone());
             }
             if response.lost_focus() {
-                if let Some(time_int) = time_type.parse_time(&time_str, ctx.app_options().time_zone)
+                if let Some(time_int) = time_type.parse_time(&time_str, ctx.app_options().timestamp_format)
                 {
                     time_ctrl.set_time(time_int);
                 }

--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -1292,7 +1292,8 @@ impl TimePanel {
                 self.time_edit_string = Some(time_str.clone());
             }
             if response.lost_focus() {
-                if let Some(time_int) = time_type.parse_time(&time_str, ctx.app_options().timestamp_format)
+                if let Some(time_int) =
+                    time_type.parse_time(&time_str, ctx.app_options().timestamp_format)
                 {
                     time_ctrl.set_time(time_int);
                 }

--- a/crates/viewer/re_ui/Cargo.toml
+++ b/crates/viewer/re_ui/Cargo.toml
@@ -58,7 +58,7 @@ smallvec.workspace = true
 strum_macros.workspace = true
 strum.workspace = true
 sublime_fuzzy.workspace = true
-time = { workspace = true, features = ["formatting", "local-offset"] }
+time = { workspace = true, features = ["formatting", "local-offset", "macros"] }
 url.workspace = true
 
 

--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -276,7 +276,7 @@ impl DisplayColumn {
                             ui.label(
                                 timeline
                                     .typ()
-                                    .format(timestamp, ctx.app_options().time_zone),
+                                    .format(timestamp, ctx.app_options().timestamp_format),
                             );
                         }
                         Err(err) => {

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -542,17 +542,7 @@ fn time_boundary_ui(
         }
         response
     } else {
-        match timeline_typ {
-            TimeType::Time => {
-                time_drag_value
-                    .temporal_drag_value_ui(ui, time, true, low_bound_override, time_zone)
-                    .0
-            }
-
-            TimeType::Sequence => {
-                time_drag_value.sequence_drag_value_ui(ui, time, true, low_bound_override)
-            }
-        }
+        time_drag_value.drag_value_ui(ui, timeline_typ, time, true, low_bound_override, time_zone)
     }
 }
 

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use re_chunk_store::{ColumnDescriptor, ColumnSelector};
 use re_log_types::{
-    EntityPath, ResolvedTimeRange, TimeInt, TimeType, TimeZone, Timeline, TimelineName,
+    EntityPath, ResolvedTimeRange, TimeInt, TimeType, Timeline, TimelineName, TimestampFormat,
 };
 use re_types::blueprint::components;
 use re_types_core::{ComponentName, ComponentNameSet};
@@ -76,7 +76,7 @@ impl Query {
                                 time_drag_value,
                                 None,
                                 *timeline_type,
-                                ctx.app_options().time_zone,
+                                ctx.app_options().timestamp_format,
                                 &mut start,
                             );
 
@@ -111,7 +111,7 @@ impl Query {
                                 time_drag_value,
                                 Some(start),
                                 *timeline_type,
-                                ctx.app_options().time_zone,
+                                ctx.app_options().timestamp_format,
                                 &mut end,
                             );
 
@@ -524,7 +524,7 @@ fn time_boundary_ui(
     time_drag_value: &TimeDragValue,
     low_bound_override: Option<TimeInt>,
     timeline_typ: TimeType,
-    time_zone: TimeZone,
+    timestamp_format: TimestampFormat,
     time: &mut TimeInt,
 ) -> egui::Response {
     if *time == TimeInt::MAX {
@@ -542,7 +542,14 @@ fn time_boundary_ui(
         }
         response
     } else {
-        time_drag_value.drag_value_ui(ui, timeline_typ, time, true, low_bound_override, time_zone)
+        time_drag_value.drag_value_ui(
+            ui,
+            timeline_typ,
+            time,
+            true,
+            low_bound_override,
+            timestamp_format,
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/tests/visible_time_range.rs
+++ b/crates/viewer/re_view_spatial/tests/visible_time_range.rs
@@ -168,7 +168,7 @@ fn intra_timestamp_test() {
 }
 
 fn visible_timerange_data(test_context: &mut TestContext) {
-    let timeline = Timeline::new_temporal("timestamp");
+    let timeline = Timeline::new_duration("timestamp");
     {
         for i in 0..10 {
             let x = i as f32 * 10.0 + 5.0;

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -4,7 +4,7 @@ use egui_plot::{Legend, Line, Plot, PlotPoint, Points};
 
 use re_chunk_store::TimeType;
 use re_format::next_grid_tick_magnitude_ns;
-use re_log_types::{EntityPath, TimeInt, TimeZone};
+use re_log_types::{EntityPath, TimeInt, TimestampFormat};
 use re_types::{
     archetypes::{SeriesLine, SeriesPoint},
     blueprint::{
@@ -398,7 +398,7 @@ impl ViewClass for TimeSeriesView {
         }
 
         // TODO(#5075): Boxed-zoom should be fixed to accommodate the locked range.
-        let time_zone_for_timestamps = ctx.app_options().time_zone;
+        let timestamp_format = ctx.app_options().timestamp_format;
 
         let plot_id = crate::plot_id(query.view_id);
 
@@ -412,7 +412,7 @@ impl ViewClass for TimeSeriesView {
                 format_time(
                     time_type,
                     (time.value as i64).saturating_add(time_offset),
-                    time_zone_for_timestamps,
+                    timestamp_format,
                 )
             })
             .y_axis_formatter(move |mark, _| format_y_axis(mark))
@@ -420,7 +420,7 @@ impl ViewClass for TimeSeriesView {
                 let name = if name.is_empty() { "y" } else { name };
                 let label = time_type.format(
                     TimeInt::new_temporal((value.x as i64).saturating_add(time_offset)),
-                    time_zone_for_timestamps,
+                    timestamp_format,
                 );
 
                 let y_value = re_format::format_f64(value.y);
@@ -737,12 +737,12 @@ fn add_series_to_plot(
     }
 }
 
-fn format_time(time_type: TimeType, time_int: i64, time_zone_for_timestamps: TimeZone) -> String {
+fn format_time(time_type: TimeType, time_int: i64, timestamp_format: TimestampFormat) -> String {
     if time_type == TimeType::Time {
         let time = re_log_types::Time::from_ns_since_epoch(time_int);
-        time.format_time_compact(time_zone_for_timestamps)
+        time.format_time_compact(timestamp_format)
     } else {
-        time_type.format(TimeInt::new_temporal(time_int), time_zone_for_timestamps)
+        time_type.format(TimeInt::new_temporal(time_int), timestamp_format)
     }
 }
 

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -377,7 +377,7 @@ impl AppState {
             // nothing: this is already handled above
         } else if *display_mode == DisplayMode::ChunkStoreBrowser {
             let should_datastore_ui_remain_active =
-                datastore_ui.ui(&ctx, ui, app_options.time_zone);
+                datastore_ui.ui(&ctx, ui, app_options.timestamp_format);
             if !should_datastore_ui_remain_active {
                 *display_mode = DisplayMode::LocalRecordings;
             }

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -1,6 +1,6 @@
 use egui::{NumExt as _, Ui};
 
-use re_log_types::TimeZone;
+use re_log_types::TimestampFormat;
 use re_ui::UiExt as _;
 use re_viewer_context::AppOptions;
 
@@ -79,13 +79,21 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
     separator_with_some_space(ui);
 
     ui.strong("Timezone");
-    ui.re_radio_value(&mut app_options.time_zone, TimeZone::Utc, "UTC")
-        .on_hover_text("Display timestamps in UTC");
-    ui.re_radio_value(&mut app_options.time_zone, TimeZone::Local, "Local")
-        .on_hover_text("Display timestamps in the local timezone");
     ui.re_radio_value(
-        &mut app_options.time_zone,
-        TimeZone::UnixEpoch,
+        &mut app_options.timestamp_format,
+        TimestampFormat::Utc,
+        "UTC",
+    )
+    .on_hover_text("Display timestamps in UTC");
+    ui.re_radio_value(
+        &mut app_options.timestamp_format,
+        TimestampFormat::LocalTimezone,
+        "Local",
+    )
+    .on_hover_text("Display timestamps in the local timezone");
+    ui.re_radio_value(
+        &mut app_options.timestamp_format,
+        TimestampFormat::UnixEpoch,
         "Unix epoch",
     )
     .on_hover_text("Display timestamps in seconds since unix epoch");

--- a/crates/viewer/re_viewer_context/src/global_context/app_options.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/app_options.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use re_log_types::TimeZone;
+use re_log_types::TimestampFormat;
 use re_video::decode::{DecodeHardwareAcceleration, DecodeSettings};
 
 const MAPBOX_ACCESS_TOKEN_ENV_VAR: &str = "RERUN_MAPBOX_ACCESS_TOKEN";
@@ -28,8 +28,8 @@ pub struct AppOptions {
     pub blueprint_gc: bool,
 
     /// What time zone to display timestamps in.
-    #[serde(rename = "time_zone_for_timestamps")]
-    pub time_zone: TimeZone,
+    #[serde(rename = "timestamp_format")]
+    pub timestamp_format: TimestampFormat,
 
     /// Preferred method for video decoding on web.
     pub video_decoder_hw_acceleration: DecodeHardwareAcceleration,
@@ -82,7 +82,7 @@ impl Default for AppOptions {
 
             blueprint_gc: true,
 
-            time_zone: TimeZone::Utc,
+            timestamp_format: TimestampFormat::Utc,
 
             video_decoder_hw_acceleration: DecodeHardwareAcceleration::default(),
             video_decoder_override_ffmpeg_path: false,

--- a/crates/viewer/re_viewer_context/src/time_drag_value.rs
+++ b/crates/viewer/re_viewer_context/src/time_drag_value.rs
@@ -73,6 +73,7 @@ impl TimeDragValue {
         TimeInt::new_temporal(*self.range.end())
     }
 
+    /// Show a drag value widget, taking into account the time type.
     pub fn drag_value_ui(
         &self,
         ui: &mut egui::Ui,
@@ -101,7 +102,7 @@ impl TimeDragValue {
     }
 
     /// Show a sequence drag value widget.
-    pub fn sequence_drag_value_ui(
+    fn sequence_drag_value_ui(
         &self,
         ui: &mut egui::Ui,
         value: &mut TimeInt,
@@ -143,7 +144,7 @@ impl TimeDragValue {
     ///
     /// Returns a tuple of the [`egui::DragValue`]'s [`egui::Response`], and the base time label's
     /// [`egui::Response`], if any.
-    pub fn temporal_drag_value_ui(
+    fn temporal_drag_value_ui(
         &self,
         ui: &mut egui::Ui,
         value: &mut TimeInt,

--- a/crates/viewer/re_viewer_context/src/time_drag_value.rs
+++ b/crates/viewer/re_viewer_context/src/time_drag_value.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use egui::{NumExt as _, Response};
 
 use re_entity_db::TimeHistogram;
-use re_log_types::{TimeInt, TimeType, TimeZone};
+use re_log_types::{TimeInt, TimeType, TimestampFormat};
 
 /// Drag value widget for editing time values for both sequence and temporal timelines.
 ///
@@ -80,7 +80,7 @@ impl TimeDragValue {
         time: &mut TimeInt,
         absolute: bool,
         low_bound_override: Option<TimeInt>,
-        time_zone: TimeZone,
+        timestamp_format: TimestampFormat,
     ) -> Response {
         match time_type {
             TimeType::Sequence => {
@@ -88,8 +88,14 @@ impl TimeDragValue {
             }
 
             TimeType::Time => {
-                self.temporal_drag_value_ui(ui, time, absolute, low_bound_override, time_zone)
-                    .0
+                self.temporal_drag_value_ui(
+                    ui,
+                    time,
+                    absolute,
+                    low_bound_override,
+                    timestamp_format,
+                )
+                .0
             }
         }
     }
@@ -143,7 +149,7 @@ impl TimeDragValue {
         value: &mut TimeInt,
         absolute: bool,
         low_bound_override: Option<TimeInt>,
-        time_zone_for_timestamps: TimeZone,
+        timestamp_format: TimestampFormat,
     ) -> (Response, Option<Response>) {
         let mut time_range = if absolute {
             self.abs_range.clone()
@@ -175,8 +181,7 @@ impl TimeDragValue {
             self.base_time.map(|base_time| {
                 ui.label(format!(
                     "{} + ",
-                    TimeType::Time
-                        .format(TimeInt::new_temporal(base_time), time_zone_for_timestamps)
+                    TimeType::Time.format(TimeInt::new_temporal(base_time), timestamp_format)
                 ))
             })
         } else {

--- a/crates/viewer/re_viewer_context/src/time_drag_value.rs
+++ b/crates/viewer/re_viewer_context/src/time_drag_value.rs
@@ -102,7 +102,7 @@ impl TimeDragValue {
     }
 
     /// Show a sequence drag value widget.
-    fn sequence_drag_value_ui(
+    pub fn sequence_drag_value_ui(
         &self,
         ui: &mut egui::Ui,
         value: &mut TimeInt,
@@ -144,7 +144,7 @@ impl TimeDragValue {
     ///
     /// Returns a tuple of the [`egui::DragValue`]'s [`egui::Response`], and the base time label's
     /// [`egui::Response`], if any.
-    fn temporal_drag_value_ui(
+    pub fn temporal_drag_value_ui(
         &self,
         ui: &mut egui::Ui,
         value: &mut TimeInt,

--- a/crates/viewer/re_viewer_context/src/time_drag_value.rs
+++ b/crates/viewer/re_viewer_context/src/time_drag_value.rs
@@ -73,6 +73,27 @@ impl TimeDragValue {
         TimeInt::new_temporal(*self.range.end())
     }
 
+    pub fn drag_value_ui(
+        &self,
+        ui: &mut egui::Ui,
+        time_type: TimeType,
+        time: &mut TimeInt,
+        absolute: bool,
+        low_bound_override: Option<TimeInt>,
+        time_zone: TimeZone,
+    ) -> Response {
+        match time_type {
+            TimeType::Sequence => {
+                self.sequence_drag_value_ui(ui, time, absolute, low_bound_override)
+            }
+
+            TimeType::Time => {
+                self.temporal_drag_value_ui(ui, time, absolute, low_bound_override, time_zone)
+                    .0
+            }
+        }
+    }
+
     /// Show a sequence drag value widget.
     pub fn sequence_drag_value_ui(
         &self,

--- a/docs/snippets/all/archetypes/points3d_column_updates.rs
+++ b/docs/snippets/all/archetypes/points3d_column_updates.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec =
         rerun::RecordingStreamBuilder::new("rerun_example_points3d_column_updates").spawn()?;
 
-    let times = rerun::TimeColumn::new_seconds("time", 10..15);
+    let times = rerun::TimeColumn::new_duration_seconds("time", 10..15);
 
     // Prepare a point cloud that evolves over 5 timesteps, changing the number of points in the process.
     #[rustfmt::skip]

--- a/docs/snippets/all/archetypes/video_auto_frames.rs
+++ b/docs/snippets/all/archetypes/video_auto_frames.rs
@@ -24,7 +24,7 @@ fn main() -> anyhow::Result<()> {
         .copied()
         .map(rerun::components::VideoTimestamp::from_nanoseconds)
         .collect::<Vec<_>>();
-    let time_column = rerun::TimeColumn::new_nanos(
+    let time_column = rerun::TimeColumn::new_duration_nanos(
         "video_time",
         // Note timeline values don't have to be the same as the video timestamps.
         frame_timestamps_ns,

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -152,7 +152,10 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
                     let values = series_values.iter().skip(offset).take(temporal_batch_size);
                     rec.send_columns(
                         path,
-                        [rerun::TimeColumn::new_seconds("sim_time", seconds.copied())],
+                        [rerun::TimeColumn::new_duration_seconds(
+                            "sim_time",
+                            seconds.copied(),
+                        )],
                         rerun::Scalar::update_fields()
                             .with_many_scalar(values.copied())
                             .columns_of_unit_batches()?,


### PR DESCRIPTION
### Related
* Follows https://github.com/rerun-io/rerun/pull/9236
* Part of #8635 

### What
A lot of refactors and cleanups in preparation for the above issue.

`struct Time` is going away (but is not yet gone).
In its place will be `struct Duration` and the new `struct Timestamp`.
I've started moving code out of `Time` and onto these types.
I've also started using [`jiff`](https://crates.io/crates/jiff), which is looking to become the best time/date library.

`IndexCell` now implements `FromStr` and `Display`, using jiff. This is used for the time range parameters for the gRPC URI.
 The format is one of:

* `123` for sequences
* `123.123s` for durations
* `2022-01-01T00:00:03.123456789Z` for timestamps

The duration and timestamps should follow ISO 8601

### Do-no-merge
Because the merge target is
* https://github.com/rerun-io/rerun/pull/9236