### PR TITLE
Upgrade `env_logger` to replace `humantime` with `jiff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,15 +2325,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "env_filter"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -6264,6 +6274,7 @@ dependencies = [
 name = "re_log"
 version = "0.23.0-alpha.1+dev"
 dependencies = [
+ "env_filter",
  "env_logger",
  "js-sys",
  "log",
@@ -7553,6 +7564,7 @@ dependencies = [
  "arrow",
  "clap",
  "document-features",
+ "env_filter",
  "env_logger",
  "itertools 0.13.0",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7565,7 +7565,6 @@ dependencies = [
  "clap",
  "document-features",
  "env_filter",
- "env_logger",
  "itertools 0.13.0",
  "log",
  "puffin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,8 @@ document-features = "0.2.8"
 econtext = "0.2" # Prints error contexts on crashes
 ehttp = "0.5.0"
 enumset = "1.0.12"
-env_logger = { version = "0.10", default-features = false }
+env_filter = { version = "0.1", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 ffmpeg-sidecar = { version = "2.0.2", default-features = false }
 fixed = { version = "1.28", default-features = false }
 fjadra = "0.2.1"

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -74,7 +74,7 @@ image = ["re_types?/image"]
 ecolor = ["re_types?/ecolor"]
 
 ## Integration with the [`log`](https://crates.io/crates/log/) crate.
-log = ["dep:env_logger", "dep:log"]
+log = ["dep:env_filter", "dep:env_logger", "dep:log"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
@@ -157,6 +157,7 @@ re_viewer = { workspace = true, optional = true }
 re_viewer_context = { workspace = true, optional = true }
 re_web_viewer_server = { workspace = true, optional = true }
 
+env_filter = { workspace = true, optional = true }
 env_logger = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -74,7 +74,7 @@ image = ["re_types?/image"]
 ecolor = ["re_types?/ecolor"]
 
 ## Integration with the [`log`](https://crates.io/crates/log/) crate.
-log = ["dep:env_filter", "dep:env_logger", "dep:log"]
+log = ["dep:env_filter", "dep:log"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
@@ -158,7 +158,6 @@ re_viewer_context = { workspace = true, optional = true }
 re_web_viewer_server = { workspace = true, optional = true }
 
 env_filter = { workspace = true, optional = true }
-env_logger = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 
 # Native dependencies:

--- a/crates/top/rerun/src/log_integration.rs
+++ b/crates/top/rerun/src/log_integration.rs
@@ -23,7 +23,7 @@ use crate::RecordingStream;
 #[derive(Debug)]
 pub struct Logger {
     rec: RecordingStream,
-    filter: Option<env_logger::filter::Filter>,
+    filter: Option<env_filter::Filter>,
     path_prefix: Option<String>,
 }
 
@@ -60,7 +60,7 @@ impl Logger {
     /// [env_logger syntax]: https://docs.rs/env_logger/latest/env_logger/index.html#enabling-logging
     #[inline]
     pub fn with_filter(mut self, filter: impl AsRef<str>) -> Self {
-        use env_logger::filter::Builder;
+        use env_filter::Builder;
         self.filter = Some(Builder::new().parse(filter.as_ref()).build());
         self
     }
@@ -70,7 +70,7 @@ impl Logger {
     /// All calls to [`log`] macros will go through this [`Logger`] from this point on.
     pub fn init(mut self) -> Result<(), log::SetLoggerError> {
         if self.filter.is_none() {
-            use env_logger::filter::Builder;
+            use env_filter::Builder;
             self.filter = Some(Builder::new().parse(&re_log::default_log_filter()).build());
         }
 

--- a/crates/utils/re_log/Cargo.toml
+++ b/crates/utils/re_log/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { workspace = true, features = ["log"] }
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+env_filter.workspace = true
 env_logger = { workspace = true, optional = true, features = [
   "auto-color",
   "humantime",

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,7 @@ version = 2
 ignore = [
   "RUSTSEC-2024-0384", # Waiting for https://github.com/console-rs/indicatif/pull/666
   "RUSTSEC-2024-0436", # https://rustsec.org/advisories/RUSTSEC-2024-0436 - paste is unmaintained - https://github.com/dtolnay/paste
-  "RUSTSEC-2025-0014", # Waiting for https://github.com/apache/arrow-rs/issues/7264
+  "RUSTSEC-2025-0014", # TODO(#9255): Waiting for https://github.com/apache/arrow-rs/issues/7264
 ]
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,7 @@ version = 2
 ignore = [
   "RUSTSEC-2024-0384", # Waiting for https://github.com/console-rs/indicatif/pull/666
   "RUSTSEC-2024-0436", # https://rustsec.org/advisories/RUSTSEC-2024-0436 - paste is unmaintained - https://github.com/dtolnay/paste
+  "RUSTSEC-2025-0014", # Waiting for https://github.com/apache/arrow-rs/issues/7264
 ]
 
 


### PR DESCRIPTION
Fixes CI failures due to `humantime` being marked as unmaintained.

It looks like it will take some time for `object_store` to move on, so I'm adding [`RUSTSEC-2025-0014`](https://rustsec.org/advisories/RUSTSEC-2025-0014) to the ignore list for now:

* https://github.com/apache/arrow-rs/issues/7264
* https://github.com/apache/arrow-rs/pull/7261
* Reminder issue: https://github.com/rerun-io/rerun/issues/9255
