### PR TITLE
Use `Hash64` instead of `RowId` as cache keys

### DIFF
--- a/crates/viewer/re_component_ui/src/fallback_ui.rs
+++ b/crates/viewer/re_component_ui/src/fallback_ui.rs
@@ -1,9 +1,6 @@
+use re_log_types::hash::Hash64;
 use re_viewer_context::{
-    external::{
-        re_chunk_store::{LatestAtQuery, RowId},
-        re_entity_db::EntityDb,
-        re_log_types::EntityPath,
-    },
+    external::{re_chunk_store::LatestAtQuery, re_entity_db::EntityDb, re_log_types::EntityPath},
     UiLayout, ViewerContext,
 };
 
@@ -15,7 +12,7 @@ pub fn fallback_component_ui(
     _query: &LatestAtQuery,
     _db: &EntityDb,
     _entity_path: &EntityPath,
-    _row_id: Option<RowId>,
+    _cache_key: Option<Hash64>,
     component: &dyn arrow::array::Array,
 ) {
     re_ui::arrow_ui(ui, ui_layout, component);

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -18,9 +18,9 @@ impl crate::EntityDataUi for re_types::components::ClassId {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        cache_key: Option<Hash64>,
+        _cache_key: Option<Hash64>,
         query: &re_chunk_store::LatestAtQuery,
-        db: &re_entity_db::EntityDb,
+        _db: &re_entity_db::EntityDb,
     ) {
         let annotations = crate::annotations(ctx, query, entity_path);
         let class = annotations
@@ -64,9 +64,9 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        cache_key: Option<Hash64>,
+        _cache_key: Option<Hash64>,
         query: &re_chunk_store::LatestAtQuery,
-        db: &re_entity_db::EntityDb,
+        _db: &re_entity_db::EntityDb,
     ) {
         if let Some(info) = annotation_info(ctx, entity_path, query, self.0) {
             ui.horizontal(|ui| {

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -1,6 +1,7 @@
 use egui::{color_picker, Vec2};
 use itertools::Itertools as _;
-
+use re_log_types::hash::Hash64;
+use re_log_types::EntityPath;
 use re_types::components::AnnotationContext;
 use re_types::datatypes::{
     AnnotationInfo, ClassDescription, ClassDescriptionMapElem, KeypointId, KeypointPair,
@@ -16,10 +17,10 @@ impl crate::EntityDataUi for re_types::components::ClassId {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
-        entity_path: &re_log_types::EntityPath,
-        _row_id: Option<re_chunk_store::RowId>,
+        entity_path: &EntityPath,
+        cache_key: Option<Hash64>,
         query: &re_chunk_store::LatestAtQuery,
-        _db: &re_entity_db::EntityDb,
+        db: &re_entity_db::EntityDb,
     ) {
         let annotations = crate::annotations(ctx, query, entity_path);
         let class = annotations
@@ -62,10 +63,10 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
-        entity_path: &re_log_types::EntityPath,
-        _row_id: Option<re_chunk_store::RowId>,
+        entity_path: &EntityPath,
+        cache_key: Option<Hash64>,
         query: &re_chunk_store::LatestAtQuery,
-        _db: &re_entity_db::EntityDb,
+        db: &re_entity_db::EntityDb,
     ) {
         if let Some(info) = annotation_info(ctx, entity_path, query, self.0) {
             ui.horizontal(|ui| {

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
 use re_types::components::{Blob, MediaType, VideoTimestamp};
@@ -6,7 +8,6 @@ use re_ui::{
     UiExt as _,
 };
 use re_viewer_context::{UiLayout, ViewerContext};
-use std::sync::Arc;
 
 use crate::{
     image::image_preview_ui,

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -1,9 +1,6 @@
 use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
-use re_types::{
-    components::{Blob, MediaType, VideoTimestamp},
-    RowId,
-};
+use re_types::components::{Blob, MediaType, VideoTimestamp};
 use re_ui::{
     list_item::{self, PropertyContent},
     UiExt as _,
@@ -26,7 +23,7 @@ impl EntityDataUi for Blob {
         entity_path: &EntityPath,
         cache_key: Option<Hash64>,
         query: &re_chunk_store::LatestAtQuery,
-        db: &re_entity_db::EntityDb,
+        _db: &re_entity_db::EntityDb,
     ) {
         let compact_size_string = re_format::format_bytes(self.len() as _);
 

--- a/crates/viewer/re_data_ui/src/component_ui_registry.rs
+++ b/crates/viewer/re_data_ui/src/component_ui_registry.rs
@@ -1,3 +1,4 @@
+use re_log_types::hash::Hash64;
 use re_ui::{arrow_ui, UiExt as _};
 use re_viewer_context::ComponentUiRegistry;
 

--- a/crates/viewer/re_data_ui/src/component_ui_registry.rs
+++ b/crates/viewer/re_data_ui/src/component_ui_registry.rs
@@ -1,4 +1,3 @@
-use re_log_types::hash::Hash64;
 use re_ui::{arrow_ui, UiExt as _};
 use re_viewer_context::ComponentUiRegistry;
 

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -3,6 +3,7 @@ use nohash_hasher::IntMap;
 
 use re_chunk_store::UnitChunkShared;
 use re_entity_db::InstancePath;
+use re_log_types::hash::Hash64;
 use re_log_types::{debug_assert_archetype_has_components, ComponentPath};
 use re_types::{
     archetypes, components,
@@ -293,7 +294,7 @@ fn preview_if_image_ui(
     );
 
     let image_buffer = component_map.get(&components::ImageBuffer::name())?;
-    let buffer_row_id = image_buffer.row_id()?;
+    let buffer_cache_key = Hash64::hash(image_buffer.row_id()?);
     let image_buffer = image_buffer
         .component_mono::<components::ImageBuffer>()?
         .ok()?;
@@ -317,7 +318,7 @@ fn preview_if_image_ui(
     };
 
     let image = ImageInfo {
-        buffer_row_id,
+        buffer_cache_key,
         buffer: image_buffer.0,
         format: image_format.0,
         kind,
@@ -509,7 +510,7 @@ fn preview_if_blob_ui(
         ui_layout,
         query,
         entity_path,
-        blob_row_id,
+        blob_row_id.map(Hash64::hash),
         &blob,
         media_type.as_ref(),
         video_timestamp,

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides ui elements for Rerun component data for the Rerun Viewer.
 
-use re_log_types::EntityPath;
+use re_log_types::{hash::Hash64, EntityPath};
 use re_types::ComponentName;
 use re_viewer_context::{UiLayout, ViewerContext};
 
@@ -71,7 +71,7 @@ pub trait EntityDataUi {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        row_id: Option<re_chunk_store::RowId>,
+        cache_key: Option<Hash64>,
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     );
@@ -87,7 +87,7 @@ where
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        _row_id: Option<re_chunk_store::RowId>,
+        _cache_key: Option<Hash64>,
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {

--- a/crates/viewer/re_data_ui/src/tensor.rs
+++ b/crates/viewer/re_data_ui/src/tensor.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools as _;
 
 use re_chunk_store::RowId;
+use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
 use re_types::datatypes::TensorData;
 use re_ui::UiExt as _;
@@ -39,14 +40,14 @@ impl EntityDataUi for re_types::components::TensorData {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         _entity_path: &EntityPath,
-        row_id: Option<re_chunk_store::RowId>,
+        cache_key: Option<Hash64>,
         _query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         re_tracing::profile_function!();
 
-        let tensor_data_row_id = row_id.unwrap_or(RowId::ZERO);
-        tensor_ui(ctx, ui, ui_layout, tensor_data_row_id, &self.0);
+        let tensor_cache_key = cache_key.unwrap_or(Hash64::ZERO);
+        tensor_ui(ctx, ui, ui_layout, tensor_cache_key, &self.0);
     }
 }
 
@@ -54,7 +55,7 @@ pub fn tensor_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     ui_layout: UiLayout,
-    tensor_data_row_id: RowId,
+    tensor_cache_key: Hash64,
     tensor: &TensorData,
 ) {
     // See if we can convert the tensor to a GPU texture.
@@ -62,7 +63,7 @@ pub fn tensor_ui(
     let tensor_stats = ctx
         .store_context
         .caches
-        .entry(|c: &mut TensorStatsCache| c.entry(tensor_data_row_id, tensor));
+        .entry(|c: &mut TensorStatsCache| c.entry(tensor_cache_key, tensor));
 
     if ui_layout.is_single_line() {
         ui.horizontal(|ui| {

--- a/crates/viewer/re_data_ui/src/tensor.rs
+++ b/crates/viewer/re_data_ui/src/tensor.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools as _;
 
-use re_chunk_store::RowId;
 use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
 use re_types::datatypes::TensorData;

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -5,6 +5,7 @@ use itertools::Itertools as _;
 use re_chunk::{Chunk, RowId};
 use re_chunk_store::LatestAtQuery;
 use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
+use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
 use re_types_core::{ComponentDescriptor, ComponentName, ComponentNameSet};
 use re_ui::{list_item::LabelContent, UiExt as _};
@@ -136,7 +137,7 @@ fn active_default_ui(
                         db,
                         &view.defaults_path,
                         component_name,
-                        row_id,
+                        row_id.map(Hash64::hash),
                         Some(&*component_array),
                         visualizer.fallback_provider(),
                     );

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -3,6 +3,7 @@ use itertools::Itertools as _;
 use re_chunk::{ComponentName, RowId, UnitChunkShared};
 use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
 use re_entity_db::EntityDb;
+use re_log_types::hash::Hash64;
 use re_log_types::{ComponentPath, EntityPath};
 use re_types::blueprint::archetypes::VisualizerOverrides;
 use re_types_core::external::arrow::array::ArrayRef;
@@ -271,7 +272,7 @@ fn visualizer_components(
                             ctx.recording(),
                             &data_result.entity_path,
                             component_name,
-                            current_value_row_id,
+                            current_value_row_id.map(Hash64::hash),
                             raw_current_value.as_ref(),
                         );
                         return;
@@ -428,7 +429,7 @@ fn editable_blueprint_component_list_item(
                     query_ctx.viewer_ctx.blueprint_db(),
                     blueprint_path,
                     component,
-                    row_id,
+                    row_id.map(Hash64::hash),
                     raw_override,
                     allow_multiline,
                 );

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -1,3 +1,4 @@
+use re_log_types::hash::Hash64;
 use re_types_core::{
     reflection::ArchetypeFieldReflection, Archetype, ArchetypeReflectionMarker, ComponentName,
 };
@@ -90,7 +91,9 @@ pub fn view_property_component_ui(
     fallback_provider: &dyn ComponentFallbackProvider,
 ) {
     let component_array = property.component_raw(field.component_name);
-    let row_id = property.component_row_id(field.component_name);
+    let cache_key = property
+        .component_row_id(field.component_name)
+        .map(Hash64::hash);
 
     let ui_types = ctx
         .viewer_ctx
@@ -104,7 +107,7 @@ pub fn view_property_component_ui(
             ctx.viewer_ctx.blueprint_db(),
             ctx.target_entity_path,
             field.component_name,
-            row_id,
+            cache_key,
             component_array.as_deref(),
             fallback_provider,
         );
@@ -117,7 +120,7 @@ pub fn view_property_component_ui(
             ctx.viewer_ctx.blueprint_db(),
             ctx.target_entity_path,
             field.component_name,
-            row_id,
+            cache_key,
             component_array.as_deref(),
             fallback_provider,
         );

--- a/crates/viewer/re_view_graph/src/ui/selection.rs
+++ b/crates/viewer/re_view_graph/src/ui/selection.rs
@@ -1,3 +1,4 @@
+use re_log_types::hash::Hash64;
 use re_types::{
     blueprint::components::Enabled, Archetype, ArchetypeReflectionMarker, Component as _,
 };
@@ -71,7 +72,7 @@ pub fn view_property_force_ui<A: Archetype + ArchetypeReflectionMarker>(
                 ctx.blueprint_db(),
                 query_ctx.target_entity_path,
                 field.component_name,
-                row_id,
+                row_id.map(Hash64::hash),
                 component_array.as_deref(),
                 fallback_provider,
             );

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) use pinhole::Pinhole;
 use re_viewer_context::{ImageDecodeCache, ViewerContext};
 
 use re_log_types::debug_assert_archetype_has_components;
+use re_log_types::hash::Hash64;
 use re_renderer::RenderContext;
 use re_types::{
     blueprint::components::BackgroundKind,
@@ -83,10 +84,9 @@ fn resolution_of_image_at(
             .latest_at_component::<MediaType>(entity_path, query)
             .map(|(_, c)| c);
 
-        let image = ctx
-            .store_context
-            .caches
-            .entry(|c: &mut ImageDecodeCache| c.entry(row_id, &blob, media_type.as_ref()));
+        let image = ctx.store_context.caches.entry(|c: &mut ImageDecodeCache| {
+            c.entry(Hash64::hash(row_id), &blob, media_type.as_ref())
+        });
 
         if let Ok(image) = image {
             return Some(Resolution::from([

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools as _;
 use re_chunk_store::RowId;
+use re_log_types::hash::Hash64;
 use re_renderer::{mesh::GpuMesh, RenderContext};
 use re_types::{components::MediaType, datatypes};
 use re_viewer_context::{gpu_bridge::texture_creation_desc_from_color_image, ImageInfo};
@@ -229,7 +230,7 @@ fn try_get_or_create_albedo_texture(
     re_tracing::profile_function!();
 
     let image_info = ImageInfo {
-        buffer_row_id: RowId::ZERO,            // unused
+        buffer_cache_key: Hash64::ZERO,        // unused
         buffer: albedo_texture_buffer.clone(), // shallow clone
         format: *albedo_texture_format,
         kind: re_types::image::ImageKind::Color,

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools as _;
-use re_chunk_store::RowId;
+
 use re_log_types::hash::Hash64;
 use re_renderer::{mesh::GpuMesh, RenderContext};
 use re_types::{components::MediaType, datatypes};

--- a/crates/viewer/re_view_spatial/src/visualizers/depth_images.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/depth_images.rs
@@ -1,6 +1,7 @@
 use nohash_hasher::IntMap;
 
 use re_entity_db::EntityPath;
+use re_log_types::hash::Hash64;
 use re_log_types::EntityPathHash;
 use re_renderer::renderer::{ColormappedTexture, DepthCloud, DepthClouds};
 use re_types::{
@@ -296,7 +297,7 @@ impl VisualizerSystem for DepthImageVisualizer {
 
                         Some(DepthImageComponentData {
                             image: ImageInfo {
-                                buffer_row_id: index.1,
+                                buffer_cache_key: Hash64::hash(index.1),
                                 buffer: buffer.clone().into(),
                                 format: first_copied(format.as_deref())?.0,
                                 kind: ImageKind::Depth,
@@ -377,7 +378,7 @@ impl TypedComponentFallbackProvider<ValueRange> for DepthImageVisualizer {
                 .latest_at_component::<ImageFormat>(ctx.target_entity_path, ctx.query)
             {
                 let image = ImageInfo {
-                    buffer_row_id,
+                    buffer_cache_key: Hash64::hash(buffer_row_id),
                     buffer: image_buffer.0,
                     format: format.0,
                     kind: ImageKind::Depth,

--- a/crates/viewer/re_view_spatial/src/visualizers/encoded_image.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/encoded_image.rs
@@ -1,3 +1,4 @@
+use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::EncodedImage,
     components::{Blob, DrawOrder, MediaType, Opacity},
@@ -160,7 +161,7 @@ impl EncodedImageVisualizer {
                 .store_context
                 .caches
                 .entry(|c: &mut ImageDecodeCache| {
-                    c.entry(tensor_data_row_id, blob, media_type.as_ref())
+                    c.entry(Hash64::hash(tensor_data_row_id), blob, media_type.as_ref())
                 });
 
             let image = match image {

--- a/crates/viewer/re_view_spatial/src/visualizers/images.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/images.rs
@@ -1,3 +1,4 @@
+use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::Image,
     components::{DrawOrder, ImageBuffer, ImageFormat, Opacity},
@@ -143,7 +144,7 @@ impl ImageVisualizer {
 
             Some(ImageComponentData {
                 image: ImageInfo {
-                    buffer_row_id: index.1,
+                    buffer_cache_key: Hash64::hash(index.1),
                     buffer: buffer.clone().into(),
                     format: first_copied(formats.as_deref())?.0,
                     kind: ImageKind::Color,

--- a/crates/viewer/re_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/segmentation_images.rs
@@ -1,3 +1,4 @@
+use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::SegmentationImage,
     components::{DrawOrder, ImageBuffer, ImageFormat, Opacity},
@@ -101,7 +102,7 @@ impl VisualizerSystem for SegmentationImageVisualizer {
                     let buffer = buffers.first()?;
                     Some(SegmentationImageComponentData {
                         image: ImageInfo {
-                            buffer_row_id: index.1,
+                            buffer_cache_key: Hash64::hash(index.1),
                             buffer: buffer.clone().into(),
                             format: first_copied(formats.as_deref())?.0,
                             kind: ImageKind::Segmentation,

--- a/crates/viewer/re_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/videos.rs
@@ -405,7 +405,7 @@ fn latest_at_query_video_from_datastore(
         let debug_name = entity_path.to_string();
         c.entry(
             debug_name,
-            blob_row_id,
+            Hash64::hash(blob_row_id),
             &blob,
             media_type.as_ref(),
             ctx.app_options().video_decoder_settings(),

--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -2,6 +2,7 @@ use egui::{epaint::TextShape, Align2, NumExt as _, Vec2};
 use ndarray::Axis;
 
 use re_data_ui::tensor_summary_ui_grid_contents;
+use re_log_types::hash::Hash64;
 use re_log_types::{EntityPath, ResolvedEntityPathFilter};
 use re_types::{
     blueprint::{
@@ -133,10 +134,9 @@ Set the displayed dimensions in a selection panel.",
                 ..
             }) = &state.tensor
             {
-                let tensor_stats = ctx
-                    .store_context
-                    .caches
-                    .entry(|c: &mut TensorStatsCache| c.entry(*tensor_row_id, tensor));
+                let tensor_stats = ctx.store_context.caches.entry(|c: &mut TensorStatsCache| {
+                    c.entry(Hash64::hash(*tensor_row_id), tensor)
+                });
 
                 tensor_summary_ui_grid_contents(ui, tensor, &tensor_stats);
             }

--- a/crates/viewer/re_view_tensor/src/visualizer_system.rs
+++ b/crates/viewer/re_view_tensor/src/visualizer_system.rs
@@ -1,4 +1,5 @@
 use re_chunk_store::{LatestAtQuery, RowId};
+use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::Tensor,
     components::{TensorData, ValueRange},
@@ -82,11 +83,9 @@ impl VisualizerSystem for TensorSystem {
                             .map(|range| ValueRange(range.into()))
                     })
                     .unwrap_or_else(|| {
-                        let tensor_stats = ctx
-                            .viewer_ctx
-                            .store_context
-                            .caches
-                            .entry(|c: &mut TensorStatsCache| c.entry(tensor_row_id, tensor));
+                        let tensor_stats = ctx.viewer_ctx.store_context.caches.entry(
+                            |c: &mut TensorStatsCache| c.entry(Hash64::hash(tensor_row_id), tensor),
+                        );
                         tensor_data_range_heuristic(&tensor_stats, tensor.dtype())
                     });
 
@@ -149,7 +148,7 @@ impl TypedComponentFallbackProvider<re_types::components::ValueRange> for Tensor
                 .viewer_ctx
                 .store_context
                 .caches
-                .entry(|c: &mut TensorStatsCache| c.entry(row_id, &tensor));
+                .entry(|c: &mut TensorStatsCache| c.entry(Hash64::hash(row_id), &tensor));
             tensor_data_range_heuristic(&tensor_stats, tensor.dtype())
         } else {
             ValueRange::new(0.0, 1.0)

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -9,6 +9,7 @@ use re_types::{
     image::{ImageKind, ImageLoadError},
     Component as _,
 };
+use wgpu::naga::FastHashMap;
 
 use crate::{Cache, ImageInfo};
 
@@ -26,7 +27,7 @@ struct DecodedImageResult {
 /// Caches the results of decoding [`re_types::archetypes::EncodedImage`].
 #[derive(Default)]
 pub struct ImageDecodeCache {
-    cache: HashMap<RowId, HashMap<Hash64, DecodedImageResult>>,
+    cache: HashMap<Hash64, HashMap<Hash64, DecodedImageResult>>,
     memory_used: u64,
     generation: u64,
 }
@@ -35,12 +36,12 @@ pub struct ImageDecodeCache {
 impl ImageDecodeCache {
     /// Decode some image data and cache the result.
     ///
-    /// The `row_id` should be the `RowId` of the blob.
+    /// The `RowId`, if available, may be used to generate the cache key.
     /// NOTE: images are never batched atm (they are mono-archetypes),
     /// so we don't need the instance id here.
     pub fn entry(
         &mut self,
-        blob_row_id: RowId,
+        blob_cache_key: Hash64,
         image_bytes: &[u8],
         media_type: Option<&MediaType>,
     ) -> Result<ImageInfo, ImageLoadError> {
@@ -60,11 +61,11 @@ impl ImageDecodeCache {
 
         let lookup = self
             .cache
-            .entry(blob_row_id)
+            .entry(blob_cache_key)
             .or_default()
             .entry(inner_key)
             .or_insert_with(|| {
-                let result = decode_image(blob_row_id, image_bytes, media_type.as_str());
+                let result = decode_image(blob_cache_key, image_bytes, media_type.as_str());
                 let memory_used = result.as_ref().map_or(0, |image| image.buffer.len() as u64);
                 self.memory_used += memory_used;
                 DecodedImageResult {
@@ -79,7 +80,7 @@ impl ImageDecodeCache {
 }
 
 fn decode_image(
-    blob_row_id: RowId,
+    blob_cache_key: Hash64,
     image_bytes: &[u8],
     media_type: &str,
 ) -> Result<ImageInfo, ImageLoadError> {
@@ -98,7 +99,7 @@ fn decode_image(
     let (buffer, format) = ImageBuffer::from_dynamic_image(dynamic_image)?;
 
     Ok(ImageInfo {
-        buffer_row_id: blob_row_id,
+        buffer_cache_key: blob_cache_key,
         buffer: buffer.0,
         format: format.0,
         kind: ImageKind::Color,
@@ -130,7 +131,7 @@ impl Cache for ImageDecodeCache {
 
         let before = self.memory_used;
 
-        self.cache.retain(|_row_id, per_key| {
+        self.cache.retain(|_cache_key, per_key| {
             per_key.retain(|_, ci| {
                 let retain = ci.last_use_generation == self.generation;
                 if !retain {
@@ -152,7 +153,7 @@ impl Cache for ImageDecodeCache {
     fn on_store_events(&mut self, events: &[ChunkStoreEvent]) {
         re_tracing::profile_function!();
 
-        let row_ids_removed: HashSet<RowId> = events
+        let cache_key_removed: HashSet<Hash64> = events
             .iter()
             .flat_map(|event| {
                 let is_deletion = || event.kind == re_chunk_store::ChunkStoreDiffKind::Deletion;
@@ -164,7 +165,7 @@ impl Cache for ImageDecodeCache {
                 };
 
                 if is_deletion() && contains_image_blob() {
-                    Either::Left(event.chunk.row_ids())
+                    Either::Left(event.chunk.row_ids().map(Hash64::hash))
                 } else {
                     Either::Right(std::iter::empty())
                 }
@@ -172,7 +173,7 @@ impl Cache for ImageDecodeCache {
             .collect();
 
         self.cache
-            .retain(|row_id, _per_key| !row_ids_removed.contains(row_id));
+            .retain(|cache_key, _per_key| !cache_key_removed.contains(cache_key));
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -1,7 +1,6 @@
 use ahash::{HashMap, HashSet};
-
 use itertools::Either;
-use re_chunk::RowId;
+
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_types::{
@@ -9,7 +8,6 @@ use re_types::{
     image::{ImageKind, ImageLoadError},
     Component as _,
 };
-use wgpu::naga::FastHashMap;
 
 use crate::{Cache, ImageInfo};
 

--- a/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
@@ -8,16 +8,16 @@ use re_types::Component as _;
 
 use crate::{Cache, ImageInfo, ImageStats};
 
-// Caches image stats using a [`RowId`]
+// Caches image stats (use e.g. `RowId` to generate cache key).
 #[derive(Default)]
-pub struct ImageStatsCache(HashMap<RowId, HashMap<Hash64, ImageStats>>);
+pub struct ImageStatsCache(HashMap<Hash64, HashMap<Hash64, ImageStats>>);
 
 impl ImageStatsCache {
     pub fn entry(&mut self, image: &ImageInfo) -> ImageStats {
         let inner_key = Hash64::hash(image.format);
         *self
             .0
-            .entry(image.buffer_row_id)
+            .entry(image.buffer_cache_key)
             .or_default()
             .entry(inner_key)
             .or_insert_with(|| ImageStats::from_image(image))
@@ -32,7 +32,7 @@ impl Cache for ImageStatsCache {
     fn on_store_events(&mut self, events: &[ChunkStoreEvent]) {
         re_tracing::profile_function!();
 
-        let row_ids_removed: HashSet<RowId> = events
+        let cache_key_removed: HashSet<Hash64> = events
             .iter()
             .flat_map(|event| {
                 let is_deletion = || event.kind == re_chunk_store::ChunkStoreDiffKind::Deletion;
@@ -44,7 +44,7 @@ impl Cache for ImageStatsCache {
                 };
 
                 if is_deletion() && contains_image_blob() {
-                    Either::Left(event.chunk.row_ids())
+                    Either::Left(event.chunk.row_ids().map(Hash64::hash))
                 } else {
                     Either::Right(std::iter::empty())
                 }
@@ -52,7 +52,7 @@ impl Cache for ImageStatsCache {
             .collect();
 
         self.0
-            .retain(|row_id, _per_key| !row_ids_removed.contains(row_id));
+            .retain(|cache_key, _per_key| !cache_key_removed.contains(cache_key));
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {

--- a/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
@@ -1,7 +1,6 @@
 use ahash::{HashMap, HashSet};
 use itertools::Either;
 
-use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_types::Component as _;

--- a/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
@@ -1,7 +1,6 @@
 use ahash::{HashMap, HashSet};
 use itertools::Either;
 
-use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_types::{datatypes::TensorData, Component as _};

--- a/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
@@ -7,8 +7,9 @@ use re_types::{datatypes::TensorData, Component as _};
 
 use crate::{Cache, TensorStats};
 
-/// Caches tensor stats using a [`RowId`], i.e. a specific instance of
-/// a `TensorData` component
+/// Caches tensor stats.
+///
+/// Use [`re_types_core::RowId`] as cache key when available.
 #[derive(Default)]
 pub struct TensorStatsCache(HashMap<Hash64, TensorStats>);
 

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -6,7 +6,6 @@ use std::sync::{
 use ahash::{HashMap, HashSet};
 use itertools::Either;
 
-use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_renderer::{external::re_video::VideoLoadError, video::Video};

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -26,18 +26,18 @@ struct Entry {
 
 /// Caches meshes based on media type & row id.
 #[derive(Default)]
-pub struct VideoCache(HashMap<RowId, HashMap<Hash64, Entry>>);
+pub struct VideoCache(HashMap<Hash64, HashMap<Hash64, Entry>>);
 
 impl VideoCache {
     /// Read in some video data and cache the result.
     ///
-    /// The `row_id` should be the `RowId` of the blob.
+    /// You may use the `RowId` as cache key if any.
     /// NOTE: videos are never batched atm (they are mono-archetypes),
     /// so we don't need the instance id here.
     pub fn entry(
         &mut self,
         debug_name: String,
-        blob_row_id: RowId,
+        blob_cache_key: Hash64,
         video_data: &re_types::datatypes::Blob,
         media_type: Option<&MediaType>,
         decode_settings: DecodeSettings,
@@ -58,7 +58,7 @@ impl VideoCache {
 
         let entry = self
             .0
-            .entry(blob_row_id)
+            .entry(blob_cache_key)
             .or_default()
             .entry(inner_key)
             .or_insert_with(|| {
@@ -110,7 +110,7 @@ impl Cache for VideoCache {
     fn on_store_events(&mut self, events: &[ChunkStoreEvent]) {
         re_tracing::profile_function!();
 
-        let row_ids_removed: HashSet<RowId> = events
+        let cache_key_removed: HashSet<Hash64> = events
             .iter()
             .flat_map(|event| {
                 let is_deletion = || event.kind == re_chunk_store::ChunkStoreDiffKind::Deletion;
@@ -122,7 +122,7 @@ impl Cache for VideoCache {
                 };
 
                 if is_deletion() && contains_video_blob() {
-                    Either::Left(event.chunk.row_ids())
+                    Either::Left(event.chunk.row_ids().map(Hash64::hash))
                 } else {
                     Either::Right(std::iter::empty())
                 }
@@ -130,7 +130,7 @@ impl Cache for VideoCache {
             .collect();
 
         self.0
-            .retain(|row_id, _per_key| !row_ids_removed.contains(row_id));
+            .retain(|cache_key, _per_key| !cache_key_removed.contains(cache_key));
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {

--- a/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeMap;
 
-use re_chunk::{RowId, UnitChunkShared};
+use re_chunk::UnitChunkShared;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::{EntityDb, EntityPath};
 use re_log::ResultExt as _;
+use re_log_types::hash::Hash64;
 use re_log_types::Instance;
 use re_types::ComponentName;
 use re_ui::{UiExt as _, UiLayout};
@@ -33,7 +34,7 @@ type LegacyDisplayComponentUiCallback = Box<
             &LatestAtQuery,
             &EntityDb,
             &EntityPath,
-            Option<RowId>,
+            Option<Hash64>,
             &dyn arrow::array::Array,
         ) + Send
         + Sync,
@@ -283,7 +284,7 @@ impl ComponentUiRegistry {
             db,
             entity_path,
             component_name,
-            unit.row_id(),
+            unit.row_id().map(Hash64::hash),
             component_raw.as_ref(),
         );
     }
@@ -299,7 +300,7 @@ impl ComponentUiRegistry {
         db: &EntityDb,
         entity_path: &EntityPath,
         component_name: ComponentName,
-        row_id: Option<RowId>,
+        cache_key: Option<Hash64>,
         component_raw: &dyn arrow::array::Array,
     ) {
         re_tracing::profile_function!(component_name.full_name());
@@ -312,7 +313,7 @@ impl ComponentUiRegistry {
                 query,
                 db,
                 entity_path,
-                row_id,
+                cache_key,
                 component_raw,
             );
             return;
@@ -327,7 +328,7 @@ impl ComponentUiRegistry {
                 query,
                 db,
                 entity_path,
-                row_id,
+                cache_key,
                 component_raw,
             );
             return;
@@ -354,7 +355,7 @@ impl ComponentUiRegistry {
             query,
             db,
             entity_path,
-            row_id,
+            cache_key,
             component_raw,
         );
     }
@@ -372,7 +373,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
-        row_id: Option<RowId>,
+        cache_key: Option<Hash64>,
         component_array: Option<&dyn arrow::array::Array>,
         fallback_provider: &dyn ComponentFallbackProvider,
     ) {
@@ -383,7 +384,7 @@ impl ComponentUiRegistry {
             origin_db,
             blueprint_write_path,
             component_name,
-            row_id,
+            cache_key,
             component_array,
             fallback_provider,
             multiline,
@@ -403,7 +404,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
-        row_id: Option<RowId>,
+        cache_key: Option<Hash64>,
         component_query_result: Option<&dyn arrow::array::Array>,
         fallback_provider: &dyn ComponentFallbackProvider,
     ) {
@@ -414,7 +415,7 @@ impl ComponentUiRegistry {
             origin_db,
             blueprint_write_path,
             component_name,
-            row_id,
+            cache_key,
             component_query_result,
             fallback_provider,
             multiline,
@@ -429,7 +430,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
-        row_id: Option<RowId>,
+        cache_key: Option<Hash64>,
         component_array: Option<&dyn arrow::array::Array>,
         fallback_provider: &dyn ComponentFallbackProvider,
         allow_multiline: bool,
@@ -443,7 +444,7 @@ impl ComponentUiRegistry {
                 origin_db,
                 blueprint_write_path,
                 component_name,
-                row_id,
+                cache_key,
                 array,
                 allow_multiline,
             );
@@ -466,7 +467,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
-        row_id: Option<RowId>,
+        cache_key: Option<Hash64>,
         component_raw: &dyn arrow::array::Array,
         allow_multiline: bool,
     ) {
@@ -487,7 +488,7 @@ impl ComponentUiRegistry {
                 origin_db,
                 ctx.target_entity_path,
                 component_name,
-                row_id,
+                cache_key,
                 component_raw,
             );
         }

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
@@ -34,14 +34,14 @@ use super::get_or_create_texture;
 fn generate_texture_key(image: &ImageInfo) -> u64 {
     // We need to inclde anything that, if changes, should result in a new texture being uploaded.
     let ImageInfo {
-        buffer_row_id: blob_row_id,
+        buffer_cache_key,
         buffer: _, // we hash `blob_row_id` instead; much faster!
 
         format,
         kind,
     } = image;
 
-    hash((blob_row_id, format, kind))
+    hash((buffer_cache_key, format, kind))
 }
 
 /// `colormap` is currently only used for depth images.

--- a/crates/viewer/re_viewer_context/src/image_info.rs
+++ b/crates/viewer/re_viewer_context/src/image_info.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, ops::RangeInclusive};
 
-use re_chunk::RowId;
 use re_log_types::hash::Hash64;
 use re_types::{
     components::Colormap,
@@ -390,7 +389,6 @@ fn get<T: bytemuck::Pod>(blob: &[u8], element_offset: usize) -> Option<T> {
 
 #[cfg(test)]
 mod tests {
-    use re_chunk::RowId;
     use re_log_types::hash::Hash64;
     use re_types::{datatypes::ColorModel, image::ImageChannelType};
 

--- a/crates/viewer/re_viewer_context/src/image_info.rs
+++ b/crates/viewer/re_viewer_context/src/image_info.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, ops::RangeInclusive};
 
 use re_chunk::RowId;
+use re_log_types::hash::Hash64;
 use re_types::{
     components::Colormap,
     datatypes::{Blob, ChannelDatatype, ColorModel, ImageFormat},
@@ -41,7 +42,7 @@ pub struct ImageInfo {
     /// The row id that contained the blob.
     ///
     /// Can be used instead of hashing [`Self::buffer`].
-    pub buffer_row_id: RowId,
+    pub buffer_cache_key: Hash64,
 
     /// The image data, row-wise, with stride=width.
     pub buffer: Blob,
@@ -390,6 +391,7 @@ fn get<T: bytemuck::Pod>(blob: &[u8], element_offset: usize) -> Option<T> {
 #[cfg(test)]
 mod tests {
     use re_chunk::RowId;
+    use re_log_types::hash::Hash64;
     use re_types::{datatypes::ColorModel, image::ImageChannelType};
 
     use super::ImageInfo;
@@ -400,7 +402,7 @@ mod tests {
     ) -> ImageInfo {
         assert_eq!(elements.len(), 2 * 2);
         ImageInfo {
-            buffer_row_id: RowId::ZERO, // unused
+            buffer_cache_key: Hash64::ZERO, // unused
             buffer: re_types::datatypes::Blob(bytemuck::cast_slice::<_, u8>(elements).into()),
             format: re_types::datatypes::ImageFormat::from_color_model(
                 [2, 2],


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/9514

### What

So far, `EntityDataUi` was taking a `row_id: Option<RowId>` argument, without making it explicit that it is actually used as a cache key. This caused two issue:
- implicit / unclear purpose of that arg
- wrong type if you happen to need to use another type of cache key

This PR migrates this, and all related apis and caches, to using `Hash64` instead.