### PR TITLE
Show tables under local and use table icon

### DIFF
--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -854,8 +854,7 @@ pub fn table_id_button_ui(
 ) {
     let item = re_viewer_context::Item::TableId(table_id.clone());
 
-    let mut item_content =
-        list_item::LabelContent::new(table_id.as_str()).with_icon(&icons::VIEW_DATAFRAME);
+    let mut item_content = list_item::LabelContent::new(table_id.as_str()).with_icon(&icons::TABLE);
 
     if ui_layout.is_selection_panel() {
         item_content = item_content.with_buttons(|ui| {

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -123,7 +123,7 @@ fn recording_list_ui(
         );
     }
 
-    if !local_recordings.is_empty()
+    if (!local_recordings.is_empty() || !ctx.storage_context.tables.is_empty())
         && ui
             .list_item()
             .header()
@@ -131,7 +131,7 @@ fn recording_list_ui(
                 ui,
                 egui::Id::new("local items"),
                 true,
-                list_item::LabelContent::header("Local Recordings"),
+                list_item::LabelContent::header("Local"),
                 |ui| {
                     for (app_id, entity_dbs) in local_recordings {
                         dataset_and_its_recordings_ui(
@@ -140,6 +140,9 @@ fn recording_list_ui(
                             &EntryKind::Local(app_id.clone()),
                             entity_dbs,
                         );
+                    }
+                    for table_id in ctx.storage_context.tables.keys() {
+                        table_id_button_ui(ctx, ui, table_id, UiLayout::SelectionPanel);
                     }
                 },
             )
@@ -151,16 +154,6 @@ fn recording_list_ui(
                 LOCAL_ORIGIN.clone(),
             )));
     }
-
-    let item = ui.list_item().header();
-    let title = list_item::LabelContent::header("Tables");
-    if !ctx.storage_context.tables.is_empty() {
-        item.show_hierarchical_with_children(ui, egui::Id::new("tables"), true, title, |ui| {
-            for table_id in ctx.storage_context.tables.keys() {
-                table_id_button_ui(ctx, ui, table_id, UiLayout::SelectionPanel);
-            }
-        });
-    };
 
     // Always show welcome screen last, if at all:
     if (ctx


### PR DESCRIPTION
### What

- Rename "Local recordings" to just "Local"
- in the design it was "Local storage", but I think that is a bit confusing since for now they aren't stored, if you close the viewer it's gone
- Also uses new table icon