### PR TITLE
Double clicking plots focuses them now in other panels

### DIFF
--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -556,6 +556,7 @@ impl ViewClass for TimeSeriesView {
             ui.ctx().request_repaint(); // Make sure we get another frame with the reset actually applied.
         } else if new_y_range != y_range {
             scalar_axis.save_blueprint_component(ctx, &new_y_range);
+            ui.ctx().request_repaint(); // Make sure we get another frame with this new range applied.
         }
 
         // Decide if the time cursor should be displayed, and if so where:


### PR DESCRIPTION
Double click on a time series (line or scatter) will now not reset the view but instead perform the viewer's "focus" action - this causes scroll-to in blueprint & streams panels.
Furthermore, since this is now relevant due to multi-scalar per entity, double click selects now the entire entity rather than an instance (similar to double clicking a point cloud point)


https://github.com/user-attachments/assets/da195f8b-4958-4deb-b1a3-4743732cd0b2

