### PR TITLE
fetch chunk manifest for a Dataset

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -311,6 +311,9 @@ message FetchChunkManifestRequest {
 
   // Chunk manifest is index speicific
   IndexColumn column = 2;
+
+  // Scan parameters
+  rerun.common.v1alpha1.ScanParameters scan_parameters = 3;
 }
 
 message FetchChunkManifestResponse {

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -14,7 +14,8 @@ service ManifestRegistryService {
   // List partitions in the Dataset
   rpc ListPartitions(ListPartitionsRequest) returns (stream ListPartitionsResponse) {}
 
-  // Create manifests for all partitions in the Dataset
+  // Create manifests for all partitions in the Dataset. Partition manifest contains information about
+  // the chunks in the partitions.
   rpc CreatePartitionManifests(CreatePartitionManifestsRequest) returns (CreatePartitionManifestsResponse) {}
 
   // Query Dataset and return a dataframe containing relevant chunk IDs
@@ -28,8 +29,13 @@ service ManifestRegistryService {
   rpc GetChunks(GetChunksRequest) returns (stream GetChunksResponse) {}
 
   // Create index for partitions in the Dataset. Index can be created for all or specific
-  // partitions
+  // partitions. Creating an index will create a new index-specific chunk manifest for the Dataset.
+  // Chunk manifest contains information about individual chunk rows for all chunks containing relevant
+  // index data.
   rpc CreatePartitionIndexes(CreatePartitionIndexesRequest) returns (CreatePartitionIndexesResponse) {}
+
+  // Fetch chunk manifest for a specific index
+  rpc FetchChunkManifest(FetchChunkManifestRequest) returns (stream FetchChunkManifestResponse) {}
 
   // List indexes for the Dataset
   rpc ListPartitionIndexes(ListPartitionIndexesRequest) returns (stream ListPartitionIndexesResponse) {}
@@ -297,6 +303,19 @@ message BTreeIndex {
 
 message CreatePartitionIndexesResponse {
   optional uint64 indexed_rows = 1;
+}
+
+message FetchChunkManifestRequest {
+  // Dataset for which we want to fetch chunk manifest
+  rerun.common.v1alpha1.DatasetHandle entry = 1;
+
+  // Chunk manifest is index speicific
+  IndexColumn column = 2;
+}
+
+message FetchChunkManifestResponse {
+  // Chunk manifest as arrow RecordBatches
+  rerun.common.v1alpha1.DataframePart data = 1;
 }
 
 message ListPartitionIndexesRequest {

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -309,7 +309,7 @@ message FetchChunkManifestRequest {
   // Dataset for which we want to fetch chunk manifest
   rerun.common.v1alpha1.DatasetHandle entry = 1;
 
-  // Chunk manifest is index speicific
+  // Chunk manifest is index specific
   IndexColumn column = 2;
 
   // Scan parameters

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -522,7 +522,7 @@ pub struct FetchChunkManifestRequest {
     /// Dataset for which we want to fetch chunk manifest
     #[prost(message, optional, tag = "1")]
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
-    /// Chunk manifest is index speicific
+    /// Chunk manifest is index specific
     #[prost(message, optional, tag = "2")]
     pub column: ::core::option::Option<IndexColumn>,
     /// Scan parameters

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -525,6 +525,9 @@ pub struct FetchChunkManifestRequest {
     /// Chunk manifest is index speicific
     #[prost(message, optional, tag = "2")]
     pub column: ::core::option::Option<IndexColumn>,
+    /// Scan parameters
+    #[prost(message, optional, tag = "3")]
+    pub scan_parameters: ::core::option::Option<super::super::common::v1alpha1::ScanParameters>,
 }
 impl ::prost::Name for FetchChunkManifestRequest {
     const NAME: &'static str = "FetchChunkManifestRequest";


### PR DESCRIPTION
### What

Add a an API that enables fetching chunk manifest data for a particular Dataset index.  This won't be a publicly exposed API, but it is very useful for developers (both for CLI tools and testing).