### PR TITLE
Rename `EntryType` to `EntryKind`

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
@@ -61,18 +61,18 @@ message ReadDatasetEntryResponse {
 message EntryFilter {
   optional rerun.common.v1alpha1.Tuid id = 1;
   optional string name = 2;
-  optional EntryType entry_type = 3;
+  optional EntryKind entry_kind = 3;
 }
 
 // What type of entry. This has strong implication on which APIs are available for this entry.
-enum EntryType {
+enum EntryKind {
   // Always reserve unspecified as default value
-  ENTRY_TYPE_UNSPECIFIED = 0;
+  ENTRY_KIND_UNSPECIFIED = 0;
   // Order as TYPE, TYPE_VIEW so things stay consistent as we introduce new types.
-  ENTRY_TYPE_DATASET = 1;
-  ENTRY_TYPE_DATASET_VIEW = 2;
-  ENTRY_TYPE_TABLE = 3;
-  ENTRY_TYPE_TABLE_VIEW = 4;
+  ENTRY_KIND_DATASET = 1;
+  ENTRY_KIND_DATASET_VIEW = 2;
+  ENTRY_KIND_TABLE = 3;
+  ENTRY_KIND_TABLE_VIEW = 4;
 }
 
 // Minimal info about an Entry for high-level catalog summary
@@ -84,8 +84,8 @@ message EntryDetails {
   // TODO(jleibs): Define valid name constraints
   optional string name = 2;
 
-  // The type of entry
-  EntryType entry_type = 3;
+  // The kind of entry
+  EntryKind entry_kind = 3;
 
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp updated_at = 5;

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
@@ -122,8 +122,8 @@ pub struct EntryFilter {
     pub id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
     #[prost(string, optional, tag = "2")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(enumeration = "EntryType", optional, tag = "3")]
-    pub entry_type: ::core::option::Option<i32>,
+    #[prost(enumeration = "EntryKind", optional, tag = "3")]
+    pub entry_kind: ::core::option::Option<i32>,
 }
 impl ::prost::Name for EntryFilter {
     const NAME: &'static str = "EntryFilter";
@@ -145,9 +145,9 @@ pub struct EntryDetails {
     /// TODO(jleibs): Define valid name constraints
     #[prost(string, optional, tag = "2")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
-    /// The type of entry
-    #[prost(enumeration = "EntryType", tag = "3")]
-    pub entry_type: i32,
+    /// The kind of entry
+    #[prost(enumeration = "EntryKind", tag = "3")]
+    pub entry_kind: i32,
     #[prost(message, optional, tag = "4")]
     pub created_at: ::core::option::Option<::prost_types::Timestamp>,
     #[prost(message, optional, tag = "5")]
@@ -184,7 +184,7 @@ impl ::prost::Name for DatasetEntry {
 /// What type of entry. This has strong implication on which APIs are available for this entry.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-pub enum EntryType {
+pub enum EntryKind {
     /// Always reserve unspecified as default value
     Unspecified = 0,
     /// Order as TYPE, TYPE_VIEW so things stay consistent as we introduce new types.
@@ -193,28 +193,28 @@ pub enum EntryType {
     Table = 3,
     TableView = 4,
 }
-impl EntryType {
+impl EntryKind {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Self::Unspecified => "ENTRY_TYPE_UNSPECIFIED",
-            Self::Dataset => "ENTRY_TYPE_DATASET",
-            Self::DatasetView => "ENTRY_TYPE_DATASET_VIEW",
-            Self::Table => "ENTRY_TYPE_TABLE",
-            Self::TableView => "ENTRY_TYPE_TABLE_VIEW",
+            Self::Unspecified => "ENTRY_KIND_UNSPECIFIED",
+            Self::Dataset => "ENTRY_KIND_DATASET",
+            Self::DatasetView => "ENTRY_KIND_DATASET_VIEW",
+            Self::Table => "ENTRY_KIND_TABLE",
+            Self::TableView => "ENTRY_KIND_TABLE_VIEW",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "ENTRY_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
-            "ENTRY_TYPE_DATASET" => Some(Self::Dataset),
-            "ENTRY_TYPE_DATASET_VIEW" => Some(Self::DatasetView),
-            "ENTRY_TYPE_TABLE" => Some(Self::Table),
-            "ENTRY_TYPE_TABLE_VIEW" => Some(Self::TableView),
+            "ENTRY_KIND_UNSPECIFIED" => Some(Self::Unspecified),
+            "ENTRY_KIND_DATASET" => Some(Self::Dataset),
+            "ENTRY_KIND_DATASET_VIEW" => Some(Self::DatasetView),
+            "ENTRY_KIND_TABLE" => Some(Self::Table),
+            "ENTRY_KIND_TABLE_VIEW" => Some(Self::TableView),
             _ => None,
         }
     }

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -42,7 +42,7 @@ impl PyCatalogClient {
             EntryFilter {
                 id: None,
                 name: None,
-                entry_type: None,
+                entry_kind: None,
             },
         )?;
 

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -2,7 +2,7 @@ use std::str::FromStr as _;
 
 use pyo3::{exceptions::PyTypeError, pyclass, pymethods, Py, PyErr, PyResult, Python};
 
-use re_protos::catalog::v1alpha1::{EntryDetails, EntryType};
+use re_protos::catalog::v1alpha1::{EntryDetails, EntryKind};
 use re_tuid::Tuid;
 
 use crate::catalog::PyCatalogClient;
@@ -45,7 +45,7 @@ impl From<re_protos::common::v1alpha1::Tuid> for PyEntryId {
 
 #[pyclass(name = "EntryType", eq, eq_int)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum PyEntryType {
+pub enum PyEntryKind {
     #[pyo3(name = "DATASET")]
     Dataset = 1,
     #[pyo3(name = "DATASET_VIEW")]
@@ -57,7 +57,7 @@ pub enum PyEntryType {
 }
 
 #[pymethods]
-impl PyEntryType {
+impl PyEntryKind {
     // This allows for EntryType.DATASET syntax in Python
     #[classattr]
     pub const DATASET: Self = Self::Dataset;
@@ -69,16 +69,16 @@ impl PyEntryType {
     pub const TABLE_VIEW: Self = Self::TableView;
 }
 
-impl TryFrom<EntryType> for PyEntryType {
+impl TryFrom<EntryKind> for PyEntryKind {
     type Error = PyErr;
 
-    fn try_from(value: EntryType) -> Result<Self, Self::Error> {
+    fn try_from(value: EntryKind) -> Result<Self, Self::Error> {
         match value {
-            EntryType::Unspecified => Err(PyTypeError::new_err("EntryType is unspecified")),
-            EntryType::Dataset => Ok(Self::Dataset),
-            EntryType::DatasetView => Ok(Self::DatasetView),
-            EntryType::Table => Ok(Self::Table),
-            EntryType::TableView => Ok(Self::TableView),
+            EntryKind::Unspecified => Err(PyTypeError::new_err("EntryType is unspecified")),
+            EntryKind::Dataset => Ok(Self::Dataset),
+            EntryKind::DatasetView => Ok(Self::DatasetView),
+            EntryKind::Table => Ok(Self::Table),
+            EntryKind::TableView => Ok(Self::TableView),
         }
     }
 }
@@ -112,9 +112,9 @@ impl PyEntry {
     }
 
     #[getter]
-    pub fn entry_type(&self) -> PyResult<PyEntryType> {
+    pub fn kind(&self) -> PyResult<PyEntryKind> {
         //TODO(ab): make this less annoying thanks to a wrapper over grpc messages.
-        EntryType::try_from(self.details.entry_type)
+        EntryKind::try_from(self.details.entry_kind)
             .map_err(|err| PyTypeError::new_err(format!("cannot deserialize EntryType: {err}")))?
             .try_into()
     }

--- a/rerun_py/src/catalog/mod.rs
+++ b/rerun_py/src/catalog/mod.rs
@@ -11,7 +11,7 @@ use pyo3::{prelude::*, Bound, PyResult};
 pub use catalog_client::PyCatalogClient;
 pub use connection_handle::ConnectionHandle;
 pub use dataset::PyDataset;
-pub use entry::{PyEntry, PyEntryId, PyEntryType};
+pub use entry::{PyEntry, PyEntryId, PyEntryKind};
 pub use errors::{to_py_err, MissingGrpcFieldError};
 
 /// Register the `rerun.catalog` module.
@@ -19,7 +19,7 @@ pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
     m.add_class::<PyCatalogClient>()?;
 
     m.add_class::<PyEntryId>()?;
-    m.add_class::<PyEntryType>()?;
+    m.add_class::<PyEntryKind>()?;
     m.add_class::<PyEntry>()?;
 
     m.add_class::<PyDataset>()?;


### PR DESCRIPTION
### Related

- Part of #9360
- Part of #9350
- Sibling https://github.com/rerun-io/dataplatform/pull/455

### What

Title. "Type" is annoying because `type` is usually a reserved keyword.

Note: intentionally breaking grpc compatibility