### PR TITLE
Update cpp/eigen_opencv README snippets

### DIFF
--- a/examples/cpp/eigen_opencv/README.md
+++ b/examples/cpp/eigen_opencv/README.md
@@ -78,7 +78,6 @@ rec.log(
 );
 
 // Or by passing a pointer to the image data.
-rec.log("image1", rerun::Image(tensor_shape(img), reinterpret_cast<const uint8_t*>(img.data)));
 rec.log(
     "image1",
     rerun::Image(


### PR DESCRIPTION
* Replaced snippet using `rerun::TensorBuffer::u8` with `rerun::borrow`
* Changed `reinterpret_cast` snippet to use an existing constructor

### Related

Closes #9459

### What

Brings snippets in the README up-to-date with the current API for the [cpp/eigen_opencv](https://github.com/rerun-io/rerun/tree/main/examples/cpp/eigen_opencv) example.
