### PR TITLE
Remove unused `serde` feature from `url`

### DIFF
--- a/crates/utils/re_uri/Cargo.toml
+++ b/crates/utils/re_uri/Cargo.toml
@@ -21,4 +21,4 @@ re_tuid.workspace = true
 # External
 serde.workspace = true
 thiserror.workspace = true
-url = { workspace = true, features = ["serde"] }
+url.workspace = true


### PR DESCRIPTION
likely has little impact, but isn't needed anymore 🤷 