### PR TITLE
Fix notebook version not being set by update script

### DIFF
--- a/scripts/ci/update_rerun_notebook_version.py
+++ b/scripts/ci/update_rerun_notebook_version.py
@@ -33,6 +33,7 @@ def run(
 
 def set_rerun_notebook_version(pyproject_path: Path, version: str) -> None:
     pyproject: dict[str, Any] = tomlkit.parse(pyproject_path.read_text())
+    pyproject["project"]["version"] = version
     pyproject_path.write_text(tomlkit.dumps(pyproject))
 
 


### PR DESCRIPTION
It got lost in this commit: https://github.com/rerun-io/rerun/commit/cba8a0f7efc602c0610856fef8f2c0528bb516b8#diff-1dd13c08fd717d18b1a4285d3c6dd11b69205298e16f12faa5bc1de01fbd2523L34