### PR TITLE
Fix `columns` for columns of multiple batch-length==1 fixed size arrays

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2654,8 +2654,15 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
                     param = kwargs[batch.component_descriptor().archetype_field_name] # type: ignore[index]
                     shape = np.shape(param)  # type: ignore[arg-type]
 
-                    batch_length = shape[1] if len(shape) > 1 else 1 # type: ignore[redundant-expr,misc]
-                    num_rows = shape[0] if len(shape) >= 1 else 1    # type: ignore[redundant-expr,misc]
+                    if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                        # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                        # `shape[1]` should be the length of the fixed sized list.
+                        # (This should have been already validated by conversion to the arrow_array)
+                        batch_length = 1
+                    else:
+                        batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
+                    num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                     sizes = batch_length * np.ones(num_rows)
                 else:
                     # For non-primitive types, default to partitioning each element separately.

--- a/docs/snippets/all/archetypes/arrows3d_column_updates.cpp
+++ b/docs/snippets/all/archetypes/arrows3d_column_updates.cpp
@@ -3,7 +3,6 @@
 // This is semantically equivalent to the `arrows3d_row_updates` example, albeit much faster.
 
 #include <rerun.hpp>
-#include <rerun/demo_utils.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -22,11 +21,13 @@ int main() {
     for (size_t i = 0; i < 5; i++) {
         float fi = static_cast<float>(i);
 
-        auto xs = rerun::demo::linspace(-1.f, 1.f, 5);
-        auto zs = rerun::demo::linspace(fi / 10.f, fi, 5);
         for (size_t j = 0; j < 5; j++) {
-            std::array<float, 3> origin = {xs[j], xs[j], 0.0};
-            std::array<float, 3> vector = {xs[j], xs[j], zs[j]};
+            auto fj = static_cast<float>(j);
+            auto xs = -1.f + fj * (2.f / 4.f);
+            auto zs = fj * (fi / 4.f);
+
+            std::array<float, 3> origin = {xs, xs, 0.f};
+            std::array<float, 3> vector = {xs, xs, zs};
 
             origins.emplace_back(origin);
             vectors.emplace_back(vector);

--- a/docs/snippets/all/archetypes/arrows3d_column_updates.py
+++ b/docs/snippets/all/archetypes/arrows3d_column_updates.py
@@ -15,7 +15,7 @@ times = np.arange(10, 15, 1.0)
 
 # At each time step, all arrows maintain their origin.
 origins = [np.linspace((-1, -1, 0), (1, 1, 0), 5)] * 5
-vectors = [np.linspace((1, 1, i / 10), (1, 1, i), 5) for i in range(5)]
+vectors = [np.linspace((-1, -1, 0), (1, 1, i), 5) for i in range(5)]
 
 
 # At each timestep, all arrows share the same but changing color.

--- a/docs/snippets/all/archetypes/arrows3d_column_updates.rs
+++ b/docs/snippets/all/archetypes/arrows3d_column_updates.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             (
                 linspace(-1., 1., 5).map(move |x| (x, x, 0.)),
                 linspace(-1., 1., 5)
-                    .zip(linspace(i / 10., i, 5))
+                    .zip(linspace(0., i, 5))
                     .map(|(x, z)| (x, x, z)),
             )
         })

--- a/docs/snippets/all/archetypes/arrows3d_row_updates.cpp
+++ b/docs/snippets/all/archetypes/arrows3d_row_updates.cpp
@@ -20,14 +20,15 @@ int main() {
     for (size_t i = 0; i < 5; i++) {
         float fi = static_cast<float>(i);
 
-        auto xs = rerun::demo::linspace(-1.f, 1.f, 5);
-        auto zs = rerun::demo::linspace(fi / 10.f, fi, 5);
-
         std::array<std::array<float, 3>, 5> origin;
         std::array<std::array<float, 3>, 5> vector;
         for (size_t j = 0; j < 5; j++) {
-            origin[j] = {xs[j], xs[j], 0.0};
-            vector[j] = {xs[j], xs[j], zs[j]};
+            auto fj = static_cast<float>(j);
+            auto xs = -1.f + fj * (2.f / 4.f);
+            auto zs = fj * (fi / 4.f);
+
+            origin[j] = {xs, xs, 0.0};
+            vector[j] = {xs, xs, zs};
         }
 
         origins.emplace_back(origin);

--- a/docs/snippets/all/archetypes/arrows3d_row_updates.py
+++ b/docs/snippets/all/archetypes/arrows3d_row_updates.py
@@ -15,7 +15,7 @@ times = np.arange(10, 15, 1.0)
 
 # At each time step, all arrows maintain their origin.
 origins = np.linspace((-1, -1, 0), (1, 1, 0), 5)
-vectors = [np.linspace((1, 1, i / 10), (1, 1, i), 5) for i in range(5)]
+vectors = [np.linspace((-1, -1, 0), (1, 1, i), 5) for i in range(5)]
 
 
 # At each timestep, all arrows share the same but changing color.

--- a/docs/snippets/all/archetypes/arrows3d_row_updates.rs
+++ b/docs/snippets/all/archetypes/arrows3d_row_updates.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             (
                 linspace(-1., 1., 5).map(move |x| (x, x, 0.)),
                 linspace(-1., 1., 5)
-                    .zip(linspace(i / 10., i, 5))
+                    .zip(linspace(0., i, 5))
                     .map(|(x, z)| (x, x, z)),
             )
         })

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -176,7 +176,14 @@ class AnnotationContext(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -248,7 +248,14 @@ class Arrows2D(Arrows2DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -234,7 +234,14 @@ class Arrows3D(Arrows3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -197,7 +197,14 @@ class Asset3D(Asset3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -231,7 +231,14 @@ class AssetVideo(AssetVideoExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -172,7 +172,14 @@ class BarChart(BarChartExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -233,7 +233,14 @@ class Boxes2D(Boxes2DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -281,7 +281,14 @@ class Boxes3D(Boxes3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
@@ -279,7 +279,14 @@ class Capsules3D(Capsules3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -147,7 +147,14 @@ class Clear(ClearExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -275,7 +275,14 @@ class DepthImage(DepthImageExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
@@ -282,7 +282,14 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
@@ -192,7 +192,14 @@ class EncodedImage(EncodedImageExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -188,7 +188,14 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
@@ -191,7 +191,14 @@ class GeoPoints(GeoPointsExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
@@ -188,7 +188,14 @@ class GraphEdges(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
@@ -245,7 +245,14 @@ class GraphNodes(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -226,7 +226,14 @@ class Image(ImageExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -250,7 +250,14 @@ class InstancePoses3D(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -324,7 +324,14 @@ class LineStrips2D(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -314,7 +314,14 @@ class LineStrips3D(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -297,7 +297,14 @@ class Mesh3D(Mesh3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -272,7 +272,14 @@ class Pinhole(PinholeExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -303,7 +303,14 @@ class Points2D(Points2DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -349,7 +349,14 @@ class Points3D(Points3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -201,7 +201,14 @@ class Scalar(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -194,7 +194,14 @@ class SegmentationImage(SegmentationImageExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -270,7 +270,14 @@ class SeriesLine(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -272,7 +272,14 @@ class SeriesPoint(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -180,7 +180,14 @@ class Tensor(TensorExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -232,7 +232,14 @@ class TextDocument(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -201,7 +201,14 @@ class TextLog(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -448,7 +448,14 @@ class Transform3D(Transform3DExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -247,7 +247,14 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -178,7 +178,14 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -285,7 +285,14 @@ class AffixFuzzer1(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -261,7 +261,14 @@ class AffixFuzzer2(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -254,7 +254,14 @@ class AffixFuzzer3(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -254,7 +254,14 @@ class AffixFuzzer4(Archetype):
                 param = kwargs[batch.component_descriptor().archetype_field_name]  # type: ignore[index]
                 shape = np.shape(param)  # type: ignore[arg-type]
 
-                batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                if pa.types.is_fixed_size_list(arrow_array.type) and len(shape) <= 2:
+                    # If shape length is 2 or less, we have `num_rows` single element batches (each element is a fixed sized list).
+                    # `shape[1]` should be the length of the fixed sized list.
+                    # (This should have been already validated by conversion to the arrow_array)
+                    batch_length = 1
+                else:
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)
             else:


### PR DESCRIPTION
### Related

* Follow-up to https://github.com/rerun-io/rerun/pull/9210

### What

In other words, the following snippet broke (which got caught by now-red main ci! phew!)

```py
rr.send_columns(
    "box",
    indexes=[rr.IndexColumn("tick", sequence=range(1, 101))],
    columns=rr.Transform3D.columns(
        translation=[[0, 0, t / 10.0] for t in range(100)],
        rotation_axis_angle=[
            rr.RotationAxisAngle(axis=[0.0, 1.0, 0.0], radians=truncated_radians(t * 4)) for t in range(100)
        ],
    ),
)
```

`rotation_axis_angle` worked fine, but `translation` broke because the `columns` call incorrectly assumed that it's 100 columns (correct) each with a batch size of 3 elements (very wrong).

* [x] pass full-ci