### PR TITLE
Don't show "no recordings loaded" when there's tables or a server connected

### DIFF
--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -114,7 +114,12 @@ fn recording_list_ui(
 
     servers.server_list_ui(ui, ctx, remote_recordings);
 
-    if local_recordings.is_empty() && welcome_screen_state.hide {
+    // Show placeholder message if there's absolutely nothing else to show.
+    if ctx.storage_context.tables.is_empty()
+        && servers.is_empty()
+        && local_recordings.is_empty()
+        && welcome_screen_state.hide
+    {
         ui.list_item().interactive(false).show_flat(
             ui,
             re_ui::list_item::LabelContent::new("No recordings loaded")


### PR DESCRIPTION
"no recordings loaded" would show even if remote recordings are loaded. Looked weird because once there's a server (with or without recordings) or a table, the list isn't really empty anymore anyways


Examples:
Technically no recording, but writing "no recordings loaded" wouldn't be helpful here (screenshot with fix)
![image](https://github.com/user-attachments/assets/8da8315e-bb6e-4731-aa5c-84b4eecd52f0)

With a table loaded this label is rather odd (screenshot without fix)
![image](https://github.com/user-attachments/assets/a73f535d-53cf-4030-bfb1-6bc9a8fd6c63)



