### PR TITLE
Fix visibility flags for series line/point not splatting correctly

### DIFF
--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -187,6 +187,43 @@ fn test_line_properties_impl(multiple_properties: bool, multiple_scalars: bool) 
     );
 }
 
+/// Test the per series visibility setting
+#[test]
+fn test_per_series_visibility() {
+    for (name, visibility) in [
+        ("per_series_visibility_show_second_only", vec![false, true]),
+        ("per_series_visibility_splat_false", vec![false]),
+        ("per_series_visibility_splat_true", vec![true]),
+    ] {
+        let mut test_context = get_test_context();
+
+        test_context.log_entity("plots".into(), |builder| {
+            builder.with_archetype(
+                RowId::new(),
+                TimePoint::default(),
+                &re_types::archetypes::SeriesLine::new().with_visible_series(visibility),
+            )
+        });
+
+        for step in 0..32 {
+            let timepoint = TimePoint::from([(test_context.active_timeline(), step)]);
+            let (scalars, _) = scalars_for_properties_test(step, true);
+            test_context.log_entity("plots".into(), |builder| {
+                builder.with_archetype(RowId::new(), timepoint.clone(), &scalars)
+            });
+        }
+
+        let view_id = setup_blueprint(&mut test_context);
+        run_view_ui_and_save_snapshot(
+            &mut test_context,
+            view_id,
+            name,
+            egui::vec2(300.0, 300.0),
+            0.0,
+        );
+    }
+}
+
 const MARKER_LIST: [re_types::components::MarkerShape; 10] = [
     re_types::components::MarkerShape::Circle,
     re_types::components::MarkerShape::Diamond,

--- a/crates/viewer/re_view_time_series/tests/snapshots/per_series_visibility_show_second_only.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/per_series_visibility_show_second_only.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b360185325b97020e0884cba0b2058b4c28832be0fd15cd413f25829b2b4eed
+size 16762

--- a/crates/viewer/re_view_time_series/tests/snapshots/per_series_visibility_splat_false.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/per_series_visibility_splat_false.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe354478225dce49e76ff12bf5a38a59de76b1d1e2b0a26a834bfbff705010d9
+size 12024

--- a/crates/viewer/re_view_time_series/tests/snapshots/per_series_visibility_splat_true.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/per_series_visibility_splat_true.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14530152143deb7b24c188653acf0182e6849d7ddb394eb332962c532d734b55
+size 22346


### PR DESCRIPTION
### Related

* builds on https://github.com/rerun-io/rerun/pull/9327
* part of https://github.com/rerun-io/rerun/issues/9021

### What

the per series visibility didn't have the usual splatting behavior, making changes in code and ui more confusing than necessary