### PR TITLE
Example showcasing `send_table` from notebooks

### DIFF
--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -909,7 +909,6 @@ pub fn set_email(email: String) {
 // This is required to send bytes around in the notebook.
 // If you ever change this, you also need to adapt `notebook.py` too.
 pub fn from_arrow_encoded(data: &RecordBatch) -> Result<TableMsg, Box<dyn std::error::Error>> {
-    re_log::info!("{:?}", data);
     let mut metadata = data.schema().metadata().clone();
     let id = metadata
         .remove("__table_id")

--- a/examples/python/notebook/send_table.ipynb
+++ b/examples/python/notebook/send_table.ipynb
@@ -1,0 +1,239 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ef6e588c-0ba8-4ce7-b22d-7f640656176c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pixi run py-build-examples\n",
+    "# pixi run -e examples py-build-notebook\n",
+    "# pixi run -e examples jupyter notebook /path/to/dataplatform/Indexing.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e5789224-afa8-4250-9eae-2ca570d46088",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"RERUN_NOTEBOOK_ASSET\"] = \"inline\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c993d2ab-5bbb-4af0-89a5-1c370b7b9523",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rerun as rr\n",
+    "\n",
+    "import pyarrow as pa\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e317e818-4a96-4c63-a9a0-cce25073b2e5",
+   "metadata": {},
+   "source": [
+    "### Send a basic table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "aea716a4-164c-436f-9b6a-ca6f171214b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c014360991394f78875bb5b755a35b79",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Viewer()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "viewer = rr.notebook.Viewer(width=1024, height=700)\n",
+    "viewer.display()\n",
+    "viewer.send_table(\n",
+    "    \"Hello from Notebook\",\n",
+    "    pa.RecordBatch.from_pydict({\"Column A\": [1, 2, 3], \"Column B\": [\"https://www.rerun.io\", \"Hello\", \"World\"]}),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59ebc9cb-cb8f-47e9-9beb-a9ff96a7ca17",
+   "metadata": {},
+   "source": [
+    "### Send a Pandas dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "e15fcb31-4e74-47f9-9eba-b6bcdc545c2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>A</th>\n",
+       "      <th>B</th>\n",
+       "      <th>C</th>\n",
+       "      <th>D</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2013-01-01</th>\n",
+       "      <td>0.724650</td>\n",
+       "      <td>1.413760</td>\n",
+       "      <td>-0.712906</td>\n",
+       "      <td>-0.846874</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2013-01-02</th>\n",
+       "      <td>-0.290926</td>\n",
+       "      <td>1.258524</td>\n",
+       "      <td>-0.486942</td>\n",
+       "      <td>-1.686135</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2013-01-03</th>\n",
+       "      <td>-2.332377</td>\n",
+       "      <td>0.095785</td>\n",
+       "      <td>-0.077341</td>\n",
+       "      <td>1.556405</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2013-01-04</th>\n",
+       "      <td>1.908649</td>\n",
+       "      <td>-0.493422</td>\n",
+       "      <td>1.764314</td>\n",
+       "      <td>0.450595</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2013-01-05</th>\n",
+       "      <td>0.869452</td>\n",
+       "      <td>-0.471848</td>\n",
+       "      <td>-0.562884</td>\n",
+       "      <td>-0.163650</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2013-01-06</th>\n",
+       "      <td>2.075900</td>\n",
+       "      <td>1.014085</td>\n",
+       "      <td>0.501736</td>\n",
+       "      <td>-0.440392</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   A         B         C         D\n",
+       "2013-01-01  0.724650  1.413760 -0.712906 -0.846874\n",
+       "2013-01-02 -0.290926  1.258524 -0.486942 -1.686135\n",
+       "2013-01-03 -2.332377  0.095785 -0.077341  1.556405\n",
+       "2013-01-04  1.908649 -0.493422  1.764314  0.450595\n",
+       "2013-01-05  0.869452 -0.471848 -0.562884 -0.163650\n",
+       "2013-01-06  2.075900  1.014085  0.501736 -0.440392"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dates = pd.date_range(\"20130101\", periods=6)\n",
+    "df = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list(\"ABCD\"))\n",
+    "df_reset = df.reset_index().rename(columns={'index': 'date'})\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "837e06ba-ad72-4dff-a6f4-5e7e211a137d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ddee9f4e26d5406ab823a792fe7c80ff",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "Viewer()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "viewer = rr.notebook.Viewer(width=1024, height=700)\n",
+    "viewer.display()\n",
+    "viewer.send_table(\"Hello from Pandas\", pa.RecordBatch.from_pandas(df))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/python/notebook/send_table.ipynb
+++ b/examples/python/notebook/send_table.ipynb
@@ -1,15 +1,17 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "ef6e588c-0ba8-4ce7-b22d-7f640656176c",
+   "cell_type": "markdown",
+   "id": "85c477c3-5f26-4294-a2ea-4042a0c38b7f",
    "metadata": {},
-   "outputs": [],
    "source": [
+    "### How to run\n",
+    "\n",
+    "```sh\n",
     "# pixi run py-build-examples\n",
     "# pixi run -e examples py-build-notebook\n",
-    "# pixi run -e examples jupyter notebook /path/to/dataplatform/Indexing.ipynb"
+    "# pixi run -e examples jupyter notebook examples/python/notebook/send_table.ipynb\n",
+    "```"
    ]
   },
   {
@@ -28,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "c993d2ab-5bbb-4af0-89a5-1c370b7b9523",
    "metadata": {},
    "outputs": [],
@@ -36,7 +38,7 @@
     "import rerun as rr\n",
     "\n",
     "import pyarrow as pa\n",
-    "import numpy as np"
+    "import pandas as pd"
    ]
   },
   {
@@ -49,14 +51,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "id": "aea716a4-164c-436f-9b6a-ca6f171214b5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c014360991394f78875bb5b755a35b79",
+       "model_id": "bd5a1609428f42d689dbde5a2b79d0db",
        "version_major": 2,
        "version_minor": 1
       },
@@ -87,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "e15fcb31-4e74-47f9-9eba-b6bcdc545c2b",
    "metadata": {},
    "outputs": [
@@ -121,45 +123,45 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2013-01-01</th>\n",
-       "      <td>0.724650</td>\n",
-       "      <td>1.413760</td>\n",
-       "      <td>-0.712906</td>\n",
-       "      <td>-0.846874</td>\n",
+       "      <td>0.823557</td>\n",
+       "      <td>-0.290076</td>\n",
+       "      <td>0.238599</td>\n",
+       "      <td>-0.629761</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2013-01-02</th>\n",
-       "      <td>-0.290926</td>\n",
-       "      <td>1.258524</td>\n",
-       "      <td>-0.486942</td>\n",
-       "      <td>-1.686135</td>\n",
+       "      <td>-0.520894</td>\n",
+       "      <td>-0.817653</td>\n",
+       "      <td>-0.169291</td>\n",
+       "      <td>-0.506261</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2013-01-03</th>\n",
-       "      <td>-2.332377</td>\n",
-       "      <td>0.095785</td>\n",
-       "      <td>-0.077341</td>\n",
-       "      <td>1.556405</td>\n",
+       "      <td>-0.002897</td>\n",
+       "      <td>0.752245</td>\n",
+       "      <td>-0.613818</td>\n",
+       "      <td>1.111361</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2013-01-04</th>\n",
-       "      <td>1.908649</td>\n",
-       "      <td>-0.493422</td>\n",
-       "      <td>1.764314</td>\n",
-       "      <td>0.450595</td>\n",
+       "      <td>0.938248</td>\n",
+       "      <td>-1.109515</td>\n",
+       "      <td>0.536320</td>\n",
+       "      <td>-1.075220</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2013-01-05</th>\n",
-       "      <td>0.869452</td>\n",
-       "      <td>-0.471848</td>\n",
-       "      <td>-0.562884</td>\n",
-       "      <td>-0.163650</td>\n",
+       "      <td>0.033130</td>\n",
+       "      <td>0.771321</td>\n",
+       "      <td>0.310634</td>\n",
+       "      <td>-0.595946</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2013-01-06</th>\n",
-       "      <td>2.075900</td>\n",
-       "      <td>1.014085</td>\n",
-       "      <td>0.501736</td>\n",
-       "      <td>-0.440392</td>\n",
+       "      <td>1.205717</td>\n",
+       "      <td>-2.282729</td>\n",
+       "      <td>1.290203</td>\n",
+       "      <td>0.592006</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -167,15 +169,15 @@
       ],
       "text/plain": [
        "                   A         B         C         D\n",
-       "2013-01-01  0.724650  1.413760 -0.712906 -0.846874\n",
-       "2013-01-02 -0.290926  1.258524 -0.486942 -1.686135\n",
-       "2013-01-03 -2.332377  0.095785 -0.077341  1.556405\n",
-       "2013-01-04  1.908649 -0.493422  1.764314  0.450595\n",
-       "2013-01-05  0.869452 -0.471848 -0.562884 -0.163650\n",
-       "2013-01-06  2.075900  1.014085  0.501736 -0.440392"
+       "2013-01-01  0.823557 -0.290076  0.238599 -0.629761\n",
+       "2013-01-02 -0.520894 -0.817653 -0.169291 -0.506261\n",
+       "2013-01-03 -0.002897  0.752245 -0.613818  1.111361\n",
+       "2013-01-04  0.938248 -1.109515  0.536320 -1.075220\n",
+       "2013-01-05  0.033130  0.771321  0.310634 -0.595946\n",
+       "2013-01-06  1.205717 -2.282729  1.290203  0.592006"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -189,14 +191,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "837e06ba-ad72-4dff-a6f4-5e7e211a137d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ddee9f4e26d5406ab823a792fe7c80ff",
+       "model_id": "aa0fb7b7b5884f3fa7f7653b2f81bb39",
        "version_major": 2,
        "version_minor": 1
       },
@@ -213,6 +215,14 @@
     "viewer.display()\n",
     "viewer.send_table(\"Hello from Pandas\", pa.RecordBatch.from_pandas(df))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7de877bf-f3ba-4f73-867a-1dd7930a2063",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Also removes a forgotten `re_log::info!` statement from development.