### PR TITLE
Improved automatically adding unknown catalog server

### DIFF
--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -185,8 +185,10 @@ impl RedapServers {
                         Server::new(runtime, egui_ctx, origin.clone()),
                     );
                 } else {
-                    re_log::warn!(
-                        "Tried to add pre-existing sever at {:?}",
+                    // Since we persist the server list on disk this happens quite often.
+                    // E.g. run `pixi run rerun "rerun+http://localhost:51234"` more than once.
+                    re_log::debug!(
+                        "Tried to add pre-existing server at {:?}",
                         origin.to_string()
                     );
                 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -465,6 +465,19 @@ impl App {
         #[cfg(not(target_arch = "wasm32"))]
         let rx = crate::wake_up_ui_thread_on_each_msg(rx, self.egui_ctx.clone());
 
+        // Whenever adding a redap receiver from a server that we don't know about already add it.
+        //
+        // Otherwise we end up in a situation where we have a data from an unknown server,
+        // which is unnecessary and can get us into a strange ui state.
+        if let SmartChannelSource::RedapGrpcStream(endpoint) = rx.source() {
+            if !self.state.redap_servers.has_server(&endpoint.origin) {
+                self.command_sender
+                    .send_system(SystemCommand::AddRedapServer {
+                        endpoint: re_uri::CatalogEndpoint::new(endpoint.origin.clone()),
+                    });
+            }
+        }
+
         self.rx.add(rx);
     }
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -465,7 +465,7 @@ impl App {
         #[cfg(not(target_arch = "wasm32"))]
         let rx = crate::wake_up_ui_thread_on_each_msg(rx, self.egui_ctx.clone());
 
-        // Whenever adding a redap receiver from a server that we don't know about already add it.
+        // Add unknown redap servers.
         //
         // Otherwise we end up in a situation where we have a data from an unknown server,
         // which is unnecessary and can get us into a strange ui state.


### PR DESCRIPTION
Like

* https://github.com/rerun-io/rerun/pull/9482

but more general! Previously, automatically opening the server wouldn't work when we got a url from somewhere else, other than clikcing a link in the viewer. This is easy to run into and made even easier now by

* https://github.com/rerun-io/rerun/pull/9493 

This fixes it by checking on new receivers directly.

Also, I made adding preexisting servers a debug message rather than a warning: Today we persist servers, so that means when you run `rerun "rerun+http://localhost:51234"` you get a warning the second time you do so which seems weird.