### PR TITLE
fix: re_uri expects Timeline to be serializable

### DIFF
--- a/crates/utils/re_uri/Cargo.toml
+++ b/crates/utils/re_uri/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-re_log_types.workspace = true
+re_log_types = { workspace = true, features = ["serde"] }
 
 # External
 serde.workspace = true


### PR DESCRIPTION
`re_uri` expects `Timeline` to be serializable.

### How to repro 

```
cargo build -p re_uri

error[E0277]: the trait bound `Timeline: Serialize` is not satisfied
    --> crates/utils/re_uri/src/lib.rs:46:45
     |
46   | #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
     |                                             ^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `Timeline`
47   | pub struct TimeRange {
48   |     pub timeline: re_log_types::Timeline,
     |     --- required by a bound introduced by this call

```