### PR TITLE
Fix rust analyzer in VSCode not running properly on test files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
     // Whether `--workspace` should be passed to `cargo check`. If false, `-p <package>` will be passed instead.
     "rust-analyzer.check.workspace": false,
     "rust-analyzer.cargo.allTargets": true,
-    // --all-features will set the `__ci` feature flag, which stops re_web_viewer_server/build.rs from building the web viewer
+    // --all-features will set the `__ci` feature flag, which stops re_web_viewer_server/build.rs from requiring the web viewer to be built.
     "rust-analyzer.cargo.features": "all",
     // Use a separate target directory for Rust Analyzer so it doesn't prevent cargo/clippy from doing things.
     "rust-analyzer.cargo.targetDir": "target_ra",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,26 +18,10 @@
     "rust-analyzer.cargo.allTargets": true,
     // --all-features will set the `__ci` feature flag, which stops re_web_viewer_server/build.rs from building the web viewer
     "rust-analyzer.cargo.features": "all",
+    // Use a separate target directory for Rust Analyzer so it doesn't prevent cargo/clippy from doing things.
     "rust-analyzer.cargo.targetDir": "target_ra",
-    "rust-analyzer.check.invocationLocation": "workspace",
     "rust-analyzer.check.invocationStrategy": "per_workspace",
-    "rust-analyzer.check.overrideCommand": [
-        "cargo",
-        "clippy",
-        "--message-format=json",
-        // We shouldn't need this, except we do based on my empirical testing.
-        "--target-dir=target_ra",
-    ],
-    "rust-analyzer.cargo.buildScripts.invocationLocation": "workspace",
     "rust-analyzer.cargo.buildScripts.invocationStrategy": "per_workspace",
-    "rust-analyzer.cargo.buildScripts.overrideCommand": [
-        "cargo",
-        "check",
-        "--quiet",
-        "--message-format=json",
-        // We shouldn't need this, except we do based on my empirical testing.
-        "--target-dir=target_ra",
-    ],
     // Our build scripts are generating code.
     // Having Rust Analyzer do this while doing other builds can lead to catastrophic failures.
     // INCLUDING attempts to publish a new release!


### PR DESCRIPTION
Rust analyzer wouldn't check any files in tests directories properly for me and others using VSCode.

Removing the override commands for check (and for build for good measure) fixes the issue for me: local testing showed that explicit target-dir specification there doesn't seem to be necessary (we have a different target dir for rust analyzer so one can run bacon/clippy/builds while rust analyzer is performing checks)

Also I removed the removed `invocationStrategy` options (they no longer had any effect)