### PR TITLE
Rename `Scalars::one` to `Scalars::single`

### DIFF
--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -38,7 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
-///         rec.log("scalars", &rerun::Scalars::one((step as f64 / 10.0).sin()))?;
+///         rec.log("scalars", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -38,7 +38,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
-///         rec.log("scalars", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
+///         rec.log(
+///             "scalars",
+///             &rerun::Scalars::single((step as f64 / 10.0).sin()),
+///         )?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/store/re_types/src/archetypes/scalars.rs
+++ b/crates/store/re_types/src/archetypes/scalars.rs
@@ -38,7 +38,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
-///         rec.log("scalars", &rerun::Scalars::one((step as f64 / 10.0).sin()))?;
+///         rec.log("scalars", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/store/re_types/src/archetypes/scalars.rs
+++ b/crates/store/re_types/src/archetypes/scalars.rs
@@ -38,7 +38,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     for step in 0..64 {
 ///         rec.set_time_sequence("step", step);
-///         rec.log("scalars", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
+///         rec.log(
+///             "scalars",
+///             &rerun::Scalars::single((step as f64 / 10.0).sin()),
+///         )?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/store/re_types/src/archetypes/scalars_ext.rs
+++ b/crates/store/re_types/src/archetypes/scalars_ext.rs
@@ -1,6 +1,6 @@
 impl crate::archetypes::Scalars {
     /// Constructor for a single scalar.
-    pub fn one(value: impl Into<crate::components::Scalar>) -> Self {
+    pub fn single(value: impl Into<crate::components::Scalar>) -> Self {
         Self::new([value.into()])
     }
 }

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -54,8 +54,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         rec.set_time_sequence("step", t);
 ///
 ///         // Log two time series under a shared root so that they show in the same plot by default.
-///         rec.log("trig/sin", &rerun::Scalars::one((t as f64 / 100.0).sin()))?;
-///         rec.log("trig/cos", &rerun::Scalars::one((t as f64 / 100.0).cos()))?;
+///         rec.log(
+///             "trig/sin",
+///             &rerun::Scalars::single((t as f64 / 100.0).sin()),
+///         )?;
+///         rec.log(
+///             "trig/cos",
+///             &rerun::Scalars::single((t as f64 / 100.0).cos()),
+///         )?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/store/re_types/src/archetypes/series_lines.rs
+++ b/crates/store/re_types/src/archetypes/series_lines.rs
@@ -56,8 +56,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         rec.set_time_sequence("step", t);
 ///
 ///         // Log two time series under a shared root so that they show in the same plot by default.
-///         rec.log("trig/sin", &rerun::Scalars::one((t as f64 / 100.0).sin()))?;
-///         rec.log("trig/cos", &rerun::Scalars::one((t as f64 / 100.0).cos()))?;
+///         rec.log(
+///             "trig/sin",
+///             &rerun::Scalars::single((t as f64 / 100.0).sin()),
+///         )?;
+///         rec.log(
+///             "trig/cos",
+///             &rerun::Scalars::single((t as f64 / 100.0).cos()),
+///         )?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -56,8 +56,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         rec.set_time_sequence("step", t);
 ///
 ///         // Log two time series under a shared root so that they show in the same plot by default.
-///         rec.log("trig/sin", &rerun::Scalars::one((t as f64 / 10.0).sin()))?;
-///         rec.log("trig/cos", &rerun::Scalars::one((t as f64 / 10.0).cos()))?;
+///         rec.log("trig/sin", &rerun::Scalars::single((t as f64 / 10.0).sin()))?;
+///         rec.log("trig/cos", &rerun::Scalars::single((t as f64 / 10.0).cos()))?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/store/re_types/src/archetypes/series_points.rs
+++ b/crates/store/re_types/src/archetypes/series_points.rs
@@ -58,8 +58,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///         rec.set_time_sequence("step", t);
 ///
 ///         // Log two time series under a shared root so that they show in the same plot by default.
-///         rec.log("trig/sin", &rerun::Scalars::one((t as f64 / 10.0).sin()))?;
-///         rec.log("trig/cos", &rerun::Scalars::one((t as f64 / 10.0).cos()))?;
+///         rec.log("trig/sin", &rerun::Scalars::single((t as f64 / 10.0).sin()))?;
+///         rec.log("trig/cos", &rerun::Scalars::single((t as f64 / 10.0).cos()))?;
 ///     }
 ///
 ///     Ok(())

--- a/crates/viewer/re_view_dataframe/tests/basic.rs
+++ b/crates/viewer/re_view_dataframe/tests/basic.rs
@@ -18,14 +18,14 @@ pub fn test_null_timeline() {
     let timeline_b = Timeline::new_sequence("timeline_b");
 
     test_context.log_entity("first".into(), |builder| {
-        builder.with_archetype(RowId::new(), [(timeline_a, 0)], &Scalars::one(10.0))
+        builder.with_archetype(RowId::new(), [(timeline_a, 0)], &Scalars::single(10.0))
     });
 
     test_context.log_entity("second".into(), |builder| {
         builder.with_archetype(
             RowId::new(),
             [(timeline_a, 1), (timeline_b, 10)],
-            &Scalars::one(12.0),
+            &Scalars::single(12.0),
         )
     });
 
@@ -46,9 +46,9 @@ pub fn test_unknown_timeline() {
 
     test_context.log_entity("some_entity".into(), |builder| {
         builder
-            .with_archetype(RowId::new(), [(timeline, 0)], &Scalars::one(10.0))
-            .with_archetype(RowId::new(), [(timeline, 1)], &Scalars::one(20.0))
-            .with_archetype(RowId::new(), [(timeline, 2)], &Scalars::one(30.0))
+            .with_archetype(RowId::new(), [(timeline, 0)], &Scalars::single(10.0))
+            .with_archetype(RowId::new(), [(timeline, 1)], &Scalars::single(20.0))
+            .with_archetype(RowId::new(), [(timeline, 2)], &Scalars::single(30.0))
     });
 
     let view_id = setup_blueprint(&mut test_context, &TimelineName::from("unknown_timeline"));

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -63,7 +63,7 @@ fn test_clear_series_points_and_line_impl(two_series_per_entity: bool) {
                         (i as f64 / 5.0 + 1.0).cos(), // Shifted a bit to make the cap more visible
                     ])
                 } else {
-                    re_types::archetypes::Scalars::one((i as f64 / 5.0).sin())
+                    re_types::archetypes::Scalars::single((i as f64 / 5.0).sin())
                 };
 
                 test_context.log_entity("plots/line".into(), |builder| {
@@ -110,8 +110,8 @@ fn scalars_for_properties_test(
         )
     } else {
         (
-            re_types::archetypes::Scalars::one((step as f64 / 5.0).sin()),
-            re_types::archetypes::Scalars::one((step as f64 / 5.0).cos()),
+            re_types::archetypes::Scalars::single((step as f64 / 5.0).sin()),
+            re_types::archetypes::Scalars::single((step as f64 / 5.0).cos()),
         )
     }
 }

--- a/docs/snippets/all/archetypes/scalars_multiple_plots.rs
+++ b/docs/snippets/all/archetypes/scalars_multiple_plots.rs
@@ -26,15 +26,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rec.set_time_sequence("step", t);
 
         // Log two time series under a shared root so that they show in the same plot by default.
-        rec.log("trig/sin", &rerun::Scalars::one((t as f64 / 100.0).sin()))?;
-        rec.log("trig/cos", &rerun::Scalars::one((t as f64 / 100.0).cos()))?;
+        rec.log(
+            "trig/sin",
+            &rerun::Scalars::single((t as f64 / 100.0).sin()),
+        )?;
+        rec.log(
+            "trig/cos",
+            &rerun::Scalars::single((t as f64 / 100.0).cos()),
+        )?;
 
         // Log scattered points under a different root so that it shows in a different plot by default.
         lcg_state = (1140671485_i64
             .wrapping_mul(lcg_state)
             .wrapping_add(128201163))
             % 16777216; // simple linear congruency generator
-        rec.log("scatter/lcg", &rerun::Scalars::one(lcg_state as f64))?;
+        rec.log("scatter/lcg", &rerun::Scalars::single(lcg_state as f64))?;
     }
 
     Ok(())

--- a/docs/snippets/all/archetypes/scalars_row_updates.rs
+++ b/docs/snippets/all/archetypes/scalars_row_updates.rs
@@ -7,7 +7,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log("scalars", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
+        rec.log(
+            "scalars",
+            &rerun::Scalars::single((step as f64 / 10.0).sin()),
+        )?;
     }
 
     Ok(())

--- a/docs/snippets/all/archetypes/scalars_row_updates.rs
+++ b/docs/snippets/all/archetypes/scalars_row_updates.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log("scalars", &rerun::Scalars::one((step as f64 / 10.0).sin()))?;
+        rec.log("scalars", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
     }
 
     Ok(())

--- a/docs/snippets/all/archetypes/scalars_simple.rs
+++ b/docs/snippets/all/archetypes/scalars_simple.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log the data on a timeline called "step".
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log("scalar", &rerun::Scalars::one((step as f64 / 10.0).sin()))?;
+        rec.log("scalar", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
     }
 
     Ok(())

--- a/docs/snippets/all/archetypes/scalars_simple.rs
+++ b/docs/snippets/all/archetypes/scalars_simple.rs
@@ -6,7 +6,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log the data on a timeline called "step".
     for step in 0..64 {
         rec.set_time_sequence("step", step);
-        rec.log("scalar", &rerun::Scalars::single((step as f64 / 10.0).sin()))?;
+        rec.log(
+            "scalar",
+            &rerun::Scalars::single((step as f64 / 10.0).sin()),
+        )?;
     }
 
     Ok(())

--- a/docs/snippets/all/archetypes/series_lines_style.rs
+++ b/docs/snippets/all/archetypes/series_lines_style.rs
@@ -25,8 +25,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rec.set_time_sequence("step", t);
 
         // Log two time series under a shared root so that they show in the same plot by default.
-        rec.log("trig/sin", &rerun::Scalars::one((t as f64 / 100.0).sin()))?;
-        rec.log("trig/cos", &rerun::Scalars::one((t as f64 / 100.0).cos()))?;
+        rec.log(
+            "trig/sin",
+            &rerun::Scalars::single((t as f64 / 100.0).sin()),
+        )?;
+        rec.log(
+            "trig/cos",
+            &rerun::Scalars::single((t as f64 / 100.0).cos()),
+        )?;
     }
 
     Ok(())

--- a/docs/snippets/all/archetypes/series_points_style.rs
+++ b/docs/snippets/all/archetypes/series_points_style.rs
@@ -27,8 +27,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rec.set_time_sequence("step", t);
 
         // Log two time series under a shared root so that they show in the same plot by default.
-        rec.log("trig/sin", &rerun::Scalars::one((t as f64 / 10.0).sin()))?;
-        rec.log("trig/cos", &rerun::Scalars::one((t as f64 / 10.0).cos()))?;
+        rec.log("trig/sin", &rerun::Scalars::single((t as f64 / 10.0).sin()))?;
+        rec.log("trig/cos", &rerun::Scalars::single((t as f64 / 10.0).cos()))?;
     }
 
     Ok(())

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -159,7 +159,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
                         rerun::Scalars::new(values.copied()).columns_of_unit_batches()?,
                     )?;
                 } else {
-                    rec.log(path, &rerun::Scalars::one(series_values[offset]))?;
+                    rec.log(path, &rerun::Scalars::single(series_values[offset]))?;
                 }
             }
         }


### PR DESCRIPTION
* Introduced in https://github.com/rerun-io/rerun/pull/9338

`one` can be confused for `1.0`
