### PR TITLE
Proto extension industrialization template/demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6403,8 +6403,10 @@ name = "re_protos"
 version = "0.23.0-alpha.1+dev"
 dependencies = [
  "arrow",
+ "jiff",
  "prost",
  "prost-types",
+ "pyo3",
  "re_build_info",
  "re_byte_size",
  "re_log_types",

--- a/crates/store/re_protos/.gitattributes
+++ b/crates/store/re_protos/.gitattributes
@@ -1,2 +1,3 @@
 src/v0/** linguist-generated=true
 src/v1alpha1/** linguist-generated=true
+src/v1alpha1/**/*.ext.rs linguist-generated=false

--- a/crates/store/re_protos/Cargo.toml
+++ b/crates/store/re_protos/Cargo.toml
@@ -12,6 +12,14 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+
+[features]
+default = []
+
+# Enable Python integration with `pyo3`.
+py = ["dep:pyo3"]
+
+
 [dependencies]
 re_build_info.workspace = true
 re_byte_size.workspace = true
@@ -21,8 +29,10 @@ re_tuid.workspace = true
 
 # External
 arrow.workspace = true
-prost.workspace = true
+jiff.workspace = true
 prost-types.workspace = true
+prost.workspace = true
+pyo3 = { workspace = true, optional = true }
 thiserror.workspace = true
 
 # Native dependencies:

--- a/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
@@ -31,7 +31,7 @@ message FindEntriesResponse {
 // DeleteDatasetEntry
 
 message DeleteEntryRequest {
-  rerun.common.v1alpha1.Tuid id = 1;
+  rerun.common.v1alpha1.EntryId id = 1;
 }
 
 message DeleteEntryResponse {}
@@ -49,7 +49,7 @@ message CreateDatasetEntryResponse {
 // ReadDatasetEntry
 
 message ReadDatasetEntryRequest {
-  rerun.common.v1alpha1.Tuid id = 1;
+  rerun.common.v1alpha1.EntryId id = 1;
 }
 
 message ReadDatasetEntryResponse {
@@ -59,7 +59,7 @@ message ReadDatasetEntryResponse {
 // ---------------- Common ------------------
 
 message EntryFilter {
-  optional rerun.common.v1alpha1.Tuid id = 1;
+  optional rerun.common.v1alpha1.EntryId id = 1;
   optional string name = 2;
   optional EntryKind entry_kind = 3;
 }
@@ -68,17 +68,21 @@ message EntryFilter {
 enum EntryKind {
   // Always reserve unspecified as default value
   ENTRY_KIND_UNSPECIFIED = 0;
+
   // Order as TYPE, TYPE_VIEW so things stay consistent as we introduce new types.
   ENTRY_KIND_DATASET = 1;
+
   ENTRY_KIND_DATASET_VIEW = 2;
+
   ENTRY_KIND_TABLE = 3;
+
   ENTRY_KIND_TABLE_VIEW = 4;
 }
 
 // Minimal info about an Entry for high-level catalog summary
 message EntryDetails {
   // The EntryId is immutable
-  rerun.common.v1alpha1.Tuid id = 1;
+  rerun.common.v1alpha1.EntryId id = 1;
 
   // The name is a short human-readable string
   // TODO(jleibs): Define valid name constraints

--- a/crates/store/re_protos/proto/rerun/v1alpha1/common.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/common.proto
@@ -210,10 +210,14 @@ message Tuid {
   optional fixed64 inc = 2;
 }
 
+message EntryId {
+  Tuid id = 1;
+}
+
 // Entry point for all ManifestRegistryService APIs
 message DatasetHandle {
   // Unique entry identifier (for debug purposes)
-  Tuid entry_id = 1;
+  EntryId entry_id = 1;
 
   // Path to Dataset backing storage (e.g. s3://bucket/file or file:///path/to/file)
   optional string dataset_url = 2;

--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -46,7 +46,7 @@ service FrontendService {
 // --- Manifest Registry ---
 
 message RegisterPartitionsRequest {
-  rerun.common.v1alpha1.Tuid dataset_id = 1;
+  rerun.common.v1alpha1.EntryId dataset_id = 1;
 
   // Partitions to add
   repeated rerun.manifest_registry.v1alpha1.Partition partitions = 2;
@@ -56,7 +56,7 @@ message RegisterPartitionsRequest {
 }
 
 message UnregisterPartitionsRequest {
-  rerun.common.v1alpha1.Tuid dataset_id = 1;
+  rerun.common.v1alpha1.EntryId dataset_id = 1;
 
   // Partitions to remove
   repeated rerun.common.v1alpha1.PartitionId partition_ids = 2;
@@ -66,7 +66,7 @@ message UnregisterPartitionsRequest {
 }
 
 message ListPartitionsRequest {
-  rerun.common.v1alpha1.Tuid dataset_id = 1;
+  rerun.common.v1alpha1.EntryId dataset_id = 1;
 
   // Scan parameters
   rerun.common.v1alpha1.ScanParameters scan_parameters = 2;

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.ext.rs
@@ -1,0 +1,109 @@
+use crate::{
+    common::v1alpha1::ext::{DatasetHandle, EntryId},
+    missing_field, TypeConversionError,
+};
+
+// --- EntryDetails ---
+
+pub struct EntryDetails {
+    pub id: EntryId,
+    pub name: String,
+    pub kind: crate::catalog::v1alpha1::EntryKind,
+    pub created_at: jiff::Timestamp,
+    pub updated_at: jiff::Timestamp,
+}
+
+impl TryFrom<crate::catalog::v1alpha1::EntryDetails> for EntryDetails {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::catalog::v1alpha1::EntryDetails) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: value
+                .id
+                .ok_or(missing_field!(crate::catalog::v1alpha1::EntryDetails, "id"))?
+                .try_into()?,
+            name: value.name.ok_or(missing_field!(
+                crate::catalog::v1alpha1::EntryDetails,
+                "name"
+            ))?,
+            kind: value.entry_kind.try_into()?,
+            created_at: {
+                let ts = value.created_at.ok_or(missing_field!(
+                    crate::catalog::v1alpha1::EntryDetails,
+                    "created_at"
+                ))?;
+                jiff::Timestamp::new(ts.seconds, ts.nanos)?
+            },
+            updated_at: {
+                let ts = value.updated_at.ok_or(missing_field!(
+                    crate::catalog::v1alpha1::EntryDetails,
+                    "updated_at"
+                ))?;
+                jiff::Timestamp::new(ts.seconds, ts.nanos)?
+            },
+        })
+    }
+}
+
+impl From<EntryDetails> for crate::catalog::v1alpha1::EntryDetails {
+    fn from(value: EntryDetails) -> Self {
+        Self {
+            id: Some(value.id.into()),
+            name: Some(value.name),
+            entry_kind: value.kind as _,
+            created_at: {
+                let ts = value.created_at;
+                Some(prost_types::Timestamp {
+                    seconds: ts.as_second(),
+                    nanos: ts.subsec_nanosecond(),
+                })
+            },
+            updated_at: {
+                let ts = value.updated_at;
+                Some(prost_types::Timestamp {
+                    seconds: ts.as_second(),
+                    nanos: ts.subsec_nanosecond(),
+                })
+            },
+        }
+    }
+}
+
+// --- DatasetEntry ---
+
+pub struct DatasetEntry {
+    pub details: EntryDetails,
+    pub handle: DatasetHandle,
+}
+
+impl TryFrom<crate::catalog::v1alpha1::DatasetEntry> for DatasetEntry {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::catalog::v1alpha1::DatasetEntry) -> Result<Self, Self::Error> {
+        Ok(Self {
+            details: value
+                .details
+                .ok_or(missing_field!(
+                    crate::catalog::v1alpha1::DatasetEntry,
+                    "details"
+                ))?
+                .try_into()?,
+            handle: value
+                .dataset_handle
+                .ok_or(missing_field!(
+                    crate::catalog::v1alpha1::DatasetEntry,
+                    "handle"
+                ))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<DatasetEntry> for crate::catalog::v1alpha1::DatasetEntry {
+    fn from(value: DatasetEntry) -> Self {
+        Self {
+            details: Some(value.details.into()),
+            dataset_handle: Some(value.handle.into()),
+        }
+    }
+}

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
@@ -32,7 +32,7 @@ impl ::prost::Name for FindEntriesResponse {
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct DeleteEntryRequest {
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    pub id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
 }
 impl ::prost::Name for DeleteEntryRequest {
     const NAME: &'static str = "DeleteEntryRequest";
@@ -89,7 +89,7 @@ impl ::prost::Name for CreateDatasetEntryResponse {
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ReadDatasetEntryRequest {
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    pub id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
 }
 impl ::prost::Name for ReadDatasetEntryRequest {
     const NAME: &'static str = "ReadDatasetEntryRequest";
@@ -119,7 +119,7 @@ impl ::prost::Name for ReadDatasetEntryResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EntryFilter {
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    pub id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
     #[prost(string, optional, tag = "2")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(enumeration = "EntryKind", optional, tag = "3")]
@@ -140,7 +140,7 @@ impl ::prost::Name for EntryFilter {
 pub struct EntryDetails {
     /// The EntryId is immutable
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    pub id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
     /// The name is a short human-readable string
     /// TODO(jleibs): Define valid name constraints
     #[prost(string, optional, tag = "2")]

--- a/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
@@ -4,7 +4,7 @@ use arrow::{datatypes::Schema as ArrowSchema, error::ArrowError};
 
 use crate::{invalid_field, missing_field, TypeConversionError};
 
-// ---
+// --- Arrow ---
 
 impl TryFrom<&crate::common::v1alpha1::Schema> for ArrowSchema {
     type Error = ArrowError;
@@ -23,6 +23,106 @@ impl TryFrom<&ArrowSchema> for crate::common::v1alpha1::Schema {
         Ok(Self {
             arrow_schema: re_sorbet::ipc_from_schema(value)?,
         })
+    }
+}
+
+// --- EntryId ---
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EntryId {
+    pub id: re_tuid::Tuid,
+}
+
+impl EntryId {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            id: re_tuid::Tuid::new(),
+        }
+    }
+}
+
+impl std::fmt::Display for EntryId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.id.fmt(f)
+    }
+}
+
+impl From<EntryId> for crate::common::v1alpha1::EntryId {
+    #[inline]
+    fn from(value: EntryId) -> Self {
+        Self {
+            id: Some(value.id.into()),
+        }
+    }
+}
+
+impl TryFrom<crate::common::v1alpha1::EntryId> for EntryId {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::common::v1alpha1::EntryId) -> Result<Self, Self::Error> {
+        let id = value
+            .id
+            .ok_or(missing_field!(crate::common::v1alpha1::EntryId, "id"))?;
+        Ok(Self { id: id.try_into()? })
+    }
+}
+
+impl From<re_tuid::Tuid> for EntryId {
+    fn from(id: re_tuid::Tuid) -> Self {
+        Self { id }
+    }
+}
+
+// shortcuts
+
+impl From<re_tuid::Tuid> for crate::common::v1alpha1::EntryId {
+    fn from(id: re_tuid::Tuid) -> Self {
+        let id: EntryId = id.into();
+        Self {
+            id: Some(id.id.into()),
+        }
+    }
+}
+
+impl TryFrom<crate::common::v1alpha1::Tuid> for crate::common::v1alpha1::EntryId {
+    type Error = TypeConversionError;
+
+    fn try_from(id: crate::common::v1alpha1::Tuid) -> Result<Self, Self::Error> {
+        let id: re_tuid::Tuid = id.try_into()?;
+        Ok(Self {
+            id: Some(id.into()),
+        })
+    }
+}
+
+// --- DatasetHandle ---
+
+pub struct DatasetHandle {
+    pub id: Option<EntryId>,
+    pub url: String,
+}
+
+impl TryFrom<crate::common::v1alpha1::DatasetHandle> for DatasetHandle {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::common::v1alpha1::DatasetHandle) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: value.entry_id.map(|id| id.try_into()).transpose()?,
+            url: value.dataset_url.ok_or(missing_field!(
+                crate::common::v1alpha1::DatasetHandle,
+                "dataset_url"
+            ))?,
+        })
+    }
+}
+
+impl From<DatasetHandle> for crate::common::v1alpha1::DatasetHandle {
+    fn from(value: DatasetHandle) -> Self {
+        Self {
+            entry_id: value.id.map(Into::into),
+            dataset_url: Some(value.url),
+        }
     }
 }
 

--- a/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.rs
@@ -448,12 +448,27 @@ impl ::prost::Name for Tuid {
         "/rerun.common.v1alpha1.Tuid".into()
     }
 }
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct EntryId {
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<Tuid>,
+}
+impl ::prost::Name for EntryId {
+    const NAME: &'static str = "EntryId";
+    const PACKAGE: &'static str = "rerun.common.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.common.v1alpha1.EntryId".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.common.v1alpha1.EntryId".into()
+    }
+}
 /// Entry point for all ManifestRegistryService APIs
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DatasetHandle {
     /// Unique entry identifier (for debug purposes)
     #[prost(message, optional, tag = "1")]
-    pub entry_id: ::core::option::Option<Tuid>,
+    pub entry_id: ::core::option::Option<EntryId>,
     /// Path to Dataset backing storage (e.g. s3://bucket/file or file:///path/to/file)
     #[prost(string, optional, tag = "2")]
     pub dataset_url: ::core::option::Option<::prost::alloc::string::String>,

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -2,7 +2,7 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterPartitionsRequest {
     #[prost(message, optional, tag = "1")]
-    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
     /// Partitions to add
     #[prost(message, repeated, tag = "2")]
     pub partitions: ::prost::alloc::vec::Vec<super::super::manifest_registry::v1alpha1::Partition>,
@@ -26,7 +26,7 @@ impl ::prost::Name for RegisterPartitionsRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnregisterPartitionsRequest {
     #[prost(message, optional, tag = "1")]
-    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
     /// Partitions to remove
     #[prost(message, repeated, tag = "2")]
     pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::PartitionId>,
@@ -50,7 +50,7 @@ impl ::prost::Name for UnregisterPartitionsRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListPartitionsRequest {
     #[prost(message, optional, tag = "1")]
-    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::Tuid>,
+    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
     /// Scan parameters
     #[prost(message, optional, tag = "2")]
     pub scan_parameters: ::core::option::Option<super::super::common::v1alpha1::ScanParameters>,

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -84,7 +84,7 @@ uuid.workspace = true
 
 # Deps for remote feature
 object_store = { workspace = true, features = ["aws"] }
-re_protos.workspace = true
+re_protos = { workspace = true, features = ["py"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tonic = { workspace = true, default-features = false, features = ["transport"] }

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -1,11 +1,8 @@
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::{pyclass, pymethods, Py, PyResult, Python};
 
-use re_protos::catalog::v1alpha1::{DatasetEntry, EntryDetails, EntryFilter};
+use re_protos::catalog::v1alpha1::EntryFilter;
 
-use crate::catalog::{
-    to_py_err, ConnectionHandle, MissingGrpcFieldError, PyDataset, PyEntry, PyEntryId,
-};
+use crate::catalog::{to_py_err, ConnectionHandle, PyDataset, PyEntry, PyEntryId};
 
 /// A connection to a remote storage node.
 #[pyclass(name = "CatalogClient")]
@@ -49,21 +46,14 @@ impl PyCatalogClient {
         // Generate entry objects.
         entry_details
             .into_iter()
-            .map(|entry| {
-                let entry_id = Py::new(
-                    py,
-                    entry
-                        .id
-                        .ok_or(PyRuntimeError::new_err("No id in entry"))
-                        .and_then(PyEntryId::try_from)?,
-                )?;
-
+            .map(|details| {
+                let id = Py::new(py, PyEntryId::from(details.id))?;
                 Py::new(
                     py,
                     PyEntry {
                         client: self_.clone_ref(py),
-                        id: entry_id,
-                        details: entry,
+                        id,
+                        details,
                     },
                 )
             })
@@ -77,21 +67,15 @@ impl PyCatalogClient {
 
         let dataset_entry = connection.read_dataset(py, entry_id)?;
 
-        let details = dataset_entry
-            .details
-            .ok_or(MissingGrpcFieldError::new_err("No details in entry"))?;
-
-        let dataset_handle = dataset_entry
-            .dataset_handle
-            .ok_or(MissingGrpcFieldError::new_err("No dataset handle in entry"))?;
-
         let entry = PyEntry {
             client,
             id,
-            details,
+            details: dataset_entry.details,
         };
 
-        let dataset = PyDataset { dataset_handle };
+        let dataset = PyDataset {
+            dataset_handle: dataset_entry.handle,
+        };
 
         Py::new(py, (dataset, entry))
     }
@@ -101,43 +85,19 @@ impl PyCatalogClient {
     fn create_dataset(self_: Py<Self>, py: Python<'_>, name: &str) -> PyResult<Py<PyDataset>> {
         let mut connection = self_.borrow_mut(py).connection.clone();
 
-        let response = connection.create_dataset(
-            py,
-            DatasetEntry {
-                details: Some(EntryDetails {
-                    name: Some(name.to_owned()),
-                    ..Default::default()
-                }),
-                dataset_handle: None,
-            },
-        )?;
+        let dataset_entry = connection.create_dataset(py, name.to_owned())?;
 
-        //TODO(ab): proper error management + wrapping in helper objects
-        let entry_details = response
-            .details
-            .ok_or(MissingGrpcFieldError::new_err("No details in response"))?;
-
-        let dataset_handle = response
-            .dataset_handle
-            .ok_or(MissingGrpcFieldError::new_err(
-                "No dataset handle in response",
-            ))?;
-
-        let entry_id = Py::new(
-            py,
-            entry_details
-                .id
-                .ok_or(MissingGrpcFieldError::new_err("No id in entry"))
-                .and_then(PyEntryId::try_from)?,
-        )?;
+        let entry_id = Py::new(py, PyEntryId::from(dataset_entry.details.id))?;
 
         let entry = PyEntry {
             client: self_.clone_ref(py),
             id: entry_id,
-            details: entry_details,
+            details: dataset_entry.details,
         };
 
-        let dataset = PyDataset { dataset_handle };
+        let dataset = PyDataset {
+            dataset_handle: dataset_entry.handle,
+        };
 
         Py::new(py, (dataset, entry))
     }

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -1,6 +1,6 @@
 use pyo3::{pyclass, pymethods};
 
-use re_protos::common::v1alpha1::DatasetHandle;
+use re_protos::common::v1alpha1::ext::DatasetHandle;
 
 use crate::catalog::PyEntry;
 
@@ -12,7 +12,7 @@ pub struct PyDataset {
 #[pymethods]
 impl PyDataset {
     #[getter]
-    fn manifest_url(&self) -> Option<String> {
-        self.dataset_handle.dataset_url.clone()
+    fn manifest_url(&self) -> String {
+        self.dataset_handle.url.clone()
     }
 }

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -124,6 +124,7 @@ impl PyEntry {
     }
 
     #[getter]
+    //TODO(ab): use jiff when updating to pyo3 0.24.0
     pub fn updated_at(&self) -> chrono::DateTime<chrono::Utc> {
         let ts = self.details.updated_at;
         // If the `prost::Timestamp` was legal, then this is also legal.

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -2,8 +2,8 @@ use std::str::FromStr as _;
 
 use pyo3::{exceptions::PyTypeError, pyclass, pymethods, Py, PyErr, PyResult, Python};
 
-use re_protos::catalog::v1alpha1::{EntryDetails, EntryKind};
-use re_tuid::Tuid;
+use re_protos::catalog::v1alpha1::{ext::EntryDetails, EntryKind};
+use re_protos::common::v1alpha1::ext::EntryId;
 
 use crate::catalog::PyCatalogClient;
 
@@ -11,7 +11,7 @@ use crate::catalog::PyCatalogClient;
 #[pyclass(name = "EntryId")]
 #[derive(Clone)]
 pub struct PyEntryId {
-    pub id: Tuid,
+    pub id: EntryId,
 }
 
 #[pymethods]
@@ -19,8 +19,9 @@ impl PyEntryId {
     #[new]
     pub fn new(id: String) -> PyResult<Self> {
         Ok(Self {
-            id: Tuid::from_str(id.as_str())
-                .map_err(|err| PyTypeError::new_err(format!("invalid Tuid: {err}")))?,
+            id: re_tuid::Tuid::from_str(id.as_str())
+                .map_err(|err| PyTypeError::new_err(format!("invalid Tuid: {err}")))?
+                .into(),
         })
     }
 
@@ -29,21 +30,9 @@ impl PyEntryId {
     }
 }
 
-impl From<Tuid> for PyEntryId {
-    fn from(id: Tuid) -> Self {
+impl From<EntryId> for PyEntryId {
+    fn from(id: EntryId) -> Self {
         Self { id }
-    }
-}
-
-impl TryFrom<re_protos::common::v1alpha1::Tuid> for PyEntryId {
-    type Error = pyo3::PyErr;
-
-    fn try_from(value: re_protos::common::v1alpha1::Tuid) -> Result<Self, Self::Error> {
-        Ok(Self {
-            id: value
-                .try_into()
-                .map_err(|err| PyTypeError::new_err(format!("invalid Tuid: {err}")))?,
-        })
     }
 }
 
@@ -54,10 +43,13 @@ impl TryFrom<re_protos::common::v1alpha1::Tuid> for PyEntryId {
 pub enum PyEntryKind {
     #[pyo3(name = "DATASET")]
     Dataset = 1,
+
     #[pyo3(name = "DATASET_VIEW")]
     DatasetView = 2,
+
     #[pyo3(name = "TABLE")]
     Table = 3,
+
     #[pyo3(name = "TABLE_VIEW")]
     TableView = 4,
 }
@@ -108,7 +100,7 @@ impl PyEntry {
     }
 
     #[getter]
-    pub fn name(&self) -> Option<String> {
+    pub fn name(&self) -> String {
         self.details.name.clone()
     }
 
@@ -119,24 +111,23 @@ impl PyEntry {
 
     #[getter]
     pub fn kind(&self) -> PyResult<PyEntryKind> {
-        //TODO(ab): make this less annoying thanks to a wrapper over grpc messages.
-        EntryKind::try_from(self.details.entry_kind)
-            .map_err(|err| PyTypeError::new_err(format!("cannot deserialize EntryType: {err}")))?
-            .try_into()
+        self.details.kind.try_into()
     }
 
     #[getter]
-    pub fn created_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
-        self.details
-            .created_at
-            .and_then(|t| chrono::DateTime::from_timestamp(t.seconds, t.nanos as u32))
+    pub fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
+        let ts = self.details.created_at;
+        // If the `prost::Timestamp` was legal, then this is also legal.
+        #[allow(clippy::unwrap_used)]
+        chrono::DateTime::from_timestamp(ts.as_second(), ts.subsec_nanosecond() as u32).unwrap()
     }
 
     #[getter]
-    pub fn updated_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
-        self.details
-            .updated_at
-            .and_then(|t| chrono::DateTime::from_timestamp(t.seconds, t.nanos as u32))
+    pub fn updated_at(&self) -> chrono::DateTime<chrono::Utc> {
+        let ts = self.details.updated_at;
+        // If the `prost::Timestamp` was legal, then this is also legal.
+        #[allow(clippy::unwrap_used)]
+        chrono::DateTime::from_timestamp(ts.as_second(), ts.subsec_nanosecond() as u32).unwrap()
     }
 
     // ---

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -115,6 +115,7 @@ impl PyEntry {
     }
 
     #[getter]
+    //TODO(ab): use jiff when updating to pyo3 0.24.0
     pub fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
         let ts = self.details.created_at;
         // If the `prost::Timestamp` was legal, then this is also legal.

--- a/rerun_py/src/catalog/errors.rs
+++ b/rerun_py/src/catalog/errors.rs
@@ -16,14 +16,9 @@
 use std::error::Error as _;
 
 use pyo3::exceptions::{PyConnectionError, PyValueError};
-use pyo3::{create_exception, PyErr};
+use pyo3::PyErr;
 
 use re_grpc_client::redap::ConnectionError;
-
-// ---
-
-// Custom exception classes.
-create_exception!(catalog, MissingGrpcFieldError, PyValueError);
 
 // ---
 

--- a/rerun_py/src/catalog/mod.rs
+++ b/rerun_py/src/catalog/mod.rs
@@ -12,10 +12,10 @@ pub use catalog_client::PyCatalogClient;
 pub use connection_handle::ConnectionHandle;
 pub use dataset::PyDataset;
 pub use entry::{PyEntry, PyEntryId, PyEntryKind};
-pub use errors::{to_py_err, MissingGrpcFieldError};
+pub use errors::to_py_err;
 
 /// Register the `rerun.catalog` module.
-pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCatalogClient>()?;
 
     m.add_class::<PyEntryId>()?;
@@ -23,8 +23,6 @@ pub(crate) fn register(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> 
     m.add_class::<PyEntry>()?;
 
     m.add_class::<PyDataset>()?;
-
-    m.add("MissingFieldError", py.get_type::<MissingGrpcFieldError>())?;
 
     Ok(())
 }


### PR DESCRIPTION
What:
* New extensions for protobuf helper objects:
    * `re_protos::common::v1alpha1::ext`
    * `re_protos::catalog::v1alpha1::ext`
    * Basic integration with `jiff` and `pyo3::Error`
* New `EntryId` type to prevent the naked `Tuid`:
    * Makes use of the new extensions to have a decent DX

The proposed design is very simple:
* Implement all your native helper objects in `re_protos::*::ext` with all the type conversion / parsing / etc logic
* Do not ever under any circumstance leak the raw protobuf objects beyond service/client trait definitions
* Profit as your business code becomes _much_ nicer to work with


I've ported a non-trivial chunk of the new catalog APIs to that design, so as to have a decent enough sample size.

* https://github.com/rerun-io/dataplatform/pull/459