### PR TITLE
Tweaks for displaymode/active application on incoming servers & applications

### DIFF
--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -525,6 +525,7 @@ impl App {
     ) {
         match cmd {
             SystemCommand::ActivateApp(app_id) => {
+                self.state.display_mode = DisplayMode::LocalRecordings;
                 store_hub.set_active_app(app_id);
             }
 
@@ -533,10 +534,7 @@ impl App {
             }
 
             SystemCommand::ActivateEntry(entry) => {
-                self.command_sender
-                    .send_system(SystemCommand::ChangeDisplayMode(
-                        DisplayMode::LocalRecordings,
-                    ));
+                self.state.display_mode = DisplayMode::LocalRecordings;
                 store_hub.set_active_entry(entry);
             }
 
@@ -584,10 +582,10 @@ impl App {
             }
 
             SystemCommand::LoadDataSource(data_source) => {
-                self.command_sender
-                    .send_system(SystemCommand::ChangeDisplayMode(
-                        DisplayMode::LocalRecordings,
-                    ));
+                // Note that we *do not* change the display mode here.
+                // For instance if the datasource is a blueprint for a dataset that may be loaded later,
+                // we don't want to switch out to it while the user browses a server.
+
                 let egui_ctx = egui_ctx.clone();
                 // On native, `add_receiver` spawns a thread that wakes up the ui thread
                 // on any new message. On web we cannot spawn threads, so instead we need

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -582,7 +582,7 @@ impl App {
                 if self
                     .store_hub
                     .as_ref()
-                    .map_or(true, |store_hub| store_hub.active_entry().is_none())
+                    .is_none_or(|store_hub| store_hub.active_entry().is_none())
                 {
                     self.state.display_mode = DisplayMode::RedapServer(origin);
                 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -577,7 +577,15 @@ impl App {
             }
             SystemCommand::AddRedapServer { endpoint } => {
                 let re_uri::CatalogEndpoint { origin } = endpoint;
-                self.state.redap_servers.add_server(origin);
+                self.state.redap_servers.add_server(origin.clone());
+
+                if self
+                    .store_hub
+                    .as_ref()
+                    .map_or(true, |store_hub| store_hub.active_entry().is_none())
+                {
+                    self.state.display_mode = DisplayMode::RedapServer(origin);
+                }
                 self.command_sender.send_ui(UICommand::ExpandBlueprintPanel);
             }
 

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -433,7 +433,7 @@ impl StoreHub {
         // If this is the welcome screen, or we didn't have any app id at all so far,
         // we set the active application_id even if we don't find a matching recording.
         // (otherwise we don't, because we don't want to leave towards a state without any recording if we don't have to)
-        if StoreHub::welcome_screen_app_id() == app_id || self.active_application_id.is_none() {
+        if Self::welcome_screen_app_id() == app_id || self.active_application_id.is_none() {
             self.active_application_id = Some(app_id.clone());
             self.active_entry = None;
         }


### PR DESCRIPTION
These are all around workflows with incoming "disembodied" blueprint in a readp server context:

(commit by commit)
* don't change display mode aggressively upon seeing a new datasource (this might be just a blueprint and we're looking at a table or a datset table right now)
* if a server was added, show that server (has relatively little effect right now since we don't have a server dataset overview _yet_
* don't set the application id if there's no matching recording for it
    * this is probably the most controversial but also most important one in here: If I send a blueprint to Rerun while I'm looking at something else, I don't want it to switch application id & active entry if we don't have a recording of interest yet.
