### PR TITLE
Do not send `StoreId` in `send_recording` Rust snippet

### DIFF
--- a/docs/snippets/all/concepts/send_recording.rs
+++ b/docs/snippets/all/concepts/send_recording.rs
@@ -1,8 +1,6 @@
 //! Send a `.rrd` to a new recording stream.
 
 use rerun::external::re_chunk_store::{ChunkStore, ChunkStoreConfig};
-use rerun::external::re_log_types::{LogMsg, SetStoreInfo};
-use rerun::external::re_tuid::Tuid;
 use rerun::VersionPolicy;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,12 +17,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Use the same app and recording IDs as the original.
     if let Some(info) = store.info().cloned() {
         let new_recording = rerun::RecordingStreamBuilder::new(info.application_id.clone())
-            .recording_id(store_id.to_string())
+            .store_id(store_id)
             .spawn()?;
 
         // Forward all chunks to the new recording stream.
         for chunk in store.iter_chunks() {
-            recording.send_chunk((**chunk).clone());
+            new_recording.send_chunk((**chunk).clone());
         }
     }
 

--- a/docs/snippets/all/concepts/send_recording.rs
+++ b/docs/snippets/all/concepts/send_recording.rs
@@ -22,11 +22,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .recording_id(store_id.to_string())
             .spawn()?;
 
-        new_recording.record_msg(LogMsg::SetStoreInfo(SetStoreInfo {
-            row_id: Tuid::new(),
-            info,
-        }));
-
         // Forward all chunks to the new recording stream.
         new_recording.send_chunks(store.iter_chunks().map(|chunk| (**chunk).clone()));
     }

--- a/docs/snippets/all/concepts/send_recording.rs
+++ b/docs/snippets/all/concepts/send_recording.rs
@@ -23,7 +23,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .spawn()?;
 
         // Forward all chunks to the new recording stream.
-        new_recording.send_chunks(store.iter_chunks().map(|chunk| (**chunk).clone()));
+        for chunk in store.iter_chunks() {
+            recording.send_chunk((**chunk).clone());
+        }
     }
 
     Ok(())

--- a/examples/assets/example.rrd
+++ b/examples/assets/example.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1868150a997a96d4a98dec7da92f5ba313918416c3b3d1b57a205b0890e72c88
-size 2250
+oid sha256:f1becccbde64dc4bdb7223400d017758f3e408b6ad7f048f255cbf77c8e28888
+size 596924


### PR DESCRIPTION
### What

Removes the line that copies over the `StoreId` from the `send_recording` Rust snippet, we decided to remove that part from the `send_recording` API.

### TODO
* [x] Full check