### PR TITLE
Convert `store_version` and `store_source` to record batches

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/recording_properties.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/recording_properties.fbs
@@ -16,4 +16,22 @@ table RecordingProperties (
 
   /// A user-chosen name for the recording.
   name: rerun.components.Name ("attr.rerun.component_optional", nullable, order: 2000);
+
+  /// The Rerun store version.
+  source_version: rerun.components.RecordingStoreVersion ("attr.rerun.component_optional", nullable, order: 3000);
+
+  ///
+  source_extra_kind: rerun.components.RecordingSourceExtraKind ("attr.rerun.component_optional", nullable, order: 4000);
+
+  ///
+  source_extra_file: rerun.components.RecordingSourceExtraRust ("attr.rerun.component_optional", nullable, order: 5000);
+
+  ///
+  source_extra_file: rerun.components.RecordingSourceExtraFile ("attr.rerun.component_optional", nullable, order: 5000);
+
+  ///
+  source_extra_python: rerun.components.RecordingSourceExtraPython ("attr.rerun.component_optional", nullable, order: 6000);
+
+  ///
+  source_extra_other: rerun.components.RecordingSourceExtraOther ("attr.rerun.component_optional", nullable, order: 7000);
 }

--- a/crates/store/re_types/definitions/rerun/components/recording_source.fbs
+++ b/crates/store/re_types/definitions/rerun/components/recording_source.fbs
@@ -1,0 +1,50 @@
+namespace rerun.components;
+
+/// What kind of source a recording comes from.
+struct RecordingSourceExtraKind (
+  "attr.rust.derive": "Default, Copy, PartialEq",
+  "attr.rust.repr": "transparent"
+) {
+    kind: rerun.datatypes.SourceKind (order: 100);
+}
+
+/// The version of the recording source (Rerun version).
+table RecordingSourceVersion (
+  "attr.rust.derive": "Default, Copy, PartialEq",
+  "attr.rust.repr": "transparent"
+) {
+  version: rerun.datatypes.SemVerBits (order: 100);
+}
+
+/// A recording which came from a file.
+table RecordingSourceExtraRust (
+  "attr.rust.derive": "Default, Copy, PartialEq",
+  "attr.rust.repr": "transparent"
+) {
+  compiler: rerun.datatypes.RustSdkSource (order: 100);
+}
+
+/// A recording which came from a file.
+table RecordingSourceExtraFile (
+  "attr.rust.derive": "Default, Copy, PartialEq",
+  "attr.rust.repr": "transparent"
+) {
+  file_kind: rerun.datatypes.FileSource (order: 100);
+}
+
+
+/// A recording which came from a file.
+table RecordingSourceExtraPython (
+  "attr.rust.derive": "Default, Copy, PartialEq",
+  "attr.rust.repr": "transparent"
+) {
+  version: rerun.datatypes.SemVer (order: 100);
+}
+
+// A recording which came from a file.
+table RecordingSourceExtraOther (
+  "attr.rust.derive": "Default, Copy, PartialEq",
+  "attr.rust.repr": "transparent"
+) {
+  version: rerun.datatypes.Utf8 (order: 100);
+}

--- a/crates/store/re_types/definitions/rerun/datatypes/sem_ver.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/sem_ver.fbs
@@ -1,0 +1,31 @@
+namespace rerun.datatypes;
+
+/// A compact semantic versioning scheme of the Rerun crate encoded as bits.
+struct SemVerBits (
+  "attr.arrow.transparent",
+  "attr.python.aliases": "int",
+  "attr.python.array_aliases": "int, npt.NDArray[np.uint32]",
+  "attr.rust.derive": "Default, Copy, PartialEq, Eq, PartialOrd, Ord",
+  "attr.docs.unreleased",
+  "attr.rust.tuple_struct"
+) {
+  bits: [ubyte: 4] (order: 100);
+}
+
+/// A general semantic versioning scheme.
+table SemVer (
+  "attr.rust.derive": "Default, PartialEq, Eq, PartialOrd, Ord",
+  "attr.docs.unreleased"
+) {
+  /// The major version number.
+  major: int32 (order: 100);
+
+  /// The minor version number.
+  minor: int32 (order: 200);
+
+  /// The batch version number.
+  patch: int32 (order: 300);
+
+  /// An optional suffix to cover additional information.
+  suffix: rerun.datatypes.Utf8 (nullable, order: 400);
+}

--- a/crates/store/re_types/definitions/rerun/datatypes/store_source.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/store_source.fbs
@@ -1,0 +1,78 @@
+namespace rerun.datatypes;
+
+/// What kind of source a recording comes from.
+enum SourceKind: ubyte (
+  "attr.docs.unreleased"
+) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
+    /// We don't know anything about the source of this recording.
+    Unspecified,
+
+    /// The recording came from the C++ SDK.
+    CSdk,
+
+    /// The recording came from the Python SDK.
+    ///
+    /// `extra` is `PythonVersion`.
+    PythonSdk,
+
+    /// The recording came from the Rust SDK.
+    ///
+    /// `extra` is `RustSdk`.
+    RustSdk,
+
+    /// The recording came from a file.
+    ///
+    /// `extra` is `FileSource`.
+    File,
+
+    /// The recording came from some action in the viewer.
+    Viewer,
+
+    // TODO: Dataplatform?
+
+    /// The recording came from some other source.
+    ///
+    /// `extra` is a string.
+    Other,
+}
+
+/// Information about the Rust SDK that created the recording.
+table RustSdkSource (
+  "attr.rust.derive": "Default, PartialEq, Eq, PartialOrd, Ord",
+  "attr.docs.unreleased"
+) {
+    /// Version of the Rust compiler used to compile the SDK.
+	  rustc_version: rerun.datatypes.SemVer (order: 100);
+
+    /// Version of LLVM used by the Rust compiler.
+	  llvm_version: rerun.datatypes.SemVer (order: 200);
+}
+
+/// A recording which came from a file.
+enum FileSource: ubyte (
+  "attr.docs.unreleased"
+) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
+    /// We don't know where the file came from.
+    Unspecified,
+
+    /// The file came from the command line.
+    Cli,
+
+    /// The file was served over HTTP.
+    Uri,
+
+    /// The file was dragged into the viewer.
+    DragAndDrop,
+
+    /// The file was opened using a file dialog.
+    FileDialog,
+
+    /// The recording was produced using a data loader, such as when logging a mesh file.
+    Sdk,
+}


### PR DESCRIPTION
### Related

* Closes #9190.

### What

> [!IMPORTANT]
> Sorry for the initial ugliness—but this should serve as a starting point for discussion about how fine granular we want to record information about the source of recordings in the future.

These fields are mainly used to show information in the viewer, as well as provide telemetry information. As such, I think we might be able to replace many of these entries with `Utf8`.

