### PR TITLE
fix-ci: update to tokio 1.44.2 to fix RUSTSEC-2025-0023

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10067,9 +10067,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ time = { version = "0.3.36", default-features = false, features = [
 tiny_http = { version = "0.12", default-features = false }
 tinystl = { version = "0.0.3", default-features = false }
 tobj = "4.0"
-tokio = { version = "1.40.0", default-features = false }
+tokio = { version = "1.44.2", default-features = false }
 tokio-stream = "0.1.16"
 tokio-util = { version = "0.7.12", default-features = false }
 toml = { version = "0.8.10", default-features = false }


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

Fixes the cargo-deny workflow

```
 error[unsound]: Broadcast channel calls clone in parallel, but does not require `Sync`
    ┌─ /home/runner/work/rerun/rerun/Cargo.lock:686:1
    │
686 │ tokio 1.44.1 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2025-0023
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0023
    ├ The broadcast channel internally calls `clone` on the stored value when
      receiving it, and only requires `T:Send`. This means that using the broadcast
      channel with values that are `Send` but not `Sync` can trigger unsoundness if
      the `clone` implementation makes use of the value being `!Sync`.
```