### PR TITLE
Improve view heuristics for time series plot

### DIFF
--- a/crates/viewer/re_view/src/heuristics.rs
+++ b/crates/viewer/re_view/src/heuristics.rs
@@ -10,7 +10,7 @@ use re_viewer_context::{
 /// to spawn a view for every single entity that is visualizable with a given visualizer.
 pub fn suggest_view_for_each_entity<TVisualizer>(
     ctx: &ViewerContext<'_>,
-    view: &impl ViewClass,
+    view: &dyn ViewClass,
     suggested_filter: &ResolvedEntityPathFilter,
 ) -> ViewSpawnHeuristics
 where

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -1,5 +1,6 @@
 use egui::ahash::{HashMap, HashSet};
 use egui_plot::{Legend, Line, Plot, PlotPoint, Points};
+use nohash_hasher::IntSet;
 use smallvec::SmallVec;
 
 use re_chunk_store::TimeType;
@@ -243,16 +244,21 @@ impl ViewClass for TimeSeriesView {
             return ViewSpawnHeuristics::default();
         }
 
-        // Spawn time series data at the root if there's time series data either
-        // directly at the root or one of its children.
+        // Spawn time series data at the root if theres 'either:
+        // * time series data directly at the root
+        // * all time series data are direct children of the root
         //
         // This is the last hold out of "child of root" spawning, which we removed otherwise
         // (see https://github.com/rerun-io/rerun/issues/4926)
-        let subtree_of_root_entity = &ctx.recording().tree().children;
+        let root_entities: IntSet<EntityPath> = ctx
+            .recording()
+            .tree()
+            .children
+            .values()
+            .map(|subtree| subtree.path.clone())
+            .collect();
         if indicated_entities.contains(&EntityPath::root())
-            || subtree_of_root_entity
-                .iter()
-                .any(|(_, subtree)| indicated_entities.contains(&subtree.path))
+            || indicated_entities.is_subset(&root_entities)
         {
             return ViewSpawnHeuristics::root();
         }

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -248,6 +248,12 @@ impl ViewClass for TimeSeriesView {
         // * time series data directly at the root
         // * all time series data are direct children of the root
         //
+        // This heuristic was last edited in 2015-04-11 by @emilk,
+        // because it was triggering too often (https://github.com/rerun-io/rerun/pull/9587).
+        // Maybe we should remove it completely?
+        // I have a feeling it was added to handle the case many scalars of the form `/x`, `/y`, `/z` etc,
+        // but we now support logging multiple scalars in one entity.
+        //
         // This is the last hold out of "child of root" spawning, which we removed otherwise
         // (see https://github.com/rerun-io/rerun/issues/4926)
         let root_entities: IntSet<EntityPath> = ctx

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -36,6 +36,7 @@ OFFICIAL_RERUN_DEVS = [
     "nikolausWest",
     "oxkitsune",
     "teh-cmc",
+    "timsaucer",
     "Wumpf",
     "zehiko",
 ]


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/9521
* Related to  #4926

### What
We added a new `/spiral` entity with time series data to our plot demo.
This hit a wird corner-case of our heuristics.

I believe the heuristic is meant for the case when you log a few top-level entities, e.g. `/x`, `/y`, `/z` and that we in that case should put them all in the same plot.

…however, I'm not sure we want or need that anymore, now that you can log multiple scalars with the new `rr.Scalars`.

But, instead of completely removing the heuristic I refined it to be more conservative in when it triggers.