### PR TITLE
Use lfs in web publish job

### DIFF
--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.release-commit }}
+          lfs: true
 
       - id: "auth"
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
Otherwise it can't read assets used by some examples

https://github.com/rerun-io/rerun/actions/runs/14381126230/job/40335789461#step:12:457