### PR TITLE
Install nextest in contrib CI

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -123,6 +123,12 @@ jobs:
       - name: Setup software rasterizer
         run: pixi run python ./scripts/ci/setup_software_rasterizer.py
 
+      # Recommended way to install nextest on CI.
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@v2.48.7
+        with:
+          tool: nextest@0.9.89
+
       - name: Rust checks & tests
         run: pixi run rs-check --skip individual_crates docs_slow
 


### PR DESCRIPTION
Contributor CI fails because we use nextest but dont install it. On regular CI, this is done by setup-rust, which we can't use for contributor CI since it relies on repo's secrets.