### PR TITLE
Default to DEBUG log level in debug builds (again)

### DIFF
--- a/crates/utils/re_log/src/lib.rs
+++ b/crates/utils/re_log/src/lib.rs
@@ -94,8 +94,7 @@ const CRATES_AT_INFO_LEVEL: &[&str] = &[
 /// Web: `debug` since web console allows arbitrary filtering.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn default_log_filter() -> String {
-    let base_log_filter = if false {
-        //cfg!(debug_assertions) {
+    let base_log_filter = if cfg!(debug_assertions) {
         "debug"
     } else {
         // Important to keep the default at (at least) "info",

--- a/crates/utils/re_log/src/lib.rs
+++ b/crates/utils/re_log/src/lib.rs
@@ -95,6 +95,8 @@ const CRATES_AT_INFO_LEVEL: &[&str] = &[
 #[cfg(not(target_arch = "wasm32"))]
 pub fn default_log_filter() -> String {
     let base_log_filter = if cfg!(debug_assertions) {
+        // We want the DEBUG level to be useful yet not too spammy.
+        // This is a good way to enforce that.
         "debug"
     } else {
         // Important to keep the default at (at least) "info",


### PR DESCRIPTION
### Related
* https://github.com/rerun-io/rerun/pull/9231
* https://github.com/rerun-io/rerun/pull/4749
* https://github.com/rerun-io/rerun/issues/4629

### What
Sets the default log level to DEBUG for debug builds.

This is what we used to have, 