### PR TITLE
Move `StartupOptions` to a separate file to reduce the size of `app.rs`

### DIFF
--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -21,6 +21,7 @@ use re_viewer_context::{
     ViewClassRegistry, ViewClassRegistryError,
 };
 
+use crate::startup_options::StartupOptions;
 use crate::{
     app_blueprint::{AppBlueprint, PanelStateOverrides},
     app_state::WelcomeScreenState,
@@ -37,125 +38,6 @@ enum TimeControlCommand {
     StepForward,
     Restart,
     Follow,
-}
-
-// ----------------------------------------------------------------------------
-
-/// Settings set once at startup (e.g. via command-line options) and not serialized.
-#[derive(Clone)]
-pub struct StartupOptions {
-    /// When the total process RAM reaches this limit, we GC old data.
-    pub memory_limit: re_memory::MemoryLimit,
-
-    pub persist_state: bool,
-
-    /// Whether or not the app is running in the context of a Jupyter Notebook.
-    pub is_in_notebook: bool,
-
-    /// Set to identify the web page the viewer is running on.
-    #[cfg(target_arch = "wasm32")]
-    pub location: Option<eframe::Location>,
-
-    /// Take a screenshot of the app and quit.
-    /// We use this to generate screenshots of our examples.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub screenshot_to_path_then_quit: Option<std::path::PathBuf>,
-
-    /// A user has specifically requested the welcome screen be hidden.
-    pub hide_welcome_screen: bool,
-
-    /// Detach Rerun Viewer process from the application process.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub detach_process: bool,
-
-    /// Set the screen resolution in logical points.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub resolution_in_points: Option<[f32; 2]>,
-
-    /// This is a hint that we expect a recording to stream in very soon.
-    ///
-    /// This is set by the `spawn()` method in our logging SDK.
-    ///
-    /// The viewer will respond by fading in the welcome screen,
-    /// instead of showing it directly.
-    /// This ensures that it won't blink for a few frames before switching to the recording.
-    pub expect_data_soon: Option<bool>,
-
-    /// Forces wgpu backend to use the specified graphics API, e.g. `webgl` or `webgpu`.
-    pub force_wgpu_backend: Option<String>,
-
-    /// Overwrites hardware acceleration option for video decoding.
-    ///
-    /// By default uses the last provided setting, which is `auto` if never configured.
-    /// This also can be changed in the viewer's option menu.
-    pub video_decoder_hw_acceleration: Option<re_video::decode::DecodeHardwareAcceleration>,
-
-    /// External interactions with the Viewer host (JS, custom egui app, notebook, etc.).
-    pub callbacks: Option<Callbacks>,
-
-    /// Fullscreen is handled by JS on web.
-    ///
-    /// This holds some callbacks which we use to communicate
-    /// about fullscreen state to JS.
-    #[cfg(target_arch = "wasm32")]
-    pub fullscreen_options: Option<crate::web::FullscreenOptions>,
-
-    /// Default overrides for state of top/side/bottom panels.
-    pub panel_state_overrides: PanelStateOverrides,
-
-    /// Whether or not to enable usage of the `History` API on web.
-    ///
-    /// It is disabled by default.
-    ///
-    /// This should only be enabled when it is acceptable for `rerun`
-    /// to push its own entries into browser history.
-    ///
-    /// That only makes sense if it has "taken over" a page, and is
-    /// the only thing on that page. If you are embedding multiple
-    /// viewers onto the same page, then it's better to turn this off.
-    ///
-    /// We use browser history in a limited way to track the currently
-    /// open example recording, see [`crate::history`].
-    #[cfg(target_arch = "wasm32")]
-    pub enable_history: bool,
-}
-
-impl Default for StartupOptions {
-    fn default() -> Self {
-        Self {
-            memory_limit: re_memory::MemoryLimit::from_fraction_of_total(0.75),
-            persist_state: true,
-            is_in_notebook: false,
-
-            #[cfg(target_arch = "wasm32")]
-            location: None,
-
-            #[cfg(not(target_arch = "wasm32"))]
-            screenshot_to_path_then_quit: None,
-
-            hide_welcome_screen: false,
-
-            #[cfg(not(target_arch = "wasm32"))]
-            detach_process: true,
-
-            #[cfg(not(target_arch = "wasm32"))]
-            resolution_in_points: None,
-
-            expect_data_soon: None,
-            force_wgpu_backend: None,
-            video_decoder_hw_acceleration: None,
-
-            callbacks: Default::default(),
-
-            #[cfg(target_arch = "wasm32")]
-            fullscreen_options: Default::default(),
-
-            panel_state_overrides: Default::default(),
-
-            #[cfg(target_arch = "wasm32")]
-            enable_history: false,
-        }
-    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -11,6 +11,7 @@ mod callback;
 pub mod env_vars;
 mod saving;
 mod screenshotter;
+mod startup_options;
 mod ui;
 mod viewer_analytics;
 
@@ -28,7 +29,8 @@ pub(crate) use {app_state::AppState, ui::memory_panel};
 
 pub use callback::{CallbackSelectionItem, Callbacks};
 
-pub use app::{App, StartupOptions};
+pub use app::App;
+pub use startup_options::StartupOptions;
 
 pub use re_capabilities::MainThreadToken;
 

--- a/crates/viewer/re_viewer/src/startup_options.rs
+++ b/crates/viewer/re_viewer/src/startup_options.rs
@@ -1,0 +1,119 @@
+use crate::app_blueprint::PanelStateOverrides;
+use crate::Callbacks;
+
+/// Settings set once at startup (e.g. via command-line options) and not serialized.
+#[derive(Clone)]
+pub struct StartupOptions {
+    /// When the total process RAM reaches this limit, we GC old data.
+    pub memory_limit: re_memory::MemoryLimit,
+
+    pub persist_state: bool,
+
+    /// Whether or not the app is running in the context of a Jupyter Notebook.
+    pub is_in_notebook: bool,
+
+    /// Set to identify the web page the viewer is running on.
+    #[cfg(target_arch = "wasm32")]
+    pub location: Option<eframe::Location>,
+
+    /// Take a screenshot of the app and quit.
+    /// We use this to generate screenshots of our examples.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub screenshot_to_path_then_quit: Option<std::path::PathBuf>,
+
+    /// A user has specifically requested the welcome screen be hidden.
+    pub hide_welcome_screen: bool,
+
+    /// Detach Rerun Viewer process from the application process.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub detach_process: bool,
+
+    /// Set the screen resolution in logical points.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub resolution_in_points: Option<[f32; 2]>,
+
+    /// This is a hint that we expect a recording to stream in very soon.
+    ///
+    /// This is set by the `spawn()` method in our logging SDK.
+    ///
+    /// The viewer will respond by fading in the welcome screen,
+    /// instead of showing it directly.
+    /// This ensures that it won't blink for a few frames before switching to the recording.
+    pub expect_data_soon: Option<bool>,
+
+    /// Forces wgpu backend to use the specified graphics API, e.g. `webgl` or `webgpu`.
+    pub force_wgpu_backend: Option<String>,
+
+    /// Overwrites hardware acceleration option for video decoding.
+    ///
+    /// By default uses the last provided setting, which is `auto` if never configured.
+    /// This also can be changed in the viewer's option menu.
+    pub video_decoder_hw_acceleration: Option<re_video::decode::DecodeHardwareAcceleration>,
+
+    /// External interactions with the Viewer host (JS, custom egui app, notebook, etc.).
+    pub callbacks: Option<Callbacks>,
+
+    /// Fullscreen is handled by JS on web.
+    ///
+    /// This holds some callbacks which we use to communicate
+    /// about fullscreen state to JS.
+    #[cfg(target_arch = "wasm32")]
+    pub fullscreen_options: Option<crate::web::FullscreenOptions>,
+
+    /// Default overrides for state of top/side/bottom panels.
+    pub panel_state_overrides: PanelStateOverrides,
+
+    /// Whether or not to enable usage of the `History` API on web.
+    ///
+    /// It is disabled by default.
+    ///
+    /// This should only be enabled when it is acceptable for `rerun`
+    /// to push its own entries into browser history.
+    ///
+    /// That only makes sense if it has "taken over" a page, and is
+    /// the only thing on that page. If you are embedding multiple
+    /// viewers onto the same page, then it's better to turn this off.
+    ///
+    /// We use browser history in a limited way to track the currently
+    /// open example recording, see [`crate::history`].
+    #[cfg(target_arch = "wasm32")]
+    pub enable_history: bool,
+}
+
+impl Default for StartupOptions {
+    fn default() -> Self {
+        Self {
+            memory_limit: re_memory::MemoryLimit::from_fraction_of_total(0.75),
+            persist_state: true,
+            is_in_notebook: false,
+
+            #[cfg(target_arch = "wasm32")]
+            location: None,
+
+            #[cfg(not(target_arch = "wasm32"))]
+            screenshot_to_path_then_quit: None,
+
+            hide_welcome_screen: false,
+
+            #[cfg(not(target_arch = "wasm32"))]
+            detach_process: true,
+
+            #[cfg(not(target_arch = "wasm32"))]
+            resolution_in_points: None,
+
+            expect_data_soon: None,
+            force_wgpu_backend: None,
+            video_decoder_hw_acceleration: None,
+
+            callbacks: Default::default(),
+
+            #[cfg(target_arch = "wasm32")]
+            fullscreen_options: Default::default(),
+
+            panel_state_overrides: Default::default(),
+
+            #[cfg(target_arch = "wasm32")]
+            enable_history: false,
+        }
+    }
+}

--- a/scripts/ci/check_large_files.py
+++ b/scripts/ci/check_large_files.py
@@ -44,9 +44,6 @@ def check_large_files(files_to_check: set[str]) -> int:
 
     result = 0
     for file_path in files_to_check:
-        if file_path.endswith(".rs"):
-            continue
-
         actual_size = os.path.getsize(file_path)
 
         if actual_size >= maximum_size:


### PR DESCRIPTION
Title. Bring back the file size to below our limit.