### PR TITLE
Snippet index links should be correct by design

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -68,6 +68,7 @@ exclude_path = [
   "scripts/screenshot_compare/assets/templates/",
   "crates/viewer/re_viewer/src/reflection/mod.rs", # Checker struggles how links from examples are escaped here. They are all checked elsewhere, so not an issue.
   "crates/utils/re_uri/src/lib.rs",                # Contains some malformed URLs, but they are not actual links.
+  "docs/snippets/INDEX.md",                        # The snippet index is guaranteed should be correct by design.
 ]
 # Exclude URLs and mail addresses from checking (supports regex).
 exclude = [
@@ -156,17 +157,4 @@ exclude = [
   'https://anaconda.org/conda-forge/arrow-cpp',
 
   # '^file:///',                                  # Ignore local file links. They need to be tested, but it's useful for external links we have to ping.
-
-  # Snippets that haven't been released yet.
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/arrows3d_column_updates.cpp",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/arrows3d_column_updates.py",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/arrows3d_column_updates.rs",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/arrows3d_row_updates.cpp",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/arrows3d_row_updates.py",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/arrows3d_row_updates.rs",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/concepts/recording_properties.cpp",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/concepts/recording_properties.py",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/concepts/recording_properties.rs",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/arrows3d_column_updates.py",
-  "https://github.com/rerun-io/rerun/blob/main/docs/snippets/all/archetypes/entity_behavior.py",
 ]


### PR DESCRIPTION
### Related

Deals with CI failures.

### What

As per @teh-cmc and @Wumpf the `docs/snippets/INDEX.md` should be safe by design. I'm not going to question them 😝.
