### PR TITLE
Refactor `re_types_builder` slightly

### DIFF
--- a/crates/build/re_types_builder/src/arrow_registry.rs
+++ b/crates/build/re_types_builder/src/arrow_registry.rs
@@ -187,7 +187,7 @@ impl ArrowRegistry {
                 is_nullable: false,
                 metadata: Default::default(),
             })),
-            Type::Object(fqname) => LazyDatatype::Unresolved(fqname),
+            Type::Object { fqname } => LazyDatatype::Unresolved { fqname },
         };
 
         field.datatype = datatype.clone().into();
@@ -212,7 +212,7 @@ impl ArrowRegistry {
             ElementType::Float32 => LazyDatatype::Float32,
             ElementType::Float64 => LazyDatatype::Float64,
             ElementType::String => LazyDatatype::Utf8,
-            ElementType::Object(fqname) => LazyDatatype::Unresolved(fqname),
+            ElementType::Object { fqname } => LazyDatatype::Unresolved { fqname },
         }
     }
 }
@@ -300,7 +300,7 @@ pub enum LazyDatatype {
     Struct(Vec<LazyField>),
     Union(Vec<LazyField>, Option<Vec<i32>>, UnionMode),
     Extension(String, Box<LazyDatatype>, Option<String>),
-    Unresolved(String), // fqname
+    Unresolved { fqname: String },
 }
 
 impl From<DataType> for LazyDatatype {
@@ -387,7 +387,7 @@ impl LazyDatatype {
                 Arc::new(datatype.resolve(registry)),
                 metadata.as_ref().map(|s| Arc::new(s.clone())),
             ),
-            Self::Unresolved(fqname) => registry.get(fqname),
+            Self::Unresolved { fqname } => registry.get(fqname),
         }
     }
 }

--- a/crates/build/re_types_builder/src/codegen/cpp/array_builder.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/array_builder.rs
@@ -86,7 +86,7 @@ fn arrow_array_builder_type_and_declaration(
             declarations.insert("arrow", ForwardDecl::Class(ident.clone()));
             ident
         }
-        Type::Object(fqname) => {
+        Type::Object { fqname } => {
             arrow_array_builder_type_object(&objects[fqname], objects, declarations)
         }
     }

--- a/crates/build/re_types_builder/src/codegen/docs/website.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/website.rs
@@ -430,7 +430,7 @@ fn write_fields(reporter: &Reporter, objects: &Objects, o: &mut String, object: 
                     type_info(objects, &Type::from(elem_type.clone()))
                 )
             }
-            Type::Object(fqname) => {
+            Type::Object { fqname } => {
                 let ty = objects.get(fqname).unwrap();
                 format!(
                     "[`{}`](../{}/{}.md)",
@@ -446,7 +446,7 @@ fn write_fields(reporter: &Reporter, objects: &Objects, o: &mut String, object: 
         assert!(object.is_struct());
         assert_eq!(object.fields.len(), 1);
         let field_type = &object.fields[0].typ;
-        if object.kind == ObjectKind::Component && matches!(field_type, Type::Object(_)) {
+        if object.kind == ObjectKind::Component && matches!(field_type, Type::Object { .. }) {
             putln!(o, "## Rerun datatype");
             putln!(o, "{}", type_info(objects, field_type));
             putln!(o);

--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -784,7 +784,7 @@ impl quote::ToTokens for TypeTokenizer<'_> {
                     quote!(Vec<#elem_type>)
                 }
             }
-            Type::Object(fqname) => quote_fqname_as_type_path(fqname),
+            Type::Object { fqname } => quote_fqname_as_type_path(fqname),
         }
         .to_tokens(tokens);
     }
@@ -806,7 +806,7 @@ impl quote::ToTokens for &ElementType {
             ElementType::Float32 => quote!(f32),
             ElementType::Float64 => quote!(f64),
             ElementType::String => quote!(::re_types_core::ArrowString),
-            ElementType::Object(fqname) => quote_fqname_as_type_path(fqname),
+            ElementType::Object { fqname } => quote_fqname_as_type_path(fqname),
         }
         .to_tokens(tokens);
     }
@@ -870,7 +870,7 @@ fn quote_trait_impls_for_datatype_or_component(
 
     let is_forwarded_type = obj.is_arrow_transparent()
         && !obj.fields[0].is_nullable
-        && matches!(obj.fields[0].typ, Type::Object(_));
+        && matches!(obj.fields[0].typ, Type::Object { .. });
     let forwarded_type =
         is_forwarded_type.then(|| quote_field_type_from_typ(&obj.fields[0].typ, true).0);
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -95,7 +95,7 @@ namespace rerun {
                     (void)variant_builder;
                     return rerun::Error(
                         ErrorCode::NotImplemented,
-                        "Failed to serialize AffixFuzzer3::craziness: objects (Object(\"rerun.testing.datatypes.AffixFuzzer1\")) in unions not yet implemented"
+                        "Failed to serialize AffixFuzzer3::craziness: objects (Object { fqname: \"rerun.testing.datatypes.AffixFuzzer1\" }) in unions not yet implemented"
                     );
                 } break;
                 case TagType::fixed_size_shenanigans: {

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -97,7 +97,7 @@ namespace rerun {
                     (void)variant_builder;
                     return rerun::Error(
                         ErrorCode::NotImplemented,
-                        "Failed to serialize AffixFuzzer4::many_required: objects (Object(\"rerun.testing.datatypes.AffixFuzzer3\")) in unions not yet implemented"
+                        "Failed to serialize AffixFuzzer4::many_required: objects (Object { fqname: \"rerun.testing.datatypes.AffixFuzzer3\" }) in unions not yet implemented"
                     );
                 } break;
                 default:


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/3741

This is on the path to removing `arrow2` from it