### PR TITLE
New API for sending files without a recording stream

### DIFF
--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -21,6 +21,8 @@ mod binary_stream_sink;
 mod global;
 mod log_sink;
 mod recording_stream;
+#[cfg(feature = "data_loaders")]
+mod send_file;
 mod spawn;
 
 // -------------
@@ -100,6 +102,9 @@ pub mod log {
     };
     pub use re_log_types::LogMsg;
 }
+
+#[cfg(feature = "data_loaders")]
+pub use send_file::{send_file_grpc, send_file_grpc_opts, send_file_to_sink};
 
 /// Time-related types.
 pub mod time {

--- a/crates/top/re_sdk/src/send_file.rs
+++ b/crates/top/re_sdk/src/send_file.rs
@@ -1,0 +1,93 @@
+use re_data_loader::DataLoaderError;
+use re_log_types::StoreId;
+
+use crate::{log_sink::GrpcSink, sink::LogSink, DataLoaderSettings, RecordingStreamError};
+
+/// Sends a local file using all [`re_data_loader::DataLoader`]s available.
+///
+/// A single `path` might be handled by more than one loader.
+///
+/// Unlike [`super::RecordingStream::log_file`] this will never append to an existing recording
+/// unless an rrd file with an already loaded recording id is provided.
+///
+/// This method blocks until either at least one [`re_data_loader::DataLoader`] starts
+/// streaming data in or all of them fail.
+///
+/// See <https://www.rerun.io/docs/reference/data-loaders/overview> for more information.
+pub fn send_file_to_sink(
+    filepath: impl AsRef<std::path::Path>,
+    sink: &dyn LogSink,
+) -> Result<(), DataLoaderError> {
+    let filepath = filepath.as_ref();
+
+    let (tx, rx) = re_smart_channel::smart_channel(
+        re_smart_channel::SmartMessageSource::Sdk,
+        re_smart_channel::SmartChannelSource::File(filepath.into()),
+    );
+
+    // TODO(andreas): Expose some of these?
+    let settings = DataLoaderSettings {
+        application_id: None,
+        opened_application_id: None,
+        store_id: StoreId::random(re_log_types::StoreKind::Recording),
+        opened_store_id: None,
+        force_store_info: false,
+        entity_path_prefix: None,
+        timepoint: None,
+    };
+
+    // TODO(andreas): Add contents version.
+    re_data_loader::load_from_path(&settings, re_log_types::FileSource::Sdk, filepath, &tx)?;
+    drop(tx);
+
+    // We can safely ignore the error on `recv()` as we're in complete control of both ends of
+    // the channel.
+    while let Some(msg) = rx.recv().ok().and_then(|msg| msg.into_data()) {
+        sink.send(msg);
+    }
+
+    Ok(())
+}
+
+/// Sends a file to a Rerun server via gRPC.
+///
+/// Unlike [`super::RecordingStream::log_file`] this will never append to an existing recording
+/// unless an rrd file with an already loaded recording id is provided.
+/// This is a convenience wrapper for [`send_file_to_sink`].
+///
+/// See also [`send_file_grpc_opts`] if you wish to configure the connection.
+pub fn send_file_grpc(filepath: impl AsRef<std::path::Path>) -> Result<(), RecordingStreamError> {
+    send_file_grpc_opts(
+        filepath,
+        format!(
+            "rerun+http://127.0.0.1:{}/proxy",
+            re_grpc_server::DEFAULT_SERVER_PORT
+        ),
+        crate::default_flush_timeout(),
+    )
+}
+
+/// Sends a file to a Rerun server via gRPC.
+///
+/// Unlike [`super::RecordingStream::log_file`] this will never append to an existing recording
+/// unless an rrd file with an already loaded recording id is provided.
+/// This is a convenience wrapper for [`send_file_to_sink`].
+///
+/// `flush_timeout` is the minimum time the [`GrpcSink`][`crate::log_sink::GrpcSink`] will
+/// wait during a flush before potentially dropping data. Note: Passing `None` here can cause a
+/// call to `flush` to block indefinitely if a connection cannot be established.
+pub fn send_file_grpc_opts(
+    filepath: impl AsRef<std::path::Path>,
+    url: impl Into<String>,
+    flush_timeout: Option<std::time::Duration>,
+) -> Result<(), RecordingStreamError> {
+    let url: String = url.into();
+    let re_uri::RedapUri::Proxy(endpoint) = url.as_str().parse()? else {
+        return Err(RecordingStreamError::NotAProxyEndpoint);
+    };
+
+    let sink = GrpcSink::new(endpoint, flush_timeout);
+    send_file_to_sink(filepath, &sink)?;
+
+    Ok(())
+}

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -913,6 +913,12 @@ def escape_entity_path_part(part: str) -> str:
 def new_entity_path(parts: list[str]) -> str:
     """Create an entity path."""
 
+def dataloader_bytes_from_path_to_callback(
+    file_path: str | os.PathLike[str],
+    callback: Callable[[bytes], Any],
+) -> None:
+    """Runs a dataloader on a file and directs the output to a callback."""
+
 def new_property_entity_path(parts: list[str]) -> str:
     """Create a property entity path."""
 

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -231,6 +232,14 @@ class Viewer:
 
         if block_until_ready:
             self._viewer.block_until_ready()
+
+    def send_file(self, file_path: str | Path) -> None:
+        """
+        Send a file to the viewer.
+
+        TODO: describe
+        """
+        bindings.dataloader_bytes_from_path_to_callback(Path(file_path), self._flush_hook)
 
     def _flush_hook(self, data: bytes) -> None:
         self._viewer.send_rrd(data)

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -17,6 +17,7 @@ use pyo3::{
 use re_log::ResultExt as _;
 use re_log_types::LogMsg;
 use re_log_types::{BlueprintActivationCommand, EntityPathPart, StoreKind};
+use re_sdk::send_file_to_sink;
 use re_sdk::sink::CallbackSink;
 use re_sdk::{external::re_log_encoding::encoder::encode_ref_as_bytes_local, TimeCell};
 use re_sdk::{
@@ -182,6 +183,7 @@ fn rerun_bindings(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(start_web_viewer_server, m)?)?;
     m.add_function(wrap_pyfunction!(escape_entity_path_part, m)?)?;
     m.add_function(wrap_pyfunction!(new_entity_path, m)?)?;
+    m.add_function(wrap_pyfunction!(dataloader_bytes_from_path_to_callback, m)?)?;
 
     // properties
     m.add_function(wrap_pyfunction!(new_property_entity_path, m)?)?;
@@ -1445,6 +1447,29 @@ fn new_entity_path(parts: Vec<Bound<'_, pyo3::types::PyString>>) -> PyResult<Str
             .collect_vec(),
     );
     Ok(path.to_string())
+}
+
+#[pyfunction]
+fn dataloader_bytes_from_path_to_callback(
+    file_path: std::path::PathBuf,
+    callback: PyObject,
+    py: Python<'_>,
+) -> PyResult<()> {
+    let callback = move |msgs: &[LogMsg]| {
+        Python::with_gil(|py| {
+            let data = encode_ref_as_bytes_local(msgs.iter().map(Ok)).ok_or_log_error()?;
+            let bytes = PyBytes::new(py, &data);
+            callback.bind(py).call1((bytes,)).ok_or_log_error()?;
+            Some(())
+        });
+    };
+
+    let callback_sink = CallbackSink::new(callback);
+
+    py.allow_threads(|| {
+        send_file_to_sink(file_path, &callback_sink)
+            .map_err(|err| PyRuntimeError::new_err(err.to_string()))
+    })
 }
 
 // --- Properties ---


### PR DESCRIPTION
### Related

* Related to #9303 
    * This here is an easy more straight forward alternative 

### What

Often it's useful to open a file without creating a recording. In particular for...
* loading an rbl without yet setting up anything else
* loading an rrd
* oneshot visualization, i.e. anything you'd do with `rerun <my file>`

Today this requires creating a recording stream which _always_ willl create a new recording that clutters the viewer.

Usage example:
```py
viewer = rr.notebook.Viewer(width=1100, height=800, url=dataset.partition_url(first_episode))
viewer.send_file("droid.rbl")
viewer.display()
```
Note that in particular for the notebook this works without any existing sinks.


Draft:
* [ ] check with teammates if we want it in this form - interaction with existing sinks is a bit strange 
* [ ] add example / test
* [ ] expose to regular python api, not just notebook
* [ ] improve docs