### PR TITLE
Revert reserved namespace warning from instance path

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -125,10 +125,6 @@ impl DataUi for InstancePath {
             preview_if_image_ui(ctx, ui, ui_layout, query, entity_path, &component_map);
             preview_if_blob_ui(ctx, ui, ui_layout, query, entity_path, &component_map);
         }
-
-        if entity_path.is_reserved() {
-            ui.label("This instance is part of a reserved entity namespace.");
-        }
     }
 }
 


### PR DESCRIPTION
This reverts some changes from the following PR, as they would clobber the display of the recording properties:

* #9390 

Since we now also have the nice icons, this warning is also not as important anymore.