### PR TITLE
CMake: Use `find_dependency` for Arrow

### DIFF
--- a/rerun_cpp/Config.cmake.in
+++ b/rerun_cpp/Config.cmake.in
@@ -47,7 +47,9 @@ else()
         )
     endif()
 
-    find_package(Arrow REQUIRED)
+    include(CMakeFindDependencyMacro)
+
+    find_dependency(Arrow)
 
     message(STATUS "Rerun is using a system installed libArrow.")
 


### PR DESCRIPTION
`CMakeFindDependencyMacro` https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html wires up `find_package` options like `REQUIRED` and `QUIET` to dependent package searches.

As written `find_package(rerun_sdk CONFIG QUIET)` can blow up despite the user saying QUIET.
