### PR TITLE
Return the URI of the gRPC server from `serve_grpc`

### DIFF
--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -10,7 +10,7 @@
 #include <sys/types.h>
 
 #include <cassert>
-#include <string> // to_string
+#include <sstream>
 #include <vector>
 
 namespace rerun {
@@ -117,7 +117,7 @@ namespace rerun {
         return status;
     }
 
-    Error RecordingStream::serve_grpc(
+    Result<std::string> RecordingStream::serve_grpc(
         std::string_view bind_ip, uint16_t port, std::string_view server_memory_limit
     ) const {
         rr_error status = {};
@@ -128,7 +128,12 @@ namespace rerun {
             detail::to_rr_string(server_memory_limit),
             &status
         );
-        return status;
+        RR_RETURN_NOT_OK(status);
+
+        // Constructing the string from scratch is easier than passing it via the C FFI:
+        std::stringstream ss;
+        ss << "rerun+http://" << bind_ip << ":" << port << "/proxy";
+        return ss.str();
     }
 
     Error RecordingStream::spawn(const SpawnOptions& options, float flush_timeout_sec) const {

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -159,8 +159,10 @@ namespace rerun {
         /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
         /// Once reached, the earliest logged data will be dropped. Static data is never dropped.
         ///
+        /// Returns the URI of the gRPC server so you can connect to it from a viewer.
+        ///
         /// This function returns immediately.
-        Error serve_grpc(
+        Result<std::string> serve_grpc(
             std::string_view bind_ip = "0.0.0.0", uint16_t port = 9876,
             std::string_view server_memory_limit = "75%"
         ) const;

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -352,7 +352,10 @@ SCENARIO("RecordingStream can serve grpc", TEST_TAG) {
     GIVEN("a new serving RecordingStream") {
         rerun::RecordingStream stream("test-local");
         THEN("serve_grpc call succeeds") {
-            CHECK(stream.serve_grpc("0.0.0.0", 21521).code == rerun::ErrorCode::Ok);
+            CHECK(
+                stream.serve_grpc("0.0.0.0", 21521).value_or_throw() ==
+                "rerun+http://0.0.0.0:21521/proxy"
+            );
         }
     }
 }

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -758,8 +758,12 @@ def serve_grpc(
     server_memory_limit: str,
     default_blueprint: Optional[PyMemorySinkStorage] = None,
     recording: Optional[PyRecordingStream] = None,
-) -> None:
-    """Spawn a gRPC server which an SDK or Viewer can connect to."""
+) -> str:
+    """
+    Spawn a gRPC server which an SDK or Viewer can connect to.
+
+    Returns the URI of the server so you can connect the viewer to it.
+    """
 
 def serve_web(
     open_browser: bool,

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -605,7 +605,7 @@ class RecordingStream:
         grpc_port: int | None = None,
         default_blueprint: BlueprintLike | None = None,
         server_memory_limit: str = "75%",
-    ) -> None:
+    ) -> str:
         """
         Serve log-data over gRPC.
 
@@ -614,6 +614,8 @@ class RecordingStream:
         The gRPC server will buffer all log data in memory so that late connecting viewers will get all the data.
         You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
         Once reached, the earliest logged data will be dropped. Static data is never dropped.
+
+        Returns the URI of the server so you can connect the viewer to it.
 
         This function returns immediately.
 
@@ -634,7 +636,7 @@ class RecordingStream:
 
         from .sinks import serve_grpc
 
-        serve_grpc(
+        return serve_grpc(
             grpc_port=grpc_port,
             default_blueprint=default_blueprint,
             server_memory_limit=server_memory_limit,

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -219,7 +219,7 @@ def serve_grpc(
     default_blueprint: BlueprintLike | None = None,
     recording: RecordingStream | None = None,
     server_memory_limit: str = "25%",
-) -> None:
+) -> str:
     """
     Serve log-data over gRPC.
 
@@ -228,6 +228,8 @@ def serve_grpc(
     The gRPC server will buffer all log data in memory so that late connecting viewers will get all the data.
     You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
     Once reached, the earliest logged data will be dropped. Static data is never dropped.
+
+    Returns the URI of the server so you can connect the viewer to it.
 
     This function returns immediately. In order to keep the server running, you must keep the Python process running
     as well.
@@ -252,7 +254,7 @@ def serve_grpc(
     """
     if not is_recording_enabled(recording):
         logging.warning("Rerun is disabled - serve_grpc() call ignored")
-        return
+        return "[rerun is disabled]"
 
     from rerun.recording_stream import get_application_id
 
@@ -270,7 +272,7 @@ def serve_grpc(
             blueprint=default_blueprint,
         ).storage
 
-    bindings.serve_grpc(
+    return bindings.serve_grpc(
         grpc_port,
         server_memory_limit=server_memory_limit,
         default_blueprint=blueprint_storage,


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/9469

### What
This will make it easier for us to add a separate `serve_web_viewer` function to which we can give the URI of the gRPC server:

```
grpc_uri = rec.serve_grpc()
rr.serve_web_viewer(connect_to=grpc_uri)
```