### PR TITLE
Upload snapshot test results as artifact

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -132,6 +132,13 @@ jobs:
       - name: Rust checks & tests
         run: pixi run rs-check --skip individual_crates docs_slow
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-ubuntu
+          path: "**/tests/snapshots"
+
   rerun-lints:
     name: Rerun lints
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -107,6 +107,13 @@ jobs:
         # See tests/assets/rrd/README.md for more
         run: pixi run check-backwards-compatibility
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-ubuntu
+          path: "**/tests/snapshots"
+
   # Run some basics tests on Mac and Windows
   mac-windows-tests:
     name: Test on ${{ matrix.name }}
@@ -160,3 +167,10 @@ jobs:
       - name: Rust all checks & tests
         if: ${{ inputs.CHANNEL == 'nightly' }}
         run: pixi run rs-check
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-${{ matrix.name }}
+          path: "**/tests/snapshots"

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -121,7 +121,7 @@ pub fn help(egui_ctx: &egui::Context) -> Help {
             icon_text!(MouseButtonText(DRAG_PAN2D_BUTTON), "+", "drag"),
         )
         .control(
-            "Zooooom",
+            "Zoom",
             shortcut_with_icon(egui_ctx, ZOOM_SCROLL_MODIFIER, icons::SCROLL),
         )
         .control("Reset view", icon_text!("double", icons::LEFT_MOUSE_CLICK))

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -121,7 +121,7 @@ pub fn help(egui_ctx: &egui::Context) -> Help {
             icon_text!(MouseButtonText(DRAG_PAN2D_BUTTON), "+", "drag"),
         )
         .control(
-            "Zoom",
+            "Zooooom",
             shortcut_with_icon(egui_ctx, ZOOM_SCROLL_MODIFIER, icons::SCROLL),
         )
         .control("Reset view", icon_text!("double", icons::LEFT_MOUSE_CLICK))

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -281,7 +281,9 @@ def docs_slow(results: list[Result]) -> None:
     results.append(run_cargo("doc", "--no-deps --all-features -p rerun"))
     results.append(run_cargo("doc", "--document-private-items --no-deps --all-features -p rerun"))
 
+
 test_failure_message = 'See the "Upload test results" step for a link to the snapshot test artifact.'
+
 
 def tests(results: list[Result]) -> None:
     # We first use `--no-run` to measure the time of compiling vs actually running

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -281,6 +281,7 @@ def docs_slow(results: list[Result]) -> None:
     results.append(run_cargo("doc", "--no-deps --all-features -p rerun"))
     results.append(run_cargo("doc", "--document-private-items --no-deps --all-features -p rerun"))
 
+test_failure_message = 'See the "Upload test results" step for a link to the snapshot test artifact.'
 
 def tests(results: list[Result]) -> None:
     # We first use `--no-run` to measure the time of compiling vs actually running
@@ -288,7 +289,7 @@ def tests(results: list[Result]) -> None:
     results.append(run_cargo("nextest", "run --all-targets --all-features"))
 
     if not results[-1].success:
-        print('Looks like the rust tests failed. See the "Upload test results" step for more details.')
+        print(test_failure_message)
 
     # Cargo nextest doesn't support doc tests yet, run those separately.
     results.append(run_cargo("test", "--all-features --doc"))
@@ -300,7 +301,7 @@ def tests_without_all_features(results: list[Result]) -> None:
     results.append(run_cargo("nextest", "run --all-targets"))
 
     if not results[-1].success:
-        print('Looks like the rust tests failed. See the "Upload test results" step for more details.')
+        print(test_failure_message)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -287,6 +287,9 @@ def tests(results: list[Result]) -> None:
     results.append(run_cargo("test", "--all-targets --all-features --no-run"))
     results.append(run_cargo("nextest", "run --all-targets --all-features"))
 
+    if not results[-1].success:
+        print('Looks like the rust tests failed. See the "Upload test results" step for more details.')
+
     # Cargo nextest doesn't support doc tests yet, run those separately.
     results.append(run_cargo("test", "--all-features --doc"))
 
@@ -295,6 +298,9 @@ def tests_without_all_features(results: list[Result]) -> None:
     # We first use `--no-run` to measure the time of compiling vs actually running
     results.append(run_cargo("test", "--all-targets --no-run"))
     results.append(run_cargo("nextest", "run --all-targets"))
+
+    if not results[-1].success:
+        print('Looks like the rust tests failed. See the "Upload test results" step for more details.')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What

Makes it easier to debug failing snapshots in CI.

See here for an example of a failed run: https://github.com/rerun-io/rerun/actions/runs/13853649550/job/38765622419?pr=9282

Click the "Upload test results" section to get a download link
