### PR TITLE
Allow using table name to create a table entry datafusion table provider

### DIFF
--- a/crates/store/re_datafusion/src/grpc_streaming_provider.rs
+++ b/crates/store/re_datafusion/src/grpc_streaming_provider.rs
@@ -22,14 +22,14 @@ pub trait GrpcStreamToTable:
 {
     type GrpcStreamData;
 
-    async fn fetch_schema(&mut self) -> Result<SchemaRef, DataFusionError>;
+    async fn fetch_schema(&mut self) -> DataFusionResult<SchemaRef>;
 
     fn process_response(&mut self, response: Self::GrpcStreamData)
         -> DataFusionResult<RecordBatch>;
 
     async fn send_streaming_request(
         &mut self,
-    ) -> Result<tonic::Response<tonic::Streaming<Self::GrpcStreamData>>, tonic::Status>;
+    ) -> DataFusionResult<tonic::Response<tonic::Streaming<Self::GrpcStreamData>>>;
 }
 
 #[derive(Debug)]

--- a/crates/store/re_datafusion/src/table_entry_provider.rs
+++ b/crates/store/re_datafusion/src/table_entry_provider.rs
@@ -10,7 +10,9 @@ use datafusion::{
 use tonic::transport::Channel;
 
 use re_log_encoding::codec::wire::decoder::Decode as _;
-use re_log_types::EntryId;
+use re_log_types::{EntryId, EntryIdOrName};
+use re_protos::catalog::v1alpha1::ext::EntryDetails;
+use re_protos::catalog::v1alpha1::{EntryFilter, EntryKind, FindEntriesRequest};
 use re_protos::frontend::v1alpha1::{
     frontend_service_client::FrontendServiceClient, GetTableSchemaRequest, ScanTableRequest,
     ScanTableResponse,
@@ -21,17 +23,57 @@ use crate::grpc_streaming_provider::{GrpcStreamProvider, GrpcStreamToTable};
 #[derive(Debug, Clone)]
 pub struct TableEntryTableProvider {
     client: FrontendServiceClient<Channel>,
-    table_id: EntryId,
+    table: EntryIdOrName,
+
+    // cache the table id when resolved
+    table_id: Option<EntryId>,
 }
 
 impl TableEntryTableProvider {
-    pub fn new(client: FrontendServiceClient<Channel>, table_id: EntryId) -> Self {
-        Self { client, table_id }
+    pub fn new(client: FrontendServiceClient<Channel>, table: impl Into<EntryIdOrName>) -> Self {
+        Self {
+            client,
+            table: table.into(),
+            table_id: None,
+        }
     }
 
     /// This is a convenience function
     pub async fn into_provider(self) -> Result<Arc<dyn TableProvider>, DataFusionError> {
         Ok(GrpcStreamProvider::prepare(self).await?)
+    }
+
+    async fn table_id(&mut self) -> Result<EntryId, DataFusionError> {
+        match &self.table {
+            EntryIdOrName::Id(entry_id) => Ok(*entry_id),
+
+            EntryIdOrName::Name(table_name) => {
+                let entry_details: EntryDetails = self
+                    .client
+                    .find_entries(FindEntriesRequest {
+                        filter: Some(EntryFilter {
+                            id: None,
+                            name: Some(table_name.clone()),
+                            entry_kind: Some(EntryKind::Table as i32),
+                        }),
+                    })
+                    .await
+                    .map_err(|err| DataFusionError::External(Box::new(err)))?
+                    .into_inner()
+                    .entries
+                    .first()
+                    .ok_or_else(|| {
+                        DataFusionError::External(
+                            format!("No entry found with name: {table_name}").into(),
+                        )
+                    })?
+                    .clone()
+                    .try_into()
+                    .map_err(|err| DataFusionError::External(Box::new(err)))?;
+
+                Ok(entry_details.id)
+            }
+        }
     }
 }
 
@@ -39,9 +81,9 @@ impl TableEntryTableProvider {
 impl GrpcStreamToTable for TableEntryTableProvider {
     type GrpcStreamData = ScanTableResponse;
 
-    async fn fetch_schema(&mut self) -> Result<SchemaRef, DataFusionError> {
+    async fn fetch_schema(&mut self) -> DataFusionResult<SchemaRef> {
         let request = GetTableSchemaRequest {
-            table_id: Some(self.table_id.into()),
+            table_id: Some(self.table_id().await?.into()),
         };
 
         Ok(Arc::new(
@@ -60,12 +102,15 @@ impl GrpcStreamToTable for TableEntryTableProvider {
 
     async fn send_streaming_request(
         &mut self,
-    ) -> Result<tonic::Response<tonic::Streaming<Self::GrpcStreamData>>, tonic::Status> {
+    ) -> DataFusionResult<tonic::Response<tonic::Streaming<Self::GrpcStreamData>>> {
         let request = ScanTableRequest {
-            table_id: Some(self.table_id.into()),
+            table_id: Some(self.table_id().await?.into()),
         };
 
-        self.client.scan_table(request).await
+        self.client
+            .scan_table(request)
+            .await
+            .map_err(|err| DataFusionError::External(Box::new(err)))
     }
 
     fn process_response(

--- a/crates/store/re_datafusion/src/table_entry_provider.rs
+++ b/crates/store/re_datafusion/src/table_entry_provider.rs
@@ -44,8 +44,12 @@ impl TableEntryTableProvider {
     }
 
     async fn table_id(&mut self) -> Result<EntryId, DataFusionError> {
-        match &self.table {
-            EntryIdOrName::Id(entry_id) => Ok(*entry_id),
+        if let Some(table_id) = self.table_id {
+            return Ok(table_id);
+        }
+
+        let table_id = match &self.table {
+            EntryIdOrName::Id(entry_id) => *entry_id,
 
             EntryIdOrName::Name(table_name) => {
                 let entry_details: EntryDetails = self
@@ -71,9 +75,12 @@ impl TableEntryTableProvider {
                     .try_into()
                     .map_err(|err| DataFusionError::External(Box::new(err)))?;
 
-                Ok(entry_details.id)
+                entry_details.id
             }
-        }
+        };
+
+        self.table_id = Some(table_id);
+        Ok(table_id)
     }
 }
 

--- a/crates/store/re_log_types/src/entry_id.rs
+++ b/crates/store/re_log_types/src/entry_id.rs
@@ -40,6 +40,10 @@ impl FromStr for EntryId {
 
 // ---
 
+/// Either an id or a name for an entry.
+///
+/// This helper type should only be used for APIs to offer the convenience to refer to entries by
+/// either name or id. For storage/indexing purposes, use [`EntryId`].
 #[derive(Debug, Clone)]
 pub enum EntryIdOrName {
     Id(EntryId),

--- a/crates/store/re_log_types/src/entry_id.rs
+++ b/crates/store/re_log_types/src/entry_id.rs
@@ -37,3 +37,29 @@ impl FromStr for EntryId {
         re_tuid::Tuid::from_str(s).map(|id| Self { id })
     }
 }
+
+// ---
+
+#[derive(Debug, Clone)]
+pub enum EntryIdOrName {
+    Id(EntryId),
+    Name(String),
+}
+
+impl From<EntryId> for EntryIdOrName {
+    fn from(id: EntryId) -> Self {
+        Self::Id(id)
+    }
+}
+
+impl From<&str> for EntryIdOrName {
+    fn from(name: &str) -> Self {
+        Self::Name(name.to_owned())
+    }
+}
+
+impl From<String> for EntryIdOrName {
+    fn from(name: String) -> Self {
+        Self::Name(name)
+    }
+}

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -37,7 +37,7 @@ use re_byte_size::SizeBytes;
 
 pub use self::{
     arrow_msg::{ArrowMsg, ArrowRecordBatchReleaseCallback},
-    entry_id::EntryId,
+    entry_id::{EntryId, EntryIdOrName},
     index::{
         Duration, NonMinI64, ResolvedTimeRange, ResolvedTimeRangeF, TimeCell, TimeInt, TimePoint,
         TimeReal, TimeType, Timeline, TimelineName, Timestamp, TimestampFormat, TryFromIntError,


### PR DESCRIPTION
Improvements made on the way to the datafusion table widget:

- Introduce `EntryIdOrName` (convenient for apis accepting both)
- Make it possible to create a `TableEntryTableProvider` using `EntryIdOrName`
- Standardise our datafusion table provider trait around `DataFusionError`