### PR TITLE
Introduce `Dataset.arrow_schema()` to return the arrow schema of the underlying data

### DIFF
--- a/crates/store/re_protos/src/lib.rs
+++ b/crates/store/re_protos/src/lib.rs
@@ -70,7 +70,7 @@ pub mod manifest_registry {
     #[rustfmt::skip] // keep these constants single line for easy sorting
     pub mod v1alpha1 {
         pub use crate::v1alpha1::rerun_manifest_registry_v1alpha1::*;
-        
+
         pub mod ext {
             pub use crate::v1alpha1::rerun_manifest_registry_v1alpha1_ext::*;
         }

--- a/crates/store/re_protos/src/lib.rs
+++ b/crates/store/re_protos/src/lib.rs
@@ -70,7 +70,7 @@ pub mod manifest_registry {
     #[rustfmt::skip] // keep these constants single line for easy sorting
     pub mod v1alpha1 {
         pub use crate::v1alpha1::rerun_manifest_registry_v1alpha1::*;
-        #[expect(unused_imports)]
+        
         pub mod ext {
             pub use crate::v1alpha1::rerun_manifest_registry_v1alpha1_ext::*;
         }

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -1,3 +1,5 @@
+use arrow::datatypes::Schema as ArrowSchema;
+use arrow::pyarrow::PyArrowType;
 use pyo3::{pyclass, pymethods, PyRef, PyResult};
 use tokio_stream::StreamExt as _;
 
@@ -5,7 +7,7 @@ use re_chunk_store::{ChunkStore, ChunkStoreHandle};
 use re_grpc_client::redap::fetch_partition_response_to_chunk;
 use re_log_types::{StoreId, StoreInfo, StoreKind, StoreSource};
 use re_protos::common::v1alpha1::ext::DatasetHandle;
-use re_protos::frontend::v1alpha1::FetchPartitionRequest;
+use re_protos::frontend::v1alpha1::{FetchPartitionRequest, GetDatasetSchemaRequest};
 
 use crate::catalog::{to_py_err, PyEntry};
 use crate::dataframe::PyRecording;
@@ -21,6 +23,28 @@ impl PyDataset {
     #[getter]
     fn manifest_url(&self) -> String {
         self.dataset_handle.url.to_string()
+    }
+
+    /// Return the Arrow schema of the data contained in the dataset.
+    //TODO(#9457): there should be another `schema` method which returns a `PySchema`
+    fn arrow_schema(self_: PyRef<'_, Self>) -> PyResult<PyArrowType<ArrowSchema>> {
+        let super_ = self_.as_super();
+        let mut client = super_.client.borrow(self_.py()).connection().client();
+        let dataset_id = super_.details.id;
+
+        let schema = wait_for_future(self_.py(), async move {
+            client
+                .get_dataset_schema(GetDatasetSchemaRequest {
+                    dataset_id: Some(dataset_id.into()),
+                })
+                .await
+                .map_err(to_py_err)?
+                .into_inner()
+                .schema()
+                .map_err(to_py_err)
+        })?;
+
+        Ok(schema.into())
     }
 
     fn download_partition(self_: PyRef<'_, Self>, partition_id: String) -> PyResult<PyRecording> {

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -7,7 +7,7 @@ use re_chunk_store::{ChunkStore, ChunkStoreHandle};
 use re_grpc_client::redap::fetch_partition_response_to_chunk;
 use re_log_types::{StoreId, StoreInfo, StoreKind, StoreSource};
 use re_protos::common::v1alpha1::ext::DatasetHandle;
-use re_protos::frontend::v1alpha1::{FetchPartitionRequest, GetDatasetSchemaRequest};
+use re_protos::frontend::v1alpha1::FetchPartitionRequest;
 
 use crate::catalog::{to_py_err, PyEntry};
 use crate::dataframe::PyRecording;
@@ -29,20 +29,9 @@ impl PyDataset {
     //TODO(#9457): there should be another `schema` method which returns a `PySchema`
     fn arrow_schema(self_: PyRef<'_, Self>) -> PyResult<PyArrowType<ArrowSchema>> {
         let super_ = self_.as_super();
-        let mut client = super_.client.borrow(self_.py()).connection().client();
-        let dataset_id = super_.details.id;
+        let mut connection = super_.client.borrow_mut(self_.py()).connection().clone();
 
-        let schema = wait_for_future(self_.py(), async move {
-            client
-                .get_dataset_schema(GetDatasetSchemaRequest {
-                    dataset_id: Some(dataset_id.into()),
-                })
-                .await
-                .map_err(to_py_err)?
-                .into_inner()
-                .schema()
-                .map_err(to_py_err)
-        })?;
+        let schema = connection.get_dataset_schema(self_.py(), super_.details.id)?;
 
         Ok(schema.into())
     }

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -483,6 +483,7 @@ impl SchemaIterator {
 
 #[pyclass(frozen, name = "Schema")]
 #[derive(Clone)]
+//TODO(#9457): improve this object and use it for `Dataset.schema()`.
 pub struct PySchema {
     pub schema: SorbetColumnDescriptors,
 }


### PR DESCRIPTION
### Related

* Part of https://github.com/rerun-io/dataplatform/issues/405
* Poor man version of #9457 

### What

This PR introduces `Dataset.arrow_schema()`, which returns a PyArrow schema object describing the underlying data. Note that in the future we want to instead (or in addition) have  a `schema()` method which return a rich wrapper to expose sorbet stuff and interoperate with the dataframe API (#9457).
