### PR TITLE
Silence pyo3 RUSTSEC since we cannot address it right now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,7 @@ version = 2
 ignore = [
   "RUSTSEC-2024-0384", # Waiting for https://github.com/console-rs/indicatif/pull/666
   "RUSTSEC-2024-0436", # https://rustsec.org/advisories/RUSTSEC-2024-0436 - paste is unmaintained - https://github.com/dtolnay/paste
-  "RUSTSEC-2025-0014", # TODO(#9255): Waiting for https://github.com/apache/arrow-rs/issues/7264
+  "RUSTSEC-2025-0020", # https://rustsec.org/advisories/RUSTSEC-2025-0020  TODO(emilk): Update pyo3 to >=0.24.1 when we update arrow again
 ]
 
 


### PR DESCRIPTION
# Related
* RUSTSEC: https://rustsec.org/advisories/RUSTSEC-2025-0020
* We are waiting for https://github.com/apache/arrow-rs/pull/7324 to make it into Rerun
* See also https://github.com/PyO3/pyo3/pull/5008#issuecomment-2768879222
* See also https://rerunio.slack.com/archives/C05694LC2EQ/p1743501811036759