### PR TITLE
Introduce `Navigation` in preparation for tabs and simplify welcome screen loading

### DIFF
--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -264,9 +264,7 @@ impl EntryKind {
 
     fn is_active(&self, ctx: &ViewerContext<'_>) -> bool {
         match self {
-            Self::Remote { entry_id, .. } => {
-                matches!(ctx.global_context.display_mode, DisplayMode::RedapEntry(id) if id == entry_id)
-            }
+            Self::Remote { entry_id, .. } => ctx.active_entry_id == Some(entry_id),
             // TODO(lucasmerlin): Update this when local datasets have a view like remote datasets
             Self::Local(_) => false,
         }

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -240,7 +240,7 @@ impl EntryKind {
         match self {
             Self::Remote { entry_id, .. } => {
                 ctx.command_sender()
-                    .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
+                    .send_system(SystemCommand::NavigationReplace(DisplayMode::RedapEntry(
                         *entry_id,
                     )));
             }

--- a/crates/viewer/re_redap_browser/src/lib.rs
+++ b/crates/viewer/re_redap_browser/src/lib.rs
@@ -14,15 +14,6 @@ use re_uri::Scheme;
 pub use servers::RedapServers;
 use std::sync::LazyLock;
 
-/// Origin used to show the examples ui in the redap browser.
-///
-/// Not actually a valid origin.
-pub static EXAMPLES_ORIGIN: LazyLock<re_uri::Origin> = LazyLock::new(|| re_uri::Origin {
-    scheme: Scheme::RerunHttps,
-    host: url::Host::Domain(String::from("_examples.rerun.io")),
-    port: 443,
-});
-
 /// Origin used to show the local ui in the redap browser.
 ///
 /// Not actually a valid origin.

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -134,7 +134,7 @@ impl Server {
         if item_response.clicked() {
             viewer_ctx
                 .command_sender()
-                .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapServer(
+                .send_system(SystemCommand::NavigationReplace(DisplayMode::RedapServer(
                     self.origin.clone(),
                 )));
         }
@@ -292,7 +292,7 @@ impl RedapServers {
         } else {
             viewer_ctx
                 .command_sender()
-                .send_system(SystemCommand::ChangeDisplayMode(
+                .send_system(SystemCommand::NavigationReplace(
                     DisplayMode::LocalRecordings,
                 ));
         }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -416,7 +416,9 @@ impl App {
     ) {
         match cmd {
             SystemCommand::ActivateApp(app_id) => {
-                self.state.navigation.replace(DisplayMode::LocalRecordings);
+                self.state
+                    .navigation
+                    .push_unique(DisplayMode::LocalRecordings);
                 store_hub.set_active_app(app_id);
             }
 
@@ -425,7 +427,9 @@ impl App {
             }
 
             SystemCommand::ActivateEntry(entry) => {
-                self.state.navigation.replace(DisplayMode::LocalRecordings);
+                self.state
+                    .navigation
+                    .push_unique(DisplayMode::LocalRecordings);
                 store_hub.set_active_entry(entry);
             }
 
@@ -465,7 +469,7 @@ impl App {
             }
 
             SystemCommand::NavigationReplace(display_mode) => {
-                self.state.navigation.replace(display_mode);
+                self.state.navigation.push_unique(display_mode);
             }
 
             SystemCommand::NavigationPop => {
@@ -482,7 +486,7 @@ impl App {
                 {
                     self.state
                         .navigation
-                        .replace(DisplayMode::RedapServer(origin));
+                        .push_unique(DisplayMode::RedapServer(origin));
                 }
                 self.command_sender.send_ui(UICommand::ExpandBlueprintPanel);
             }
@@ -599,13 +603,13 @@ impl App {
                     Item::RedapEntry(entry_id) => {
                         self.state
                             .navigation
-                            .replace(DisplayMode::RedapEntry(*entry_id));
+                            .push_unique(DisplayMode::RedapEntry(*entry_id));
                     }
 
                     Item::RedapServer(origin) => {
                         self.state
                             .navigation
-                            .replace(DisplayMode::RedapServer(origin.clone()));
+                            .push_unique(DisplayMode::RedapServer(origin.clone()));
                     }
 
                     Item::AppId(_)
@@ -617,7 +621,9 @@ impl App {
                     | Item::Container(_)
                     | Item::View(_)
                     | Item::DataResult(_, _) => {
-                        self.state.navigation.replace(DisplayMode::LocalRecordings);
+                        self.state
+                            .navigation
+                            .push_unique(DisplayMode::LocalRecordings);
                     }
                 }
 
@@ -915,8 +921,11 @@ impl App {
                 DisplayMode::LocalRecordings
                 | DisplayMode::RedapEntry(_)
                 | DisplayMode::RedapServer(_) => {
-                    self.state.navigation.push(DisplayMode::ChunkStoreBrowser);
+                    self.state
+                        .navigation
+                        .push_unique(DisplayMode::ChunkStoreBrowser);
                 }
+
                 DisplayMode::ChunkStoreBrowser => {
                     self.state.navigation.pop();
                 }
@@ -944,7 +953,7 @@ impl App {
             }
 
             UICommand::Settings => {
-                self.state.navigation.push(DisplayMode::Settings);
+                self.state.navigation.push_unique(DisplayMode::Settings);
             }
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -464,9 +464,14 @@ impl App {
                 self.add_log_receiver(rx);
             }
 
-            SystemCommand::ChangeDisplayMode(display_mode) => {
+            SystemCommand::NavigationReplace(display_mode) => {
                 self.state.navigation.replace(display_mode);
             }
+
+            SystemCommand::NavigationPop => {
+                self.state.navigation.pop();
+            }
+
             SystemCommand::AddRedapServer(origin) => {
                 self.state.redap_servers.add_server(origin.clone());
 
@@ -915,8 +920,12 @@ impl App {
                 DisplayMode::ChunkStoreBrowser => {
                     self.state.navigation.pop();
                 }
-                DisplayMode::WelcomeScreen => {
-                    re_log::debug!("Cannot toggle chunk store browser from welcome screen");
+
+                DisplayMode::Settings | DisplayMode::WelcomeScreen => {
+                    re_log::debug!(
+                        "Cannot toggle chunk store browser from current display mode: {:?}",
+                        self.state.navigation.peek()
+                    );
                 }
             },
 
@@ -935,7 +944,7 @@ impl App {
             }
 
             UICommand::Settings => {
-                self.state.show_settings_ui = true;
+                self.state.navigation.push(DisplayMode::Settings);
             }
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/viewer/re_viewer/src/app_blueprint.rs
+++ b/crates/viewer/re_viewer/src/app_blueprint.rs
@@ -182,29 +182,6 @@ pub struct PanelStateOverrides {
     pub time: Option<PanelState>,
 }
 
-pub fn setup_welcome_screen_blueprint(welcome_screen_blueprint: &mut EntityDb) {
-    // Most things are hidden in the welcome screen:
-    for (panel_name, value) in [
-        (TOP_PANEL_PATH, PanelState::Expanded),
-        (BLUEPRINT_PANEL_PATH, PanelState::Hidden),
-        (SELECTION_PANEL_PATH, PanelState::Hidden),
-        (TIME_PANEL_PATH, PanelState::Hidden),
-    ] {
-        let entity_path = EntityPath::from(panel_name);
-
-        let timepoint = re_viewer_context::blueprint_timepoint_for_writes(welcome_screen_blueprint);
-
-        let chunk = Chunk::builder(entity_path)
-            .with_component_batches(RowId::new(), timepoint, [&value as &dyn ComponentBatch])
-            .build()
-            .expect("Failed to build chunk - incorrect number of instances for the component");
-
-        welcome_screen_blueprint
-            .add_chunk(&Arc::new(chunk))
-            .expect("Failed to add new chunk for welcome screen");
-    }
-}
-
 // ----------------------------------------------------------------------------
 
 impl AppBlueprint<'_> {

--- a/crates/viewer/re_viewer/src/app_blueprint.rs
+++ b/crates/viewer/re_viewer/src/app_blueprint.rs
@@ -1,8 +1,5 @@
-use std::sync::Arc;
-
 use re_chunk::{Chunk, RowId};
 use re_chunk_store::LatestAtQuery;
-use re_entity_db::EntityDb;
 use re_log_types::EntityPath;
 use re_types::{blueprint::components::PanelState, ComponentBatch};
 use re_viewer_context::{CommandSender, StoreContext, SystemCommand, SystemCommandSender as _};

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -184,9 +184,11 @@ impl AppState {
                     is_history_enabled,
                 );
             }
+
             (DisplayMode::Settings, _) => {
                 settings_screen_ui(ui, &mut self.app_options, command_sender);
             }
+
             (_, Some(store_context)) => {
                 let blueprint_query = self.blueprint_query_for_viewer(store_context.blueprint);
                 let Self {
@@ -635,6 +637,7 @@ impl AppState {
                 // Process deferred layout operations and apply updates back to blueprint:
                 viewport_ui.save_to_blueprint_store(&ctx);
             }
+
             // TODO(grtlr): If all fails we display the welcome screen. We will get rid of this in the future,
             // as `store_context` will move into the routes that requires it.
             (_, None) => {

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -203,7 +203,6 @@ impl AppState {
                     time_panel,
                     blueprint_time_panel,
                     blueprint_tree,
-                    welcome_screen,
                     datastore_ui,
                     redap_servers,
                     show_settings_ui,
@@ -315,7 +314,7 @@ impl AppState {
                     store_context,
                     storage_context,
                     active_entry_id: match self.navigation.peek() {
-                        DisplayMode::RedapEntry(id) => Some(&id),
+                        DisplayMode::RedapEntry(id) => Some(id),
                         _ => None,
                     },
                     maybe_visualizable_entities_per_visualizer:
@@ -402,7 +401,7 @@ impl AppState {
                     store_context,
                     storage_context,
                     active_entry_id: match self.navigation.peek() {
-                        DisplayMode::RedapEntry(id) => Some(&id),
+                        DisplayMode::RedapEntry(id) => Some(id),
                         _ => None,
                     },
                     maybe_visualizable_entities_per_visualizer:

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -9,6 +9,7 @@ mod app_state;
 mod background_tasks;
 mod callback;
 pub mod env_vars;
+mod navigation;
 mod saving;
 mod screenshotter;
 mod startup_options;
@@ -27,10 +28,11 @@ pub mod blueprint;
 
 pub(crate) use {app_state::AppState, ui::memory_panel};
 
-pub use callback::{CallbackSelectionItem, Callbacks};
-
-pub use app::App;
-pub use startup_options::StartupOptions;
+pub use self::{
+    app::App,
+    callback::{CallbackSelectionItem, Callbacks},
+    startup_options::StartupOptions,
+};
 
 pub use re_capabilities::MainThreadToken;
 

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -10,16 +10,17 @@ use re_viewer_context::DisplayMode;
 pub(crate) struct Navigation(Vec<DisplayMode>);
 
 impl Navigation {
-    pub fn push(&mut self, display_mode: DisplayMode) {
-        re_log::debug!("Pushed display mode `{:?}`", display_mode);
-        self.0.push(display_mode);
-    }
+    pub fn push_unique(&mut self, display_mode: DisplayMode) {
+        let before = self.0.len();
+        self.0.retain(|d| d != &display_mode);
+        let after = self.0.len();
 
-    pub fn replace(&mut self, display_mode: DisplayMode) -> Option<DisplayMode> {
-        let previous = self.0.pop();
-        re_log::debug!("Replaced `{:?}` with `{:?}`", previous, display_mode);
+        if before == after {
+            re_log::debug!("Pushed new display mode `{:?}`", display_mode);
+        } else {
+            re_log::debug!("Reusing existing display mode `{:?}`", display_mode);
+        }
         self.0.push(display_mode);
-        previous
     }
 
     pub fn pop(&mut self) -> Option<DisplayMode> {

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -9,24 +9,26 @@ use re_viewer_context::DisplayMode;
 #[derive(Default)]
 pub(crate) struct Navigation(Vec<DisplayMode>);
 
-// TODO(grtlr): Make the welcome screen a display mode too, and store its state.
-
 impl Navigation {
     pub fn push(&mut self, display_mode: DisplayMode) {
+        re_log::debug!("Pushed display mode `{:?}`", display_mode);
         self.0.push(display_mode);
     }
 
     pub fn replace(&mut self, display_mode: DisplayMode) -> Option<DisplayMode> {
         let previous = self.0.pop();
+        re_log::debug!("Replaced `{:?}` with `{:?}`", previous, display_mode);
         self.0.push(display_mode);
         previous
     }
 
     pub fn pop(&mut self) -> Option<DisplayMode> {
-        self.0.pop()
+        let previous = self.0.pop();
+        re_log::debug!("Popped display mode `{:?}`", previous);
+        previous
     }
 
     pub fn peek(&self) -> &DisplayMode {
-        self.0.first().unwrap_or(&DisplayMode::WelcomeScreen)
+        self.0.last().unwrap_or(&DisplayMode::WelcomeScreen)
     }
 }

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -1,0 +1,32 @@
+use re_viewer_context::DisplayMode;
+
+// TODO(grtlr): Move this to `history.rs` and merge with the router there.
+
+/// The navigation history of the viewer.
+///
+/// This object should never be exposed to directly via contexts. Instead,
+/// we retrieve the display mode and pass that around.
+#[derive(Default)]
+pub(crate) struct Navigation(Vec<DisplayMode>);
+
+// TODO(grtlr): Make the welcome screen a display mode too, and store its state.
+
+impl Navigation {
+    pub fn push(&mut self, display_mode: DisplayMode) {
+        self.0.push(display_mode);
+    }
+
+    pub fn replace(&mut self, display_mode: DisplayMode) -> Option<DisplayMode> {
+        let previous = self.0.pop();
+        self.0.push(display_mode);
+        previous
+    }
+
+    pub fn pop(&mut self) -> Option<DisplayMode> {
+        self.0.pop()
+    }
+
+    pub fn peek(&self) -> &DisplayMode {
+        self.0.first().unwrap_or(&DisplayMode::WelcomeScreen)
+    }
+}

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -151,7 +151,7 @@ fn recording_list_ui(
             .clicked()
     {
         ctx.command_sender()
-            .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapServer(
+            .send_system(SystemCommand::NavigationReplace(DisplayMode::RedapServer(
                 LOCAL_ORIGIN.clone(),
             )));
     }
@@ -190,7 +190,7 @@ fn recording_list_ui(
 
         if response.clicked() {
             ctx.command_sender()
-                .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::WelcomeScreen));
+                .send_system(SystemCommand::NavigationReplace(DisplayMode::WelcomeScreen));
         }
     }
 }

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -1,14 +1,10 @@
 use re_data_ui::item_ui::table_id_button_ui;
 use re_log_types::LogMsg;
-use re_redap_browser::{
-    dataset_and_its_recordings_ui, EntryKind, RedapServers, EXAMPLES_ORIGIN, LOCAL_ORIGIN,
-};
+use re_redap_browser::{dataset_and_its_recordings_ui, EntryKind, RedapServers, LOCAL_ORIGIN};
 use re_smart_channel::{ReceiveSet, SmartChannelSource};
 use re_ui::list_item::ItemMenuButton;
 use re_ui::{list_item, UiExt as _, UiLayout};
-use re_viewer_context::{
-    DisplayMode, Item, SystemCommand, SystemCommandSender as _, ViewerContext,
-};
+use re_viewer_context::{DisplayMode, SystemCommand, SystemCommandSender as _, ViewerContext};
 
 use crate::app_state::WelcomeScreenState;
 
@@ -167,9 +163,7 @@ fn recording_list_ui(
         && !welcome_screen_state.hide)
         || !example_recordings.is_empty()
     {
-        let item = Item::RedapServer(EXAMPLES_ORIGIN.clone());
-        let selected = ctx.selection().contains_item(&item);
-        let list_item = ui.list_item().header().selected(selected);
+        let list_item = ui.list_item().header();
         let title = list_item::LabelContent::header("Rerun examples");
         let response = if example_recordings.is_empty() {
             list_item.show_flat(ui, title)
@@ -196,13 +190,7 @@ fn recording_list_ui(
 
         if response.clicked() {
             ctx.command_sender()
-                .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapServer(
-                    EXAMPLES_ORIGIN.clone(),
-                )));
-            ctx.command_sender()
-                .send_system(SystemCommand::SetSelection(Item::RedapServer(
-                    EXAMPLES_ORIGIN.clone(),
-                )));
+                .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::WelcomeScreen));
         }
     }
 }

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -2,9 +2,13 @@ use egui::{NumExt as _, Ui};
 
 use re_log_types::TimestampFormat;
 use re_ui::UiExt as _;
-use re_viewer_context::AppOptions;
+use re_viewer_context::{AppOptions, CommandSender, SystemCommandSender as _};
 
-pub fn settings_screen_ui(ui: &mut egui::Ui, app_options: &mut AppOptions, keep_open: &mut bool) {
+pub fn settings_screen_ui(
+    ui: &mut egui::Ui,
+    app_options: &mut AppOptions,
+    command_sender: &CommandSender,
+) {
     egui::Frame {
         inner_margin: egui::Margin::same(5),
         ..Default::default()
@@ -17,15 +21,17 @@ pub fn settings_screen_ui(ui: &mut egui::Ui, app_options: &mut AppOptions, keep_
         let max_rect = ui.max_rect().expand2(-centering_margin * egui::Vec2::X);
         let mut child_ui = ui.new_child(egui::UiBuilder::new().max_rect(max_rect));
 
+        let mut keep_open = true;
         egui::ScrollArea::both()
             .auto_shrink(false)
             .show(&mut child_ui, |ui| {
                 ui.set_min_width(MIN_WIDTH);
-                settings_screen_ui_impl(ui, app_options, keep_open);
+                settings_screen_ui_impl(ui, app_options, &mut keep_open);
             });
 
-        if ui.input_mut(|ui| ui.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
-            *keep_open = false;
+        if !keep_open || ui.input_mut(|ui| ui.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
+        {
+            command_sender.send_system(re_viewer_context::SystemCommand::NavigationPop);
         }
     });
 }

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -448,7 +448,7 @@ fn open_example_url(
     command_sender.send_system(SystemCommand::LoadDataSource(data_source));
 
     // The welcome screen might be rendered from the redap browser ui
-    command_sender.send_system(SystemCommand::ChangeDisplayMode(
+    command_sender.send_system(SystemCommand::NavigationReplace(
         DisplayMode::LocalRecordings,
     ));
 

--- a/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
@@ -30,7 +30,11 @@ pub enum SystemCommand {
     /// Add a new server to the redap browser.
     AddRedapServer(re_uri::Origin),
 
-    ChangeDisplayMode(crate::DisplayMode),
+    /// Replaces the topmost element from the navigation stack.
+    NavigationReplace(crate::DisplayMode),
+
+    /// Pops the topmost element from the navigation stack.
+    NavigationPop,
 
     /// Reset the `Viewer` to the default state
     ResetViewer,

--- a/crates/viewer/re_viewer_context/src/global_context/display_mode.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/display_mode.rs
@@ -1,0 +1,15 @@
+/// Which display mode are we currently in?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DisplayMode {
+    WelcomeScreen,
+
+    /// Regular view of the local recordings, including the current recording's viewport.
+    LocalRecordings,
+
+    /// The Redap server/catalog/collection browser.
+    RedapEntry(re_log_types::EntryId),
+    RedapServer(re_uri::Origin),
+
+    /// The current recording's data store browser.
+    ChunkStoreBrowser,
+}

--- a/crates/viewer/re_viewer_context/src/global_context/display_mode.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/display_mode.rs
@@ -1,7 +1,13 @@
+// TODO(grtlr): It would be nice, if we could store the welcome screen state within its variant here too.
+
 /// Which display mode are we currently in?
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DisplayMode {
+    /// The welcome screen with example recordings.
     WelcomeScreen,
+
+    /// The settings dialog for application-wide configuration.
+    Settings,
 
     /// Regular view of the local recordings, including the current recording's viewport.
     LocalRecordings,

--- a/crates/viewer/re_viewer_context/src/global_context/mod.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/mod.rs
@@ -7,6 +7,7 @@
 mod app_options;
 mod command_sender;
 mod component_ui_registry;
+mod display_mode;
 mod item;
 
 pub use self::{
@@ -15,6 +16,7 @@ pub use self::{
         command_channel, CommandReceiver, CommandSender, SystemCommand, SystemCommandSender,
     },
     component_ui_registry::{ComponentUiRegistry, ComponentUiTypes},
+    display_mode::DisplayMode,
     item::Item,
 };
 
@@ -50,20 +52,4 @@ pub struct GlobalContext<'a> {
 
     /// Interface for sending commands back to the app
     pub command_sender: &'a CommandSender,
-
-    pub display_mode: &'a DisplayMode,
-}
-
-/// Which display mode are we currently in?
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DisplayMode {
-    /// Regular view of the local recordings, including the current recording's viewport.
-    LocalRecordings,
-
-    /// The Redap server/catalog/collection browser.
-    RedapEntry(re_log_types::EntryId),
-    RedapServer(re_uri::Origin),
-
-    /// The current recording's data store browser.
-    ChunkStoreBrowser,
 }

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -487,7 +487,8 @@ impl TestContext {
                 | SystemCommand::ClearSourceAndItsStores(_)
                 | SystemCommand::AddReceiver { .. }
                 | SystemCommand::ResetViewer
-                | SystemCommand::ChangeDisplayMode(_)
+                | SystemCommand::NavigationReplace(_)
+                | SystemCommand::NavigationPop
                 | SystemCommand::ClearActiveBlueprint
                 | SystemCommand::ClearActiveBlueprintAndEnableHeuristics
                 | SystemCommand::AddRedapServer { .. }

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -8,9 +8,9 @@ use parking_lot::Mutex;
 
 use crate::{
     blueprint_timeline, command_channel, ApplicationSelectionState, CommandReceiver, CommandSender,
-    ComponentUiRegistry, DataQueryResult, DisplayMode, GlobalContext, ItemCollection,
-    RecordingConfig, StorageContext, StoreContext, SystemCommand, ViewClass, ViewClassRegistry,
-    ViewId, ViewStates, ViewerContext,
+    ComponentUiRegistry, DataQueryResult, GlobalContext, ItemCollection, RecordingConfig,
+    StorageContext, StoreContext, SystemCommand, ViewClass, ViewClassRegistry, ViewId, ViewStates,
+    ViewerContext,
 };
 use re_chunk::{Chunk, ChunkBuilder};
 use re_chunk_store::LatestAtQuery;
@@ -342,7 +342,6 @@ impl TestContext {
                 egui_ctx,
                 command_sender: &self.command_sender,
                 render_ctx,
-                display_mode: &DisplayMode::LocalRecordings,
             },
             store_context: &store_context,
             storage_context: &StorageContext {
@@ -350,6 +349,7 @@ impl TestContext {
                 bundle: &Default::default(),
                 tables: &Default::default(),
             },
+            active_entry_id: None,
             maybe_visualizable_entities_per_visualizer: &maybe_visualizable_entities_per_visualizer,
             indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
             query_results: &self.query_results,

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -299,10 +299,9 @@ impl ViewerContext<'_> {
     ///
     /// It excludes the globally hardcoded welcome screen app ID.
     pub fn has_active_recording(&self) -> bool {
-        self.recording().app_id().is_some_and(|active_app_id| {
-            active_app_id != &StoreHub::welcome_screen_app_id()
-                && active_app_id != &StoreHub::table_app_id()
-        })
+        self.recording()
+            .app_id()
+            .is_some_and(|active_app_id| active_app_id != &StoreHub::table_app_id())
     }
 }
 

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -20,7 +20,10 @@ pub struct ViewerContext<'a> {
     /// Global context shared across all parts of the viewer.
     pub global_context: GlobalContext<'a>,
 
+    // TODO(grtlr): Once we untangled the welcome screen, combine these into an `active_context`.
+    pub active_entry_id: Option<&'a re_log_types::EntryId>,
     pub store_context: &'a StoreContext<'a>,
+
     pub storage_context: &'a StorageContext<'a>,
 
     /// Mapping from class and system to entities for the store


### PR DESCRIPTION
### Related

* Follow up of #9566.

### What

This introduces a `Navigation` object to manage display modes. It also converts the welcome screen into a display mode.

In follow up PRs I will:

* Create display mode for `DataStore`.
* Get rid of requirement for application id.
* Change the display modes to include `StoreId` (or other relevant ids, where appropriate).