### PR TITLE
Ignore `__init__.py` in snippets.toml

### DIFF
--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -73,6 +73,7 @@ features = [
 # You should only ever use this if the test isn't implemented and cannot yet be implemented
 # for one or more specific SDKs.
 [opt_out.run]
+"__init__" = ["py"] # That init file is to make mypy happy.
 "concepts/explicit_recording" = [ # python-specific check
   "cpp",
   "rust",


### PR DESCRIPTION
Adding that `__init__.py` in #9260 made mypy happy but snippets sad. It's now explicitly ignored.