### PR TITLE
Fix 2D image split heuristic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7050,6 +7050,7 @@ dependencies = [
  "glam",
  "hexasphere",
  "image",
+ "insta",
  "itertools 0.14.0",
  "ndarray",
  "nohash-hasher",

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -360,11 +360,8 @@ impl EntityPathFilter {
     /// Creates a filter that accepts everything.
     pub fn all() -> Self {
         Self {
-            rules: std::iter::once((
-                EntityPathRule::exact_entity(&EntityPath::root()),
-                RuleEffect::Include,
-            ))
-            .collect(),
+            rules: std::iter::once((EntityPathRule::including_subtree(""), RuleEffect::Include))
+                .collect(),
         }
     }
 

--- a/crates/viewer/re_view_spatial/Cargo.toml
+++ b/crates/viewer/re_view_spatial/Cargo.toml
@@ -69,6 +69,7 @@ re_viewer_context = { workspace = true, features = ["testing"] }
 re_viewport.workspace = true
 re_viewport_blueprint = { workspace = true, features = ["testing"] }
 
+insta.workspace = true
 ndarray.workspace = true
 
 [lib]

--- a/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
@@ -143,8 +143,11 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
                         max_dim.height = max_dim.height.max(height);
 
                         // TODO(andreas): this should be part of the Blob component's tag instead.
-                        max_dim.image_types.insert(ImageTypes::ENCODED_IMAGE);
-                        max_dim.image_types.insert(ImageTypes::VIDEO);
+                        if media_type.is_image() {
+                            max_dim.image_types.insert(ImageTypes::ENCODED_IMAGE);
+                        } else if media_type.is_video() {
+                            max_dim.image_types.insert(ImageTypes::VIDEO);
+                        }
                     }
                 }
             }

--- a/crates/viewer/re_view_spatial/tests/snapshots/spawn_heuristics__detect_and_track_objects_like_scene_2d_view_heuristic.snap
+++ b/crates/viewer/re_view_spatial/tests/snapshots/spawn_heuristics__detect_and_track_objects_like_scene_2d_view_heuristic.snap
@@ -1,0 +1,28 @@
+---
+source: crates/viewer/re_view_spatial/tests/spawn_heuristics.rs
+expression: recommended_views
+---
+ViewSpawnHeuristics {
+    recommended_views: [
+        RecommendedView {
+            origin: /segmentation,
+            query_filter: EntityPathFilter {
+                rules: {
+                    EntityPathRule(
+                        "$origin/**",
+                    ): Include,
+                },
+            },
+        },
+        RecommendedView {
+            origin: /video,
+            query_filter: EntityPathFilter {
+                rules: {
+                    EntityPathRule(
+                        "$origin",
+                    ): Include,
+                },
+            },
+        },
+    ],
+}

--- a/crates/viewer/re_view_spatial/tests/snapshots/spawn_heuristics__detect_and_track_objects_like_scene_2d_view_heuristic.snap
+++ b/crates/viewer/re_view_spatial/tests/snapshots/spawn_heuristics__detect_and_track_objects_like_scene_2d_view_heuristic.snap
@@ -19,7 +19,7 @@ ViewSpawnHeuristics {
             query_filter: EntityPathFilter {
                 rules: {
                     EntityPathRule(
-                        "$origin",
+                        "$origin/**",
                     ): Include,
                 },
             },

--- a/crates/viewer/re_view_spatial/tests/spawn_heuristics.rs
+++ b/crates/viewer/re_view_spatial/tests/spawn_heuristics.rs
@@ -1,0 +1,96 @@
+use re_log_types::Timeline;
+use re_types::archetypes;
+use re_viewer_context::{test_context::TestContext, ViewClass as _};
+
+use ndarray::{Array, ShapeBuilder as _};
+
+// Creates a 2D scene that mimics the `detect_and_track_objects` example.
+#[allow(clippy::unwrap_used)]
+fn build_2d_scene(test_context: &mut TestContext) {
+    let timeline_step = Timeline::new_sequence("step");
+    let time = [(timeline_step, 1)];
+
+    const IMAGE_WIDTH: usize = 64;
+    const IMAGE_HEIGHT: usize = 48;
+
+    test_context.log_entity("segmentation/rgb_scaled".into(), |builder| {
+        builder.with_archetype(
+            re_types::RowId::new(),
+            time,
+            &archetypes::Image::from_color_model_and_tensor(
+                re_types::datatypes::ColorModel::RGB,
+                Array::<u8, _>::zeros((IMAGE_HEIGHT, IMAGE_WIDTH, 3).f()),
+            )
+            .unwrap(),
+        )
+    });
+    test_context.log_entity("segmentation".into(), |builder| {
+        builder.with_archetype(
+            re_types::RowId::new(),
+            time,
+            &archetypes::SegmentationImage::try_from(Array::<u8, _>::zeros(
+                (IMAGE_HEIGHT, IMAGE_WIDTH).f(),
+            ))
+            .unwrap(),
+        )
+    });
+    test_context.log_entity("segmentation/detections/things".into(), |builder| {
+        builder.with_archetype(
+            re_types::RowId::new(),
+            time,
+            &archetypes::Boxes2D::from_centers_and_half_sizes(
+                [(5.0, 5.0), (10.0, 10.0), (15.0, 15.0)],
+                [(10.0, 10.0), (10.0, 10.0), (10.0, 10.0)],
+            ),
+        )
+    });
+
+    test_context.log_entity("video".into(), |builder| {
+        builder
+            .with_archetype(
+                re_types::RowId::new(),
+                time,
+                &archetypes::AssetVideo::from_file_path("../../../tests/assets/empty.mp4").unwrap(),
+            )
+            .with_archetype(
+                re_types::RowId::new(),
+                time,
+                &archetypes::VideoFrameReference::new(0),
+            )
+    });
+
+    // Since we haven't registered the text view, it won't show up in automatically generated views at all.
+    // This is just here to mimic an entity the 2D spatial view can't handle at all.
+    test_context.log_entity("description".into(), |builder| {
+        builder.with_archetype(
+            re_types::RowId::new(),
+            re_log_types::TimePoint::default(),
+            &archetypes::TextDocument::new("test document"),
+        )
+    });
+}
+
+#[test]
+fn test_spatial_view_2d_spawn_heuristics() {
+    let mut test_context = TestContext::default();
+    // It's important to first register the view class before adding any entities,
+    // otherwise the `VisualizerEntitySubscriber` for our visualizers doesn't exist yet,
+    // and thus will not find anything applicable to the visualizer.
+    test_context.register_view_class::<re_view_spatial::SpatialView2D>();
+
+    build_2d_scene(&mut test_context);
+
+    let view_class = test_context
+        .view_class_registry
+        .get_class_or_log_error(re_view_spatial::SpatialView2D::identifier());
+
+    test_context.run_in_egui_central_panel(|ctx, _ui| {
+        let recommended_views =
+            view_class.spawn_heuristics(ctx, &re_log_types::ResolvedEntityPathFilter::properties());
+
+        insta::assert_debug_snapshot!(
+            "detect_and_track_objects_like_scene_2d_view_heuristic",
+            recommended_views
+        );
+    });
+}

--- a/crates/viewer/re_view_spatial/tests/spawn_heuristics.rs
+++ b/crates/viewer/re_view_spatial/tests/spawn_heuristics.rs
@@ -58,6 +58,18 @@ fn build_2d_scene(test_context: &mut TestContext) {
                 &archetypes::VideoFrameReference::new(0),
             )
     });
+    for i in 0..3 {
+        test_context.log_entity(format!("video/tracked/{i}").into(), |builder| {
+            builder.with_archetype(
+                re_types::RowId::new(),
+                time,
+                &archetypes::Boxes2D::from_centers_and_half_sizes(
+                    [(i as f32, i as f32)],
+                    [(1.0, 1.0)],
+                ),
+            )
+        });
+    }
 
     // Since we haven't registered the text view, it won't show up in automatically generated views at all.
     // This is just here to mimic an entity the 2D spatial view can't handle at all.

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -315,6 +315,9 @@ impl TestContext {
         let indicated_entities_per_visualizer = self
             .view_class_registry
             .indicated_entities_per_visualizer(&store_context.recording.store_id());
+        let maybe_visualizable_entities_per_visualizer = self
+            .view_class_registry
+            .maybe_visualizable_entities_for_visualizer_systems(&self.recording_store.store_id());
 
         let drag_and_drop_manager = crate::DragAndDropManager::new(ItemCollection::default());
 
@@ -341,7 +344,7 @@ impl TestContext {
                 render_ctx,
             },
             store_context: &store_context,
-            maybe_visualizable_entities_per_visualizer: &Default::default(),
+            maybe_visualizable_entities_per_visualizer: &maybe_visualizable_entities_per_visualizer,
             indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
             query_results: &self.query_results,
             rec_cfg: &self.recording_config,

--- a/crates/viewer/re_viewer_context/src/view/spawn_heuristics.rs
+++ b/crates/viewer/re_viewer_context/src/view/spawn_heuristics.rs
@@ -13,7 +13,7 @@ pub struct RecommendedView {
 /// Provides information in order to decide whether to spawn a views, putting them in relationship to others and spawning them.
 // TODO(andreas): allow bucketing decisions for 0-n buckets for recommended views.
 // TODO(andreas): Should `ViewClassLayoutPriority` be part of this struct?
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ViewSpawnHeuristics {
     /// The recommended views to spawn
     recommended_views: Vec<RecommendedView>,

--- a/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
+++ b/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
@@ -76,7 +76,7 @@ impl TestContextExt for TestContext {
                                 .class(class_identifier)
                                 .unwrap_or_else(|| panic!("The class '{class_identifier}' must be registered beforehand"))
                                 .determine_visualizable_entities(
-                                    &ctx.maybe_visualizable_entities_per_visualizer,
+                                    ctx.maybe_visualizable_entities_per_visualizer,
                                     ctx.recording(),
                                     &ctx.view_class_registry()
                                         .new_visualizer_collection(class_identifier),
@@ -97,7 +97,7 @@ impl TestContextExt for TestContext {
                             let resolver = DataQueryPropertyResolver::new(
                                 view_blueprint,
                                 ctx.view_class_registry(),
-                                &ctx.maybe_visualizable_entities_per_visualizer,
+                                ctx.maybe_visualizable_entities_per_visualizer,
                                 &visualizable_entities,
                                 &indicated_entities_per_visualizer,
                             );

--- a/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
+++ b/crates/viewer/re_viewport_blueprint/src/test_context_ext.rs
@@ -61,11 +61,6 @@ impl TestContextExt for TestContext {
                 let viewport_blueprint =
                     ViewportBlueprint::try_from_db(&self.blueprint_store, &self.blueprint_query);
 
-                let maybe_visualizable_entities_per_visualizer = self
-                    .view_class_registry
-                    .maybe_visualizable_entities_for_visualizer_systems(
-                        &self.recording_store.store_id(),
-                    );
                 let mut query_results = HashMap::default();
 
                 self.run(egui_ctx, |ctx| {
@@ -81,7 +76,7 @@ impl TestContextExt for TestContext {
                                 .class(class_identifier)
                                 .unwrap_or_else(|| panic!("The class '{class_identifier}' must be registered beforehand"))
                                 .determine_visualizable_entities(
-                                    &maybe_visualizable_entities_per_visualizer,
+                                    &ctx.maybe_visualizable_entities_per_visualizer,
                                     ctx.recording(),
                                     &ctx.view_class_registry()
                                         .new_visualizer_collection(class_identifier),
@@ -102,7 +97,7 @@ impl TestContextExt for TestContext {
                             let resolver = DataQueryPropertyResolver::new(
                                 view_blueprint,
                                 ctx.view_class_registry(),
-                                &maybe_visualizable_entities_per_visualizer,
+                                &ctx.maybe_visualizable_entities_per_visualizer,
                                 &visualizable_entities,
                                 &indicated_entities_per_visualizer,
                             );


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/9363
* Regression caused by https://github.com/rerun-io/rerun/pull/9308

### What

As far as I can tell the main breakage occurred because previously we tracked which visualizable entities remain in the subtree during image split computation. That's fixed by stopping image split detection when there's no images anymore (duh! ;-)). There was another issue where we'd count videos and encoded images both as each other additionally.

Adds a simple snapshot test for the spawn heuristic which was confirmed catching this! First of its kind 😱 
