### PR TITLE
manifest registry service spec update: make partition id a string type

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -89,7 +89,7 @@ message UnregisterPartitionsRequest {
   rerun.common.v1alpha1.DatasetHandle entry = 1;
 
   // Partitions to remove
-  repeated rerun.common.v1alpha1.Tuid partition_ids = 2;
+  repeated string partition_ids = 2;
 
   // What to do if partition is not found
   rerun.common.v1alpha1.IfMissingBehavior on_unknown_partition = 3;
@@ -119,7 +119,7 @@ message CreatePartitionManifestsRequest {
 
   // Create manifest for specific partitions. All will be
   // created if left unspecified (empty list)
-  repeated rerun.common.v1alpha1.Tuid partition_ids = 2;
+  repeated string partition_ids = 2;
 
   // Define what happens if create is called multiple times for the same
   // Dataset / partitions
@@ -136,7 +136,7 @@ message QueryDatasetRequest {
 
   // Client can specify what partitions are queried. If left unspecified (empty list),
   // all partitions will be queried.
-  repeated rerun.common.v1alpha1.Tuid partition_ids = 2;
+  repeated string partition_ids = 2;
 
   // Client can specify specific chunk ids to include. If left unspecified (empty list),
   // all chunks that match other query parameters will be included.
@@ -201,7 +201,7 @@ message FetchPartitionRequest {
   rerun.common.v1alpha1.DatasetHandle entry = 1;
 
   // Partition for which we want to get chunks
-  rerun.common.v1alpha1.Tuid partition_id = 2;
+  string partition_id = 2;
 }
 
 message FetchPartitionResponse {
@@ -215,7 +215,7 @@ message GetChunksRequest {
 
   // Client can specify from which partitions to get chunks. If left unspecified (empty list),
   // data from all partition (that match other query parameters) will be included.
-  repeated rerun.common.v1alpha1.Tuid partition_ids = 2;
+  repeated string partition_ids = 2;
 
   // Client can specify chunk ids to include. If left unspecified (empty list),
   // all chunks (that match other query parameters) will be included.
@@ -235,7 +235,7 @@ message CreatePartitionIndexesRequest {
 
   // List of specific partitions that will be indexes.
   // All partitions will be indexed if left unspecified (empty list)
-  repeated rerun.common.v1alpha1.Tuid partition_ids = 2;
+  repeated string partition_ids = 2;
 
   // what kind of index do we want to create and what are
   // its index specific properties

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -64,8 +64,8 @@ pub struct UnregisterPartitionsRequest {
     #[prost(message, optional, tag = "1")]
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
     /// Partitions to remove
-    #[prost(message, repeated, tag = "2")]
-    pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::Tuid>,
+    #[prost(string, repeated, tag = "2")]
+    pub partition_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// What to do if partition is not found
     #[prost(
         enumeration = "super::super::common::v1alpha1::IfMissingBehavior",
@@ -141,8 +141,8 @@ pub struct CreatePartitionManifestsRequest {
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
     /// Create manifest for specific partitions. All will be
     /// created if left unspecified (empty list)
-    #[prost(message, repeated, tag = "2")]
-    pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::Tuid>,
+    #[prost(string, repeated, tag = "2")]
+    pub partition_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Define what happens if create is called multiple times for the same
     /// Dataset / partitions
     #[prost(enumeration = "IfDuplicateBehavior", tag = "3")]
@@ -180,8 +180,8 @@ pub struct QueryDatasetRequest {
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
     /// Client can specify what partitions are queried. If left unspecified (empty list),
     /// all partitions will be queried.
-    #[prost(message, repeated, tag = "2")]
-    pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::Tuid>,
+    #[prost(string, repeated, tag = "2")]
+    pub partition_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Client can specify specific chunk ids to include. If left unspecified (empty list),
     /// all chunks that match other query parameters will be included.
     #[prost(message, repeated, tag = "3")]
@@ -289,8 +289,8 @@ pub struct FetchPartitionRequest {
     #[prost(message, optional, tag = "1")]
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
     /// Partition for which we want to get chunks
-    #[prost(message, optional, tag = "2")]
-    pub partition_id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    #[prost(string, tag = "2")]
+    pub partition_id: ::prost::alloc::string::String,
 }
 impl ::prost::Name for FetchPartitionRequest {
     const NAME: &'static str = "FetchPartitionRequest";
@@ -325,8 +325,8 @@ pub struct GetChunksRequest {
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
     /// Client can specify from which partitions to get chunks. If left unspecified (empty list),
     /// data from all partition (that match other query parameters) will be included.
-    #[prost(message, repeated, tag = "2")]
-    pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::Tuid>,
+    #[prost(string, repeated, tag = "2")]
+    pub partition_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Client can specify chunk ids to include. If left unspecified (empty list),
     /// all chunks (that match other query parameters) will be included.
     #[prost(message, repeated, tag = "3")]
@@ -367,8 +367,8 @@ pub struct CreatePartitionIndexesRequest {
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
     /// List of specific partitions that will be indexes.
     /// All partitions will be indexed if left unspecified (empty list)
-    #[prost(message, repeated, tag = "2")]
-    pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::Tuid>,
+    #[prost(string, repeated, tag = "2")]
+    pub partition_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// what kind of index do we want to create and what are
     /// its index specific properties
     #[prost(message, optional, tag = "3")]


### PR DESCRIPTION
### What

Partition ids can be user defined fields (episode id, recording id, etc). For simplicity we now represents  in the manifest registry service with a  simple string type.  What actual field and type defines the partition id will most likely be defined as part of creating the ``Dataset``. 

This will also simplify the initial integration with ``rrd`` and the ``StoreId::id()``. 

We might revisit how we represent and deal with the partition ids e2e, but it will be simpler to do that as concrete cases and client integration comes along. 