### PR TITLE
Fix Bazel build: shader reloading only on in Rerun workspace

### DIFF
--- a/crates/viewer/re_renderer/README.md
+++ b/crates/viewer/re_renderer/README.md
@@ -32,7 +32,7 @@ Goals & philosophy:
 
 #### Iterating
 
-In debug mode shaders are live-reloaded.
+In debug mode shaders are live-reloaded, if built from the Rerun workspace.
 If a failure occurs during live-reload, an error is logged and the previous shader is kept.
 
 #### Inspecting final source


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/9368

### What
Hot shader reloading is only interesting for us developers.

I've tested that:
* It still works in-repo in debug builds
* It still does not work in release builds