### PR TITLE
re_uri: Use correct default port (51234, not 80)

### DIFF
--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -102,7 +102,7 @@ impl DataSource {
             }
         }
 
-        if let Ok(endpoint) = re_uri::RedapUri::try_from(uri.as_str()) {
+        if let Ok(endpoint) = uri.as_str().parse::<re_uri::RedapUri>() {
             return Self::RerunGrpcStream(endpoint);
         }
 

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -61,12 +61,10 @@ pub struct EntityPathFilter {
     rules: BTreeMap<EntityPathRule, RuleEffect>,
 }
 
-// Note: it's not possible to implement that for `S: AsRef<str>` because this conflicts with some
-// blanket implementation in `core` :(
-impl TryFrom<&str> for EntityPathFilter {
-    type Error = EntityPathFilterError;
+impl std::str::FromStr for EntityPathFilter {
+    type Err = EntityPathFilterError;
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         Self::parse_strict(value)
     }
 }

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -384,8 +384,7 @@ impl RecordingStreamBuilder {
         let (enabled, store_info, properties, batcher_config) = self.into_args();
         if enabled {
             let url: String = url.into();
-            let re_uri::RedapUri::Proxy(endpoint) = re_uri::RedapUri::try_from(url.as_str())?
-            else {
+            let re_uri::RedapUri::Proxy(endpoint) = url.as_str().parse()? else {
                 return Err(RecordingStreamError::NotAProxyEndpoint);
             };
 
@@ -1809,7 +1808,7 @@ impl RecordingStream {
         }
 
         let url: String = url.into();
-        let re_uri::RedapUri::Proxy(endpoint) = re_uri::RedapUri::try_from(url.as_str())? else {
+        let re_uri::RedapUri::Proxy(endpoint) = url.as_str().parse()? else {
             return Err(RecordingStreamError::NotAProxyEndpoint);
         };
 

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -762,8 +762,7 @@ fn run_impl(
         #[cfg(feature = "server")]
         if let Some(url) = args.connect {
             let url = url.unwrap_or_else(|| format!("rerun+http://{server_addr}/proxy"));
-            let re_uri::RedapUri::Proxy(endpoint) = re_uri::RedapUri::try_from(url.as_str())?
-            else {
+            let re_uri::RedapUri::Proxy(endpoint) = url.as_str().parse()? else {
                 anyhow::bail!("expected `/proxy` endpoint");
             };
             let rx = re_sdk::external::re_grpc_client::message_proxy::stream(endpoint, None);
@@ -857,8 +856,7 @@ fn run_impl(
                 format!("rerun+http://{server_addr}/proxy")
             };
 
-            let re_uri::RedapUri::Proxy(endpoint) = re_uri::RedapUri::try_from(url.as_str())?
-            else {
+            let re_uri::RedapUri::Proxy(endpoint) = url.as_str().parse()? else {
                 anyhow::bail!("expected `/proxy` endpoint");
             };
 

--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -152,7 +152,7 @@ fn setup_filter_test(query: Option<&str>) -> (TestContext, BlueprintTree) {
                 re_view_spatial::SpatialView3D::identifier(),
                 RecommendedView {
                     origin: "/path/to".into(),
-                    query_filter: "+ /**".try_into().expect("valid entity path filter"),
+                    query_filter: "+ /**".parse().expect("valid entity path filter"),
                 },
             )),
             None,

--- a/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
@@ -128,7 +128,7 @@ fn test_context(test_case: &TestCase) -> TestContext {
                 origin: test_case.origin.clone(),
                 query_filter: test_case
                     .entity_filter
-                    .try_into()
+                    .parse()
                     .expect("invalid entity filter"),
             },
             ViewId::hashed_from_str(VIEW_ID),

--- a/crates/viewer/re_view_spatial/tests/transform_clamping.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_clamping.rs
@@ -163,7 +163,7 @@ fn setup_blueprint(test_context: &mut TestContext) -> (ViewId, ViewId) {
             re_view_spatial::SpatialView3D::identifier(),
             RecommendedView {
                 origin: "/boxes".into(),
-                query_filter: "+ $origin/**".try_into().unwrap(),
+                query_filter: "+ $origin/**".parse().unwrap(),
             },
         );
 
@@ -171,7 +171,7 @@ fn setup_blueprint(test_context: &mut TestContext) -> (ViewId, ViewId) {
             re_view_spatial::SpatialView3D::identifier(),
             RecommendedView {
                 origin: "/spheres".into(),
-                query_filter: "+ $origin/**".try_into().unwrap(),
+                query_filter: "+ $origin/**".parse().unwrap(),
             },
         );
 

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -895,7 +895,7 @@ fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
     ctx.egui_ctx().output_mut(|o| {
         o.commands.retain_mut(|command| {
             if let egui::OutputCommand::OpenUrl(open_url) = command {
-                let is_rerun_url = re_uri::RedapUri::try_from(open_url.url.as_ref()).is_ok();
+                let is_rerun_url = open_url.url.parse::<re_uri::RedapUri>().is_ok();
 
                 if is_rerun_url {
                     let data_source = re_data_source::DataSource::from_uri(

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -99,7 +99,7 @@ enum EndpointCategory {
 
 impl EndpointCategory {
     fn categorize_uri(uri: String) -> Self {
-        if let Ok(uri) = re_uri::RedapUri::try_from(uri.as_ref()) {
+        if let Ok(uri) = uri.parse() {
             return Self::RerunGrpcStream(uri);
         }
 

--- a/examples/rust/dataframe_query/src/main.rs
+++ b/examples/rust/dataframe_query/src/main.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 
 use rerun::{
-    dataframe::{EntityPathFilter, QueryEngine, QueryExpression, SparseFillStrategy, TimelineName},
+    dataframe::{QueryEngine, QueryExpression, SparseFillStrategy, TimelineName},
     external::{arrow, re_format_arrow::format_record_batch},
     ChunkStoreConfig, StoreKind, VersionPolicy,
 };
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let path_to_rrd = get_arg(1);
-    let entity_path_filter = EntityPathFilter::try_from(args.get(2).map_or("/**", |s| s.as_str()))?;
+    let entity_path_filter = args.get(2).map_or("/**", |s| s.as_str()).parse()?;
     let timeline = TimelineName::log_time();
 
     let engines = QueryEngine::from_rrd_filepath(

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -26,7 +26,7 @@ impl PyCatalogClient {
     /// Create a new catalog client object.
     #[new]
     fn new(py: Python<'_>, addr: String) -> PyResult<Self> {
-        let origin = re_uri::Origin::try_from(addr.as_str()).map_err(to_py_err)?;
+        let origin = addr.as_str().parse::<re_uri::Origin>().map_err(to_py_err)?;
 
         let connection = ConnectionHandle::new(py, origin.clone())?;
 


### PR DESCRIPTION
This makes it more ergonomic to connect to redap.

Also: use more idiomatic `FromStr` instead of `TryFrom<&str>`. I've opened a clippy lint about this: https://github.com/rust-lang/rust-clippy/issues/14522

Review each commit seperately.