### PR TITLE
Enable scalar arrays per time point for scatter plots

### DIFF
--- a/crates/viewer/re_view/src/lib.rs
+++ b/crates/viewer/re_view/src/lib.rs
@@ -28,7 +28,8 @@ pub use query::{
     latest_at_with_blueprint_resolved_data, range_with_blueprint_resolved_data, DataResultQuery,
 };
 pub use results_ext::{
-    HybridLatestAtResults, HybridResults, HybridResultsChunkIter, RangeResultsExt,
+    HybridLatestAtResults, HybridRangeResults, HybridResults, HybridResultsChunkIter,
+    RangeResultsExt,
 };
 pub use view_property_ui::{
     view_property_component_ui, view_property_component_ui_custom, view_property_ui,

--- a/crates/viewer/re_view_time_series/Cargo.toml
+++ b/crates/viewer/re_view_time_series/Cargo.toml
@@ -21,14 +21,14 @@ all-features = true
 [dependencies]
 re_chunk_store.workspace = true
 re_format.workspace = true
-re_log.workspace = true
 re_log_types.workspace = true
+re_log.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
-re_view.workspace = true
 re_tracing.workspace = true
 re_types = { workspace = true, features = ["egui_plot"] }
 re_ui.workspace = true
+re_view.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 

--- a/crates/viewer/re_view_time_series/src/lib.rs
+++ b/crates/viewer/re_view_time_series/src/lib.rs
@@ -8,6 +8,7 @@
 mod aggregation;
 mod line_visualizer_system;
 mod point_visualizer_system;
+mod series_query;
 mod util;
 mod view_class;
 

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -10,14 +10,18 @@ use re_types::{
     components::{Color, Name, Scalar, StrokeWidth},
     Archetype as _, Component as _, Loggable as _,
 };
-use re_view::{clamped_or_nothing, range_with_blueprint_resolved_data};
+use re_view::{clamped_or_nothing, range_with_blueprint_resolved_data, RangeResultsExt as _};
 use re_viewer_context::external::re_entity_db::InstancePath;
 use re_viewer_context::{
-    auto_color_egui, auto_color_for_entity_path, IdentifiedViewSystem, QueryContext,
-    TypedComponentFallbackProvider, ViewContext, ViewQuery, ViewStateExt as _,
-    ViewSystemExecutionError, VisualizerQueryInfo, VisualizerSystem,
+    auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, TypedComponentFallbackProvider,
+    ViewContext, ViewQuery, ViewStateExt as _, ViewSystemExecutionError, VisualizerQueryInfo,
+    VisualizerSystem,
 };
 
+use crate::series_query::{
+    all_scalars_indices, allocate_plot_points, collect_colors, collect_scalars,
+    collect_series_name, collect_series_visibility, determine_num_series,
+};
 use crate::util::{determine_time_per_pixel, determine_time_range, points_to_series};
 use crate::view_class::TimeSeriesViewState;
 use crate::{PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind};
@@ -181,8 +185,6 @@ impl SeriesLineSystem {
         let fallback_color: Color = self.fallback_for(&query_ctx);
         let fallback_stroke_width: StrokeWidth = self.fallback_for(&query_ctx);
 
-        let mut points_per_series;
-
         let time_offset = ctx
             .view_state
             .downcast_ref::<TimeSeriesViewState>()
@@ -220,275 +222,30 @@ impl SeriesLineSystem {
                 return;
             };
 
-            let all_scalars_indices = || {
-                all_scalar_chunks
-                    .iter()
-                    .flat_map(|chunk| {
-                        chunk.iter_component_indices(query.timeline(), &Scalar::name())
-                    })
-                    // That is just so we can satisfy the `range_zip` contract later on.
-                    .map(|index| (index, ()))
+            // All the default values for a `PlotPoint`, accounting for both overrides and default values.
+            let default_point = PlotPoint {
+                time: 0,
+                value: 0.0,
+                attrs: PlotPointAttrs {
+                    color: fallback_color.into(),
+                    radius_ui: 0.5 * *fallback_stroke_width.0,
+                    kind: PlotSeriesKind::Continuous,
+                },
             };
 
-            // Determine how many lines we have.
-            // TODO(andreas): We should determine this only once and cache the result.
-            // As data comes in we can validate that the number of series is consistent.
-            // Keep in mind clears here.
-            let num_series = all_scalar_chunks
-                .iter()
-                .find_map(|chunk| {
-                    chunk
-                        .iter_slices::<f64>(Scalar::name())
-                        .find_map(|slice| (!slice.is_empty()).then_some(slice.len()))
-                })
-                .unwrap_or(1);
+            let num_series = determine_num_series(&all_scalar_chunks);
+            let mut points_per_series =
+                allocate_plot_points(&query, &default_point, &all_scalar_chunks, num_series);
 
-            // Determine per-series visibility flags.
-            let mut series_visibility_flags: Vec<bool> = results
-                .iter_as(*query.timeline(), SeriesVisible::name())
-                .slice::<bool>()
-                .next()
-                .map_or(Vec::new(), |(_, visible)| visible.iter().collect_vec());
-            series_visibility_flags.resize(num_series, true);
-
-            // Allocate all points.
-            {
-                re_tracing::profile_scope!("alloc");
-
-                // All the default values for a `PlotPoint`, accounting for both overrides and default values.
-                let default_point = PlotPoint {
-                    time: 0,
-                    value: 0.0,
-                    attrs: PlotPointAttrs {
-                        color: fallback_color.into(),
-                        radius_ui: 0.5 * *fallback_stroke_width.0,
-                        kind: PlotSeriesKind::Continuous,
-                    },
-                };
-
-                let points = all_scalar_chunks
-                    .iter()
-                    .flat_map(|chunk| {
-                        chunk.iter_component_indices(query.timeline(), &Scalar::name())
-                    })
-                    .map(|(data_time, _)| {
-                        debug_assert_eq!(Scalar::arrow_datatype(), ArrowDatatype::Float64);
-
-                        PlotPoint {
-                            time: data_time.as_i64(),
-                            ..default_point.clone()
-                        }
-                    })
-                    .collect_vec();
-                points_per_series = vec![points; num_series];
-            }
-
-            // Fill in values.
-            {
-                re_tracing::profile_scope!("fill values");
-
-                debug_assert_eq!(Scalar::arrow_datatype(), ArrowDatatype::Float64);
-
-                if num_series == 1 {
-                    let points = &mut points_per_series[0];
-                    all_scalar_chunks
-                        .iter()
-                        .flat_map(|chunk| chunk.iter_slices::<f64>(Scalar::name()))
-                        .enumerate()
-                        .for_each(|(i, values)| {
-                            if let Some(value) = values.first() {
-                                points[i].value = *value;
-                            } else {
-                                points[i].attrs.kind = PlotSeriesKind::Clear;
-                            }
-                        });
-                } else {
-                    all_scalar_chunks
-                        .iter()
-                        .flat_map(|chunk| chunk.iter_slices::<f64>(Scalar::name()))
-                        .enumerate()
-                        .for_each(|(i, values)| {
-                            for (points, value) in points_per_series.iter_mut().zip(values) {
-                                points[i].value = *value;
-                            }
-                            for points in points_per_series.iter_mut().skip(values.len()) {
-                                points[i].attrs.kind = PlotSeriesKind::Clear;
-                            }
-                        });
-                }
-            }
-
-            // Fill in colors.
-            {
-                re_tracing::profile_scope!("fill colors");
-
-                debug_assert_eq!(Color::arrow_datatype(), ArrowDatatype::UInt32);
-
-                fn map_raw_color(raw: &u32) -> re_renderer::Color32 {
-                    let [a, b, g, r] = raw.to_le_bytes();
-                    re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
-                }
-
-                let all_color_chunks = results.get_optional_chunks(&Color::name());
-                if all_color_chunks.len() == 1 && all_color_chunks[0].is_static() {
-                    re_tracing::profile_scope!("override/default fast path");
-
-                    if let Some(colors) =
-                        all_color_chunks[0].iter_slices::<u32>(Color::name()).next()
-                    {
-                        for (points, color) in points_per_series
-                            .iter_mut()
-                            .zip(clamped_or_nothing(colors, num_series))
-                        {
-                            let color = map_raw_color(color);
-                            for point in points {
-                                point.attrs.color = color;
-                            }
-                        }
-                    }
-                } else if all_color_chunks.is_empty() {
-                    if num_series > 1 {
-                        re_tracing::profile_scope!("default color for multiple series");
-
-                        // Have to fill in additional default colors.
-                        // TODO(andreas): Could they somehow be provided by the fallback provider?
-                        // It's tricky since the fallback provider doesn't know how many colors to produce!
-                        for (i, points) in points_per_series.iter_mut().skip(1).enumerate() {
-                            // Normally we generate colors from entity names, but getting the display label needs extra processing,
-                            // and it's nice to not care about that here.
-                            let fallback_color = auto_color_egui(
-                                (re_log_types::hash::Hash64::hash((entity_path, i)).hash64()
-                                    % u16::MAX as u64) as u16,
-                            );
-                            for point in points {
-                                point.attrs.color = fallback_color;
-                            }
-                        }
-                    }
-                } else {
-                    re_tracing::profile_scope!("standard path");
-
-                    let all_colors = all_color_chunks.iter().flat_map(|chunk| {
-                        itertools::izip!(
-                            chunk.iter_component_indices(query.timeline(), &Color::name()),
-                            chunk.iter_slices::<u32>(Color::name())
-                        )
-                    });
-
-                    let all_frames =
-                        re_query::range_zip_1x1(all_scalars_indices(), all_colors).enumerate();
-
-                    // Simplified path for single series.
-                    if num_series == 1 {
-                        let points = &mut points_per_series[0];
-                        all_frames.for_each(|(i, (_index, _scalars, colors))| {
-                            if let Some(color) = colors.and_then(|c| c.first()) {
-                                points[i].attrs.color = map_raw_color(color);
-                            }
-                        });
-                    } else {
-                        all_frames.for_each(|(i, (_index, _scalars, colors))| {
-                            if let Some(colors) = colors {
-                                for (points, color) in points_per_series
-                                    .iter_mut()
-                                    .zip(clamped_or_nothing(colors, num_series))
-                                {
-                                    points[i].attrs.color = map_raw_color(color);
-                                }
-                            }
-                        });
-                    }
-                }
-            }
-
-            // Fill in stroke widths
-            {
-                re_tracing::profile_scope!("fill stroke widths");
-
-                debug_assert_eq!(StrokeWidth::arrow_datatype(), ArrowDatatype::Float32);
-
-                {
-                    let all_stroke_width_chunks = results.get_optional_chunks(&StrokeWidth::name());
-
-                    if all_stroke_width_chunks.len() == 1 && all_stroke_width_chunks[0].is_static()
-                    {
-                        re_tracing::profile_scope!("override/default fast path");
-
-                        if let Some(stroke_widths) = all_stroke_width_chunks[0]
-                            .iter_slices::<f32>(StrokeWidth::name())
-                            .next()
-                        {
-                            for (points, stroke_width) in points_per_series
-                                .iter_mut()
-                                .zip(clamped_or_nothing(stroke_widths, num_series))
-                            {
-                                for point in points {
-                                    point.attrs.radius_ui = stroke_width * 0.5;
-                                }
-                            }
-                        }
-                    } else {
-                        re_tracing::profile_scope!("standard path");
-
-                        let all_stroke_widths = all_stroke_width_chunks.iter().flat_map(|chunk| {
-                            itertools::izip!(
-                                chunk
-                                    .iter_component_indices(query.timeline(), &StrokeWidth::name()),
-                                chunk.iter_slices::<f32>(StrokeWidth::name())
-                            )
-                        });
-
-                        let all_frames =
-                            re_query::range_zip_1x1(all_scalars_indices(), all_stroke_widths)
-                                .enumerate();
-
-                        // Simplified path for single series.
-                        if num_series == 1 {
-                            let points = &mut points_per_series[0];
-                            all_frames.for_each(|(i, (_index, _scalars, stroke_widths))| {
-                                if let Some(stroke_width) = stroke_widths
-                                    .and_then(|stroke_widths| stroke_widths.first().copied())
-                                {
-                                    points[i].attrs.radius_ui = stroke_width * 0.5;
-                                }
-                            });
-                        } else {
-                            all_frames.for_each(|(i, (_index, _scalars, stroke_widths))| {
-                                if let Some(stroke_widths) = stroke_widths {
-                                    for (points, stroke_width) in points_per_series
-                                        .iter_mut()
-                                        .zip(clamped_or_nothing(stroke_widths, num_series))
-                                    {
-                                        points[i].attrs.radius_ui = stroke_width * 0.5;
-                                    }
-                                }
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Extract the series name
-            let mut series_names: Vec<String> = results
-                .get_optional_chunks(&Name::name())
-                .iter()
-                .find(|chunk| !chunk.is_empty())
-                .and_then(|chunk| chunk.iter_slices::<String>(Name::name()).next())
-                .map(|slice| slice.into_iter().map(|s| s.to_string()).collect())
-                .unwrap_or_default();
-            if series_names.len() < num_series {
-                let fallback_name: String =
-                    TypedComponentFallbackProvider::<Name>::fallback_for(self, &query_ctx)
-                        .to_string();
-                if num_series == 1 {
-                    series_names.push(fallback_name);
-                } else {
-                    // Repeating a name never makes sense, so we fill up the remaining names with made up ones instead.
-                    series_names.extend(
-                        (series_names.len()..num_series).map(|i| format!("{fallback_name}/{i}")),
-                    );
-                }
-            }
+            collect_scalars(&all_scalar_chunks, &mut points_per_series);
+            collect_colors(
+                entity_path,
+                &query,
+                &results,
+                &all_scalar_chunks,
+                &mut points_per_series,
+            );
+            collect_stroke_width(&query, &results, &all_scalar_chunks, &mut points_per_series);
 
             // Now convert the `PlotPoints` into `Vec<PlotSeries>`
             let aggregator = results
@@ -547,11 +304,14 @@ impl SeriesLineSystem {
                 }
             }
 
+            let series_visibility = collect_series_visibility(&query, &results, num_series);
+            let series_names = collect_series_name(self, &query_ctx, &results, num_series);
+
             debug_assert_eq!(points_per_series.len(), series_names.len());
             for (instance, (points, label, visible)) in itertools::izip!(
                 points_per_series.into_iter(),
                 series_names.into_iter(),
-                series_visibility_flags.into_iter()
+                series_visibility.into_iter()
             )
             .enumerate()
             {
@@ -575,6 +335,79 @@ impl SeriesLineSystem {
                     aggregator,
                     all_series,
                 );
+            }
+        }
+    }
+}
+
+fn collect_stroke_width(
+    query: &RangeQuery,
+    results: &re_view::HybridRangeResults<'_>,
+    all_scalar_chunks: &[re_chunk_store::Chunk],
+    points_per_series: &mut smallvec::SmallVec<[Vec<PlotPoint>; 1]>,
+) {
+    re_tracing::profile_function!();
+
+    let num_series = points_per_series.len();
+
+    debug_assert_eq!(StrokeWidth::arrow_datatype(), ArrowDatatype::Float32);
+
+    {
+        let all_stroke_width_chunks = results.get_optional_chunks(&StrokeWidth::name());
+
+        if all_stroke_width_chunks.len() == 1 && all_stroke_width_chunks[0].is_static() {
+            re_tracing::profile_scope!("override/default fast path");
+
+            if let Some(stroke_widths) = all_stroke_width_chunks[0]
+                .iter_slices::<f32>(StrokeWidth::name())
+                .next()
+            {
+                for (points, stroke_width) in points_per_series
+                    .iter_mut()
+                    .zip(clamped_or_nothing(stroke_widths, num_series))
+                {
+                    for point in points {
+                        point.attrs.radius_ui = stroke_width * 0.5;
+                    }
+                }
+            }
+        } else {
+            re_tracing::profile_scope!("standard path");
+
+            let all_stroke_widths = all_stroke_width_chunks.iter().flat_map(|chunk| {
+                itertools::izip!(
+                    chunk.iter_component_indices(query.timeline(), &StrokeWidth::name()),
+                    chunk.iter_slices::<f32>(StrokeWidth::name())
+                )
+            });
+
+            let all_frames = re_query::range_zip_1x1(
+                all_scalars_indices(query, all_scalar_chunks),
+                all_stroke_widths,
+            )
+            .enumerate();
+
+            // Simplified path for single series.
+            if num_series == 1 {
+                let points = &mut *points_per_series[0];
+                all_frames.for_each(|(i, (_index, _scalars, stroke_widths))| {
+                    if let Some(stroke_width) =
+                        stroke_widths.and_then(|stroke_widths| stroke_widths.first().copied())
+                    {
+                        points[i].attrs.radius_ui = stroke_width * 0.5;
+                    }
+                });
+            } else {
+                all_frames.for_each(|(i, (_index, _scalars, stroke_widths))| {
+                    if let Some(stroke_widths) = stroke_widths {
+                        for (points, stroke_width) in points_per_series
+                            .iter_mut()
+                            .zip(clamped_or_nothing(stroke_widths, num_series))
+                        {
+                            points[i].attrs.radius_ui = stroke_width * 0.5;
+                        }
+                    }
+                });
             }
         }
     }

--- a/crates/viewer/re_view_time_series/src/series_query.rs
+++ b/crates/viewer/re_view_time_series/src/series_query.rs
@@ -228,7 +228,7 @@ pub fn collect_series_name(
     series_names
 }
 
-/// Collects radius_ui for the series into pre-allocated plot points.
+/// Collects `radius_ui` for the series into pre-allocated plot points.
 pub fn collect_radius_ui(
     query: &RangeQuery,
     results: &re_view::HybridRangeResults<'_>,

--- a/crates/viewer/re_view_time_series/src/series_query.rs
+++ b/crates/viewer/re_view_time_series/src/series_query.rs
@@ -1,0 +1,242 @@
+//! Shared functionality for querying time series data.
+
+use itertools::Itertools as _;
+
+use re_chunk_store::RangeQuery;
+use re_log_types::{EntityPath, TimeInt};
+use re_types::external::arrow::datatypes::DataType as ArrowDatatype;
+use re_types::{components, Component as _, Loggable as _, RowId};
+use re_view::{clamped_or_nothing, HybridRangeResults, RangeResultsExt as _};
+use re_viewer_context::{auto_color_egui, QueryContext, TypedComponentFallbackProvider};
+
+use crate::{PlotPoint, PlotSeriesKind};
+
+type PlotPointsPerSeries = smallvec::SmallVec<[Vec<PlotPoint>; 1]>;
+
+/// Determines how many series there are in the scalar chunks.
+pub fn determine_num_series(all_scalar_chunks: &[re_chunk_store::Chunk]) -> usize {
+    // TODO(andreas): We should determine this only once and cache the result.
+    // As data comes in we can validate that the number of series is consistent.
+    // Keep in mind clears here.
+    all_scalar_chunks
+        .iter()
+        .find_map(|chunk| {
+            chunk
+                .iter_slices::<f64>(components::Scalar::name())
+                .find_map(|slice| (!slice.is_empty()).then_some(slice.len()))
+        })
+        .unwrap_or(1)
+}
+
+/// Queries the visibility flags for all series in a query.
+pub fn collect_series_visibility(
+    query: &RangeQuery,
+    results: &HybridRangeResults<'_>,
+    num_series: usize,
+) -> Vec<bool> {
+    let mut series_visibility_flags: Vec<bool> = results
+        .iter_as(*query.timeline(), components::SeriesVisible::name())
+        .slice::<bool>()
+        .next()
+        .map_or(Vec::new(), |(_, visible)| visible.iter().collect_vec());
+    series_visibility_flags.resize(num_series, true);
+
+    series_visibility_flags
+}
+
+/// Allocates all points for the series.
+pub fn allocate_plot_points(
+    query: &RangeQuery,
+    default_point: &PlotPoint,
+    all_scalar_chunks: &[re_chunk_store::Chunk],
+    num_series: usize,
+) -> PlotPointsPerSeries {
+    re_tracing::profile_function!();
+
+    // TODO(andreas): skip invisible?
+
+    let points = all_scalar_chunks
+        .iter()
+        .flat_map(|chunk| {
+            chunk.iter_component_indices(query.timeline(), &components::Scalar::name())
+        })
+        .map(|(data_time, _)| PlotPoint {
+            time: data_time.as_i64(),
+            ..default_point.clone()
+        })
+        .collect_vec();
+
+    smallvec::smallvec![points; num_series]
+}
+
+/// Allocates scalars per series into pre-allocated plot points.
+pub fn collect_scalars(
+    all_scalar_chunks: &[re_chunk_store::Chunk],
+    points_per_series: &mut PlotPointsPerSeries,
+) {
+    re_tracing::profile_function!();
+
+    if points_per_series.len() == 1 {
+        let points = &mut *points_per_series[0];
+        all_scalar_chunks
+            .iter()
+            .flat_map(|chunk| chunk.iter_slices::<f64>(components::Scalar::name()))
+            .enumerate()
+            .for_each(|(i, values)| {
+                if let Some(value) = values.first() {
+                    points[i].value = *value;
+                } else {
+                    points[i].attrs.kind = PlotSeriesKind::Clear;
+                }
+            });
+    } else {
+        all_scalar_chunks
+            .iter()
+            .flat_map(|chunk| chunk.iter_slices::<f64>(components::Scalar::name()))
+            .enumerate()
+            .for_each(|(i, values)| {
+                for (points, value) in points_per_series.iter_mut().zip(values) {
+                    points[i].value = *value;
+                }
+                for points in points_per_series.iter_mut().skip(values.len()) {
+                    points[i].attrs.kind = PlotSeriesKind::Clear;
+                }
+            });
+    }
+}
+
+pub fn all_scalars_indices<'a>(
+    query: &'a RangeQuery,
+    all_scalar_chunks: &'a [re_chunk_store::Chunk],
+) -> impl Iterator<Item = ((TimeInt, RowId), ())> + 'a {
+    all_scalar_chunks
+        .iter()
+        .flat_map(|chunk| {
+            chunk.iter_component_indices(query.timeline(), &components::Scalar::name())
+        })
+        // That is just so we can satisfy the `range_zip` contract later on.
+        .map(|index| (index, ()))
+}
+
+/// Collects colors for the series into pre-allocated plot points.
+pub fn collect_colors(
+    entity_path: &EntityPath,
+    query: &RangeQuery,
+    results: &re_view::HybridRangeResults<'_>,
+    all_scalar_chunks: &[re_chunk_store::Chunk],
+    points_per_series: &mut smallvec::SmallVec<[Vec<PlotPoint>; 1]>,
+) {
+    re_tracing::profile_function!();
+
+    let num_series = points_per_series.len();
+
+    debug_assert_eq!(components::Color::arrow_datatype(), ArrowDatatype::UInt32);
+
+    fn map_raw_color(raw: &u32) -> re_renderer::Color32 {
+        let [a, b, g, r] = raw.to_le_bytes();
+        re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
+    }
+    let all_color_chunks = results.get_optional_chunks(&components::Color::name());
+    if all_color_chunks.len() == 1 && all_color_chunks[0].is_static() {
+        re_tracing::profile_scope!("override/default fast path");
+
+        if let Some(colors) = all_color_chunks[0]
+            .iter_slices::<u32>(components::Color::name())
+            .next()
+        {
+            for (points, color) in points_per_series
+                .iter_mut()
+                .zip(clamped_or_nothing(colors, num_series))
+            {
+                let color = map_raw_color(color);
+                for point in points {
+                    point.attrs.color = color;
+                }
+            }
+        }
+    } else if all_color_chunks.is_empty() {
+        if num_series > 1 {
+            re_tracing::profile_scope!("default color for multiple series");
+
+            // Have to fill in additional default colors.
+            // TODO(andreas): Could they somehow be provided by the fallback provider?
+            // It's tricky since the fallback provider doesn't know how many colors to produce!
+            for (i, points) in points_per_series.iter_mut().skip(1).enumerate() {
+                // Normally we generate colors from entity names, but getting the display label needs extra processing,
+                // and it's nice to not care about that here.
+                let fallback_color = auto_color_egui(
+                    (re_log_types::hash::Hash64::hash((entity_path, i)).hash64() % u16::MAX as u64)
+                        as u16,
+                );
+                for point in points {
+                    point.attrs.color = fallback_color;
+                }
+            }
+        }
+    } else {
+        re_tracing::profile_scope!("standard path");
+
+        let all_colors = all_color_chunks.iter().flat_map(|chunk| {
+            itertools::izip!(
+                chunk.iter_component_indices(query.timeline(), &components::Color::name()),
+                chunk.iter_slices::<u32>(components::Color::name())
+            )
+        });
+
+        let all_frames =
+            re_query::range_zip_1x1(all_scalars_indices(query, all_scalar_chunks), all_colors)
+                .enumerate();
+
+        // Simplified path for single series.
+        if num_series == 1 {
+            let points = &mut *points_per_series[0];
+            all_frames.for_each(|(i, (_index, _scalars, colors))| {
+                if let Some(color) = colors.and_then(|c| c.first()) {
+                    points[i].attrs.color = map_raw_color(color);
+                }
+            });
+        } else {
+            all_frames.for_each(|(i, (_index, _scalars, colors))| {
+                if let Some(colors) = colors {
+                    for (points, color) in points_per_series
+                        .iter_mut()
+                        .zip(clamped_or_nothing(colors, num_series))
+                    {
+                        points[i].attrs.color = map_raw_color(color);
+                    }
+                }
+            });
+        }
+    }
+}
+
+/// Collects series names for the series into pre-allocated plot points.
+pub fn collect_series_name(
+    fallback_provider: &dyn TypedComponentFallbackProvider<components::Name>,
+    query_ctx: &QueryContext<'_>,
+    results: &re_view::HybridRangeResults<'_>,
+    num_series: usize,
+) -> Vec<String> {
+    re_tracing::profile_function!();
+
+    let mut series_names: Vec<String> = results
+        .get_optional_chunks(&components::Name::name())
+        .iter()
+        .find(|chunk| !chunk.is_empty())
+        .and_then(|chunk| chunk.iter_slices::<String>(components::Name::name()).next())
+        .map(|slice| slice.into_iter().map(|s| s.to_string()).collect())
+        .unwrap_or_default();
+
+    if series_names.len() < num_series {
+        let fallback_name: String = fallback_provider.fallback_for(query_ctx).to_string();
+        if num_series == 1 {
+            series_names.push(fallback_name);
+        } else {
+            // Repeating a name never makes sense, so we fill up the remaining names with made up ones instead.
+            series_names
+                .extend((series_names.len()..num_series).map(|i| format!("{fallback_name}/{i}")));
+        }
+    }
+
+    series_names
+}

--- a/crates/viewer/re_view_time_series/tests/snapshots/clear_series_points_and_line_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/clear_series_points_and_line_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80b6386cad609a28b5fed071809851a6bc5a2b34ed1383732e95a83615a00972
-size 23312
+oid sha256:1c9a4035b725880d2a1912f5dc915fedcb36d4464c79fc5f4c42d27d6c97a32b
+size 27499

--- a/crates/viewer/re_view_time_series/tests/snapshots/point_properties_multiple_properties_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/point_properties_multiple_properties_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:990f74a62d82f66b6e39c99f77122da8d121b86b82063b2fe7adee03f08d9b21
-size 24675
+oid sha256:03a656316afcb872bbd285aa6b12e97b26acf632a4281f4ec3c204337b0c28a0
+size 31203

--- a/crates/viewer/re_view_time_series/tests/snapshots/point_properties_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/point_properties_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7858b239391ded37fcf3fa8a359eeccda35f5da286823b503c41e5fabc353391
-size 21812
+oid sha256:172781c932f28621084c38b9bac93a265bffc9f27c1d661bb52caf9e097ccba5
+size 37323


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/9020

### What

Works mostly by ripping out a whole bunch of code from the `SeriesLineVisualizer` and re-use it in the `SeriesPointVisualizer`.

![image](https://github.com/user-attachments/assets/67c3fa9d-340d-47ea-804f-95b1f52f00fe)

There's _so much_ that could be improved there and lots of duplication to be avoided. But I refrained falling down that rabbit hole - also I believe the "zipping up" into an array of structs is premature there to begin with, we should rather keep the arrays separate for longer (but without having tried it that's pure speculation whether this would be actually better since we do have to "zip up" things for egui plot eventually, also aggregation can profit from this setup).

Plots have decent image comparison test coverage already - in fact I already had a test for how arrays of scalars interact with point series, see updated images :)