### PR TITLE
Don't trigger callbacks on welcome screen

### DIFF
--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -661,10 +661,14 @@ fn move_time(
         false
     };
 
+    let should_diff_time_ctrl = ctx.has_active_recording();
     let recording_time_ctrl_response = ctx.rec_cfg.time_ctrl.write().update(
         recording.times_per_timeline(),
         dt,
         more_data_is_coming,
+        // The state diffs are used to trigger callbacks if they are configured.
+        // Unless we have a real recording open, we should not actually trigger any callbacks.
+        should_diff_time_ctrl,
     );
 
     handle_time_ctrl_callbacks(callbacks, &recording_time_ctrl_response);
@@ -672,6 +676,7 @@ fn move_time(
     let recording_needs_repaint = recording_time_ctrl_response.needs_repaint;
 
     let blueprint_needs_repaint = if ctx.app_options().inspect_blueprint_timeline {
+        let should_diff_time_ctrl = false; /* we don't need state diffing here */
         ctx.blueprint_cfg
             .time_ctrl
             .write()
@@ -679,6 +684,7 @@ fn move_time(
                 ctx.store_context.blueprint.times_per_timeline(),
                 dt,
                 more_data_is_coming,
+                should_diff_time_ctrl,
             )
             .needs_repaint
     } else {

--- a/crates/viewer/re_viewer_context/src/time_control.rs
+++ b/crates/viewer/re_viewer_context/src/time_control.rs
@@ -315,6 +315,11 @@ impl TimeControl {
 
         let mut response = TimeControlResponse::new(needs_repaint);
 
+        // Only diff if the caller asked for it, _and_ we have some times on the timeline.
+        let should_diff_state = should_diff_state
+            && times_per_timeline
+                .get(self.timeline.name())
+                .is_some_and(|stats| !stats.per_time.is_empty());
         if should_diff_state {
             self.diff_last_frame(&mut response);
         }

--- a/crates/viewer/re_viewer_context/src/time_control.rs
+++ b/crates/viewer/re_viewer_context/src/time_control.rs
@@ -219,12 +219,16 @@ impl TimeControlResponse {
 
 impl TimeControl {
     /// Move the time forward (if playing), and perhaps pause if we've reached the end.
+    ///
+    /// If `should_diff_state` is true, then the response also contains any changes in state
+    /// between last frame and the current one.
     #[must_use]
     pub fn update(
         &mut self,
         times_per_timeline: &TimesPerTimeline,
         stable_dt: f32,
         more_data_is_coming: bool,
+        should_diff_state: bool,
     ) -> TimeControlResponse {
         self.select_a_valid_timeline(times_per_timeline);
 
@@ -311,7 +315,9 @@ impl TimeControl {
 
         let mut response = TimeControlResponse::new(needs_repaint);
 
-        self.diff_last_frame(&mut response);
+        if should_diff_state {
+            self.diff_last_frame(&mut response);
+        }
 
         response
     }

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -7,13 +7,13 @@ use re_entity_db::entity_db::EntityDb;
 use re_query::StorageEngineReadGuard;
 
 use crate::drag_and_drop::DragAndDropPayload;
-use crate::GlobalContext;
 use crate::{
     query_context::DataQueryResult, AppOptions, ApplicationSelectionState, CommandSender,
     ComponentUiRegistry, DragAndDropManager, IndicatedEntities, ItemCollection,
     MaybeVisualizableEntities, PerVisualizer, StoreContext, SystemCommandSender as _, TimeControl,
     ViewClassRegistry, ViewId,
 };
+use crate::{GlobalContext, StoreHub};
 
 /// Common things needed by many parts of the viewer.
 pub struct ViewerContext<'a> {
@@ -290,6 +290,15 @@ impl ViewerContext<'_> {
         }
 
         is_safari_browser_inner().unwrap_or(false)
+    }
+
+    /// This returns `true` if we have an active recording.
+    ///
+    /// It excludes the globally hardcoded welcome screen app ID.
+    pub fn has_active_recording(&self) -> bool {
+        self.recording()
+            .app_id()
+            .is_some_and(|active_app_id| active_app_id != &StoreHub::welcome_screen_app_id())
     }
 }
 


### PR DESCRIPTION
Right now when the Viewer is "empty" (=no active recordings), it still has an active app, which is the welcome screen, and that has an empty recording in it. As a result, we trigger time update callbacks, even if the user doesn't see any active recordings. This is not only confusing but also actively harmful behavior for anyone who's trying to use callbacks to build on top of the Viewer.

The solution here is to disable timeline callbacks if we don't have an active recording. We define that as "has an app id which isn't the welcome screen app id".

Additionally, we don't trigger timeline callbacks if the active timeline is empty (=has no timepoints).