### PR TITLE
Add context helpers for dataframes

### DIFF
--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -159,7 +159,7 @@ impl PyCatalogClient {
             Ok(datafusion_ctx.clone_ref(py))
         } else {
             Err(PyRuntimeError::new_err(
-                "DataFusion context not available".to_string(),
+                "DataFusion context not available (the `datafusion` package may need to be installed)".to_string(),
             ))
         }
     }

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -149,7 +149,6 @@ impl PyCatalogClient {
         Py::new(py, (table, entry))
     }
 
-    #[getter]
     fn entries_table(self_: Py<Self>, py: Python<'_>) -> PyResult<Py<PyTable>> {
         Self::get_table(self_, EntryIdLike::Str("__entries".to_string()), py)
     }

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -1,4 +1,9 @@
-use pyo3::{exceptions::PyLookupError, pyclass, pymethods, FromPyObject, Py, PyResult, Python};
+use pyo3::{
+    exceptions::{PyLookupError, PyRuntimeError},
+    pyclass, pymethods,
+    types::PyAnyMethods as _,
+    FromPyObject, Py, PyAny, PyResult, Python,
+};
 
 use re_protos::catalog::v1alpha1::EntryFilter;
 
@@ -13,6 +18,9 @@ pub struct PyCatalogClient {
     origin: re_uri::Origin,
 
     connection: ConnectionHandle,
+
+    // If this isn't set, it means datafusion wasn't found
+    datafusion_ctx: Option<Py<PyAny>>,
 }
 
 impl PyCatalogClient {
@@ -30,7 +38,16 @@ impl PyCatalogClient {
 
         let connection = ConnectionHandle::new(py, origin.clone())?;
 
-        Ok(Self { origin, connection })
+        let datafusion_ctx = py
+            .import("datafusion")
+            .and_then(|datafusion| Ok(datafusion.getattr("SessionContext")?.call0()?.unbind()))
+            .ok();
+
+        Ok(Self {
+            origin,
+            connection,
+            datafusion_ctx,
+        })
     }
 
     fn entries(self_: Py<Self>, py: Python<'_>) -> PyResult<Vec<Py<PyEntry>>> {
@@ -130,6 +147,22 @@ impl PyCatalogClient {
         let table = PyTable::default();
 
         Py::new(py, (table, entry))
+    }
+
+    #[getter]
+    fn entries_table(self_: Py<Self>, py: Python<'_>) -> PyResult<Py<PyTable>> {
+        Self::get_table(self_, EntryIdLike::Str("__entries".to_string()), py)
+    }
+
+    #[getter]
+    pub fn ctx(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        if let Some(datafusion_ctx) = &self.datafusion_ctx {
+            Ok(datafusion_ctx.clone_ref(py))
+        } else {
+            Err(PyRuntimeError::new_err(
+                "DataFusion context not available".to_string(),
+            ))
+        }
     }
 }
 

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -150,7 +150,7 @@ impl PyCatalogClient {
     }
 
     fn entries_table(self_: Py<Self>, py: Python<'_>) -> PyResult<Py<PyTable>> {
-        Self::get_table(self_, EntryIdLike::Str("__entries".to_string()), py)
+        Self::get_table(self_, EntryIdLike::Str("__entries".to_owned()), py)
     }
 
     #[getter]
@@ -159,7 +159,7 @@ impl PyCatalogClient {
             Ok(datafusion_ctx.clone_ref(py))
         } else {
             Err(PyRuntimeError::new_err(
-                "DataFusion context not available (the `datafusion` package may need to be installed)".to_string(),
+                "DataFusion context not available (the `datafusion` package may need to be installed)".to_owned(),
             ))
         }
     }

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -423,7 +423,7 @@ impl PyDataframeQueryView {
         PyCapsule::new(py, provider, Some(capsule_name))
     }
 
-    fn df<'py>(self_: PyRef<'py, Self>) -> PyResult<Bound<'py, PyAny>> {
+    fn df(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyAny>> {
         let py = self_.py();
 
         let dataset = self_.dataset.borrow(py);

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -68,6 +68,7 @@ impl PyDataset {
                 .map_err(to_py_err)
         })?;
 
+        #[expect(clippy::string_add)]
         Ok(PyDataFusionTable {
             client: super_.client.clone_ref(self_.py()),
             name: super_.name() + "_partition_table",
@@ -332,7 +333,7 @@ impl PyDataset {
 
         Ok(PyDataFusionTable {
             client: super_.client.clone_ref(self_.py()),
-            name: name,
+            name,
             provider,
         })
     }
@@ -384,7 +385,7 @@ impl PyDataset {
 
         Ok(PyDataFusionTable {
             client: super_.client.clone_ref(self_.py()),
-            name: name,
+            name,
             provider,
         })
     }

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -68,7 +68,11 @@ impl PyDataset {
                 .map_err(to_py_err)
         })?;
 
-        Ok(PyDataFusionTable { provider })
+        Ok(PyDataFusionTable {
+            client: super_.client.clone_ref(self_.py()),
+            name: super_.name() + "_partition_table",
+            provider,
+        })
     }
 
     /// Register a RRD URI to the dataset.
@@ -323,7 +327,14 @@ impl PyDataset {
                 .map_err(to_py_err)
         })?;
 
-        Ok(PyDataFusionTable { provider })
+        let uuid = uuid::Uuid::new_v4();
+        let name = format!("{}_search_fts_{uuid}", super_.name());
+
+        Ok(PyDataFusionTable {
+            client: super_.client.clone_ref(self_.py()),
+            name: name,
+            provider,
+        })
     }
 
     fn search_vector(
@@ -368,6 +379,13 @@ impl PyDataset {
                 .map_err(to_py_err)
         })?;
 
-        Ok(PyDataFusionTable { provider })
+        let uuid = uuid::Uuid::new_v4();
+        let name = format!("{}_search_vector_{uuid}", super_.name());
+
+        Ok(PyDataFusionTable {
+            client: super_.client.clone_ref(self_.py()),
+            name: name,
+            provider,
+        })
     }
 }

--- a/rerun_py/src/catalog/table.rs
+++ b/rerun_py/src/catalog/table.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use datafusion::catalog::TableProvider;
 use datafusion_ffi::table_provider::FFI_TableProvider;
 use pyo3::{
-    exceptions::PyRuntimeError, pyclass, pymethods, types::PyCapsule, Bound, PyRefMut, PyResult,
-    Python,
+    exceptions::PyRuntimeError,
+    pyclass, pymethods,
+    types::{PyAnyMethods, PyCapsule},
+    Bound, PyAny, PyRef, PyRefMut, PyResult,
 };
 
 use re_datafusion::TableEntryTableProvider;
@@ -24,8 +26,8 @@ pub struct PyTable {
 impl PyTable {
     fn __datafusion_table_provider__<'py>(
         mut self_: PyRefMut<'py, Self>,
-        py: Python<'py>,
     ) -> PyResult<Bound<'py, PyCapsule>> {
+        let py = self_.py();
         if self_.lazy_provider.is_none() {
             let super_ = self_.as_mut();
 
@@ -56,5 +58,26 @@ impl PyTable {
         let provider = FFI_TableProvider::new(provider, false, Some(runtime));
 
         PyCapsule::new(py, provider, Some(capsule_name))
+    }
+
+    fn df<'py>(self_: PyRef<'py, Self>) -> PyResult<Bound<'py, PyAny>> {
+        let py = self_.py();
+
+        let super_ = self_.as_super();
+        let client = super_.client.borrow(py);
+        let table_name = super_.name().clone();
+        let ctx = client.ctx(py)?;
+        let ctx = ctx.bind(py);
+
+        drop(client);
+
+        // We're fine with this failing.
+        ctx.call_method1("deregister_table", (table_name.clone(),))?;
+
+        ctx.call_method1("register_table_provider", (table_name.clone(), self_))?;
+
+        let df = ctx.call_method1("table", (table_name,))?;
+
+        Ok(df)
     }
 }

--- a/rerun_py/src/catalog/table.rs
+++ b/rerun_py/src/catalog/table.rs
@@ -5,7 +5,7 @@ use datafusion_ffi::table_provider::FFI_TableProvider;
 use pyo3::{
     exceptions::PyRuntimeError,
     pyclass, pymethods,
-    types::{PyAnyMethods, PyCapsule},
+    types::{PyAnyMethods as _, PyCapsule},
     Bound, PyAny, PyRef, PyRefMut, PyResult,
 };
 
@@ -24,9 +24,9 @@ pub struct PyTable {
 
 #[pymethods]
 impl PyTable {
-    fn __datafusion_table_provider__<'py>(
-        mut self_: PyRefMut<'py, Self>,
-    ) -> PyResult<Bound<'py, PyCapsule>> {
+    fn __datafusion_table_provider__(
+        mut self_: PyRefMut<'_, Self>,
+    ) -> PyResult<Bound<'_, PyCapsule>> {
         let py = self_.py();
         if self_.lazy_provider.is_none() {
             let super_ = self_.as_mut();
@@ -60,7 +60,7 @@ impl PyTable {
         PyCapsule::new(py, provider, Some(capsule_name))
     }
 
-    fn df<'py>(self_: PyRef<'py, Self>) -> PyResult<Bound<'py, PyAny>> {
+    fn df(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyAny>> {
         let py = self_.py();
 
         let super_ = self_.as_super();

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -35,7 +35,7 @@ use re_log_types::{EntityPathFilter, ResolvedTimeRange};
 use re_sdk::{ComponentName, EntityPath, StoreId, StoreKind};
 use re_sorbet::SorbetColumnDescriptors;
 
-use crate::utils::get_tokio_runtime;
+use crate::{catalog::PyCatalogClient, utils::get_tokio_runtime};
 
 /// Register the `rerun.dataframe` module.
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -1471,9 +1471,10 @@ pub fn load_archive(path_to_rrd: std::path::PathBuf) -> PyResult<PyRRDArchive> {
 }
 
 #[pyclass(frozen, name = "DataFusionTable")]
-#[derive(Clone)]
 pub struct PyDataFusionTable {
     pub provider: Arc<dyn TableProvider + Send>,
+    pub name: String,
+    pub client: Py<PyCatalogClient>,
 }
 
 #[pymethods]
@@ -1488,5 +1489,32 @@ impl PyDataFusionTable {
         let provider = FFI_TableProvider::new(Arc::clone(&self.provider), false, Some(runtime));
 
         PyCapsule::new(py, provider, Some(capsule_name))
+    }
+
+    fn df<'py>(self_: PyRef<'py, Self>) -> PyResult<Bound<'py, PyAny>> {
+        let py = self_.py();
+
+        let client = self_.client.borrow(py);
+
+        let ctx = client.ctx(py)?;
+        let ctx = ctx.bind(py);
+
+        drop(client);
+
+        let name = self_.name.clone();
+
+        // We're fine with this failing.
+        ctx.call_method1("deregister_table", (name.clone(),))?;
+
+        ctx.call_method1("register_table_provider", (name.clone(), self_))?;
+
+        let df = ctx.call_method1("table", (name.clone(),))?;
+
+        Ok(df)
+    }
+
+    #[getter]
+    fn name(&self) -> PyResult<String> {
+        Ok(self.name.clone())
     }
 }

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -1491,7 +1491,7 @@ impl PyDataFusionTable {
         PyCapsule::new(py, provider, Some(capsule_name))
     }
 
-    fn df<'py>(self_: PyRef<'py, Self>) -> PyResult<Bound<'py, PyAny>> {
+    fn df(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyAny>> {
         let py = self_.py();
 
         let client = self_.client.borrow(py);
@@ -1514,7 +1514,7 @@ impl PyDataFusionTable {
     }
 
     #[getter]
-    fn name(&self) -> PyResult<String> {
-        Ok(self.name.clone())
+    fn name(&self) -> String {
+        self.name.clone()
     }
 }


### PR DESCRIPTION
### What

- Builds on top of https://github.com/rerun-io/rerun/pull/9479
- Recommend merging that first then rebasing

All the tableproviders now implement a `.df()` helper that registers the provider with a global ctx and then returns it.

Example usage:
![image](https://github.com/user-attachments/assets/49ca7f48-d0ae-4ea0-b33f-1bc269df2877)

