### PR TITLE
Add basic server ui

### DIFF
--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -101,6 +101,18 @@ impl Entries {
         self.datasets.try_as_ref()?.as_ref().ok()?.get(&entry_id)
     }
 
+    pub fn dataset_count(&self) -> Option<Result<usize, &EntryError>> {
+        self.datasets
+            .try_as_ref()
+            .map(|r| r.as_ref().map(|datasets| datasets.len()))
+    }
+
+    #[expect(clippy::unused_self)]
+    pub fn table_count(&self) -> usize {
+        //TODO(ab): hopefully we have tables there soon!
+        0
+    }
+
     /// [`list_item::ListItem`]-based UI for the datasets.
     pub fn panel_ui(
         &self,

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -1,9 +1,11 @@
+use egui::{Frame, Margin, RichText};
+use re_log_types::EntryId;
+use re_ui::{icons, list_item, UiExt as _};
+use re_viewer_context::{
+    AsyncRuntimeHandle, DisplayMode, Item, SystemCommand, SystemCommandSender as _, ViewerContext,
+};
 use std::collections::BTreeMap;
 use std::sync::mpsc::{Receiver, Sender};
-
-use re_log_types::EntryId;
-use re_ui::{list_item, UiExt as _};
-use re_viewer_context::{AsyncRuntimeHandle, ViewerContext};
 
 use crate::add_server_modal::AddServerModal;
 use crate::context::Context;
@@ -34,13 +36,68 @@ impl Server {
         self.entries.find_dataset(entry_id)
     }
 
+    /// Central panel UI for when a server is selected.
+    fn server_ui(&self, ctx: &Context<'_>, ui: &mut egui::Ui) {
+        Frame::new()
+            .inner_margin(Margin {
+                top: 16,
+                bottom: 12,
+                left: 16,
+                right: 16,
+            })
+            .show(ui, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading(RichText::new("Catalog").strong());
+                    if ui.small_icon_button(&icons::RESET).clicked() {
+                        let _ = ctx
+                            .command_sender
+                            .send(Command::RefreshCollection(self.origin.clone()));
+                    }
+                });
+
+                ui.add_space(12.0);
+
+                ui.list_item_scope(
+                    egui::Id::new(&self.origin).with("catalog server ui"),
+                    |ui| {
+                        ui.list_item_flat_noninteractive(
+                            list_item::PropertyContent::new("Address").value_fn(|ui, _| {
+                                ui.strong(self.origin.to_string());
+                            }),
+                        );
+
+                        ui.list_item_flat_noninteractive(
+                            list_item::PropertyContent::new("Datasets").value_fn(|ui, _| {
+                                match self.entries.dataset_count() {
+                                    None => ui.label("loading…"),
+                                    Some(Ok(count)) => ui.strong(format!("{count}")),
+                                    Some(Err(err)) => ui
+                                        .error_label("could not load entries")
+                                        .on_hover_text(err.to_string()),
+                                };
+                            }),
+                        );
+
+                        ui.list_item_flat_noninteractive(
+                            list_item::PropertyContent::new("Tables").value_fn(|ui, _| {
+                                ui.strong(format!("{}", self.entries.table_count()));
+                            }),
+                        );
+                    },
+                );
+            });
+    }
+
     fn panel_ui(
         &self,
-        viewer_context: &ViewerContext<'_>,
+        viewer_ctx: &ViewerContext<'_>,
         ctx: &Context<'_>,
         ui: &mut egui::Ui,
         recordings: Option<DatasetRecordings<'_>>,
     ) {
+        let item = Item::RedapServer(self.origin.clone());
+        let is_selected = viewer_ctx.selection().contains_item(&item);
+
         let content =
             list_item::LabelContent::header(self.origin.host.to_string()).with_buttons(|ui| {
                 let response = ui
@@ -56,19 +113,31 @@ impl Server {
                 response
             });
 
-        ui.list_item()
+        let item_response = ui
+            .list_item()
             .header()
+            .selected(is_selected)
             .show_hierarchical_with_children(
                 ui,
                 egui::Id::new(&self.origin).with("server_item"),
                 true,
                 content,
                 |ui| {
-                    self.entries.panel_ui(viewer_context, ctx, ui, recordings);
+                    self.entries.panel_ui(viewer_ctx, ctx, ui, recordings);
                 },
             )
             .item_response
             .on_hover_text(self.origin.to_string());
+
+        viewer_ctx.handle_select_hover_drag_interactions(&item_response, item, false);
+
+        if item_response.clicked() {
+            viewer_ctx
+                .command_sender()
+                .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapServer(
+                    self.origin.clone(),
+                )));
+        }
     }
 }
 
@@ -210,10 +279,29 @@ impl RedapServers {
         }
     }
 
+    pub fn server_central_panel_ui(
+        &self,
+        viewer_ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        origin: &re_uri::Origin,
+    ) {
+        if let Some(server) = self.servers.get(origin) {
+            self.with_ctx(|ctx| {
+                server.server_ui(ctx, ui);
+            });
+        } else {
+            viewer_ctx
+                .command_sender()
+                .send_system(SystemCommand::ChangeDisplayMode(
+                    DisplayMode::LocalRecordings,
+                ));
+        }
+    }
+
     pub fn server_list_ui(
         &self,
-        ui: &mut egui::Ui,
         viewer_ctx: &ViewerContext<'_>,
+        ui: &mut egui::Ui,
         mut remote_recordings: RemoteRecordings<'_>,
     ) {
         self.with_ctx(|ctx| {

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -612,8 +612,9 @@ impl AppState {
                                     welcome_screen_state,
                                     is_history_enabled,
                                 );
+                            } else {
+                                redap_servers.server_central_panel_ui(&ctx, ui, origin);
                             }
-                            // Servers have no ui yet
                         }
 
                         DisplayMode::ChunkStoreBrowser => {} // Handled above

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -112,7 +112,7 @@ fn recording_list_ui(
         local_recordings,
     } = re_redap_browser::sort_datasets(ctx);
 
-    servers.server_list_ui(ui, ctx, remote_recordings);
+    servers.server_list_ui(ctx, ui, remote_recordings);
 
     // Show placeholder message if there's absolutely nothing else to show.
     if ctx.storage_context.tables.is_empty()


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/9555

### What

This PR adds a basic server UI. It also allows selecting severs by clicking on them in the recording panel.

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/642db819-faa4-40a9-8284-40b2d56eb12b" />
