### PR TITLE
Fix outdated usage of `rerun::show` in rust getting started guide

### DIFF
--- a/docs/content/getting-started/data-in/rust.md
+++ b/docs/content/getting-started/data-in/rust.md
@@ -373,7 +373,13 @@ let (rec, storage) = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacu
 
 // … log data to `rec` …
 
-rerun::native_viewer::show(storage.take())?;
+// Blocks until the viewer is closed.
+// For more customizations, refer to `re_viewer::run_native_app`.
+rerun::show(
+    // Show has to be called on the main thread.
+    rerun::MainThreadToken::i_promise_i_am_on_the_main_thread(),
+    storage.take(),
+)?;
 ```
 
 The Viewer will block the main thread until it is closed.


### PR DESCRIPTION
was brought up on discord here https://discord.com/channels/1062300748202921994/1352330894827978804/1352331198193729737