### PR TITLE
Support `#datapath` fragment on redap URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7800,6 +7800,7 @@ dependencies = [
 name = "re_uri"
 version = "0.23.0-alpha.1+dev"
 dependencies = [
+ "re_log",
  "re_log_types",
  "re_tuid",
  "serde",

--- a/crates/utils/re_uri/Cargo.toml
+++ b/crates/utils/re_uri/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
+re_log.workspace = true
 re_log_types = { workspace = true, features = ["serde"] }
 re_tuid.workspace = true
 

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -14,6 +14,7 @@ pub struct DatasetDataEndpoint {
     pub origin: Origin,
     pub dataset_id: re_tuid::Tuid,
 
+    // Query parameters: these affect what data is returned.
     pub partition_id: String,
     pub time_range: Option<TimeRange>,
 }
@@ -43,29 +44,28 @@ impl std::fmt::Display for DatasetDataEndpoint {
 }
 
 impl DatasetDataEndpoint {
-    pub fn new(
-        origin: Origin,
-        dataset_id: re_tuid::Tuid,
-        partition_id: String,
-        time_range: Option<TimeRange>,
-    ) -> Self {
+    /// All the mandatory fields.
+    pub fn new(origin: Origin, dataset_id: re_tuid::Tuid, partition_id: String) -> Self {
         Self {
             origin,
             dataset_id,
             partition_id,
-            time_range,
+            time_range: None,
         }
     }
 
-    /// Returns a [`DatasetDataEndpoint`] without the optional query part.
-    pub fn without_query(&self) -> std::borrow::Cow<'_, Self> {
-        let mut cow = std::borrow::Cow::Borrowed(self);
+    /// Returns a [`DatasetDataEndpoint`] without any (optional) query or fragment..
+    pub fn without_query_and_fragment(mut self) -> Self {
+        let Self {
+            origin: _,       // Mandatory
+            dataset_id: _,   // Mandatory
+            partition_id: _, // Mandatory
+            time_range,
+        } = &mut self;
 
-        if self.time_range.is_some() {
-            cow.to_mut().time_range = None;
-        }
+        *time_range = None;
 
-        cow
+        self
     }
 }
 

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -7,7 +7,7 @@ use crate::{Error, Fragment, Origin, RedapUri, TimeRange};
 /// Currently, the following format is supported:
 /// `<origin>/dataset/$DATASET_ID/data?partition_id=$PARTITION_ID&time_range=$TIME_RANGE`
 ///
-/// `partition_id` is currnelty mandatory, and `time_range` is optional.
+/// `partition_id` is currently mandatory, and `time_range` is optional.
 /// In the future we will add richer queries.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DatasetDataEndpoint {

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -51,10 +51,10 @@ impl DatasetDataEndpoint {
         for (key, value) in url.query_pairs() {
             match key.as_ref() {
                 "partition_id" => {
-                    partition_id = Some(value.to_owned());
+                    partition_id = Some(value.to_string());
                 }
                 "time_range" => {
-                    time_range = Some(value.parse()?);
+                    time_range = Some(value.parse::<TimeRange>()?);
                 }
                 _ => {
                     re_log::warn_once!("Unknown query parameter: {key}={value}");
@@ -70,7 +70,7 @@ impl DatasetDataEndpoint {
             origin,
             dataset_id,
             partition_id,
-            time_range: None,
+            time_range,
         })
     }
 

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -7,14 +7,15 @@ use crate::{Origin, RedapUri, TimeRange};
 /// Currently, the following format is supported:
 /// `<origin>/dataset/$DATASET_ID/data?partition_id=$PARTITION_ID&time_range=$TIME_RANGE`
 ///
-/// `partition_id` is mandatory, and `time_range` is optional. In the future, it will be extended to
-/// richer queries.
+/// `partition_id` is currnelty mandatory, and `time_range` is optional.
+/// In the future we will add richer queries.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DatasetDataEndpoint {
     pub origin: Origin,
     pub dataset_id: re_tuid::Tuid,
 
     // Query parameters: these affect what data is returned.
+    /// Currently mandatory.
     pub partition_id: String,
     pub time_range: Option<TimeRange>,
 }
@@ -30,11 +31,10 @@ impl std::fmt::Display for DatasetDataEndpoint {
 
         write!(f, "{origin}/dataset/{dataset_id}")?;
 
-        // query (for now, partition_id is the only supported one and is mandatory)
+        // ?query:
         {
             write!(f, "?partition_id={partition_id}")?;
         }
-
         if let Some(time_range) = time_range {
             write!(f, "&time_range={time_range}")?;
         }

--- a/crates/utils/re_uri/src/fragment.rs
+++ b/crates/utils/re_uri/src/fragment.rs
@@ -1,0 +1,39 @@
+use re_log_types::DataPath;
+
+/// We use the `#fragment` of the URI to point to a specific entity.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct Fragment {
+    pub data_path: Option<DataPath>,
+}
+
+impl std::fmt::Display for Fragment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { data_path } = self;
+
+        if let Some(data_path) = data_path {
+            write!(f, "{data_path}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Fragment {
+    /// Parse fragment, excluding hash
+    pub fn parse_forgiving(fragment: &str) -> Self {
+        let mut data_path = None;
+
+        match fragment.parse::<DataPath>() {
+            Ok(path) => {
+                data_path = Some(path);
+            }
+            Err(err) => {
+                re_log::warn_once!(
+                    "Failed to parse URL fragment '#{fragment}`: {err} (expected a data path)"
+                );
+            }
+        }
+
+        Self { data_path }
+    }
+}

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -35,6 +35,7 @@
 
 mod endpoints;
 mod error;
+mod fragment;
 mod origin;
 mod redap_uri;
 mod scheme;
@@ -43,6 +44,7 @@ mod time_range;
 pub use self::{
     endpoints::{catalog::CatalogEndpoint, dataset::DatasetDataEndpoint, proxy::ProxyEndpoint},
     error::Error,
+    fragment::Fragment,
     origin::Origin,
     redap_uri::RedapUri,
     scheme::Scheme,

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -1,4 +1,4 @@
-use crate::{CatalogEndpoint, DatasetDataEndpoint, Error, Origin, ProxyEndpoint, TimeRange};
+use crate::{CatalogEndpoint, DatasetDataEndpoint, Error, Origin, ProxyEndpoint};
 
 /// Parsed from `rerun://addr:port/recording/12345` or `rerun://addr:port/catalog`
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -79,7 +79,7 @@ impl<'de> serde::Deserialize<'de> for RedapUri {
 #[cfg(test)]
 mod tests {
 
-    use crate::Scheme;
+    use crate::{Scheme, TimeRange};
 
     use super::*;
     use core::net::Ipv4Addr;

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -79,6 +79,8 @@ impl<'de> serde::Deserialize<'de> for RedapUri {
 #[cfg(test)]
 mod tests {
 
+    use re_log_types::DataPath;
+
     use crate::{Scheme, TimeRange};
 
     use super::*;
@@ -126,6 +128,7 @@ mod tests {
             dataset_id,
             partition_id,
             time_range,
+            data_path,
         }) = address
         else {
             panic!("Expected recording");
@@ -140,6 +143,43 @@ mod tests {
         );
         assert_eq!(partition_id, "pid");
         assert_eq!(time_range, None);
+        assert_eq!(data_path, None);
+    }
+
+    #[test]
+    fn test_dataset_data_url_with_fragment() {
+        let url =
+            "rerun://127.0.0.1:1234/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid#/some/entity[#42]";
+        let address: RedapUri = url.parse().unwrap();
+
+        let RedapUri::DatasetData(DatasetDataEndpoint {
+            origin,
+            dataset_id,
+            partition_id,
+            time_range,
+            data_path,
+        }) = address
+        else {
+            panic!("Expected recording");
+        };
+
+        assert_eq!(origin.scheme, Scheme::Rerun);
+        assert_eq!(origin.host, url::Host::<String>::Ipv4(Ipv4Addr::LOCALHOST));
+        assert_eq!(origin.port, 1234);
+        assert_eq!(
+            dataset_id,
+            "1830B33B45B963E7774455beb91701ae".parse().unwrap(),
+        );
+        assert_eq!(partition_id, "pid");
+        assert_eq!(time_range, None);
+        assert_eq!(
+            data_path,
+            Some(DataPath {
+                entity_path: "/some/entity".into(),
+                instance: Some(42.into()),
+                component_name: None,
+            })
+        );
     }
 
     #[test]
@@ -152,6 +192,7 @@ mod tests {
             dataset_id,
             partition_id,
             time_range,
+            data_path,
         }) = address
         else {
             panic!("Expected recording");
@@ -175,6 +216,7 @@ mod tests {
                 )
             })
         );
+        assert_eq!(data_path, None);
     }
 
     #[test]
@@ -187,6 +229,7 @@ mod tests {
             dataset_id,
             partition_id,
             time_range,
+            data_path,
         }) = address
         else {
             panic!("Expected recording");
@@ -214,6 +257,7 @@ mod tests {
                 )
             })
         );
+        assert_eq!(data_path, None);
     }
 
     #[test]
@@ -229,6 +273,7 @@ mod tests {
                 dataset_id,
                 partition_id,
                 time_range,
+                data_path,
             }) = address
             else {
                 panic!("Expected recording");
@@ -252,6 +297,7 @@ mod tests {
                     )
                 })
             );
+            assert_eq!(data_path, None);
         }
     }
 

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -1,4 +1,4 @@
-use crate::{CatalogEndpoint, DatasetDataEndpoint, Error, Origin, ProxyEndpoint};
+use crate::{CatalogEndpoint, DatasetDataEndpoint, Error, Fragment, Origin, ProxyEndpoint};
 
 /// Parsed from `rerun://addr:port/recording/12345` or `rerun://addr:port/catalog`
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -9,6 +9,16 @@ pub enum RedapUri {
 
     /// We use the `/proxy` endpoint to access another _local_ viewer.
     Proxy(ProxyEndpoint),
+}
+
+impl RedapUri {
+    /// Return the parsed `#fragment` of the URI, if any.
+    pub fn fragment(&self) -> Option<&Fragment> {
+        match self {
+            Self::Catalog(_) | Self::Proxy(_) => None,
+            Self::DatasetData(dataset_data_endpoint) => Some(&dataset_data_endpoint.fragment),
+        }
+    }
 }
 
 impl std::fmt::Display for RedapUri {

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -81,7 +81,7 @@ mod tests {
 
     use re_log_types::DataPath;
 
-    use crate::{Scheme, TimeRange};
+    use crate::{Fragment, Scheme, TimeRange};
 
     use super::*;
     use core::net::Ipv4Addr;
@@ -128,7 +128,7 @@ mod tests {
             dataset_id,
             partition_id,
             time_range,
-            data_path,
+            fragment,
         }) = address
         else {
             panic!("Expected recording");
@@ -143,7 +143,7 @@ mod tests {
         );
         assert_eq!(partition_id, "pid");
         assert_eq!(time_range, None);
-        assert_eq!(data_path, None);
+        assert_eq!(fragment, Default::default());
     }
 
     #[test]
@@ -157,7 +157,7 @@ mod tests {
             dataset_id,
             partition_id,
             time_range,
-            data_path,
+            fragment,
         }) = address
         else {
             panic!("Expected recording");
@@ -173,12 +173,14 @@ mod tests {
         assert_eq!(partition_id, "pid");
         assert_eq!(time_range, None);
         assert_eq!(
-            data_path,
-            Some(DataPath {
-                entity_path: "/some/entity".into(),
-                instance: Some(42.into()),
-                component_name: None,
-            })
+            fragment,
+            Fragment {
+                data_path: Some(DataPath {
+                    entity_path: "/some/entity".into(),
+                    instance: Some(42.into()),
+                    component_name: None,
+                })
+            }
         );
     }
 
@@ -192,7 +194,7 @@ mod tests {
             dataset_id,
             partition_id,
             time_range,
-            data_path,
+            fragment,
         }) = address
         else {
             panic!("Expected recording");
@@ -216,7 +218,7 @@ mod tests {
                 )
             })
         );
-        assert_eq!(data_path, None);
+        assert_eq!(fragment, Default::default());
     }
 
     #[test]
@@ -229,7 +231,7 @@ mod tests {
             dataset_id,
             partition_id,
             time_range,
-            data_path,
+            fragment,
         }) = address
         else {
             panic!("Expected recording");
@@ -257,7 +259,7 @@ mod tests {
                 )
             })
         );
-        assert_eq!(data_path, None);
+        assert_eq!(fragment, Default::default());
     }
 
     #[test]
@@ -273,7 +275,7 @@ mod tests {
                 dataset_id,
                 partition_id,
                 time_range,
-                data_path,
+                fragment,
             }) = address
             else {
                 panic!("Expected recording");
@@ -297,7 +299,7 @@ mod tests {
                     )
                 })
             );
-            assert_eq!(data_path, None);
+            assert_eq!(fragment, Default::default());
         }
     }
 

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -56,12 +56,12 @@ impl std::str::FromStr for RedapUri {
                     .1
                     .into_owned();
 
-                Ok(Self::DatasetData(DatasetDataEndpoint::new(
+                Ok(Self::DatasetData(DatasetDataEndpoint {
                     origin,
                     dataset_id,
                     partition_id,
-                    time_range.transpose()?,
-                )))
+                    time_range: time_range.transpose()?,
+                }))
             }
             [unknown, ..] => Err(Error::UnexpectedEndpoint(format!("{unknown}/"))),
         }

--- a/crates/utils/re_uri/src/time_range.rs
+++ b/crates/utils/re_uri/src/time_range.rs
@@ -8,10 +8,6 @@ pub struct TimeRange {
     pub range: re_log_types::ResolvedTimeRangeF,
 }
 
-impl TimeRange {
-    pub(crate) const QUERY_KEY: &'static str = "time_range";
-}
-
 impl std::fmt::Display for TimeRange {
     /// Used for formatting time ranges in URLs
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -565,7 +565,8 @@ impl App {
                 self.state.display_mode = display_mode;
             }
             SystemCommand::AddRedapServer { endpoint } => {
-                self.state.redap_servers.add_server(endpoint.origin);
+                let re_uri::CatalogEndpoint { origin } = endpoint;
+                self.state.redap_servers.add_server(origin);
                 self.command_sender.send_ui(UICommand::ExpandBlueprintPanel);
             }
 

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -226,7 +226,10 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
                 format!("Waiting for data on {url}…")
             }
             re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
-                format!("Waiting for data on {}…", endpoint.without_query())
+                format!(
+                    "Waiting for data on {}…",
+                    endpoint.without_query_and_fragment()
+                )
             }
             re_smart_channel::SmartChannelSource::RrdWebEventListener
             | re_smart_channel::SmartChannelSource::JsChannel { .. } => {

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -228,7 +228,7 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
             re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
                 format!(
                     "Waiting for data on {}…",
-                    endpoint.without_query_and_fragment()
+                    endpoint.clone().without_query_and_fragment()
                 )
             }
             re_smart_channel::SmartChannelSource::RrdWebEventListener

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -249,11 +249,6 @@ def lint_line(
             if not app_id.startswith("rerun_example_") and not app_id == "<your_app_name>":
                 return f"All examples should have an app_id starting with 'rerun_example_'. Found '{app_id}'"
 
-    # Methods that return Self should usually be marked #[inline] or #[inline(always)] since they indicate a builder.
-    if re.search(r"\(mut self.*-> Self", line):
-        if prev_line_stripped != "#[inline]" and prev_line_stripped != "#[inline(always)]":
-            return "Builder methods impls should be marked #[inline]"
-
     # Deref impls should be marked #[inline] or #[inline(always)].
     if "fn deref(&self)" in line or "fn deref_mut(&mut self)" in line:
         if prev_line_stripped != "#[inline]" and prev_line_stripped != "#[inline(always)]":
@@ -406,7 +401,6 @@ def test_lint_line() -> None:
         'rr.script_setup(args, "missing_prefix")',
         'rr.script_setup(args, "")',
         "I accidentally wrote the same same word twice",
-        "fn foo(mut self) -> Self {",
         "fn deref(&self) -> Self::Target {",
         "fn deref_mut(&mut self) -> &mut Self::Target",
         "fn borrow(&self) -> &Self",


### PR DESCRIPTION
This adds support for appending a data path (e.g. `/some/entity[#42]`) to a redap URL, as a `#fragment`.

When clicking a redap URI with such a fragment, we will focus on that entity.
This is untested, however, and depends on us keeping the focus until the entity is loaded.

A `DataPath` is currently defined as

```rs
pub struct DataPath {
    pub entity_path: EntityPath,
    pub instance: Option<Instance>,
    pub component_name: Option<ComponentName>,
}
```

We will wanna extend this in the future to support tagging, and maybe even a timepoint.

### Extending it with time point

It's not clear how to specify _both_ time _and_ a data path in the fragment 🤔  I guess we need to use a special character, like comma:

`#/entity/path,log_tick=42` maybe

…and then comes the trouble of escaping