### PR TITLE
Set `RERUN_ARROW_LINK_SHARED_DEFAULT` based on found Arrow build

### DIFF
--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -109,16 +109,24 @@ target_link_libraries(rerun_sdk PRIVATE rerun_c)
 # Arrow dependency.
 # This makes the setup a lot easier on Windows where we otherwise need to put Arrow.dll either in path or copy it with the executable.
 # Additionally reduces risk of picking up system libraries on Mac / Linux.
-set(RERUN_ARROW_LINK_SHARED_DEFAULT OFF)
-option(RERUN_ARROW_LINK_SHARED "Link to the Arrow shared library." ${RERUN_ARROW_LINK_SHARED_DEFAULT})
 option(RERUN_DOWNLOAD_AND_BUILD_ARROW "If enabled, arrow will be added as an external project and built with the minimal set required by the Rerun C++ SDK" ON)
+
+if (NOT RERUN_DOWNLOAD_AND_BUILD_ARROW)
+    find_package(Arrow REQUIRED)
+endif()
+
+if (ARROW_BUILD_SHARED)
+    set(RERUN_ARROW_LINK_SHARED_DEFAULT ON)
+else()
+    set(RERUN_ARROW_LINK_SHARED_DEFAULT OFF)
+endif()
+
+option(RERUN_ARROW_LINK_SHARED "Link to the Arrow shared library." ${RERUN_ARROW_LINK_SHARED_DEFAULT})
 
 if(RERUN_DOWNLOAD_AND_BUILD_ARROW)
     include(download_and_build_arrow.cmake)
     download_and_build_arrow() # populates `rerun_arrow_target`
 else()
-    find_package(Arrow REQUIRED)
-
     if(RERUN_ARROW_LINK_SHARED)
         add_library(rerun_arrow_target ALIAS Arrow::arrow_shared)
     else()

--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -108,7 +108,6 @@ target_link_libraries(rerun_sdk PRIVATE rerun_c)
 # -----------------------------------------------------------------------------
 # Arrow dependency.
 # This makes the setup a lot easier on Windows where we otherwise need to put Arrow.dll either in path or copy it with the executable.
-# Additionally reduces risk of picking up system libraries on Mac / Linux.
 option(RERUN_DOWNLOAD_AND_BUILD_ARROW "If enabled, arrow will be added as an external project and built with the minimal set required by the Rerun C++ SDK" ON)
 
 if (NOT RERUN_DOWNLOAD_AND_BUILD_ARROW)


### PR DESCRIPTION
Arrow provides an `ArrowOptions.cmake` in its package includes, with the following:

```cmake
### Build static libraries
set(ARROW_BUILD_STATIC "0")
### Build shared libraries
set(ARROW_BUILD_SHARED "1")
```

(It is generated by https://github.com/apache/arrow/blob/d8d7e79b60092f643f16b045eaff0b4359e32bae/cpp/cmake_modules/DefineOptions.cmake#L745 )

This is why vcpkg suggests handling Arrow by listening to that value:

```console
The package arrow provides CMake targets:

    find_package(Arrow CONFIG REQUIRED)
    target_link_libraries(main PRIVATE "$<IF:$<BOOL:${ARROW_BUILD_STATIC}>,Arrow::arrow_static,Arrow::arrow_shared>")
```

This PR tests `ARROW_BUILD_SHARED` just in case older versions of Arrow I can't test with didn't define these variables. In that case, `ARROW_BUILD_SHARED` is undefined, so `if (ARROW_BUILD_SHARED)` will choose the else branch, and give the same behavior as before the edit (`OFF`).
