### PR TITLE
Update pyo3 and bump abi to python 3.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,8 +255,8 @@ prost-build = "0.13.3"
 prost-types = "0.13.3"
 puffin = "0.19.1"
 puffin_http = "0.16"
-pyo3 = "0.23.3"
-pyo3-build-config = "0.23.3"
+pyo3 = "0.24.0"
+pyo3-build-config = "0.24.0"
 quote = "1.0"
 rand = { version = "0.8", default-features = false }
 rand_distr = { version = "0.4", default-features = false }

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -73,7 +73,7 @@ mimalloc = { version = "0.1.43", features = ["local_dynamic_tls"] }
 numpy.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
-pyo3 = { workspace = true, features = ["abi3-py38"] }
+pyo3 = { workspace = true, features = ["abi3-py39"] }
 rand = { workspace = true, features = ["std", "std_rng"] }
 uuid.workspace = true
 

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -50,10 +50,6 @@ rerun = "rerun_cli.__main__:main"
 ######################
 
 [tool.ruff]
-# https://beta.ruff.rs/docs/configuration/
-
-# target-version = "py38"  # inferred from requires-python, see https://beta.ruff.rs/docs/settings/#target-version
-
 # Enable unsafe fixes to allow ruff to apply fixes that may change the behavior of the code.
 # This is needed because otherwise ruff will not be able to trim whitespaces in (codegened) docstrings.
 unsafe-fixes = true


### PR DESCRIPTION
Title. There was one last (??) place where we didn't update our min python 3.9 version.