### PR TITLE
Fix `duration` conversion in `send_columns`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -97,7 +97,14 @@ class TimeColumn(TimeColumnLike):
             self.times = pa.array(sequence, pa.int64())
         elif duration is not None:
             if isinstance(duration, np.ndarray):
-                self.times = pa.array((1_000_000_000 * duration).astype("timedelta64[ns]"), pa.duration("ns"))
+                if np.issubdtype(duration.dtype, np.timedelta64):
+                    # Already a timedelta array, just ensure it's in nanoseconds
+                    self.times = pa.array(duration.astype("timedelta64[ns]"), pa.duration("ns"))
+                elif np.issubdtype(duration.dtype, np.number):
+                    # Numeric array that needs conversion to nanoseconds
+                    self.times = pa.array((duration * 1e9).astype("timedelta64[ns]"), pa.duration("ns"))
+                else:
+                    raise TypeError(f"Unsupported numpy array dtype: {duration.dtype}")
             else:
                 self.times = pa.array(
                     [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration], pa.duration("ns")

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -97,7 +97,7 @@ class TimeColumn(TimeColumnLike):
             self.times = pa.array(sequence, pa.int64())
         elif duration is not None:
             if isinstance(duration, np.ndarray):
-                self.times = pa.array(duration.astype("timedelta64[s]"), pa.duration("ns"))
+                self.times = pa.array((1_000_000_000 * duration).astype("timedelta64[ns]"), pa.duration("ns"))
             else:
                 self.times = pa.array(
                     [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration], pa.duration("ns")

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -97,7 +97,7 @@ class TimeColumn(TimeColumnLike):
             self.times = pa.array(sequence, pa.int64())
         elif duration is not None:
             if isinstance(duration, np.ndarray):
-                self.times = pa.array(duration.astype("timedelta64[ns]"), pa.duration("ns"))
+                self.times = pa.array(duration.astype("timedelta64[s]"), pa.duration("ns"))
             else:
                 self.times = pa.array(
                     [np.int64(to_nanos(duration)).astype("timedelta64[ns]") for duration in duration], pa.duration("ns")

--- a/rerun_py/tests/unit/test_time_column.py
+++ b/rerun_py/tests/unit/test_time_column.py
@@ -23,6 +23,13 @@ def test_sequence_column(sequence: Iterable[int], expected: pa.Array) -> None:
 
 VALID_DURATION_CASES = [
     ([0, 1, 2, 3], pa.array([0, 1_000_000_000, 2_000_000_000, 3_000_000_000], type=pa.duration("ns"))),
+    (
+        np.arange(10, 15, 1.0),
+        pa.array(
+            [10_000_000_000, 11_000_000_000, 12_000_000_000, 13_000_000_000, 14_000_000_000],
+            type=pa.duration("ns"),
+        ),
+    ),
     ([0.0, 1.5, 2.25, 3.0], pa.array([0, 1_500_000_000, 2_250_000_000, 3_000_000_000], type=pa.duration("ns"))),
     (
         [


### PR DESCRIPTION
### Related

* Bug introduced in #9321 

### What

This fixes a subtle bug introduced in the PR above—the `duration` (in seconds) was not converted properly to nanoseconds.

Should fix some CI problems that we currently have.
