### PR TITLE
Replace uses of `arrow2` in `rerun_c` with `arrow-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8521,7 +8521,6 @@ dependencies = [
  "infer",
  "once_cell",
  "parking_lot",
- "re_arrow2",
  "re_arrow_util",
  "re_log",
  "re_sdk",

--- a/crates/top/rerun_c/Cargo.toml
+++ b/crates/top/rerun_c/Cargo.toml
@@ -42,7 +42,6 @@ re_video.workspace = true
 
 ahash.workspace = true
 arrow.workspace = true
-arrow2.workspace = true
 infer.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true

--- a/crates/top/rerun_c/Cargo.toml
+++ b/crates/top/rerun_c/Cargo.toml
@@ -41,7 +41,7 @@ re_sdk = { workspace = true, features = ["data_loaders", "server"] }
 re_video.workspace = true
 
 ahash.workspace = true
-arrow.workspace = true
+arrow = { workspace = true, features = ["ffi"] }
 infer.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true

--- a/crates/top/rerun_c/src/arrow_utils.rs
+++ b/crates/top/rerun_c/src/arrow_utils.rs
@@ -12,7 +12,7 @@ pub unsafe fn arrow_array_from_c_ffi(
     array: FFI_ArrowArray,
     datatype: arrow::datatypes::DataType,
 ) -> Result<arrow::array::ArrayRef, CError> {
-    // Arrow2 implements drop for Arrow2Array and Arrow2Schema.
+    // arrow-rs implements `Drop` for `FFI_ArrowArray`.
     //
     // Therefore, for things to work correctly we have to take ownership of the array!
     // All methods passing arrow arrays through our C interface are documented to take ownership of the component batch.

--- a/crates/top/rerun_c/src/arrow_utils.rs
+++ b/crates/top/rerun_c/src/arrow_utils.rs
@@ -1,32 +1,17 @@
+use arrow::ffi::FFI_ArrowArray;
+
 use crate::{CError, CErrorCode};
 
 /// Converts a C-FFI arrow array into a Rust component batch, taking ownership of the underlying arrow data.
 ///
-/// Safety:
-/// This must only be ever called once for a given ffi array.
-/// Conceptually, this takes ownership of the array, i.e. this should really be a move operation,
-/// but since we have typically pass c arrays (ptr + length), we can't actually move out data.
+/// ### Safety
+/// This struct assumes that the incoming data agrees with the C data interface.
 #[allow(unsafe_code)]
 #[allow(clippy::result_large_err)]
 pub unsafe fn arrow_array_from_c_ffi(
-    array: &arrow2::ffi::ArrowArray,
-    datatype: arrow2::datatypes::DataType,
+    array: FFI_ArrowArray,
+    datatype: arrow::datatypes::DataType,
 ) -> Result<arrow::array::ArrayRef, CError> {
-    unsafe { arrow2_array_from_c_ffi(array, datatype).map(|array| array.into()) }
-}
-
-/// Converts a C-FFI arrow array into a Rust component batch, taking ownership of the underlying arrow data.
-///
-/// Safety:
-/// This must only be ever called once for a given ffi array.
-/// Conceptually, this takes ownership of the array, i.e. this should really be a move operation,
-/// but since we have typically pass c arrays (ptr + length), we can't actually move out data.
-#[allow(unsafe_code)]
-#[allow(clippy::result_large_err)]
-unsafe fn arrow2_array_from_c_ffi(
-    array: &arrow2::ffi::ArrowArray,
-    datatype: arrow2::datatypes::DataType,
-) -> Result<Box<dyn arrow2::array::Array>, CError> {
     // Arrow2 implements drop for Arrow2Array and Arrow2Schema.
     //
     // Therefore, for things to work correctly we have to take ownership of the array!
@@ -35,10 +20,12 @@ unsafe fn arrow2_array_from_c_ffi(
     //
     // This makes sense because from here on out we want to manage the lifetime of the underlying schema and array data
     // from the rust side.
-    unsafe { arrow2::ffi::import_array_from_c(std::ptr::read(array), datatype) }.map_err(|err| {
-        CError::new(
-            CErrorCode::ArrowFfiArrayImportError,
-            &format!("Failed to import ffi array: {err}"),
-        )
-    })
+    unsafe { arrow::ffi::from_ffi_and_data_type(array, datatype) }
+        .map(arrow::array::make_array)
+        .map_err(|err| {
+            CError::new(
+                CErrorCode::ArrowFfiArrayImportError,
+                &format!("Failed to import ffi array: {err}"),
+            )
+        })
 }

--- a/crates/top/rerun_c/src/component_type_registry.rs
+++ b/crates/top/rerun_c/src/component_type_registry.rs
@@ -6,7 +6,7 @@ use crate::{CComponentTypeHandle, CError, CErrorCode};
 
 pub struct ComponentType {
     pub descriptor: ComponentDescriptor,
-    pub datatype: arrow2::datatypes::DataType,
+    pub datatype: arrow::datatypes::DataType,
 }
 
 #[derive(Default)]
@@ -19,7 +19,7 @@ impl ComponentTypeRegistry {
     pub fn register(
         &mut self,
         descriptor: ComponentDescriptor,
-        datatype: arrow2::datatypes::DataType,
+        datatype: arrow::datatypes::DataType,
     ) -> CComponentTypeHandle {
         #[cfg(debug_assertions)]
         {

--- a/crates/top/rerun_c/src/lib.rs
+++ b/crates/top/rerun_c/src/lib.rs
@@ -403,7 +403,7 @@ fn rr_register_component_type_impl(
 #[allow(unsafe_code)]
 #[no_mangle]
 pub extern "C" fn rr_register_component_type(
-    // Note that since this is passed by value, Arrow2 will release the schema on drop!
+    // Note that since this is passed by value, arrow will release the schema on drop!
     component_type: CComponentType,
     error: *mut CError,
 ) -> u32 {

--- a/crates/top/rerun_c/src/lib.rs
+++ b/crates/top/rerun_c/src/lib.rs
@@ -14,7 +14,10 @@ mod video;
 
 use std::ffi::{c_char, c_uchar, CString};
 
-use arrow::array::{ArrayRef as ArrowArrayRef, ListArray as ArrowListArray};
+use arrow::{
+    array::{ArrayRef as ArrowArrayRef, ListArray as ArrowListArray},
+    ffi::{FFI_ArrowArray, FFI_ArrowSchema},
+};
 use arrow_utils::arrow_array_from_c_ffi;
 use once_cell::sync::Lazy;
 
@@ -178,14 +181,14 @@ pub struct CComponentDescriptor {
 #[repr(C)]
 pub struct CComponentType {
     pub descriptor: CComponentDescriptor,
-    pub schema: arrow2::ffi::ArrowSchema,
+    pub schema: FFI_ArrowSchema,
 }
 
 /// See `rr_component_batch` in the C header.
 #[repr(C)]
 pub struct CComponentBatch {
     pub component_type: CComponentTypeHandle,
-    pub array: arrow2::ffi::ArrowArray,
+    pub array: FFI_ArrowArray,
 }
 
 #[repr(C)]
@@ -201,7 +204,7 @@ pub struct CComponentColumns {
     pub component_type: CComponentTypeHandle,
 
     /// A `ListArray` with the datatype `List(component_type)`.
-    pub array: arrow2::ffi::ArrowArray,
+    pub array: FFI_ArrowArray,
 }
 
 /// See `rr_sorting_status` in the C header.
@@ -271,7 +274,7 @@ pub struct CTimeColumn {
     pub timeline: CTimeline,
 
     /// Times, a primitive array of i64.
-    pub times: arrow2::ffi::ArrowArray,
+    pub times: FFI_ArrowArray,
 
     /// The sorting order of the times array.
     pub sorting_status: CSortingStatus,
@@ -385,17 +388,16 @@ fn rr_register_component_type_impl(
         component_name: component_name.into(),
     };
 
-    let schema =
-        unsafe { arrow2::ffi::import_field_from_c(&component_type.schema) }.map_err(|err| {
-            CError::new(
-                CErrorCode::ArrowFfiSchemaImportError,
-                &format!("Failed to import ffi schema: {err}"),
-            )
-        })?;
+    let field = arrow::datatypes::Field::try_from(&component_type.schema).map_err(|err| {
+        CError::new(
+            CErrorCode::ArrowFfiSchemaImportError,
+            &format!("Failed to import ffi schema: {err}"),
+        )
+    })?;
 
     Ok(COMPONENT_TYPES
         .write()
-        .register(component_descr, schema.data_type))
+        .register(component_descr, field.data_type().clone()))
 }
 
 #[allow(unsafe_code)]
@@ -824,9 +826,10 @@ fn rr_recording_stream_log_impl(
             let CComponentBatch {
                 component_type,
                 array,
-            } = &batch;
+            } = batch;
             let component_type = component_type_registry.get(*component_type)?;
             let datatype = component_type.datatype.clone();
+            let array = unsafe { FFI_ArrowArray::from_raw(array) }; // Move out from `batches`
             let values = unsafe { arrow_array_from_c_ffi(array, datatype) }?;
             components.insert(component_type.descriptor.clone(), values);
         }
@@ -955,8 +958,8 @@ pub unsafe extern "C" fn rr_recording_stream_log_file_from_contents(
 fn rr_recording_stream_send_columns_impl(
     stream: CRecordingStream,
     entity_path: CStringView,
-    time_columns: &[CTimeColumn],
-    component_columns: &[CComponentColumns],
+    time_columns: &mut [CTimeColumn],
+    component_columns: &mut [CComponentColumns],
 ) -> Result<(), CError> {
     // Create chunk-id as early as possible. It has a timestamp and is used to estimate e2e latency.
     let id = ChunkId::new();
@@ -965,11 +968,12 @@ fn rr_recording_stream_send_columns_impl(
     let entity_path = entity_path.as_str("entity_path")?;
 
     let time_columns: IntMap<TimelineName, TimeColumn> = time_columns
-        .iter()
+        .iter_mut()
         .map(|time_column| {
             let timeline: Timeline = time_column.timeline.clone().try_into()?;
-            let datatype = arrow2::datatypes::DataType::Int64;
-            let time_values_untyped = unsafe { arrow_array_from_c_ffi(&time_column.times, datatype) }?;
+            let datatype = arrow::datatypes::DataType::Int64;
+            let array = unsafe { FFI_ArrowArray::from_raw(&mut time_column.times) } ; // Move out of the array
+            let time_values_untyped = unsafe { arrow_array_from_c_ffi(array, datatype) }?;
             let time_values = TimeColumn::read_array(&ArrowArrayRef::from(time_values_untyped)).map_err(|err| {
                 CError::new(
                     CErrorCode::ArrowFfiArrayImportError,
@@ -991,18 +995,19 @@ fn rr_recording_stream_send_columns_impl(
     let components: IntMap<ComponentDescriptor, ArrowListArray> = {
         let component_type_registry = COMPONENT_TYPES.read();
         component_columns
-            .iter()
+            .iter_mut()
             .map(|batch| {
                 let CComponentColumns {
                     component_type,
                     array,
-                } = &batch;
+                } = batch;
                 let component_type = component_type_registry.get(*component_type)?;
-                let datatype = arrow2::array::ListArray::<i32>::default_datatype(
-                    component_type.datatype.clone(),
-                );
 
-                let component_values_untyped = unsafe { arrow_array_from_c_ffi(array, datatype) }?;
+                let nullable = true;
+                let list_datatype = arrow::datatypes::DataType::List(arrow::datatypes::Field::new_list_field(component_type.datatype.clone(), nullable).into());
+
+                let array = unsafe { FFI_ArrowArray::from_raw(array) }; // Move out of the array
+                let component_values_untyped = unsafe { arrow_array_from_c_ffi(array, list_datatype) }?;
                 let component_values = component_values_untyped
                     .downcast_array_ref::<ArrowListArray>()
                     .ok_or_else(|| {
@@ -1040,16 +1045,17 @@ fn rr_recording_stream_send_columns_impl(
 pub unsafe extern "C" fn rr_recording_stream_send_columns(
     stream: CRecordingStream,
     entity_path: CStringView,
-    time_columns: *const CTimeColumn,
+    time_columns: *mut CTimeColumn,
     num_time_columns: u32,
-    component_batches: *const CComponentColumns,
+    component_batches: *mut CComponentColumns,
     num_component_batches: u32,
     error: *mut CError,
 ) {
     let time_columns =
-        unsafe { std::slice::from_raw_parts(time_columns, num_time_columns as usize) };
-    let component_batches =
-        unsafe { std::slice::from_raw_parts(component_batches, num_component_batches as usize) };
+        unsafe { std::slice::from_raw_parts_mut(time_columns, num_time_columns as usize) };
+    let component_batches = unsafe {
+        std::slice::from_raw_parts_mut(component_batches, num_component_batches as usize)
+    };
 
     if let Err(err) =
         rr_recording_stream_send_columns_impl(stream, entity_path, time_columns, component_batches)

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -566,10 +566,12 @@ extern void rr_recording_stream_log_file_from_contents(
 /// Note that this API ignores any stateful time set on the log stream via the
 /// `rr_recording_stream_set_time_sequence`/`rr_recording_stream_set_time_nanos`/etc. APIs.
 /// Furthermore, this will _not_ inject the default timelines `log_tick` and `log_time` timeline columns.
+///
+/// The contents of `time_columns` and `component_columns` AFTER this call is undefined.
 extern void rr_recording_stream_send_columns(
-    rr_recording_stream stream, rr_string entity_path,                            //
-    const rr_time_column* time_columns, uint32_t num_time_columns,                //
-    const rr_component_column* component_columns, uint32_t num_component_columns, //
+    rr_recording_stream stream, rr_string entity_path,                      //
+    rr_time_column* time_columns, uint32_t num_time_columns,                //
+    rr_component_column* component_columns, uint32_t num_component_columns, //
     rr_error* error
 );
 


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/3741

### What
After this, the only arrow2 remaining is in `re_types_builder`