### PR TITLE
Opt-out of `howto/send_table` snippet (requires running Viewer)

### DIFF
--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -147,6 +147,9 @@ features = [
   "cpp",
   "rust",
 ]
+"howto/send_table" = [ # Only supported with a running viewer
+  "py",
+]
 "views" = [
   "cpp",  # TODO(#5520): C++ views are not yet implemented
   "rust", # TODO(#5521): Rust views are not yet implemented


### PR DESCRIPTION
This snippet would require a running viewer and can therefore not run in CI.