### PR TITLE
Run git lfs checkout on contribuor PR

### DIFF
--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -50,6 +50,8 @@ jobs:
       image: rerunio/ci_docker:0.15.0
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:


### PR DESCRIPTION
Should fix the following problem:
* https://github.com/rerun-io/rerun/actions/runs/14362937419/job/40310541274?pr=9550

(`docs/snippets/all/concepts/send_recording.py` uses a file from `git lfs`)