### PR TITLE
Make use of the new `serve_web_viewer` function

### DIFF
--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -37,6 +37,7 @@ use re_protos::{
     },
 };
 
+/// Default port of the OSS /proxy server.
 pub const DEFAULT_SERVER_PORT: u16 = 9876;
 pub const DEFAULT_MEMORY_LIMIT: MemoryLimit = MemoryLimit::UNLIMITED;
 

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -33,10 +33,10 @@ pub use self::recording_stream::{
     RecordingStreamResult,
 };
 
-/// The default port of a Rerun gRPC server.
+/// The default port of a Rerun gRPC /proxy server.
 pub const DEFAULT_SERVER_PORT: u16 = re_uri::DEFAULT_PROXY_PORT;
 
-/// The default URL of a Rerun gRPC server.
+/// The default URL of a Rerun gRPC /proxy server.
 ///
 /// This isn't used to _host_ the server, only to _connect_ to it.
 pub const DEFAULT_CONNECT_URL: &str =

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -34,7 +34,7 @@ pub use self::recording_stream::{
 };
 
 /// The default port of a Rerun gRPC server.
-pub const DEFAULT_SERVER_PORT: u16 = 9876;
+pub const DEFAULT_SERVER_PORT: u16 = re_uri::DEFAULT_GRPC_SERVER_PORT;
 
 /// The default URL of a Rerun gRPC server.
 ///

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -34,7 +34,7 @@ pub use self::recording_stream::{
 };
 
 /// The default port of a Rerun gRPC server.
-pub const DEFAULT_SERVER_PORT: u16 = re_uri::DEFAULT_GRPC_SERVER_PORT;
+pub const DEFAULT_SERVER_PORT: u16 = re_uri::DEFAULT_PROXY_PORT;
 
 /// The default URL of a Rerun gRPC server.
 ///

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -409,7 +409,7 @@ impl RecordingStreamBuilder {
     /// locally hosted gRPC server.
     ///
     /// The server is hosted on the default IP and port, and may be connected to by any SDK or Viewer
-    /// at `rerun+http://127.0.0.1:9876/proxy`.
+    /// at `rerun+http://127.0.0.1:9876/proxy` or by just running `rerun --connect`.
     ///
     /// To configure the gRPC server's IP and port, use [`Self::serve_grpc_opts`] instead.
     ///
@@ -1909,6 +1909,8 @@ impl RecordingStream {
     /// `rerun+http://127.0.0.1:9876/proxy`.
     ///
     /// To configure the gRPC server's IP and port, use [`Self::serve_grpc_opts`] instead.
+    ///
+    /// You can connect a viewer to it with `rerun --connect`.
     ///
     /// The gRPC server will buffer all log data in memory so that late connecting viewers will get all the data.
     /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -619,7 +619,10 @@ impl RecordingStreamBuilder {
     //
     // # TODO(#5531): keep static data around.
     #[cfg(feature = "web_viewer")]
-    #[deprecated(since = "0.20.0", note = "use serve_web() instead")]
+    #[deprecated(
+        since = "0.20.0",
+        note = "use rec.serve_grpc() with rerun::serve_web_viewer() instead"
+    )]
     pub fn serve(
         self,
         bind_ip: &str,
@@ -652,6 +655,8 @@ impl RecordingStreamBuilder {
     /// The gRPC server will buffer all log data in memory so that late connecting viewers will get all the data.
     /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
     /// Once reached, the earliest logged data will be dropped. Static data is never dropped.
+    ///
+    /// Calling `serve_web` is equivalent to calling [`Seldf::serve_grpc`] followed by [`rerun::serve_web_viewer`].
     ///
     /// ## Example
     ///

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -656,7 +656,7 @@ impl RecordingStreamBuilder {
     /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
     /// Once reached, the earliest logged data will be dropped. Static data is never dropped.
     ///
-    /// Calling `serve_web` is equivalent to calling [`Seldf::serve_grpc`] followed by [`rerun::serve_web_viewer`].
+    /// Calling `serve_web` is equivalent to calling [`Self::serve_grpc`] followed by [`crate::serve_web_viewer`].
     ///
     /// ## Example
     ///

--- a/crates/top/rerun/src/clap.rs
+++ b/crates/top/rerun/src/clap.rs
@@ -131,14 +131,15 @@ impl RerunArgs {
                 let server_memory_limit = re_memory::MemoryLimit::parse(&self.server_memory_limit)
                     .map_err(|err| anyhow::format_err!("Bad --server-memory-limit: {err}"))?;
 
-                let open_browser = true;
-                let rec = RecordingStreamBuilder::new(application_id).serve_web(
-                    &self.bind,
-                    Default::default(),
-                    crate::DEFAULT_SERVER_PORT,
-                    server_memory_limit,
-                    open_browser,
-                )?;
+                let rec = RecordingStreamBuilder::new("rerun_example_minimal_serve")
+                    .serve_grpc_opts(&self.bind, crate::DEFAULT_SERVER_PORT, server_memory_limit)?;
+
+                crate::serve_web_viewer(crate::web_viewer::WebViewerConfig {
+                    open_browser: true,
+                    connect_to: Some("rerun+http://localhost:9876/proxy".to_owned()),
+                    ..Default::default()
+                })?
+                .detach();
 
                 // Ensure the server stays alive until the end of the program.
                 let sleep_guard = ServeGuard {

--- a/crates/top/rerun/src/clap.rs
+++ b/crates/top/rerun/src/clap.rs
@@ -135,7 +135,7 @@ impl RerunArgs {
                 let rec = RecordingStreamBuilder::new(application_id).serve_web(
                     &self.bind,
                     Default::default(),
-                    Default::default(),
+                    crate::DEFAULT_SERVER_PORT,
                     server_memory_limit,
                     open_browser,
                 )?;

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -54,3 +54,6 @@ pub use self::{
 pub mod external {
     pub use url;
 }
+
+/// The default port of a Rerun gRPC server.
+pub const DEFAULT_GRPC_SERVER_PORT: u16 = 9876;

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -55,5 +55,5 @@ pub mod external {
     pub use url;
 }
 
-/// The default port of a Rerun gRPC server.
-pub const DEFAULT_GRPC_SERVER_PORT: u16 = 9876;
+/// The default port of a Rerun gRPC proxy server .
+pub const DEFAULT_PROXY_PORT: u16 = 9876;

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -55,5 +55,8 @@ pub mod external {
     pub use url;
 }
 
-/// The default port of a Rerun gRPC proxy server .
+/// The default port of a Rerun gRPC proxy server.
 pub const DEFAULT_PROXY_PORT: u16 = 9876;
+
+/// The default port of a redap server.
+pub const DEFAULT_REDAP_PORT: u16 = 51234;

--- a/crates/utils/re_uri/src/origin.rs
+++ b/crates/utils/re_uri/src/origin.rs
@@ -86,15 +86,9 @@ impl Origin {
 
         if !has_port {
             // If no port is specified, we assume the default redap port:
-            http_url.set_port(Some(51234)).ok();
-        }
-
-        // If we parse a Url from e.g. `https://redap.rerun.io:443`, `port` in the Url struct will
-        // be `None`. So we need to use `port_or_known_default` to get the port back.
-        // See also: https://github.com/servo/rust-url/issues/957
-        if http_url.port_or_known_default().is_none() {
-            // If no port is specified, we assume the default redap port:
-            http_url.set_port(Some(51234)).ok();
+            http_url
+                .set_port(Some(crate::DEFAULT_GRPC_SERVER_PORT))
+                .ok();
         }
 
         let url::Origin::Tuple(_, host, port) = http_url.origin() else {

--- a/crates/utils/re_uri/src/origin.rs
+++ b/crates/utils/re_uri/src/origin.rs
@@ -85,10 +85,8 @@ impl Origin {
         }
 
         if !has_port {
-            // If no port is specified, we assume the default redap port:
-            http_url
-                .set_port(Some(crate::DEFAULT_GRPC_SERVER_PORT))
-                .ok();
+            // If no port is specified, we assume the default:
+            http_url.set_port(Some(crate::DEFAULT_PROXY_PORT)).ok();
         }
 
         let url::Origin::Tuple(_, host, port) = http_url.origin() else {

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_localhost_url() {
-        let url = "rerun+http://localhost:51234/catalog";
+        let url = "rerun+http://localhost:9876/catalog";
         let address: RedapUri = url.parse().unwrap();
 
         assert_eq!(
@@ -371,7 +371,7 @@ mod tests {
                 origin: Origin {
                     scheme: Scheme::RerunHttp,
                     host: url::Host::<String>::Domain("localhost".to_owned()),
-                    port: 51234
+                    port: 9876
                 }
             })
         );
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_invalid_path() {
-        let url = "rerun://0.0.0.0:51234/redap/recordings/12345";
+        let url = "rerun://0.0.0.0:9876/redap/recordings/12345";
         let address: Result<RedapUri, _> = url.parse();
 
         assert!(matches!(
@@ -401,20 +401,20 @@ mod tests {
 
     #[test]
     fn test_proxy_endpoint() {
-        let url = "rerun://localhost:51234/proxy";
+        let url = "rerun://localhost:9876/proxy";
         let address: Result<RedapUri, _> = url.parse();
 
         let expected = RedapUri::Proxy(ProxyUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
-                port: 51234,
+                port: 9876,
             },
         });
 
         assert_eq!(address.unwrap(), expected);
 
-        let url = "rerun://localhost:51234/proxy/";
+        let url = "rerun://localhost:9876/proxy/";
         let address: Result<RedapUri, _> = url.parse();
 
         assert_eq!(address.unwrap(), expected);
@@ -422,20 +422,20 @@ mod tests {
 
     #[test]
     fn test_catalog_default() {
-        let url = "rerun://localhost:51234";
+        let url = "rerun://localhost:9876";
         let address: Result<RedapUri, _> = url.parse();
 
         let expected = RedapUri::Catalog(CatalogUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
-                port: 51234,
+                port: 9876,
             },
         });
 
         assert_eq!(address.unwrap(), expected);
 
-        let url = "rerun://localhost:51234/";
+        let url = "rerun://localhost:9876/";
         let address: Result<RedapUri, _> = url.parse();
 
         assert_eq!(address.unwrap(), expected);
@@ -449,7 +449,7 @@ mod tests {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
-                port: 51234,
+                port: 9876,
             },
         });
 
@@ -465,7 +465,7 @@ mod tests {
                     origin: Origin {
                         scheme: Scheme::RerunHttp,
                         host: url::Host::Domain("localhost".to_owned()),
-                        port: 51234,
+                        port: 9876,
                     },
                 }),
             ),
@@ -475,7 +475,17 @@ mod tests {
                     origin: Origin {
                         scheme: Scheme::RerunHttp,
                         host: url::Host::Domain("localhost".to_owned()),
-                        port: 51234,
+                        port: 9876,
+                    },
+                }),
+            ),
+            (
+                "127.0.0.1/proxy",
+                RedapUri::Proxy(ProxyUri {
+                    origin: Origin {
+                        scheme: Scheme::RerunHttp,
+                        host: url::Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)),
+                        port: 9876,
                     },
                 }),
             ),

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_localhost_url() {
-        let url = "rerun+http://localhost:50051/catalog";
+        let url = "rerun+http://localhost:51234/catalog";
         let address: RedapUri = url.parse().unwrap();
 
         assert_eq!(
@@ -373,7 +373,7 @@ mod tests {
                 origin: Origin {
                     scheme: Scheme::RerunHttp,
                     host: url::Host::<String>::Domain("localhost".to_owned()),
-                    port: 50051
+                    port: 51234
                 }
             })
         );
@@ -392,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_invalid_path() {
-        let url = "rerun://0.0.0.0:50051/redap/recordings/12345";
+        let url = "rerun://0.0.0.0:51234/redap/recordings/12345";
         let address: Result<RedapUri, _> = url.parse();
 
         assert!(matches!(
@@ -424,20 +424,20 @@ mod tests {
 
     #[test]
     fn test_catalog_default() {
-        let url = "rerun://localhost:50051";
+        let url = "rerun://localhost:51234";
         let address: Result<RedapUri, _> = url.parse();
 
         let expected = RedapUri::Catalog(CatalogUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
-                port: 50051,
+                port: 51234,
             },
         });
 
         assert_eq!(address.unwrap(), expected);
 
-        let url = "rerun://localhost:50051/";
+        let url = "rerun://localhost:51234/";
         let address: Result<RedapUri, _> = url.parse();
 
         assert_eq!(address.unwrap(), expected);

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -442,16 +442,27 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    // TODO(lucasmerlin): This should ideally work but doesn't right now because of a issue in the `url` crate:
-    // https://github.com/servo/rust-url/issues/957
-    // See also `replace_and_parse` in `origin.rs`
     fn test_default_port() {
         let url = "rerun://localhost";
 
         let expected = RedapUri::Catalog(CatalogUri {
             origin: Origin {
                 scheme: Scheme::Rerun,
+                host: url::Host::Domain("localhost".to_owned()),
+                port: 51234,
+            },
+        });
+
+        assert_eq!(url.parse::<RedapUri>().unwrap(), expected);
+    }
+
+    #[test]
+    fn test_default_everything() {
+        let url = "localhost";
+
+        let expected = RedapUri::Catalog(CatalogUri {
+            origin: Origin {
+                scheme: Scheme::RerunHttp,
                 host: url::Host::Domain("localhost".to_owned()),
                 port: 51234,
             },

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -474,4 +474,34 @@ mod tests {
 
         assert_eq!(url.parse::<RedapUri>().unwrap(), expected);
     }
+
+    #[test]
+    fn test_default_localhost_scheme() {
+        let test_cases = [
+            (
+                "localhost:123",
+                RedapUri::Catalog(CatalogUri {
+                    origin: Origin {
+                        scheme: Scheme::RerunHttp,
+                        host: url::Host::Domain("localhost".to_owned()),
+                        port: 123,
+                    },
+                }),
+            ),
+            (
+                "127.0.0.1:1234/proxy",
+                RedapUri::Proxy(ProxyUri {
+                    origin: Origin {
+                        scheme: Scheme::RerunHttp,
+                        host: url::Host::Ipv4(Ipv4Addr::new(127, 0, 0, 1)),
+                        port: 1234,
+                    },
+                }),
+            ),
+        ];
+
+        for (url, expected) in test_cases {
+            assert_eq!(url.parse::<RedapUri>().unwrap(), expected);
+        }
+    }
 }

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -458,17 +458,32 @@ mod tests {
 
     #[test]
     fn test_default_everything() {
-        let url = "localhost";
+        let test_cases = [
+            (
+                "localhost",
+                RedapUri::Catalog(CatalogUri {
+                    origin: Origin {
+                        scheme: Scheme::RerunHttp,
+                        host: url::Host::Domain("localhost".to_owned()),
+                        port: 51234,
+                    },
+                }),
+            ),
+            (
+                "localhost/proxy",
+                RedapUri::Proxy(ProxyUri {
+                    origin: Origin {
+                        scheme: Scheme::RerunHttp,
+                        host: url::Host::Domain("localhost".to_owned()),
+                        port: 51234,
+                    },
+                }),
+            ),
+        ];
 
-        let expected = RedapUri::Catalog(CatalogUri {
-            origin: Origin {
-                scheme: Scheme::RerunHttp,
-                host: url::Host::Domain("localhost".to_owned()),
-                port: 51234,
-            },
-        });
-
-        assert_eq!(url.parse::<RedapUri>().unwrap(), expected);
+        for (url, expected) in test_cases {
+            assert_eq!(url.parse::<RedapUri>().unwrap(), expected);
+        }
     }
 
     #[test]

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -190,7 +190,7 @@ impl RedapServers {
                     );
                 } else {
                     // Since we persist the server list on disk this happens quite often.
-                    // E.g. run `pixi run rerun "rerun+http://localhost:51234"` more than once.
+                    // E.g. run `pixi run rerun "rerun+http://localhost"` more than once.
                     re_log::debug!(
                         "Tried to add pre-existing server at {:?}",
                         origin.to_string()

--- a/docs/content/reference/sdk/operating-modes.md
+++ b/docs/content/reference/sdk/operating-modes.md
@@ -48,7 +48,7 @@ You will need to start a stand-alone Viewer first by typing `rerun` in your term
 
 ### `serve_grpc`
 Calling `serve_grpc` will start a Rerun gRPC server in your process, and stream logged data to it.
-This gRPC server can then be connected to from the Rerun Viewer, e.g. by running `rerun --connect localhost/proxy`.
+This gRPC server can then be connected to from the Rerun Viewer, e.g. by running `rerun --connect`.
 The gRPC server acts as a proxy, buffering and forwarding log data to the Rerun Viewer.
 
 You can also connect to the gRPC server from a Rerun Web Viewer.

--- a/docs/content/reference/sdk/operating-modes.md
+++ b/docs/content/reference/sdk/operating-modes.md
@@ -12,11 +12,11 @@ Before reading this document, you might want to familiarize yourself with the [R
 
 ## Operating modes
 
-The Rerun SDK provides 4 modes of operation: `spawn`, `connect`, `serve`, and `save`.
+The Rerun SDK provides 4 modes of operation: `spawn`, `connect`, `serve_grpc`, and `save`.
 
 All four of them are optional: when none of these modes are active, the client will simply buffer the logged data in memory, waiting for one of these modes to be enabled so that it can flush it.
 
-### Spawn
+### `spawn`
 
 This is the default behavior you get when running all of our C++/Python/Rust examples, and is generally the most convenient when you're experimenting.
 
@@ -30,7 +30,7 @@ Call [`rr.spawn`](https://ref.rerun.io/docs/python/stable/common/initialization_
 [`RecordingStream::spawn`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.spawn) spawns a new Rerun Viewer process using an executable available in your PATH, then streams all the data to it via gRPC. If an external Viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
 
-### Connect
+### `connect`
 
 Connects to a remote Rerun Viewer and streams all the data via gRPC.
 
@@ -46,31 +46,28 @@ You will need to start a stand-alone Viewer first by typing `rerun` in your term
 [`RecordingStream::connect`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.connect)
 
 
-### Serve
+### `serve_grpc`
+Calling `serve_grpc` will start a Rerun gRPC server in your process, and stream logged data to it.
+This gRPC server can then be connected to from the Rerun Viewer, e.g. by running `rerun --connect localhost/proxy`.
+The gRPC server acts as a proxy, buffering and forwarding log data to the Rerun Viewer.
 
-There are two kinds of `serve` calls:
-
-* `serve_web`
-* `serve_grpc`
-
-Both will start a Rerun gRPC server in your process, and stream logged data to it.
-
-The `serve_web` call starts an additional server which hosts the assets required to run the Rerun Viewer in your browser.
+You can also connect to the gRPC server from a Rerun Web Viewer.
+To host a Rerun Web Viewer, you can use the `serve_web_viewer` function.
 
 #### C++
 * [`RecordingStream::serve_grpc`](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html).
-* `serve_web` is not available.
+* `serve_web_viewer` is not available.
 
 #### Python
 * [`rr.serve_grpc`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.serve_grpc?speculative-link)
-* [`rr.serve_web`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.serve_web)
+* [`rr.serve_web_viewer`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.serve_web_viewer?speculative-link)
 
 #### Rust
 * [`RecordingStream::serve_grpc`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.serve_grpc?speculative-link)
-* [`RecordingStream::serve_web`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.serve_web?speculative-link)
+* [`RecordingStream::serve_web_viewer`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.serve_web_viewer?speculative-link)
 
 
-### Save
+### `save`
 
 Streams all logging data into an `.rrd` file on disk, which can then be loaded into a stand-alone viewer.
 

--- a/examples/rust/minimal_serve/src/main.rs
+++ b/examples/rust/minimal_serve/src/main.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_serve").serve_web(
         "0.0.0.0",
         Default::default(),
-        Default::default(),
+        rerun::DEFAULT_SERVER_PORT,
         rerun::MemoryLimit::from_fraction_of_total(0.25),
         open_browser,
     )?;

--- a/examples/rust/minimal_serve/src/main.rs
+++ b/examples/rust/minimal_serve/src/main.rs
@@ -3,14 +3,13 @@
 use rerun::{demo_util::grid, external::glam};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let open_browser = true;
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_serve").serve_web(
-        "0.0.0.0",
-        Default::default(),
-        rerun::DEFAULT_SERVER_PORT,
-        rerun::MemoryLimit::from_fraction_of_total(0.25),
-        open_browser,
-    )?;
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_minimal_serve").serve_grpc()?;
+
+    rerun::serve_web_viewer(rerun::web_viewer::WebViewerConfig {
+        connect_to: Some("localhost/proxy".to_owned()),
+        ..Default::default()
+    })?
+    .detach();
 
     let points = grid(glam::Vec3::splat(-10.0), glam::Vec3::splat(10.0), 10);
     let colors = grid(glam::Vec3::ZERO, glam::Vec3::splat(255.0), 10)

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -89,7 +89,7 @@ SECTION_TABLE: Final[list[Section]] = [
             "save",
             "send_blueprint",
             "serve_grpc",
-            "serve_web",
+            "serve_web_viewer",
             "spawn",
             "memory_recording",
             "notebook_show",

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -663,6 +663,8 @@ class RecordingStream:
 
         This function returns immediately.
 
+        Calling `serve_web` is equivalent to calling [`rerun.RecordingStream.serve_grpc`][] followed by [`rerun.serve_web_viewer`][].
+
         Parameters
         ----------
         open_browser:

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -300,6 +300,8 @@ def serve_web(
 
     This function returns immediately.
 
+    Calling `serve_web` is equivalent to calling [`rerun.serve_grpc`][] followed by [`rerun.serve_web_viewer`][].
+
     Parameters
     ----------
     open_browser:

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -81,8 +81,8 @@ async fn connect_async(
 /// addresses:
 ///
 /// * `rerun://<addr>:<port>` Defaults to a secure TLS connection.
-/// * `rerun+http://localhost:9876` Falls back to using HTTP only.
-/// * `rerun+https://localhost:9876` Same as `rerun://` but explicit.
+/// * `rerun+http://localhost:51234` Falls back to using HTTP only.
+/// * `rerun+https://localhost:51234` Same as `rerun://` but explicit.
 ///
 /// Parameters
 /// ----------

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -81,8 +81,8 @@ async fn connect_async(
 /// addresses:
 ///
 /// * `rerun://<addr>:<port>` Defaults to a secure TLS connection.
-/// * `rerun+http://localhost:51234` Falls back to using HTTP only.
-/// * `rerun+https://localhost:51234` Same as `rerun://` but explicit.
+/// * `rerun+http://localhost:9876` Falls back to using HTTP only.
+/// * `rerun+https://localhost:9876` Same as `rerun://` but explicit.
 ///
 /// Parameters
 /// ----------


### PR DESCRIPTION
### Related
* Follows https://github.com/rerun-io/rerun/pull/9540
* Closes https://github.com/rerun-io/rerun/issues/9469
* Later: #9541

### What
This makes use of the new `serve_web_viewer` function, and refers to it from docs.