### PR TITLE
Disable run notebook job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -293,14 +293,15 @@ jobs:
 
   # ---------------------------------------------------------------------------
 
-  run-notebook:
-    name: "Run Notebook"
-    needs: [build-wheel-linux-x64]
-    uses: ./.github/workflows/reusable_run_notebook.yml
-    with:
-      CONCURRENCY: nightly
-      WHEEL_ARTIFACT_NAME: linux-x64-wheel
-    secrets: inherit
+  # TODO(#9304): make the notebook export work
+  # run-notebook:
+  #   name: "Run Notebook"
+  #   needs: [build-wheel-linux-x64]
+  #   uses: ./.github/workflows/reusable_run_notebook.yml
+  #   with:
+  #     CONCURRENCY: nightly
+  #     WHEEL_ARTIFACT_NAME: linux-x64-wheel
+  #   secrets: inherit
 
   build-examples:
     name: "Build Examples"

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -1,3 +1,4 @@
+# TODO(#9304): make the notebook export work
 name: Reusable Build and Upload Notebook
 
 on:


### PR DESCRIPTION
It has been broken for a while, and is causing `nightly` to take an extra 6 hours to run before it times out...

* https://github.com/rerun-io/rerun/issues/9304