### PR TITLE
Switch to bufbuild instead of vscode-proto3

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
+    "bufbuild.vscode-buf",
     "charliermarsh.ruff",
     "esbenp.prettier-vscode",
     "fill-labs.dependi",
@@ -21,6 +22,5 @@
     "wayou.vscode-todo-highlight",
     "webfreak.debug",
     "xaver.clang-format", // C++ formatter
-    "zxh404.vscode-proto3",
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,7 +46,7 @@
     "prettier.requireConfig": true,
     "prettier.configPath": ".prettierrc.toml",
     "[proto3]": {
-        "editor.defaultFormatter": "zxh404.vscode-proto3"
+        "editor.defaultFormatter": "bufbuild.vscode-buf"
     },
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff"
@@ -62,5 +62,5 @@
     },
     "[yaml]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    }
+    },
 }


### PR DESCRIPTION
Our recommended tooling for formatting protobufs is `buf`.

`vscode-proto3` was behaving inconsistently.