### PR TITLE
Implement dataframe API over `Dataset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,7 +7024,6 @@ dependencies = [
  "datafusion",
  "futures-util",
  "itertools 0.14.0",
- "re_chunk_store",
  "re_dataframe",
  "re_log_encoding",
  "re_log_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7024,6 +7024,8 @@ dependencies = [
  "datafusion",
  "futures-util",
  "itertools 0.14.0",
+ "re_chunk_store",
+ "re_dataframe",
  "re_log_encoding",
  "re_log_types",
  "re_protos",

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -402,9 +402,7 @@ pub struct QueryExpression {
 
 impl QueryExpression {
     pub fn min_latest_at(&self) -> Option<LatestAtQuery> {
-        let Some(index) = self.filtered_index else {
-            return None;
-        };
+        let index = self.filtered_index?;
 
         if let Some(using_index_values) = &self.using_index_values {
             return Some(LatestAtQuery::new(
@@ -424,13 +422,11 @@ impl QueryExpression {
             return Some(LatestAtQuery::new(index, filtered_index_range.min()));
         }
 
-        return None;
+        None
     }
 
     pub fn max_range(&self) -> Option<RangeQuery> {
-        let Some(index) = self.filtered_index else {
-            return None;
-        };
+        let index = self.filtered_index?;
 
         if let Some(using_index_values) = &self.using_index_values {
             return Some(RangeQuery::new(
@@ -453,10 +449,10 @@ impl QueryExpression {
         }
 
         if let Some(filtered_index_range) = &self.filtered_index_range {
-            return Some(RangeQuery::new(index, filtered_index_range.clone()));
+            return Some(RangeQuery::new(index, *filtered_index_range));
         }
 
-        return None;
+        None
     }
 }
 

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -11,7 +11,7 @@ use arrow::{
 };
 use itertools::Itertools as _;
 
-use re_chunk::TimelineName;
+use re_chunk::{LatestAtQuery, RangeQuery, TimelineName};
 use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, Timeline};
 use re_sorbet::{
     ColumnDescriptor, ComponentColumnDescriptor, IndexColumnDescriptor, SorbetColumnDescriptors,
@@ -398,6 +398,66 @@ pub struct QueryExpression {
     //
     // TODO(cmc): the selection has to be on the QueryHandle, otherwise it's hell to use.
     pub selection: Option<Vec<ColumnSelector>>,
+}
+
+impl QueryExpression {
+    pub fn min_latest_at(&self) -> Option<LatestAtQuery> {
+        let Some(index) = self.filtered_index else {
+            return None;
+        };
+
+        if let Some(using_index_values) = &self.using_index_values {
+            return Some(LatestAtQuery::new(
+                index,
+                using_index_values.first().copied()?,
+            ));
+        }
+
+        if let Some(filtered_index_values) = &self.filtered_index_values {
+            return Some(LatestAtQuery::new(
+                index,
+                filtered_index_values.first().copied()?,
+            ));
+        }
+
+        if let Some(filtered_index_range) = &self.filtered_index_range {
+            return Some(LatestAtQuery::new(index, filtered_index_range.min()));
+        }
+
+        return None;
+    }
+
+    pub fn max_range(&self) -> Option<RangeQuery> {
+        let Some(index) = self.filtered_index else {
+            return None;
+        };
+
+        if let Some(using_index_values) = &self.using_index_values {
+            return Some(RangeQuery::new(
+                index,
+                ResolvedTimeRange::new(
+                    using_index_values.first().copied()?,
+                    using_index_values.last().copied()?,
+                ),
+            ));
+        }
+
+        if let Some(filtered_index_values) = &self.filtered_index_values {
+            return Some(RangeQuery::new(
+                index,
+                ResolvedTimeRange::new(
+                    filtered_index_values.first().copied()?,
+                    filtered_index_values.last().copied()?,
+                ),
+            ));
+        }
+
+        if let Some(filtered_index_range) = &self.filtered_index_range {
+            return Some(RangeQuery::new(index, filtered_index_range.clone()));
+        }
+
+        return None;
+    }
 }
 
 // ---

--- a/crates/store/re_datafusion/Cargo.toml
+++ b/crates/store/re_datafusion/Cargo.toml
@@ -26,6 +26,8 @@ default = []
 
 [dependencies]
 # Rerun dependencies:
+re_chunk_store.workspace = true
+re_dataframe.workspace = true
 re_log_encoding.workspace = true
 re_log_types.workspace = true
 re_protos.workspace = true

--- a/crates/store/re_datafusion/Cargo.toml
+++ b/crates/store/re_datafusion/Cargo.toml
@@ -26,7 +26,6 @@ default = []
 
 [dependencies]
 # Rerun dependencies:
-re_chunk_store.workspace = true
 re_dataframe.workspace = true
 re_log_encoding.workspace = true
 re_log_types.workspace = true

--- a/crates/store/re_datafusion/src/dataframe_query_provider.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_provider.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use datafusion::{catalog::TableProvider, datasource::MemTable, error::Result as DataFusionResult};
+use re_chunk_store::ChunkStore;
+use re_dataframe::{ChunkStoreHandle, QueryEngine, QueryExpression};
+
+pub struct DataframeQueryTableProvider {
+    query_expression: QueryExpression,
+    chunk_store: ChunkStoreHandle,
+}
+
+impl DataframeQueryTableProvider {
+    pub fn new(chunk_store: ChunkStore, query_expression: QueryExpression) -> Self {
+        Self {
+            chunk_store: ChunkStoreHandle::new(chunk_store),
+            query_expression,
+        }
+    }
+
+    pub fn create_table(&self) -> DataFusionResult<Arc<dyn TableProvider>> {
+        let cache = re_dataframe::QueryCacheHandle::new(re_dataframe::QueryCache::new(
+            self.chunk_store.clone(),
+        ));
+
+        let engine = QueryEngine::new(self.chunk_store.clone(), cache);
+
+        let query_handle = engine.query(self.query_expression.clone());
+
+        let schema = Arc::clone(query_handle.schema());
+
+        let batches: Vec<_> = query_handle.into_batch_iter().collect();
+
+        let table = MemTable::try_new(schema, vec![batches])?;
+
+        Ok(Arc::new(table))
+    }
+}

--- a/crates/store/re_datafusion/src/dataframe_query_provider.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_provider.rs
@@ -1,37 +1,78 @@
 use std::sync::Arc;
 
-use datafusion::{catalog::TableProvider, datasource::MemTable, error::Result as DataFusionResult};
+use arrow::datatypes::SchemaRef;
+use datafusion::{
+    catalog::{streaming::StreamingTable, TableProvider},
+    error::DataFusionError,
+    execution::SendableRecordBatchStream,
+    physical_plan::{stream::RecordBatchStreamAdapter, streaming::PartitionStream},
+};
+use futures_util::StreamExt;
 use re_chunk_store::ChunkStore;
-use re_dataframe::{ChunkStoreHandle, QueryEngine, QueryExpression};
+use re_dataframe::{ChunkStoreHandle, QueryEngine, QueryExpression, QueryHandle, StorageEngine};
 
 pub struct DataframeQueryTableProvider {
+    pub schema: SchemaRef,
     query_expression: QueryExpression,
     chunk_store: ChunkStoreHandle,
 }
 
+fn create_query_handle(
+    query_expression: &QueryExpression,
+    chunk_store: &ChunkStoreHandle,
+) -> QueryHandle<StorageEngine> {
+    let cache =
+        re_dataframe::QueryCacheHandle::new(re_dataframe::QueryCache::new(chunk_store.clone()));
+
+    let engine = QueryEngine::new(chunk_store.clone(), cache);
+    engine.query(query_expression.clone())
+}
+
 impl DataframeQueryTableProvider {
     pub fn new(chunk_store: ChunkStore, query_expression: QueryExpression) -> Self {
+        let chunk_store = ChunkStoreHandle::new(chunk_store);
+        let schema = create_query_handle(&query_expression, &chunk_store)
+            .schema()
+            .to_owned();
         Self {
-            chunk_store: ChunkStoreHandle::new(chunk_store),
+            schema,
+            chunk_store,
             query_expression,
         }
     }
+}
 
-    pub fn create_table(&self) -> DataFusionResult<Arc<dyn TableProvider>> {
-        let cache = re_dataframe::QueryCacheHandle::new(re_dataframe::QueryCache::new(
-            self.chunk_store.clone(),
-        ));
+impl TryFrom<DataframeQueryTableProvider> for Arc<dyn TableProvider> {
+    type Error = DataFusionError;
 
-        let engine = QueryEngine::new(self.chunk_store.clone(), cache);
-
-        let query_handle = engine.query(self.query_expression.clone());
-
-        let schema = Arc::clone(query_handle.schema());
-
-        let batches: Vec<_> = query_handle.into_batch_iter().collect();
-
-        let table = MemTable::try_new(schema, vec![batches])?;
+    fn try_from(value: DataframeQueryTableProvider) -> Result<Self, Self::Error> {
+        let schema = Arc::clone(&value.schema);
+        let partition_stream = Arc::new(value);
+        let table = StreamingTable::try_new(schema, vec![partition_stream])?;
 
         Ok(Arc::new(table))
+    }
+}
+
+impl PartitionStream for DataframeQueryTableProvider {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<datafusion::execution::TaskContext>) -> SendableRecordBatchStream {
+        let query_handle = create_query_handle(&self.query_expression, &self.chunk_store);
+
+        let stream = futures_util::stream::iter(query_handle.into_batch_iter()).map(|v| (Ok(v)));
+        let adapter = RecordBatchStreamAdapter::new(Arc::clone(&self.schema), stream);
+        Box::pin(adapter)
+    }
+}
+
+impl std::fmt::Debug for DataframeQueryTableProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataframeQueryTableProvider")
+            .field("schema", &self.schema)
+            .field("query_expression", &self.query_expression)
+            .finish()
     }
 }

--- a/crates/store/re_datafusion/src/lib.rs
+++ b/crates/store/re_datafusion/src/lib.rs
@@ -1,11 +1,13 @@
 //! The Rerun public data APIs. Access `DataFusion` `TableProviders`.
 
+mod dataframe_query_provider;
 mod datafusion_connector;
 mod grpc_streaming_provider;
 mod partition_table;
 mod search_provider;
 mod table_entry_provider;
 
+pub use dataframe_query_provider::DataframeQueryTableProvider;
 pub use datafusion_connector::DataFusionConnector;
 pub use partition_table::PartitionTableProvider;
 pub use search_provider::SearchResultsTableProvider;

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -6,6 +6,7 @@ use arrow::{
     error::ArrowError,
 };
 
+use re_chunk::TimelineName;
 use re_log_types::EntityPath;
 
 use crate::manifest_registry::v1alpha1::{
@@ -162,6 +163,41 @@ impl TryFrom<crate::manifest_registry::v1alpha1::Query> for Query {
             columns_always_include_global_indexes: value.columns_always_include_global_indexes,
             columns_always_include_static_indexes: value.columns_always_include_static_indexes,
         })
+    }
+}
+
+impl From<Query> for crate::manifest_registry::v1alpha1::Query {
+    fn from(value: Query) -> Self {
+        crate::manifest_registry::v1alpha1::Query {
+            latest_at: value.latest_at.map(|latest_at| {
+                crate::manifest_registry::v1alpha1::QueryLatestAt {
+                    index: Some({
+                        let timeline: TimelineName = latest_at.index.into();
+                        timeline.into()
+                    }),
+                    at: Some(latest_at.at),
+                    fuzzy_descriptors: latest_at.fuzzy_descriptors,
+                }
+            }),
+            range: value
+                .range
+                .map(|range| crate::manifest_registry::v1alpha1::QueryRange {
+                    index: Some({
+                        let timeline: TimelineName = range.index.into();
+                        timeline.into()
+                    }),
+                    index_range: Some(range.index_range.into()),
+                    fuzzy_descriptors: range.fuzzy_descriptors,
+                }),
+            columns_always_include_byte_offsets: value.columns_always_include_byte_offsets,
+            columns_always_include_chunk_ids: value.columns_always_include_chunk_ids,
+            columns_always_include_component_indexes: value
+                .columns_always_include_component_indexes,
+            columns_always_include_entity_paths: value.columns_always_include_entity_paths,
+            columns_always_include_everything: value.columns_always_include_everything,
+            columns_always_include_global_indexes: value.columns_always_include_global_indexes,
+            columns_always_include_static_indexes: value.columns_always_include_static_indexes,
+        }
     }
 }
 

--- a/crates/store/re_sorbet/src/column_descriptor.rs
+++ b/crates/store/re_sorbet/src/column_descriptor.rs
@@ -8,6 +8,7 @@ use arrow::datatypes::{
 };
 
 use re_log_types::EntityPath;
+use re_types_core::ComponentName;
 
 use crate::{ColumnKind, ComponentColumnDescriptor, IndexColumnDescriptor};
 
@@ -54,6 +55,14 @@ impl ColumnDescriptor {
         match self {
             Self::Time(_) => None,
             Self::Component(descr) => Some(&descr.entity_path),
+        }
+    }
+
+    #[inline]
+    pub fn component_name(&self) -> Option<&ComponentName> {
+        match self {
+            Self::Time(_) => None,
+            Self::Component(descr) => Some(&descr.component_name),
         }
     }
 

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -177,7 +177,6 @@ impl ConnectionHandle {
         })
     }
 
-    // TODO(jleibs): Time range filtering
     pub fn get_chunks(
         &mut self,
         py: Python<'_>,
@@ -196,7 +195,6 @@ impl ConnectionHandle {
         store.set_info(store_info);
 
         let query = Query {
-            // TODO
             latest_at: latest_at.map(|latest_at| QueryLatestAt {
                 index: latest_at.timeline().to_string(),
                 at: latest_at.at().as_i64(),

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -3,11 +3,11 @@ use pyo3::{
     create_exception, exceptions::PyConnectionError, exceptions::PyRuntimeError, PyErr, PyResult,
     Python,
 };
-use re_chunk::{LatestAtQuery, RangeQuery};
-use re_dataframe::ViewContentsSelector;
 use tokio_stream::StreamExt as _;
 
+use re_chunk::{LatestAtQuery, RangeQuery};
 use re_chunk_store::ChunkStore;
+use re_dataframe::ViewContentsSelector;
 use re_grpc_client::redap::{client, get_chunks_response_to_chunk};
 use re_log_types::{EntryId, StoreInfo};
 use re_protos::common::v1alpha1::IfDuplicateBehavior;
@@ -246,7 +246,7 @@ impl ConnectionHandle {
                     .map_err(to_py_err)?;
             }
 
-            Ok::<(), PyErr>(())
+            Ok::<_, PyErr>(())
         })?;
 
         Ok(store)

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -177,6 +177,7 @@ impl ConnectionHandle {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn get_chunks(
         &mut self,
         py: Python<'_>,
@@ -203,7 +204,7 @@ impl ConnectionHandle {
             range: range.map(|range| {
                 QueryRange {
                     index: range.timeline().to_string(),
-                    index_range: range.range.into(),
+                    index_range: range.range,
                     fuzzy_descriptors: vec![], // TODO(jleibs): support this
                 }
             }),
@@ -223,7 +224,7 @@ impl ConnectionHandle {
                     dataset_id: Some(dataset_id.into()),
                     partition_ids: partition_ids
                         .iter()
-                        .map(|id| id.as_ref().to_string().into())
+                        .map(|id| id.as_ref().to_owned().into())
                         .collect(),
                     chunk_ids: vec![],
                     entity_paths: entity_paths

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -390,12 +390,6 @@ impl PyDataframeQueryView {
             store_version: None,
         };
 
-        let entity_paths = self_
-            .query_expression
-            .view_contents
-            .as_ref()
-            .map_or(vec![], |contents| contents.keys().collect::<Vec<_>>());
-
         //
         // Fetch relevant chunks
         //
@@ -405,7 +399,9 @@ impl PyDataframeQueryView {
             py,
             store_info,
             dataset_id,
-            entity_paths.as_slice(),
+            &self_.query_expression.view_contents,
+            self_.query_expression.min_latest_at(),
+            self_.query_expression.max_range(),
             self_.partition_ids.as_slice(),
         )?;
 

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -408,7 +408,7 @@ impl PyDataframeQueryView {
         query_expression.view_contents = Some(contents);
 
         let provider: Arc<dyn TableProvider> =
-            DataframeQueryTableProvider::new(query_engine, self_.query_expression.clone())
+            DataframeQueryTableProvider::new(query_engine, query_expression)
                 .try_into()
                 .map_err(to_py_err)?;
 

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -447,7 +447,7 @@ fn extract_contents_expr(
         .iter()
         .filter_map(|descriptor| match descriptor {
             ColumnDescriptor::Component(component) => Some(component),
-            _ => None,
+            ColumnDescriptor::Time(_) => None,
         })
         .cloned()
         .collect::<Vec<_>>();
@@ -520,7 +520,7 @@ fn extract_contents_expr(
                     let components: BTreeSet<ComponentName> = component_strs
                         .iter()
                         .map(|component_name| {
-                            find_best_component(&known_components, &entity_path, component_name)
+                            find_best_component(&known_components, entity_path, component_name)
                         })
                         .collect();
                     (entity_path.clone(), Some(components))
@@ -550,6 +550,6 @@ fn find_best_component(
                 .iter()
                 .find(|component| component.component_name.matches(component_name))
         })
-        .map(|component| component.component_name.clone())
+        .map(|component| component.component_name)
         .unwrap_or_else(|| ComponentName::new(component_name))
 }

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -1,0 +1,523 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use datafusion::catalog::TableProvider;
+use datafusion_ffi::table_provider::FFI_TableProvider;
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::prelude::PyAnyMethods as _;
+use pyo3::types::{PyCapsule, PyDict};
+use pyo3::{pyclass, pymethods, Bound, Py, PyAny, PyRef, PyRefMut, PyResult, Python};
+
+use re_chunk::ComponentName;
+use re_chunk_store::{
+    ChunkStoreHandle, ComponentColumnSelector, QueryExpression, SparseFillStrategy,
+    TimeColumnSelector, ViewContentsSelector,
+};
+use re_dataframe::{QueryCache, QueryEngine, StorageEngine};
+use re_datafusion::DataframeQueryTableProvider;
+use re_log_types::{
+    EntityPath, EntityPathFilter, ResolvedTimeRange, StoreId, StoreInfo, StoreKind, StoreSource,
+};
+
+use crate::catalog::{to_py_err, PyDataset};
+use crate::dataframe::ComponentLike;
+use crate::utils::get_tokio_runtime;
+
+#[pyclass(name = "DataframeQueryView")]
+pub struct PyDataframeQueryView {
+    dataset: Py<PyDataset>,
+
+    /// Index to use (resolved last minute)
+    index: String,
+
+    /// Contents to use (resolved last minute)
+    contents: Py<PyAny>,
+
+    query_expression: QueryExpression,
+
+    /// Limit the query to these partition ids.
+    ///
+    /// If empty, use the whole dataset.
+    partition_ids: Vec<String>,
+}
+
+impl PyDataframeQueryView {
+    #[expect(clippy::fn_params_excessive_bools)]
+    pub fn new(
+        dataset: Py<PyDataset>,
+        index: String,
+        contents: Py<PyAny>,
+        include_semantically_empty_columns: bool,
+        include_indicator_columns: bool,
+        include_tombstone_columns: bool,
+    ) -> Self {
+        Self {
+            dataset,
+            index,
+            contents,
+
+            query_expression: QueryExpression {
+                view_contents: None, // this is resolved and populated when we have a chunk store
+                include_semantically_empty_columns,
+                include_indicator_columns,
+                include_tombstone_columns,
+                filtered_index: None, // this is resolved and populated when we have a chunk store
+                filtered_index_range: None,
+                filtered_index_values: None,
+                using_index_values: None,
+                filtered_is_not_null: None,
+                sparse_fill_strategy: SparseFillStrategy::None,
+                selection: None,
+            },
+            partition_ids: vec![],
+        }
+    }
+}
+
+#[pymethods]
+impl PyDataframeQueryView {
+    fn filter_partition_id(
+        mut self_: PyRefMut<'_, Self>,
+        //TODO(ab): provide a nicer API (single, etc.)
+        partition_ids: Vec<String>,
+    ) -> PyRefMut<'_, Self> {
+        self_.partition_ids = partition_ids;
+        self_
+    }
+
+    #[allow(rustdoc::private_doc_tests)]
+    /// Filter the view to only include data between the given index sequence numbers.
+    ///
+    /// This range is inclusive and will contain both the value at the start and the value at the end.
+    ///
+    /// The view must be of a sequential index type to use this method.
+    ///
+    /// Parameters
+    /// ----------
+    /// start : int
+    ///     The inclusive start of the range.
+    /// end : int
+    ///     The inclusive end of the range.
+    ///
+    /// Returns
+    /// -------
+    /// RecordingView
+    ///     A new view containing only the data within the specified range.
+    ///
+    ///     The original view will not be modified.
+    fn filter_range_sequence(
+        mut self_: PyRefMut<'_, Self>,
+        start: i64,
+        end: i64,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        match self_.query_expression.filtered_index.as_ref() {
+            // TODO(#9084): do we need this check? If so, how can we accomplish it?
+            // Some(filtered_index) if filtered_index.typ() != TimeType::Sequence => {
+            //     return Err(PyValueError::new_err(format!(
+            //         "Index for {} is not a sequence.",
+            //         filtered_index.name()
+            //     )));
+            // }
+            Some(_) => {}
+
+            None => {
+                return Err(PyValueError::new_err(
+                    "Specify an index to filter on first.".to_owned(),
+                ));
+            }
+        }
+
+        let start = if let Ok(seq) = re_chunk::TimeInt::try_from(start) {
+            seq
+        } else {
+            re_log::error!(
+                illegal_value = start,
+                new_value = re_chunk::TimeInt::MIN.as_i64(),
+                "set_time_sequence() called with illegal value - clamped to minimum legal value"
+            );
+            re_chunk::TimeInt::MIN
+        };
+
+        let end = if let Ok(seq) = re_chunk::TimeInt::try_from(end) {
+            seq
+        } else {
+            re_log::error!(
+                illegal_value = end,
+                new_value = re_chunk::TimeInt::MAX.as_i64(),
+                "set_time_sequence() called with illegal value - clamped to maximum legal value"
+            );
+            re_chunk::TimeInt::MAX
+        };
+
+        let resolved = ResolvedTimeRange::new(start, end);
+
+        self_.query_expression.filtered_index_range = Some(resolved);
+
+        Ok(self_)
+    }
+
+    #[allow(rustdoc::private_doc_tests)]
+    /// Filter the view to only include data between the given index values expressed as seconds.
+    ///
+    /// This range is inclusive and will contain both the value at the start and the value at the end.
+    ///
+    /// The view must be of a temporal index type to use this method.
+    ///
+    /// Parameters
+    /// ----------
+    /// start : int
+    ///     The inclusive start of the range.
+    /// end : int
+    ///     The inclusive end of the range.
+    ///
+    /// Returns
+    /// -------
+    /// RecordingView
+    ///     A new view containing only the data within the specified range.
+    ///
+    ///     The original view will not be modified.
+    fn filter_range_secs(
+        mut self_: PyRefMut<'_, Self>,
+        start: f64,
+        end: f64,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        match self_.query_expression.filtered_index.as_ref() {
+            // TODO(#9084): do we need this check? If so, how can we accomplish it?
+            // Some(filtered_index) if filtered_index.typ() != TimeType::Time => {
+            //     return Err(PyValueError::new_err(format!(
+            //         "Index for {} is not temporal.",
+            //         filtered_index.name()
+            //     )));
+            // }
+            Some(_) => {}
+
+            None => {
+                return Err(PyValueError::new_err(
+                    "Specify an index to filter on first.".to_owned(),
+                ));
+            }
+        }
+
+        let start = re_log_types::Timestamp::from_secs_since_epoch(start);
+        let end = re_log_types::Timestamp::from_secs_since_epoch(end);
+
+        let resolved = ResolvedTimeRange::new(start, end);
+
+        self_.query_expression.filtered_index_range = Some(resolved);
+
+        Ok(self_)
+    }
+
+    #[allow(rustdoc::private_doc_tests)]
+    /// Filter the view to only include data between the given index values expressed as seconds.
+    ///
+    /// This range is inclusive and will contain both the value at the start and the value at the end.
+    ///
+    /// The view must be of a temporal index type to use this method.
+    ///
+    /// Parameters
+    /// ----------
+    /// start : int
+    ///     The inclusive start of the range.
+    /// end : int
+    ///     The inclusive end of the range.
+    ///
+    /// Returns
+    /// -------
+    /// RecordingView
+    ///     A new view containing only the data within the specified range.
+    ///
+    ///     The original view will not be modified.
+    fn filter_range_nanos(
+        mut self_: PyRefMut<'_, Self>,
+        start: i64,
+        end: i64,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        match self_.query_expression.filtered_index.as_ref() {
+            // TODO(#9084): do we need this?
+            // Some(filtered_index) if filtered_index.typ() != TimeType::Time => {
+            //     return Err(PyValueError::new_err(format!(
+            //         "Index for {} is not temporal.",
+            //         filtered_index.name()
+            //     )));
+            // }
+            Some(_) => {}
+
+            None => {
+                return Err(PyValueError::new_err(
+                    "Specify an index to filter on first.".to_owned(),
+                ));
+            }
+        }
+
+        let start = re_log_types::Timestamp::from_nanos_since_epoch(start);
+        let end = re_log_types::Timestamp::from_nanos_since_epoch(end);
+
+        let resolved = ResolvedTimeRange::new(start, end);
+
+        self_.query_expression.filtered_index_range = Some(resolved);
+
+        Ok(self_)
+    }
+
+    #[allow(rustdoc::private_doc_tests)]
+    /// Filter the view to only include data at the provided index values.
+    ///
+    /// The index values returned will be the intersection between the provided values and the
+    /// original index values.
+    ///
+    /// This requires index values to be a precise match. Index values in Rerun are
+    /// represented as i64 sequence counts or nanoseconds. This API does not expose an interface
+    /// in floating point seconds, as the numerical conversion would risk false mismatches.
+    ///
+    /// Parameters
+    /// ----------
+    /// values : IndexValuesLike
+    ///     The index values to filter by.
+    ///
+    /// Returns
+    /// -------
+    /// RecordingView
+    ///     A new view containing only the data at the specified index values.
+    ///
+    ///     The original view will not be modified.
+    fn filter_index_values<'py>(
+        mut self_: PyRefMut<'py, Self>,
+        values: crate::dataframe::IndexValuesLike<'_>,
+    ) -> PyResult<PyRefMut<'py, Self>> {
+        let values = values.to_index_values()?;
+
+        self_.query_expression.filtered_index_values = Some(values);
+
+        Ok(self_)
+    }
+
+    #[allow(rustdoc::private_doc_tests)]
+    /// Filter the view to only include rows where the given component column is not null.
+    ///
+    /// This corresponds to rows for index values where this component was provided to Rerun explicitly
+    /// via `.log()` or `.send_columns()`.
+    ///
+    /// Parameters
+    /// ----------
+    /// column : AnyComponentColumn
+    ///     The component column to filter by.
+    ///
+    /// Returns
+    /// -------
+    /// RecordingView
+    ///     A new view containing only the data where the specified component column is not null.
+    ///
+    ///     The original view will not be modified.
+    fn filter_is_not_null(
+        mut self_: PyRefMut<'_, Self>,
+        column: crate::dataframe::AnyComponentColumn,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        let column = column.into_selector();
+        self_.query_expression.filtered_is_not_null = Some(column?);
+        Ok(self_)
+    }
+
+    #[allow(rustdoc::private_doc_tests)]
+    /// Replace the index in the view with the provided values.
+    ///
+    /// The output view will always have the same number of rows as the provided values, even if
+    /// those rows are empty. Use with [`.fill_latest_at()`][rerun.dataframe.RecordingView.fill_latest_at]
+    /// to populate these rows with the most recent data.
+    ///
+    /// This requires index values to be a precise match. Index values in Rerun are
+    /// represented as i64 sequence counts or nanoseconds. This API does not expose an interface
+    /// in floating point seconds, as the numerical conversion would risk false mismatches.
+    ///
+    /// Parameters
+    /// ----------
+    /// values : IndexValuesLike
+    ///     The index values to use.
+    ///
+    /// Returns
+    /// -------
+    /// RecordingView
+    ///     A new view containing the provided index values.
+    ///
+    ///     The original view will not be modified.
+    fn using_index_values<'py>(
+        mut self_: PyRefMut<'py, Self>,
+        values: crate::dataframe::IndexValuesLike<'_>,
+    ) -> PyResult<PyRefMut<'py, Self>> {
+        let values = values.to_index_values()?;
+
+        self_.query_expression.using_index_values = Some(values);
+        Ok(self_)
+    }
+
+    #[allow(rustdoc::private_doc_tests)]
+    /// Populate any null values in a row with the latest valid data according to the index.
+    ///
+    /// Returns
+    /// -------
+    /// RecordingView
+    ///     A new view with the null values filled in.
+    ///
+    ///     The original view will not be modified.
+    fn fill_latest_at(mut self_: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        self_.query_expression.sparse_fill_strategy = SparseFillStrategy::LatestAtGlobal;
+        self_
+    }
+
+    fn __datafusion_table_provider__<'py>(
+        self_: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let dataset = self_.dataset.borrow(py);
+        let entry = dataset.as_super();
+        let dataset_id = entry.details.id;
+        let mut connection = entry.client.borrow(py).connection().clone();
+
+        //TODO: fetch all partition ids if none are specified
+
+        //
+        // Fetch relevant chunks
+        //
+
+        let store_id = StoreId::from_string(StoreKind::Recording, "query_chunks".to_owned());
+        let store_info = StoreInfo {
+            application_id: "query_chunks".into(),
+            store_id,
+            cloned_from: None,
+            store_source: StoreSource::Unknown,
+            store_version: None,
+        };
+        let chunk_store =
+            connection.get_chunks(py, store_info, dataset_id, self_.partition_ids.as_slice())?;
+        let store_handle = ChunkStoreHandle::new(chunk_store);
+        let query_engine = QueryEngine::new(
+            store_handle.clone(),
+            QueryCache::new_handle(store_handle.clone()),
+        );
+
+        //
+        // Resolve index and contents, and build final query.
+        //
+
+        let selector = TimeColumnSelector::from(self_.index.as_str());
+        let time_column = store_handle.read().resolve_time_selector(&selector);
+        let contents = extract_contents_expr(self_.contents.bind(py), &query_engine)?;
+
+        let mut query_expression = self_.query_expression.clone();
+        query_expression.filtered_index = Some(*time_column.timeline().name());
+        query_expression.view_contents = Some(contents);
+
+        let provider: Arc<dyn TableProvider> =
+            DataframeQueryTableProvider::new(query_engine, self_.query_expression.clone())
+                .try_into()
+                .map_err(to_py_err)?;
+
+        let capsule_name = cr"datafusion_table_provider".into();
+
+        let runtime = get_tokio_runtime().handle().clone();
+        let provider = FFI_TableProvider::new(provider, false, Some(runtime));
+
+        PyCapsule::new(py, provider, Some(capsule_name))
+    }
+}
+
+/// Convert a `ViewContentsLike` into a `ViewContentsSelector`.
+///
+/// ```python
+/// ViewContentsLike = Union[str, Dict[str, Union[ComponentLike, Sequence[ComponentLike]]]]
+/// ```
+///
+/// We cant do this with the normal `FromPyObject` mechanisms because we want access to the
+/// `QueryEngine` to resolve the entity paths.
+fn extract_contents_expr(
+    expr: &Bound<'_, PyAny>,
+    engine: &QueryEngine<StorageEngine>,
+) -> PyResult<re_chunk_store::ViewContentsSelector> {
+    if let Ok(expr) = expr.extract::<String>() {
+        // `str`
+
+        let path_filter =
+                EntityPathFilter::parse_strict(&expr)
+                    .map_err(|err| {
+                        PyValueError::new_err(format!(
+                            "Could not interpret `contents` as a ViewContentsLike. Failed to parse {expr}: {err}.",
+                        ))
+                    })?;
+
+        let contents = engine
+            .iter_entity_paths_sorted(&path_filter)
+            .map(|p| (p, None))
+            .collect();
+
+        Ok(contents)
+    } else if let Ok(dict) = expr.downcast::<PyDict>() {
+        // `Union[ComponentLike, Sequence[ComponentLike]]]`
+
+        let mut contents = ViewContentsSelector::default();
+
+        for (key, value) in dict {
+            let key = key.extract::<String>().map_err(|_err| {
+                    PyTypeError::new_err(
+                        format!("Could not interpret `contents` as a ViewContentsLike. Key: {key} is not a path expression."),
+                    )
+                })?;
+
+            let path_filter = EntityPathFilter::parse_strict(&key).map_err(|err| {
+                    PyValueError::new_err(format!(
+                        "Could not interpret `contents` as a ViewContentsLike. Failed to parse {key}: {err}.",
+                    ))
+                })?;
+
+            let component_strs: BTreeSet<String> = if let Ok(component) =
+                value.extract::<ComponentLike>()
+            {
+                std::iter::once(component.0).collect()
+            } else if let Ok(components) = value.extract::<Vec<ComponentLike>>() {
+                components.into_iter().map(|c| c.0).collect()
+            } else {
+                return Err(PyTypeError::new_err(
+                        format!("Could not interpret `contents` as a ViewContentsLike. Value: {value} is not a ComponentLike or Sequence[ComponentLike]."),
+                    ));
+            };
+
+            contents.append(
+                &mut engine
+                    .iter_entity_paths_sorted(&path_filter)
+                    .map(|entity_path| {
+                        let components = component_strs
+                            .iter()
+                            .map(|component_name| {
+                                find_best_component(engine, &entity_path, component_name)
+                            })
+                            .collect();
+                        (entity_path, Some(components))
+                    })
+                    .collect(),
+            );
+        }
+
+        Ok(contents)
+    } else {
+        return Err(PyTypeError::new_err(
+                "Could not interpret `contents` as a ViewContentsLike. Top-level type must be a string or a dictionary.",
+            ));
+    }
+}
+
+fn find_best_component(
+    engine: &QueryEngine<StorageEngine>,
+    entity_path: &EntityPath,
+    component_name: &str,
+) -> ComponentName {
+    let selector = ComponentColumnSelector {
+        entity_path: entity_path.clone(),
+        component_name: component_name.into(),
+    };
+
+    engine
+        .engine
+        .read()
+        .store()
+        .resolve_component_selector(&selector)
+        .component_name
+}

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -394,7 +394,6 @@ impl PyDataframeQueryView {
         // Fetch relevant chunks
         //
 
-        // TODO(jleibs): Time filters?
         let chunk_store = connection.get_chunks(
             py,
             store_info,

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use arrow::array::{RecordBatch, StringArray};
 use arrow::datatypes::{Field, Schema as ArrowSchema};
 use arrow::pyarrow::PyArrowType;
-use pyo3::exceptions::PyRuntimeError;
-use pyo3::{pyclass, pymethods, Py, PyAny, PyRef, PyResult, Python};
+use pyo3::{exceptions::PyRuntimeError, pyclass, pymethods, Py, PyAny, PyRef, PyResult, Python};
 use tokio_stream::StreamExt as _;
 
 use re_chunk_store::{ChunkStore, ChunkStoreHandle};
@@ -25,8 +24,9 @@ use re_protos::manifest_registry::v1alpha1::{
 };
 use re_sdk::{ComponentDescriptor, ComponentName};
 
-use crate::catalog::dataframe_query::PyDataframeQueryView;
-use crate::catalog::{to_py_err, PyEntry, VectorDistanceMetricLike, VectorLike};
+use crate::catalog::{
+    dataframe_query::PyDataframeQueryView, to_py_err, PyEntry, VectorDistanceMetricLike, VectorLike,
+};
 use crate::dataframe::{
     PyComponentColumnSelector, PyDataFusionTable, PyIndexColumnSelector, PyRecording,
 };

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -4,7 +4,7 @@ use arrow::array::{RecordBatch, StringArray};
 use arrow::datatypes::{Field, Schema as ArrowSchema};
 use arrow::pyarrow::PyArrowType;
 use pyo3::exceptions::PyRuntimeError;
-use pyo3::{pyclass, pymethods, Py, PyAny, PyRef, PyResult};
+use pyo3::{pyclass, pymethods, Py, PyAny, PyRef, PyResult, Python};
 use tokio_stream::StreamExt as _;
 
 use re_chunk_store::{ChunkStore, ChunkStoreHandle};
@@ -141,7 +141,8 @@ impl PyDataset {
         include_semantically_empty_columns: bool,
         include_indicator_columns: bool,
         include_tombstone_columns: bool,
-    ) -> PyDataframeQueryView {
+        py: Python<'_>,
+    ) -> PyResult<PyDataframeQueryView> {
         PyDataframeQueryView::new(
             self_,
             index,
@@ -149,6 +150,7 @@ impl PyDataset {
             include_semantically_empty_columns,
             include_indicator_columns,
             include_tombstone_columns,
+            py,
         )
     }
 

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -134,6 +134,14 @@ impl PyDataset {
     }
 
     #[expect(clippy::fn_params_excessive_bools)]
+    #[pyo3(signature = (
+        *,
+        index,
+        contents,
+        include_semantically_empty_columns = false,
+        include_indicator_columns = false,
+        include_tombstone_columns = false,
+    ))]
     fn dataframe_query_view(
         self_: Py<Self>,
         index: String,

--- a/rerun_py/src/catalog/mod.rs
+++ b/rerun_py/src/catalog/mod.rs
@@ -2,6 +2,7 @@
 
 mod catalog_client;
 mod connection_handle;
+mod dataframe_query;
 mod dataset;
 mod entry;
 mod errors;
@@ -15,6 +16,7 @@ use arrow::{
 };
 use pyo3::{exceptions::PyRuntimeError, prelude::*, Bound, PyResult};
 
+use crate::catalog::dataframe_query::PyDataframeQueryView;
 pub use catalog_client::PyCatalogClient;
 pub use connection_handle::ConnectionHandle;
 pub use dataset::PyDataset;
@@ -30,6 +32,8 @@ pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()>
     m.add_class::<PyEntry>()?;
 
     m.add_class::<PyDataset>()?;
+
+    m.add_class::<PyDataframeQueryView>()?;
 
     m.add_class::<PyVectorDistanceMetric>()?;
 

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -310,7 +310,7 @@ impl AnyColumn {
 
 /// A type alias for any component-column-like object.
 #[derive(FromPyObject)]
-enum AnyComponentColumn {
+pub(crate) enum AnyComponentColumn {
     #[pyo3(transparent, annotation = "name")]
     Name(String),
     #[pyo3(transparent, annotation = "component_descriptor")]
@@ -321,7 +321,7 @@ enum AnyComponentColumn {
 
 impl AnyComponentColumn {
     #[allow(dead_code)]
-    fn into_selector(self) -> PyResult<ComponentColumnSelector> {
+    pub(crate) fn into_selector(self) -> PyResult<ComponentColumnSelector> {
         match self {
             Self::Name(name) => {
                 let component_path =
@@ -344,7 +344,7 @@ impl AnyComponentColumn {
 ///
 /// This can be any numpy-compatible array of integers, or a [`pa.Int64Array`][]
 #[derive(FromPyObject)]
-enum IndexValuesLike<'py> {
+pub(crate) enum IndexValuesLike<'py> {
     PyArrow(PyArrowType<ArrayData>),
     NumPy(numpy::PyArrayLike1<'py, i64>),
 
@@ -354,7 +354,7 @@ enum IndexValuesLike<'py> {
 }
 
 impl IndexValuesLike<'_> {
-    fn to_index_values(&self) -> PyResult<BTreeSet<re_chunk_store::TimeInt>> {
+    pub(crate) fn to_index_values(&self) -> PyResult<BTreeSet<re_chunk_store::TimeInt>> {
         match self {
             Self::PyArrow(array) => {
                 let array = make_array(array.0.clone());


### PR DESCRIPTION
### What

This adds support for running Dataframe queries directly over a `Dataset`, via a minimal datafusion table provider for our python api in which we have a query and a chunk store already created.

TODO:
- [x] use `GetChunk` instead of `FetchPartition`
- [x] make sure the result is correct
