### PR TITLE
Correct truncation of AnyValues when using strings or bytes

### DIFF
--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -88,9 +88,11 @@ class AnyBatchValue(ComponentBatchLike):
                         except TypeError as e:
                             pass
                     if self.pa_array is None:
-                        pa_scalar = pa.scalar(value, type=pa_type)
-                        if pa_scalar is not None:
+                        try:
+                            pa_scalar = pa.scalar(value, type=pa_type)
                             self.pa_array = pa.array([pa_scalar], type=pa_type)
+                        except TypeError:
+                            pass
                     if self.pa_array is None:
                         # Fall back - use numpy
                         np_value = np.atleast_1d(np.asarray(value, dtype=np_type))
@@ -109,10 +111,12 @@ class AnyBatchValue(ComponentBatchLike):
                             except TypeError:
                                 pass
                         if self.pa_array is None:
-                            pa_scalar = pa.scalar(value)
-                            if pa_scalar is not None:
+                            try:
+                                pa_scalar = pa.scalar(value)
                                 self.pa_array = pa.array([pa_scalar])
                                 ANY_VALUE_TYPE_REGISTRY[descriptor] = (None, self.pa_array.type)
+                            except TypeError:
+                                pass
                         if self.pa_array is None:
                             # Fall back - use numpy which handles a wide variety of lists, tuples,
                             # and mixtures of them and will turn into a well formed array

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -85,7 +85,7 @@ class AnyBatchValue(ComponentBatchLike):
                     if not isinstance(value, (str, bytes)):
                         try:
                             self.pa_array = pa.array(value, type=pa_type)
-                        except TypeError as e:
+                        except TypeError:
                             pass
                     if self.pa_array is None:
                         try:

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 import pyarrow as pa
+from pyarrow import ArrowInvalid
 
 from rerun._baseclasses import ComponentDescriptor
 
@@ -85,13 +86,13 @@ class AnyBatchValue(ComponentBatchLike):
                     if not isinstance(value, (str, bytes)):
                         try:
                             self.pa_array = pa.array(value, type=pa_type)
-                        except TypeError:
+                        except (ArrowInvalid, TypeError):
                             pass
                     if self.pa_array is None:
                         try:
                             pa_scalar = pa.scalar(value, type=pa_type)
                             self.pa_array = pa.array([pa_scalar], type=pa_type)
-                        except TypeError:
+                        except (ArrowInvalid, TypeError):
                             pass
                     if self.pa_array is None:
                         # Fall back - use numpy
@@ -108,14 +109,14 @@ class AnyBatchValue(ComponentBatchLike):
                             try:
                                 self.pa_array = pa.array(value)
                                 ANY_VALUE_TYPE_REGISTRY[descriptor] = (None, self.pa_array.type)
-                            except TypeError:
+                            except (ArrowInvalid, TypeError):
                                 pass
                         if self.pa_array is None:
                             try:
                                 pa_scalar = pa.scalar(value)
                                 self.pa_array = pa.array([pa_scalar])
                                 ANY_VALUE_TYPE_REGISTRY[descriptor] = (None, self.pa_array.type)
-                            except TypeError:
+                            except (ArrowInvalid, TypeError):
                                 pass
                         if self.pa_array is None:
                             # Fall back - use numpy which handles a wide variety of lists, tuples,

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -42,12 +42,12 @@ class AnyBatchValue(ComponentBatchLike):
         will be dropped, and a warning will be sent to the log.
 
         If you are want to inspect how your component will be converted to the
-        underlying arrow code, the following snippet is what is happening
-        internally:
+        underlying arrow code, we first attempt to cast it directly to a pyarrow
+        array. Failing this, we call
 
         ```
-        np_value = np.atleast_1d(np.array(value, copy=False))
-        pa_value = pa.array(value)
+        pa_scalar = pa.scalar(value)
+        pa_value = pa.array(pa_scalar)
         ```
 
         Parameters
@@ -77,19 +77,48 @@ class AnyBatchValue(ComponentBatchLike):
             elif hasattr(value, "as_arrow_array"):
                 self.pa_array = value.as_arrow_array()
             else:
-                if np_type is not None:
+                if pa_type is not None:
                     if value is None:
                         value = []
-                    np_value = np.atleast_1d(np.asarray(value, dtype=np_type))
-                    self.pa_array = pa.array(np_value, type=pa_type)
+                    # Special case: strings are iterables so pyarrow will not
+                    # handle them properly
+                    if not isinstance(value, (str, bytes)):
+                        try:
+                            self.pa_array = pa.array(value, type=pa_type)
+                        except TypeError as e:
+                            pass
+                    if self.pa_array is None:
+                        pa_scalar = pa.scalar(value, type=pa_type)
+                        if pa_scalar is not None:
+                            self.pa_array = pa.array([pa_scalar], type=pa_type)
+                    if self.pa_array is None:
+                        # Fall back - use numpy
+                        np_value = np.atleast_1d(np.asarray(value, dtype=np_type))
+                        self.pa_array = pa.array(np_value, type=pa_type)
                 else:
                     if value is None:
                         if not drop_untyped_nones:
                             raise ValueError("Cannot convert None to arrow array. Type is unknown.")
                     else:
-                        np_value = np.atleast_1d(np.asarray(value))
-                        self.pa_array = pa.array(np_value)
-                        ANY_VALUE_TYPE_REGISTRY[descriptor] = (np_value.dtype, self.pa_array.type)
+                        # This should handle most non-scalar values, but we have to
+                        # treat str and bytes special because they are iterable
+                        if not isinstance(value, (str, bytes)) and value is not None:
+                            try:
+                                self.pa_array = pa.array(value)
+                                ANY_VALUE_TYPE_REGISTRY[descriptor] = (None, self.pa_array.type)
+                            except TypeError:
+                                pass
+                        if self.pa_array is None:
+                            pa_scalar = pa.scalar(value)
+                            if pa_scalar is not None:
+                                self.pa_array = pa.array([pa_scalar])
+                                ANY_VALUE_TYPE_REGISTRY[descriptor] = (None, self.pa_array.type)
+                        if self.pa_array is None:
+                            # Fall back - use numpy which handles a wide variety of lists, tuples,
+                            # and mixtures of them and will turn into a well formed array
+                            np_value = np.atleast_1d(np.asarray(value))
+                            self.pa_array = pa.array(np_value)
+                            ANY_VALUE_TYPE_REGISTRY[descriptor] = (np_value.dtype, self.pa_array.type)
 
     def is_valid(self) -> bool:
         return self.pa_array is not None


### PR DESCRIPTION
### Related

* Closes #8781

### What

This PR adjusts the way we process AnyValues. WIthout this change we have cases where numpy is setting data types to have fixed length based on the first value it receives. This ends up truncating the data.

Additionally, we cannot simply call `pa.array()` because types like strings and bytes are iterable and will get turned into an array of characters or bytes, respectively.

This PR attempts three passes at converting values

- Attempt to call `pa.array()` directly, but with a special case to ignore string and bytes
- Attempt to cast to a pyarrow Scalar and make an array from the scalar
- Fall back to handling with numpy, which handles a wide variety of mixes between lists, tuples, etc.

Added unit test to capture failure mode in attached issue.


* [x] pass full-check ci