### PR TITLE
Change `DeleteDatasetEntry` to `DeleteEntry` in both the protos and the Python SDK

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
@@ -10,9 +10,11 @@ import "rerun/v1alpha1/common.proto";
 
 service CatalogService {
   rpc FindEntries(FindEntriesRequest) returns (FindEntriesResponse) {}
+  rpc DeleteEntry(DeleteEntryRequest) returns (DeleteEntryResponse) {}
+
   rpc CreateDatasetEntry(CreateDatasetEntryRequest) returns (CreateDatasetEntryResponse) {}
   rpc ReadDatasetEntry(ReadDatasetEntryRequest) returns (ReadDatasetEntryResponse) {}
-  rpc DeleteDatasetEntry(DeleteDatasetEntryRequest) returns (DeleteDatasetEntryResponse) {}
+
 }
 
 // ---------------- Services ------------------
@@ -26,6 +28,15 @@ message FindEntriesRequest {
 message FindEntriesResponse {
   repeated EntryDetails entries = 1;
 }
+
+// DeleteDatasetEntry
+
+message DeleteEntryRequest {
+  rerun.common.v1alpha1.Tuid id = 1;
+}
+
+message DeleteEntryResponse {}
+
 
 // CreateDatasetEntry
 
@@ -47,13 +58,7 @@ message ReadDatasetEntryResponse {
   DatasetEntry dataset = 1;
 }
 
-// DeleteDatasetEntry
 
-message DeleteDatasetEntryRequest {
-  rerun.common.v1alpha1.Tuid id = 1;
-}
-
-message DeleteDatasetEntryResponse {}
 
 // ---------------- Common ------------------
 

--- a/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
@@ -14,7 +14,6 @@ service CatalogService {
 
   rpc CreateDatasetEntry(CreateDatasetEntryRequest) returns (CreateDatasetEntryResponse) {}
   rpc ReadDatasetEntry(ReadDatasetEntryRequest) returns (ReadDatasetEntryResponse) {}
-
 }
 
 // ---------------- Services ------------------
@@ -37,7 +36,6 @@ message DeleteEntryRequest {
 
 message DeleteEntryResponse {}
 
-
 // CreateDatasetEntry
 
 message CreateDatasetEntryRequest {
@@ -57,8 +55,6 @@ message ReadDatasetEntryRequest {
 message ReadDatasetEntryResponse {
   DatasetEntry dataset = 1;
 }
-
-
 
 // ---------------- Common ------------------
 

--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -21,13 +21,11 @@ service FrontendService {
 
   rpc FindEntries(rerun.catalog.v1alpha1.FindEntriesRequest) returns (rerun.catalog.v1alpha1.FindEntriesResponse) {}
 
-  rpc DeleteDatasetEntry(rerun.catalog.v1alpha1.DeleteEntryRequest) returns (rerun.catalog.v1alpha1.DeleteEntryResponse) {}
+  rpc DeleteEntry(rerun.catalog.v1alpha1.DeleteEntryRequest) returns (rerun.catalog.v1alpha1.DeleteEntryResponse) {}
 
   rpc CreateDatasetEntry(rerun.catalog.v1alpha1.CreateDatasetEntryRequest) returns (rerun.catalog.v1alpha1.CreateDatasetEntryResponse) {}
 
   rpc ReadDatasetEntry(rerun.catalog.v1alpha1.ReadDatasetEntryRequest) returns (rerun.catalog.v1alpha1.ReadDatasetEntryResponse) {}
-
-
 
   // --- Manifest Registry ---
   // Automatically handles entry/dataset resolution.

--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -21,11 +21,13 @@ service FrontendService {
 
   rpc FindEntries(rerun.catalog.v1alpha1.FindEntriesRequest) returns (rerun.catalog.v1alpha1.FindEntriesResponse) {}
 
+  rpc DeleteDatasetEntry(rerun.catalog.v1alpha1.DeleteEntryRequest) returns (rerun.catalog.v1alpha1.DeleteEntryResponse) {}
+
   rpc CreateDatasetEntry(rerun.catalog.v1alpha1.CreateDatasetEntryRequest) returns (rerun.catalog.v1alpha1.CreateDatasetEntryResponse) {}
 
   rpc ReadDatasetEntry(rerun.catalog.v1alpha1.ReadDatasetEntryRequest) returns (rerun.catalog.v1alpha1.ReadDatasetEntryResponse) {}
 
-  rpc DeleteDatasetEntry(rerun.catalog.v1alpha1.DeleteDatasetEntryRequest) returns (rerun.catalog.v1alpha1.DeleteDatasetEntryResponse) {}
+
 
   // --- Manifest Registry ---
   // Automatically handles entry/dataset resolution.

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
@@ -29,6 +29,33 @@ impl ::prost::Name for FindEntriesResponse {
         "/rerun.catalog.v1alpha1.FindEntriesResponse".into()
     }
 }
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct DeleteEntryRequest {
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+}
+impl ::prost::Name for DeleteEntryRequest {
+    const NAME: &'static str = "DeleteEntryRequest";
+    const PACKAGE: &'static str = "rerun.catalog.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.catalog.v1alpha1.DeleteEntryRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.catalog.v1alpha1.DeleteEntryRequest".into()
+    }
+}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct DeleteEntryResponse {}
+impl ::prost::Name for DeleteEntryResponse {
+    const NAME: &'static str = "DeleteEntryResponse";
+    const PACKAGE: &'static str = "rerun.catalog.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.catalog.v1alpha1.DeleteEntryResponse".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.catalog.v1alpha1.DeleteEntryResponse".into()
+    }
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateDatasetEntryRequest {
     #[prost(message, optional, tag = "1")]
@@ -87,33 +114,6 @@ impl ::prost::Name for ReadDatasetEntryResponse {
     }
     fn type_url() -> ::prost::alloc::string::String {
         "/rerun.catalog.v1alpha1.ReadDatasetEntryResponse".into()
-    }
-}
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct DeleteDatasetEntryRequest {
-    #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
-}
-impl ::prost::Name for DeleteDatasetEntryRequest {
-    const NAME: &'static str = "DeleteDatasetEntryRequest";
-    const PACKAGE: &'static str = "rerun.catalog.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        "rerun.catalog.v1alpha1.DeleteDatasetEntryRequest".into()
-    }
-    fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.catalog.v1alpha1.DeleteDatasetEntryRequest".into()
-    }
-}
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct DeleteDatasetEntryResponse {}
-impl ::prost::Name for DeleteDatasetEntryResponse {
-    const NAME: &'static str = "DeleteDatasetEntryResponse";
-    const PACKAGE: &'static str = "rerun.catalog.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        "rerun.catalog.v1alpha1.DeleteDatasetEntryResponse".into()
-    }
-    fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.catalog.v1alpha1.DeleteDatasetEntryResponse".into()
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -317,6 +317,25 @@ pub mod catalog_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn delete_entry(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DeleteEntryRequest>,
+        ) -> std::result::Result<tonic::Response<super::DeleteEntryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.catalog.v1alpha1.CatalogService/DeleteEntry",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.catalog.v1alpha1.CatalogService",
+                "DeleteEntry",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn create_dataset_entry(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateDatasetEntryRequest>,
@@ -355,25 +374,6 @@ pub mod catalog_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
-        pub async fn delete_dataset_entry(
-            &mut self,
-            request: impl tonic::IntoRequest<super::DeleteDatasetEntryRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteDatasetEntryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rerun.catalog.v1alpha1.CatalogService/DeleteDatasetEntry",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rerun.catalog.v1alpha1.CatalogService",
-                "DeleteDatasetEntry",
-            ));
-            self.inner.unary(req, path, codec).await
-        }
     }
 }
 /// Generated server implementations.
@@ -393,6 +393,10 @@ pub mod catalog_service_server {
             &self,
             request: tonic::Request<super::FindEntriesRequest>,
         ) -> std::result::Result<tonic::Response<super::FindEntriesResponse>, tonic::Status>;
+        async fn delete_entry(
+            &self,
+            request: tonic::Request<super::DeleteEntryRequest>,
+        ) -> std::result::Result<tonic::Response<super::DeleteEntryResponse>, tonic::Status>;
         async fn create_dataset_entry(
             &self,
             request: tonic::Request<super::CreateDatasetEntryRequest>,
@@ -401,10 +405,6 @@ pub mod catalog_service_server {
             &self,
             request: tonic::Request<super::ReadDatasetEntryRequest>,
         ) -> std::result::Result<tonic::Response<super::ReadDatasetEntryResponse>, tonic::Status>;
-        async fn delete_dataset_entry(
-            &self,
-            request: tonic::Request<super::DeleteDatasetEntryRequest>,
-        ) -> std::result::Result<tonic::Response<super::DeleteDatasetEntryResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct CatalogServiceServer<T> {
@@ -520,6 +520,47 @@ pub mod catalog_service_server {
                     };
                     Box::pin(fut)
                 }
+                "/rerun.catalog.v1alpha1.CatalogService/DeleteEntry" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteEntrySvc<T: CatalogService>(pub Arc<T>);
+                    impl<T: CatalogService> tonic::server::UnaryService<super::DeleteEntryRequest>
+                        for DeleteEntrySvc<T>
+                    {
+                        type Response = super::DeleteEntryResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DeleteEntryRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CatalogService>::delete_entry(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = DeleteEntrySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/rerun.catalog.v1alpha1.CatalogService/CreateDatasetEntry" => {
                     #[allow(non_camel_case_types)]
                     struct CreateDatasetEntrySvc<T: CatalogService>(pub Arc<T>);
@@ -589,48 +630,6 @@ pub mod catalog_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ReadDatasetEntrySvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/rerun.catalog.v1alpha1.CatalogService/DeleteDatasetEntry" => {
-                    #[allow(non_camel_case_types)]
-                    struct DeleteDatasetEntrySvc<T: CatalogService>(pub Arc<T>);
-                    impl<T: CatalogService>
-                        tonic::server::UnaryService<super::DeleteDatasetEntryRequest>
-                        for DeleteDatasetEntrySvc<T>
-                    {
-                        type Response = super::DeleteDatasetEntryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::DeleteDatasetEntryRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as CatalogService>::delete_dataset_entry(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = DeleteDatasetEntrySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -166,7 +166,7 @@ pub mod frontend_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
-        pub async fn delete_dataset_entry(
+        pub async fn delete_entry(
             &mut self,
             request: impl tonic::IntoRequest<super::super::super::catalog::v1alpha1::DeleteEntryRequest>,
         ) -> std::result::Result<
@@ -178,12 +178,12 @@ pub mod frontend_service_client {
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/rerun.frontend.v1alpha1.FrontendService/DeleteDatasetEntry",
+                "/rerun.frontend.v1alpha1.FrontendService/DeleteEntry",
             );
             let mut req = request.into_request();
             req.extensions_mut().insert(GrpcMethod::new(
                 "rerun.frontend.v1alpha1.FrontendService",
-                "DeleteDatasetEntry",
+                "DeleteEntry",
             ));
             self.inner.unary(req, path, codec).await
         }
@@ -329,7 +329,7 @@ pub mod frontend_service_server {
             tonic::Response<super::super::super::catalog::v1alpha1::FindEntriesResponse>,
             tonic::Status,
         >;
-        async fn delete_dataset_entry(
+        async fn delete_entry(
             &self,
             request: tonic::Request<super::super::super::catalog::v1alpha1::DeleteEntryRequest>,
         ) -> std::result::Result<
@@ -507,13 +507,13 @@ pub mod frontend_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/rerun.frontend.v1alpha1.FrontendService/DeleteDatasetEntry" => {
+                "/rerun.frontend.v1alpha1.FrontendService/DeleteEntry" => {
                     #[allow(non_camel_case_types)]
-                    struct DeleteDatasetEntrySvc<T: FrontendService>(pub Arc<T>);
+                    struct DeleteEntrySvc<T: FrontendService>(pub Arc<T>);
                     impl<T: FrontendService>
                         tonic::server::UnaryService<
                             super::super::super::catalog::v1alpha1::DeleteEntryRequest,
-                        > for DeleteDatasetEntrySvc<T>
+                        > for DeleteEntrySvc<T>
                     {
                         type Response = super::super::super::catalog::v1alpha1::DeleteEntryResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
@@ -525,7 +525,7 @@ pub mod frontend_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as FrontendService>::delete_dataset_entry(&inner, request).await
+                                <T as FrontendService>::delete_entry(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -536,7 +536,7 @@ pub mod frontend_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = DeleteDatasetEntrySvc(inner);
+                        let method = DeleteEntrySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -166,6 +166,27 @@ pub mod frontend_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn delete_dataset_entry(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::super::catalog::v1alpha1::DeleteEntryRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::catalog::v1alpha1::DeleteEntryResponse>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.frontend.v1alpha1.FrontendService/DeleteDatasetEntry",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.frontend.v1alpha1.FrontendService",
+                "DeleteDatasetEntry",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn create_dataset_entry(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -209,29 +230,6 @@ pub mod frontend_service_client {
             req.extensions_mut().insert(GrpcMethod::new(
                 "rerun.frontend.v1alpha1.FrontendService",
                 "ReadDatasetEntry",
-            ));
-            self.inner.unary(req, path, codec).await
-        }
-        pub async fn delete_dataset_entry(
-            &mut self,
-            request: impl tonic::IntoRequest<
-                super::super::super::catalog::v1alpha1::DeleteDatasetEntryRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::super::super::catalog::v1alpha1::DeleteDatasetEntryResponse>,
-            tonic::Status,
-        > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rerun.frontend.v1alpha1.FrontendService/DeleteDatasetEntry",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rerun.frontend.v1alpha1.FrontendService",
-                "DeleteDatasetEntry",
             ));
             self.inner.unary(req, path, codec).await
         }
@@ -331,6 +329,13 @@ pub mod frontend_service_server {
             tonic::Response<super::super::super::catalog::v1alpha1::FindEntriesResponse>,
             tonic::Status,
         >;
+        async fn delete_dataset_entry(
+            &self,
+            request: tonic::Request<super::super::super::catalog::v1alpha1::DeleteEntryRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::catalog::v1alpha1::DeleteEntryResponse>,
+            tonic::Status,
+        >;
         async fn create_dataset_entry(
             &self,
             request: tonic::Request<
@@ -347,15 +352,6 @@ pub mod frontend_service_server {
             >,
         ) -> std::result::Result<
             tonic::Response<super::super::super::catalog::v1alpha1::ReadDatasetEntryResponse>,
-            tonic::Status,
-        >;
-        async fn delete_dataset_entry(
-            &self,
-            request: tonic::Request<
-                super::super::super::catalog::v1alpha1::DeleteDatasetEntryRequest,
-            >,
-        ) -> std::result::Result<
-            tonic::Response<super::super::super::catalog::v1alpha1::DeleteDatasetEntryResponse>,
             tonic::Status,
         >;
         /// Register new partitions with the Dataset
@@ -511,6 +507,51 @@ pub mod frontend_service_server {
                     };
                     Box::pin(fut)
                 }
+                "/rerun.frontend.v1alpha1.FrontendService/DeleteDatasetEntry" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteDatasetEntrySvc<T: FrontendService>(pub Arc<T>);
+                    impl<T: FrontendService>
+                        tonic::server::UnaryService<
+                            super::super::super::catalog::v1alpha1::DeleteEntryRequest,
+                        > for DeleteDatasetEntrySvc<T>
+                    {
+                        type Response = super::super::super::catalog::v1alpha1::DeleteEntryResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::super::catalog::v1alpha1::DeleteEntryRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as FrontendService>::delete_dataset_entry(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = DeleteDatasetEntrySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/rerun.frontend.v1alpha1.FrontendService/CreateDatasetEntry" => {
                     #[allow(non_camel_case_types)]
                     struct CreateDatasetEntrySvc<T: FrontendService>(pub Arc<T>);
@@ -588,52 +629,6 @@ pub mod frontend_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ReadDatasetEntrySvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/rerun.frontend.v1alpha1.FrontendService/DeleteDatasetEntry" => {
-                    #[allow(non_camel_case_types)]
-                    struct DeleteDatasetEntrySvc<T: FrontendService>(pub Arc<T>);
-                    impl<T: FrontendService>
-                        tonic::server::UnaryService<
-                            super::super::super::catalog::v1alpha1::DeleteDatasetEntryRequest,
-                        > for DeleteDatasetEntrySvc<T>
-                    {
-                        type Response =
-                            super::super::super::catalog::v1alpha1::DeleteDatasetEntryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<
-                                super::super::super::catalog::v1alpha1::DeleteDatasetEntryRequest,
-                            >,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as FrontendService>::delete_dataset_entry(&inner, request).await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = DeleteDatasetEntrySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -58,14 +58,14 @@ impl ConnectionHandle {
         Ok(entries)
     }
 
-    pub fn delete_entry(&mut self, entry_id: Tuid) -> PyResult<()> {
+    pub fn delete_entry(&mut self, py: Python<'_>, entry_id: Tuid) -> PyResult<()> {
         let _response = wait_for_future(
             py,
             self.client.delete_entry(DeleteEntryRequest {
                 id: Some(entry_id.into()),
             }),
         )
-            .map_err(to_py_err)?;
+        .map_err(to_py_err)?;
 
         Ok(())
     }

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -1,4 +1,4 @@
-use pyo3::{pyclass, pymethods, PyRefMut, PyResult, Python};
+use pyo3::{pyclass, pymethods};
 
 use re_protos::common::v1alpha1::DatasetHandle;
 
@@ -11,15 +11,6 @@ pub struct PyDataset {
 
 #[pymethods]
 impl PyDataset {
-    //TODO(ab): this should be a method on PyEntry
-    fn delete(mut self_: PyRefMut<'_, Self>, py: Python<'_>) -> PyResult<()> {
-        let super_ = self_.as_super();
-        let entry_id = super_.id.borrow(py).id;
-        let mut connection = super_.client.borrow_mut(py).connection().clone();
-
-        connection.delete_dataset(py, entry_id)
-    }
-
     #[getter]
     fn manifest_url(&self) -> Option<String> {
         self.dataset_handle.dataset_url.clone()

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -132,4 +132,13 @@ impl PyEntry {
             .updated_at
             .and_then(|t| chrono::DateTime::from_timestamp(t.seconds, t.nanos as u32))
     }
+
+    // ---
+
+    fn delete(&mut self, py: Python<'_>) -> PyResult<()> {
+        let entry_id = self.id.borrow(py).id;
+        let mut connection = self.client.borrow_mut(py).connection().clone();
+
+        py.allow_threads(move || connection.delete_entry(entry_id))
+    }
 }

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -139,6 +139,6 @@ impl PyEntry {
         let entry_id = self.id.borrow(py).id;
         let mut connection = self.client.borrow_mut(py).connection().clone();
 
-        py.allow_threads(move || connection.delete_entry(entry_id))
+        connection.delete_entry(py, entry_id)
     }
 }


### PR DESCRIPTION
### Related

- Fixes #9344
- Sibling https://github.com/rerun-io/dataplatform/pull/444

### What

All entries should be deletable, so it was a mistake to make it specific to dataset in the first place. 