### PR TITLE
fix: typo in apps-and-recordings.md

### DIFF
--- a/docs/content/concepts/apps-and-recordings.md
+++ b/docs/content/concepts/apps-and-recordings.md
@@ -12,7 +12,7 @@ Similarly, there is no such thing as "closing" a recording: as long as there exi
 
 This design naturally allows for both the production and the storage of recordings to be horizontally distributed:
 * Production can be handled by multiple producers that all log data to the same _Recording ID_, independently.
-* Storage can be sharded over multiple independent files (or any other storage medium).
+* Storage can be shared over multiple independent files (or any other storage medium).
 
 You can learn more about sharding in the [dedicated documentation page](../howto/logging/shared-recordings.md).
 


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

Small typo in apps and recordings section md.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
