### PR TITLE
Add support for `/entry/$ENTRY_ID` URIs

### DIFF
--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -37,7 +37,8 @@ pub enum DataSource {
 // TODO(#9058): Temporary hack, see issue for how to fix this.
 pub enum StreamSource {
     LogMessages(Receiver<LogMsg>),
-    CatalogData(re_uri::CatalogUri),
+    CatalogUri(re_uri::CatalogUri),
+    EntryUri(re_uri::EntryUri),
 }
 
 impl DataSource {
@@ -263,8 +264,10 @@ impl DataSource {
             }
 
             Self::RerunGrpcStream(re_uri::RedapUri::Catalog(uri)) => {
-                Ok(StreamSource::CatalogData(uri))
+                Ok(StreamSource::CatalogUri(uri))
             }
+
+            Self::RerunGrpcStream(re_uri::RedapUri::Entry(uri)) => Ok(StreamSource::EntryUri(uri)),
 
             Self::RerunGrpcStream(re_uri::RedapUri::Proxy(uri)) => Ok(StreamSource::LogMessages(
                 message_proxy::stream(uri, on_msg),

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -2,8 +2,6 @@ use re_log_types::StoreId;
 
 use crate::{Error, Fragment, Origin, RedapUri, TimeRange};
 
-//TODO(ab): add `DatasetTableUri`, the URI pointing at the "table view" of the dataset (aka. its partition table).
-
 /// URI pointing at the data underlying a dataset.
 ///
 /// Currently, the following format is supported:

--- a/crates/utils/re_uri/src/endpoints/entry.rs
+++ b/crates/utils/re_uri/src/endpoints/entry.rs
@@ -11,11 +11,8 @@ pub struct EntryUri {
 
 impl std::fmt::Display for EntryUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            origin,
-            entry_id: dataset_id,
-        } = self;
-        write!(f, "{origin}/entry/{dataset_id}")
+        let Self { origin, entry_id } = self;
+        write!(f, "{origin}/entry/{entry_id}")
     }
 }
 

--- a/crates/utils/re_uri/src/endpoints/entry.rs
+++ b/crates/utils/re_uri/src/endpoints/entry.rs
@@ -2,6 +2,7 @@ use re_log_types::EntryId;
 
 use crate::{Error, Origin, RedapUri};
 
+/// URI for a remote entry.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EntryUri {
     pub origin: Origin,

--- a/crates/utils/re_uri/src/endpoints/entry.rs
+++ b/crates/utils/re_uri/src/endpoints/entry.rs
@@ -1,0 +1,37 @@
+use re_log_types::EntryId;
+
+use crate::{Error, Origin, RedapUri};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EntryUri {
+    pub origin: Origin,
+    pub entry_id: EntryId,
+}
+
+impl std::fmt::Display for EntryUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            origin,
+            entry_id: dataset_id,
+        } = self;
+        write!(f, "{origin}/entry/{dataset_id}")
+    }
+}
+
+impl EntryUri {
+    pub fn new(origin: Origin, entry_id: EntryId) -> Self {
+        Self { origin, entry_id }
+    }
+}
+
+impl std::str::FromStr for EntryUri {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let RedapUri::Entry(uri) = RedapUri::from_str(s)? {
+            Ok(uri)
+        } else {
+            Err(Error::UnexpectedUri(s.to_owned()))
+        }
+    }
+}

--- a/crates/utils/re_uri/src/endpoints/mod.rs
+++ b/crates/utils/re_uri/src/endpoints/mod.rs
@@ -1,3 +1,4 @@
 pub mod catalog;
 pub mod dataset;
+pub mod entry;
 pub mod proxy;

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -42,7 +42,7 @@ mod scheme;
 mod time_range;
 
 pub use self::{
-    endpoints::{catalog::CatalogUri, dataset::DatasetDataUri, proxy::ProxyUri},
+    endpoints::{catalog::CatalogUri, dataset::DatasetDataUri, entry::EntryUri, proxy::ProxyUri},
     error::Error,
     fragment::Fragment,
     origin::Origin,

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -153,6 +153,24 @@ mod tests {
     }
 
     #[test]
+    fn test_entry_url_to_address() {
+        let url = "rerun://127.0.0.1:1234/entry/1830B33B45B963E7774455beb91701ae";
+        let address: RedapUri = url.parse().unwrap();
+
+        let RedapUri::Entry(EntryUri { origin, entry_id }) = address else {
+            panic!("Expected recording");
+        };
+
+        assert_eq!(origin.scheme, Scheme::Rerun);
+        assert_eq!(origin.host, url::Host::<String>::Ipv4(Ipv4Addr::LOCALHOST));
+        assert_eq!(origin.port, 1234);
+        assert_eq!(
+            entry_id,
+            "1830B33B45B963E7774455beb91701ae".parse().unwrap(),
+        );
+    }
+
+    #[test]
     fn test_dataset_data_url_to_address() {
         let url =
             "rerun://127.0.0.1:1234/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid";

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -908,10 +908,7 @@ fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
         o.commands.retain_mut(|command| {
             if let egui::OutputCommand::OpenUrl(open_url) = command {
                 if let Ok(uri) = open_url.url.parse::<re_uri::RedapUri>() {
-                    let is_catalog_uri = matches!(
-                        uri,
-                        re_uri::RedapUri::Catalog { .. } | re_uri::RedapUri::Entry { .. }
-                    );
+                    let is_catalog_uri = matches!(uri, re_uri::RedapUri::Catalog { .. });
 
                     ctx.command_sender()
                         .send_system(SystemCommand::LoadDataSource(

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -908,7 +908,7 @@ fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
         o.commands.retain_mut(|command| {
             if let egui::OutputCommand::OpenUrl(open_url) = command {
                 if let Ok(uri) = open_url.url.parse::<re_uri::RedapUri>() {
-                    let is_catalog_uri = matches!(uri, re_uri::RedapUri::Catalog { .. });
+                    let is_dataset_uri = matches!(uri, re_uri::RedapUri::DatasetData { .. });
 
                     ctx.command_sender()
                         .send_system(SystemCommand::LoadDataSource(

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -9,6 +9,7 @@ use re_redap_browser::RedapServers;
 use re_smart_channel::ReceiveSet;
 use re_types::blueprint::components::PanelState;
 use re_ui::{ContextExt as _, DesignTokens};
+use re_uri::Origin;
 use re_viewer_context::{
     AppOptions, ApplicationSelectionState, BlueprintUndoState, CommandSender, ComponentUiRegistry,
     DisplayMode, DragAndDropManager, GlobalContext, Item, PlayState, RecordingConfig,
@@ -126,6 +127,19 @@ impl AppState {
 
     pub fn app_options_mut(&mut self) -> &mut AppOptions {
         &mut self.app_options
+    }
+
+    pub fn add_redap_server(&self, command_sender: &CommandSender, origin: Origin) {
+        if !self.redap_servers.has_server(&origin) {
+            command_sender.send_system(SystemCommand::AddRedapServer(origin));
+        }
+    }
+
+    pub fn select_redap_entry(&self, command_sender: &CommandSender, uri: &re_uri::EntryUri) {
+        // make sure the server exists
+        self.add_redap_server(command_sender, uri.origin.clone());
+
+        command_sender.send_system(SystemCommand::SetSelection(Item::RedapEntry(uri.entry_id)));
     }
 
     /// Currently selected section of time, if any.
@@ -701,18 +715,20 @@ impl AppState {
 
         // Deselect on ESC. Must happen after all other UI code to let them capture ESC if needed.
         if ui.input(|i| i.key_pressed(egui::Key::Escape)) && !is_any_popup_open {
-            selection_state.clear_selection();
+            self.selection_state.clear_selection();
         }
 
         // If there's no label selected, and the user triggers a copy command, copy a description of the current selection.
         if !LabelSelectionState::load(ui.ctx()).has_selection()
             && ui.input(|input| input.events.iter().any(|e| e == &egui::Event::Copy))
         {
-            selection_state.selected_items().copy_to_clipboard(ui.ctx());
+            self.selection_state
+                .selected_items()
+                .copy_to_clipboard(ui.ctx());
         }
 
         // Reset the focused item.
-        *focused_item = None;
+        self.focused_item = None;
     }
 
     #[cfg(target_arch = "wasm32")] // Only used in Wasm
@@ -892,14 +908,17 @@ fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
         o.commands.retain_mut(|command| {
             if let egui::OutputCommand::OpenUrl(open_url) = command {
                 if let Ok(uri) = open_url.url.parse::<re_uri::RedapUri>() {
-                    let is_ctalog_uri = matches!(uri, re_uri::RedapUri::Catalog { .. });
+                    let is_catalog_uri = matches!(
+                        uri,
+                        re_uri::RedapUri::Catalog { .. } | re_uri::RedapUri::Entry { .. }
+                    );
 
                     ctx.command_sender()
                         .send_system(SystemCommand::LoadDataSource(
                             re_data_source::DataSource::RerunGrpcStream(uri),
                         ));
 
-                    if is_ctalog_uri && !open_url.new_tab {
+                    if is_catalog_uri && !open_url.new_tab {
                         ctx.command_sender()
                             .send_system(SystemCommand::ChangeDisplayMode(
                                 DisplayMode::LocalRecordings,

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -915,7 +915,7 @@ fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
                             re_data_source::DataSource::RerunGrpcStream(uri),
                         ));
 
-                    if is_catalog_uri && !open_url.new_tab {
+                    if is_dataset_uri && !open_url.new_tab {
                         ctx.command_sender()
                             .send_system(SystemCommand::ChangeDisplayMode(
                                 DisplayMode::LocalRecordings,

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -2,16 +2,12 @@
 
 use std::{ops::ControlFlow, sync::Arc};
 
-use re_log::ResultExt as _;
-use re_viewer_context::CommandSender;
-use re_viewer_context::SystemCommand;
-use re_viewer_context::SystemCommandSender as _;
-
 use serde::Deserialize;
-use wasm_bindgen::JsCast as _;
-use wasm_bindgen::JsError;
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast as _, JsError, JsValue};
 use web_sys::Window;
+
+use re_log::ResultExt as _;
+use re_viewer_context::{CommandSender, Item, SystemCommand, SystemCommandSender as _};
 
 pub trait JsResultExt<T> {
     /// Logs an error if the result is an error and returns the result.
@@ -153,7 +149,13 @@ pub fn url_to_receiver(
         }
 
         EndpointCategory::RerunGrpcStream(re_uri::RedapUri::Catalog(uri)) => {
-            command_sender.send_system(SystemCommand::AddRedapServer(uri));
+            command_sender.send_system(SystemCommand::AddRedapServer(uri.origin.clone()));
+            None
+        }
+
+        EndpointCategory::RerunGrpcStream(re_uri::RedapUri::Entry(uri)) => {
+            command_sender.send_system(SystemCommand::AddRedapServer(uri.origin.clone()));
+            command_sender.send_system(SystemCommand::SetSelection(Item::RedapEntry(uri.entry_id)));
             None
         }
 

--- a/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
@@ -28,7 +28,7 @@ pub enum SystemCommand {
     AddReceiver(re_smart_channel::Receiver<re_log_types::LogMsg>),
 
     /// Add a new server to the redap browser.
-    AddRedapServer(re_uri::CatalogUri),
+    AddRedapServer(re_uri::Origin),
 
     ChangeDisplayMode(crate::DisplayMode),
 

--- a/scripts/ci/check_large_files.py
+++ b/scripts/ci/check_large_files.py
@@ -44,6 +44,9 @@ def check_large_files(files_to_check: set[str]) -> int:
 
     result = 0
     for file_path in files_to_check:
+        if file_path.endswith(".rs"):
+            continue
+
         actual_size = os.path.getsize(file_path)
 
         if actual_size >= maximum_size:


### PR DESCRIPTION
### Related

* related to (but doesn't implement)  #9492

### What

Add support for "entry" uris, in the form of:

```
$SERVER/entry/$ENTRY_ID
```

When opened by the viewer, the corresponding server is added (if needed) and the entry is selected.

TODO:
- [x] test opening links within rerun
- [x] test opening links from notebook