### PR TITLE
`DisplayRecordbatch`: route `RowId` to `ComponentData::data_ui` if available

### DIFF
--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -257,7 +257,7 @@ impl DisplayColumn {
     ) -> Result<Self, DisplayRecordBatchError> {
         match column_descriptor {
             ColumnDescriptorRef::RowId(_desc) => Ok(Self::RowId {
-                row_ids: Arc::new(Tuid::from_arrow(column_data)?),
+                row_ids: Arc::new(RowId::from_arrow(column_data)?),
             }),
 
             ColumnDescriptorRef::Time(desc) => {

--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -246,7 +246,7 @@ pub enum DisplayColumn {
         component_data: ComponentData,
 
         // if available, used to pass a row id to the component UI (e.g. to cache image)
-        row_ids: Option<Arc<Vec<Tuid>>>,
+        row_ids: Option<Arc<Vec<RowId>>>,
     },
 }
 

--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -233,7 +233,7 @@ fn quick_partial_hash(data: &[u8], section_length: usize) -> u128 {
 #[derive(Debug)]
 pub enum DisplayColumn {
     RowId {
-        row_ids: Arc<Vec<Tuid>>,
+        row_ids: Arc<Vec<RowId>>,
     },
     Timeline {
         timeline: Timeline,

--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -10,6 +10,7 @@ use arrow::{
     buffer::ScalarBuffer as ArrowScalarBuffer,
     datatypes::DataType as ArrowDataType,
 };
+use std::sync::Arc;
 use thiserror::Error;
 
 use re_arrow_util::ArrowArrayDowncastRef as _;
@@ -123,6 +124,7 @@ impl ComponentData {
         latest_at_query: &LatestAtQuery,
         entity_path: &EntityPath,
         component_name: ComponentName,
+        row_ids: Option<&[Tuid]>,
         row_index: usize,
         instance_index: Option<u64>,
     ) {
@@ -151,26 +153,31 @@ impl ComponentData {
                 data
             };
 
+            let mut row_id = row_ids
+                .and_then(|row_ids| row_ids.get(row_index).map(|&tuid| RowId::from_tuid(tuid)));
+
             // TODO(ab): we should find an alternative to using content-hashing to generate cache
             // keys.
+            //
+            // Generate a content-based "fake" row id if we don't have one already.
             //
             // Background: the `row_id` passed to `ui_raw` is only ever used as a cache key for
             // images, and we must provide one for images to be displayed. Since in general we don't
             // have a row id available (e.g. for an arbitrary table entry, or for a dataframe query
             // result), we just hash the data to get a deterministic row id.
-            let row_id = (component_name.as_str() == "rerun.components.Blob")
-                .then(|| {
-                    re_tracing::profile_scope!("Blob hash");
+            if row_id.is_none() && (component_name.as_str() == "rerun.components.Blob") {
+                re_tracing::profile_scope!("Blob hash");
 
-                    let blob = re_types::components::Blob::from_arrow(&data_to_display).ok()?;
-                    let buffer = blob.first().map(|b| b.as_slice())?;
-
+                if let Ok(Some(buffer)) = re_types::components::Blob::from_arrow(&data_to_display)
+                    .as_ref()
+                    .map(|blob| blob.first().map(|blob| blob.as_slice()))
+                {
                     // cap the max amount of data to hash to 9 KiB
                     const SECTION_LENGTH: usize = 3 * 1024;
 
-                    Some(RowId::from_u128(quick_partial_hash(buffer, SECTION_LENGTH)))
-                })
-                .flatten();
+                    row_id = Some(RowId::from_u128(quick_partial_hash(buffer, SECTION_LENGTH)));
+                }
+            }
 
             ctx.component_ui_registry().ui_raw(
                 ctx,
@@ -226,7 +233,7 @@ fn quick_partial_hash(data: &[u8], section_length: usize) -> u128 {
 #[derive(Debug)]
 pub enum DisplayColumn {
     RowId {
-        row_ids: Vec<Tuid>,
+        row_ids: Arc<Vec<Tuid>>,
     },
     Timeline {
         timeline: Timeline,
@@ -237,6 +244,9 @@ pub enum DisplayColumn {
         entity_path: EntityPath,
         component_name: ComponentName,
         component_data: ComponentData,
+
+        // if available, used to pass a row id to the component UI (e.g. to cache image)
+        row_ids: Option<Arc<Vec<Tuid>>>,
     },
 }
 
@@ -247,7 +257,7 @@ impl DisplayColumn {
     ) -> Result<Self, DisplayRecordBatchError> {
         match column_descriptor {
             ColumnDescriptorRef::RowId(_desc) => Ok(Self::RowId {
-                row_ids: Tuid::from_arrow(column_data)?,
+                row_ids: Arc::new(Tuid::from_arrow(column_data)?),
             }),
 
             ColumnDescriptorRef::Time(desc) => {
@@ -269,6 +279,7 @@ impl DisplayColumn {
                 entity_path: desc.entity_path.clone(),
                 component_name: desc.component_name,
                 component_data: ComponentData::try_new(desc, column_data)?,
+                row_ids: None,
             }),
         }
     }
@@ -346,6 +357,7 @@ impl DisplayColumn {
                 entity_path,
                 component_name,
                 component_data,
+                row_ids,
             } => {
                 component_data.data_ui(
                     ctx,
@@ -353,6 +365,7 @@ impl DisplayColumn {
                     latest_at_query,
                     entity_path,
                     *component_name,
+                    row_ids.as_deref().map(|row_ids| row_ids.as_slice()),
                     row_index,
                     instance_index,
                 );
@@ -389,19 +402,39 @@ impl DisplayRecordBatch {
         data: impl Iterator<Item = (ColumnDescriptorRef<'a>, ArrowArrayRef)>,
     ) -> Result<Self, DisplayRecordBatchError> {
         let mut num_rows = None;
+        let mut batch_row_ids = None;
 
-        let columns: Result<Vec<_>, _> = data
+        let mut columns = data
             .map(|(column_descriptor, column_data)| {
                 if num_rows.is_none() {
                     num_rows = Some(column_data.len());
                 }
-                DisplayColumn::try_new(&column_descriptor, &column_data)
+
+                let column = DisplayColumn::try_new(&column_descriptor, &column_data);
+
+                // find the batch row ids, if any
+                if batch_row_ids.is_none() {
+                    if let Ok(DisplayColumn::RowId { row_ids }) = &column {
+                        batch_row_ids = Some(Arc::clone(row_ids));
+                    }
+                }
+
+                column
             })
-            .collect();
+            .collect::<Result<Vec<DisplayColumn>, _>>()?;
+
+        // If we have row_ids, give a reference to all component columns.
+        if let Some(batch_row_ids) = batch_row_ids {
+            for column in &mut columns {
+                if let DisplayColumn::Component { row_ids, .. } = column {
+                    *row_ids = Some(Arc::clone(&batch_row_ids));
+                }
+            }
+        }
 
         Ok(Self {
             num_rows: num_rows.unwrap_or(0),
-            columns: columns?,
+            columns,
         })
     }
 

--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -124,7 +124,7 @@ impl ComponentData {
         latest_at_query: &LatestAtQuery,
         entity_path: &EntityPath,
         component_name: ComponentName,
-        row_ids: Option<&[Tuid]>,
+        row_ids: Option<&[RowId]>,
         row_index: usize,
         instance_index: Option<u64>,
     ) {

--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -16,7 +16,6 @@ use thiserror::Error;
 use re_arrow_util::ArrowArrayDowncastRef as _;
 use re_chunk_store::LatestAtQuery;
 use re_dataframe::external::re_chunk::{TimeColumn, TimeColumnError};
-use re_log_types::external::re_tuid::Tuid;
 use re_log_types::{EntityPath, TimeInt, Timeline};
 use re_sorbet::{ColumnDescriptorRef, ComponentColumnDescriptor};
 use re_types_core::{ComponentName, DeserializationError, Loggable as _, RowId};
@@ -153,8 +152,7 @@ impl ComponentData {
                 data
             };
 
-            let mut row_id = row_ids
-                .and_then(|row_ids| row_ids.get(row_index).map(|&tuid| RowId::from_tuid(tuid)));
+            let mut row_id = row_ids.and_then(|row_ids| row_ids.get(row_index)).copied();
 
             // TODO(ab): we should find an alternative to using content-hashing to generate cache
             // keys.


### PR DESCRIPTION
### Related

* Follow up to https://github.com/rerun-io/rerun/pull/9500
* Closes https://github.com/rerun-io/rerun/issues/9501

### What

This PR improves `DisplayRecordBatch` such that it uses row ids if they are available. Unfortunately, this is kind of hard to test as there is no simple way to get dataframe with both row ids and thumbnails.

DNM: chained PR