### PR TITLE
Remove debug-assert that asserted that column names have no colons

### DIFF
--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -161,8 +161,7 @@ impl ComponentName {
     pub fn sanity_check(&self) {
         let full_name = self.0.as_str();
         debug_assert!(
-            !full_name.starts_with("rerun.components.rerun.components.")
-                && !full_name.contains(':'),
+            !full_name.starts_with("rerun.components.rerun.components."),
             "DEBUG ASSERT: Found component with full name {full_name:?}. Maybe some bad round-tripping?"
         );
     }


### PR DESCRIPTION
When using `AnyValue`, users are free to pick any column name. In our OSM (`openstreetmap_data`) example, we for instance had columns called `addr:city` etc