### PR TITLE
Fix rustdocs for `re_video`

### DIFF
--- a/crates/utils/re_video/Cargo.toml
+++ b/crates/utils/re_video/Cargo.toml
@@ -17,9 +17,7 @@ workspace = true
 
 
 [package.metadata.docs.rs]
-all-features = false
-no-default-features = true
-features = ["all"]
+all-features = true
 
 
 [features]


### PR DESCRIPTION
### Related
The rustdocs flags were set up incorrectly (likely copied from `re_types`)