### PR TITLE
Rename 'endpoint' to 'uri' where it makes sense

### DIFF
--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -8,7 +8,7 @@ use re_protos::catalog::v1alpha1::ReadDatasetEntryRequest;
 use re_protos::frontend::v1alpha1::frontend_service_client::FrontendServiceClient;
 use re_protos::frontend::v1alpha1::FetchPartitionRequest;
 use re_protos::manifest_registry::v1alpha1::FetchPartitionResponse;
-use re_uri::{DatasetDataEndpoint, Origin};
+use re_uri::{DatasetDataUri, Origin};
 
 use crate::{spawn_future, StreamError, MAX_DECODING_MESSAGE_SIZE};
 
@@ -24,21 +24,21 @@ pub enum Command {
 ///
 /// `on_msg` can be used to wake up the UI thread on Wasm.
 pub fn stream_dataset_from_redap(
-    endpoint: DatasetDataEndpoint,
+    uri: DatasetDataUri,
     on_cmd: Box<dyn Fn(Command) + Send + Sync>,
     on_msg: Option<Box<dyn Fn() + Send + Sync>>,
 ) -> re_smart_channel::Receiver<LogMsg> {
-    re_log::debug!("Loading {endpoint}…");
+    re_log::debug!("Loading {uri}…");
 
     let (tx, rx) = re_smart_channel::smart_channel(
-        re_smart_channel::SmartMessageSource::RedapGrpcStream(endpoint.clone()),
-        re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint.clone()),
+        re_smart_channel::SmartMessageSource::RedapGrpcStream(uri.clone()),
+        re_smart_channel::SmartChannelSource::RedapGrpcStream(uri.clone()),
     );
 
     spawn_future(async move {
-        if let Err(err) = stream_partition_async(tx, endpoint.clone(), on_cmd, on_msg).await {
+        if let Err(err) = stream_partition_async(tx, uri.clone(), on_cmd, on_msg).await {
             re_log::error!(
-                "Error while streaming {endpoint}: {}",
+                "Error while streaming {uri}: {}",
                 re_error::format_ref(&err)
             );
         }
@@ -189,22 +189,26 @@ pub fn get_chunks_response_to_chunk_and_partition_id(
 
 pub async fn stream_partition_async(
     tx: re_smart_channel::Sender<LogMsg>,
-    endpoint: re_uri::DatasetDataEndpoint,
+    uri: re_uri::DatasetDataUri,
     on_cmd: Box<dyn Fn(Command) + Send + Sync>,
     on_msg: Option<Box<dyn Fn() + Send + Sync>>,
 ) -> Result<(), StreamError> {
-    re_log::debug!("Connecting to {}…", endpoint.origin);
-    let mut client = client(endpoint.origin).await?;
+    let re_uri::DatasetDataUri {
+        origin,
+        dataset_id,
+        partition_id,
+        time_range,
+        fragment: _, // Only affects the viewer
+    } = uri;
 
-    re_log::debug!(
-        "Fetching catalog data for partition {} of dataset {}…",
-        endpoint.partition_id,
-        endpoint.dataset_id
-    );
+    re_log::debug!("Connecting to {}…", origin);
+    let mut client = client(origin).await?;
+
+    re_log::debug!("Fetching catalog data for partition {partition_id} of dataset {dataset_id}…");
 
     let read_dataset_response: ReadDatasetEntryResponse = client
         .read_dataset_entry(ReadDatasetEntryRequest {
-            id: Some(endpoint.dataset_id.into()),
+            id: Some(dataset_id.into()),
         })
         .await?
         .into_inner()
@@ -215,15 +219,15 @@ pub async fn stream_partition_async(
     let catalog_chunk_stream = client
         //TODO(rerun-io/dataplatform#474): filter chunks by time range
         .fetch_partition(FetchPartitionRequest {
-            dataset_id: Some(endpoint.dataset_id.into()),
-            partition_id: Some(endpoint.partition_id.clone().into()),
+            dataset_id: Some(dataset_id.into()),
+            partition_id: Some(partition_id.clone().into()),
         })
         .await?
         .into_inner();
 
     drop(client);
 
-    let store_id = StoreId::from_string(StoreKind::Recording, endpoint.partition_id.clone());
+    let store_id = StoreId::from_string(StoreKind::Recording, partition_id.clone());
     let store_info = StoreInfo {
         application_id: dataset_name.into(),
         store_id: store_id.clone(),
@@ -232,7 +236,7 @@ pub async fn stream_partition_async(
         store_version: None,
     };
 
-    if let Some(time_range) = endpoint.time_range {
+    if let Some(time_range) = time_range {
         on_cmd(Command::SetLoopSelection {
             recording_id: store_id.clone(),
             timeline: time_range.timeline,

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -259,13 +259,13 @@ pub fn spawn_with_recv(
     re_smart_channel::Receiver<re_log_types::LogMsg>,
     crossbeam::channel::Receiver<re_log_types::TableMsg>,
 ) {
-    let url = re_uri::ProxyEndpoint::new(re_uri::Origin::from_scheme_and_socket_addr(
+    let uri = re_uri::ProxyUri::new(re_uri::Origin::from_scheme_and_socket_addr(
         re_uri::Scheme::RerunHttp,
         addr,
     ));
     let (channel_log_tx, channel_log_rx) = re_smart_channel::smart_channel(
-        re_smart_channel::SmartMessageSource::MessageProxy(url.clone()),
-        re_smart_channel::SmartChannelSource::MessageProxy(url),
+        re_smart_channel::SmartMessageSource::MessageProxy(uri.clone()),
+        re_smart_channel::SmartChannelSource::MessageProxy(uri),
     );
     let (channel_table_tx, channel_table_rx) = crossbeam::channel::unbounded();
     let (message_proxy, mut broadcast_log_rx, mut broadcast_table_rx) =

--- a/crates/top/re_sdk/src/grpc_server.rs
+++ b/crates/top/re_sdk/src/grpc_server.rs
@@ -27,12 +27,12 @@ impl GrpcServerSink {
 
         let grpc_server_addr = format!("{bind_ip}:{grpc_port}").parse()?;
 
-        let endpoint = re_uri::ProxyEndpoint::new(re_uri::Origin::from_scheme_and_socket_addr(
+        let uri = re_uri::ProxyUri::new(re_uri::Origin::from_scheme_and_socket_addr(
             re_uri::Scheme::RerunHttp,
             grpc_server_addr,
         ));
         let (channel_tx, channel_rx) = re_smart_channel::smart_channel::<re_log_types::LogMsg>(
-            re_smart_channel::SmartMessageSource::MessageProxy(endpoint),
+            re_smart_channel::SmartMessageSource::MessageProxy(uri),
             re_smart_channel::SmartChannelSource::Sdk,
         );
         let server_handle = std::thread::Builder::new()

--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -351,13 +351,13 @@ impl GrpcSink {
     /// GrpcSink::new("rerun+http://127.0.0.1:9434/proxy");
     /// ```
     #[inline]
-    pub fn new(endpoint: re_uri::ProxyEndpoint, flush_timeout: Option<Duration>) -> Self {
+    pub fn new(uri: re_uri::ProxyUri, flush_timeout: Option<Duration>) -> Self {
         let options = Options {
             flush_timeout,
             ..Default::default()
         };
         Self {
-            client: MessageProxyClient::new(endpoint, options),
+            client: MessageProxyClient::new(uri, options),
         }
     }
 }

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -388,7 +388,7 @@ impl RecordingStreamBuilder {
         let (enabled, store_info, properties, batcher_config) = self.into_args();
         if enabled {
             let url: String = url.into();
-            let re_uri::RedapUri::Proxy(endpoint) = url.as_str().parse()? else {
+            let re_uri::RedapUri::Proxy(uri) = url.as_str().parse()? else {
                 return Err(RecordingStreamError::NotAProxyEndpoint);
             };
 
@@ -396,7 +396,7 @@ impl RecordingStreamBuilder {
                 store_info,
                 properties,
                 batcher_config,
-                Box::new(crate::log_sink::GrpcSink::new(endpoint, flush_timeout)),
+                Box::new(crate::log_sink::GrpcSink::new(uri, flush_timeout)),
             )
         } else {
             re_log::debug!("Rerun disabled - call to connect() ignored");
@@ -1889,11 +1889,11 @@ impl RecordingStream {
         }
 
         let url: String = url.into();
-        let re_uri::RedapUri::Proxy(endpoint) = url.as_str().parse()? else {
+        let re_uri::RedapUri::Proxy(uri) = url.as_str().parse()? else {
             return Err(RecordingStreamError::NotAProxyEndpoint);
         };
 
-        let sink = crate::log_sink::GrpcSink::new(endpoint, flush_timeout);
+        let sink = crate::log_sink::GrpcSink::new(uri, flush_timeout);
 
         self.set_sink(Box::new(sink));
         Ok(())

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -1,5 +1,5 @@
 use re_log_types::LogMsg;
-use re_uri::ProxyEndpoint;
+use re_uri::ProxyUri;
 use re_web_viewer_server::{WebViewerServer, WebViewerServerError, WebViewerServerPort};
 
 // ----------------------------------------------------------------------------
@@ -47,12 +47,12 @@ impl WebViewerSink {
         let (server_shutdown_signal, shutdown) = re_grpc_server::shutdown::shutdown();
 
         let grpc_server_addr = format!("{bind_ip}:{grpc_port}").parse()?;
-        let endpoint = re_uri::ProxyEndpoint::new(re_uri::Origin::from_scheme_and_socket_addr(
+        let uri = re_uri::ProxyUri::new(re_uri::Origin::from_scheme_and_socket_addr(
             re_uri::Scheme::RerunHttp,
             grpc_server_addr,
         ));
         let (channel_tx, channel_rx) = re_smart_channel::smart_channel::<re_log_types::LogMsg>(
-            re_smart_channel::SmartMessageSource::MessageProxy(endpoint),
+            re_smart_channel::SmartMessageSource::MessageProxy(uri),
             re_smart_channel::SmartChannelSource::Sdk,
         );
         let server_handle = std::thread::Builder::new()
@@ -144,7 +144,7 @@ pub struct WebViewerConfig {
     ///
     /// This url is a hosted RRD file that we retrieve via the message proxy.
     /// Has no effect if [`Self::open_browser`] is false.
-    pub source_url: Option<ProxyEndpoint>,
+    pub source_url: Option<ProxyUri>,
 
     /// If set, adjusts the browser url to force a specific backend, either `webgl` or `webgpu`.
     ///

--- a/crates/utils/re_smart_channel/src/lib.rs
+++ b/crates/utils/re_smart_channel/src/lib.rs
@@ -50,10 +50,10 @@ pub enum SmartChannelSource {
     Stdin,
 
     /// The data is streaming in directly from a Rerun Data Platform server, over gRPC.
-    RedapGrpcStream(re_uri::DatasetDataEndpoint),
+    RedapGrpcStream(re_uri::DatasetDataUri),
 
     /// The data is streaming in via a message proxy.
-    MessageProxy(re_uri::ProxyEndpoint),
+    MessageProxy(re_uri::ProxyUri),
 }
 
 impl std::fmt::Display for SmartChannelSource {
@@ -61,8 +61,8 @@ impl std::fmt::Display for SmartChannelSource {
         match self {
             Self::File(path) => path.display().fmt(f),
             Self::RrdHttpStream { url, follow: _ } => url.fmt(f),
-            Self::MessageProxy(endpoint) => endpoint.fmt(f),
-            Self::RedapGrpcStream(endpoint) => endpoint.fmt(f),
+            Self::MessageProxy(uri) => uri.fmt(f),
+            Self::RedapGrpcStream(uri) => uri.fmt(f),
             Self::RrdWebEventListener => "Web event listener".fmt(f),
             Self::JsChannel { channel_name } => write!(f, "Javascript channel: {channel_name}"),
             Self::Sdk => "SDK".fmt(f),
@@ -121,10 +121,10 @@ pub enum SmartMessageSource {
     Stdin,
 
     /// A file on a Rerun Data Platform server, over `rerun://` gRPC interface.
-    RedapGrpcStream(re_uri::DatasetDataEndpoint),
+    RedapGrpcStream(re_uri::DatasetDataUri),
 
     /// A stream of messages over message proxy gRPC interface.
-    MessageProxy(re_uri::ProxyEndpoint),
+    MessageProxy(re_uri::ProxyUri),
 }
 
 impl std::fmt::Display for SmartMessageSource {
@@ -133,8 +133,8 @@ impl std::fmt::Display for SmartMessageSource {
             Self::Unknown => "unknown".into(),
             Self::File(path) => format!("file://{}", path.to_string_lossy()),
             Self::RrdHttpStream { url } => url.clone(),
-            Self::MessageProxy(endpoint) => endpoint.to_string(),
-            Self::RedapGrpcStream(endpoint) => endpoint.to_string(),
+            Self::MessageProxy(uri) => uri.to_string(),
+            Self::RedapGrpcStream(uri) => uri.to_string(),
             Self::RrdWebEventCallback => "web_callback".into(),
             Self::JsChannelPush => "javascript".into(),
             Self::Sdk => "sdk".into(),

--- a/crates/utils/re_smart_channel/src/receive_set.rs
+++ b/crates/utils/re_smart_channel/src/receive_set.rs
@@ -53,8 +53,8 @@ impl<T: Send> ReceiveSet<T> {
             // - aren't network sources
             // - don't point at the given `uri`
             SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
-            SmartChannelSource::MessageProxy(endpoint) => endpoint.to_string() != uri,
-            SmartChannelSource::RedapGrpcStream(endpoint) => endpoint.to_string() != uri,
+            SmartChannelSource::MessageProxy(uri) => uri.to_string() != uri,
+            SmartChannelSource::RedapGrpcStream(uri) => uri.to_string() != uri,
 
             SmartChannelSource::File(_)
             | SmartChannelSource::Stdin

--- a/crates/utils/re_smart_channel/src/receive_set.rs
+++ b/crates/utils/re_smart_channel/src/receive_set.rs
@@ -53,8 +53,8 @@ impl<T: Send> ReceiveSet<T> {
             // - aren't network sources
             // - don't point at the given `uri`
             SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
-            SmartChannelSource::MessageProxy(uri) => uri.to_string() != uri,
-            SmartChannelSource::RedapGrpcStream(uri) => uri.to_string() != uri,
+            SmartChannelSource::MessageProxy(url) => url.to_string() != uri,
+            SmartChannelSource::RedapGrpcStream(url) => url.to_string() != uri,
 
             SmartChannelSource::File(_)
             | SmartChannelSource::Stdin

--- a/crates/utils/re_uri/src/endpoints/catalog.rs
+++ b/crates/utils/re_uri/src/endpoints/catalog.rs
@@ -1,40 +1,37 @@
 use crate::{Origin, RedapUri};
 
+/// `scheme://hostname:port/catalog`
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct CatalogEndpoint {
+pub struct CatalogUri {
     pub origin: Origin,
 }
 
-impl std::fmt::Display for CatalogEndpoint {
+impl std::fmt::Display for CatalogUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/catalog", self.origin)
     }
 }
 
-impl CatalogEndpoint {
+impl CatalogUri {
     pub fn new(origin: Origin) -> Self {
         Self { origin }
     }
 }
 
-impl std::str::FromStr for CatalogEndpoint {
+impl std::str::FromStr for CatalogUri {
     type Err = crate::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match RedapUri::from_str(s)? {
-            RedapUri::Catalog(endpoint) => Ok(endpoint),
-            RedapUri::Proxy(endpoint) => {
-                Err(crate::Error::UnexpectedEndpoint(format!("/{endpoint}")))
-            }
-            RedapUri::DatasetData(endpoint) => {
-                Err(crate::Error::UnexpectedEndpoint(format!("/{endpoint}")))
-            }
+        if let RedapUri::Catalog(uri) = RedapUri::from_str(s)? {
+            Ok(uri)
+        } else {
+            Err(crate::Error::UnexpectedUri(s.to_owned()))
         }
     }
 }
 
 // Serialize as string:
-impl serde::Serialize for CatalogEndpoint {
+impl serde::Serialize for CatalogUri {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -43,7 +40,7 @@ impl serde::Serialize for CatalogEndpoint {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for CatalogEndpoint {
+impl<'de> serde::Deserialize<'de> for CatalogUri {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Fragment, Origin, RedapUri, TimeRange};
 
-//TODO(ab): add `DatasetTableEndpoint`, the URI pointing at the "table view" of the dataset (aka. its partition table).
+//TODO(ab): add `DatasetTableUri`, the URI pointing at the "table view" of the dataset (aka. its partition table).
 
 /// URI pointing at the data underlying a dataset.
 ///
@@ -10,7 +10,7 @@ use crate::{Error, Fragment, Origin, RedapUri, TimeRange};
 /// `partition_id` is currently mandatory, and `time_range` is optional.
 /// In the future we will add richer queries.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct DatasetDataEndpoint {
+pub struct DatasetDataUri {
     pub origin: Origin,
     pub dataset_id: re_tuid::Tuid,
 
@@ -23,7 +23,7 @@ pub struct DatasetDataEndpoint {
     pub fragment: Fragment,
 }
 
-impl std::fmt::Display for DatasetDataEndpoint {
+impl std::fmt::Display for DatasetDataUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
             origin,
@@ -53,7 +53,7 @@ impl std::fmt::Display for DatasetDataEndpoint {
     }
 }
 
-impl DatasetDataEndpoint {
+impl DatasetDataUri {
     pub fn new(origin: Origin, dataset_id: re_tuid::Tuid, url: &url::Url) -> Result<Self, Error> {
         let mut partition_id = None;
         let mut time_range = None;
@@ -90,7 +90,7 @@ impl DatasetDataEndpoint {
         })
     }
 
-    /// Returns a [`DatasetDataEndpoint`] without any (optional) `?query` or `#fragment`.
+    /// Returns [`Self`] without any (optional) `?query` or `#fragment`.
     pub fn without_query_and_fragment(mut self) -> Self {
         let Self {
             origin: _,       // Mandatory
@@ -107,14 +107,14 @@ impl DatasetDataEndpoint {
     }
 }
 
-impl std::str::FromStr for DatasetDataEndpoint {
+impl std::str::FromStr for DatasetDataUri {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match RedapUri::from_str(s)? {
-            RedapUri::DatasetData(endpoint) => Ok(endpoint),
-            RedapUri::Catalog(endpoint) => Err(Error::UnexpectedEndpoint(format!("/{endpoint}"))),
-            RedapUri::Proxy(endpoint) => Err(Error::UnexpectedEndpoint(format!("/{endpoint}"))),
+        if let RedapUri::DatasetData(uri) = RedapUri::from_str(s)? {
+            Ok(uri)
+        } else {
+            Err(Error::UnexpectedUri(s.to_owned()))
         }
     }
 }
@@ -122,7 +122,7 @@ impl std::str::FromStr for DatasetDataEndpoint {
 // --------------------------------
 
 // Serialize as string:
-impl serde::Serialize for DatasetDataEndpoint {
+impl serde::Serialize for DatasetDataUri {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -131,7 +131,7 @@ impl serde::Serialize for DatasetDataEndpoint {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for DatasetDataEndpoint {
+impl<'de> serde::Deserialize<'de> for DatasetDataUri {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -1,40 +1,36 @@
 use crate::{Origin, RedapUri};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ProxyEndpoint {
+pub struct ProxyUri {
     pub origin: Origin,
 }
 
-impl std::fmt::Display for ProxyEndpoint {
+impl std::fmt::Display for ProxyUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/proxy", self.origin)
     }
 }
 
-impl ProxyEndpoint {
+impl ProxyUri {
     pub fn new(origin: Origin) -> Self {
         Self { origin }
     }
 }
 
-impl std::str::FromStr for ProxyEndpoint {
+impl std::str::FromStr for ProxyUri {
     type Err = crate::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match RedapUri::from_str(s)? {
-            RedapUri::Proxy(endpoint) => Ok(endpoint),
-            RedapUri::Catalog(endpoint) => {
-                Err(crate::Error::UnexpectedEndpoint(format!("/{endpoint}")))
-            }
-            RedapUri::DatasetData(endpoint) => {
-                Err(crate::Error::UnexpectedEndpoint(format!("/{endpoint}")))
-            }
+        if let RedapUri::Proxy(uri) = RedapUri::from_str(s)? {
+            Ok(uri)
+        } else {
+            Err(crate::Error::UnexpectedUri(s.to_owned()))
         }
     }
 }
 
 // Serialize as string:
-impl serde::Serialize for ProxyEndpoint {
+impl serde::Serialize for ProxyUri {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -43,7 +39,7 @@ impl serde::Serialize for ProxyEndpoint {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for ProxyEndpoint {
+impl<'de> serde::Deserialize<'de> for ProxyUri {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/crates/utils/re_uri/src/error.rs
+++ b/crates/utils/re_uri/src/error.rs
@@ -5,19 +5,19 @@ pub enum Error {
     #[error(transparent)]
     Parse(#[from] url::ParseError),
 
-    #[error("invalid or missing scheme (expected one of: `rerun://`, `rerun+http://`, `rerun+https://`)")]
+    #[error("Invalid or missing scheme (expected one of: `rerun://`, `rerun+http://`, `rerun+https://`)")]
     InvalidScheme,
 
-    #[error("invalid time range (expected `TIMELINE@time..time`): {0}")]
+    #[error("Invalid time range (expected `TIMELINE@time..time`): {0}")]
     InvalidTimeRange(String),
 
-    #[error("unexpected endpoint: {0}")]
-    UnexpectedEndpoint(String),
+    #[error("Unexpected URI:: {0}")]
+    UnexpectedUri(String),
 
-    #[error("unexpected opaque origin: {0}")]
+    #[error("Unexpected opaque origin: {0}")]
     UnexpectedOpaqueOrigin(String),
 
-    #[error("unexpected base URL: {0}")]
+    #[error("Unexpected base URL: {0}")]
     UnexpectedBaseUrl(String),
 
     #[error("URL {url:?} cannot be loaded as a recording")]
@@ -26,6 +26,6 @@ pub enum Error {
     #[error("Dataset data URL required a `?partition_id` query parameter")]
     MissingPartitionId,
 
-    #[error("invalid TUID: {0}")]
+    #[error("Invalid TUID: {0}")]
     InvalidTuid(<re_tuid::Tuid as FromStr>::Err),
 }

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -42,7 +42,7 @@ mod scheme;
 mod time_range;
 
 pub use self::{
-    endpoints::{catalog::CatalogEndpoint, dataset::DatasetDataEndpoint, proxy::ProxyEndpoint},
+    endpoints::{catalog::CatalogUri, dataset::DatasetDataUri, proxy::ProxyUri},
     error::Error,
     fragment::Fragment,
     origin::Origin,

--- a/crates/utils/re_uri/src/origin.rs
+++ b/crates/utils/re_uri/src/origin.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 
 use crate::{Error, Scheme};
 
+/// `scheme://hostname:port`
 #[derive(
     Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -1,14 +1,14 @@
-use crate::{CatalogEndpoint, DatasetDataEndpoint, Error, Fragment, Origin, ProxyEndpoint};
+use crate::{CatalogUri, DatasetDataUri, Error, Fragment, Origin, ProxyUri};
 
 /// Parsed from `rerun://addr:port/recording/12345` or `rerun://addr:port/catalog`
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum RedapUri {
-    Catalog(CatalogEndpoint),
+    Catalog(CatalogUri),
 
-    DatasetData(DatasetDataEndpoint),
+    DatasetData(DatasetDataUri),
 
     /// We use the `/proxy` endpoint to access another _local_ viewer.
-    Proxy(ProxyEndpoint),
+    Proxy(ProxyUri),
 }
 
 impl RedapUri {
@@ -24,9 +24,9 @@ impl RedapUri {
 impl std::fmt::Display for RedapUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Catalog(endpoint) => write!(f, "{endpoint}",),
-            Self::DatasetData(endpoints) => write!(f, "{endpoints}",),
-            Self::Proxy(endpoint) => write!(f, "{endpoint}",),
+            Self::Catalog(uri) => write!(f, "{uri}",),
+            Self::DatasetData(uri) => write!(f, "{uri}",),
+            Self::Proxy(uri) => write!(f, "{uri}",),
         }
     }
 }
@@ -47,16 +47,16 @@ impl std::str::FromStr for RedapUri {
             .collect::<Vec<_>>();
 
         match segments.as_slice() {
-            ["proxy"] => Ok(Self::Proxy(ProxyEndpoint::new(origin))),
+            ["proxy"] => Ok(Self::Proxy(ProxyUri::new(origin))),
 
-            ["catalog"] | [] => Ok(Self::Catalog(CatalogEndpoint::new(origin))),
+            ["catalog"] | [] => Ok(Self::Catalog(CatalogUri::new(origin))),
 
             ["dataset", dataset_id] => {
                 let dataset_id = re_tuid::Tuid::from_str(dataset_id).map_err(Error::InvalidTuid)?;
 
-                DatasetDataEndpoint::new(origin, dataset_id, &http_url).map(Self::DatasetData)
+                DatasetDataUri::new(origin, dataset_id, &http_url).map(Self::DatasetData)
             }
-            [unknown, ..] => Err(Error::UnexpectedEndpoint(format!("{unknown}/"))),
+            [unknown, ..] => Err(Error::UnexpectedUri(format!("{unknown}/"))),
         }
     }
 }
@@ -133,7 +133,7 @@ mod tests {
             "rerun://127.0.0.1:1234/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid";
         let address: RedapUri = url.parse().unwrap();
 
-        let RedapUri::DatasetData(DatasetDataEndpoint {
+        let RedapUri::DatasetData(DatasetDataUri {
             origin,
             dataset_id,
             partition_id,
@@ -162,7 +162,7 @@ mod tests {
             "rerun://127.0.0.1:1234/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid#/some/entity[#42]";
         let address: RedapUri = url.parse().unwrap();
 
-        let RedapUri::DatasetData(DatasetDataEndpoint {
+        let RedapUri::DatasetData(DatasetDataUri {
             origin,
             dataset_id,
             partition_id,
@@ -199,7 +199,7 @@ mod tests {
         let url = "rerun://127.0.0.1:1234/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid&time_range=timeline@100..200";
         let address: RedapUri = url.parse().unwrap();
 
-        let RedapUri::DatasetData(DatasetDataEndpoint {
+        let RedapUri::DatasetData(DatasetDataUri {
             origin,
             dataset_id,
             partition_id,
@@ -236,7 +236,7 @@ mod tests {
         let url = "rerun://127.0.0.1:1234/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid&time_range=log_time@2022-01-01T00:00:03.123456789Z..2022-01-01T00:00:13.123456789Z";
         let address: RedapUri = url.parse().unwrap();
 
-        let RedapUri::DatasetData(DatasetDataEndpoint {
+        let RedapUri::DatasetData(DatasetDataUri {
             origin,
             dataset_id,
             partition_id,
@@ -280,7 +280,7 @@ mod tests {
         ] {
             let address: RedapUri = url.parse().unwrap();
 
-            let RedapUri::DatasetData(DatasetDataEndpoint {
+            let RedapUri::DatasetData(DatasetDataUri {
                 origin,
                 dataset_id,
                 partition_id,
@@ -326,7 +326,7 @@ mod tests {
         let address: RedapUri = url.parse().unwrap();
         assert!(matches!(
             address,
-            RedapUri::Catalog(CatalogEndpoint {
+            RedapUri::Catalog(CatalogUri {
                 origin: Origin {
                     scheme: Scheme::RerunHttp,
                     host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
@@ -343,7 +343,7 @@ mod tests {
 
         assert!(matches!(
             address,
-            RedapUri::Catalog(CatalogEndpoint {
+            RedapUri::Catalog(CatalogUri {
                 origin: Origin {
                     scheme: Scheme::RerunHttps,
                     host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
@@ -360,7 +360,7 @@ mod tests {
 
         assert_eq!(
             address,
-            RedapUri::Catalog(CatalogEndpoint {
+            RedapUri::Catalog(CatalogUri {
                 origin: Origin {
                     scheme: Scheme::RerunHttp,
                     host: url::Host::<String>::Domain("localhost".to_owned()),
@@ -388,7 +388,7 @@ mod tests {
 
         assert!(matches!(
             address.unwrap_err(),
-            super::Error::UnexpectedEndpoint(unknown) if &unknown == "redap/"
+            super::Error::UnexpectedUri(unknown) if &unknown == "redap/"
         ));
     }
 
@@ -397,7 +397,7 @@ mod tests {
         let url = "rerun://localhost:51234/proxy";
         let address: Result<RedapUri, _> = url.parse();
 
-        let expected = RedapUri::Proxy(ProxyEndpoint {
+        let expected = RedapUri::Proxy(ProxyUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
@@ -418,7 +418,7 @@ mod tests {
         let url = "rerun://localhost:51234";
         let address: Result<RedapUri, _> = url.parse();
 
-        let expected = RedapUri::Catalog(CatalogEndpoint {
+        let expected = RedapUri::Catalog(CatalogUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
@@ -442,7 +442,7 @@ mod tests {
     fn test_default_port() {
         let url = "rerun://localhost";
 
-        let expected = RedapUri::Catalog(CatalogEndpoint {
+        let expected = RedapUri::Catalog(CatalogUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
@@ -457,7 +457,7 @@ mod tests {
     fn test_custom_port() {
         let url = "rerun://localhost:123";
 
-        let expected = RedapUri::Catalog(CatalogEndpoint {
+        let expected = RedapUri::Catalog(CatalogUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -173,14 +173,12 @@ pub fn sort_datasets<'a>(viewer_ctx: &ViewerContext<'a>) -> SortDatasetsResults<
         let Some(app_id) = entity_db.app_id().cloned() else {
             continue; // this only happens if we haven't even started loading it, or if something is really wrong with it.
         };
-        if let Some(SmartChannelSource::RedapGrpcStream(endpoint)) = &entity_db.data_source {
-            let origin_recordings = remote_recordings
-                .entry(endpoint.origin.clone())
-                .or_default();
+        if let Some(SmartChannelSource::RedapGrpcStream(uri)) = &entity_db.data_source {
+            let origin_recordings = remote_recordings.entry(uri.origin.clone()).or_default();
 
             let dataset_recordings = origin_recordings
                 // Currently a origin only has a single dataset, this should change soon
-                .entry(EntryId::from(endpoint.dataset_id))
+                .entry(EntryId::from(uri.dataset_id))
                 .or_default();
 
             dataset_recordings.push(entity_db);

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -930,9 +930,9 @@ fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
                             }
                         }
 
-                        Ok(re_data_source::StreamSource::CatalogData { endpoint }) => ctx
+                        Ok(re_data_source::StreamSource::CatalogData(uri)) => ctx
                             .command_sender()
-                            .send_system(SystemCommand::AddRedapServer { endpoint }),
+                            .send_system(SystemCommand::AddRedapServer(uri)),
                         Err(err) => {
                             re_log::warn!("Could not handle url {:?}: {err}", open_url.url);
                         }

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -62,7 +62,7 @@ fn loading_receivers_ui(ctx: &ViewerContext<'_>, rx: &ReceiveSet<LogMsg>, ui: &m
             // We only show things we know are very-soon-to-be recordings:
             SmartChannelSource::File(path) => format!("Loading {}…", path.display()),
             SmartChannelSource::RrdHttpStream { url, .. } => format!("Loading {url}…"),
-            SmartChannelSource::RedapGrpcStream(endpoint) => format!("Loading {endpoint}…"),
+            SmartChannelSource::RedapGrpcStream(uri) => format!("Loading {uri}…"),
 
             SmartChannelSource::RrdWebEventListener
             | SmartChannelSource::JsChannel { .. }

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -224,13 +224,13 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
             re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. } => {
                 format!("Waiting for data on {url}…")
             }
-            re_smart_channel::SmartChannelSource::MessageProxy(endpoint) => {
-                format!("Waiting for data on {endpoint}…")
+            re_smart_channel::SmartChannelSource::MessageProxy(uri) => {
+                format!("Waiting for data on {uri}…")
             }
-            re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
+            re_smart_channel::SmartChannelSource::RedapGrpcStream(uri) => {
                 format!(
                     "Waiting for data on {}…",
-                    endpoint.clone().without_query_and_fragment()
+                    uri.clone().without_query_and_fragment()
                 )
             }
             re_smart_channel::SmartChannelSource::RrdWebEventListener

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -433,7 +433,7 @@ fn open_example_url(
     _is_history_enabled: bool,
 ) {
     let data_source = re_data_source::DataSource::RrdHttpUrl {
-        url: rrd_url.to_owned(),
+        uri: rrd_url.to_owned(),
         follow: false,
     };
 

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -146,7 +146,7 @@ pub fn url_to_receiver(
                 }),
             });
             Some(re_grpc_client::redap::stream_dataset_from_redap(
-                endpoint,
+                uri,
                 on_cmd,
                 Some(ui_waker),
             ))
@@ -158,7 +158,7 @@ pub fn url_to_receiver(
         }
 
         EndpointCategory::RerunGrpcStream(re_uri::RedapUri::Proxy(uri)) => Some(
-            re_grpc_client::message_proxy::read::stream(endpoint, Some(ui_waker)),
+            re_grpc_client::message_proxy::read::stream(uri, Some(ui_waker)),
         ),
 
         EndpointCategory::WebEventListener(url) => {

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -133,7 +133,7 @@ pub fn url_to_receiver(
             ),
         ),
 
-        EndpointCategory::RerunGrpcStream(re_uri::RedapUri::DatasetData(endpoint)) => {
+        EndpointCategory::RerunGrpcStream(re_uri::RedapUri::DatasetData(uri)) => {
             let on_cmd = Box::new(move |cmd| match cmd {
                 re_grpc_client::redap::Command::SetLoopSelection {
                     recording_id,
@@ -152,12 +152,12 @@ pub fn url_to_receiver(
             ))
         }
 
-        EndpointCategory::RerunGrpcStream(re_uri::RedapUri::Catalog(endpoint)) => {
-            command_sender.send_system(SystemCommand::AddRedapServer { endpoint });
+        EndpointCategory::RerunGrpcStream(re_uri::RedapUri::Catalog(uri)) => {
+            command_sender.send_system(SystemCommand::AddRedapServer(uri));
             None
         }
 
-        EndpointCategory::RerunGrpcStream(re_uri::RedapUri::Proxy(endpoint)) => Some(
+        EndpointCategory::RerunGrpcStream(re_uri::RedapUri::Proxy(uri)) => Some(
             re_grpc_client::message_proxy::read::stream(endpoint, Some(ui_waker)),
         ),
 

--- a/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
@@ -28,9 +28,7 @@ pub enum SystemCommand {
     AddReceiver(re_smart_channel::Receiver<re_log_types::LogMsg>),
 
     /// Add a new server to the redap browser.
-    AddRedapServer {
-        endpoint: re_uri::CatalogEndpoint,
-    },
+    AddRedapServer(re_uri::CatalogUri),
 
     ChangeDisplayMode(crate::DisplayMode),
 

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -270,11 +270,11 @@ impl ItemCollection {
                     re_smart_channel::SmartChannelSource::JsChannel { .. } => None,
                     re_smart_channel::SmartChannelSource::Sdk => None,
                     re_smart_channel::SmartChannelSource::Stdin => None,
-                    re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
-                        Some((ClipboardTextDesc::Url, endpoint.to_string()))
+                    re_smart_channel::SmartChannelSource::RedapGrpcStream(uri) => {
+                        Some((ClipboardTextDesc::Url, uri.to_string()))
                     }
-                    re_smart_channel::SmartChannelSource::MessageProxy(endpoint) => {
-                        Some((ClipboardTextDesc::Url, endpoint.to_string()))
+                    re_smart_channel::SmartChannelSource::MessageProxy(uri) => {
+                        Some((ClipboardTextDesc::Url, uri.to_string()))
                     }
                 },
 

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -814,8 +814,8 @@ impl StoreHub {
             // - don't point at the given `uri`
             match data_source {
                 re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
-                re_smart_channel::SmartChannelSource::RedapGrpcStream(endpoint) => {
-                    endpoint.to_string() != uri
+                re_smart_channel::SmartChannelSource::RedapGrpcStream(redap_uri) => {
+                    redap_uri.to_string() != uri
                 }
                 _ => true,
             }

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -84,7 +84,7 @@ impl PyDataset {
         let super_ = self_.as_super();
         let connection = super_.client.borrow(self_.py()).connection().clone();
 
-        let url = re_uri::DatasetDataEndpoint {
+        re_uri::DatasetDataUri {
             origin: connection.origin().clone(),
             dataset_id: super_.details.id.id,
             partition_id,
@@ -92,9 +92,8 @@ impl PyDataset {
             //TODO(ab): add support for these two
             time_range: None,
             fragment: Default::default(),
-        };
-
-        url.to_string()
+        }
+        .to_string()
     }
 
     /// Register a RRD URI to the dataset.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -616,8 +616,8 @@ fn connect_grpc(
     };
 
     let url = url.unwrap_or_else(|| re_sdk::DEFAULT_CONNECT_URL.to_owned());
-    let endpoint = url
-        .parse::<re_uri::ProxyEndpoint>()
+    let uri = url
+        .parse::<re_uri::ProxyUri>()
         .map_err(|err| PyRuntimeError::wrap(err, format!("invalid endpoint {url:?}")))?;
 
     if re_sdk::forced_sink_path().is_some() {
@@ -627,7 +627,7 @@ fn connect_grpc(
 
     py.allow_threads(|| {
         let sink = re_sdk::sink::GrpcSink::new(
-            endpoint,
+            uri,
             flush_timeout_sec.map(std::time::Duration::from_secs_f32),
         );
 


### PR DESCRIPTION
I’m renaming a bunch of “endpoint” in our code to “uri”. Reminder of the nomenclature:

```
ORIGIN:   scheme://host:port
ENDPOINT: /endpoint
URL/URI:  scheme://host:port/endpoint
```

(URI and URL are technically different things, but since we called it `re_uri`, I suggest we stick with “URI”)