### PR TITLE
Grtlr/recording properties UI tweaks

### DIFF
--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -580,15 +580,16 @@ mod tests {
 
     #[test]
     fn test_properties() {
-        assert_eq!(EntityPath::properties(), EntityPath::from("/__properties"),);
+        let path = EntityPath::properties();
+        assert_eq!(path, EntityPath::from("/__properties"));
+        assert!(path.is_reserved());
     }
 
     #[test]
     fn test_recording_properties() {
-        assert_eq!(
-            EntityPath::recording_properties(),
-            EntityPath::from("/__properties/recording"),
-        );
+        let path = EntityPath::recording_properties();
+        assert_eq!(path, EntityPath::from("/__properties/recording"),);
+        assert!(path.is_reserved());
     }
 
     #[test]

--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -127,6 +127,14 @@ impl EntityPath {
         ])
     }
 
+    /// Returns `true` if the [`EntityPath`] belongs to a reserved namespace.
+    #[inline]
+    pub fn is_reserved(&self) -> bool {
+        self.iter()
+            .next()
+            .is_some_and(|part| part.unescaped_str().starts_with(RESERVED_NAMESPACE_PREFIX))
+    }
+
     #[inline]
     pub fn new(parts: Vec<EntityPathPart>) -> Self {
         Self::from(parts)
@@ -433,6 +441,8 @@ where
 // ----------------------------------------------------------------------------
 
 use re_types_core::Loggable;
+
+use super::entity_path_part::RESERVED_NAMESPACE_PREFIX;
 
 re_types_core::macros::impl_into_cow!(EntityPath);
 

--- a/crates/store/re_log_types/src/path/entity_path_part.rs
+++ b/crates/store/re_log_types/src/path/entity_path_part.rs
@@ -2,6 +2,7 @@ use re_string_interner::InternedString;
 
 use crate::PathParseError;
 
+pub const RESERVED_NAMESPACE_PREFIX: &str = "__";
 const PROPERTIES_PART: &str = "__properties";
 const RECORDING_PART: &str = "recording";
 

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -125,6 +125,10 @@ impl DataUi for InstancePath {
             preview_if_image_ui(ctx, ui, ui_layout, query, entity_path, &component_map);
             preview_if_blob_ui(ctx, ui, ui_layout, query, entity_path, &component_map);
         }
+
+        if entity_path.is_reserved() {
+            ui.label("This instance is part of a reserved entity namespace.");
+        }
     }
 }
 

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -637,6 +637,10 @@ pub fn instance_hover_card_ui(
         ui.label(instance_path.syntax_highlighted(ui.style()));
     });
 
+    if instance_path.entity_path.is_reserved() {
+        ui.label("This entity is part of a reserved namespace.");
+    }
+
     // TODO(emilk): give data_ui an alternate "everything on this timeline" query?
     // Then we can move the size view into `data_ui`.
 

--- a/crates/viewer/re_time_panel/src/streams_tree_data.rs
+++ b/crates/viewer/re_time_panel/src/streams_tree_data.rs
@@ -172,7 +172,7 @@ impl EntityData {
 
             let is_this_a_match = !children.is_empty();
             let default_open = filter_matcher.is_active()
-                || (entity_tree.path.len() <= 1 && entity_tree.path != EntityPath::properties());
+                || (entity_tree.path.len() <= 1 && !entity_tree.path.is_reserved());
 
             NodeInfo {
                 is_leaf: false,

--- a/crates/viewer/re_time_panel/src/streams_tree_data.rs
+++ b/crates/viewer/re_time_panel/src/streams_tree_data.rs
@@ -171,7 +171,8 @@ impl EntityData {
                 .collect_vec();
 
             let is_this_a_match = !children.is_empty();
-            let default_open = filter_matcher.is_active() || entity_tree.path.len() <= 1;
+            let default_open = filter_matcher.is_active()
+                || (entity_tree.path.len() <= 1 && entity_tree.path != EntityPath::properties());
 
             NodeInfo {
                 is_leaf: false,


### PR DESCRIPTION
### Related

* Part of #9188.

### What

This brings some UI tweak to how we handle and display recording properties. I'll try to make it that the commit log contains all the changes.

### Screenshots
<img width="404" alt="image" src="https://github.com/user-attachments/assets/75111407-270b-4684-a017-ad488de10e78" />
<img width="412" alt="image" src="https://github.com/user-attachments/assets/49667975-198a-40d7-97fb-f9f32c336b5c" />
<img width="256" alt="image" src="https://github.com/user-attachments/assets/19c47381-137c-45c2-9b22-4375f67754d7" />

