### PR TITLE
Manifest registry service spec update: make few more calls stream back the response

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -9,10 +9,10 @@ service ManifestRegistryService {
   rpc RegisterPartitions(RegisterPartitionsRequest) returns (RegisterPartitionsResponse) {}
 
   // Unregister partitions from the Dataset
-  rpc UnregisterPartitions(UnregisterPartitionsRequest) returns (UnregisterPartitionsResponse) {}
+  rpc UnregisterPartitions(UnregisterPartitionsRequest) returns (stream UnregisterPartitionsResponse) {}
 
   // List partitions in the Dataset
-  rpc ListPartitions(ListPartitionsRequest) returns (ListPartitionsResponse) {}
+  rpc ListPartitions(ListPartitionsRequest) returns (stream ListPartitionsResponse) {}
 
   // Create manifests for all partitions in the Dataset
   rpc CreatePartitionManifests(CreatePartitionManifestsRequest) returns (CreatePartitionManifestsResponse) {}
@@ -32,7 +32,7 @@ service ManifestRegistryService {
   rpc CreatePartitionIndexes(CreatePartitionIndexesRequest) returns (CreatePartitionIndexesResponse) {}
 
   // List indexes for the Dataset
-  rpc ListPartitionIndexes(ListPartitionIndexesRequest) returns (ListPartitionIndexesResponse) {}
+  rpc ListPartitionIndexes(ListPartitionIndexesRequest) returns (stream ListPartitionIndexesResponse) {}
 
   // Do a full text, vector or scalar search. Currently only an Indexed search
   // is supported, user must first call `CreatePartitionIndexes` for the relevant column.

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -6,7 +6,7 @@ import "rerun/v1alpha1/common.proto";
 
 service ManifestRegistryService {
   // Register new partitions with the Dataset
-  rpc RegisterPartitions(RegisterPartitionsRequest) returns (RegisterPartitionsResponse) {}
+  rpc RegisterPartitions(RegisterPartitionsRequest) returns (stream RegisterPartitionsResponse) {}
 
   // Unregister partitions from the Dataset
   rpc UnregisterPartitions(UnregisterPartitionsRequest) returns (stream UnregisterPartitionsResponse) {}
@@ -15,7 +15,7 @@ service ManifestRegistryService {
   rpc ListPartitions(ListPartitionsRequest) returns (stream ListPartitionsResponse) {}
 
   // Create manifests for all partitions in the Dataset
-  rpc CreatePartitionManifests(CreatePartitionManifestsRequest) returns (CreatePartitionManifestsResponse) {}
+  rpc CreatePartitionManifests(CreatePartitionManifestsRequest) returns (stream CreatePartitionManifestsResponse) {}
 
   // Query Dataset and return a dataframe containing relevant chunk IDs
   rpc QueryDataset(QueryDatasetRequest) returns (stream QueryDatasetResponse) {}
@@ -29,7 +29,7 @@ service ManifestRegistryService {
 
   // Create index for partitions in the Dataset. Index can be created for all or specific
   // partitions
-  rpc CreatePartitionIndexes(CreatePartitionIndexesRequest) returns (CreatePartitionIndexesResponse) {}
+  rpc CreatePartitionIndexes(CreatePartitionIndexesRequest) returns (stream CreatePartitionIndexesResponse) {}
 
   // List indexes for the Dataset
   rpc ListPartitionIndexes(ListPartitionIndexesRequest) returns (stream ListPartitionIndexesResponse) {}

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -6,16 +6,16 @@ import "rerun/v1alpha1/common.proto";
 
 service ManifestRegistryService {
   // Register new partitions with the Dataset
-  rpc RegisterPartitions(RegisterPartitionsRequest) returns (stream RegisterPartitionsResponse) {}
+  rpc RegisterPartitions(RegisterPartitionsRequest) returns (RegisterPartitionsResponse) {}
 
   // Unregister partitions from the Dataset
-  rpc UnregisterPartitions(UnregisterPartitionsRequest) returns (stream UnregisterPartitionsResponse) {}
+  rpc UnregisterPartitions(UnregisterPartitionsRequest) returns (UnregisterPartitionsResponse) {}
 
   // List partitions in the Dataset
   rpc ListPartitions(ListPartitionsRequest) returns (stream ListPartitionsResponse) {}
 
   // Create manifests for all partitions in the Dataset
-  rpc CreatePartitionManifests(CreatePartitionManifestsRequest) returns (stream CreatePartitionManifestsResponse) {}
+  rpc CreatePartitionManifests(CreatePartitionManifestsRequest) returns (CreatePartitionManifestsResponse) {}
 
   // Query Dataset and return a dataframe containing relevant chunk IDs
   rpc QueryDataset(QueryDatasetRequest) returns (stream QueryDatasetResponse) {}
@@ -29,7 +29,7 @@ service ManifestRegistryService {
 
   // Create index for partitions in the Dataset. Index can be created for all or specific
   // partitions
-  rpc CreatePartitionIndexes(CreatePartitionIndexesRequest) returns (stream CreatePartitionIndexesResponse) {}
+  rpc CreatePartitionIndexes(CreatePartitionIndexesRequest) returns (CreatePartitionIndexesResponse) {}
 
   // List indexes for the Dataset
   rpc ListPartitionIndexes(ListPartitionIndexesRequest) returns (stream ListPartitionIndexesResponse) {}

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -920,8 +920,10 @@ pub mod manifest_registry_service_client {
         pub async fn unregister_partitions(
             &mut self,
             request: impl tonic::IntoRequest<super::UnregisterPartitionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnregisterPartitionsResponse>, tonic::Status>
-        {
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::UnregisterPartitionsResponse>>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
@@ -934,14 +936,16 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "UnregisterPartitions",
             ));
-            self.inner.unary(req, path, codec).await
+            self.inner.server_streaming(req, path, codec).await
         }
         /// List partitions in the Dataset
         pub async fn list_partitions(
             &mut self,
             request: impl tonic::IntoRequest<super::ListPartitionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListPartitionsResponse>, tonic::Status>
-        {
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::ListPartitionsResponse>>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
@@ -954,7 +958,7 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "ListPartitions",
             ));
-            self.inner.unary(req, path, codec).await
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Create manifests for all partitions in the Dataset
         pub async fn create_partition_manifests(
@@ -1072,8 +1076,10 @@ pub mod manifest_registry_service_client {
         pub async fn list_partition_indexes(
             &mut self,
             request: impl tonic::IntoRequest<super::ListPartitionIndexesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListPartitionIndexesResponse>, tonic::Status>
-        {
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::ListPartitionIndexesResponse>>,
+            tonic::Status,
+        > {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
@@ -1086,7 +1092,7 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "ListPartitionIndexes",
             ));
-            self.inner.unary(req, path, codec).await
+            self.inner.server_streaming(req, path, codec).await
         }
         /// Do a full text, vector or scalar search. Currently only an Indexed search
         /// is supported, user must first call `CreatePartitionIndexes` for the relevant column.
@@ -1145,16 +1151,26 @@ pub mod manifest_registry_service_server {
             &self,
             request: tonic::Request<super::RegisterPartitionsRequest>,
         ) -> std::result::Result<tonic::Response<super::RegisterPartitionsResponse>, tonic::Status>;
+        /// Server streaming response type for the UnregisterPartitions method.
+        type UnregisterPartitionsStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::UnregisterPartitionsResponse, tonic::Status>,
+            > + std::marker::Send
+            + 'static;
         /// Unregister partitions from the Dataset
         async fn unregister_partitions(
             &self,
             request: tonic::Request<super::UnregisterPartitionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnregisterPartitionsResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::UnregisterPartitionsStream>, tonic::Status>;
+        /// Server streaming response type for the ListPartitions method.
+        type ListPartitionsStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::ListPartitionsResponse, tonic::Status>,
+            > + std::marker::Send
+            + 'static;
         /// List partitions in the Dataset
         async fn list_partitions(
             &self,
             request: tonic::Request<super::ListPartitionsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListPartitionsResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::ListPartitionsStream>, tonic::Status>;
         /// Create manifests for all partitions in the Dataset
         async fn create_partition_manifests(
             &self,
@@ -1203,11 +1219,16 @@ pub mod manifest_registry_service_server {
             tonic::Response<super::CreatePartitionIndexesResponse>,
             tonic::Status,
         >;
+        /// Server streaming response type for the ListPartitionIndexes method.
+        type ListPartitionIndexesStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::ListPartitionIndexesResponse, tonic::Status>,
+            > + std::marker::Send
+            + 'static;
         /// List indexes for the Dataset
         async fn list_partition_indexes(
             &self,
             request: tonic::Request<super::ListPartitionIndexesRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListPartitionIndexesResponse>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::ListPartitionIndexesStream>, tonic::Status>;
         /// Server streaming response type for the SearchDataset method.
         type SearchDatasetStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::SearchDatasetResponse, tonic::Status>,
@@ -1363,11 +1384,13 @@ pub mod manifest_registry_service_server {
                     );
                     impl<
                         T: ManifestRegistryService,
-                    > tonic::server::UnaryService<super::UnregisterPartitionsRequest>
-                    for UnregisterPartitionsSvc<T> {
+                    > tonic::server::ServerStreamingService<
+                        super::UnregisterPartitionsRequest,
+                    > for UnregisterPartitionsSvc<T> {
                         type Response = super::UnregisterPartitionsResponse;
+                        type ResponseStream = T::UnregisterPartitionsStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
+                            tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1402,7 +1425,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.unary(method, req).await;
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
@@ -1412,11 +1435,12 @@ pub mod manifest_registry_service_server {
                     struct ListPartitionsSvc<T: ManifestRegistryService>(pub Arc<T>);
                     impl<
                         T: ManifestRegistryService,
-                    > tonic::server::UnaryService<super::ListPartitionsRequest>
+                    > tonic::server::ServerStreamingService<super::ListPartitionsRequest>
                     for ListPartitionsSvc<T> {
                         type Response = super::ListPartitionsResponse;
+                        type ResponseStream = T::ListPartitionsStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
+                            tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1451,7 +1475,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.unary(method, req).await;
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
@@ -1714,11 +1738,13 @@ pub mod manifest_registry_service_server {
                     );
                     impl<
                         T: ManifestRegistryService,
-                    > tonic::server::UnaryService<super::ListPartitionIndexesRequest>
-                    for ListPartitionIndexesSvc<T> {
+                    > tonic::server::ServerStreamingService<
+                        super::ListPartitionIndexesRequest,
+                    > for ListPartitionIndexesSvc<T> {
                         type Response = super::ListPartitionIndexesResponse;
+                        type ResponseStream = T::ListPartitionIndexesStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
+                            tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1753,7 +1779,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.unary(method, req).await;
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -900,10 +900,8 @@ pub mod manifest_registry_service_client {
         pub async fn register_partitions(
             &mut self,
             request: impl tonic::IntoRequest<super::RegisterPartitionsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::RegisterPartitionsResponse>>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<super::RegisterPartitionsResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
@@ -916,16 +914,14 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "RegisterPartitions",
             ));
-            self.inner.server_streaming(req, path, codec).await
+            self.inner.unary(req, path, codec).await
         }
         /// Unregister partitions from the Dataset
         pub async fn unregister_partitions(
             &mut self,
             request: impl tonic::IntoRequest<super::UnregisterPartitionsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::UnregisterPartitionsResponse>>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<super::UnregisterPartitionsResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
@@ -938,7 +934,7 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "UnregisterPartitions",
             ));
-            self.inner.server_streaming(req, path, codec).await
+            self.inner.unary(req, path, codec).await
         }
         /// List partitions in the Dataset
         pub async fn list_partitions(
@@ -967,7 +963,7 @@ pub mod manifest_registry_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreatePartitionManifestsRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::CreatePartitionManifestsResponse>>,
+            tonic::Response<super::CreatePartitionManifestsResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
@@ -982,7 +978,7 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "CreatePartitionManifests",
             ));
-            self.inner.server_streaming(req, path, codec).await
+            self.inner.unary(req, path, codec).await
         }
         /// Query Dataset and return a dataframe containing relevant chunk IDs
         pub async fn query_dataset(
@@ -1057,7 +1053,7 @@ pub mod manifest_registry_service_client {
             &mut self,
             request: impl tonic::IntoRequest<super::CreatePartitionIndexesRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::CreatePartitionIndexesResponse>>,
+            tonic::Response<super::CreatePartitionIndexesResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
@@ -1072,7 +1068,7 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "CreatePartitionIndexes",
             ));
-            self.inner.server_streaming(req, path, codec).await
+            self.inner.unary(req, path, codec).await
         }
         /// List indexes for the Dataset
         pub async fn list_partition_indexes(
@@ -1148,26 +1144,16 @@ pub mod manifest_registry_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with ManifestRegistryServiceServer.
     #[async_trait]
     pub trait ManifestRegistryService: std::marker::Send + std::marker::Sync + 'static {
-        /// Server streaming response type for the RegisterPartitions method.
-        type RegisterPartitionsStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::RegisterPartitionsResponse, tonic::Status>,
-            > + std::marker::Send
-            + 'static;
         /// Register new partitions with the Dataset
         async fn register_partitions(
             &self,
             request: tonic::Request<super::RegisterPartitionsRequest>,
-        ) -> std::result::Result<tonic::Response<Self::RegisterPartitionsStream>, tonic::Status>;
-        /// Server streaming response type for the UnregisterPartitions method.
-        type UnregisterPartitionsStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::UnregisterPartitionsResponse, tonic::Status>,
-            > + std::marker::Send
-            + 'static;
+        ) -> std::result::Result<tonic::Response<super::RegisterPartitionsResponse>, tonic::Status>;
         /// Unregister partitions from the Dataset
         async fn unregister_partitions(
             &self,
             request: tonic::Request<super::UnregisterPartitionsRequest>,
-        ) -> std::result::Result<tonic::Response<Self::UnregisterPartitionsStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::UnregisterPartitionsResponse>, tonic::Status>;
         /// Server streaming response type for the ListPartitions method.
         type ListPartitionsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::ListPartitionsResponse, tonic::Status>,
@@ -1178,16 +1164,14 @@ pub mod manifest_registry_service_server {
             &self,
             request: tonic::Request<super::ListPartitionsRequest>,
         ) -> std::result::Result<tonic::Response<Self::ListPartitionsStream>, tonic::Status>;
-        /// Server streaming response type for the CreatePartitionManifests method.
-        type CreatePartitionManifestsStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::CreatePartitionManifestsResponse, tonic::Status>,
-            > + std::marker::Send
-            + 'static;
         /// Create manifests for all partitions in the Dataset
         async fn create_partition_manifests(
             &self,
             request: tonic::Request<super::CreatePartitionManifestsRequest>,
-        ) -> std::result::Result<tonic::Response<Self::CreatePartitionManifestsStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePartitionManifestsResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the QueryDataset method.
         type QueryDatasetStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::QueryDatasetResponse, tonic::Status>,
@@ -1219,17 +1203,15 @@ pub mod manifest_registry_service_server {
             &self,
             request: tonic::Request<super::GetChunksRequest>,
         ) -> std::result::Result<tonic::Response<Self::GetChunksStream>, tonic::Status>;
-        /// Server streaming response type for the CreatePartitionIndexes method.
-        type CreatePartitionIndexesStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::CreatePartitionIndexesResponse, tonic::Status>,
-            > + std::marker::Send
-            + 'static;
         /// Create index for partitions in the Dataset. Index can be created for all or specific
         /// partitions
         async fn create_partition_indexes(
             &self,
             request: tonic::Request<super::CreatePartitionIndexesRequest>,
-        ) -> std::result::Result<tonic::Response<Self::CreatePartitionIndexesStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::CreatePartitionIndexesResponse>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the ListPartitionIndexes method.
         type ListPartitionIndexesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::ListPartitionIndexesResponse, tonic::Status>,
@@ -1344,13 +1326,11 @@ pub mod manifest_registry_service_server {
                     struct RegisterPartitionsSvc<T: ManifestRegistryService>(pub Arc<T>);
                     impl<
                         T: ManifestRegistryService,
-                    > tonic::server::ServerStreamingService<
-                        super::RegisterPartitionsRequest,
-                    > for RegisterPartitionsSvc<T> {
+                    > tonic::server::UnaryService<super::RegisterPartitionsRequest>
+                    for RegisterPartitionsSvc<T> {
                         type Response = super::RegisterPartitionsResponse;
-                        type ResponseStream = T::RegisterPartitionsStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
+                            tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1385,7 +1365,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.server_streaming(method, req).await;
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
@@ -1397,13 +1377,11 @@ pub mod manifest_registry_service_server {
                     );
                     impl<
                         T: ManifestRegistryService,
-                    > tonic::server::ServerStreamingService<
-                        super::UnregisterPartitionsRequest,
-                    > for UnregisterPartitionsSvc<T> {
+                    > tonic::server::UnaryService<super::UnregisterPartitionsRequest>
+                    for UnregisterPartitionsSvc<T> {
                         type Response = super::UnregisterPartitionsResponse;
-                        type ResponseStream = T::UnregisterPartitionsStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
+                            tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1438,7 +1416,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.server_streaming(method, req).await;
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
@@ -1500,13 +1478,11 @@ pub mod manifest_registry_service_server {
                     );
                     impl<
                         T: ManifestRegistryService,
-                    > tonic::server::ServerStreamingService<
-                        super::CreatePartitionManifestsRequest,
-                    > for CreatePartitionManifestsSvc<T> {
+                    > tonic::server::UnaryService<super::CreatePartitionManifestsRequest>
+                    for CreatePartitionManifestsSvc<T> {
                         type Response = super::CreatePartitionManifestsResponse;
-                        type ResponseStream = T::CreatePartitionManifestsStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
+                            tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1543,7 +1519,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.server_streaming(method, req).await;
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
@@ -1702,13 +1678,11 @@ pub mod manifest_registry_service_server {
                     );
                     impl<
                         T: ManifestRegistryService,
-                    > tonic::server::ServerStreamingService<
-                        super::CreatePartitionIndexesRequest,
-                    > for CreatePartitionIndexesSvc<T> {
+                    > tonic::server::UnaryService<super::CreatePartitionIndexesRequest>
+                    for CreatePartitionIndexesSvc<T> {
                         type Response = super::CreatePartitionIndexesResponse;
-                        type ResponseStream = T::CreatePartitionIndexesStream;
                         type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
+                            tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
@@ -1743,7 +1717,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.server_streaming(method, req).await;
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)


### PR DESCRIPTION
### What

Quick follow up to
*  https://github.com/rerun-io/rerun/pull/9273.

I forgot to make few endpoints stream back the responses (noticed as soon as I started stubbing server side), hence fixing that here. 

I initially made all remaining APIs stream back responses, but then I realized that create/register/unregister endpoints should actually return a handle. So for now making only the ones I obviously missed (listing).