### PR TITLE
Prevent switches to welcome screen if tables are present

### DIFF
--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -873,7 +873,7 @@ pub fn table_id_button_ui(
     let mut list_item = ui
         .list_item()
         .selected(ctx.selection().contains_item(&item))
-        .active(ctx.active_table.as_ref() == Some(table_id));
+        .active(ctx.storage_context.hub.active_table_id() == Some(table_id));
 
     if ctx.hovered().contains_item(&item) {
         list_item = list_item.force_hovered(true);

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -433,6 +433,7 @@ impl App {
             }
 
             SystemCommand::CloseEntry(entry) => {
+                // TODO(#9464): Find a better successor here.
                 store_hub.remove(&entry);
             }
 

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -304,7 +304,6 @@ impl AppState {
             maybe_visualizable_entities_per_visualizer: &maybe_visualizable_entities_per_visualizer,
             indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
             query_results: &query_results,
-            active_table: storage_context.hub.active_table_id().cloned(),
             rec_cfg,
             blueprint_cfg,
             selection_state,
@@ -387,7 +386,6 @@ impl AppState {
             maybe_visualizable_entities_per_visualizer: &maybe_visualizable_entities_per_visualizer,
             indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
             query_results: &query_results,
-            active_table: storage_context.hub.active_table_id().cloned(),
             rec_cfg,
             blueprint_cfg,
             selection_state,
@@ -573,7 +571,7 @@ impl AppState {
                 .show_inside(ui, |ui| {
                     match display_mode {
                         DisplayMode::LocalRecordings => {
-                            if let Some(table_id) = ctx.active_table.as_ref() {
+                            if let Some(table_id) = ctx.storage_context.hub.active_table_id() {
                                 if let Some(store) = ctx.storage_context.tables.get(table_id) {
                                     let context = TableContext {
                                         table_id: table_id.clone(),

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -597,7 +597,7 @@ impl StoreHub {
     /// Activate a recording by its [`TableId`].
     fn set_activate_table(&mut self, table_id: TableId) {
         self.active_entry = Some(StoreHubEntry::Table { table_id });
-        self.active_application_id = Some(StoreHub::table_app_id());
+        self.active_application_id = Some(Self::table_app_id());
     }
 
     // ---------------------

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -141,7 +141,7 @@ impl StoreHub {
         "Welcome screen".into()
     }
 
-    /// App ID used as a marker to display the welcome screen.
+    /// App ID used as a marker to display tables.
     pub fn table_app_id() -> ApplicationId {
         "table".into()
     }

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -141,6 +141,11 @@ impl StoreHub {
         "Welcome screen".into()
     }
 
+    /// App ID used as a marker to display the welcome screen.
+    pub fn table_app_id() -> ApplicationId {
+        "table".into()
+    }
+
     /// Blueprint ID used for the default welcome screen blueprint
     fn welcome_screen_blueprint_id() -> StoreId {
         StoreId::from_string(
@@ -412,7 +417,9 @@ impl StoreHub {
 
         self.table_stores.clear();
 
-        self.active_entry = None;
+        if self.active_table_id().is_none() {
+            self.active_entry = None;
+        }
         self.active_application_id = Some(Self::welcome_screen_app_id());
     }
 
@@ -440,7 +447,9 @@ impl StoreHub {
         // If this is the welcome screen, or we didn't have any app id at all so far,
         // we set the active application_id even if we don't find a matching recording.
         // (otherwise we don't, because we don't want to leave towards a state without any recording if we don't have to)
-        if Self::welcome_screen_app_id() == app_id || self.active_application_id.is_none() {
+        if Self::welcome_screen_app_id() == app_id
+            || (self.active_application_id.is_none() && self.active_table_id().is_none())
+        {
             self.active_application_id = Some(app_id.clone());
             self.active_entry = None;
         }
@@ -481,7 +490,9 @@ impl StoreHub {
 
         if self.active_application_id.as_ref() == Some(app_id) {
             self.active_application_id = None;
-            self.active_entry = None;
+            if self.active_table_id().is_none() {
+                self.active_entry = None;
+            }
         }
 
         self.default_blueprint_by_app_id.remove(app_id);
@@ -586,6 +597,7 @@ impl StoreHub {
     /// Activate a recording by its [`TableId`].
     fn set_activate_table(&mut self, table_id: TableId) {
         self.active_entry = Some(StoreHubEntry::Table { table_id });
+        self.active_application_id = Some(StoreHub::table_app_id());
     }
 
     // ---------------------

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -350,7 +350,6 @@ impl TestContext {
                 bundle: &Default::default(),
                 tables: &Default::default(),
             },
-            active_table: None,
             maybe_visualizable_entities_per_visualizer: &maybe_visualizable_entities_per_visualizer,
             indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
             query_results: &self.query_results,

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -4,7 +4,6 @@ use parking_lot::RwLock;
 
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::entity_db::EntityDb;
-use re_log_types::TableId;
 use re_query::StorageEngineReadGuard;
 
 use crate::drag_and_drop::DragAndDropPayload;
@@ -23,9 +22,6 @@ pub struct ViewerContext<'a> {
 
     pub store_context: &'a StoreContext<'a>,
     pub storage_context: &'a StorageContext<'a>,
-
-    /// If `active_table` is `Some(...)`, we have a table in the context, otherwise it's a regular store.
-    pub active_table: Option<TableId>,
 
     /// Mapping from class and system to entities for the store
     ///
@@ -300,9 +296,10 @@ impl ViewerContext<'_> {
     ///
     /// It excludes the globally hardcoded welcome screen app ID.
     pub fn has_active_recording(&self) -> bool {
-        self.recording()
-            .app_id()
-            .is_some_and(|active_app_id| active_app_id != &StoreHub::welcome_screen_app_id())
+        self.recording().app_id().is_some_and(|active_app_id| {
+            active_app_id != &StoreHub::welcome_screen_app_id()
+                && active_app_id != &StoreHub::table_app_id()
+        })
     }
 }
 


### PR DESCRIPTION
### Related

* Closes #9465

### What

All of this logic is quite brittle, but it should to unblock the `v0.23` release.
