### PR TITLE
Fixed spelling error, binstall -> install

### DIFF
--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -39,7 +39,7 @@ There are many ways to install the viewer. Please pick whatever works best for y
 
 -   Download `rerun-cli` for your platform from the [GitHub Release artifacts](https://github.com/rerun-io/rerun/releases/latest/).
 -   Via Cargo
-    -   `cargo binstall rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
+    -   `cargo install rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
     -   `cargo install rerun-cli --locked` - build it from source (this requires Rust 1.84+)
 -   Via Snap (_community maintained_)
     -   `snap install rerun` - download the viewer from the [Store](https://snapcraft.io/rerun).


### PR DESCRIPTION
### Related


Closes #9287 9287

### What

`install` was misspelled `binstall` I tried to ignore it but I had to give in. 