### PR TITLE
Implement `Dataset.partition_table()` to expose the partition table as a datafusion table provider

### DIFF
--- a/crates/store/re_datafusion/examples/catalog.rs
+++ b/crates/store/re_datafusion/examples/catalog.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
                 println!("Partitions for dataset: {name}");
                 let _ = ctx.register_table(
                     &registration_name,
-                    df_connector.get_partition_table(tuid).await?,
+                    df_connector.get_partition_table(tuid.into()).await?,
                 )?;
 
                 let df = ctx.table(registration_name).await?;

--- a/crates/store/re_datafusion/src/datafusion_connector.rs
+++ b/crates/store/re_datafusion/src/datafusion_connector.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 use datafusion::{catalog::TableProvider, error::DataFusionError};
 use tonic::transport::Channel;
 
+use crate::partition_table::PartitionTableProvider;
+use crate::table_entry_provider::TableEntryTableProvider;
 use re_log_types::external::re_tuid::Tuid;
+use re_protos::common::v1alpha1::ext::EntryId;
 use re_protos::{
     catalog::v1alpha1::{ext::EntryDetails, DatasetEntry, EntryFilter, ReadDatasetEntryRequest},
     frontend::v1alpha1::frontend_service_client::FrontendServiceClient,
 };
-
-use crate::partition_table::PartitionTableProvider;
-use crate::table_entry_provider::TableEntryTableProvider;
 
 pub struct DataFusionConnector {
     catalog: FrontendServiceClient<Channel>,
@@ -67,9 +67,9 @@ impl DataFusionConnector {
 
     pub async fn get_partition_table(
         &self,
-        tuid: Tuid,
+        dataset_id: EntryId,
     ) -> Result<Arc<dyn TableProvider>, DataFusionError> {
-        PartitionTableProvider::new(self.catalog.clone(), tuid)
+        PartitionTableProvider::new(self.catalog.clone(), dataset_id)
             .into_provider()
             .await
     }

--- a/crates/store/re_datafusion/src/lib.rs
+++ b/crates/store/re_datafusion/src/lib.rs
@@ -7,5 +7,6 @@ mod search_provider;
 mod table_entry_provider;
 
 pub use datafusion_connector::DataFusionConnector;
+pub use partition_table::PartitionTableProvider;
 pub use search_provider::SearchResultsTableProvider;
 pub use table_entry_provider::TableEntryTableProvider;


### PR DESCRIPTION
### Related

* part of https://github.com/rerun-io/dataplatform/issues/405
* closes https://github.com/rerun-io/dataplatform/issues/402

### What

- Fixes `PartitionTableProvider` to use `GetPartitionTableSchema` instead of a hard-coded schema
- Expose it in python as `Dataset.partition_table()`

<img width="999" alt="image" src="https://github.com/user-attachments/assets/00950d11-937d-4702-b768-8dc3efc41aca" />
