### PR TITLE
Catalog API improvements and typing stubs

### DIFF
--- a/crates/store/re_log_types/src/entry_id.rs
+++ b/crates/store/re_log_types/src/entry_id.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 /// The id for an entry (i.e. a dataset or a table) in a remote catalog.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -25,5 +27,13 @@ impl std::fmt::Display for EntryId {
 impl From<re_tuid::Tuid> for EntryId {
     fn from(id: re_tuid::Tuid) -> Self {
         Self { id }
+    }
+}
+
+impl FromStr for EntryId {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        re_tuid::Tuid::from_str(s).map(|id| Self { id })
     }
 }

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Optional, Self, Iterable
+from typing import Any, Callable, Optional, Self
 
 import pyarrow as pa
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -257,7 +257,7 @@ class RecordingView:
 
     def filter_range_nanos(self, start: int, end: int) -> RecordingView:
         """
-        Filter the view to only include data between the given index values expressed as seconds.
+        Filter the view to only include data between the given index values expressed as nanoseconds.
 
         This range is inclusive and will contain both the value at the start and the value at the end.
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1122,7 +1122,7 @@ class DataframeQueryView:
 
     def filter_range_nanos(self, start: int, end: int) -> Self:
         """
-        Filter the view to only include data between the given index values expressed as seconds.
+        Filter the view to only include data between the given index values expressed as nanoseconds.
 
         This range is inclusive and will contain both the value at the start and the value at the end.
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -935,13 +935,11 @@ def asset_video_read_frame_timestamps_nanos(
 ## CATALOG                                                                                                         ##
 #####################################################################################################################
 
-
 class EntryId:
     """A unique identifier for an entry in the catalog."""
 
     def __str__(self) -> str:
         """Return str(self)."""
-
 
 class EntryKind:
     """The kinds of entries that can be stored in the catalog."""
@@ -953,7 +951,6 @@ class EntryKind:
 
     def __str__(self, /) -> str:
         """Return str(self)."""
-
 
 class Entry:
     """An entry in the catalog."""
@@ -985,7 +982,6 @@ class Entry:
     def delete(self) -> None:
         """Delete this entry from the catalog."""
 
-
 class Dataset(Entry):
     @property
     def manifest_url(self) -> str:
@@ -1007,49 +1003,49 @@ class Dataset(Entry):
         """Download a partition from the dataset."""
 
     def dataframe_query_view(
-            self,
-            *,
-            index: str,
-            contents: Any,
-            include_semantically_empty_columns: bool = False,
-            include_indicator_columns: bool = False,
-            include_tombstone_columns: bool = False,
+        self,
+        *,
+        index: str,
+        contents: Any,
+        include_semantically_empty_columns: bool = False,
+        include_indicator_columns: bool = False,
+        include_tombstone_columns: bool = False,
     ) -> DataframeQueryView:
         """Create a view to run a dataframe query on the dataset."""
 
     def create_fts_index(
-            self,
-            *,
-            column: ComponentColumnSelector,
-            time_index: IndexColumnSelector,
-            store_position: bool = False,
-            base_tokenizer: str = "simple",
+        self,
+        *,
+        column: ComponentColumnSelector,
+        time_index: IndexColumnSelector,
+        store_position: bool = False,
+        base_tokenizer: str = "simple",
     ) -> None:
         """Create a full-text search index on the given column."""
 
     def create_vector_index(
-            self,
-            *,
-            column: ComponentColumnSelector,
-            time_index: IndexColumnSelector,
-            num_partitions: int = 5,
-            num_sub_vectors: int = 16,
-            distance_metric: VectorDistanceMetric |  str = ...,
+        self,
+        *,
+        column: ComponentColumnSelector,
+        time_index: IndexColumnSelector,
+        num_partitions: int = 5,
+        num_sub_vectors: int = 16,
+        distance_metric: VectorDistanceMetric | str = ...,
     ) -> None:
         """Create a vector index on the given column."""
 
     def search_fts(
-            self,
-            query: str,
-            column: ComponentColumnSelector,
+        self,
+        query: str,
+        column: ComponentColumnSelector,
     ) -> DataFusionTable:
         """Search the dataset using a full-text search query."""
 
     def search_vector(
-            self,
-            query: Any,  # VectorLike
-            column: ComponentColumnSelector,
-            top_k: int,
+        self,
+        query: Any,  # VectorLike
+        column: ComponentColumnSelector,
+        top_k: int,
     ) -> DataFusionTable:
         """Search the dataset using a vector search query."""
 
@@ -1061,14 +1057,12 @@ class Table(Entry):
     """
 
     def __datafusion_table_provider__(self) -> Any:
-       """Returns a DataFusion table provider capsule."""
-
+        """Returns a DataFusion table provider capsule."""
 
     def df(self) -> Any:
         """Registers the table with the DataFusion context and return a DataFrame."""
 
 class DataframeQueryView:
-
     def filter_partition_id(self, partition_id: str, *args: Iterable[str]) -> Self:
         """Filter by one or more partition ids. All partition ids are included if not specified."""
 
@@ -1266,5 +1260,5 @@ class DataFusionTable:
         """Register this view to the global DataFusion context and return a DataFrame."""
 
     @property
-    def name(self)-> str:
+    def name(self) -> str:
         """Name of this table."""

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -4,7 +4,7 @@ import os
 from collections.abc import Iterator, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Optional, Self
+from typing import Any, Callable, Optional, Self, Iterable
 
 import pyarrow as pa
 
@@ -1069,7 +1069,7 @@ class Table(Entry):
 
 class DataframeQueryView:
 
-    def filter_partition_id(self, partition_id: str, *args: str) -> Self:
+    def filter_partition_id(self, partition_id: str, *args: Iterable[str]) -> Self:
         """Filter by one or more partition ids. All partition ids are included if not specified."""
 
     def filter_range_sequence(self, start: int, end: int) -> Self:

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 from collections.abc import Iterator, Sequence
+from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Self
 
 import pyarrow as pa
 
@@ -927,3 +930,341 @@ def asset_video_read_frame_timestamps_nanos(
     Python `bytes` can be done with `to_pybytes` but this requires copying the data.
     So instead, we pass the arrow array directly.
     """
+
+#####################################################################################################################
+## CATALOG                                                                                                         ##
+#####################################################################################################################
+
+
+class EntryId:
+    """A unique identifier for an entry in the catalog."""
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+
+
+class EntryKind:
+    """The kinds of entries that can be stored in the catalog."""
+
+    DATASET: EntryKind
+    DATASET_VIEW: EntryKind
+    TABLE: EntryKind
+    TABLE_VIEW: EntryKind
+
+    def __str__(self, /) -> str:
+        """Return str(self)."""
+
+
+class Entry:
+    """An entry in the catalog."""
+
+    @property
+    def id(self) -> EntryId:
+        """The entry's id."""
+
+    @property
+    def name(self) -> str:
+        """The entry's name."""
+
+    @property
+    def catalog(self) -> CatalogClient:
+        """The catalog client that this entry belongs to."""
+
+    @property
+    def kind(self) -> EntryKind:
+        """The entry's kind."""
+
+    @property
+    def created_at(self) -> datetime:
+        """The entry's creation date and time."""
+
+    @property
+    def updated_at(self) -> datetime:
+        """The entry's last updated date and time."""
+
+    def delete(self) -> None:
+        """Delete this entry from the catalog."""
+
+
+class Dataset(Entry):
+    @property
+    def manifest_url(self) -> str:
+        """Return the dataset manifest URL."""
+
+    def arrow_schema(self) -> pa.Schema:
+        """Return the Arrow schema of the data contained in the dataset."""
+
+    def partition_table(self) -> DataFusionTable:
+        """Return the partition table as a Datafusion table provider."""
+
+    def partition_url(self, partition_id: str) -> str:
+        """Return the URL for the given partition."""
+
+    def register(self, recording_uri: str) -> None:
+        """Register a RRD URI to the dataset."""
+
+    def download_partition(self, partition_id: str) -> Recording:
+        """Download a partition from the dataset."""
+
+    def dataframe_query_view(
+            self,
+            *,
+            index: str,
+            contents: Any,
+            include_semantically_empty_columns: bool = False,
+            include_indicator_columns: bool = False,
+            include_tombstone_columns: bool = False,
+    ) -> DataframeQueryView:
+        """Create a view to run a dataframe query on the dataset."""
+
+    def create_fts_index(
+            self,
+            *,
+            column: ComponentColumnSelector,
+            time_index: IndexColumnSelector,
+            store_position: bool = False,
+            base_tokenizer: str = "simple",
+    ) -> None:
+        """Create a full-text search index on the given column."""
+
+    def create_vector_index(
+            self,
+            *,
+            column: ComponentColumnSelector,
+            time_index: IndexColumnSelector,
+            num_partitions: int = 5,
+            num_sub_vectors: int = 16,
+            distance_metric: VectorDistanceMetric |  str = ...,
+    ) -> None:
+        """Create a vector index on the given column."""
+
+    def search_fts(
+            self,
+            query: str,
+            column: ComponentColumnSelector,
+    ) -> DataFusionTable:
+        """Search the dataset using a full-text search query."""
+
+    def search_vector(
+            self,
+            query: Any,  # VectorLike
+            column: ComponentColumnSelector,
+            top_k: int,
+    ) -> DataFusionTable:
+        """Search the dataset using a vector search query."""
+
+class Table(Entry):
+    """
+    A table entry in the catalog.
+
+    Note: this object acts as a table provider for DataFusion.
+    """
+
+    def __datafusion_table_provider__(self) -> Any:
+       """Returns a DataFusion table provider capsule."""
+
+
+    def df(self) -> Any:
+        """Registers the table with the DataFusion context and return a DataFrame."""
+
+class DataframeQueryView:
+
+    def filter_partition_id(self, partition_id: str, *args: str) -> Self:
+        """Filter by one or more partition ids. All partition ids are included if not specified."""
+
+    def filter_range_sequence(self, start: int, end: int) -> Self:
+        """
+        Filter the view to only include data between the given index sequence numbers.
+
+        This range is inclusive and will contain both the value at the start and the value at the end.
+
+        The view must be of a sequential index type to use this method.
+
+        Parameters
+        ----------
+        start : int
+            The inclusive start of the range.
+        end : int
+            The inclusive end of the range.
+
+        Returns
+        -------
+        RecordingView
+            A new view containing only the data within the specified range.
+
+            The original view will not be modified.
+
+        """
+
+    def filter_range_secs(self, start: float, end: float) -> Self:
+        """
+        Filter the view to only include data between the given index values expressed as seconds.
+
+        This range is inclusive and will contain both the value at the start and the value at the end.
+
+        The view must be of a temporal index type to use this method.
+
+        Parameters
+        ----------
+        start : int
+            The inclusive start of the range.
+        end : int
+            The inclusive end of the range.
+
+        Returns
+        -------
+        RecordingView
+            A new view containing only the data within the specified range.
+
+            The original view will not be modified.
+
+        """
+
+    def filter_range_nanos(self, start: int, end: int) -> Self:
+        """
+        Filter the view to only include data between the given index values expressed as seconds.
+
+        This range is inclusive and will contain both the value at the start and the value at the end.
+
+        The view must be of a temporal index type to use this method.
+
+        Parameters
+        ----------
+        start : int
+            The inclusive start of the range.
+        end : int
+            The inclusive end of the range.
+
+        Returns
+        -------
+        RecordingView
+            A new view containing only the data within the specified range.
+
+            The original view will not be modified.
+
+        """
+
+    def filter_index_values(self, values: IndexValuesLike) -> Self:
+        """
+        Filter the view to only include data at the provided index values.
+
+        The index values returned will be the intersection between the provided values and the
+        original index values.
+
+        This requires index values to be a precise match. Index values in Rerun are
+        represented as i64 sequence counts or nanoseconds. This API does not expose an interface
+        in floating point seconds, as the numerical conversion would risk false mismatches.
+
+        Parameters
+        ----------
+        values : IndexValuesLike
+            The index values to filter by.
+
+        Returns
+        -------
+        RecordingView
+            A new view containing only the data at the specified index values.
+
+            The original view will not be modified.
+
+        """
+
+    def filter_is_not_null(self, column: AnyComponentColumn) -> Self:
+        """
+        Filter the view to only include rows where the given component column is not null.
+
+        This corresponds to rows for index values where this component was provided to Rerun explicitly
+        via `.log()` or `.send_columns()`.
+
+        Parameters
+        ----------
+        column : AnyComponentColumn
+            The component column to filter by.
+
+        Returns
+        -------
+        RecordingView
+            A new view containing only the data where the specified component column is not null.
+
+            The original view will not be modified.
+
+        """
+
+    def using_index_values(self, values: IndexValuesLike) -> Self:
+        """
+        Replace the index in the view with the provided values.
+
+        The output view will always have the same number of rows as the provided values, even if
+        those rows are empty. Use with [`.fill_latest_at()`][rerun.dataframe.RecordingView.fill_latest_at]
+        to populate these rows with the most recent data.
+
+        This requires index values to be a precise match. Index values in Rerun are
+        represented as i64 sequence counts or nanoseconds. This API does not expose an interface
+        in floating point seconds, as the numerical conversion would risk false mismatches.
+
+        Parameters
+        ----------
+        values : IndexValuesLike
+            The index values to use.
+
+        Returns
+        -------
+        RecordingView
+            A new view containing the provided index values.
+
+            The original view will not be modified.
+
+        """
+
+    def fill_latest_at(self) -> Self:
+        """
+        Populate any null values in a row with the latest valid data according to the index.
+
+        Returns
+        -------
+        RecordingView
+            A new view with the null values filled in.
+
+            The original view will not be modified.
+
+        """
+
+    def df(self) -> Any:
+        """Register this view to the global DataFusion context and return a DataFrame."""
+
+class CatalogClient:
+    """Client for a remote Rerun catalog server."""
+
+    def entries(self) -> list[Entry]:
+        """Get a list of all entries in the catalog."""
+
+    def get_dataset(self, name_or_id: str | EntryId) -> Dataset:
+        """Get a dataset by name or id."""
+
+    def create_dataset(self, name: str) -> Dataset:
+        """Create a new dataset with the provided name."""
+
+    def get_table(self, name_or_id: str | EntryId) -> Table:
+        """
+        Get a table by name or id.
+
+        Note: the entry table is named `__entries`.
+        """
+
+    def entries_table(self) -> Table:
+        """Get the entries table."""
+
+    @property
+    def ctx(self) -> Any:
+        """The DataFusion context (if available)."""
+
+class DataFusionTable:
+    def __datafusion_table_provider__(self) -> Any:
+        """Returns a DataFusion table provider capsule."""
+
+    def df(self) -> Any:
+        """Register this view to the global DataFusion context and return a DataFrame."""
+
+    @property
+    def name(self)-> str:
+        """Name of this table."""

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -25,6 +25,7 @@ import rerun_bindings as bindings
 
 from . import (
     blueprint as blueprint,
+    catalog as catalog,
     dataframe as dataframe,
     experimental as experimental,
     notebook as notebook,

--- a/rerun_py/rerun_sdk/rerun/catalog.py
+++ b/rerun_py/rerun_sdk/rerun/catalog.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from rerun_bindings import (
+    CatalogClient as CatalogClient,
+    DataframeQueryView as DataframeQueryView,
+    Dataset as Dataset,
+    Entry as Entry,
+    EntryId as EntryId,
+    EntryKind as EntryKind,
+    Table as Table,
+    VectorDistanceMetric as VectorDistanceMetric,
+)

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -135,6 +135,7 @@ impl PyCatalogClient {
     //TODO(#9360): `dataset_from_url()`
 
     /// Get a table by name or id.
+    ///
     /// Note: the entry table is named `__entries`.
     fn get_table(
         self_: Py<Self>,

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -135,7 +135,6 @@ impl PyCatalogClient {
     //TODO(#9360): `dataset_from_url()`
 
     /// Get a table by name or id.
-    ///
     /// Note: the entry table is named `__entries`.
     fn get_table(
         self_: Py<Self>,

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -90,13 +90,14 @@ impl PyDataframeQueryView {
         partition_id: String,
         args: &Bound<'py, PyTuple>,
     ) -> PyResult<PyRefMut<'py, Self>> {
-        self_.partition_ids = std::iter::once(Ok(partition_id))
-            .chain(args.try_iter().map(|s| {
-                s.extract::<String>().map_err(|_err| {
-                    PyValueError::new_err("All arguments to `filter_partition_id` must be strings.")
-                })
-            }))
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut partition_ids = vec![partition_id];
+
+        for i in 0..args.len()? {
+            let item = args.get_item(i)?;
+            partition_ids.push(item.extract()?);
+        }
+
+        self_.partition_ids = partition_ids;
 
         Ok(self_)
     }

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -226,7 +226,7 @@ impl PyDataframeQueryView {
     }
 
     #[allow(rustdoc::private_doc_tests)]
-    /// Filter the view to only include data between the given index values expressed as seconds.
+    /// Filter the view to only include data between the given index values expressed as nanoseconds.
     ///
     /// This range is inclusive and will contain both the value at the start and the value at the end.
     ///

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -32,6 +32,7 @@ use crate::dataframe::{
 };
 use crate::utils::wait_for_future;
 
+/// A dataset entry in the catalog.
 #[pyclass(name = "Dataset", extends=PyEntry)]
 pub struct PyDataset {
     pub dataset_handle: DatasetHandle,
@@ -39,6 +40,8 @@ pub struct PyDataset {
 
 #[pymethods]
 impl PyDataset {
+    /// Return the dataset manifest URL.
+    //TODO(ab): not sure we want this to be public
     #[getter]
     fn manifest_url(&self) -> String {
         self.dataset_handle.url.to_string()
@@ -103,6 +106,7 @@ impl PyDataset {
         connection.register_with_dataset(self_.py(), dataset_id, recording_uri)
     }
 
+    /// Download a partition from the dataset.
     fn download_partition(self_: PyRef<'_, Self>, partition_id: String) -> PyResult<PyRecording> {
         let super_ = self_.as_super();
         let mut client = super_.client.borrow(self_.py()).connection().client();
@@ -156,6 +160,7 @@ impl PyDataset {
         })
     }
 
+    /// Create a view to run a dataframe query on the dataset.
     #[expect(clippy::fn_params_excessive_bools)]
     #[pyo3(signature = (
         *,
@@ -185,6 +190,14 @@ impl PyDataset {
         )
     }
 
+    /// Create a full-text search index on the given column.
+    #[pyo3(signature = (
+            *,
+            column,
+            time_index,
+            store_position = false,
+            base_tokenizer = "simple",
+        ))]
     fn create_fts_index(
         self_: PyRef<'_, Self>,
         column: PyComponentColumnSelector,
@@ -241,6 +254,15 @@ impl PyDataset {
         })
     }
 
+    /// Create a vector index on the given column.
+    #[pyo3(signature = (
+        *,
+        column,
+        time_index,
+        num_partitions = 5,
+        num_sub_vectors = 16,
+        distance_metric = VectorDistanceMetricLike::VectorDistanceMetric(crate::catalog::PyVectorDistanceMetric::Cosine),
+    ))]
     fn create_vector_index(
         self_: PyRef<'_, Self>,
         column: PyComponentColumnSelector,
@@ -294,6 +316,7 @@ impl PyDataset {
         })
     }
 
+    /// Search the dataset using a full-text search query.
     fn search_fts(
         self_: PyRef<'_, Self>,
         query: String,
@@ -356,6 +379,7 @@ impl PyDataset {
         })
     }
 
+    /// Search the dataset using a vector search query.
     fn search_vector(
         self_: PyRef<'_, Self>,
         query: VectorLike<'_>,

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -16,6 +16,7 @@ pub struct PyEntryId {
 
 #[pymethods]
 impl PyEntryId {
+    /// Create a new `EntryId` from a string.
     #[new]
     pub fn new(id: String) -> PyResult<Self> {
         Ok(Self {
@@ -25,6 +26,7 @@ impl PyEntryId {
         })
     }
 
+    /// Entry id as a string.
     pub fn __str__(&self) -> String {
         self.id.to_string()
     }
@@ -38,7 +40,8 @@ impl From<EntryId> for PyEntryId {
 
 // ---
 
-#[pyclass(name = "EntryType", eq, eq_int)]
+/// The kinds of entries that can be stored in the catalog.
+#[pyclass(name = "EntryKind", eq, eq_int)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PyEntryKind {
     #[pyo3(name = "DATASET")]
@@ -83,6 +86,7 @@ impl TryFrom<EntryKind> for PyEntryKind {
 
 // ---
 
+/// An entry in the catalog.
 #[pyclass(name = "Entry", subclass)]
 pub struct PyEntry {
     pub client: Py<PyCatalogClient>,
@@ -94,26 +98,31 @@ pub struct PyEntry {
 
 #[pymethods]
 impl PyEntry {
+    /// The entry's id.
     #[getter]
     pub fn id(&self, py: Python<'_>) -> Py<PyEntryId> {
         self.id.clone_ref(py)
     }
 
+    /// The entry's name.
     #[getter]
     pub fn name(&self) -> String {
         self.details.name.clone()
     }
 
+    /// The catalog client that this entry belongs to.
     #[getter]
     pub fn catalog(&self, py: Python<'_>) -> Py<PyCatalogClient> {
         self.client.clone_ref(py)
     }
 
+    /// The entry's kind.
     #[getter]
     pub fn kind(&self) -> PyResult<PyEntryKind> {
         self.details.kind.try_into()
     }
 
+    /// The entry's creation date and time.
     #[getter]
     //TODO(ab): use jiff when updating to pyo3 0.24.0
     pub fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
@@ -123,6 +132,7 @@ impl PyEntry {
         chrono::DateTime::from_timestamp(ts.as_second(), ts.subsec_nanosecond() as u32).unwrap()
     }
 
+    /// The entry's last updated date and time.
     #[getter]
     //TODO(ab): use jiff when updating to pyo3 0.24.0
     pub fn updated_at(&self) -> chrono::DateTime<chrono::Utc> {
@@ -134,6 +144,7 @@ impl PyEntry {
 
     // ---
 
+    /// Delete this entry from the catalog.
     fn delete(&mut self, py: Python<'_>) -> PyResult<()> {
         let entry_id = self.id.borrow(py).id;
         let mut connection = self.client.borrow_mut(py).connection().clone();

--- a/rerun_py/src/catalog/mod.rs
+++ b/rerun_py/src/catalog/mod.rs
@@ -17,11 +17,13 @@ use arrow::{
 use pyo3::{exceptions::PyRuntimeError, prelude::*, Bound, PyResult};
 
 use crate::catalog::dataframe_query::PyDataframeQueryView;
+
 pub use catalog_client::PyCatalogClient;
 pub use connection_handle::ConnectionHandle;
 pub use dataset::PyDataset;
 pub use entry::{PyEntry, PyEntryId, PyEntryKind};
 pub use errors::to_py_err;
+pub use table::PyTable;
 
 /// Register the `rerun.catalog` module.
 pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -30,8 +32,8 @@ pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()>
     m.add_class::<PyEntryId>()?;
     m.add_class::<PyEntryKind>()?;
     m.add_class::<PyEntry>()?;
-
     m.add_class::<PyDataset>()?;
+    m.add_class::<PyTable>()?;
 
     m.add_class::<PyDataframeQueryView>()?;
 
@@ -43,6 +45,7 @@ pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()>
 // TODO(ab): when the new query APIs are implemented, move these type next to it (they were salvaged
 // from the legacy server API)
 
+/// The type of distance metric to use for vector index and search.
 #[pyclass(name = "VectorDistanceMetric", eq, eq_int)]
 #[derive(Clone, Debug, PartialEq)]
 enum PyVectorDistanceMetric {

--- a/rerun_py/src/catalog/table.rs
+++ b/rerun_py/src/catalog/table.rs
@@ -16,6 +16,9 @@ use crate::{
     utils::{get_tokio_runtime, wait_for_future},
 };
 
+/// A table entry in the catalog.
+///
+/// Note: this object acts as a table provider for DataFusion.
 #[pyclass(name = "Table", extends=PyEntry)]
 #[derive(Default)]
 pub struct PyTable {
@@ -24,6 +27,7 @@ pub struct PyTable {
 
 #[pymethods]
 impl PyTable {
+    /// Returns a DataFusion table provider capsule.
     fn __datafusion_table_provider__(
         mut self_: PyRefMut<'_, Self>,
     ) -> PyResult<Bound<'_, PyCapsule>> {
@@ -60,6 +64,7 @@ impl PyTable {
         PyCapsule::new(py, provider, Some(capsule_name))
     }
 
+    /// Registers the table with the DataFusion context and return a DataFrame.
     fn df(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyAny>> {
         let py = self_.py();
 

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -967,7 +967,7 @@ impl PyRecordingView {
     }
 
     #[allow(rustdoc::private_doc_tests)]
-    /// Filter the view to only include data between the given index values expressed as seconds.
+    /// Filter the view to only include data between the given index values expressed as nanoseconds.
     ///
     /// This range is inclusive and will contain both the value at the start and the value at the end.
     ///

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -1479,6 +1479,7 @@ pub struct PyDataFusionTable {
 
 #[pymethods]
 impl PyDataFusionTable {
+    /// Returns a DataFusion table provider capsule.
     fn __datafusion_table_provider__<'py>(
         &self,
         py: Python<'py>,
@@ -1491,6 +1492,7 @@ impl PyDataFusionTable {
         PyCapsule::new(py, provider, Some(capsule_name))
     }
 
+    /// Register this view to the global DataFusion context and return a DataFrame.
     fn df(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyAny>> {
         let py = self_.py();
 
@@ -1513,6 +1515,7 @@ impl PyDataFusionTable {
         Ok(df)
     }
 
+    /// Name of this table.
     #[getter]
     fn name(&self) -> String {
         self.name.clone()


### PR DESCRIPTION
### What

- Add (basic) docstring to all APIs (this will need to be further improved)
- Add typing stubs in `rerun_bindings.pyi`
- export everything in the `rr.catalog` namespace (ie. use `rr.catalog.CatalogClient(...)`)
- `get_dataset()` and `get_table()` can be passed either a name or an id as string (both will be tried before raising an error)
- BREAKING: `filter_paritition_id()` accepts one or more partition id as `*arg`: `view.filter_parition_id("part_1", "part_2")`
- default argument for `create_[vector|fts]_index`
- BREAKING: `EntryType` -> `EntryKind` on python side