### PR TITLE
rerun_py: adapt the `register` API to the new asynchronous nature of  `register_with_dataset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8492,6 +8492,7 @@ dependencies = [
  "object_store",
  "once_cell",
  "parking_lot",
+ "prost-types",
  "pyo3",
  "pyo3-build-config",
  "rand",

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -89,6 +89,7 @@ uuid.workspace = true
 # Deps for remote feature
 object_store = { workspace = true, features = ["aws"] }
 re_protos = { workspace = true, features = ["py"] }
+prost-types.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-stream.workspace = true
 tonic = { workspace = true, default-features = false, features = ["transport"] }


### PR DESCRIPTION
### Related

* Related to: https://github.com/rerun-io/dataplatform/issues/527
* Follows:
  * https://github.com/rerun-io/rerun/pull/9537
  * https://github.com/rerun-io/dataplatform/pull/543 

### What
In https://github.com/rerun-io/dataplatform/pull/543, we replaced the synchronous register_with_dataset endpoint with an
asynchronous equivalent. The python client, however, expects the
endpoint to be synchronous.

This change is a quick-fix to make the python client block for dataset
registration task completion so that current user should not feel the
difference.

We should improve this in the future by exposing the asynchronous nature
of the endpoint directly to the client.
