### PR TITLE
Python/CI: Raise exception on warning, e.g. call of @deprecated

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Check for release checklist
         if: ${{ inputs.FAST }}
         # Only check that the release checklist executes successfully
-        run: RUST_LOG=warn RERUN_STRICT=1 pixi run -e wheel-test-min python tests/python/release_checklist/main.py --stdout > /dev/null
+        run: RUST_LOG=warn RERUN_STRICT=1 PYTHONWARNINGS=error pixi run -e wheel-test-min python tests/python/release_checklist/main.py --stdout > /dev/null
 
       - name: Build C++ roundtrips
         if: ${{ !inputs.FAST }}

--- a/crates/build/re_dev_tools/src/build_examples/rrd.rs
+++ b/crates/build/re_dev_tools/src/build_examples/rrd.rs
@@ -90,6 +90,10 @@ impl Example {
             cmd.env("RERUN_FLUSH_TICK_SECS", 1_000_000_000.to_string());
             cmd.env("RERUN_FLUSH_NUM_BYTES", (128 * 1024).to_string());
 
+            cmd.env("PYTHONWARNINGS", "error"); // raise exception on warnings, e.g. when using a @deprecated function
+            cmd.env("RERUN_PANIC_ON_WARN", "1"); // any logged warnings/errors should cause a failure
+            cmd.env("RERUN_STRICT", "1"); // any misuse of the API should cause a failure
+
             wait_for_output(cmd, &self.name, progress)?;
         }
 

--- a/crates/build/re_dev_tools/src/build_examples/snippets.rs
+++ b/crates/build/re_dev_tools/src/build_examples/snippets.rs
@@ -167,6 +167,7 @@ impl Snippet {
         cmd.args(&self.extra_args);
 
         cmd.envs([
+            ("PYTHONWARNINGS", "error"), // raise exception on warnings, e.g. when using a @deprecated function
             ("RERUN_FLUSH_NUM_ROWS", "0"),
             ("RERUN_STRICT", "1"),
             ("RERUN_PANIC_ON_WARN", "1"),

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.py
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.py
@@ -48,6 +48,6 @@ for i in range(6 * 120):
         "sun/planet/moon",
         rr.Transform3D(
             translation=[np.cos(r_moon) * d_moon, np.sin(r_moon) * d_moon, 0.0],
-            from_parent=True,
+            relation=rr.TransformRelation.ChildFromParent,
         ),
     )

--- a/examples/python/arkit_scenes/arkit_scenes/__main__.py
+++ b/examples/python/arkit_scenes/arkit_scenes/__main__.py
@@ -141,7 +141,7 @@ def read_camera_from_world(traj_string: str) -> tuple[str, rr.Transform3D]:
     camera_from_world = rr.Transform3D(
         translation=translation,
         rotation=rr.Quaternion(xyzw=rotation.as_quat()),
-        from_parent=True,
+        relation=rr.TransformRelation.ChildFromParent,
     )
 
     return (ts, camera_from_world)

--- a/examples/python/graphs/graphs.py
+++ b/examples/python/graphs/graphs.py
@@ -13,18 +13,17 @@ import rerun.blueprint as rrb
 from rerun.blueprint.archetypes.force_collision_radius import ForceCollisionRadius
 from rerun.blueprint.archetypes.force_link import ForceLink
 from rerun.blueprint.archetypes.force_many_body import ForceManyBody
-from rerun.components.color import Color
 
 color_scheme = [
-    Color([228, 26, 28]),  # Red
-    Color([55, 126, 184]),  # Blue
-    Color([77, 175, 74]),  # Green
-    Color([152, 78, 163]),  # Purple
-    Color([255, 127, 0]),  # Orange
-    Color([255, 255, 51]),  # Yellow
-    Color([166, 86, 40]),  # Brown
-    Color([247, 129, 191]),  # Pink
-    Color([153, 153, 153]),  # Gray
+    [228, 26, 28, 255],  # Red
+    [55, 126, 184, 255],  # Blue
+    [77, 175, 74, 255],  # Green
+    [152, 78, 163, 255],  # Purple
+    [255, 127, 0, 255],  # Orange
+    [255, 255, 51, 255],  # Yellow
+    [166, 86, 40, 255],  # Brown
+    [247, 129, 191, 255],  # Pink
+    [153, 153, 153, 255],  # Gray
 ]
 
 DESCRIPTION = """
@@ -49,7 +48,7 @@ def log_lattice(num_nodes: int) -> None:
     nodes, colors = zip(*[
         (
             str(i),
-            rr.components.Color([round((x / (num_nodes - 1)) * 255), round((y / (num_nodes - 1)) * 255), 0]),
+            rr.components.Color([round((x / (num_nodes - 1)) * 255), round((y / (num_nodes - 1)) * 255), 0, 255]),
         )
         for i, (x, y) in enumerate(coordinates)
     ])
@@ -81,7 +80,7 @@ def log_lattice(num_nodes: int) -> None:
 def log_trees() -> None:
     nodes = ["root"]
     radii = [42]
-    colors = [Color([81, 81, 81])]
+    colors = [[81, 81, 81, 255]]
     edges = []
 
     # Randomly add nodes and edges to the graph
@@ -114,11 +113,11 @@ def log_markov_chain() -> None:
     state_names = ["sunny", "rainy", "cloudy"]
     # For this example, we use hardcoded positions.
     positions = [[0, 0], [150, 150], [300, 0]]
-    inactive_color = Color([153, 153, 153])  # Gray
+    inactive_color = [153, 153, 153, 255]  # Gray
     active_colors = [
-        Color([255, 127, 0]),  # Orange
-        Color([55, 126, 184]),  # Blue
-        Color([152, 78, 163]),  # Purple
+        [255, 127, 0, 255],  # Orange
+        [55, 126, 184, 255],  # Blue
+        [152, 78, 163, 255],  # Purple
     ]
 
     edges = [

--- a/examples/python/live_depth_sensor/README.md
+++ b/examples/python/live_depth_sensor/README.md
@@ -49,7 +49,7 @@ rr.log(
     rr.Transform3D(
         translation=rgb_from_depth.translation,
         mat3x3=np.reshape(rgb_from_depth.rotation, (3, 3)),
-        from_parent=True,
+        relation=rr.TransformRelation.ChildFromParent,
     ),
     static=True,
 )

--- a/examples/python/live_depth_sensor/live_depth_sensor.py
+++ b/examples/python/live_depth_sensor/live_depth_sensor.py
@@ -44,7 +44,7 @@ def run_realsense(num_frames: int | None) -> None:
         rr.Transform3D(
             translation=rgb_from_depth.translation,
             mat3x3=np.reshape(rgb_from_depth.rotation, (3, 3)),
-            from_parent=True,
+            relation=rr.TransformRelation.ChildFromParent,
         ),
         static=True,
     )

--- a/examples/python/structure_from_motion/README.md
+++ b/examples/python/structure_from_motion/README.md
@@ -58,7 +58,7 @@ This defines how to go from the 3D camera frame to the 2D image plane. The extri
 [`Transform3D`](https://www.rerun.io/docs/reference/types/archetypes/transform3d) to the `camera` entity.
 
 ```python
-rr.log("camera", rr.Transform3D(translation=image.tvec, rotation=rr.Quaternion(xyzw=quat_xyzw), from_parent=True))
+rr.log("camera", rr.Transform3D(translation=image.tvec, rotation=rr.Quaternion(xyzw=quat_xyzw), relation=rr.TransformRelation.ChildFromParent))
 ```
 
 ```python

--- a/examples/python/structure_from_motion/structure_from_motion/__main__.py
+++ b/examples/python/structure_from_motion/structure_from_motion/__main__.py
@@ -145,7 +145,11 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         # COLMAP's camera transform is "camera from world"
         rr.log(
             "camera",
-            rr.Transform3D(translation=image.tvec, rotation=rr.Quaternion(xyzw=quat_xyzw), from_parent=True),
+            rr.Transform3D(
+                translation=image.tvec,
+                rotation=rr.Quaternion(xyzw=quat_xyzw),
+                relation=rr.TransformRelation.ChildFromParent,
+            ),
         )
         rr.log("camera", rr.ViewCoordinates.RDF, static=True)  # X=Right, Y=Down, Z=Forward
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -457,13 +457,13 @@ cpp-build-log-benchmark = { cmd = "cmake --build build/release --config Release 
 cpp-build-plot-dashboard-stress = { cmd = "cmake --build build/release --config Release --target plot_dashboard_stress", depends-on = [
   "cpp-prepare-release",
 ] }
-cpp-test = { cmd = "export RERUN_STRICT=1 && ./build/debug/rerun_cpp/tests/rerun_sdk_tests", depends-on = [
+cpp-test = { cmd = "export RERUN_STRICT=1 PYTHONWARNINGS=error && ./build/debug/rerun_cpp/tests/rerun_sdk_tests", depends-on = [
   "cpp-build-tests",
 ] }
-cpp-log-benchmark = { cmd = "export RERUN_STRICT=1 && ./build/release/tests/cpp/log_benchmark/log_benchmark", depends-on = [
+cpp-log-benchmark = { cmd = "export RERUN_STRICT=1 PYTHONWARNINGS=error && ./build/release/tests/cpp/log_benchmark/log_benchmark", depends-on = [
   "cpp-build-log-benchmark",
 ] }
-cpp-plot-dashboard = { cmd = "export RERUN_STRICT=1 && ./build/release/tests/cpp/plot_dashboard_stress/plot_dashboard_stress", depends-on = [
+cpp-plot-dashboard = { cmd = "export RERUN_STRICT=1 PYTHONWARNINGS=error && ./build/release/tests/cpp/plot_dashboard_stress/plot_dashboard_stress", depends-on = [
   "cpp-build-plot-dashboard-stress",
 ] }
 cpp-build-and-test-all = { depends-on = ["cpp-build-all", "cpp-test"] }

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -123,7 +123,7 @@ class Transform3D(Transform3DExt, Archetype):
             "sun/planet/moon",
             rr.Transform3D(
                 translation=[np.cos(r_moon) * d_moon, np.sin(r_moon) * d_moon, 0.0],
-                from_parent=True,
+                relation=rr.TransformRelation.ChildFromParent,
             ),
         )
     ```

--- a/scripts/roundtrip_utils.py
+++ b/scripts/roundtrip_utils.py
@@ -51,6 +51,9 @@ def run(
 def roundtrip_env(*, save_path: str | None = None) -> dict[str, str]:
     env = os.environ.copy()
 
+    # raise exception on warnings, e.g. when using a @deprecated function:
+    env["PYTHONWARNINGS"] = "error"
+
     # NOTE: Make sure to disable batching, otherwise the Arrow concatenation logic within
     # the batcher will happily insert uninitialized padding bytes as needed!
     env["RERUN_FLUSH_NUM_ROWS"] = "0"

--- a/scripts/run_python_e2e_test.py
+++ b/scripts/run_python_e2e_test.py
@@ -78,6 +78,10 @@ def main() -> None:
 
 def run_example(example: str, extra_args: list[str]) -> None:
     env = os.environ.copy()
+
+    # raise exception on warnings, e.g. when using a @deprecated function:
+    env["PYTHONWARNINGS"] = "error"
+
     env["RERUN_STRICT"] = "1"
     env["RERUN_PANIC_ON_WARN"] = "1"
 

--- a/tests/python/roundtrips/transform3d/main.py
+++ b/tests/python/roundtrips/transform3d/main.py
@@ -20,7 +20,7 @@ def main() -> None:
 
     rr.log(
         "transform/translation",
-        rr.Transform3D(translation=[1, 2, 3], from_parent=True),
+        rr.Transform3D(translation=[1, 2, 3], relation=rr.TransformRelation.ChildFromParent),
     )
 
     rr.log(
@@ -30,7 +30,7 @@ def main() -> None:
 
     rr.log(
         "transform/translation_scale",
-        rr.Transform3D(translation=[1, 2, 3], scale=42, from_parent=True),
+        rr.Transform3D(translation=[1, 2, 3], scale=42, relation=rr.TransformRelation.ChildFromParent),
     )
 
     rr.log(
@@ -47,7 +47,7 @@ def main() -> None:
             translation=[1, 2, 3],
             rotation=RotationAxisAngle([0.2, 0.2, 0.8], pi),
             scale=42,
-            from_parent=True,
+            relation=rr.TransformRelation.ChildFromParent,
         ),
     )
 

--- a/tests/python/test_api/test_api.py
+++ b/tests/python/test_api/test_api.py
@@ -111,7 +111,7 @@ def transforms() -> None:
     # Log a transform from parent to child with a translation and skew along y and x.
     rr.log(
         "transforms/child_from_parent_translation",
-        rr.Transform3D(translation=(-1, 0, 0), from_parent=True),
+        rr.Transform3D(translation=(-1, 0, 0), relation=rr.TransformRelation.ChildFromParent),
     )
 
     # Log translation only.


### PR DESCRIPTION
### Related
* https://github.com/rerun-io/rerun/pull/9338

### What
We do not want to call deprecated functions from our examples and snippets (it sets a bad example!).

Unfortunately there is nothing stopping us from doing so right now.
Until this PR.

With `PYTHONWARNINGS="error"` _any_ Python `warning` results in an exception, which should fail the example/snippet.

### TODO
* [x] `@rerun-bot full-check`