### PR TITLE
Run `cargo +1.85.0 fmt --all` with Rust `edition=2024`

### DIFF
--- a/crates/build/re_types_builder/src/arrow_registry.rs
+++ b/crates/build/re_types_builder/src/arrow_registry.rs
@@ -66,7 +66,8 @@ impl ArrowRegistry {
             assert!(
                 num_fields == 1,
                 "{}: arrow-transparent structs must have exactly one field, but {:?} has {num_fields}",
-                obj.virtpath, obj.fqname,
+                obj.virtpath,
+                obj.fqname,
             );
         }
 

--- a/crates/build/re_types_builder/src/codegen/cpp/includes.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/includes.rs
@@ -59,9 +59,9 @@ impl Includes {
             ["rerun", scope, obj_kind, typname] => (format!("{scope}/{obj_kind}"), typname),
             _ => {
                 panic!(
-                "Can't figure out include for {included_fqname:?} when adding includes for {:?}",
-                self.fqname
-            );
+                    "Can't figure out include for {included_fqname:?} when adding includes for {:?}",
+                    self.fqname
+                );
             }
         };
 

--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -325,7 +325,9 @@ fn hpp_type_extensions(
                     });
                     includes.insert_system(&line[start + 1..end]);
                 } else {
-                    panic!("Expected to find '\"' or '<' in include line {line} in file {extension_file:?}");
+                    panic!(
+                        "Expected to find '\"' or '<' in include line {line} in file {extension_file:?}"
+                    );
                 }
             } else {
                 hpp_extension_string += line;
@@ -743,7 +745,9 @@ impl QuotedObject {
             .iter()
             .map(|m| m.to_cpp_tokens(&quote!(#archetype_type_ident)));
 
-        let indicator_comment = quote_doc_comment("Indicator component, used to identify the archetype when converting to a list of components.");
+        let indicator_comment = quote_doc_comment(
+            "Indicator component, used to identify the archetype when converting to a list of components.",
+        );
         let indicator_component_fqname =
             format!("{}Indicator", obj.fqname).replace("archetypes", "components");
         let doc_hide_comment = quote_hide_from_docs();
@@ -1310,7 +1314,9 @@ impl QuotedObject {
             }
         };
 
-        let swap_comment = quote_comment("This bitwise swap would fail for self-referential types, but we don't have any of those.");
+        let swap_comment = quote_comment(
+            "This bitwise swap would fail for self-referential types, but we don't have any of those.",
+        );
         let hide_from_docs_comment = quote_hide_from_docs();
 
         let (hpp_loggable, cpp_loggable) = quote_loggable_hpp_and_cpp(
@@ -2566,7 +2572,10 @@ fn lines_from_docs(reporter: &Reporter, objects: &Objects, docs: &Docs) -> Vec<S
             } = &example.base;
 
             for line in &example.lines {
-                assert!(!line.contains("```"), "Example {path:?} contains ``` in it, so we can't embed it in the C++ API docs.");
+                assert!(
+                    !line.contains("```"),
+                    "Example {path:?} contains ``` in it, so we can't embed it in the C++ API docs."
+                );
             }
 
             if let Some(title) = title {

--- a/crates/build/re_types_builder/src/codegen/docs/snippets_ref.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/snippets_ref.rs
@@ -211,7 +211,9 @@ impl SnippetsRefCodeGenerator {
             #[allow(clippy::invisible_characters)]
             let snippet_name_qualified = &snippet.name_qualified.replace('/', "⁠/⁠");
 
-            let row = format!("| **{obj_name_rendered}** | `{snippet_name_qualified}` | {snippet_descr} | {link_py} | {link_rs} | {link_cpp} |");
+            let row = format!(
+                "| **{obj_name_rendered}** | `{snippet_name_qualified}` | {snippet_descr} | {link_py} | {link_rs} | {link_cpp} |"
+            );
 
             Ok(row)
         }

--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2075,8 +2075,9 @@ fn quote_arrow_serialization(
 
                         // Type checker struggles with this occasionally, exact pattern is unclear.
                         // Tried casting the array earlier via `cast(Sequence[{name}], data)` but to no avail.
-                        let field_fwd =
-                            format!("{field_batch_type}({field_array}).as_arrow_array(),  # type: ignore[misc, arg-type]");
+                        let field_fwd = format!(
+                            "{field_batch_type}({field_array}).as_arrow_array(),  # type: ignore[misc, arg-type]"
+                        );
                         code.push_indented(2, &field_fwd, 1);
                     }
                 }

--- a/crates/build/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/serializer.rs
@@ -579,7 +579,9 @@ fn quote_arrow_field_serializer(
         }
 
         DataType::Null => {
-            panic!("Null fields should only occur within enums and unions where they are handled separately.");
+            panic!(
+                "Null fields should only occur within enums and unions where they are handled separately."
+            );
         }
 
         DataType::Utf8 => {

--- a/crates/build/re_types_builder/src/docs.rs
+++ b/crates/build/re_types_builder/src/docs.rs
@@ -404,8 +404,8 @@ mod doclink_translation {
 
                 if let Some(field_or_enum_name) = field_or_enum_name {
                     format!(
-                            "[`{kind_and_type}::{field_or_enum_name}`][crate::{object_path}::{field_or_enum_name}]"
-                        )
+                        "[`{kind_and_type}::{field_or_enum_name}`][crate::{object_path}::{field_or_enum_name}]"
+                    )
                 } else {
                     format!("[`{kind_and_type}`][crate::{object_path}]")
                 }
@@ -418,7 +418,9 @@ mod doclink_translation {
                     format!("rerun.{scope}.{kind_and_type}")
                 };
                 if let Some(field_or_enum_name) = field_or_enum_name {
-                    format!("[`{kind_and_type}.{field_or_enum_name}`][{object_path}.{field_or_enum_name}]")
+                    format!(
+                        "[`{kind_and_type}.{field_or_enum_name}`][{object_path}.{field_or_enum_name}]"
+                    )
                 } else {
                     format!("[`{kind_and_type}`][{object_path}]")
                 }
@@ -543,32 +545,17 @@ mod tests {
         );
 
         assert_eq!(
-            translate_doc_line(
-                &reporter,
-                &objects,
-                input,
-                Target::Python
-            ),
+            translate_doc_line(&reporter, &objects, input, Target::Python),
             "A vector `[1, 2, 3]` and a doclink [`views.Spatial2DView`][rerun.blueprint.views.Spatial2DView] and a [url](www.rerun.io)."
         );
 
         assert_eq!(
-            translate_doc_line(
-                &reporter,
-                &objects,
-                input,
-                Target::Rust
-            ),
+            translate_doc_line(&reporter, &objects, input, Target::Rust),
             "A vector `[1, 2, 3]` and a doclink [`views::Spatial2DView`][crate::blueprint::views::Spatial2DView] and a [url](www.rerun.io)."
         );
 
         assert_eq!(
-            translate_doc_line(
-                &reporter,
-                &objects,
-                input,
-                Target::WebDocsMarkdown
-            ),
+            translate_doc_line(&reporter, &objects, input, Target::WebDocsMarkdown),
             "A vector `[1, 2, 3]` and a doclink [`views.Spatial2DView`](https://rerun.io/docs/reference/types/views/spatial2d_view) and a [url](www.rerun.io)."
         );
     }
@@ -578,46 +565,25 @@ mod tests {
         let objects = test_objects();
         let (_report, reporter) = crate::report::init();
 
-        let input =
-            "A vector `[1, 2, 3]` and a doclink [views.Spatial2DView.position] and a [url](www.rerun.io).";
+        let input = "A vector `[1, 2, 3]` and a doclink [views.Spatial2DView.position] and a [url](www.rerun.io).";
 
         assert_eq!(
-            translate_doc_line(
-                &reporter,
-                &objects,
-                input,
-                Target::Cpp
-            ),
+            translate_doc_line(&reporter, &objects, input, Target::Cpp),
             "A vector `[1, 2, 3]` and a doclink `views::Spatial2DView::position` and a [url](www.rerun.io)."
         );
 
         assert_eq!(
-            translate_doc_line(
-                &reporter,
-                &objects,
-                input,
-                Target::Python
-            ),
+            translate_doc_line(&reporter, &objects, input, Target::Python),
             "A vector `[1, 2, 3]` and a doclink [`views.Spatial2DView.position`][rerun.blueprint.views.Spatial2DView.position] and a [url](www.rerun.io)."
         );
 
         assert_eq!(
-            translate_doc_line(
-                &reporter,
-                &objects,
-                input,
-                Target::Rust
-            ),
+            translate_doc_line(&reporter, &objects, input, Target::Rust),
             "A vector `[1, 2, 3]` and a doclink [`views::Spatial2DView::position`][crate::blueprint::views::Spatial2DView::position] and a [url](www.rerun.io)."
         );
 
         assert_eq!(
-            translate_doc_line(
-                &reporter,
-                &objects,
-                input,
-                Target::WebDocsMarkdown
-            ),
+            translate_doc_line(&reporter, &objects, input, Target::WebDocsMarkdown),
             "A vector `[1, 2, 3]` and a doclink [`views.Spatial2DView#position`](https://rerun.io/docs/reference/types/views/spatial2d_view) and a [url](www.rerun.io)."
         );
     }

--- a/crates/build/re_types_builder/src/objects.rs
+++ b/crates/build/re_types_builder/src/objects.rs
@@ -291,7 +291,9 @@ impl State {
                             notice: notice.clone(),
                         })
                     } else {
-                        Err(format!("Deprecated object must have {ATTR_RERUN_DEPRECATED_SINCE:?} and {ATTR_RERUN_DEPRECATED_NOTICE:?} set"))
+                        Err(format!(
+                            "Deprecated object must have {ATTR_RERUN_DEPRECATED_SINCE:?} and {ATTR_RERUN_DEPRECATED_NOTICE:?} set"
+                        ))
                     }
                 }
                 unknown => Err(format!("Unknown value for {ATTR_RERUN_STATE:?}: {unknown}")),
@@ -1183,9 +1185,11 @@ impl Type {
             match (typ, type_override.as_str()) {
                 (FbsBaseType::UShort, "float16") => {
                     return Self::Float16;
-                },
+                }
                 (FbsBaseType::Array | FbsBaseType::Vector, "float16") => {}
-                _ => unreachable!("UShort -> float16 is the only permitted type override. Not {typ:#?}->{type_override}"),
+                _ => unreachable!(
+                    "UShort -> float16 is the only permitted type override. Not {typ:#?}->{type_override}"
+                ),
             }
         }
 
@@ -1474,7 +1478,9 @@ impl ElementType {
                 (FbsBaseType::UShort, "float16") => {
                     return Self::Float16;
                 }
-                _ => unreachable!("UShort -> float16 is the only permitted type override. Not {inner_type:#?}->{type_override}"),
+                _ => unreachable!(
+                    "UShort -> float16 is the only permitted type override. Not {inner_type:#?}->{type_override}"
+                ),
             }
         }
 

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -1572,7 +1572,8 @@ impl Chunk {
                     reason: format!(
                         "All timelines in a chunk must have the same number of timestamps, matching the number of row IDs. \
                          Found {} row IDs but {} timestamps for timeline '{timeline_name}'",
-                        row_ids.len(), time_column.times.len(),
+                        row_ids.len(),
+                        time_column.times.len(),
                     ),
                 });
             }
@@ -1603,7 +1604,8 @@ impl Chunk {
                         reason: format!(
                             "All component batches in a chunk must have the same number of rows, matching the number of row IDs. \
                              Found {} row IDs but {} rows for component batch {component_desc}",
-                            row_ids.len(), list_array.len(),
+                            row_ids.len(),
+                            list_array.len(),
                         ),
                     });
                 }

--- a/crates/store/re_chunk_store/tests/memory_test.rs
+++ b/crates/store/re_chunk_store/tests/memory_test.rs
@@ -80,7 +80,9 @@ use re_types::{components::Scalar, Component as _, Loggable as _};
 fn scalar_memory_overhead() {
     re_log::setup_logging();
 
-    re_log::warn!("THIS TEST HAS TO ACCOUNT FOR THE MEMORY OF ALL RUNNING THREADS -- IT MUST BE RUN ON ITS OWN, WITH NO OTHER TESTS RUNNING IN PARALLEL: `cargo t --all-features -p re_chunk_store memory_tests -- scalar_memory_overhead`");
+    re_log::warn!(
+        "THIS TEST HAS TO ACCOUNT FOR THE MEMORY OF ALL RUNNING THREADS -- IT MUST BE RUN ON ITS OWN, WITH NO OTHER TESTS RUNNING IN PARALLEL: `cargo t --all-features -p re_chunk_store memory_tests -- scalar_memory_overhead`"
+    );
 
     const NUM_SCALARS: usize = 1024 * 1024;
 

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -252,7 +252,10 @@ pub fn load_episode(
                 match num_channels {
                     1 => chunks.extend(load_episode_depth_images(feature_key, &timeline, &data)?),
                     3 => chunks.extend(load_episode_images(feature_key, &timeline, &data)?),
-                    _ => re_log::warn_once!("Unsupported channel count {num_channels} (shape: {:?}) for LeRobot dataset; Only 1- and 3-channel images are supported", feature.shape)
+                    _ => re_log::warn_once!(
+                        "Unsupported channel count {num_channels} (shape: {:?}) for LeRobot dataset; Only 1- and 3-channel images are supported",
+                        feature.shape
+                    ),
                 };
             }
             DType::Int64 if feature_key == "task_index" => {

--- a/crates/store/re_entity_db/examples/memory_usage.rs
+++ b/crates/store/re_entity_db/examples/memory_usage.rs
@@ -133,7 +133,8 @@ fn log_messages() {
         let encoded = encode_log_msg(&log_msg);
         println!(
             "Arrow LogMsg containing a Pos2 uses {}-{log_msg_bytes} bytes in RAM, and {} bytes encoded",
-            size_decoded(&encoded), encoded.len()
+            size_decoded(&encoded),
+            encoded.len()
         );
     }
 
@@ -154,7 +155,8 @@ fn log_messages() {
         let encoded = encode_log_msg(&log_msg);
         println!(
             "Arrow LogMsg containing {NUM_POINTS}x Pos2 uses {}-{log_msg_bytes} bytes in RAM, and {} bytes encoded",
-            size_decoded(&encoded), encoded.len()
+            size_decoded(&encoded),
+            encoded.len()
         );
     }
 }

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -162,7 +162,7 @@ impl std::fmt::Display for DisplayDatatype<'_> {
             DataType::Union(fields, _) => return write!(f, "Union[{}]", fields.len()),
             DataType::Map(field, _) => return write!(f, "Map[{}]", Self(field.data_type())),
             DataType::Dictionary(key, value) => {
-                return write!(f, "Dictionary{{{}: {}}}", Self(key), Self(value))
+                return write!(f, "Dictionary{{{}: {}}}", Self(key), Self(value));
             }
             DataType::Decimal128(_, _) => "Decimal128",
             DataType::Decimal256(_, _) => "Decimal256",
@@ -170,10 +170,10 @@ impl std::fmt::Display for DisplayDatatype<'_> {
             DataType::Utf8View => "Utf8View",
             DataType::ListView(field) => return write!(f, "ListView[{}]", Self(field.data_type())),
             DataType::LargeListView(field) => {
-                return write!(f, "LargeListView[{}]", Self(field.data_type()))
+                return write!(f, "LargeListView[{}]", Self(field.data_type()));
             }
             DataType::RunEndEncoded(_run_ends, values) => {
-                return write!(f, "RunEndEncoded[{}]", Self(values.data_type()))
+                return write!(f, "RunEndEncoded[{}]", Self(values.data_type()));
             }
         };
         f.write_str(s)

--- a/crates/store/re_log_encoding/src/codec/file/mod.rs
+++ b/crates/store/re_log_encoding/src/codec/file/mod.rs
@@ -79,7 +79,7 @@ impl MessageHeader {
             _ => {
                 return Err(crate::decoder::DecodeError::Codec(
                     crate::codec::CodecError::UnknownMessageHeader,
-                ))
+                ));
             }
         };
 

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -63,7 +63,9 @@ pub enum DecodeError {
     #[error("Data was from an old, incompatible Rerun version")]
     OldRrdVersion,
 
-    #[error("Data from Rerun version {file}, which is incompatible with the local Rerun version {local}")]
+    #[error(
+        "Data from Rerun version {file}, which is incompatible with the local Rerun version {local}"
+    )]
     IncompatibleRerunVersion {
         file: CrateVersion,
         local: CrateVersion,

--- a/crates/store/re_log_encoding/src/decoder/streaming.rs
+++ b/crates/store/re_log_encoding/src/decoder/streaming.rs
@@ -135,7 +135,10 @@ impl<R: AsyncBufRead + Unpin> Stream for StreamingDecoder<R> {
                     // there's more unprocessed data, but there's nothing in the underlying
                     // bytes stream - this indicates a corrupted stream
                     if *expect_more_data {
-                        warn!("There's {} unprocessed data, but not enough for decoding a full message", unprocessed_bytes.len());
+                        warn!(
+                            "There's {} unprocessed data, but not enough for decoding a full message",
+                            unprocessed_bytes.len()
+                        );
                         return std::task::Poll::Ready(None);
                     }
                 }
@@ -213,8 +216,8 @@ impl<R: AsyncBufRead + Unpin> Stream for StreamingDecoder<R> {
                     &unprocessed_bytes[processed_length..processed_length + FileHeader::SIZE];
                 if Self::peek_file_header(data) {
                     re_log::debug!(
-                            "Reached end of stream, but it seems we have a concatenated file, continuing"
-                        );
+                        "Reached end of stream, but it seems we have a concatenated file, continuing"
+                    );
 
                     Pin::new(&mut self.reader).consume(buf_length);
                     continue;

--- a/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
+++ b/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
@@ -113,7 +113,7 @@ pub fn stream_rrd_from_http(url: String, on_msg: Arc<HttpMessageCallback>) {
                             Err(err) => {
                                 return on_msg(HttpMessage::Failure(
                                     format!("Failed to fetch .rrd file from {url}: {err}").into(),
-                                ))
+                                ));
                             }
                         }
                     }

--- a/crates/store/re_log_types/src/index/non_min_i64.rs
+++ b/crates/store/re_log_types/src/index/non_min_i64.rs
@@ -213,7 +213,9 @@ impl<'de> serde::Deserialize<'de> for NonMinI64 {
 pub enum ParseNonMinI64Error {
     Std(#[from] std::num::ParseIntError),
 
-    #[error("Value is equal to minimum i64. Every i64 integer *except* the lowest representable number of a signed 64 bit number is valid.")]
+    #[error(
+        "Value is equal to minimum i64. Every i64 integer *except* the lowest representable number of a signed 64 bit number is valid."
+    )]
     InvalidValue,
 }
 

--- a/crates/store/re_log_types/src/path/parse_path.rs
+++ b/crates/store/re_log_types/src/path/parse_path.rs
@@ -191,7 +191,9 @@ impl EntityPath {
             // We want to warn on some things, like
             // passing a windows file path (`C:\Users\image.jpg`) as an entity path,
             // which would result in a lot of unknown escapes.
-            re_log::warn_once!("When parsing the entity path {input:?}: {warning}. The path will be interpreted as {path}");
+            re_log::warn_once!(
+                "When parsing the entity path {input:?}: {warning}. The path will be interpreted as {path}"
+            );
         }
 
         path

--- a/crates/store/re_sorbet/src/index_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/index_column_descriptor.rs
@@ -134,7 +134,10 @@ impl TryFrom<&ArrowField> for IndexColumnDescriptor {
         let name = if let Some(name) = field.metadata().get("rerun.index_name") {
             name.to_owned()
         } else {
-            re_log::warn_once!("Timeline '{}' is missing 'rerun.index_name' metadata. Falling back on field/column name", field.name());
+            re_log::warn_once!(
+                "Timeline '{}' is missing 'rerun.index_name' metadata. Falling back on field/column name",
+                field.name()
+            );
             field.name().to_owned()
         };
 

--- a/crates/store/re_types/src/archetypes/depth_image_ext.rs
+++ b/crates/store/re_types/src/archetypes/depth_image_ext.rs
@@ -50,7 +50,9 @@ impl DepthImage {
         let num_expected_bytes = image_format.num_bytes();
         if buffer.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {} {datatype:?} image to be {num_expected_bytes} B, but got {} B", ColorModel::L, buffer.len()
+                "Expected {width}x{height} {} {datatype:?} image to be {num_expected_bytes} B, but got {} B",
+                ColorModel::L,
+                buffer.len()
             );
         }
 
@@ -77,7 +79,9 @@ impl DepthImage {
                 format.datatype(),
             ))
         } else {
-            re_log::warn_once!("Unsupported image format encountered while processing file contents. Only TIFF files with valid dimensions and supported data types are currently supported.");
+            re_log::warn_once!(
+                "Unsupported image format encountered while processing file contents. Only TIFF files with valid dimensions and supported data types are currently supported."
+            );
 
             Ok(Self::new(
                 ImageBuffer(bytes.into()),

--- a/crates/store/re_types/src/archetypes/image_ext.rs
+++ b/crates/store/re_types/src/archetypes/image_ext.rs
@@ -76,7 +76,8 @@ impl Image {
         let num_expected_bytes = image_format.num_bytes();
         if buffer.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {pixel_format:?} image to be {num_expected_bytes} B, but got {} B", buffer.len()
+                "Expected {width}x{height} {pixel_format:?} image to be {num_expected_bytes} B, but got {} B",
+                buffer.len()
             );
         }
 
@@ -98,7 +99,8 @@ impl Image {
         let num_expected_bytes = image_format.num_bytes();
         if buffer.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B", buffer.len()
+                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B",
+                buffer.len()
             );
         }
 

--- a/crates/store/re_types/src/archetypes/mesh3d_ext.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d_ext.rs
@@ -9,7 +9,9 @@ use super::Mesh3D;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Mesh3DError {
-    #[error("No indices were specified, so the number of positions must be divisible by 9 [(xyz xyz xyz), …], got {0}")]
+    #[error(
+        "No indices were specified, so the number of positions must be divisible by 9 [(xyz xyz xyz), …], got {0}"
+    )]
     PositionsAreNotTriangles(usize),
 
     #[error("Index out of bounds: got index={index} with {num_vertices} vertices")]

--- a/crates/store/re_types/src/components/image_buffer_ext.rs
+++ b/crates/store/re_types/src/components/image_buffer_ext.rs
@@ -20,7 +20,8 @@ impl ImageBuffer {
         let num_expected_bytes = image_format.num_bytes();
         if bytes.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B", bytes.len()
+                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B",
+                bytes.len()
             );
         }
 
@@ -56,14 +57,14 @@ impl ImageBuffer {
 
             image::DynamicImage::ImageLumaA8(image) => {
                 re_log::warn!(
-                        "Rerun doesn't have native support for 8-bit Luma + Alpha. The image will be convert to RGBA."
-                    );
+                    "Rerun doesn't have native support for 8-bit Luma + Alpha. The image will be convert to RGBA."
+                );
                 Self::from_image(image::DynamicImage::ImageLumaA8(image).to_rgba8())
             }
             image::DynamicImage::ImageLumaA16(image) => {
                 re_log::warn!(
-                        "Rerun doesn't have native support for 16-bit Luma + Alpha. The image will be convert to RGBA."
-                    );
+                    "Rerun doesn't have native support for 16-bit Luma + Alpha. The image will be convert to RGBA."
+                );
                 Self::from_image(image::DynamicImage::ImageLumaA16(image).to_rgba16())
             }
 

--- a/crates/store/re_types/src/image.rs
+++ b/crates/store/re_types/src/image.rs
@@ -40,7 +40,9 @@ pub enum ImageConversionError {
     /// This should only happen if you are using a newer `image` crate than the one Rerun was built for,
     /// because `image` can add new color types without it being a breaking change,
     /// so we cannot exhaustively match on all color types.
-    #[error("Unsupported color type: {0:?}. We support 8-bit, 16-bit, and f32 images, and RGB, RGBA, Luminance, and Luminance-Alpha.")]
+    #[error(
+        "Unsupported color type: {0:?}. We support 8-bit, 16-bit, and f32 images, and RGB, RGBA, Luminance, and Luminance-Alpha."
+    )]
     UnsupportedImageColorType(image::ColorType),
 }
 
@@ -114,7 +116,9 @@ where
     BadImageShape(ArrowBuffer<u64>),
 
     /// Happens if you try to cast `NV12` or `YUY2` to a depth image or segmentation image.
-    #[error("Chroma downsampling is not supported for this image type (e.g. DepthImage or SegmentationImage)")]
+    #[error(
+        "Chroma downsampling is not supported for this image type (e.g. DepthImage or SegmentationImage)"
+    )]
     ChromaDownsamplingNotSupported,
 }
 

--- a/crates/store/re_types/src/tensor_data.rs
+++ b/crates/store/re_types/src/tensor_data.rs
@@ -31,7 +31,9 @@ pub enum TensorImageLoadError {
     #[error(transparent)]
     Image(std::sync::Arc<image::ImageError>),
 
-    #[error("Unsupported color type: {0:?}. We support 8-bit, 16-bit, and f32 images, and RGB, RGBA, Luminance, and Luminance-Alpha.")]
+    #[error(
+        "Unsupported color type: {0:?}. We support 8-bit, 16-bit, and f32 images, and RGB, RGBA, Luminance, and Luminance-Alpha."
+    )]
     UnsupportedImageColorType(image::ColorType),
 
     #[error("Failed to load file: {0}")]

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -145,7 +145,8 @@ impl ArchetypeName {
     pub fn sanity_check(&self) {
         let full_name = self.0.as_str();
         debug_assert!(
-            !full_name.starts_with("rerun.archetypes.rerun.archetypes.") && !full_name.contains(':'),
+            !full_name.starts_with("rerun.archetypes.rerun.archetypes.")
+                && !full_name.contains(':'),
             "DEBUG ASSERT: Found archetype with full name {full_name:?}. Maybe some bad round-tripping?"
         );
     }

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -161,7 +161,8 @@ impl ComponentName {
     pub fn sanity_check(&self) {
         let full_name = self.0.as_str();
         debug_assert!(
-            !full_name.starts_with("rerun.components.rerun.components.") && !full_name.contains(':'),
+            !full_name.starts_with("rerun.components.rerun.components.")
+                && !full_name.contains(':'),
             "DEBUG ASSERT: Found component with full name {full_name:?}. Maybe some bad round-tripping?"
         );
     }

--- a/crates/top/re_sdk/src/global.rs
+++ b/crates/top/re_sdk/src/global.rs
@@ -51,7 +51,9 @@ impl Drop for ThreadLocalRecording {
             // Calling drop on `self.stream` will panic the calling thread.
             // But we want to make sure we don't loose the data in the stream.
             // So how?
-            re_log::warn!("Using thread-local RecordingStream on macOS & Windows can result in data loss because of https://github.com/rerun-io/rerun/issues/3937");
+            re_log::warn!(
+                "Using thread-local RecordingStream on macOS & Windows can result in data loss because of https://github.com/rerun-io/rerun/issues/3937"
+            );
 
             // Give the batcher and sink threads a chance to process the data.
             std::thread::sleep(std::time::Duration::from_millis(500));

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -825,7 +825,9 @@ impl fmt::Debug for RecordingStreamInner {
 impl Drop for RecordingStreamInner {
     fn drop(&mut self) {
         if self.is_forked_child() {
-            re_log::error_once!("Fork detected while dropping RecordingStreamInner. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
+            re_log::error_once!(
+                "Fork detected while dropping RecordingStreamInner. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK."
+            );
             return;
         }
 
@@ -1287,7 +1289,9 @@ impl RecordingStream {
         prefer_current_recording: bool,
     ) -> RecordingStreamResult<()> {
         let Some(store_info) = self.store_info().clone() else {
-            re_log::warn!("Ignored call to log_file() because RecordingStream has not been properly initialized");
+            re_log::warn!(
+                "Ignored call to log_file() because RecordingStream has not been properly initialized"
+            );
             return Ok(());
         };
 
@@ -1663,7 +1667,9 @@ impl RecordingStream {
     /// cannot be repaired), all pending data in its buffers will be dropped.
     pub fn set_sink(&self, sink: Box<dyn LogSink>) {
         if self.is_forked_child() {
-            re_log::error_once!("Fork detected during set_sink. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
+            re_log::error_once!(
+                "Fork detected during set_sink. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK."
+            );
             return;
         }
 
@@ -1700,7 +1706,9 @@ impl RecordingStream {
     /// See [`RecordingStream`] docs for ordering semantics and multithreading guarantees.
     pub fn flush_async(&self) {
         if self.is_forked_child() {
-            re_log::error_once!("Fork detected during flush_async. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
+            re_log::error_once!(
+                "Fork detected during flush_async. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK."
+            );
             return;
         }
 
@@ -1733,7 +1741,9 @@ impl RecordingStream {
     /// See [`RecordingStream`] docs for ordering semantics and multithreading guarantees.
     pub fn flush_blocking(&self) {
         if self.is_forked_child() {
-            re_log::error_once!("Fork detected during flush. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
+            re_log::error_once!(
+                "Fork detected during flush. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK."
+            );
             return;
         }
 

--- a/crates/top/rerun/src/clap.rs
+++ b/crates/top/rerun/src/clap.rs
@@ -170,7 +170,7 @@ impl RerunArgs {
             Some(None) => {
                 return Ok(RerunBehavior::Connect(
                     re_sdk::DEFAULT_CONNECT_URL.to_owned(),
-                ))
+                ));
             }
             None => {}
         }

--- a/crates/top/rerun/src/commands/rrd/print.rs
+++ b/crates/top/rerun/src/commands/rrd/print.rs
@@ -132,7 +132,9 @@ fn print_msg(verbose: u8, msg: LogMsg) -> anyhow::Result<()> {
             make_active,
             make_default,
         }) => {
-            println!("BlueprintActivationCommand({blueprint_id}, make_active: {make_active}, make_default: {make_default})");
+            println!(
+                "BlueprintActivationCommand({blueprint_id}, make_active: {make_active}, make_default: {make_default})"
+            );
         }
     }
 

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -125,7 +125,9 @@ impl Verifier {
                 .ok_or_else(|| anyhow::anyhow!("Unknown component"))?;
 
             if let Some(deprecation_summary) = component_reflection.deprecation_summary {
-                anyhow::bail!("Component is deprecated. Deprecated types should be migrated on ingestion in re_sorbet. Deprecation notice: {deprecation_summary:?}");
+                anyhow::bail!(
+                    "Component is deprecated. Deprecated types should be migrated on ingestion in re_sorbet. Deprecation notice: {deprecation_summary:?}"
+                );
             }
 
             let list_array = column.as_list_opt::<i32>().ok_or_else(|| {

--- a/crates/top/rerun_c/src/error.rs
+++ b/crates/top/rerun_c/src/error.rs
@@ -21,7 +21,9 @@ impl CError {
         let mut bytes_next = 0;
         for c in message.chars() {
             if bytes_next + c.len_utf8() >= message_c.len() {
-                re_log::warn_once!("Error message was too long for C error description buffer. Full message\n{message}");
+                re_log::warn_once!(
+                    "Error message was too long for C error description buffer. Full message\n{message}"
+                );
                 break;
             }
 

--- a/crates/top/rerun_c/src/ptr.rs
+++ b/crates/top/rerun_c/src/ptr.rs
@@ -45,7 +45,9 @@ pub fn try_char_ptr_as_str(
     if let Some(null_terminator_position) = byte_slice.iter().position(|b| *b == b'\0') {
         return Err(CError::new(
             CErrorCode::InvalidStringArgument,
-            &format!("Argument {argument_name:?} was specified to be a string with length {string_length_in_bytes}, but there is an unexpected null-terminator at position {null_terminator_position}."),
+            &format!(
+                "Argument {argument_name:?} was specified to be a string with length {string_length_in_bytes}, but there is an unexpected null-terminator at position {null_terminator_position}."
+            ),
         ));
     }
 

--- a/crates/utils/re_analytics/src/event.rs
+++ b/crates/utils/re_analytics/src/event.rs
@@ -363,7 +363,9 @@ mod tests {
             Some("rerun.io".to_owned())
         );
         assert_eq!(
-            extract_root_domain("https://www.rerun.io/viewer?url=https://app.rerun.io/version/0.15.1/examples/detect_and_track_objects.rrd"),
+            extract_root_domain(
+                "https://www.rerun.io/viewer?url=https://app.rerun.io/version/0.15.1/examples/detect_and_track_objects.rrd"
+            ),
             Some("rerun.io".to_owned())
         );
 

--- a/crates/utils/re_arrow_util/src/arrays.rs
+++ b/crates/utils/re_arrow_util/src/arrays.rs
@@ -300,7 +300,8 @@ pub fn concat_arrays(arrays: &[&dyn Array]) -> arrow::error::Result<ArrayRef> {
 /// [filter]: arrow::compute::filter
 pub fn filter_array<A: Array + Clone + 'static>(array: &A, filter: &BooleanArray) -> A {
     assert_eq!(
-        array.len(), filter.len(),
+        array.len(),
+        filter.len(),
         "the length of the filter must match the length of the array (the underlying kernel will panic otherwise)",
     );
     debug_assert!(

--- a/crates/utils/re_capabilities/src/main_thread_token.rs
+++ b/crates/utils/re_capabilities/src/main_thread_token.rs
@@ -34,7 +34,9 @@ impl MainThreadToken {
         // but there is nothing preventing a user from also naming another thread "main".
         // In any case, since `MainThreadToken` is just best-effort, we only check this in debug builds.
         #[cfg(not(target_arch = "wasm32"))]
-        debug_assert_eq!(std::thread::current().name(), Some("main"),
+        debug_assert_eq!(
+            std::thread::current().name(),
+            Some("main"),
             "DEBUG ASSERT: Trying to construct a MainThreadToken on a thread that is not the main thread!"
         );
 

--- a/crates/utils/re_crash_handler/src/lib.rs
+++ b/crates/utils/re_crash_handler/src/lib.rs
@@ -340,12 +340,17 @@ fn anonymize_source_file_path(path: &std::path::Path) -> String {
 #[test]
 fn test_anonymize_path() {
     for (before, after) in [
-        ("/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs", "tokio-1.24.1/src/runtime/runtime.rs"),
+        (
+            "/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs",
+            "tokio-1.24.1/src/runtime/runtime.rs",
+        ),
         ("crates/rerun/src/main.rs", "rerun/src/main.rs"),
-        ("/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs", "core/src/ops/function.rs"),
+        (
+            "/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs",
+            "core/src/ops/function.rs",
+        ),
         ("/weird/path/file.rs", "file.rs"),
-        ]
-        {
+    ] {
         use std::str::FromStr as _;
         let before = std::path::PathBuf::from_str(before).unwrap();
         assert_eq!(anonymize_source_file_path(&before), after);

--- a/crates/utils/re_log/src/lib.rs
+++ b/crates/utils/re_log/src/lib.rs
@@ -221,12 +221,17 @@ fn shorten_file_path(file_path: &str) -> &str {
 #[test]
 fn test_shorten_file_path() {
     for (before, after) in [
-        ("/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs", "tokio-1.24.1/src/runtime/runtime.rs"),
+        (
+            "/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs",
+            "tokio-1.24.1/src/runtime/runtime.rs",
+        ),
         ("crates/rerun/src/main.rs", "rerun/src/main.rs"),
-        ("/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs", "core/src/ops/function.rs"),
+        (
+            "/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs",
+            "core/src/ops/function.rs",
+        ),
         ("/weird/path/file.rs", "/weird/path/file.rs"),
-        ]
-    {
+    ] {
         assert_eq!(shorten_file_path(before), after);
     }
 }

--- a/crates/utils/re_memory/src/backtrace_native.rs
+++ b/crates/utils/re_memory/src/backtrace_native.rs
@@ -107,12 +107,17 @@ fn shorten_source_file_path(path: &std::path::Path) -> String {
 #[test]
 fn test_shorten_path() {
     for (before, after) in [
-        ("/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs", "tokio-1.24.1/src/runtime/runtime.rs"),
+        (
+            "/Users/emilk/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.24.1/src/runtime/runtime.rs",
+            "tokio-1.24.1/src/runtime/runtime.rs",
+        ),
         ("crates/rerun/src/main.rs", "rerun/src/main.rs"),
-        ("/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs", "core/src/ops/function.rs"),
+        (
+            "/rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs",
+            "core/src/ops/function.rs",
+        ),
         ("/weird/path/file.rs", "/weird/path/file.rs"),
-        ]
-        {
+    ] {
         use std::str::FromStr as _;
         let before = std::path::PathBuf::from_str(before).unwrap();
         assert_eq!(shorten_source_file_path(&before), after);

--- a/crates/utils/re_memory/src/memory_limit.rs
+++ b/crates/utils/re_memory/src/memory_limit.rs
@@ -84,7 +84,9 @@ impl MemoryLimit {
                 return Some((counted_use - max_bytes) as f32 / counted_use as f32);
             }
         } else if let Some(resident_use) = mem_use.resident {
-            re_log::warn_once!("Using resident memory use (RSS) for memory limiting, because a memory tracker was not available.");
+            re_log::warn_once!(
+                "Using resident memory use (RSS) for memory limiting, because a memory tracker was not available."
+            );
             if max_bytes < resident_use {
                 return Some((resident_use - max_bytes) as f32 / resident_use as f32);
             }

--- a/crates/utils/re_tracing/src/server.rs
+++ b/crates/utils/re_tracing/src/server.rs
@@ -30,8 +30,8 @@ impl Profiler {
         self.server = match puffin_http::Server::new(&bind_addr) {
             Ok(puffin_server) => {
                 re_log::info!(
-                        "Started puffin profiling server. View with:  cargo install puffin_viewer && puffin_viewer"
-                    );
+                    "Started puffin profiling server. View with:  cargo install puffin_viewer && puffin_viewer"
+                );
                 Some(puffin_server)
             }
             Err(err) => {

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -47,9 +47,11 @@ impl TryFrom<&str> for TimeRange {
         })?;
 
         if min.typ() != max.typ() {
-            return Err(Error::InvalidTimeRange(
-                format!("min/max had differing types. Min was identified as {}, whereas max was identified as {}", min.typ(), max.typ()),
-            ));
+            return Err(Error::InvalidTimeRange(format!(
+                "min/max had differing types. Min was identified as {}, whereas max was identified as {}",
+                min.typ(),
+                max.typ()
+            )));
         }
 
         let timeline = re_log_types::Timeline::new(timeline, min.typ());

--- a/crates/utils/re_video/src/decode/av1.rs
+++ b/crates/utils/re_video/src/decode/av1.rs
@@ -28,8 +28,10 @@ impl SyncDecoder for SyncDav1dDecoder {
 
         self.decoder.flush();
 
-        debug_assert!(matches!(self.decoder.get_picture(), Err(dav1d::Error::Again)),
-            "There should be no pending pictures, since we output them directly after submitting a chunk.");
+        debug_assert!(
+            matches!(self.decoder.get_picture(), Err(dav1d::Error::Again)),
+            "There should be no pending pictures, since we output them directly after submitting a chunk."
+        );
     }
 }
 
@@ -88,7 +90,10 @@ impl SyncDav1dDecoder {
         ) {
             Ok(()) => {}
             Err(err) => {
-                debug_assert!(err != dav1d::Error::Again, "Bug in AV1 decoder: send_data returned `Error::Again`. This shouldn't happen, since we process all images in a chunk right away");
+                debug_assert!(
+                    err != dav1d::Error::Again,
+                    "Bug in AV1 decoder: send_data returned `Error::Again`. This shouldn't happen, since we process all images in a chunk right away"
+                );
                 on_output(Err(Error::Dav1d(err)));
             }
         };
@@ -320,7 +325,9 @@ fn yuv_matrix_coefficients(debug_name: &str, picture: &dav1d::Picture) -> YuvMat
         | dav1d::pixel::MatrixCoefficients::ICtCp
         | dav1d::pixel::MatrixCoefficients::ST2085 => {
             // TODO(#7594): HDR support (we'll probably only care about `BT2020NonConstantLuminance`?)
-            re_log::warn_once!("Video {debug_name:?} specified HDR color primaries. Rerun doesn't handle HDR colors correctly yet. Color artifacts may be visible.");
+            re_log::warn_once!(
+                "Video {debug_name:?} specified HDR color primaries. Rerun doesn't handle HDR colors correctly yet. Color artifacts may be visible."
+            );
             YuvMatrixCoefficients::Bt709
         }
 
@@ -328,9 +335,9 @@ fn yuv_matrix_coefficients(debug_name: &str, picture: &dav1d::Picture) -> YuvMat
         | dav1d::pixel::MatrixCoefficients::ChromaticityDerivedConstantLuminance
         | dav1d::pixel::MatrixCoefficients::YCgCo => {
             re_log::warn_once!(
-                 "Video {debug_name:?} specified unsupported matrix coefficients {:?}. Color artifacts may be visible.",
-                 picture.matrix_coefficients()
-             );
+                "Video {debug_name:?} specified unsupported matrix coefficients {:?}. Color artifacts may be visible.",
+                picture.matrix_coefficients()
+            );
             YuvMatrixCoefficients::Bt709
         }
     }

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -39,7 +39,9 @@ pub enum Error {
     #[error("Failed to start FFmpeg: {0}")]
     FailedToStartFfmpeg(std::io::Error),
 
-    #[error("FFmpeg version is {actual_version}. Only versions >= {minimum_version_major}.{minimum_version_minor} are officially supported.")]
+    #[error(
+        "FFmpeg version is {actual_version}. Only versions >= {minimum_version_major}.{minimum_version_minor} are officially supported."
+    )]
     UnsupportedFFmpegVersion {
         actual_version: FFmpegVersion,
         minimum_version_major: u32,
@@ -537,8 +539,12 @@ impl FrameBuffer {
                 // We'd expect the video player to do a reset prior to that and close the channel as part of that, but we may not have noticed that in here yet!
                 // In any case, we'll have to just run with this as the new highest timestamp, not much else we can do.
                 if self.highest_dts > frame_info.decode_timestamp {
-                    re_log::warn!("Video decode timestamps are expected to monotonically increase unless there was a decoder reset.\n\
-                                It went from {:?} to {:?} for the decoder of {debug_name}. This is probably a bug in Rerun.", self.highest_dts, frame_info.decode_timestamp);
+                    re_log::warn!(
+                        "Video decode timestamps are expected to monotonically increase unless there was a decoder reset.\n\
+                                It went from {:?} to {:?} for the decoder of {debug_name}. This is probably a bug in Rerun.",
+                        self.highest_dts,
+                        frame_info.decode_timestamp
+                    );
                 }
                 self.highest_dts = frame_info.decode_timestamp;
 
@@ -733,7 +739,9 @@ fn read_ffmpeg_output(
             FfmpegEvent::ParsedVersion(ffmpeg_version) => {
                 fn download_advice() -> String {
                     if let Ok(download_url) = ffmpeg_sidecar::download::ffmpeg_download_url() {
-                        format!("\nYou can download an up to date version for your system at {download_url}.")
+                        format!(
+                            "\nYou can download an up to date version for your system at {download_url}."
+                        )
                     } else {
                         String::new()
                     }
@@ -1105,12 +1113,16 @@ mod tests {
         );
 
         assert_eq!(
-            sanitize_ffmpeg_log_message("[swscaler @ 0x148db8100] Warning: invalid poxel format specified [swscaler @ 0x148db8200]"),
+            sanitize_ffmpeg_log_message(
+                "[swscaler @ 0x148db8100] Warning: invalid poxel format specified [swscaler @ 0x148db8200]"
+            ),
             "[swscaler] Warning: invalid poxel format specified [swscaler]"
         );
 
         assert_eq!(
-            sanitize_ffmpeg_log_message("[swscaler @ 0x248db8000] Warning: invalid päxel format specified [swscaler @ 0x198db8000] [swscaler @ 0x148db8030]"),
+            sanitize_ffmpeg_log_message(
+                "[swscaler @ 0x248db8000] Warning: invalid päxel format specified [swscaler @ 0x198db8000] [swscaler @ 0x148db8030]"
+            ),
             "[swscaler] Warning: invalid päxel format specified [swscaler] [swscaler]"
         );
 

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -112,7 +112,9 @@ pub enum Error {
     #[error("To enabled native AV1 decoding, compile Rerun with the `nasm` feature enabled.")]
     Dav1dWithoutNasm,
 
-    #[error("Rerun does not yet support native AV1 decoding on Linux ARM64. See https://github.com/rerun-io/rerun/issues/7755")]
+    #[error(
+        "Rerun does not yet support native AV1 decoding on Linux ARM64. See https://github.com/rerun-io/rerun/issues/7755"
+    )]
     #[cfg(linux_arm64)]
     NoDav1dOnLinuxArm64,
 

--- a/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -20,14 +20,18 @@ pub enum CpuWriteGpuReadError {
         num_elements_actually_added: usize,
     },
 
-    #[error("Target buffer has a size of {target_buffer_size}, can't write {copy_size} bytes with an offset of {destination_offset}!")]
+    #[error(
+        "Target buffer has a size of {target_buffer_size}, can't write {copy_size} bytes with an offset of {destination_offset}!"
+    )]
     TargetBufferTooSmall {
         target_buffer_size: u64,
         copy_size: u64,
         destination_offset: u64,
     },
 
-    #[error("Target texture doesn't fit the size of the written data to this buffer! Texture target buffer should be at most {max_copy_size} bytes, but the to be written data was {written_data_size} bytes.")]
+    #[error(
+        "Target texture doesn't fit the size of the written data to this buffer! Texture target buffer should be at most {max_copy_size} bytes, but the to be written data was {written_data_size} bytes."
+    )]
     TargetTextureBufferSizeMismatch {
         max_copy_size: u64,
         written_data_size: usize,

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -597,10 +597,14 @@ fn log_adapter_info(info: &wgpu::AdapterInfo) {
         // If we're testing then software rasterizers are just fine, preferred even!
         re_log::debug!("wgpu adapter {human_readable_summary}");
     } else if is_software_rasterizer_with_known_crashes {
-        re_log::warn!("Bad software rasterizer detected - expect poor performance and crashes. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
+        re_log::warn!(
+            "Bad software rasterizer detected - expect poor performance and crashes. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues"
+        );
         re_log::info!("wgpu adapter {human_readable_summary}");
     } else if info.device_type == wgpu::DeviceType::Cpu {
-        re_log::warn!("Software rasterizer detected - expect poor performance. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues");
+        re_log::warn!(
+            "Software rasterizer detected - expect poor performance. See: https://www.rerun.io/docs/getting-started/troubleshooting#graphics-issues"
+        );
         re_log::info!("wgpu adapter {human_readable_summary}");
     } else {
         re_log::debug!("wgpu adapter {human_readable_summary}");

--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -150,13 +150,17 @@ pub enum WgpuBackendType {
 
 #[derive(thiserror::Error, Debug)]
 pub enum InsufficientDeviceCapabilities {
-    #[error("Adapter does not support the minimum shader model required. Supported is {actual:?} but required is {required:?}.")]
+    #[error(
+        "Adapter does not support the minimum shader model required. Supported is {actual:?} but required is {required:?}."
+    )]
     TooLowShaderModel {
         required: wgpu::ShaderModel,
         actual: wgpu::ShaderModel,
     },
 
-    #[error("Adapter does not have all the required capability flags required. Supported are {actual:?} but required are {required:?}.")]
+    #[error(
+        "Adapter does not have all the required capability flags required. Supported are {actual:?} but required are {required:?}."
+    )]
     MissingCapabilitiesFlags {
         required: wgpu::DownlevelFlags,
         actual: wgpu::DownlevelFlags,
@@ -299,7 +303,9 @@ impl DeviceCaps {
             //
             // That's a lot of murky information, so let's keep the actual message crisp for now.
             #[cfg(not(web))]
-            re_log::warn!("Running on a GPU/graphics driver with very limited abilitites. Consider updating your driver.");
+            re_log::warn!(
+                "Running on a GPU/graphics driver with very limited abilitites. Consider updating your driver."
+            );
         };
 
         Ok(caps)
@@ -332,14 +338,18 @@ pub fn instance_descriptor(force_backend: Option<&str>) -> wgpu::InstanceDescrip
     let backends = if let Some(force_backend) = force_backend {
         if let Some(backend) = parse_graphics_backend(force_backend) {
             if let Err(err) = validate_graphics_backend_applicability(backend) {
-                re_log::error!("Failed to force rendering backend parsed from {force_backend:?}: {err}\nUsing default backend instead.");
+                re_log::error!(
+                    "Failed to force rendering backend parsed from {force_backend:?}: {err}\nUsing default backend instead."
+                );
                 supported_backends()
             } else {
                 re_log::info!("Forcing graphics backend to {backend:?}.");
                 backend.into()
             }
         } else {
-            re_log::error!("Failed to parse rendering backend string {force_backend:?}. Using default backend instead.");
+            re_log::error!(
+                "Failed to parse rendering backend string {force_backend:?}. Using default backend instead."
+            );
             supported_backends()
         }
     } else {

--- a/crates/viewer/re_renderer/src/error_handling/mod.rs
+++ b/crates/viewer/re_renderer/src/error_handling/mod.rs
@@ -24,7 +24,9 @@ fn handle_async_error(
             if let Some(error) = now_or_never::now_or_never(error_future) {
                 resolve_callback(error);
             } else {
-                re_log::error_once!("Expected wgpu errors to be ready immediately when using any of the wgpu-core based (native & webgl) backends.");
+                re_log::error_once!(
+                    "Expected wgpu errors to be ready immediately when using any of the wgpu-core based (native & webgl) backends."
+                );
             }
         }
     }

--- a/crates/viewer/re_renderer/src/importer/gltf.rs
+++ b/crates/viewer/re_renderer/src/importer/gltf.rs
@@ -20,7 +20,9 @@ pub enum GltfImportError {
     #[error("Unsupported texture format {0:?}.")]
     UnsupportedTextureFormat(gltf::image::Format),
 
-    #[error("Mesh {mesh_name:?} has multiple sets of texture coordinates. Only a single one is supported.")]
+    #[error(
+        "Mesh {mesh_name:?} has multiple sets of texture coordinates. Only a single one is supported."
+    )]
     MultipleTextureCoordinateSets { mesh_name: String },
 
     #[error("Mesh {mesh_name:?} has no triangles.")]

--- a/crates/viewer/re_renderer/src/line_drawable_builder.rs
+++ b/crates/viewer/re_renderer/src/line_drawable_builder.rs
@@ -137,7 +137,8 @@ impl<'ctx> LineBatchBuilder<'_, 'ctx> {
         let num_new_vertices = if reserve_count > num_available_points {
             re_log::error_once!(
                 "Reached maximum number of vertices for lines strips of {}. Ignoring all excess vertices.",
-                self.0.vertices_buffer.len() + num_available_points - LineVertex::NUM_SENTINEL_VERTICES
+                self.0.vertices_buffer.len() + num_available_points
+                    - LineVertex::NUM_SENTINEL_VERTICES
             );
             num_available_points - num_sentinels_to_add
         } else {

--- a/crates/viewer/re_renderer/src/mesh.rs
+++ b/crates/viewer/re_renderer/src/mesh.rs
@@ -129,13 +129,19 @@ impl CpuMesh {
 
 #[derive(thiserror::Error, Debug)]
 pub enum MeshError {
-    #[error("Number of vertex positions {num_pos} differed from the number of vertex colors {num_color}")]
+    #[error(
+        "Number of vertex positions {num_pos} differed from the number of vertex colors {num_color}"
+    )]
     WrongNumberOfColors { num_pos: usize, num_color: usize },
 
-    #[error("Number of vertex positions {num_pos} differed from the number of vertex normals {num_normals}")]
+    #[error(
+        "Number of vertex positions {num_pos} differed from the number of vertex normals {num_normals}"
+    )]
     WrongNumberOfNormals { num_pos: usize, num_normals: usize },
 
-    #[error("Number of vertex positions {num_pos} differed from the number of vertex tex-coords {num_texcoords}")]
+    #[error(
+        "Number of vertex positions {num_pos} differed from the number of vertex tex-coords {num_texcoords}"
+    )]
     WrongNumberOfTexcoord {
         num_pos: usize,
         num_texcoords: usize,

--- a/crates/viewer/re_renderer/src/renderer/debug_overlay.rs
+++ b/crates/viewer/re_renderer/src/renderer/debug_overlay.rs
@@ -92,7 +92,7 @@ impl DebugOverlayDrawData {
             None => {
                 return Err(DebugOverlayError::UnsupportedTextureFormat(
                     debug_texture.texture.format(),
-                ))
+                ));
             }
         };
 

--- a/crates/viewer/re_renderer/src/renderer/rectangles.rs
+++ b/crates/viewer/re_renderer/src/renderer/rectangles.rs
@@ -198,7 +198,9 @@ pub enum RectangleError {
     #[error("Texture format not supported: {0:?} - use float or integer textures instead.")]
     TextureFormatNotSupported(wgpu::TextureFormat),
 
-    #[error("Color mapping cannot be applied to a four-component RGBA image, but only to a single-component image.")]
+    #[error(
+        "Color mapping cannot be applied to a four-component RGBA image, but only to a single-component image."
+    )]
     ColormappingRgbaTexture,
 
     #[error("Only 1 and 4 component textures are supported, got {0} components")]

--- a/crates/viewer/re_renderer/src/resource_managers/image_data_to_texture.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/image_data_to_texture.rs
@@ -77,14 +77,18 @@ pub enum ImageDataToTextureError {
     #[error("Gpu-based conversion for texture {label:?} did not succeed: {err}")]
     GpuBasedConversionError { label: DebugLabel, err: DrawError },
 
-    #[error("Texture {label:?} has invalid texture usage flags: {actual_usage:?}, expected at least {required_usage:?}")]
+    #[error(
+        "Texture {label:?} has invalid texture usage flags: {actual_usage:?}, expected at least {required_usage:?}"
+    )]
     InvalidTargetTextureUsageFlags {
         label: DebugLabel,
         actual_usage: wgpu::TextureUsages,
         required_usage: wgpu::TextureUsages,
     },
 
-    #[error("Texture {label:?} has invalid texture format: {actual_format:?}, expected at least {required_format:?}")]
+    #[error(
+        "Texture {label:?} has invalid texture format: {actual_format:?}, expected at least {required_format:?}"
+    )]
     InvalidTargetTextureFormat {
         label: DebugLabel,
         actual_format: wgpu::TextureFormat,

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -81,7 +81,9 @@ impl VideoPlayer {
             if bit_depth < 8 {
                 re_log::warn_once!("{debug_name} has unusual bit_depth of {bit_depth}");
             } else if 8 < bit_depth {
-                re_log::warn_once!("{debug_name}: HDR videos not supported. See https://github.com/rerun-io/rerun/issues/7594 for more.");
+                re_log::warn_once!(
+                    "{debug_name}: HDR videos not supported. See https://github.com/rerun-io/rerun/issues/7594 for more."
+                );
             }
         }
 

--- a/crates/viewer/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
@@ -167,7 +167,10 @@ where
             );
             for resource in resources {
                 let Some(removed_resource) = state.all_resources.remove(resource) else {
-                    debug_assert!(false, "a resource was marked as destroyed last frame that we no longer kept track of");
+                    debug_assert!(
+                        false,
+                        "a resource was marked as destroyed last frame that we no longer kept track of"
+                    );
                     continue;
                 };
                 update_stats(&desc);

--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -107,34 +107,57 @@ impl UICommand {
 
     pub fn text_and_tooltip(self) -> (&'static str, &'static str) {
         match self {
-            Self::SaveRecording => ("Save recording…", "Save all data to a Rerun data file (.rrd)"),
+            Self::SaveRecording => (
+                "Save recording…",
+                "Save all data to a Rerun data file (.rrd)",
+            ),
 
             Self::SaveRecordingSelection => (
                 "Save current time selection…",
                 "Save data for the current loop selection to a Rerun data file (.rrd)",
             ),
 
-            Self::SaveBlueprint => ("Save blueprint…", "Save the current viewer setup as a Rerun blueprint file (.rbl)"),
+            Self::SaveBlueprint => (
+                "Save blueprint…",
+                "Save the current viewer setup as a Rerun blueprint file (.rbl)",
+            ),
 
-            Self::Open => ("Open…", "Open any supported files (.rrd, images, meshes, …) in a new recording"),
-            Self::Import => ("Import…", "Import any supported files (.rrd, images, meshes, …) in the current recording"),
+            Self::Open => (
+                "Open…",
+                "Open any supported files (.rrd, images, meshes, …) in a new recording",
+            ),
+            Self::Import => (
+                "Import…",
+                "Import any supported files (.rrd, images, meshes, …) in the current recording",
+            ),
 
             Self::CloseCurrentRecording => (
                 "Close current recording",
                 "Close the current recording (unsaved data will be lost)",
             ),
 
-            Self::CloseAllRecordings => ("Close all recordings",
-                                         "Close all open current recording (unsaved data will be lost)"),
+            Self::CloseAllRecordings => (
+                "Close all recordings",
+                "Close all open current recording (unsaved data will be lost)",
+            ),
 
-            Self::Undo => ("Undo", "Undo the last blueprint edit for the open recording"),
+            Self::Undo => (
+                "Undo",
+                "Undo the last blueprint edit for the open recording",
+            ),
             Self::Redo => ("Redo", "Redo the last undone thing"),
 
             #[cfg(not(target_arch = "wasm32"))]
             Self::Quit => ("Quit", "Close the Rerun Viewer"),
 
-            Self::OpenWebHelp => ("Help", "Visit the help page on our website, with troubleshooting tips and more"),
-            Self::OpenRerunDiscord => ("Rerun Discord", "Visit the Rerun Discord server, where you can ask questions and get help"),
+            Self::OpenWebHelp => (
+                "Help",
+                "Visit the help page on our website, with troubleshooting tips and more",
+            ),
+            Self::OpenRerunDiscord => (
+                "Rerun Discord",
+                "Visit the Rerun Discord server, where you can ask questions and get help",
+            ),
 
             Self::ResetViewer => (
                 "Reset Viewer",
@@ -143,12 +166,12 @@ impl UICommand {
 
             Self::ClearActiveBlueprint => (
                 "Reset to default blueprint",
-                "Clear active blueprint and use the default blueprint instead. If no default blueprint is set, this will use a heuristic blueprint."
+                "Clear active blueprint and use the default blueprint instead. If no default blueprint is set, this will use a heuristic blueprint.",
             ),
 
             Self::ClearActiveBlueprintAndEnableHeuristics => (
                 "Reset to heuristic blueprint",
-                "Re-populate viewport with automatically chosen views using default visualizers"
+                "Re-populate viewport with automatically chosen views using default visualizers",
             ),
 
             #[cfg(not(target_arch = "wasm32"))]
@@ -162,13 +185,19 @@ impl UICommand {
                 "View and track current RAM usage inside Rerun Viewer",
             ),
 
-            Self::TogglePanelStateOverrides => ("Toggle panel state overrides", "Toggle panel state between app blueprint and overrides"),
+            Self::TogglePanelStateOverrides => (
+                "Toggle panel state overrides",
+                "Toggle panel state between app blueprint and overrides",
+            ),
             Self::ToggleTopPanel => ("Toggle top panel", "Toggle the top panel"),
             Self::ToggleBlueprintPanel => ("Toggle blueprint panel", "Toggle the left panel"),
             Self::ExpandBlueprintPanel => ("Expand blueprint panel", "Expand the left panel"),
             Self::ToggleSelectionPanel => ("Toggle selection panel", "Toggle the right panel"),
             Self::ToggleTimePanel => ("Toggle time panel", "Toggle the bottom panel"),
-            Self::ToggleChunkStoreBrowser => ("Toggle chunk store browser", "Toggle the chunk store browser"),
+            Self::ToggleChunkStoreBrowser => (
+                "Toggle chunk store browser",
+                "Toggle the chunk store browser",
+            ),
             Self::Settings => ("Settings…", "Show the settings screen"),
 
             #[cfg(debug_assertions)]
@@ -192,7 +221,7 @@ impl UICommand {
             #[cfg(target_arch = "wasm32")]
             Self::ToggleFullscreen => (
                 "Toggle fullscreen",
-                "Toggle between full viewport dimensions and initial dimensions"
+                "Toggle between full viewport dimensions and initial dimensions",
             ),
 
             #[cfg(not(target_arch = "wasm32"))]
@@ -207,9 +236,7 @@ impl UICommand {
 
             Self::ToggleCommandPalette => ("Command palette…", "Toggle the Command Palette"),
 
-            Self::PlaybackTogglePlayPause => {
-                ("Toggle play/pause", "Either play or pause the time")
-            }
+            Self::PlaybackTogglePlayPause => ("Toggle play/pause", "Either play or pause the time"),
             Self::PlaybackFollow => ("Follow", "Follow on from end of timeline"),
             Self::PlaybackStepBack => (
                 "Step time back",
@@ -251,24 +278,23 @@ impl UICommand {
             #[cfg(target_arch = "wasm32")]
             Self::CopyDirectLink => (
                 "Copy direct link",
-                "Copy a link to the viewer with the URL parameter set to the current .rrd data source."
+                "Copy a link to the viewer with the URL parameter set to the current .rrd data source.",
             ),
-
 
             Self::CopyTimeRangeLink => (
                 "Copy link to selected time range",
-                "Copy a link to the part of the active recording within the loop selection bounds."
+                "Copy a link to the part of the active recording within the loop selection bounds.",
             ),
 
             #[cfg(target_arch = "wasm32")]
             Self::RestartWithWebGl => (
                 "Restart with WebGL",
-                "Reloads the webpage and force WebGL for rendering. All data will be lost."
+                "Reloads the webpage and force WebGL for rendering. All data will be lost.",
             ),
             #[cfg(target_arch = "wasm32")]
             Self::RestartWithWebGpu => (
                 "Restart with WebGPU",
-                "Reloads the webpage and force WebGPU for rendering. All data will be lost."
+                "Reloads the webpage and force WebGPU for rendering. All data will be lost.",
             ),
         }
     }

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -241,7 +241,9 @@ fn try_get_or_create_albedo_texture(
     )
     .is_some()
     {
-        re_log::warn_once!("Mesh can't yet handle encoded image formats like NV12 & YUY2 or BGR(A) formats without a channel type other than U8. Ignoring the texture at {name:?}.");
+        re_log::warn_once!(
+            "Mesh can't yet handle encoded image formats like NV12 & YUY2 or BGR(A) formats without a channel type other than U8. Ignoring the texture at {name:?}."
+        );
         return None;
     }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
@@ -91,7 +91,9 @@ impl CamerasVisualizer {
         let Some(twod_in_threed_info) = &transform_info.twod_in_threed_info else {
             // This implies that the transform context didn't see the pinhole transform.
             // Should be impossible!
-            re_log::error_once!("Transform context didn't register the pinhole transform, but `CamerasVisualizer` is trying to display it!");
+            re_log::error_once!(
+                "Transform context didn't register the pinhole transform, but `CamerasVisualizer` is trying to display it!"
+            );
             return;
         };
         if &twod_in_threed_info.parent_pinhole != ent_path {

--- a/crates/viewer/re_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/lines3d.rs
@@ -107,7 +107,12 @@ impl Lines3DVisualizer {
 
                 num_rendered_strips += 1;
             }
-            debug_assert_eq!(data.strips.len(), num_rendered_strips, "the number of renderer strips after all post-processing is done should be equal to {} (got {num_rendered_strips} instead)", data.strips.len());
+            debug_assert_eq!(
+                data.strips.len(),
+                num_rendered_strips,
+                "the number of renderer strips after all post-processing is done should be equal to {} (got {num_rendered_strips} instead)",
+                data.strips.len()
+            );
 
             self.data
                 .add_bounding_box(entity_path.hash(), obj_space_bounding_box, world_from_obj);

--- a/crates/viewer/re_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/mod.rs
@@ -244,7 +244,9 @@ pub fn load_keypoint_connections(
             let (Some(a), Some(b)) = (keypoints_in_class.get(a), keypoints_in_class.get(b)) else {
                 re_log::warn_once!(
                     "Keypoint connection from index {:?} to {:?} could not be resolved in object {:?}",
-                    a, b, ent_path
+                    a,
+                    b,
+                    ent_path
                 );
                 continue;
             };

--- a/crates/viewer/re_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/mod.rs
@@ -243,10 +243,7 @@ pub fn load_keypoint_connections(
         {
             let (Some(a), Some(b)) = (keypoints_in_class.get(a), keypoints_in_class.get(b)) else {
                 re_log::warn_once!(
-                    "Keypoint connection from index {:?} to {:?} could not be resolved in object {:?}",
-                    a,
-                    b,
-                    ent_path
+                    "Keypoint connection from index {a:?} to {b:?} could not be resolved in entity {ent_path:?}"
                 );
                 continue;
             };

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1016,7 +1016,9 @@ impl App {
             #[cfg(target_arch = "wasm32")]
             UICommand::CopyDirectLink => {
                 if self.run_copy_direct_link_command(store_context).is_none() {
-                    re_log::error!("Failed to copy direct link to clipboard. Is this not running in a browser?");
+                    re_log::error!(
+                        "Failed to copy direct link to clipboard. Is this not running in a browser?"
+                    );
                 }
             }
 
@@ -1149,7 +1151,9 @@ impl App {
 
         let Some(range) = time_ctrl.loop_selection() else {
             // no loop selection
-            re_log::warn!("Could not copy time range link: No loop selection set. Use shift+left click on the timeline to create a loop");
+            re_log::warn!(
+                "Could not copy time range link: No loop selection set. Use shift+left click on the timeline to create a loop"
+            );
             return;
         };
 
@@ -1375,7 +1379,9 @@ impl App {
 
             if store_hub.is_active_blueprint(store_id) {
                 // TODO(#5514): handle loading of active blueprints.
-                re_log::warn_once!("Loading a blueprint {store_id} that is active. See https://github.com/rerun-io/rerun/issues/5514 for details.");
+                re_log::warn_once!(
+                    "Loading a blueprint {store_id} that is active. See https://github.com/rerun-io/rerun/issues/5514 for details."
+                );
             }
 
             // TODO(cmc): we have to keep grabbing and releasing entity_db because everything references
@@ -1513,7 +1519,9 @@ impl App {
                     {
                         for &view_type in archetype.view_types {
                             if !cfg!(feature = "map_view") && view_type == "MapView" {
-                                re_log::warn_once!("Found map-related archetype, but viewer was not compiled with the `map_view` feature.");
+                                re_log::warn_once!(
+                                    "Found map-related archetype, but viewer was not compiled with the `map_view` feature."
+                                );
                             }
                         }
                     } else {
@@ -1874,7 +1882,9 @@ fn blueprint_loader() -> BlueprintPersistence {
                 if store.store_kind() == StoreKind::Blueprint
                     && !crate::blueprint::is_valid_blueprint(store)
                 {
-                    re_log::warn_once!("Blueprint for {app_id} at {blueprint_path:?} appears invalid - will ignore. This is expected if you have just upgraded Rerun versions.");
+                    re_log::warn_once!(
+                        "Blueprint for {app_id} at {blueprint_path:?} appears invalid - will ignore. This is expected if you have just upgraded Rerun versions."
+                    );
                     return Ok(None);
                 }
             }

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -507,8 +507,7 @@ fn input_queue_latency_ui(ui: &mut egui::Ui, app: &mut App) {
                 latency_text(latency_sec),
                 format_uint(queue_len),
             );
-            let hover_text =
-                    "When more data is arriving over network than the Rerun Viewer can ingest, a queue starts building up, leading to latency and increased RAM use.\n\
+            let hover_text = "When more data is arriving over network than the Rerun Viewer can ingest, a queue starts building up, leading to latency and increased RAM use.\n\
                     This latency does NOT include network latency.";
 
             if latency_sec < app.app_options().warn_latency {

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -176,7 +176,9 @@ pub fn url_to_receiver(
                             if tx.send(msg).is_ok() {
                                 ControlFlow::Continue(())
                             } else {
-                                re_log::info_once!("Failed to send log message to viewer - closing connection to {url}");
+                                re_log::info_once!(
+                                    "Failed to send log message to viewer - closing connection to {url}"
+                                );
                                 ControlFlow::Break(())
                             }
                         }

--- a/crates/viewer/re_viewer_context/src/component_fallbacks.rs
+++ b/crates/viewer/re_viewer_context/src/component_fallbacks.rs
@@ -65,7 +65,9 @@ pub trait ComponentFallbackProvider {
                 // but arrow serialization should never fail.
                 // Giving out _both_ the error and the fallback value gets messy,
                 // so given that this should be a rare bug, we log it and return the fallback value as success.
-                re_log::error_once!("Arrow serialization failed trying to provide a fallback for {component}. Using base fallback instead: {err}");
+                re_log::error_once!(
+                    "Arrow serialization failed trying to provide a fallback for {component}. Using base fallback instead: {err}"
+                );
             }
             ComponentFallbackProviderResult::ComponentNotHandled => {}
         }

--- a/crates/viewer/re_web_viewer_server/src/lib.rs
+++ b/crates/viewer/re_web_viewer_server/src/lib.rs
@@ -223,7 +223,9 @@ impl WebViewerServerInner {
         if false {
             self.on_serve_wasm(); // to silence warning about the function being unused
         }
-        panic!("web_server compiled with '__ci' feature, `--all-features`, or '--cfg disable_web_viewer_server'. DON'T DO THAT! It's only for the CI!");
+        panic!(
+            "web_server compiled with '__ci' feature, `--all-features`, or '--cfg disable_web_viewer_server'. DON'T DO THAT! It's only for the CI!"
+        );
     }
 
     #[cfg(not(any(disable_web_viewer_server, feature = "__ci")))]

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -195,11 +195,11 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
         let total_elapsed = total_start_time.elapsed();
         if total_elapsed.as_secs_f64() >= 1.0 {
             println!(
-                        "logged {total_num_scalars} scalars over {:?} (freq={:.3}Hz, expected={expected_total_freq:.3}Hz, load={:.3}%)",
-                        total_elapsed,
-                        total_num_scalars as f64 / total_elapsed.as_secs_f64(),
-                        max_load * 100.0,
-                    );
+                "logged {total_num_scalars} scalars over {:?} (freq={:.3}Hz, expected={expected_total_freq:.3}Hz, load={:.3}%)",
+                total_elapsed,
+                total_num_scalars as f64 / total_elapsed.as_secs_f64(),
+                max_load * 100.0,
+            );
 
             let elapsed_debt =
                 std::time::Duration::from_secs_f64(total_elapsed.as_secs_f64().fract());
@@ -212,11 +212,11 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
     if total_num_scalars > 0 {
         let total_elapsed = total_start_time.elapsed();
         println!(
-        "logged {total_num_scalars} scalars over {:?} (freq={:.3}Hz, expected={expected_total_freq:.3}Hz, load={:.3}%)",
-        total_elapsed,
-        total_num_scalars as f64 / total_elapsed.as_secs_f64(),
-        max_load * 100.0,
-    );
+            "logged {total_num_scalars} scalars over {:?} (freq={:.3}Hz, expected={expected_total_freq:.3}Hz, load={:.3}%)",
+            total_elapsed,
+            total_num_scalars as f64 / total_elapsed.as_secs_f64(),
+            max_load * 100.0,
+        );
     }
 
     Ok(())


### PR DESCRIPTION
This re-formats some code that failed to format under `edition=2021`.

This will make it easier for us to update to `edition=2024`