### PR TITLE
Move opt-in of recording properties rule to `ViewContent`

### DIFF
--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -81,6 +81,18 @@ impl ViewContents {
     }
 }
 
+fn maybe_add_properties(
+    mut entity_path_filter: ResolvedEntityPathFilter,
+) -> ResolvedEntityPathFilter {
+    if !entity_path_filter.is_anything_in_subtree_included(&EntityPath::properties()) {
+        entity_path_filter.add_rule(
+            RuleEffect::Exclude,
+            ResolvedEntityPathRule::including_subtree(&EntityPath::properties()),
+        );
+    }
+    entity_path_filter
+}
+
 impl ViewContents {
     /// The prefix for entity override paths.
     ///
@@ -101,7 +113,7 @@ impl ViewContents {
         Self {
             view_id,
             view_class_identifier,
-            entity_path_filter,
+            entity_path_filter: maybe_add_properties(entity_path_filter),
             new_entity_path_filter,
         }
     }
@@ -157,7 +169,7 @@ impl ViewContents {
         Self {
             view_id,
             view_class_identifier,
-            entity_path_filter,
+            entity_path_filter: maybe_add_properties(entity_path_filter),
             new_entity_path_filter,
         }
     }


### PR DESCRIPTION
### Related

* Closes #9351 

### What

This moves the opt-in logic for querying recording properties down one level to the `ViewContents`. This should unify our handling of that query in the UI as well as across our different SDKs (dataframe, ...).
