### PR TITLE
Format random IDs withour dashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7003,7 +7003,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.65",
- "uuid",
  "walkdir",
 ]
 
@@ -8242,7 +8241,6 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror 1.0.65",
- "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -47,7 +47,6 @@ rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-uuid.workspace = true
 walkdir.workspace = true
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]

--- a/crates/store/re_data_loader/src/load_file.rs
+++ b/crates/store/re_data_loader/src/load_file.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use ahash::{HashMap, HashMapExt as _};
-use re_log_types::{FileSource, LogMsg};
+use re_log_types::{ApplicationId, FileSource, LogMsg};
 use re_smart_channel::Sender;
 
 use crate::{DataLoader as _, DataLoaderError, LoadedData, RrdLoader};
@@ -338,7 +338,7 @@ pub(crate) fn send(
                     let app_id = settings
                         .opened_application_id
                         .clone()
-                        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().into());
+                        .unwrap_or_else(ApplicationId::random);
                     let store_info = prepare_store_info(app_id, &store_id, file_source.clone());
                     tx.send(store_info).ok();
                 }

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -113,7 +113,7 @@ impl StoreId {
     pub fn random(kind: StoreKind) -> Self {
         Self {
             kind,
-            id: Arc::new(uuid::Uuid::new_v4().to_string()),
+            id: Arc::new(uuid::Uuid::new_v4().simple().to_string()),
         }
     }
 
@@ -126,7 +126,7 @@ impl StoreId {
     pub fn from_uuid(kind: StoreKind, uuid: uuid::Uuid) -> Self {
         Self {
             kind,
-            id: Arc::new(uuid.to_string()),
+            id: Arc::new(uuid.simple().to_string()),
         }
     }
 
@@ -189,6 +189,11 @@ impl ApplicationId {
 
     pub fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+
+    /// A randomly generated app id
+    pub fn random() -> Self {
+        Self(format!("app_{}", uuid::Uuid::new_v4().simple()))
     }
 }
 

--- a/crates/utils/re_analytics/examples/end_to_end.rs
+++ b/crates/utils/re_analytics/examples/end_to_end.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let analytics = Analytics::new(Duration::from_secs(3))?;
     let application_id = "end_to_end_example".to_owned();
-    let recording_id = uuid::Uuid::new_v4().to_string();
+    let recording_id = uuid::Uuid::new_v4().simple().to_string();
 
     println!("any non-empty line written here will be sent as an analytics datapoint");
     loop {

--- a/crates/utils/re_analytics/src/native/config.rs
+++ b/crates/utils/re_analytics/src/native/config.rs
@@ -64,7 +64,7 @@ impl Config {
         let config_path = dirs.config_dir().join("analytics.json");
         let data_path = dirs.data_local_dir().join("analytics");
         Ok(Self {
-            analytics_id: Uuid::new_v4().to_string(),
+            analytics_id: Uuid::new_v4().simple().to_string(),
             analytics_enabled: true,
             opt_in_metadata: Default::default(),
             session_id: Uuid::new_v4(),

--- a/crates/utils/re_analytics/src/web/config.rs
+++ b/crates/utils/re_analytics/src/web/config.rs
@@ -90,7 +90,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            analytics_id: Uuid::new_v4().to_string(),
+            analytics_id: Uuid::new_v4().simple().to_string(),
             session_id: Uuid::new_v4(),
             opt_in_metadata: HashMap::new(),
         }

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -127,7 +127,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde-wasm-bindgen.workspace = true
 thiserror.workspace = true
-uuid.workspace = true
 web-time.workspace = true
 wgpu.workspace = true
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -719,7 +719,7 @@ impl App {
             .cloned()
             // If we don't have any application ID to recommend (which means we are on the welcome screen),
             // then just generate a new one using a UUID.
-            .or_else(|| Some(uuid::Uuid::new_v4().to_string().into()));
+            .or_else(|| Some(ApplicationId::random()));
         let active_recording_id = storage_ctx.hub.active_recording_id().cloned().or_else(|| {
             // When we're on the welcome screen, there is no recording ID to recommend.
             // But we want one, otherwise multiple things being dropped simultaneously on the
@@ -1701,7 +1701,7 @@ impl App {
             .cloned()
             // If we don't have any application ID to recommend (which means we are on the welcome screen),
             // then just generate a new one using a UUID.
-            .or_else(|| Some(uuid::Uuid::new_v4().to_string().into()));
+            .or_else(|| Some(ApplicationId::random()));
         let active_recording_id = storage_ctx.hub.active_recording_id().cloned().or_else(|| {
             // When we're on the welcome screen, there is no recording ID to recommend.
             // But we want one, otherwise multiple things being dropped simultaneously on the

--- a/crates/viewer/re_viewer_context/src/blueprint_id.rs
+++ b/crates/viewer/re_viewer_context/src/blueprint_id.rs
@@ -136,14 +136,14 @@ impl<T: BlueprintIdRegistry> From<BlueprintId<T>> for re_types::datatypes::Uuid 
 impl<T: BlueprintIdRegistry> std::fmt::Display for BlueprintId<T> {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}({})", T::registry_name(), self.id)
+        write!(f, "{}({})", T::registry_name(), self.id.simple())
     }
 }
 
 impl<T: BlueprintIdRegistry> std::fmt::Debug for BlueprintId<T> {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}({})", T::registry_name(), self.id)
+        write!(f, "{}({})", T::registry_name(), self.id.simple())
     }
 }
 

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -455,7 +455,7 @@ impl PyDataframeQueryView {
         let ctx = client.ctx(py)?;
         let ctx = ctx.bind(py);
 
-        let uuid = uuid::Uuid::new_v4();
+        let uuid = uuid::Uuid::new_v4().simple();
         let name = format!("{}_dataframe_query_{uuid}", super_.name());
 
         drop(client);

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -368,7 +368,7 @@ impl PyDataset {
                 .map_err(to_py_err)
         })?;
 
-        let uuid = uuid::Uuid::new_v4();
+        let uuid = uuid::Uuid::new_v4().simple();
         let name = format!("{}_search_fts_{uuid}", super_.name());
 
         Ok(PyDataFusionTable {
@@ -421,7 +421,7 @@ impl PyDataset {
                 .map_err(to_py_err)
         })?;
 
-        let uuid = uuid::Uuid::new_v4();
+        let uuid = uuid::Uuid::new_v4().simple();
         let name = format!("{}_search_vector_{uuid}", super_.name());
 
         Ok(PyDataFusionTable {


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/dataplatform/issues/250

### What
We sometimes use a string-formatted UUIDv4 as a random ID. I think it's better we skip the dashes in these cases, so that we can double-click-to-select.

Before: `0840159d-1af9-48fb-8d14-208e388b26ee`
After: `0840159d1af948fb8d14208e388b26ee`

For AppId I also decided to prefix the id with `app_`: `app_0840159d1af948fb8d14208e388b26ee`

It also makes it clear that this is indeed not _always_ a UUID. For instance, our AppId is a custom string, but _somtimes_ a random string (currently generated with a UUID, but that isn't fixed).