### PR TITLE
Add `rr.serve_web_viewer`

### DIFF
--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -143,6 +143,9 @@ pub mod external {
     pub use re_data_loader;
 }
 
+#[cfg(feature = "web_viewer")]
+pub use web_viewer::serve_web_viewer;
+
 // -----
 // Misc:
 

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -262,3 +262,18 @@ pub fn new_sink(
         server_memory_limit,
     )?))
 }
+
+/// Serves the Rerun Web Viewer (HTML+JS+WASM) over http.
+///
+/// The server will immediately start listening for incoming connections
+/// and stop doing so when the returned [`WebViewerServer`] is dropped.
+///
+/// Note: this does NOT start a gRPC server.
+/// To start a gRPC server, use [`crate::RecordingStreamBuilder::serve_grpc`] and connect to it
+/// by setting [`WebViewerConfig::source_url`] to `rerun+http://localhost/proxy`.
+///
+/// Note: this function just calls [`WebViewerConfig::host_web_viewer`] and is here only
+/// for convenience, visibility, and for symmetry with our Python SDK.
+pub fn serve_web_viewer(config: WebViewerConfig) -> Result<WebViewerServer, WebViewerServerError> {
+    config.host_web_viewer()
+}

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -263,7 +263,7 @@ pub fn new_sink(
     )?))
 }
 
-/// Serves the Rerun Web Viewer (HTML+JS+WASM) over http.
+/// Serves the Rerun Web Viewer (HTML+JS+Wasm) over http.
 ///
 /// The server will immediately start listening for incoming connections
 /// and stop doing so when the returned [`WebViewerServer`] is dropped.

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -143,7 +143,7 @@ pub struct WebViewerConfig {
     ///
     /// This url is a hosted RRD file that we retrieve via the message proxy.
     /// Has no effect if [`Self::open_browser`] is false.
-    pub source_url: Option<String>,
+    pub connect_to: Option<String>,
 
     /// If set, adjusts the browser url to force a specific backend, either `webgl` or `webgpu`.
     ///
@@ -167,7 +167,7 @@ impl Default for WebViewerConfig {
         Self {
             bind_ip: "0.0.0.0".to_owned(),
             web_port: WebViewerServerPort::AUTO,
-            source_url: None,
+            connect_to: None,
             force_wgpu_backend: None,
             video_decoder: None,
             open_browser: true,
@@ -187,7 +187,7 @@ impl WebViewerConfig {
     pub fn host_web_viewer(self) -> Result<WebViewerServer, WebViewerServerError> {
         let Self {
             bind_ip,
-            source_url,
+            connect_to,
             web_port,
             force_wgpu_backend,
             video_decoder,
@@ -210,7 +210,7 @@ impl WebViewerConfig {
             viewer_url = format!("{viewer_url}{arg_delimiter}{arg}");
         };
 
-        if let Some(source_url) = source_url {
+        if let Some(source_url) = connect_to {
             // TODO(jan): remove after we change from `rerun+http` to `rerun-http`
             let source_url = percent_encoding::utf8_percent_encode(
                 &source_url,
@@ -270,7 +270,7 @@ pub fn new_sink(
 ///
 /// Note: this does NOT start a gRPC server.
 /// To start a gRPC server, use [`crate::RecordingStreamBuilder::serve_grpc`] and connect to it
-/// by setting [`WebViewerConfig::source_url`] to `rerun+http://localhost/proxy`.
+/// by setting [`WebViewerConfig::connect_to`] to `rerun+http://localhost/proxy`.
 ///
 /// Note: this function just calls [`WebViewerConfig::host_web_viewer`] and is here only
 /// for convenience, visibility, and for symmetry with our Python SDK.

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -737,7 +737,7 @@ fn run_impl(
                 WebViewerConfig {
                     bind_ip: args.bind.to_string(),
                     web_port: args.web_viewer_port,
-                    source_url: Some(uri.to_string()),
+                    connect_to: Some(uri.to_string()),
                     force_wgpu_backend: args.renderer,
                     video_decoder: args.video_decoder,
                     open_browser: true,
@@ -919,7 +919,7 @@ fn run_impl(
             WebViewerConfig {
                 bind_ip: args.bind.to_string(),
                 web_port: args.web_viewer_port,
-                source_url: Some(url),
+                connect_to: Some(url),
                 force_wgpu_backend: args.renderer,
                 video_decoder: args.video_decoder,
                 open_browser,

--- a/crates/viewer/re_web_viewer_server/src/lib.rs
+++ b/crates/viewer/re_web_viewer_server/src/lib.rs
@@ -81,6 +81,7 @@ impl FromStr for WebViewerServerPort {
 
 /// HTTP host for the Rerun Web Viewer application
 /// This serves the HTTP+Wasm+JS files that make up the web-viewer.
+#[must_use = "Dropping this means stopping the server"]
 pub struct WebViewerServer {
     inner: Arc<WebViewerServerInner>,
     thread_handle: Option<std::thread::JoinHandle<()>>,
@@ -168,6 +169,12 @@ impl WebViewerServer {
         if let Some(thread_handle) = self.thread_handle.take() {
             thread_handle.join().ok();
         }
+    }
+
+    /// Keeps the web viewer running until the parent process shuts down.
+    pub fn detach(self) {
+        #[expect(clippy::mem_forget)]
+        std::mem::forget(self);
     }
 }
 

--- a/crates/viewer/re_web_viewer_server/src/lib.rs
+++ b/crates/viewer/re_web_viewer_server/src/lib.rs
@@ -172,9 +172,11 @@ impl WebViewerServer {
     }
 
     /// Keeps the web viewer running until the parent process shuts down.
-    pub fn detach(self) {
-        #[expect(clippy::mem_forget)]
-        std::mem::forget(self);
+    pub fn detach(mut self) {
+        if let Some(thread_handle) = self.thread_handle.take() {
+            // dropping the thread handle detaches the thread.
+            drop(thread_handle);
+        }
     }
 }
 

--- a/docs/content/concepts/app-model.md
+++ b/docs/content/concepts/app-model.md
@@ -6,7 +6,7 @@ order: 0
 The Rerun distribution comes with numerous moving pieces:
 * The **SDKs** (Python, Rust & C++), for logging data and querying it back. These are libraries running directly in the end user's process.
 * The **Native Viewer**: the Rerun GUI application for native platforms (Linux, macOS, Windows).
-* The **Web Viewer**, which packs the **Native Viewer** into a WASM application that can run on the Web and its derivatives (notebooks, etc).
+* The **Web Viewer**, which packs the **Native Viewer** into a Wasm application that can run on the Web and its derivatives (notebooks, etc).
 * The **gRPC server**, which receives data from the **SDKs** and forwards it to the **Native Viewer** and/or **Web Viewer**. The communication is unidirectional: clients push data into the connection, never the other way around.
 * The **Web/HTTP Server**, for serving the web page that hosts the **Web Viewer**.
 * The **CLI**, which allows you to control all the pieces above as well as manipulate RRD files.
@@ -28,7 +28,7 @@ Keep in mind that even the **Native Viewer** can be disabled (headless mode).
 
 The **SDKs** are vanilla software libraries and therefore always executes in the same context as the end-user's code.
 
-Finally, the **Web Viewer** is a WASM application and therefore has its own dedicated `.wasm` artifact, and always runs in isolation in the end-user's web browser.
+Finally, the **Web Viewer** is a Wasm application and therefore has its own dedicated `.wasm` artifact, and always runs in isolation in the end-user's web browser.
 
 The best way to make sense of it all it to look at some of the most common scenarios when:
 * Logging and visualizing data on native.

--- a/lychee.toml
+++ b/lychee.toml
@@ -123,6 +123,7 @@ exclude = [
   'https://redap.rerun.io',
   'http://wrong-scheme',
   'rerun\+http://localhost:\{grpc_port\}/proxy',
+  'scheme://.*',
 
   # Link fragments and data links in examples.
   'https://raw.githubusercontent.com/googlefonts/noto-emoji/', # URL fragment.

--- a/lychee.toml
+++ b/lychee.toml
@@ -123,7 +123,7 @@ exclude = [
   'https://redap.rerun.io',
   'http://wrong-scheme',
   'rerun\+http://localhost:\{grpc_port\}/proxy',
-  'scheme://.*',
+  '.*scheme:/.*',
 
   # Link fragments and data links in examples.
   'https://raw.githubusercontent.com/googlefonts/noto-emoji/', # URL fragment.
@@ -150,6 +150,7 @@ exclude = [
   'https://eu.posthog.com/project/',                      # Requires to be logged in on PostHog.
   'https://github.com/rerun-io/internal-test-assets/\.*',
   'https://github.com/google/mediapipe/issues/5188',      # For some reason that link has always failed.
+  'https://www.figma.com/.*',
 
   # Temporarily down or not accessible.
   'https://eigen.tuxfamily.org/',                                   # Website down https://gitlab.com/libeigen/eigen/-/issues/2804

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -771,7 +771,7 @@ def serve_web_viewer(
     """
     Serve a web-viewer over HTTP.
 
-    This only serves HTML+JS+WASM, but does NOT host a gRPC server.
+    This only serves HTML+JS+Wasm, but does NOT host a gRPC server.
     """
 
 def serve_web(

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -766,7 +766,7 @@ def serve_grpc(
     """
 
 def serve_web_viewer(
-    *, web_port: Optional[int] = None, open_browser: bool = True, connect_to_url: Optional[str] = None
+    *, web_port: Optional[int] = None, open_browser: bool = True, connect_to: Optional[str] = None
 ) -> None:
     """
     Serve a web-viewer over HTTP.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -765,6 +765,15 @@ def serve_grpc(
     Returns the URI of the server so you can connect the viewer to it.
     """
 
+def serve_web_viewer(
+    *, web_port: Optional[int] = None, open_browser: bool = True, connect_to_url: Optional[str] = None
+) -> None:
+    """
+    Serve a web-viewer over HTTP.
+
+    This only serves HTML+JS+WASM, but does NOT host a gRPC server.
+    """
+
 def serve_web(
     open_browser: bool,
     web_port: Optional[int],

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -766,7 +766,7 @@ def serve_grpc(
     """
 
 def serve_web_viewer(
-    *, web_port: Optional[int] = None, open_browser: bool = True, connect_to: Optional[str] = None
+    web_port: Optional[int] = None, open_browser: bool = True, connect_to: Optional[str] = None
 ) -> None:
     """
     Serve a web-viewer over HTTP.

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -196,6 +196,7 @@ from .time import (
     set_time_seconds as set_time_seconds,
     set_time_sequence as set_time_sequence,
 )
+from .web import serve_web_viewer as serve_web_viewer
 
 # =====================================
 # UTILITIES

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -107,7 +107,8 @@ def script_setup(
     if args.stdout:
         rec.stdout(default_blueprint=default_blueprint)
     elif args.serve:
-        rec.serve_web(default_blueprint=default_blueprint)
+        connect_to = rec.serve_grpc(default_blueprint=default_blueprint)
+        rr.serve_web_viewer(open_browser=True, connect_to=connect_to)
     elif args.connect:
         # Send logging data to separate `rerun` process.
         # You can omit the argument to connect to the default URL.

--- a/rerun_py/rerun_sdk/rerun/web.py
+++ b/rerun_py/rerun_sdk/rerun/web.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import rerun_bindings as bindings
+
+
+def serve_web_viewer(
+    *, web_port: int | None = None, open_browser: bool = True, connect_to_url: str | None = None
+) -> None:
+    """
+    Host a web viewer over HTTP.
+
+    You can pass this function the URL returned from [`rerun.serve_grpc`][] and  [`rerun.RecordingStream.serve_grpc`][]
+    so that the spawned web viewer connects to that server.
+
+    Note that this is NOT a log sink, and this does NOT host a gRPC server.
+
+    This function returns immediately.
+    In order to keep the web server running you must keep the Python process running too.
+
+    Parameters
+    ----------
+    web_port:
+        The port to serve the web viewer on (defaults to 9090).
+    open_browser:
+        Open the default browser to the viewer.
+    connect_to_url:
+        If `open_browser` is true, then this is the URL the web viewer will connect to.
+
+    """
+
+    bindings.serve_web_viewer(
+        web_port=web_port,
+        open_browser=open_browser,
+        connect_to_url=connect_to_url,
+    )

--- a/rerun_py/rerun_sdk/rerun/web.py
+++ b/rerun_py/rerun_sdk/rerun/web.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import rerun_bindings as bindings
 
 
-def serve_web_viewer(
-    *, web_port: int | None = None, open_browser: bool = True, connect_to_url: str | None = None
-) -> None:
+def serve_web_viewer(*, web_port: int | None = None, open_browser: bool = True, connect_to: str | None = None) -> None:
     """
     Host a web viewer over HTTP.
 
@@ -23,7 +21,7 @@ def serve_web_viewer(
         The port to serve the web viewer on (defaults to 9090).
     open_browser:
         Open the default browser to the viewer.
-    connect_to_url:
+    connect_to:
         If `open_browser` is true, then this is the URL the web viewer will connect to.
 
     """
@@ -31,5 +29,5 @@ def serve_web_viewer(
     bindings.serve_web_viewer(
         web_port=web_port,
         open_browser=open_browser,
-        connect_to_url=connect_to_url,
+        connect_to=connect_to,
     )

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1035,7 +1035,7 @@ fn serve_web_viewer(
     {
         re_sdk::web_viewer::WebViewerConfig {
             open_browser,
-            source_url: connect_to,
+            connect_to,
             web_port: web_port.map(WebViewerServerPort).unwrap_or_default(),
             ..Default::default()
         }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1022,7 +1022,7 @@ fn serve_grpc(
 
 /// Serve a web-viewer over HTTP.
 ///
-/// This only serves HTML+JS+WASM, but does NOT host a gRPC server.
+/// This only serves HTML+JS+Wasm, but does NOT host a gRPC server.
 #[allow(clippy::unnecessary_wraps)] // False positive
 #[pyfunction]
 #[pyo3(signature = (web_port = None, open_browser = true, connect_to = None))]

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1025,17 +1025,17 @@ fn serve_grpc(
 /// This only serves HTML+JS+WASM, but does NOT host a gRPC server.
 #[allow(clippy::unnecessary_wraps)] // False positive
 #[pyfunction]
-#[pyo3(signature = (web_port = None, open_browser = true, connect_to_url = None))]
+#[pyo3(signature = (web_port = None, open_browser = true, connect_to = None))]
 fn serve_web_viewer(
     web_port: Option<u16>,
     open_browser: bool,
-    connect_to_url: Option<String>,
+    connect_to: Option<String>,
 ) -> PyResult<()> {
     #[cfg(feature = "web_viewer")]
     {
         re_sdk::web_viewer::WebViewerConfig {
             open_browser,
-            source_url: connect_to_url,
+            source_url: connect_to,
             web_port: web_port.map(WebViewerServerPort).unwrap_or_default(),
             ..Default::default()
         }
@@ -1050,7 +1050,7 @@ fn serve_web_viewer(
     {
         _ = web_port;
         _ = open_browser;
-        _ = connect_to_url;
+        _ = connect_to;
         Err(PyRuntimeError::new_err(
             "The Rerun SDK was not compiled with the 'web_viewer' feature",
         ))

--- a/scripts/screenshot_compare/build_screenshot_compare.py
+++ b/scripts/screenshot_compare/build_screenshot_compare.py
@@ -245,7 +245,8 @@ def serve_files() -> None:
         os.environ["RUST_LOG"] = "rerun=warn"
 
         rr.init("rerun_example_screenshot_compare")
-        rr.serve_web(open_browser=False)
+        connect_to = rr.serve_grpc()
+        rr.serve_web_viewer(open_browser=False, connect_to=connect_to)
 
     threading.Thread(target=serve, daemon=True).start()
 

--- a/scripts/snapshots.py
+++ b/scripts/snapshots.py
@@ -80,7 +80,8 @@ def log_failed_snapshot_tests(original_path: Path, new_path: Path, diff_path: Pa
         if args.stdout:
             rr.stdout(default_blueprint=default_blueprint)
         elif args.serve:
-            rr.serve_web(default_blueprint=default_blueprint)
+            connect_to = rr.serve_grpc(default_blueprint=default_blueprint)
+            rr.serve_web_viewer(open_browser=True, connect_to=connect_to)
         elif args.connect:
             rr.connect_grpc(args.addr, default_blueprint=default_blueprint)
         elif args.save is not None:


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/9469
* Chained to https://github.com/rerun-io/rerun/pull/9539

### What
This adds `rr.serve_web_viewer` which ONLY hosts the web viewer HTML+JS+WASM.

In contrast to the existing `serve_web`, the new `serve_web_viewer`
* does NOT host a gRPC server
* is NOT a log sink
* is NOT available on `RecordingStream`


### Why?
`rr.serve_web` (and the old `rr.serve`) were confusing users because it did two things:
* Hosted the web viewer over HTTP
* Started a gRPC server (previously: WebSocket server)

The new `rr.serve_web_viewer` which is completely orthogonal to `rr.serve_grpc` (no overlap in functionality).
Thus everything `rr.serve()` did can now be done with two function calls, to make it clear what is happening:

#### OLD
```py
rr.serve_web()
```

#### NEW

```py
url = rr.serve_grpc()
rr.serve_web_viewer(connect_to=url)
```
