### PR TITLE
Use `RecordingEndpoint` in `SmartMessageSource::RedapGrpcStream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6670,6 +6670,7 @@ dependencies = [
  "crossbeam",
  "parking_lot",
  "re_tracing",
+ "re_uri",
  "serde",
  "web-time",
 ]

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -41,12 +41,8 @@ pub fn stream_from_redap(
     re_log::debug!("Loading {endpoint}…");
 
     let (tx, rx) = re_smart_channel::smart_channel(
-        re_smart_channel::SmartMessageSource::RerunGrpcStream {
-            url: endpoint.to_string(),
-        },
-        re_smart_channel::SmartChannelSource::RedapGrpcStream {
-            url: endpoint.to_string(),
-        },
+        re_smart_channel::SmartMessageSource::RedapGrpcStream(endpoint.clone()),
+        re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint.clone()),
     );
 
     spawn_future(async move {

--- a/crates/store/re_log_types/src/index/resolved_time_range.rs
+++ b/crates/store/re_log_types/src/index/resolved_time_range.rs
@@ -135,7 +135,7 @@ impl re_byte_size::SizeBytes for ResolvedTimeRange {
 // ----------------------------------------------------------------------------
 
 /// Like [`ResolvedTimeRange`], but using [`TimeReal`] for improved precision.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ResolvedTimeRangeF {
     pub min: TimeReal,

--- a/crates/utils/re_smart_channel/Cargo.toml
+++ b/crates/utils/re_smart_channel/Cargo.toml
@@ -20,6 +20,7 @@ all-features = true
 
 [dependencies]
 re_tracing.workspace = true
+re_uri.workspace = true
 
 crossbeam.workspace = true
 parking_lot.workspace = true

--- a/crates/utils/re_smart_channel/Cargo.toml
+++ b/crates/utils/re_smart_channel/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 
 [dependencies]
 re_tracing.workspace = true
-re_uri = { workspace = true, features = ["serde"] }
+re_uri.workspace = true
 
 crossbeam.workspace = true
 parking_lot.workspace = true

--- a/crates/utils/re_smart_channel/Cargo.toml
+++ b/crates/utils/re_smart_channel/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 
 [dependencies]
 re_tracing.workspace = true
-re_uri.workspace = true
+re_uri = { workspace = true, features = ["serde"] }
 
 crossbeam.workspace = true
 parking_lot.workspace = true

--- a/crates/utils/re_smart_channel/src/lib.rs
+++ b/crates/utils/re_smart_channel/src/lib.rs
@@ -50,7 +50,7 @@ pub enum SmartChannelSource {
     Stdin,
 
     /// The data is streaming in directly from a Rerun Data Platform server, over gRPC.
-    RedapGrpcStream { url: String },
+    RedapGrpcStream(re_uri::RecordingEndpoint),
 
     /// The data is streaming in via a message proxy.
     MessageProxy { url: String },
@@ -60,9 +60,8 @@ impl std::fmt::Display for SmartChannelSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::File(path) => path.display().fmt(f),
-            Self::RrdHttpStream { url, follow: _ }
-            | Self::RedapGrpcStream { url }
-            | Self::MessageProxy { url } => url.fmt(f),
+            Self::RrdHttpStream { url, follow: _ } | Self::MessageProxy { url } => url.fmt(f),
+            Self::RedapGrpcStream(endpoint) => endpoint.fmt(f),
             Self::RrdWebEventListener => "Web event listener".fmt(f),
             Self::JsChannel { channel_name } => write!(f, "Javascript channel: {channel_name}"),
             Self::Sdk => "SDK".fmt(f),
@@ -121,7 +120,7 @@ pub enum SmartMessageSource {
     Stdin,
 
     /// A file on a Rerun Data Platform server, over `rerun://` gRPC interface.
-    RerunGrpcStream { url: String },
+    RedapGrpcStream(re_uri::RecordingEndpoint),
 
     /// A stream of messages over message proxy gRPC interface.
     MessageProxy { url: String },
@@ -132,9 +131,8 @@ impl std::fmt::Display for SmartMessageSource {
         f.write_str(&match self {
             Self::Unknown => "unknown".into(),
             Self::File(path) => format!("file://{}", path.to_string_lossy()),
-            Self::RrdHttpStream { url }
-            | Self::RerunGrpcStream { url }
-            | Self::MessageProxy { url } => url.clone(),
+            Self::RrdHttpStream { url } | Self::MessageProxy { url } => url.clone(),
+            Self::RedapGrpcStream(endpoint) => endpoint.to_string(),
             Self::RrdWebEventCallback => "web_callback".into(),
             Self::JsChannelPush => "javascript".into(),
             Self::Sdk => "sdk".into(),

--- a/crates/utils/re_smart_channel/src/receive_set.rs
+++ b/crates/utils/re_smart_channel/src/receive_set.rs
@@ -53,8 +53,8 @@ impl<T: Send> ReceiveSet<T> {
             // - aren't network sources
             // - don't point at the given `uri`
             SmartChannelSource::RrdHttpStream { url, .. }
-            | SmartChannelSource::RedapGrpcStream { url }
             | SmartChannelSource::MessageProxy { url } => url != uri,
+            SmartChannelSource::RedapGrpcStream(endpoint) => &endpoint.to_string() != uri,
             _ => true,
         });
     }

--- a/crates/utils/re_smart_channel/src/receive_set.rs
+++ b/crates/utils/re_smart_channel/src/receive_set.rs
@@ -54,7 +54,7 @@ impl<T: Send> ReceiveSet<T> {
             // - don't point at the given `uri`
             SmartChannelSource::RrdHttpStream { url, .. }
             | SmartChannelSource::MessageProxy { url } => url != uri,
-            SmartChannelSource::RedapGrpcStream(endpoint) => &endpoint.to_string() != uri,
+            SmartChannelSource::RedapGrpcStream(endpoint) => endpoint.to_string() != uri,
             _ => true,
         });
     }

--- a/crates/utils/re_uri/Cargo.toml
+++ b/crates/utils/re_uri/Cargo.toml
@@ -14,13 +14,10 @@ version.workspace = true
 [lints]
 workspace = true
 
-[features]
-serde = ["dep:serde", "url/serde"]
-
 [dependencies]
 re_log_types.workspace = true
 
 # External
-serde = { workspace = true, optional = true }
+serde.workspace = true
 thiserror.workspace = true
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }

--- a/crates/utils/re_uri/Cargo.toml
+++ b/crates/utils/re_uri/Cargo.toml
@@ -14,10 +14,13 @@ version.workspace = true
 [lints]
 workspace = true
 
+[features]
+serde = ["dep:serde", "url/serde"]
+
 [dependencies]
 re_log_types.workspace = true
 
 # External
-serde.workspace = true
+serde = { workspace = true, optional = true }
 thiserror.workspace = true
-url = { workspace = true, features = ["serde"] }
+url = { workspace = true }

--- a/crates/utils/re_uri/src/endpoints/catalog.rs
+++ b/crates/utils/re_uri/src/endpoints/catalog.rs
@@ -1,6 +1,7 @@
 use crate::Origin;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CatalogEndpoint {
     pub origin: Origin,
 }

--- a/crates/utils/re_uri/src/endpoints/catalog.rs
+++ b/crates/utils/re_uri/src/endpoints/catalog.rs
@@ -1,6 +1,6 @@
 use crate::Origin;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CatalogEndpoint {
     pub origin: Origin,
 }

--- a/crates/utils/re_uri/src/endpoints/catalog.rs
+++ b/crates/utils/re_uri/src/endpoints/catalog.rs
@@ -1,7 +1,6 @@
 use crate::Origin;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CatalogEndpoint {
     pub origin: Origin,
 }

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -1,6 +1,7 @@
 use crate::Origin;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ProxyEndpoint {
     pub origin: Origin,
 }

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -1,7 +1,6 @@
 use crate::Origin;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ProxyEndpoint {
     pub origin: Origin,
 }

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -1,6 +1,6 @@
 use crate::Origin;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ProxyEndpoint {
     pub origin: Origin,
 }

--- a/crates/utils/re_uri/src/endpoints/recording.rs
+++ b/crates/utils/re_uri/src/endpoints/recording.rs
@@ -1,7 +1,6 @@
 use crate::{Origin, TimeRange};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RecordingEndpoint {
     pub origin: Origin,
     pub recording_id: String,

--- a/crates/utils/re_uri/src/endpoints/recording.rs
+++ b/crates/utils/re_uri/src/endpoints/recording.rs
@@ -1,6 +1,7 @@
 use crate::{Origin, TimeRange};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct RecordingEndpoint {
     pub origin: Origin,
     pub recording_id: String,

--- a/crates/utils/re_uri/src/endpoints/recording.rs
+++ b/crates/utils/re_uri/src/endpoints/recording.rs
@@ -1,6 +1,6 @@
 use crate::{Origin, TimeRange};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct RecordingEndpoint {
     pub origin: Origin,
     pub recording_id: String,

--- a/crates/utils/re_uri/src/endpoints/recording.rs
+++ b/crates/utils/re_uri/src/endpoints/recording.rs
@@ -26,6 +26,15 @@ impl RecordingEndpoint {
             time_range,
         }
     }
+
+    /// Returns a [`RecordingEndpoint`] without the optional query part.
+    pub fn without_query(&self) -> std::borrow::Cow<'_, Self> {
+        let mut cow = std::borrow::Cow::Borrowed(self);
+        if self.time_range.is_some() {
+            cow.to_mut().time_range = None;
+        }
+        cow
+    }
 }
 
 impl std::str::FromStr for RecordingEndpoint {

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -227,7 +227,7 @@ impl std::fmt::Display for Origin {
 }
 
 /// Parsed from `rerun://addr:port/recording/12345` or `rerun://addr:port/catalog`
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub enum RedapUri {
     Recording(RecordingEndpoint),
     Catalog(CatalogEndpoint),

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -43,8 +43,7 @@ pub use self::{
     error::Error,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct TimeRange {
     pub timeline: re_log_types::Timeline,
     pub range: re_log_types::ResolvedTimeRangeF,
@@ -102,8 +101,9 @@ impl TryFrom<&str> for TimeRange {
 /// The different schemes supported by Rerun.
 ///
 /// We support `rerun`, `rerun+http`, and `rerun+https`.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(
+    Debug, PartialEq, Eq, Copy, Clone, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub enum Scheme {
     Rerun,
     RerunHttp,
@@ -164,8 +164,9 @@ impl TryFrom<&str> for Scheme {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct Origin {
     pub scheme: Scheme,
     pub host: url::Host<String>,
@@ -227,7 +228,6 @@ impl std::fmt::Display for Origin {
 
 /// Parsed from `rerun://addr:port/recording/12345` or `rerun://addr:port/catalog`
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RedapUri {
     Recording(RecordingEndpoint),
     Catalog(CatalogEndpoint),

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -43,7 +43,7 @@ pub use self::{
     error::Error,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct TimeRange {
     pub timeline: re_log_types::Timeline,
     pub range: re_log_types::ResolvedTimeRangeF,

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -43,7 +43,8 @@ pub use self::{
     error::Error,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct TimeRange {
     pub timeline: re_log_types::Timeline,
     pub range: re_log_types::ResolvedTimeRangeF,
@@ -101,9 +102,8 @@ impl TryFrom<&str> for TimeRange {
 /// The different schemes supported by Rerun.
 ///
 /// We support `rerun`, `rerun+http`, and `rerun+https`.
-#[derive(
-    Debug, PartialEq, Eq, Copy, Clone, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Scheme {
     Rerun,
     RerunHttp,
@@ -164,9 +164,8 @@ impl TryFrom<&str> for Scheme {
     }
 }
 
-#[derive(
-    Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Origin {
     pub scheme: Scheme,
     pub host: url::Host<String>,
@@ -228,6 +227,7 @@ impl std::fmt::Display for Origin {
 
 /// Parsed from `rerun://addr:port/recording/12345` or `rerun://addr:port/catalog`
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum RedapUri {
     Recording(RecordingEndpoint),
     Catalog(CatalogEndpoint),

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1156,6 +1156,7 @@ impl App {
                 return;
             };
 
+            let time_range_url = endpoint.to_string();
             // %-encode the time range URL, because it's a url-within-a-url.
             // This results in VERY ugly links.
             // TODO(jan): Tweak the asciiset used here.
@@ -1163,7 +1164,7 @@ impl App {
             //            for linking to recordings that isn't a full url and
             //            can actually exist in a query value.
             let url_query = percent_encoding::utf8_percent_encode(
-                &endpoint.to_string(),
+                &time_range_url,
                 percent_encoding::NON_ALPHANUMERIC,
             );
 

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -60,8 +60,8 @@ fn loading_receivers_ui(ctx: &ViewerContext<'_>, rx: &ReceiveSet<LogMsg>, ui: &m
         let string = match source.as_ref() {
             // We only show things we know are very-soon-to-be recordings:
             SmartChannelSource::File(path) => format!("Loading {}…", path.display()),
-            SmartChannelSource::RrdHttpStream { url, .. }
-            | SmartChannelSource::RedapGrpcStream { url } => format!("Loading {url}…"),
+            SmartChannelSource::RrdHttpStream { url, .. } => format!("Loading {url}…"),
+            SmartChannelSource::RedapGrpcStream(endpoint) => format!("Loading {endpoint}…"),
 
             SmartChannelSource::RrdWebEventListener
             | SmartChannelSource::JsChannel { .. }

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -222,9 +222,11 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
             }
             re_smart_channel::SmartChannelSource::Stdin => "Loading stdin…".to_owned(),
             re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. }
-            | re_smart_channel::SmartChannelSource::RedapGrpcStream { url }
             | re_smart_channel::SmartChannelSource::MessageProxy { url } => {
                 format!("Waiting for data on {url}…")
+            }
+            re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
+                format!("Waiting for data on {endpoint}…")
             }
             re_smart_channel::SmartChannelSource::RrdWebEventListener
             | re_smart_channel::SmartChannelSource::JsChannel { .. } => {

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -226,7 +226,7 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
                 format!("Waiting for data on {url}…")
             }
             re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
-                format!("Waiting for data on {endpoint}…")
+                format!("Waiting for data on {}…", endpoint.without_query())
             }
             re_smart_channel::SmartChannelSource::RrdWebEventListener
             | re_smart_channel::SmartChannelSource::JsChannel { .. } => {

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -266,8 +266,8 @@ impl ItemCollection {
                     re_smart_channel::SmartChannelSource::JsChannel { .. } => None,
                     re_smart_channel::SmartChannelSource::Sdk => None,
                     re_smart_channel::SmartChannelSource::Stdin => None,
-                    re_smart_channel::SmartChannelSource::RedapGrpcStream { url } => {
-                        Some((ClipboardTextDesc::Url, url.clone()))
+                    re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
+                        Some((ClipboardTextDesc::Url, endpoint.to_string()))
                     }
                     re_smart_channel::SmartChannelSource::MessageProxy { url } => {
                         Some((ClipboardTextDesc::Url, url.clone()))

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -726,8 +726,10 @@ impl StoreHub {
             // - aren't network sources
             // - don't point at the given `uri`
             match data_source {
-                re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. }
-                | re_smart_channel::SmartChannelSource::RedapGrpcStream { url } => url != uri,
+                re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
+                re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
+                    &endpoint.to_string() != uri
+                }
                 _ => true,
             }
         });

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -728,7 +728,7 @@ impl StoreHub {
             match data_source {
                 re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
                 re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
-                    &endpoint.to_string() != uri
+                    endpoint.to_string() != uri
                 }
                 _ => true,
             }


### PR DESCRIPTION
### Related
This in preparation for https://github.com/rerun-io/dataplatform/issues/396

### What

Changes `SmartMessageSource::RedapGrpcStream` to hold a RecordingEndpoint, which should make it more typesafe and convenient to use. This also allowed me to clean up the `CopyTimeRangeLink` implementation by using the `RecordingEndpoint` to format the url instead of doing it manually.