### PR TITLE
Fix several typing annotations in the SDK and run mypy on snippets

### DIFF
--- a/docs/snippets/all/archetypes/scalar_multiple_plots.py
+++ b/docs/snippets/all/archetypes/scalar_multiple_plots.py
@@ -24,4 +24,4 @@ for t in range(int(tau * 2 * 100.0)):
     rr.log("trig/cos", rr.Scalar(cos(float(t) / 100.0)))
 
     lcg_state = (1140671485 * lcg_state + 128201163) % 16777216  # simple linear congruency generator
-    rr.log("scatter/lcg", rr.Scalar(lcg_state))
+    rr.log("scatter/lcg", rr.Scalar(lcg_state.astype(np.float64)))

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.py
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.py
@@ -1,4 +1,4 @@
-"""Logs a transforms transform hierarchy."""
+"""Logs a transform hierarchy."""
 
 import numpy as np
 import rerun as rr
@@ -26,7 +26,7 @@ rr.log("sun/planet/moon", rr.Points3D([0.0, 0.0, 0.0], radii=0.15, colors=[180, 
 d_planet = 6.0
 d_moon = 3.0
 angles = np.arange(0.0, 1.01, 0.01) * np.pi * 2
-circle = np.array([np.sin(angles), np.cos(angles), angles * 0.0]).transpose()
+circle = np.array([np.sin(angles), np.cos(angles), angles * 0.0], dtype=np.float32).transpose()
 rr.log("sun/planet_path", rr.LineStrips3D(circle * d_planet))
 rr.log("sun/planet/moon_path", rr.LineStrips3D(circle * d_moon))
 

--- a/docs/snippets/all/concepts/different_data_per_timeline.py
+++ b/docs/snippets/all/concepts/different_data_per_timeline.py
@@ -12,12 +12,12 @@ rr.log("points", rr.Points2D([[0, 0], [1, 1]], radii=rr.Radius.ui_points(10.0)))
 # Log a red color on one timeline.
 rr.reset_time()  # Clears all set timeline info.
 rr.set_index("red timeline", timedelta=1.0)
-rr.log("points", [rr.components.Color(0xFF0000FF)])
+rr.log("points", rr.Points2D.from_fields(colors=[255, 0, 0]))
 
 # And a blue color on the other.
 rr.reset_time()  # Clears all set timeline info.
 rr.set_index("blue timeline", sequence=1)
-rr.log("points", [rr.components.Color(0x0000FFFF)])
+rr.log("points", rr.Points2D.from_fields(colors=[0, 0, 255]))
 
 
 # Set view bounds:

--- a/docs/snippets/all/concepts/static/log_static.py
+++ b/docs/snippets/all/concepts/static/log_static.py
@@ -1,1 +1,1 @@
-rr.log("skybox", static=True, generate_skybox_mesh())
+rr.log("skybox", generate_skybox_mesh(), static=True)

--- a/docs/snippets/all/concepts/static/log_static_10x.py
+++ b/docs/snippets/all/concepts/static/log_static_10x.py
@@ -1,2 +1,2 @@
 for _ in range(10):
-    rr.log("camera/image", static=True, camera.save_current_frame())
+    rr.log("camera/image", camera.save_current_frame(), static=True)

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -11,17 +11,21 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 import tomlkit
+from tomlkit.container import Container
 
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/../../scripts/")
 from roundtrip_utils import roundtrip_env, run, run_comparison  # noqa
 
 config_path = Path(__file__).parent / "snippets.toml"
 config = tomlkit.loads(config_path.read_text())
-OPT_OUT_ENTIRELY = config["opt_out"]["run"]
-OPT_OUT_COMPARE = config["opt_out"]["compare"]
-EXTRA_ARGS = config["extra_args"]
+assert isinstance(config["opt_out"], Container)
+
+OPT_OUT_ENTIRELY: dict[str, Any] = config["opt_out"]["run"].value
+OPT_OUT_COMPARE = config["opt_out"]["compare"].value
+EXTRA_ARGS = config["extra_args"].value
 
 
 class Example:
@@ -32,13 +36,13 @@ class Example:
     def opt_out_entirely(self) -> list[str]:
         for key in [self.subdir, self.subdir + "/" + self.name]:
             if key in OPT_OUT_ENTIRELY:
-                return OPT_OUT_ENTIRELY[key]
+                return list(OPT_OUT_ENTIRELY[key])
         return []
 
     def opt_out_compare(self) -> list[str]:
         for key in [self.subdir, self.subdir + "/" + self.name]:
             if key in OPT_OUT_COMPARE:
-                return OPT_OUT_COMPARE[key]
+                return list(OPT_OUT_COMPARE[key])
         return []
 
     def extra_args(self) -> list[str]:

--- a/pixi.lock
+++ b/pixi.lock
@@ -26224,7 +26224,7 @@ packages:
 - pypi: rerun_py
   name: rerun-sdk
   version: 0.23.0a1+dev
-  sha256: 71b678331f64040e2ae0bd8ffe91328213f3b5f3c45a2d3fce30fc04fe882fe8
+  sha256: 68d71759a757bb33ba88ec2ef5df733bb4cf0b722e20b7634433fa1833c0f023
   requires_dist:
   - attrs>=23.1.0
   - numpy>=1.23

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -208,6 +208,7 @@ norecursedirs = ".* venv* target* build"
 
 [tool.mypy]
 files = [
+  "docs/snippets",
   "rerun_py/rerun_sdk/rerun",
   "rerun_py/rerun_bindings",
   "rerun_py/tests",
@@ -215,7 +216,23 @@ files = [
   "scripts",
   "tests/python",
 ]
-exclude = ["examples/python/objectron", "examples/python/ros_node"]
+exclude = [
+  # snippets that are not runnable
+  "docs/snippets/all/concepts/how_helix_was_logged",
+  "docs/snippets/all/concepts/static/log_static",
+  "docs/snippets/all/concepts/static/log_static_10x",
+  "docs/snippets/all/concepts/static/log_temporal_10x",
+  "docs/snippets/all/concepts/static/send_static",
+  "docs/snippets/all/concepts/static/send_static_10x",
+  "docs/snippets/all/migration/log_line",
+  "docs/snippets/all/tutorials/custom-application-id",
+  "docs/snippets/all/tutorials/custom-recording-id",
+  "docs/snippets/all/tutorials/timelines_example",
+
+  # hopeless examples
+  "examples/python/objectron",
+  "examples/python/ros_node",
+]
 namespace_packages = true
 show_error_codes = true
 strict = true

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -53,7 +53,7 @@ class IndicatorComponentBatch:
 
 @catch_and_log_exceptions()
 def log(
-    entity_path: str | list[str],
+    entity_path: str | list[object],
     entity: AsComponents | Iterable[DescribedComponentBatch],
     *extra: AsComponents | Iterable[DescribedComponentBatch],
     static: bool = False,
@@ -172,7 +172,7 @@ def log(
 
 
 def _log_components(
-    entity_path: str | list[str],
+    entity_path: str | list[object],
     components: list[DescribedComponentBatch],
     *,
     static: bool = False,

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
@@ -23,7 +23,7 @@ class Boxes3DExt:
         rotations: datatypes.RotationAxisAngleArrayLike | datatypes.QuaternionArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
         radii: datatypes.Float32ArrayLike | None = None,
-        fill_mode: components.FillMode | None = None,
+        fill_mode: components.FillModeLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image_ext.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 
 from rerun.datatypes.range1d import Range1DLike
 
-from ..components import Colormap, ImageFormat
+from ..components import ColormapLike, ImageFormat
 from ..datatypes import ChannelDatatype, Float32Like
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ class DepthImageExt:
         image: ImageLike,
         *,
         meter: Float32Like | None = None,
-        colormap: Colormap | None = None,
+        colormap: ColormapLike | None = None,
         depth_range: Range1DLike | None = None,
         point_fill_ratio: Float32Like | None = None,
         draw_order: Float32Like | None = None,

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d_ext.py
@@ -21,7 +21,7 @@ class Ellipsoids3DExt:
         quaternions: datatypes.QuaternionArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
         line_radii: datatypes.Float32ArrayLike | None = None,
-        fill_mode: components.FillMode | None = None,
+        fill_mode: components.FillModeLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -960,7 +960,7 @@ class RecordingStream:
 
     def log(
         self,
-        entity_path: str | list[str],
+        entity_path: str | list[object],
         entity: AsComponents | Iterable[DescribedComponentBatch],
         *extra: AsComponents | Iterable[DescribedComponentBatch],
         static: bool = False,


### PR DESCRIPTION
### Related

* Some more leftovers from #9209 

### What

Snippets, a key aspect of our documentation, were not typed checked by mypy so far... 😱 No longer. This lead to several fixes in user-facing typing annotation in the python SDK. Plus the usual load of fixes in the snippets themselves.

Note: snippets that are "not runnable" (as per `snippets.toml`) must now also be mypy-ignore in our `pyproject.toml`. I don't mind this added complexity a single second: make your snippets runnable! :)