### PR TITLE
Include field names in Archetype docs

### DIFF
--- a/crates/build/re_types_builder/src/objects.rs
+++ b/crates/build/re_types_builder/src/objects.rs
@@ -1109,11 +1109,25 @@ impl ObjectField {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FieldKind {
     Required,
     Recommended,
     Optional,
+}
+
+impl FieldKind {
+    pub const ALL: [Self; 3] = [Self::Required, Self::Recommended, Self::Optional];
+}
+
+impl std::fmt::Display for FieldKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Required => "Required".fmt(f),
+            Self::Recommended => "Recommended".fmt(f),
+            Self::Optional => "Optional".fmt(f),
+        }
+    }
 }
 
 /// The underlying type of an [`ObjectField`].

--- a/docs/content/reference/types/archetypes/annotation_context.md
+++ b/docs/content/reference/types/archetypes/annotation_context.md
@@ -14,11 +14,12 @@ path.
 
 See also [`datatypes.ClassDescription`](https://rerun.io/docs/reference/types/datatypes/class_description).
 
-## Components
+## Fields
+### Required
+* `context`: [`AnnotationContext`](../components/annotation_context.md)
 
-**Required**: [`AnnotationContext`](../components/annotation_context.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/arrows2d.md
+++ b/docs/content/reference/types/archetypes/arrows2d.md
@@ -5,15 +5,23 @@ title: "Arrows2D"
 
 2D arrows with optional colors, radii, labels, etc.
 
-## Components
+## Fields
+### Required
+* `vectors`: [`Vector2D`](../components/vector2d.md)
 
-**Required**: [`Vector2D`](../components/vector2d.md)
+### Recommended
+* `origins`: [`Position2D`](../components/position2d.md)
 
-**Recommended**: [`Position2D`](../components/position2d.md)
+### Optional
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/arrows3d.md
+++ b/docs/content/reference/types/archetypes/arrows3d.md
@@ -5,15 +5,22 @@ title: "Arrows3D"
 
 3D arrows with optional colors, radii, labels, etc.
 
-## Components
+## Fields
+### Required
+* `vectors`: [`Vector3D`](../components/vector3d.md)
 
-**Required**: [`Vector3D`](../components/vector3d.md)
+### Recommended
+* `origins`: [`Position3D`](../components/position3d.md)
 
-**Recommended**: [`Position3D`](../components/position3d.md)
+### Optional
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/asset3d.md
+++ b/docs/content/reference/types/archetypes/asset3d.md
@@ -10,15 +10,18 @@ See also [`archetypes.Mesh3D`](https://rerun.io/docs/reference/types/archetypes/
 If there are multiple [`archetypes.InstancePoses3D`](https://rerun.io/docs/reference/types/archetypes/instance_poses3d) instances logged to the same entity as a mesh,
 an instance of the mesh will be drawn for each transform.
 
-## Components
+## Fields
+### Required
+* `blob`: [`Blob`](../components/blob.md)
 
-**Required**: [`Blob`](../components/blob.md)
+### Recommended
+* `media_type`: [`MediaType`](../components/media_type.md)
 
-**Recommended**: [`MediaType`](../components/media_type.md)
+### Optional
+* `albedo_factor`: [`AlbedoFactor`](../components/albedo_factor.md)
 
-**Optional**: [`AlbedoFactor`](../components/albedo_factor.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/asset_video.md
+++ b/docs/content/reference/types/archetypes/asset_video.md
@@ -12,13 +12,15 @@ See <https://rerun.io/docs/reference/video> for details of what is and isn't sup
 
 In order to display a video, you also need to log a [`archetypes.VideoFrameReference`](https://rerun.io/docs/reference/types/archetypes/video_frame_reference) for each frame.
 
-## Components
+## Fields
+### Required
+* `blob`: [`Blob`](../components/blob.md)
 
-**Required**: [`Blob`](../components/blob.md)
+### Recommended
+* `media_type`: [`MediaType`](../components/media_type.md)
 
-**Recommended**: [`MediaType`](../components/media_type.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -7,13 +7,15 @@ A bar chart.
 
 The x values will be the indices of the array, and the bar heights will be the provided values.
 
-## Components
+## Fields
+### Required
+* `values`: [`TensorData`](../components/tensor_data.md)
 
-**Required**: [`TensorData`](../components/tensor_data.md)
+### Optional
+* `color`: [`Color`](../components/color.md)
 
-**Optional**: [`Color`](../components/color.md)
 
-## Shown in
+## Can be shown in
 * [BarChartView](../views/bar_chart_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/boxes2d.md
+++ b/docs/content/reference/types/archetypes/boxes2d.md
@@ -5,15 +5,23 @@ title: "Boxes2D"
 
 2D boxes with half-extents and optional center, colors etc.
 
-## Components
+## Fields
+### Required
+* `half_sizes`: [`HalfSize2D`](../components/half_size2d.md)
 
-**Required**: [`HalfSize2D`](../components/half_size2d.md)
+### Recommended
+* `centers`: [`Position2D`](../components/position2d.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`Position2D`](../components/position2d.md), [`Color`](../components/color.md)
+### Optional
+* `radii`: [`Radius`](../components/radius.md)
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -9,15 +9,25 @@ Note that orienting and placing the box is handled via `[archetypes.InstancePose
 Some of its component are repeated here for convenience.
 If there's more instance poses than half sizes, the last half size will be repeated for the remaining poses.
 
-## Components
+## Fields
+### Required
+* `half_sizes`: [`HalfSize3D`](../components/half_size3d.md)
 
-**Required**: [`HalfSize3D`](../components/half_size3d.md)
+### Recommended
+* `centers`: [`PoseTranslation3D`](../components/pose_translation3d.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`PoseTranslation3D`](../components/pose_translation3d.md), [`Color`](../components/color.md)
+### Optional
+* `rotation_axis_angles`: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md)
+* `quaternions`: [`PoseRotationQuat`](../components/pose_rotation_quat.md)
+* `radii`: [`Radius`](../components/radius.md)
+* `fill_mode`: [`FillMode`](../components/fill_mode.md)
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md), [`PoseRotationQuat`](../components/pose_rotation_quat.md), [`Radius`](../components/radius.md), [`FillMode`](../components/fill_mode.md), [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/capsules3d.md
+++ b/docs/content/reference/types/archetypes/capsules3d.md
@@ -10,15 +10,24 @@ at (0, 0, 0) and (0, 0, length), that is, extending along the positive direction
 Capsules in other orientations may be produced by applying a rotation to the entity or
 instances.
 
-## Components
+## Fields
+### Required
+* `lengths`: [`Length`](../components/length.md)
+* `radii`: [`Radius`](../components/radius.md)
 
-**Required**: [`Length`](../components/length.md), [`Radius`](../components/radius.md)
+### Recommended
+* `translations`: [`PoseTranslation3D`](../components/pose_translation3d.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`PoseTranslation3D`](../components/pose_translation3d.md), [`Color`](../components/color.md)
+### Optional
+* `rotation_axis_angles`: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md)
+* `quaternions`: [`PoseRotationQuat`](../components/pose_rotation_quat.md)
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md), [`PoseRotationQuat`](../components/pose_rotation_quat.md), [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -15,11 +15,12 @@ Meaning that in practice clears are ineffective when making use of visible time 
 Scalar plots are an exception: they track clears and use them to represent holes in the
 data (i.e. discontinuous lines).
 
-## Components
+## Fields
+### Required
+* `is_recursive`: [`ClearIsRecursive`](../components/clear_is_recursive.md)
 
-**Required**: [`ClearIsRecursive`](../components/clear_is_recursive.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md)
 * [TimeSeriesView](../views/time_series_view.md)

--- a/docs/content/reference/types/archetypes/depth_image.md
+++ b/docs/content/reference/types/archetypes/depth_image.md
@@ -7,13 +7,20 @@ A depth image, i.e. as captured by a depth camera.
 
 Each pixel corresponds to a depth value in units specified by [`components.DepthMeter`](https://rerun.io/docs/reference/types/components/depth_meter).
 
-## Components
+## Fields
+### Required
+* `buffer`: [`ImageBuffer`](../components/image_buffer.md)
+* `format`: [`ImageFormat`](../components/image_format.md)
 
-**Required**: [`ImageBuffer`](../components/image_buffer.md), [`ImageFormat`](../components/image_format.md)
+### Optional
+* `meter`: [`DepthMeter`](../components/depth_meter.md)
+* `colormap`: [`Colormap`](../components/colormap.md)
+* `depth_range`: [`ValueRange`](../components/value_range.md)
+* `point_fill_ratio`: [`FillRatio`](../components/fill_ratio.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
 
-**Optional**: [`DepthMeter`](../components/depth_meter.md), [`Colormap`](../components/colormap.md), [`ValueRange`](../components/value_range.md), [`FillRatio`](../components/fill_ratio.md), [`DrawOrder`](../components/draw_order.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/ellipsoids3d.md
+++ b/docs/content/reference/types/archetypes/ellipsoids3d.md
@@ -13,15 +13,25 @@ Note that orienting and placing the ellipsoids/spheres is handled via `[archetyp
 Some of its component are repeated here for convenience.
 If there's more instance poses than half sizes, the last half size will be repeated for the remaining poses.
 
-## Components
+## Fields
+### Required
+* `half_sizes`: [`HalfSize3D`](../components/half_size3d.md)
 
-**Required**: [`HalfSize3D`](../components/half_size3d.md)
+### Recommended
+* `centers`: [`PoseTranslation3D`](../components/pose_translation3d.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`PoseTranslation3D`](../components/pose_translation3d.md), [`Color`](../components/color.md)
+### Optional
+* `rotation_axis_angles`: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md)
+* `quaternions`: [`PoseRotationQuat`](../components/pose_rotation_quat.md)
+* `line_radii`: [`Radius`](../components/radius.md)
+* `fill_mode`: [`FillMode`](../components/fill_mode.md)
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md), [`PoseRotationQuat`](../components/pose_rotation_quat.md), [`Radius`](../components/radius.md), [`FillMode`](../components/fill_mode.md), [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/encoded_image.md
+++ b/docs/content/reference/types/archetypes/encoded_image.md
@@ -8,15 +8,19 @@ An image encoded as e.g. a JPEG or PNG.
 Rerun also supports uncompressed images with the [`archetypes.Image`](https://rerun.io/docs/reference/types/archetypes/image).
 For images that refer to video frames see [`archetypes.VideoFrameReference`](https://rerun.io/docs/reference/types/archetypes/video_frame_reference).
 
-## Components
+## Fields
+### Required
+* `blob`: [`Blob`](../components/blob.md)
 
-**Required**: [`Blob`](../components/blob.md)
+### Recommended
+* `media_type`: [`MediaType`](../components/media_type.md)
 
-**Recommended**: [`MediaType`](../components/media_type.md)
+### Optional
+* `opacity`: [`Opacity`](../components/opacity.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
 
-**Optional**: [`Opacity`](../components/opacity.md), [`DrawOrder`](../components/draw_order.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/geo_line_strings.md
+++ b/docs/content/reference/types/archetypes/geo_line_strings.md
@@ -7,13 +7,16 @@ Geospatial line strings with positions expressed in [EPSG:4326](https://epsg.io/
 
 Also known as "line strips" or "polylines".
 
-## Components
+## Fields
+### Required
+* `line_strings`: [`GeoLineString`](../components/geo_line_string.md)
 
-**Required**: [`GeoLineString`](../components/geo_line_string.md)
+### Recommended
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
 
-## Shown in
+## Can be shown in
 * [MapView](../views/map_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/geo_points.md
+++ b/docs/content/reference/types/archetypes/geo_points.md
@@ -5,15 +5,19 @@ title: "GeoPoints"
 
 Geospatial points with positions expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees), and optional colors and radii.
 
-## Components
+## Fields
+### Required
+* `positions`: [`LatLon`](../components/lat_lon.md)
 
-**Required**: [`LatLon`](../components/lat_lon.md)
+### Recommended
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
+### Optional
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [MapView](../views/map_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/graph_edges.md
+++ b/docs/content/reference/types/archetypes/graph_edges.md
@@ -7,13 +7,15 @@ A list of edges in a graph.
 
 By default, edges are undirected.
 
-## Components
+## Fields
+### Required
+* `edges`: [`GraphEdge`](../components/graph_edge.md)
 
-**Required**: [`GraphEdge`](../components/graph_edge.md)
+### Recommended
+* `graph_type`: [`GraphType`](../components/graph_type.md)
 
-**Recommended**: [`GraphType`](../components/graph_type.md)
 
-## Shown in
+## Can be shown in
 * [GraphView](../views/graph_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/graph_nodes.md
+++ b/docs/content/reference/types/archetypes/graph_nodes.md
@@ -5,13 +5,19 @@ title: "GraphNodes"
 
 A list of nodes in a graph with optional labels, colors, etc.
 
-## Components
+## Fields
+### Required
+* `node_ids`: [`GraphNode`](../components/graph_node.md)
 
-**Required**: [`GraphNode`](../components/graph_node.md)
+### Optional
+* `positions`: [`Position2D`](../components/position2d.md)
+* `colors`: [`Color`](../components/color.md)
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `radii`: [`Radius`](../components/radius.md)
 
-**Optional**: [`Position2D`](../components/position2d.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`Radius`](../components/radius.md)
 
-## Shown in
+## Can be shown in
 * [GraphView](../views/graph_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -18,13 +18,17 @@ and the pixel format (e.g. RGB, RGBA, …).
 The order of dimensions in the underlying [`components.Blob`](https://rerun.io/docs/reference/types/components/blob) follows the typical
 row-major, interleaved-pixel image format.
 
-## Components
+## Fields
+### Required
+* `buffer`: [`ImageBuffer`](../components/image_buffer.md)
+* `format`: [`ImageFormat`](../components/image_format.md)
 
-**Required**: [`ImageBuffer`](../components/image_buffer.md), [`ImageFormat`](../components/image_format.md)
+### Optional
+* `opacity`: [`Opacity`](../components/opacity.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
 
-**Optional**: [`Opacity`](../components/opacity.md), [`DrawOrder`](../components/draw_order.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/instance_poses3d.md
+++ b/docs/content/reference/types/archetypes/instance_poses3d.md
@@ -18,11 +18,16 @@ Check archetype documentations for details - if not otherwise specified, only th
 Some visualizers like the mesh visualizer used for [`archetypes.Mesh3D`](https://rerun.io/docs/reference/types/archetypes/mesh3d),
 will draw an object for every pose, a behavior also known as "instancing".
 
-## Components
+## Fields
+### Optional
+* `translations`: [`PoseTranslation3D`](../components/pose_translation3d.md)
+* `rotation_axis_angles`: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md)
+* `quaternions`: [`PoseRotationQuat`](../components/pose_rotation_quat.md)
+* `scales`: [`PoseScale3D`](../components/pose_scale3d.md)
+* `mat3x3`: [`PoseTransformMat3x3`](../components/pose_transform_mat3x3.md)
 
-**Optional**: [`PoseTranslation3D`](../components/pose_translation3d.md), [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md), [`PoseRotationQuat`](../components/pose_rotation_quat.md), [`PoseScale3D`](../components/pose_scale3d.md), [`PoseTransformMat3x3`](../components/pose_transform_mat3x3.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/line_strips2d.md
+++ b/docs/content/reference/types/archetypes/line_strips2d.md
@@ -5,15 +5,22 @@ title: "LineStrips2D"
 
 2D line strips with positions and optional colors, radii, labels, etc.
 
-## Components
+## Fields
+### Required
+* `strips`: [`LineStrip2D`](../components/line_strip2d.md)
 
-**Required**: [`LineStrip2D`](../components/line_strip2d.md)
+### Recommended
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
+### Optional
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/line_strips3d.md
+++ b/docs/content/reference/types/archetypes/line_strips3d.md
@@ -5,15 +5,21 @@ title: "LineStrips3D"
 
 3D line strips with positions and optional colors, radii, labels, etc.
 
-## Components
+## Fields
+### Required
+* `strips`: [`LineStrip3D`](../components/line_strip3d.md)
 
-**Required**: [`LineStrip3D`](../components/line_strip3d.md)
+### Recommended
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
+### Optional
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -10,15 +10,24 @@ See also [`archetypes.Asset3D`](https://rerun.io/docs/reference/types/archetypes
 If there are multiple [`archetypes.InstancePoses3D`](https://rerun.io/docs/reference/types/archetypes/instance_poses3d) instances logged to the same entity as a mesh,
 an instance of the mesh will be drawn for each transform.
 
-## Components
+## Fields
+### Required
+* `vertex_positions`: [`Position3D`](../components/position3d.md)
 
-**Required**: [`Position3D`](../components/position3d.md)
+### Recommended
+* `triangle_indices`: [`TriangleIndices`](../components/triangle_indices.md)
+* `vertex_normals`: [`Vector3D`](../components/vector3d.md)
 
-**Recommended**: [`TriangleIndices`](../components/triangle_indices.md), [`Vector3D`](../components/vector3d.md)
+### Optional
+* `vertex_colors`: [`Color`](../components/color.md)
+* `vertex_texcoords`: [`Texcoord2D`](../components/texcoord2d.md)
+* `albedo_factor`: [`AlbedoFactor`](../components/albedo_factor.md)
+* `albedo_texture_buffer`: [`ImageBuffer`](../components/image_buffer.md)
+* `albedo_texture_format`: [`ImageFormat`](../components/image_format.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
 
-**Optional**: [`Color`](../components/color.md), [`Texcoord2D`](../components/texcoord2d.md), [`AlbedoFactor`](../components/albedo_factor.md), [`ImageBuffer`](../components/image_buffer.md), [`ImageFormat`](../components/image_format.md), [`ClassId`](../components/class_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/pinhole.md
+++ b/docs/content/reference/types/archetypes/pinhole.md
@@ -6,15 +6,19 @@ title: "Pinhole"
 ⚠️ **This type is _unstable_ and may change significantly in a way that the data won't be backwards compatible.**
 Camera perspective projection (a.k.a. intrinsics).
 
-## Components
+## Fields
+### Required
+* `image_from_camera`: [`PinholeProjection`](../components/pinhole_projection.md)
 
-**Required**: [`PinholeProjection`](../components/pinhole_projection.md)
+### Recommended
+* `resolution`: [`Resolution`](../components/resolution.md)
 
-**Recommended**: [`Resolution`](../components/resolution.md)
+### Optional
+* `camera_xyz`: [`ViewCoordinates`](../components/view_coordinates.md)
+* `image_plane_distance`: [`ImagePlaneDistance`](../components/image_plane_distance.md)
 
-**Optional**: [`ViewCoordinates`](../components/view_coordinates.md), [`ImagePlaneDistance`](../components/image_plane_distance.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -5,15 +5,23 @@ title: "Points2D"
 
 A 2D point cloud with positions and optional colors, radii, labels, etc.
 
-## Components
+## Fields
+### Required
+* `positions`: [`Position2D`](../components/position2d.md)
 
-**Required**: [`Position2D`](../components/position2d.md)
+### Recommended
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
+### Optional
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
+* `keypoint_ids`: [`KeypointId`](../components/keypoint_id.md)
 
-**Optional**: [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -5,15 +5,22 @@ title: "Points3D"
 
 A 3D point cloud with positions and optional colors, radii, labels, etc.
 
-## Components
+## Fields
+### Required
+* `positions`: [`Position3D`](../components/position3d.md)
 
-**Required**: [`Position3D`](../components/position3d.md)
+### Recommended
+* `radii`: [`Radius`](../components/radius.md)
+* `colors`: [`Color`](../components/color.md)
 
-**Recommended**: [`Radius`](../components/radius.md), [`Color`](../components/color.md)
+### Optional
+* `labels`: [`Text`](../components/text.md)
+* `show_labels`: [`ShowLabels`](../components/show_labels.md)
+* `class_ids`: [`ClassId`](../components/class_id.md)
+* `keypoint_ids`: [`KeypointId`](../components/keypoint_id.md)
 
-**Optional**: [`Text`](../components/text.md), [`ShowLabels`](../components/show_labels.md), [`ClassId`](../components/class_id.md), [`KeypointId`](../components/keypoint_id.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/recording_properties.md
+++ b/docs/content/reference/types/archetypes/recording_properties.md
@@ -5,11 +5,13 @@ title: "RecordingProperties"
 
 A list of properties associated with a recording.
 
-## Components
+## Fields
+### Optional
+* `start_time`: [`Timestamp`](../components/timestamp.md)
+* `name`: [`Name`](../components/name.md)
 
-**Optional**: [`Timestamp`](../components/timestamp.md), [`Name`](../components/name.md)
 
-## Shown in
+## Can be shown in
 * [DataframeView](../views/dataframe_view.md)
 
 ## API reference links

--- a/docs/content/reference/types/archetypes/scalar.md
+++ b/docs/content/reference/types/archetypes/scalar.md
@@ -14,11 +14,12 @@ is referenced by [`archetypes.SeriesLines`](https://rerun.io/docs/reference/type
 this by logging both archetypes to the same path, or alternatively configuring
 the plot-specific archetypes through the blueprint.
 
-## Components
+## Fields
+### Required
+* `scalar`: [`Scalar`](../components/scalar.md)
 
-**Required**: [`Scalar`](../components/scalar.md)
 
-## Shown in
+## Can be shown in
 * [TimeSeriesView](../views/time_series_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/scalars.md
+++ b/docs/content/reference/types/archetypes/scalars.md
@@ -14,11 +14,12 @@ is referenced by [`archetypes.SeriesLines`](https://rerun.io/docs/reference/type
 this by logging both archetypes to the same path, or alternatively configuring
 the plot-specific archetypes through the blueprint.
 
-## Components
+## Fields
+### Required
+* `scalars`: [`Scalar`](../components/scalar.md)
 
-**Required**: [`Scalar`](../components/scalar.md)
 
-## Shown in
+## Can be shown in
 * [TimeSeriesView](../views/time_series_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/segmentation_image.md
+++ b/docs/content/reference/types/archetypes/segmentation_image.md
@@ -12,13 +12,17 @@ integer value.
 
 Use [`archetypes.AnnotationContext`](https://rerun.io/docs/reference/types/archetypes/annotation_context) to associate each class with a color and a label.
 
-## Components
+## Fields
+### Required
+* `buffer`: [`ImageBuffer`](../components/image_buffer.md)
+* `format`: [`ImageFormat`](../components/image_format.md)
 
-**Required**: [`ImageBuffer`](../components/image_buffer.md), [`ImageFormat`](../components/image_format.md)
+### Optional
+* `opacity`: [`Opacity`](../components/opacity.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
 
-**Optional**: [`Opacity`](../components/opacity.md), [`DrawOrder`](../components/draw_order.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/series_line.md
+++ b/docs/content/reference/types/archetypes/series_line.md
@@ -10,11 +10,16 @@ This archetype only provides styling information and should be logged as static
 when possible. The underlying data needs to be logged to the same entity-path using
 [`archetypes.Scalars`](https://rerun.io/docs/reference/types/archetypes/scalars?speculative-link).
 
-## Components
+## Fields
+### Optional
+* `color`: [`Color`](../components/color.md)
+* `width`: [`StrokeWidth`](../components/stroke_width.md)
+* `name`: [`Name`](../components/name.md)
+* `visible_series`: [`SeriesVisible`](../components/series_visible.md)
+* `aggregation_policy`: [`AggregationPolicy`](../components/aggregation_policy.md)
 
-**Optional**: [`Color`](../components/color.md), [`StrokeWidth`](../components/stroke_width.md), [`Name`](../components/name.md), [`SeriesVisible`](../components/series_visible.md), [`AggregationPolicy`](../components/aggregation_policy.md)
 
-## Shown in
+## Can be shown in
 * [TimeSeriesView](../views/time_series_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/series_lines.md
+++ b/docs/content/reference/types/archetypes/series_lines.md
@@ -12,11 +12,16 @@ it's generally recommended to log this type as static.
 The underlying data needs to be logged to the same entity-path using [`archetypes.Scalars`](https://rerun.io/docs/reference/types/archetypes/scalars?speculative-link).
 Dimensionality of the scalar arrays logged at each time point is assumed to be the same over time.
 
-## Components
+## Fields
+### Optional
+* `colors`: [`Color`](../components/color.md)
+* `widths`: [`StrokeWidth`](../components/stroke_width.md)
+* `names`: [`Name`](../components/name.md)
+* `visible_series`: [`SeriesVisible`](../components/series_visible.md)
+* `aggregation_policy`: [`AggregationPolicy`](../components/aggregation_policy.md)
 
-**Optional**: [`Color`](../components/color.md), [`StrokeWidth`](../components/stroke_width.md), [`Name`](../components/name.md), [`SeriesVisible`](../components/series_visible.md), [`AggregationPolicy`](../components/aggregation_policy.md)
 
-## Shown in
+## Can be shown in
 * [TimeSeriesView](../views/time_series_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/series_point.md
+++ b/docs/content/reference/types/archetypes/series_point.md
@@ -10,11 +10,16 @@ This archetype only provides styling information and should be logged as static
 when possible. The underlying data needs to be logged to the same entity-path using
 [`archetypes.Scalars`](https://rerun.io/docs/reference/types/archetypes/scalars?speculative-link).
 
-## Components
+## Fields
+### Optional
+* `color`: [`Color`](../components/color.md)
+* `marker`: [`MarkerShape`](../components/marker_shape.md)
+* `name`: [`Name`](../components/name.md)
+* `visible_series`: [`SeriesVisible`](../components/series_visible.md)
+* `marker_size`: [`MarkerSize`](../components/marker_size.md)
 
-**Optional**: [`Color`](../components/color.md), [`MarkerShape`](../components/marker_shape.md), [`Name`](../components/name.md), [`SeriesVisible`](../components/series_visible.md), [`MarkerSize`](../components/marker_size.md)
 
-## Shown in
+## Can be shown in
 * [TimeSeriesView](../views/time_series_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/series_points.md
+++ b/docs/content/reference/types/archetypes/series_points.md
@@ -12,11 +12,16 @@ it's generally recommended to log this type as static.
 The underlying data needs to be logged to the same entity-path using [`archetypes.Scalars`](https://rerun.io/docs/reference/types/archetypes/scalars?speculative-link).
 Dimensionality of the scalar arrays logged at each time point is assumed to be the same over time.
 
-## Components
+## Fields
+### Optional
+* `colors`: [`Color`](../components/color.md)
+* `markers`: [`MarkerShape`](../components/marker_shape.md)
+* `names`: [`Name`](../components/name.md)
+* `visible_series`: [`SeriesVisible`](../components/series_visible.md)
+* `marker_sizes`: [`MarkerSize`](../components/marker_size.md)
 
-**Optional**: [`Color`](../components/color.md), [`MarkerShape`](../components/marker_shape.md), [`Name`](../components/name.md), [`SeriesVisible`](../components/series_visible.md), [`MarkerSize`](../components/marker_size.md)
 
-## Shown in
+## Can be shown in
 * [TimeSeriesView](../views/time_series_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/tensor.md
+++ b/docs/content/reference/types/archetypes/tensor.md
@@ -5,13 +5,15 @@ title: "Tensor"
 
 An N-dimensional array of numbers.
 
-## Components
+## Fields
+### Required
+* `data`: [`TensorData`](../components/tensor_data.md)
 
-**Required**: [`TensorData`](../components/tensor_data.md)
+### Optional
+* `value_range`: [`ValueRange`](../components/value_range.md)
 
-**Optional**: [`ValueRange`](../components/value_range.md)
 
-## Shown in
+## Can be shown in
 * [TensorView](../views/tensor_view.md)
 * [BarChartView](../views/bar_chart_view.md) (for 1D tensors)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/text_document.md
+++ b/docs/content/reference/types/archetypes/text_document.md
@@ -7,13 +7,15 @@ A text element intended to be displayed in its own text box.
 
 Supports raw text and markdown.
 
-## Components
+## Fields
+### Required
+* `text`: [`Text`](../components/text.md)
 
-**Required**: [`Text`](../components/text.md)
+### Optional
+* `media_type`: [`MediaType`](../components/media_type.md)
 
-**Optional**: [`MediaType`](../components/media_type.md)
 
-## Shown in
+## Can be shown in
 * [TextDocumentView](../views/text_document_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/text_log.md
+++ b/docs/content/reference/types/archetypes/text_log.md
@@ -5,15 +5,18 @@ title: "TextLog"
 
 A log entry in a text log, comprised of a text body and its log level.
 
-## Components
+## Fields
+### Required
+* `text`: [`Text`](../components/text.md)
 
-**Required**: [`Text`](../components/text.md)
+### Recommended
+* `level`: [`TextLogLevel`](../components/text_log_level.md)
 
-**Recommended**: [`TextLogLevel`](../components/text_log_level.md)
+### Optional
+* `color`: [`Color`](../components/color.md)
 
-**Optional**: [`Color`](../components/color.md)
 
-## Shown in
+## Can be shown in
 * [TextLogView](../views/text_log_view.md)
 * [DataframeView](../views/dataframe_view.md)
 

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -16,11 +16,18 @@ it will be resolved to a transform with only a rotation.
 
 For transforms that affect only a single entity and do not propagate along the entity tree refer to [`archetypes.InstancePoses3D`](https://rerun.io/docs/reference/types/archetypes/instance_poses3d).
 
-## Components
+## Fields
+### Optional
+* `translation`: [`Translation3D`](../components/translation3d.md)
+* `rotation_axis_angle`: [`RotationAxisAngle`](../components/rotation_axis_angle.md)
+* `quaternion`: [`RotationQuat`](../components/rotation_quat.md)
+* `scale`: [`Scale3D`](../components/scale3d.md)
+* `mat3x3`: [`TransformMat3x3`](../components/transform_mat3x3.md)
+* `relation`: [`TransformRelation`](../components/transform_relation.md)
+* `axis_length`: [`AxisLength`](../components/axis_length.md)
 
-**Optional**: [`Translation3D`](../components/translation3d.md), [`RotationAxisAngle`](../components/rotation_axis_angle.md), [`RotationQuat`](../components/rotation_quat.md), [`Scale3D`](../components/scale3d.md), [`TransformMat3x3`](../components/transform_mat3x3.md), [`TransformRelation`](../components/transform_relation.md), [`AxisLength`](../components/axis_length.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [Spatial2DView](../views/spatial2d_view.md) (if logged above active projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/video_frame_reference.md
+++ b/docs/content/reference/types/archetypes/video_frame_reference.md
@@ -10,13 +10,15 @@ To show an entire video, a video frame reference for each frame of the video sho
 
 See <https://rerun.io/docs/reference/video> for details of what is and isn't supported.
 
-## Components
+## Fields
+### Required
+* `timestamp`: [`VideoTimestamp`](../components/video_timestamp.md)
 
-**Required**: [`VideoTimestamp`](../components/video_timestamp.md)
+### Optional
+* `video_reference`: [`EntityPath`](../components/entity_path.md)
 
-**Optional**: [`EntityPath`](../components/entity_path.md)
 
-## Shown in
+## Can be shown in
 * [Spatial2DView](../views/spatial2d_view.md)
 * [Spatial3DView](../views/spatial3d_view.md) (if logged under a projection)
 * [DataframeView](../views/dataframe_view.md)

--- a/docs/content/reference/types/archetypes/view_coordinates.md
+++ b/docs/content/reference/types/archetypes/view_coordinates.md
@@ -17,11 +17,12 @@ Make sure that this archetype is logged at or above the origin entity path of yo
 
 ⚠ [Rerun does not yet support left-handed coordinate systems](https://github.com/rerun-io/rerun/issues/5032).
 
-## Components
+## Fields
+### Required
+* `xyz`: [`ViewCoordinates`](../components/view_coordinates.md)
 
-**Required**: [`ViewCoordinates`](../components/view_coordinates.md)
 
-## Shown in
+## Can be shown in
 * [Spatial3DView](../views/spatial3d_view.md)
 * [DataframeView](../views/dataframe_view.md)
 


### PR DESCRIPTION
Include field names when listing the components of an archetype.

Field names will become more important in the future, and is already important context.

## Before
<img width="703" alt="image" src="https://github.com/user-attachments/assets/14dcea5a-47b0-4b24-8231-d010c82e7b99" />


## After
<img width="408" alt="image" src="https://github.com/user-attachments/assets/f2b53546-a1d3-409d-8ea5-661a451d03d8" />
