### PR TITLE
Fix `to_nanos` incorrectly handling `np.timedelta` 

### DIFF
--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -102,7 +102,7 @@ class TimeColumn(TimeColumnLike):
         elif timestamp is not None:
             # TODO(zehiko) add back timezone support (#9310)
             self.type = pa.timestamp("ns")
-            self.times = [to_nanos_since_epoch(timestamp) for timestamp in timestamp]
+            self.times = [to_nanos_since_epoch(timestamp).astype("datetime64[ns]") for timestamp in timestamp]
 
     def timeline_name(self) -> str:
         """Returns the name of the timeline."""

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -99,14 +99,14 @@ class TimeColumn(TimeColumnLike):
         elif duration is not None:
             self.type = pa.duration("ns")
             if isinstance(duration, np.ndarray):
-                self.times = duration.astype("timedelta64[ns]").tolist()
+                self.times = duration.astype("timedelta64[ns]").tolist()  # type: ignore[assignment]
             else:
                 self.times = [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration]
         elif timestamp is not None:
             # TODO(zehiko) add back timezone support (#9310)
             self.type = pa.timestamp("ns")
             if isinstance(timestamp, np.ndarray):
-                self.times = timestamp.astype("datetime64[ns]").tolist()
+                self.times = timestamp.astype("datetime64[ns]").tolist()  # type: ignore[assignment]
             else:
                 self.times = [
                     np.int64(to_nanos_since_epoch(timestamp)).astype("datetime64[ns]") for timestamp in timestamp

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -99,9 +99,9 @@ class TimeColumn(TimeColumnLike):
         elif duration is not None:
             self.type = pa.duration("ns")
             if isinstance(timestamp, np.ndarray):
-                self.times = timestamp.astype("timedelta64[ns]").astype("int64").tolist()
+                self.times = timestamp.astype("timedelta64[ns]").tolist()
             else:
-                self.times = [to_nanos(duration) for duration in duration]
+                self.times = [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration]
         elif timestamp is not None:
             # TODO(zehiko) add back timezone support (#9310)
             self.type = pa.timestamp("ns")

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -98,8 +98,8 @@ class TimeColumn(TimeColumnLike):
             self.times = sequence
         elif duration is not None:
             self.type = pa.duration("ns")
-            if isinstance(timestamp, np.ndarray):
-                self.times = timestamp.astype("timedelta64[ns]").tolist()
+            if isinstance(duration, np.ndarray):
+                self.times = duration.astype("timedelta64[ns]").tolist()
             else:
                 self.times = [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration]
         elif timestamp is not None:

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -98,7 +98,10 @@ class TimeColumn(TimeColumnLike):
             self.times = sequence
         elif duration is not None:
             self.type = pa.duration("ns")
-            self.times = [to_nanos(duration) for duration in duration]
+            if isinstance(timestamp, np.ndarray):
+                self.times = timestamp.astype("timedelta64[ns]").astype("int64").tolist()
+            else:
+                self.times = [to_nanos(duration) for duration in duration]
         elif timestamp is not None:
             # TODO(zehiko) add back timezone support (#9310)
             self.type = pa.timestamp("ns")

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -94,30 +94,30 @@ class TimeColumn(TimeColumnLike):
         self.timeline = timeline
 
         if sequence is not None:
-            self.type = pa.int64()
-            self.times = sequence
+            self.times = pa.array(sequence, pa.int64())
         elif duration is not None:
-            self.type = pa.duration("ns")
             if isinstance(duration, np.ndarray):
-                self.times = duration.astype("timedelta64[ns]").tolist()  # type: ignore[assignment]
+                self.times = pa.array(duration.astype("timedelta64[ns]"), pa.duration("ns"))
             else:
-                self.times = [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration]
+                self.times = pa.array(
+                    [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration], pa.duration("ns")
+                )
         elif timestamp is not None:
             # TODO(zehiko) add back timezone support (#9310)
-            self.type = pa.timestamp("ns")
             if isinstance(timestamp, np.ndarray):
-                self.times = timestamp.astype("datetime64[ns]").tolist()  # type: ignore[assignment]
+                self.times = pa.array(timestamp.astype("datetime64[ns]"), pa.timestamp("ns"))
             else:
-                self.times = [
-                    np.int64(to_nanos_since_epoch(timestamp)).astype("datetime64[ns]") for timestamp in timestamp
-                ]
+                self.times = pa.array(
+                    [np.int64(to_nanos_since_epoch(timestamp)).astype("datetime64[ns]") for timestamp in timestamp],
+                    pa.timestamp("ns"),
+                )
 
     def timeline_name(self) -> str:
         """Returns the name of the timeline."""
         return self.timeline
 
     def as_arrow_array(self) -> pa.Array:
-        return pa.array(self.times, type=self.type)
+        return self.times
 
 
 @deprecated(

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -102,7 +102,7 @@ class TimeColumn(TimeColumnLike):
         elif timestamp is not None:
             # TODO(zehiko) add back timezone support (#9310)
             self.type = pa.timestamp("ns")
-            self.times = [to_nanos_since_epoch(timestamp).astype("datetime64[ns]") for timestamp in timestamp]
+            self.times = [np.int64(to_nanos_since_epoch(timestamp)).astype("datetime[ns]") for timestamp in timestamp]
 
     def timeline_name(self) -> str:
         """Returns the name of the timeline."""

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -102,7 +102,12 @@ class TimeColumn(TimeColumnLike):
         elif timestamp is not None:
             # TODO(zehiko) add back timezone support (#9310)
             self.type = pa.timestamp("ns")
-            self.times = [np.int64(to_nanos_since_epoch(timestamp)).astype("datetime[ns]") for timestamp in timestamp]
+            if isinstance(timestamp, np.ndarray):
+                self.times = timestamp.astype("datetime64[ns]").tolist()
+            else:
+                self.times = [
+                    np.int64(to_nanos_since_epoch(timestamp)).astype("datetime64[ns]") for timestamp in timestamp
+                ]
 
     def timeline_name(self) -> str:
         """Returns the name of the timeline."""

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -117,8 +117,7 @@ def to_nanos(duration: int | np.integer | float | np.float64 | timedelta | np.ti
         return 1_000_000_000 * int(duration)  # Interpret as seconds and convert to nanos
     elif isinstance(
         duration,
-        # Only allowing doubles since 32-bit and 16-bit floats lose precision when multiplying at this scale
-        (float, np.float64),
+        (float, np.floating),
     ):
         return round(1e9 * float(duration))  # Interpret as seconds and convert to nanos
     else:
@@ -132,7 +131,7 @@ def to_nanos_since_epoch(timestamp: int | np.integer | float | np.float64 | date
         return 1_000_000_000 * int(timestamp)  # Interpret as seconds and convert to nanos
     elif isinstance(
         timestamp,
-        # Only allowing doubles since 32-bit and 16-bit floats lose precision when multiplying at this scale
+        # Only allowing f64 since anything less has way too little precision for measuring time since 1970
         (float, np.float64),
     ):
         # Interpret as seconds and convert to nanos

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -127,9 +127,9 @@ def to_nanos(duration: int | np.integer | float | np.float64 | timedelta | np.ti
         )
 
 
-def to_nanos_since_epoch(timestamp: int | np.integer | float | np.float64 | datetime | np.datetime64) -> np.int64:
+def to_nanos_since_epoch(timestamp: int | np.integer | float | np.float64 | datetime | np.datetime64) -> int:
     if isinstance(timestamp, (int, np.integer)):
-        return np.int64(1_000_000_000 * int(timestamp))  # Interpret as seconds and convert to nanos
+        return 1_000_000_000 * int(timestamp)  # Interpret as seconds and convert to nanos
     elif isinstance(
         timestamp,
         # Only allowing doubles since 32-bit and 16-bit floats lose precision when multiplying at this scale

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -135,7 +135,8 @@ def to_nanos_since_epoch(timestamp: int | np.integer | float | np.float64 | date
         # Only allowing doubles since 32-bit and 16-bit floats lose precision when multiplying at this scale
         (float, np.float64),
     ):
-        return np.round(1e9 * timestamp).astype("int64")  # Interpret as seconds and convert to nanos
+        # Interpret as seconds and convert to nanos
+        return np.round(1e9 * timestamp).astype("int64")  # type: ignore[no-any-return]
     elif isinstance(timestamp, datetime):
         if timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
@@ -143,7 +144,7 @@ def to_nanos_since_epoch(timestamp: int | np.integer | float | np.float64 | date
             timestamp = timestamp.astimezone(timezone.utc)
         epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
-        return np.round(1e9 * (timestamp - epoch).total_seconds()).astype("int64")
+        return np.round(1e9 * (timestamp - epoch).total_seconds()).astype("int64")  # type: ignore[no-any-return]
     elif isinstance(timestamp, np.datetime64):
         return timestamp.astype("datetime64[ns]").astype("int64")  # type: ignore[no-any-return]
     else:

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -128,7 +128,7 @@ def to_nanos(duration: int | np.integer | float | np.float64 | timedelta | np.ti
 
 def to_nanos_since_epoch(
     timestamp: int | np.integer | float | np.float64 | datetime | np.datetime64,
-) -> np.integer:
+) -> np.int64:
     if isinstance(timestamp, (int, np.integer)):
         return 1_000_000_000 * np.int64(timestamp)  # Interpret as seconds and convert to nanos
     elif isinstance(

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -126,16 +126,18 @@ def to_nanos(duration: int | np.integer | float | np.float64 | timedelta | np.ti
         )
 
 
-def to_nanos_since_epoch(timestamp: int | np.integer | float | np.float64 | datetime | np.datetime64) -> int:
+def to_nanos_since_epoch(
+    timestamp: int | np.integer | float | np.float64 | datetime | np.datetime64,
+) -> np.integer:
     if isinstance(timestamp, (int, np.integer)):
-        return 1_000_000_000 * int(timestamp)  # Interpret as seconds and convert to nanos
+        return 1_000_000_000 * np.int64(timestamp)  # Interpret as seconds and convert to nanos
     elif isinstance(
         timestamp,
         # Only allowing f64 since anything less has way too little precision for measuring time since 1970
         (float, np.float64),
     ):
         # Interpret as seconds and convert to nanos
-        return np.round(1e9 * timestamp).astype("int64")  # type: ignore[no-any-return]
+        return np.round(1e9 * timestamp).astype("int64")
     elif isinstance(timestamp, datetime):
         if timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
@@ -143,9 +145,9 @@ def to_nanos_since_epoch(timestamp: int | np.integer | float | np.float64 | date
             timestamp = timestamp.astimezone(timezone.utc)
         epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
-        return np.round(1e9 * (timestamp - epoch).total_seconds()).astype("int64")  # type: ignore[no-any-return]
+        return np.round(1e9 * (timestamp - epoch).total_seconds()).astype("int64")
     elif isinstance(timestamp, np.datetime64):
-        return timestamp.astype("datetime64[ns]").astype("int64")  # type: ignore[no-any-return]
+        return timestamp.astype("datetime64[ns]").astype("int64")
     else:
         raise TypeError(
             f"set_time: timestamp must be an int, float, datetime, or numpy.datetime64 object, got {type(timestamp)}",

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -128,16 +128,16 @@ def to_nanos(duration: int | np.integer | float | np.float64 | timedelta | np.ti
 
 def to_nanos_since_epoch(
     timestamp: int | np.integer | float | np.float64 | datetime | np.datetime64,
-) -> np.int64:
+) -> int:
     if isinstance(timestamp, (int, np.integer)):
-        return 1_000_000_000 * np.int64(timestamp)  # Interpret as seconds and convert to nanos
+        return 1_000_000_000 * int(timestamp)  # Interpret as seconds and convert to nanos
     elif isinstance(
         timestamp,
         # Only allowing f64 since anything less has way too little precision for measuring time since 1970
         (float, np.float64),
     ):
         # Interpret as seconds and convert to nanos
-        return np.round(1e9 * timestamp).astype("int64")
+        return int(np.round(1e9 * timestamp))
     elif isinstance(timestamp, datetime):
         if timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=timezone.utc)
@@ -145,9 +145,9 @@ def to_nanos_since_epoch(
             timestamp = timestamp.astimezone(timezone.utc)
         epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
-        return np.round(1e9 * (timestamp - epoch).total_seconds()).astype("int64")
+        return int(np.round(1e9 * (timestamp - epoch).total_seconds()))
     elif isinstance(timestamp, np.datetime64):
-        return timestamp.astype("datetime64[ns]").astype("int64")
+        return int(timestamp.astype("datetime64[ns]").astype("int64"))
     else:
         raise TypeError(
             f"set_time: timestamp must be an int, float, datetime, or numpy.datetime64 object, got {type(timestamp)}",

--- a/rerun_py/tests/unit/test_time.py
+++ b/rerun_py/tests/unit/test_time.py
@@ -36,9 +36,6 @@ def test_to_nanos_valid(duration: int | float | timedelta | np.timedelta64, expe
 INVALID_TO_NANOS_CASES = [
     "invalid",
     None,
-    # Not enough precision for nanosecond scale
-    np.float16(1.2),
-    np.float32(2.4),
     [1, 2, 3],
     3 + 4j,
 ]

--- a/rerun_py/tests/unit/test_time.py
+++ b/rerun_py/tests/unit/test_time.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import numpy as np
+import pytest
+from rerun.time import to_nanos, to_nanos_since_epoch
+
+VALID_TO_NANOS_CASES = [
+    (0, 0),
+    (2, 2_000_000_000),
+    (np.int8(3), 3_000_000_000),
+    (np.int16(4), 4_000_000_000),
+    (np.int32(5), 5_000_000_000),
+    (np.int64(6), 6_000_000_000),
+    (0.75, 750_000_000),
+    (np.float64(3.6), 3_600_000_000),
+    (timedelta(seconds=2, microseconds=500_000), 2_500_000_000),
+    (np.timedelta64(4, "s"), 4_000_000_000),
+    (np.timedelta64(2500, "ms"), 2_500_000_000),
+    (np.timedelta64(25, "ns"), 25),
+    (-3, -3_000_000_000),
+    (np.int64(-2), -2_000_000_000),
+    (np.float64(-1.5), -1_500_000_000),
+    (timedelta(seconds=-4, microseconds=-500_000), -4_500_000_000),
+    (np.timedelta64(-7, "s"), -7_000_000_000),
+]
+
+
+@pytest.mark.parametrize("duration,expected", VALID_TO_NANOS_CASES)
+def test_to_nanos_valid(duration: int | float | timedelta | np.timedelta64, expected: int) -> None:
+    assert to_nanos(duration) == expected
+
+
+INVALID_TO_NANOS_CASES = [
+    "invalid",
+    None,
+    # Not enough precision for nanosecond scale
+    np.float16(1.2),
+    np.float32(2.4),
+    [1, 2, 3],
+    3 + 4j,
+]
+
+
+@pytest.mark.parametrize("duration", INVALID_TO_NANOS_CASES)
+def test_to_nanos_invalid(duration: Any) -> None:
+    with pytest.raises(TypeError):
+        to_nanos(duration)
+
+
+VALID_TO_NANOS_SINCE_EPOCH_CASES = [
+    (0, 0),
+    (10, 10_000_000_000),
+    (np.int8(127), 127_000_000_000),
+    (np.int32(50), 50_000_000_000),
+    (np.int64(1223334444), 1_223_334_444_000_000_000),
+    (1.5, 1_500_000_000),
+    (np.float64(2.7), 2_700_000_000),
+    (datetime(1970, 1, 1), 0),
+    (datetime(1970, 1, 1, tzinfo=timezone.utc), 0),
+    (datetime(1970, 1, 1, 0, 0, 1), 1_000_000_000),
+    (np.datetime64("1970-01-01T00:00:00"), 0),
+    (np.datetime64("1970-01-01T00:00:01"), 1_000_000_000),
+    (np.datetime64("1970-01-01T00:00:00.000000000"), 0),
+    (datetime(1969, 12, 31, 23, 59, 59, tzinfo=timezone.utc), -1_000_000_000),
+    (np.datetime64("1969-12-31T23:59:59"), -1_000_000_000),
+    (datetime(2050, 1, 1, 0, 0, 0, tzinfo=timezone.utc), 2524608000000000000),
+    (np.datetime64("2050-01-01T00:00:00"), 2524608000000000000),
+    (np.datetime64("2000-01-01T00:00:00.123456789"), 946684800123456789),
+]
+
+
+@pytest.mark.parametrize("timestamp,expected", VALID_TO_NANOS_SINCE_EPOCH_CASES)
+def test_to_nanos_since_epoch_valid(timestamp: int | float | datetime | np.datetime64, expected: int) -> None:
+    assert to_nanos_since_epoch(timestamp) == expected
+
+
+INVALID_TO_NANOS_SINCE_EPOCH_CASES = [
+    "invalid",
+    None,
+    # Not enough precision for nanosecond scale
+    np.float16(14.234),
+    np.float32(211.623),
+    [1, 2, 3],
+]
+
+
+@pytest.mark.parametrize("timestamp", INVALID_TO_NANOS_SINCE_EPOCH_CASES)
+def test_to_nanos_since_epoch_invalid(timestamp: Any) -> None:
+    with pytest.raises(TypeError):
+        to_nanos_since_epoch(timestamp)

--- a/rerun_py/tests/unit/test_time_column.py
+++ b/rerun_py/tests/unit/test_time_column.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+import numpy as np
+import pytest
+
+import pyarrow as pa
+import rerun as rr
+
+VALID_DURATION_CASES = [
+    ([0, 1, 2, 3], pa.array([0, 1_000_000_000, 2_000_000_000, 3_000_000_000], type=pa.duration("ns"))),
+]
+
+
+@pytest.mark.parametrize("duration,expected", VALID_DURATION_CASES)
+def test_time_column(
+    duration: Iterable[int] | Iterable[float] | Iterable[timedelta] | Iterable[np.timedelta64], expected: pa.Array
+) -> None:
+    column = rr.TimeColumn("duration", duration=duration)
+
+    assert column.as_arrow_array() == expected

--- a/rerun_py/tests/unit/test_time_column.py
+++ b/rerun_py/tests/unit/test_time_column.py
@@ -16,7 +16,7 @@ VALID_SEQUENCE_CASES = [
 
 
 @pytest.mark.parametrize("sequence,expected", VALID_SEQUENCE_CASES)
-def test_sequence_column(sequence, expected) -> None:
+def test_sequence_column(sequence: Iterable[int], expected: pa.Array) -> None:
     column = rr.TimeColumn("sequence", sequence=sequence)
     assert column.as_arrow_array() == expected
 
@@ -100,6 +100,8 @@ VALID_TIMESTAMP_CASES = [
 
 
 @pytest.mark.parametrize("timestamp,expected", VALID_TIMESTAMP_CASES)
-def test_timestamp_column(timestamp, expected) -> None:
+def test_timestamp_column(
+    timestamp: Iterable[int] | Iterable[float] | Iterable[datetime] | Iterable[np.datetime64], expected: pa.Array
+) -> None:
     column = rr.TimeColumn("timestamp", timestamp=timestamp)
     assert column.as_arrow_array() == expected

--- a/rerun_py/tests/unit/test_time_column.py
+++ b/rerun_py/tests/unit/test_time_column.py
@@ -1,23 +1,105 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-from typing import Any, Iterable
+from collections.abc import Iterable
+from datetime import datetime, timedelta
 
 import numpy as np
-import pytest
-
 import pyarrow as pa
+import pytest
 import rerun as rr
+
+VALID_SEQUENCE_CASES = [
+    ([0, 1, 2, 3], pa.array([0, 1, 2, 3], type=pa.int64())),
+    ([-1, 0, 1], pa.array([-1, 0, 1], type=pa.int64())),
+    (np.array([10, 20, 30]), pa.array([10, 20, 30], type=pa.int64())),
+]
+
+
+@pytest.mark.parametrize("sequence,expected", VALID_SEQUENCE_CASES)
+def test_sequence_column(sequence, expected) -> None:
+    column = rr.TimeColumn("sequence", sequence=sequence)
+    assert column.as_arrow_array() == expected
+
 
 VALID_DURATION_CASES = [
     ([0, 1, 2, 3], pa.array([0, 1_000_000_000, 2_000_000_000, 3_000_000_000], type=pa.duration("ns"))),
+    ([0.0, 1.5, 2.25, 3.0], pa.array([0, 1_500_000_000, 2_250_000_000, 3_000_000_000], type=pa.duration("ns"))),
+    (
+        [
+            timedelta(seconds=0),
+            timedelta(seconds=1),
+            timedelta(seconds=1, microseconds=500000),
+            timedelta(seconds=2, microseconds=250000),
+        ],
+        pa.array([0, 1_000_000_000, 1_500_000_000, 2_250_000_000], type=pa.duration("ns")),
+    ),
+    (
+        [np.timedelta64(0, "s"), np.timedelta64(1, "s"), np.timedelta64(1500, "ms"), np.timedelta64(2250, "ms")],
+        pa.array([0, 1_000_000_000, 1_500_000_000, 2_250_000_000], type=pa.duration("ns")),
+    ),
+    ([-1, 0, 1], pa.array([-1_000_000_000, 0, 1_000_000_000], type=pa.duration("ns"))),
+    (
+        np.array([np.timedelta64(0, "s"), np.timedelta64(1, "s"), np.timedelta64(1500, "ms")]),
+        pa.array([0, 1_000_000_000, 1_500_000_000], type=pa.duration("ns")),
+    ),
 ]
 
 
 @pytest.mark.parametrize("duration,expected", VALID_DURATION_CASES)
-def test_time_column(
+def test_duration_column(
     duration: Iterable[int] | Iterable[float] | Iterable[timedelta] | Iterable[np.timedelta64], expected: pa.Array
 ) -> None:
     column = rr.TimeColumn("duration", duration=duration)
 
+    assert column.as_arrow_array() == expected
+
+
+VALID_TIMESTAMP_CASES = [
+    (
+        [0, 1, 2, 3],
+        pa.array(
+            [
+                np.datetime64("1970-01-01T00:00:00", "ns"),
+                np.datetime64("1970-01-01T00:00:01", "ns"),
+                np.datetime64("1970-01-01T00:00:02", "ns"),
+                np.datetime64("1970-01-01T00:00:03", "ns"),
+            ],
+            type=pa.timestamp("ns"),
+        ),
+    ),
+    (
+        [0.0, 1.5, 2.25, 3.0],
+        pa.array(
+            [
+                np.datetime64("1970-01-01T00:00:00", "ns"),
+                np.datetime64("1970-01-01T00:00:01.50", "ns"),
+                np.datetime64("1970-01-01T00:00:02.25", "ns"),
+                np.datetime64("1970-01-01T00:00:03", "ns"),
+            ],
+            type=pa.timestamp("ns"),
+        ),
+    ),
+    (
+        [datetime(2020, 1, 1, 0, 0, 0), datetime(2020, 1, 1, 0, 0, 1)],
+        pa.array(
+            [
+                np.datetime64("2020-01-01T00:00:00", "ns"),
+                np.datetime64("2020-01-01T00:00:01", "ns"),
+            ],
+            type=pa.timestamp("ns"),
+        ),
+    ),
+    (
+        np.array([np.datetime64("2020-01-01T00:00:00"), np.datetime64("2020-01-01T00:00:01")]),
+        pa.array(
+            [np.datetime64("2020-01-01T00:00:00", "ns"), np.datetime64("2020-01-01T00:00:01", "ns")],
+            type=pa.timestamp("ns"),
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("timestamp,expected", VALID_TIMESTAMP_CASES)
+def test_timestamp_column(timestamp, expected) -> None:
+    column = rr.TimeColumn("timestamp", timestamp=timestamp)
     assert column.as_arrow_array() == expected


### PR DESCRIPTION
### What

Fixed the following:
- `np.timedelta` has `np.integer` as superclass so we should do the instance check before that happens.
- `pa.timestamp("ns")` expects the values passed in to be of type `np.datetime64[ns]`
- `np.datetime` that contain non-nanosecond timestamps should first be converted to nanosecond scale.

I also added a bunch of unit tests for the `to_nanos` and `to_nanos_since_epoch` methods.