### PR TITLE
Hide excluding `EntityPath::properties` in `ViewContents` UI

### DIFF
--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -525,8 +525,11 @@ fn entity_path_filter_ui(
     let filter_text_id = ui.id().with("filter_text");
 
     let mut filter_string = ui.data_mut(|data| {
-        data.get_temp_mut_or_insert_with::<String>(filter_text_id, || filter.formatted())
-            .clone()
+        data.get_temp_mut_or_insert_with::<String>(filter_text_id, || {
+            // We hide the properties filter by default.
+            filter.formatted_without_properties()
+        })
+        .clone()
     });
 
     let response = ui.add(


### PR DESCRIPTION
### Related

* Closes #9351.
* Supersedes #9362. 

### What

We want to have a unified UI behavior across the UI and our SDKs, which is why the `EntityPath::properties`, which are opt-in in the `ViewContents` should be hidden by default.

It would be nice to have a general `ViewContents` mechanism that is shared between blueprints and dataframe view queries. For now the only shared functionality among all places where we have the concept of `ViewContents` is parsing into `ResolvedEntityPathFilter`.

Because of this, for now I've implemented the opt-in mechanism is implemented on `ResolvedEntityPathFilter`.

Demo:
https://github.com/user-attachments/assets/de57ffbd-1296-47cd-bba0-1fe4f22b07ca

