### PR TITLE
Settle for microsecond precision in test

### DIFF
--- a/crates/store/re_log_types/src/index/time_type.rs
+++ b/crates/store/re_log_types/src/index/time_type.rs
@@ -159,9 +159,7 @@ impl TimeType {
                 // If the timezone is empty/None, it means we don't know the epoch.
                 // But we will assume it's UTC anyway.
                 if timezone.as_ref().is_none_or(|tz| tz.is_empty()) {
-                    re_log::debug_once!(
-                        "Got arrow timestamp array with unknown timezone. Assuming UTC"
-                    );
+                    // TODO(#9310): warn when timezone is missing
                 } else {
                     // Regardless of the timezone, that actual values are in UTC (per arrow standard)
                     // The timezone is mostly a hint on how to _display_ the time, and we currently ignore that.

--- a/docs/snippets/all/concepts/indices.cpp
+++ b/docs/snippets/all/concepts/indices.cpp
@@ -9,7 +9,7 @@ int main() {
     rec.set_time_sequence("frame_nr", 42);
     rec.set_time_duration_secs("elapsed", 12.0);
     rec.set_time_timestamp_seconds_since_epoch("time", 1'741'017'564);
-    rec.set_time_timestamp_nanos_since_epoch("precise_time", 1'741'017'564'987'654'321);
+    rec.set_time_timestamp_nanos_since_epoch("precise_time", 1'741'017'564'987'654'000);
 
     // All following logged data will be timestamped with the above times:
     rec.log("points", rerun::Points2D({{0.0, 0.0}, {1.0, 1.0}}));

--- a/docs/snippets/all/concepts/indices.py
+++ b/docs/snippets/all/concepts/indices.py
@@ -11,7 +11,7 @@ rr.set_time("frame_nr", sequence=42)
 rr.set_time("elapsed", duration=12)  # elapsed seconds
 rr.set_time("time", timestamp=1_741_017_564)  # Seconds since unix epoch
 rr.set_time("time", timestamp=datetime.fromisoformat("2025-03-03T15:59:24"))
-rr.set_time("precise_time", timestamp=np.datetime64(1_741_017_564_987_654_321, "ns"))  # Nanoseconds since unix epoch
+rr.set_time("precise_time", timestamp=np.datetime64(1_741_017_564_987_654_000, "ns"))  # Nanoseconds since unix epoch
 
 # All following logged data will be timestamped with the above times:
 rr.log("points", rr.Points2D([[0, 0], [1, 1]]))

--- a/docs/snippets/all/concepts/indices.rs
+++ b/docs/snippets/all/concepts/indices.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rec.set_time(
         "precise_time",
         std::time::SystemTime::UNIX_EPOCH
-            + std::time::Duration::from_nanos(1_741_017_564_987_654_321),
+            + std::time::Duration::from_nanos(1_741_017_564_987_654_000),
     );
 
     // All following logged data will be timestamped with the above times:


### PR DESCRIPTION
This is because Rust's `SystemTime` has system-dependant accuracy:

https://doc.rust-lang.org/stable/std/time/struct.SystemTime.html#platform-specific-behavior
