### PR TITLE
DEMO HACK: blob acts as thumbnail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7968,6 +7968,7 @@ dependencies = [
  "re_arrow_util",
  "re_chunk_store",
  "re_component_ui",
+ "re_data_ui",
  "re_dataframe",
  "re_error",
  "re_format",

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -27,6 +27,7 @@ pub mod item_ui;
 pub use crate::tensor::tensor_summary_ui_grid_contents;
 pub use component::ComponentPathLatestAtResults;
 pub use component_ui_registry::{add_to_registry, register_component_uis};
+pub use image::image_preview_ui;
 
 /// Sort components for display in the UI.
 pub fn sorted_component_list_for_ui<'a>(

--- a/crates/viewer/re_view_dataframe/Cargo.toml
+++ b/crates/viewer/re_view_dataframe/Cargo.toml
@@ -26,6 +26,7 @@ testing = ["re_viewer_context/testing", "re_viewport_blueprint/testing"]
 re_arrow_util.workspace = true
 re_chunk_store.workspace = true
 re_dataframe.workspace = true
+re_data_ui.workspace = true
 re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true

--- a/crates/viewer/re_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_view_dataframe/src/display_record_batch.rs
@@ -177,6 +177,33 @@ impl ComponentData {
                 }
             }
 
+            // Override the way `Blob` are rendered
+            //TODO: un-mergeable hack!
+            if component_name.as_str() == "rerun.components.Blob" {
+                if let Ok(Some(buffer)) = re_types::components::Blob::from_arrow(&data_to_display)
+                    .as_ref()
+                    .map(|blob| blob.first().map(|blob| blob.as_slice()))
+                {
+                    if let Ok(image) = ctx.store_context.caches.entry(
+                        |c: &mut re_viewer_context::ImageDecodeCache| {
+                            c.entry(row_id.expect("always generated for such Bob"), buffer, None)
+                        },
+                    ) {
+                        re_data_ui::image_preview_ui(
+                            ctx,
+                            ui,
+                            UiLayout::List,
+                            latest_at_query,
+                            entity_path,
+                            &image,
+                            None,
+                        );
+
+                        return;
+                    }
+                }
+            }
+
             ctx.component_ui_registry().ui_raw(
                 ctx,
                 ui,

--- a/crates/viewer/re_viewer/src/ui/table/mod.rs
+++ b/crates/viewer/re_viewer/src/ui/table/mod.rs
@@ -7,6 +7,7 @@ use re_redap_browser::table_utils::{
     apply_table_style_fixes, cell_ui, header_title, ColumnConfig, TableConfig, CELL_MARGIN,
 };
 use re_sorbet::{ColumnDescriptorRef, SorbetBatch};
+use re_types_core::ComponentName;
 use re_ui::UiExt as _;
 use re_view_dataframe::display_record_batch::{DisplayRecordBatch, DisplayRecordBatchError};
 use re_viewer_context::{TableContext, ViewerContext};
@@ -62,6 +63,16 @@ pub fn table_ui(viewer_ctx: &ViewerContext<'_>, ui: &mut egui::Ui, context: &Tab
         }),
     );
 
+    let has_thumbnail = columns.iter().any(|desc| {
+        matches!(
+            desc,
+            ColumnDescriptorRef::Component(&re_sorbet::ComponentColumnDescriptor {
+                component_name,
+                ..
+            } ) if component_name == ComponentName::from("rerun.components.Blob")
+        )
+    });
+
     Frame::new()
         .inner_margin(Margin {
             top: 16,
@@ -86,6 +97,7 @@ pub fn table_ui(viewer_ctx: &ViewerContext<'_>, ui: &mut egui::Ui, context: &Tab
         display_record_batches: &display_record_batches,
         selected_columns: &columns,
         table_config,
+        has_thumbnail,
     };
 
     apply_table_style_fixes(ui.style_mut());
@@ -123,6 +135,7 @@ struct CollectionTableDelegate<'a> {
     display_record_batches: &'a Vec<DisplayRecordBatch>,
     selected_columns: &'a Vec<ColumnDescriptorRef<'a>>,
     table_config: TableConfig,
+    has_thumbnail: bool,
 }
 
 impl egui_table::TableDelegate for CollectionTableDelegate<'_> {
@@ -183,7 +196,10 @@ impl egui_table::TableDelegate for CollectionTableDelegate<'_> {
     }
 
     fn default_row_height(&self) -> f32 {
-        //re_ui::DesignTokens::table_line_height() + CELL_MARGIN.sum().y
-        100.0
+        if self.has_thumbnail {
+            70.0
+        } else {
+            re_ui::DesignTokens::table_line_height() + CELL_MARGIN.sum().y
+        }
     }
 }

--- a/crates/viewer/re_viewer/src/ui/table/mod.rs
+++ b/crates/viewer/re_viewer/src/ui/table/mod.rs
@@ -183,6 +183,7 @@ impl egui_table::TableDelegate for CollectionTableDelegate<'_> {
     }
 
     fn default_row_height(&self) -> f32 {
-        re_ui::DesignTokens::table_line_height() + CELL_MARGIN.sum().y
+        //re_ui::DesignTokens::table_line_height() + CELL_MARGIN.sum().y
+        100.0
     }
 }

--- a/crates/viewer/re_viewer_context/src/tables.rs
+++ b/crates/viewer/re_viewer_context/src/tables.rs
@@ -10,6 +10,7 @@ use re_types::external::arrow::{
     array::{ArrayRef, RecordBatch},
     datatypes::Schema,
 };
+use re_types_core::ComponentBatch as _;
 
 #[derive(Default)]
 struct SorbetBatchStore {
@@ -48,7 +49,7 @@ impl TableStore {
                 is_static: true,
                 is_tombstone: false,
                 is_semantically_empty: false,
-                is_indicator: true,
+                is_indicator: false,
             });
 
             descriptors.push(descriptor);
@@ -67,7 +68,7 @@ impl TableStore {
                 is_static: true,
                 is_tombstone: false,
                 is_semantically_empty: false,
-                is_indicator: true,
+                is_indicator: false,
             });
 
             let data = ListArray::new(
@@ -93,7 +94,7 @@ impl TableStore {
                 is_static: true,
                 is_tombstone: false,
                 is_semantically_empty: false,
-                is_indicator: true,
+                is_indicator: false,
             });
 
             let data = ListArray::new(
@@ -105,6 +106,32 @@ impl TableStore {
 
             descriptors.push(descriptor);
             columns.push(Arc::new(data) as ArrayRef);
+        }
+
+        {
+            let blob = re_types::components::Blob(re_types::datatypes::Blob::from(
+                re_ui::icons::RERUN_MENU.png_bytes,
+            ));
+
+            let array = Arc::new(
+                blob.to_arrow_list_array()
+                    .expect("serialization should succeed"),
+            ) as ArrayRef;
+
+            let descriptor = re_sorbet::ColumnDescriptor::Component(ComponentColumnDescriptor {
+                entity_path: re_log_types::EntityPath::from("/some/path"),
+                archetype_name: Some("archetype".to_owned().into()),
+                archetype_field_name: Some("thumbnail".to_owned().into()),
+                component_name: "rerun.components.Blob".into(),
+                store_datatype: array.data_type().clone(),
+                is_static: true,
+                is_tombstone: false,
+                is_semantically_empty: false,
+                is_indicator: false,
+            });
+
+            descriptors.push(descriptor);
+            columns.push(array);
         }
 
         let schema = Arc::new(Schema::new_with_metadata(


### PR DESCRIPTION
DO NOT MERGE.

This commit can be cherry picked to:
1) force Table entry rows to be 100px heigh
2) render `Blob` as thumbnail (instead of the usual component ui)

**NOTE**: make sure #9500 and #9507 are merged beforehand, or merge conflict might arise.


<img width="1233" alt="image" src="https://github.com/user-attachments/assets/786940b6-0ece-41d3-ba82-3badfbf46b36" />
