### PR TITLE
dataplatform tasks: rename task related methods

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -109,13 +109,13 @@ service FrontendService {
 
   // --- Tasks service ---
   // Query the status of submitted tasks
-  rpc Query(rerun.redap_tasks.v1alpha1.QueryRequest) returns (rerun.redap_tasks.v1alpha1.QueryResponse) {}
+  rpc QueryTasks(rerun.redap_tasks.v1alpha1.QueryTasksRequest) returns (rerun.redap_tasks.v1alpha1.QueryTasksResponse) {}
 
   // Fetch the output of a completed task
-  rpc FetchOutput(rerun.redap_tasks.v1alpha1.FetchOutputRequest) returns (rerun.redap_tasks.v1alpha1.FetchOutputResponse) {}
+  rpc FetchTaskOutput(rerun.redap_tasks.v1alpha1.FetchTaskOutputRequest) returns (rerun.redap_tasks.v1alpha1.FetchTaskOutputResponse) {}
 
   // Query the status of submitted tasks as soon as they are no longer pending
-  rpc QueryOnCompletion(rerun.redap_tasks.v1alpha1.QueryOnCompletionRequest) returns (stream rerun.redap_tasks.v1alpha1.QueryOnCompletionResponse) {}
+  rpc QueryTasksOnCompletion(rerun.redap_tasks.v1alpha1.QueryTasksOnCompletionRequest) returns (stream rerun.redap_tasks.v1alpha1.QueryTasksOnCompletionResponse) {}
 }
 
 // --- Manifest Registry ---

--- a/crates/store/re_protos/proto/rerun/v1alpha1/tasks.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/tasks.proto
@@ -11,10 +11,10 @@ service TasksService {
   rpc SubmitTasks(SubmitTasksRequest) returns (SubmitTasksResponse);
 
   // Query the status of submitted tasks
-  rpc Query(QueryRequest) returns (QueryResponse);
+  rpc QueryTasks(QueryTasksRequest) returns (QueryTasksResponse);
 
   // Fetch the output of a completed task
-  rpc FetchOutput(FetchOutputRequest) returns (FetchOutputResponse);
+  rpc FetchTaskOutput(FetchTaskOutputRequest) returns (FetchTaskOutputResponse);
 
   // Query the status of submitted tasks, waiting for their completion.
   //
@@ -22,7 +22,7 @@ service TasksService {
   // the status of a subset of the tasks, as they complete.
   // The server does not guarantee to immediately send one stream item as soon as a task
   // completes, but may decide to arbitrarily aggregate results into larger batches.
-  rpc QueryOnCompletion(QueryOnCompletionRequest) returns (stream QueryOnCompletionResponse);
+  rpc QueryTasksOnCompletion(QueryTasksOnCompletionRequest) returns (stream QueryTasksOnCompletionResponse);
 }
 
 // A task is a unit of work that can be submitted to the system
@@ -46,21 +46,21 @@ message SubmitTasksResponse {
   rerun.common.v1alpha1.DataframePart data = 1;
 }
 
-// `QueryRequest` is the request message for querying tasks status
-message QueryRequest {
+// `QueryTasksRequest` is the request message for querying tasks status
+message QueryTasksRequest {
   // Empty queries for all tasks if the server allows it.
   repeated rerun.common.v1alpha1.TaskId ids = 1;
 }
 
-// `QueryResponse` is the response message for querying tasks status
+// `QueryTasksResponse` is the response message for querying tasks status
 // encoded as a record batch
-message QueryResponse {
+message QueryTasksResponse {
   rerun.common.v1alpha1.DataframePart data = 1;
 }
 
-// `QueryOnCompletionRequest` is the request message for querying tasks status.
-// This is close-to-a-copy of `QueryRequest`, with the addition of a timeout.
-message QueryOnCompletionRequest {
+// `QueryTasksOnCompletionRequest` is the request message for querying tasks status.
+// This is close-to-a-copy of `QueryTasksRequest`, with the addition of a timeout.
+message QueryTasksOnCompletionRequest {
   // Empty queries for all tasks if the server allows it.
   repeated rerun.common.v1alpha1.TaskId ids = 1;
   // Time limit for the server to wait for task completion.
@@ -68,20 +68,20 @@ message QueryOnCompletionRequest {
   google.protobuf.Duration timeout = 2;
 }
 
-// `QueryOnCompletionResponse` is the response message for querying tasks status
-// encoded as a record batch. This is a copy of `QueryResponse`.
-message QueryOnCompletionResponse {
+// `QueryTaskOnCompletionResponse` is the response message for querying tasks status
+// encoded as a record batch. This is a copy of `QueryTasksResponse`.
+message QueryTasksOnCompletionResponse {
   rerun.common.v1alpha1.DataframePart data = 1;
 }
 
-// `FetchOutputRequest` is the request message for fetching task output
-message FetchOutputRequest {
+// `FetchTaskOutputRequest` is the request message for fetching task output
+message FetchTaskOutputRequest {
   // Unique identifier for the task
   rerun.common.v1alpha1.TaskId id = 1;
 }
 
-/// `FetchOutputResponse` is the response message for fetching task output
-message FetchOutputResponse {
+/// `FetchTaskOutputResponse` is the response message for fetching task output
+message FetchTaskOutputResponse {
   // The output of the task, encoded as a record batch
   rerun.common.v1alpha1.DataframePart data = 1;
 }

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -827,11 +827,13 @@ pub mod frontend_service_client {
         }
         /// --- Tasks service ---
         /// Query the status of submitted tasks
-        pub async fn query(
+        pub async fn query_tasks(
             &mut self,
-            request: impl tonic::IntoRequest<super::super::super::redap_tasks::v1alpha1::QueryRequest>,
+            request: impl tonic::IntoRequest<
+                super::super::super::redap_tasks::v1alpha1::QueryTasksRequest,
+            >,
         ) -> std::result::Result<
-            tonic::Response<super::super::super::redap_tasks::v1alpha1::QueryResponse>,
+            tonic::Response<super::super::super::redap_tasks::v1alpha1::QueryTasksResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
@@ -839,23 +841,23 @@ pub mod frontend_service_client {
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/rerun.frontend.v1alpha1.FrontendService/Query",
+                "/rerun.frontend.v1alpha1.FrontendService/QueryTasks",
             );
             let mut req = request.into_request();
             req.extensions_mut().insert(GrpcMethod::new(
                 "rerun.frontend.v1alpha1.FrontendService",
-                "Query",
+                "QueryTasks",
             ));
             self.inner.unary(req, path, codec).await
         }
         /// Fetch the output of a completed task
-        pub async fn fetch_output(
+        pub async fn fetch_task_output(
             &mut self,
             request: impl tonic::IntoRequest<
-                super::super::super::redap_tasks::v1alpha1::FetchOutputRequest,
+                super::super::super::redap_tasks::v1alpha1::FetchTaskOutputRequest,
             >,
         ) -> std::result::Result<
-            tonic::Response<super::super::super::redap_tasks::v1alpha1::FetchOutputResponse>,
+            tonic::Response<super::super::super::redap_tasks::v1alpha1::FetchTaskOutputResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
@@ -863,25 +865,25 @@ pub mod frontend_service_client {
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/rerun.frontend.v1alpha1.FrontendService/FetchOutput",
+                "/rerun.frontend.v1alpha1.FrontendService/FetchTaskOutput",
             );
             let mut req = request.into_request();
             req.extensions_mut().insert(GrpcMethod::new(
                 "rerun.frontend.v1alpha1.FrontendService",
-                "FetchOutput",
+                "FetchTaskOutput",
             ));
             self.inner.unary(req, path, codec).await
         }
         /// Query the status of submitted tasks as soon as they are no longer pending
-        pub async fn query_on_completion(
+        pub async fn query_tasks_on_completion(
             &mut self,
             request: impl tonic::IntoRequest<
-                super::super::super::redap_tasks::v1alpha1::QueryOnCompletionRequest,
+                super::super::super::redap_tasks::v1alpha1::QueryTasksOnCompletionRequest,
             >,
         ) -> std::result::Result<
             tonic::Response<
                 tonic::codec::Streaming<
-                    super::super::super::redap_tasks::v1alpha1::QueryOnCompletionResponse,
+                    super::super::super::redap_tasks::v1alpha1::QueryTasksOnCompletionResponse,
                 >,
             >,
             tonic::Status,
@@ -891,12 +893,12 @@ pub mod frontend_service_client {
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/rerun.frontend.v1alpha1.FrontendService/QueryOnCompletion",
+                "/rerun.frontend.v1alpha1.FrontendService/QueryTasksOnCompletion",
             );
             let mut req = request.into_request();
             req.extensions_mut().insert(GrpcMethod::new(
                 "rerun.frontend.v1alpha1.FrontendService",
-                "QueryOnCompletion",
+                "QueryTasksOnCompletion",
             ));
             self.inner.server_streaming(req, path, codec).await
         }
@@ -1119,36 +1121,38 @@ pub mod frontend_service_server {
         ) -> std::result::Result<tonic::Response<Self::ScanTableStream>, tonic::Status>;
         /// --- Tasks service ---
         /// Query the status of submitted tasks
-        async fn query(
+        async fn query_tasks(
             &self,
-            request: tonic::Request<super::super::super::redap_tasks::v1alpha1::QueryRequest>,
+            request: tonic::Request<super::super::super::redap_tasks::v1alpha1::QueryTasksRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::super::super::redap_tasks::v1alpha1::QueryResponse>,
+            tonic::Response<super::super::super::redap_tasks::v1alpha1::QueryTasksResponse>,
             tonic::Status,
         >;
         /// Fetch the output of a completed task
-        async fn fetch_output(
+        async fn fetch_task_output(
             &self,
-            request: tonic::Request<super::super::super::redap_tasks::v1alpha1::FetchOutputRequest>,
+            request: tonic::Request<
+                super::super::super::redap_tasks::v1alpha1::FetchTaskOutputRequest,
+            >,
         ) -> std::result::Result<
-            tonic::Response<super::super::super::redap_tasks::v1alpha1::FetchOutputResponse>,
+            tonic::Response<super::super::super::redap_tasks::v1alpha1::FetchTaskOutputResponse>,
             tonic::Status,
         >;
-        /// Server streaming response type for the QueryOnCompletion method.
-        type QueryOnCompletionStream: tonic::codegen::tokio_stream::Stream<
+        /// Server streaming response type for the QueryTasksOnCompletion method.
+        type QueryTasksOnCompletionStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
-                    super::super::super::redap_tasks::v1alpha1::QueryOnCompletionResponse,
+                    super::super::super::redap_tasks::v1alpha1::QueryTasksOnCompletionResponse,
                     tonic::Status,
                 >,
             > + std::marker::Send
             + 'static;
         /// Query the status of submitted tasks as soon as they are no longer pending
-        async fn query_on_completion(
+        async fn query_tasks_on_completion(
             &self,
             request: tonic::Request<
-                super::super::super::redap_tasks::v1alpha1::QueryOnCompletionRequest,
+                super::super::super::redap_tasks::v1alpha1::QueryTasksOnCompletionRequest,
             >,
-        ) -> std::result::Result<tonic::Response<Self::QueryOnCompletionStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<Self::QueryTasksOnCompletionStream>, tonic::Status>;
     }
     /// Redap's public API.
     #[derive(Debug)]
@@ -2015,25 +2019,27 @@ pub mod frontend_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/rerun.frontend.v1alpha1.FrontendService/Query" => {
+                "/rerun.frontend.v1alpha1.FrontendService/QueryTasks" => {
                     #[allow(non_camel_case_types)]
-                    struct QuerySvc<T: FrontendService>(pub Arc<T>);
+                    struct QueryTasksSvc<T: FrontendService>(pub Arc<T>);
                     impl<T: FrontendService>
                         tonic::server::UnaryService<
-                            super::super::super::redap_tasks::v1alpha1::QueryRequest,
-                        > for QuerySvc<T>
+                            super::super::super::redap_tasks::v1alpha1::QueryTasksRequest,
+                        > for QueryTasksSvc<T>
                     {
-                        type Response = super::super::super::redap_tasks::v1alpha1::QueryResponse;
+                        type Response =
+                            super::super::super::redap_tasks::v1alpha1::QueryTasksResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<
-                                super::super::super::redap_tasks::v1alpha1::QueryRequest,
+                                super::super::super::redap_tasks::v1alpha1::QueryTasksRequest,
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as FrontendService>::query(&inner, request).await };
+                            let fut = async move {
+                                <T as FrontendService>::query_tasks(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -2043,7 +2049,7 @@ pub mod frontend_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = QuerySvc(inner);
+                        let method = QueryTasksSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -2059,26 +2065,26 @@ pub mod frontend_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/rerun.frontend.v1alpha1.FrontendService/FetchOutput" => {
+                "/rerun.frontend.v1alpha1.FrontendService/FetchTaskOutput" => {
                     #[allow(non_camel_case_types)]
-                    struct FetchOutputSvc<T: FrontendService>(pub Arc<T>);
+                    struct FetchTaskOutputSvc<T: FrontendService>(pub Arc<T>);
                     impl<T: FrontendService>
                         tonic::server::UnaryService<
-                            super::super::super::redap_tasks::v1alpha1::FetchOutputRequest,
-                        > for FetchOutputSvc<T>
+                            super::super::super::redap_tasks::v1alpha1::FetchTaskOutputRequest,
+                        > for FetchTaskOutputSvc<T>
                     {
                         type Response =
-                            super::super::super::redap_tasks::v1alpha1::FetchOutputResponse;
+                            super::super::super::redap_tasks::v1alpha1::FetchTaskOutputResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<
-                                super::super::super::redap_tasks::v1alpha1::FetchOutputRequest,
+                                super::super::super::redap_tasks::v1alpha1::FetchTaskOutputRequest,
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as FrontendService>::fetch_output(&inner, request).await
+                                <T as FrontendService>::fetch_task_output(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2089,7 +2095,7 @@ pub mod frontend_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = FetchOutputSvc(inner);
+                        let method = FetchTaskOutputSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -2105,28 +2111,33 @@ pub mod frontend_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/rerun.frontend.v1alpha1.FrontendService/QueryOnCompletion" => {
+                "/rerun.frontend.v1alpha1.FrontendService/QueryTasksOnCompletion" => {
                     #[allow(non_camel_case_types)]
-                    struct QueryOnCompletionSvc<T: FrontendService>(pub Arc<T>);
-                    impl<T: FrontendService>
-                        tonic::server::ServerStreamingService<
-                            super::super::super::redap_tasks::v1alpha1::QueryOnCompletionRequest,
-                        > for QueryOnCompletionSvc<T>
-                    {
-                        type Response =
-                            super::super::super::redap_tasks::v1alpha1::QueryOnCompletionResponse;
-                        type ResponseStream = T::QueryOnCompletionStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                    struct QueryTasksOnCompletionSvc<T: FrontendService>(pub Arc<T>);
+                    impl<
+                        T: FrontendService,
+                    > tonic::server::ServerStreamingService<
+                        super::super::super::redap_tasks::v1alpha1::QueryTasksOnCompletionRequest,
+                    > for QueryTasksOnCompletionSvc<T> {
+                        type Response = super::super::super::redap_tasks::v1alpha1::QueryTasksOnCompletionResponse;
+                        type ResponseStream = T::QueryTasksOnCompletionStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<
-                                super::super::super::redap_tasks::v1alpha1::QueryOnCompletionRequest,
+                                super::super::super::redap_tasks::v1alpha1::QueryTasksOnCompletionRequest,
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as FrontendService>::query_on_completion(&inner, request).await
+                                <T as FrontendService>::query_tasks_on_completion(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2137,7 +2148,7 @@ pub mod frontend_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = QueryOnCompletionSvc(inner);
+                        let method = QueryTasksOnCompletionSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/store/re_protos/src/v1alpha1/rerun.redap_tasks.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.redap_tasks.v1alpha1.rs
@@ -55,44 +55,44 @@ impl ::prost::Name for SubmitTasksResponse {
         "/rerun.redap_tasks.v1alpha1.SubmitTasksResponse".into()
     }
 }
-/// `QueryRequest` is the request message for querying tasks status
+/// `QueryTasksRequest` is the request message for querying tasks status
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryRequest {
+pub struct QueryTasksRequest {
     /// Empty queries for all tasks if the server allows it.
     #[prost(message, repeated, tag = "1")]
     pub ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::TaskId>,
 }
-impl ::prost::Name for QueryRequest {
-    const NAME: &'static str = "QueryRequest";
+impl ::prost::Name for QueryTasksRequest {
+    const NAME: &'static str = "QueryTasksRequest";
     const PACKAGE: &'static str = "rerun.redap_tasks.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
-        "rerun.redap_tasks.v1alpha1.QueryRequest".into()
+        "rerun.redap_tasks.v1alpha1.QueryTasksRequest".into()
     }
     fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.redap_tasks.v1alpha1.QueryRequest".into()
+        "/rerun.redap_tasks.v1alpha1.QueryTasksRequest".into()
     }
 }
-/// `QueryResponse` is the response message for querying tasks status
+/// `QueryTasksResponse` is the response message for querying tasks status
 /// encoded as a record batch
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryResponse {
+pub struct QueryTasksResponse {
     #[prost(message, optional, tag = "1")]
     pub data: ::core::option::Option<super::super::common::v1alpha1::DataframePart>,
 }
-impl ::prost::Name for QueryResponse {
-    const NAME: &'static str = "QueryResponse";
+impl ::prost::Name for QueryTasksResponse {
+    const NAME: &'static str = "QueryTasksResponse";
     const PACKAGE: &'static str = "rerun.redap_tasks.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
-        "rerun.redap_tasks.v1alpha1.QueryResponse".into()
+        "rerun.redap_tasks.v1alpha1.QueryTasksResponse".into()
     }
     fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.redap_tasks.v1alpha1.QueryResponse".into()
+        "/rerun.redap_tasks.v1alpha1.QueryTasksResponse".into()
     }
 }
-/// `QueryOnCompletionRequest` is the request message for querying tasks status.
-/// This is close-to-a-copy of `QueryRequest`, with the addition of a timeout.
+/// `QueryTasksOnCompletionRequest` is the request message for querying tasks status.
+/// This is close-to-a-copy of `QueryTasksRequest`, with the addition of a timeout.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryOnCompletionRequest {
+pub struct QueryTasksOnCompletionRequest {
     /// Empty queries for all tasks if the server allows it.
     #[prost(message, repeated, tag = "1")]
     pub ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::TaskId>,
@@ -101,65 +101,65 @@ pub struct QueryOnCompletionRequest {
     #[prost(message, optional, tag = "2")]
     pub timeout: ::core::option::Option<::prost_types::Duration>,
 }
-impl ::prost::Name for QueryOnCompletionRequest {
-    const NAME: &'static str = "QueryOnCompletionRequest";
+impl ::prost::Name for QueryTasksOnCompletionRequest {
+    const NAME: &'static str = "QueryTasksOnCompletionRequest";
     const PACKAGE: &'static str = "rerun.redap_tasks.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
-        "rerun.redap_tasks.v1alpha1.QueryOnCompletionRequest".into()
+        "rerun.redap_tasks.v1alpha1.QueryTasksOnCompletionRequest".into()
     }
     fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.redap_tasks.v1alpha1.QueryOnCompletionRequest".into()
+        "/rerun.redap_tasks.v1alpha1.QueryTasksOnCompletionRequest".into()
     }
 }
-/// `QueryOnCompletionResponse` is the response message for querying tasks status
-/// encoded as a record batch. This is a copy of `QueryResponse`.
+/// `QueryTaskOnCompletionResponse` is the response message for querying tasks status
+/// encoded as a record batch. This is a copy of `QueryTasksResponse`.
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryOnCompletionResponse {
+pub struct QueryTasksOnCompletionResponse {
     #[prost(message, optional, tag = "1")]
     pub data: ::core::option::Option<super::super::common::v1alpha1::DataframePart>,
 }
-impl ::prost::Name for QueryOnCompletionResponse {
-    const NAME: &'static str = "QueryOnCompletionResponse";
+impl ::prost::Name for QueryTasksOnCompletionResponse {
+    const NAME: &'static str = "QueryTasksOnCompletionResponse";
     const PACKAGE: &'static str = "rerun.redap_tasks.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
-        "rerun.redap_tasks.v1alpha1.QueryOnCompletionResponse".into()
+        "rerun.redap_tasks.v1alpha1.QueryTasksOnCompletionResponse".into()
     }
     fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.redap_tasks.v1alpha1.QueryOnCompletionResponse".into()
+        "/rerun.redap_tasks.v1alpha1.QueryTasksOnCompletionResponse".into()
     }
 }
-/// `FetchOutputRequest` is the request message for fetching task output
+/// `FetchTaskOutputRequest` is the request message for fetching task output
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FetchOutputRequest {
+pub struct FetchTaskOutputRequest {
     /// Unique identifier for the task
     #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<super::super::common::v1alpha1::TaskId>,
 }
-impl ::prost::Name for FetchOutputRequest {
-    const NAME: &'static str = "FetchOutputRequest";
+impl ::prost::Name for FetchTaskOutputRequest {
+    const NAME: &'static str = "FetchTaskOutputRequest";
     const PACKAGE: &'static str = "rerun.redap_tasks.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
-        "rerun.redap_tasks.v1alpha1.FetchOutputRequest".into()
+        "rerun.redap_tasks.v1alpha1.FetchTaskOutputRequest".into()
     }
     fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.redap_tasks.v1alpha1.FetchOutputRequest".into()
+        "/rerun.redap_tasks.v1alpha1.FetchTaskOutputRequest".into()
     }
 }
-/// / `FetchOutputResponse` is the response message for fetching task output
+/// / `FetchTaskOutputResponse` is the response message for fetching task output
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct FetchOutputResponse {
+pub struct FetchTaskOutputResponse {
     /// The output of the task, encoded as a record batch
     #[prost(message, optional, tag = "1")]
     pub data: ::core::option::Option<super::super::common::v1alpha1::DataframePart>,
 }
-impl ::prost::Name for FetchOutputResponse {
-    const NAME: &'static str = "FetchOutputResponse";
+impl ::prost::Name for FetchTaskOutputResponse {
+    const NAME: &'static str = "FetchTaskOutputResponse";
     const PACKAGE: &'static str = "rerun.redap_tasks.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
-        "rerun.redap_tasks.v1alpha1.FetchOutputResponse".into()
+        "rerun.redap_tasks.v1alpha1.FetchTaskOutputResponse".into()
     }
     fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.redap_tasks.v1alpha1.FetchOutputResponse".into()
+        "/rerun.redap_tasks.v1alpha1.FetchTaskOutputResponse".into()
     }
 }
 /// Generated client implementations.
@@ -263,41 +263,42 @@ pub mod tasks_service_client {
             self.inner.unary(req, path, codec).await
         }
         /// Query the status of submitted tasks
-        pub async fn query(
+        pub async fn query_tasks(
             &mut self,
-            request: impl tonic::IntoRequest<super::QueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rerun.redap_tasks.v1alpha1.TasksService/Query",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rerun.redap_tasks.v1alpha1.TasksService",
-                "Query",
-            ));
-            self.inner.unary(req, path, codec).await
-        }
-        /// Fetch the output of a completed task
-        pub async fn fetch_output(
-            &mut self,
-            request: impl tonic::IntoRequest<super::FetchOutputRequest>,
-        ) -> std::result::Result<tonic::Response<super::FetchOutputResponse>, tonic::Status>
+            request: impl tonic::IntoRequest<super::QueryTasksRequest>,
+        ) -> std::result::Result<tonic::Response<super::QueryTasksResponse>, tonic::Status>
         {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/rerun.redap_tasks.v1alpha1.TasksService/FetchOutput",
+                "/rerun.redap_tasks.v1alpha1.TasksService/QueryTasks",
             );
             let mut req = request.into_request();
             req.extensions_mut().insert(GrpcMethod::new(
                 "rerun.redap_tasks.v1alpha1.TasksService",
-                "FetchOutput",
+                "QueryTasks",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        /// Fetch the output of a completed task
+        pub async fn fetch_task_output(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FetchTaskOutputRequest>,
+        ) -> std::result::Result<tonic::Response<super::FetchTaskOutputResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.redap_tasks.v1alpha1.TasksService/FetchTaskOutput",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.redap_tasks.v1alpha1.TasksService",
+                "FetchTaskOutput",
             ));
             self.inner.unary(req, path, codec).await
         }
@@ -307,11 +308,11 @@ pub mod tasks_service_client {
         /// the status of a subset of the tasks, as they complete.
         /// The server does not guarantee to immediately send one stream item as soon as a task
         /// completes, but may decide to arbitrarily aggregate results into larger batches.
-        pub async fn query_on_completion(
+        pub async fn query_tasks_on_completion(
             &mut self,
-            request: impl tonic::IntoRequest<super::QueryOnCompletionRequest>,
+            request: impl tonic::IntoRequest<super::QueryTasksOnCompletionRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::QueryOnCompletionResponse>>,
+            tonic::Response<tonic::codec::Streaming<super::QueryTasksOnCompletionResponse>>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
@@ -319,12 +320,12 @@ pub mod tasks_service_client {
             })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/rerun.redap_tasks.v1alpha1.TasksService/QueryOnCompletion",
+                "/rerun.redap_tasks.v1alpha1.TasksService/QueryTasksOnCompletion",
             );
             let mut req = request.into_request();
             req.extensions_mut().insert(GrpcMethod::new(
                 "rerun.redap_tasks.v1alpha1.TasksService",
-                "QueryOnCompletion",
+                "QueryTasksOnCompletion",
             ));
             self.inner.server_streaming(req, path, codec).await
         }
@@ -349,18 +350,18 @@ pub mod tasks_service_server {
             request: tonic::Request<super::SubmitTasksRequest>,
         ) -> std::result::Result<tonic::Response<super::SubmitTasksResponse>, tonic::Status>;
         /// Query the status of submitted tasks
-        async fn query(
+        async fn query_tasks(
             &self,
-            request: tonic::Request<super::QueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::QueryResponse>, tonic::Status>;
+            request: tonic::Request<super::QueryTasksRequest>,
+        ) -> std::result::Result<tonic::Response<super::QueryTasksResponse>, tonic::Status>;
         /// Fetch the output of a completed task
-        async fn fetch_output(
+        async fn fetch_task_output(
             &self,
-            request: tonic::Request<super::FetchOutputRequest>,
-        ) -> std::result::Result<tonic::Response<super::FetchOutputResponse>, tonic::Status>;
-        /// Server streaming response type for the QueryOnCompletion method.
-        type QueryOnCompletionStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::QueryOnCompletionResponse, tonic::Status>,
+            request: tonic::Request<super::FetchTaskOutputRequest>,
+        ) -> std::result::Result<tonic::Response<super::FetchTaskOutputResponse>, tonic::Status>;
+        /// Server streaming response type for the QueryTasksOnCompletion method.
+        type QueryTasksOnCompletionStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::QueryTasksOnCompletionResponse, tonic::Status>,
             > + std::marker::Send
             + 'static;
         /// Query the status of submitted tasks, waiting for their completion.
@@ -369,10 +370,10 @@ pub mod tasks_service_server {
         /// the status of a subset of the tasks, as they complete.
         /// The server does not guarantee to immediately send one stream item as soon as a task
         /// completes, but may decide to arbitrarily aggregate results into larger batches.
-        async fn query_on_completion(
+        async fn query_tasks_on_completion(
             &self,
-            request: tonic::Request<super::QueryOnCompletionRequest>,
-        ) -> std::result::Result<tonic::Response<Self::QueryOnCompletionStream>, tonic::Status>;
+            request: tonic::Request<super::QueryTasksOnCompletionRequest>,
+        ) -> std::result::Result<tonic::Response<Self::QueryTasksOnCompletionStream>, tonic::Status>;
     }
     /// `TasksService` is the service for submitting and querying persistent redap tasks.
     #[derive(Debug)]
@@ -487,57 +488,19 @@ pub mod tasks_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/rerun.redap_tasks.v1alpha1.TasksService/Query" => {
+                "/rerun.redap_tasks.v1alpha1.TasksService/QueryTasks" => {
                     #[allow(non_camel_case_types)]
-                    struct QuerySvc<T: TasksService>(pub Arc<T>);
-                    impl<T: TasksService> tonic::server::UnaryService<super::QueryRequest> for QuerySvc<T> {
-                        type Response = super::QueryResponse;
+                    struct QueryTasksSvc<T: TasksService>(pub Arc<T>);
+                    impl<T: TasksService> tonic::server::UnaryService<super::QueryTasksRequest> for QueryTasksSvc<T> {
+                        type Response = super::QueryTasksResponse;
                         type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::QueryRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as TasksService>::query(&inner, request).await };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = QuerySvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/rerun.redap_tasks.v1alpha1.TasksService/FetchOutput" => {
-                    #[allow(non_camel_case_types)]
-                    struct FetchOutputSvc<T: TasksService>(pub Arc<T>);
-                    impl<T: TasksService> tonic::server::UnaryService<super::FetchOutputRequest> for FetchOutputSvc<T> {
-                        type Response = super::FetchOutputResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::FetchOutputRequest>,
+                            request: tonic::Request<super::QueryTasksRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as TasksService>::fetch_output(&inner, request).await
+                                <T as TasksService>::query_tasks(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -548,7 +511,7 @@ pub mod tasks_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = FetchOutputSvc(inner);
+                        let method = QueryTasksSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -564,24 +527,66 @@ pub mod tasks_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/rerun.redap_tasks.v1alpha1.TasksService/QueryOnCompletion" => {
+                "/rerun.redap_tasks.v1alpha1.TasksService/FetchTaskOutput" => {
                     #[allow(non_camel_case_types)]
-                    struct QueryOnCompletionSvc<T: TasksService>(pub Arc<T>);
-                    impl<T: TasksService>
-                        tonic::server::ServerStreamingService<super::QueryOnCompletionRequest>
-                        for QueryOnCompletionSvc<T>
+                    struct FetchTaskOutputSvc<T: TasksService>(pub Arc<T>);
+                    impl<T: TasksService> tonic::server::UnaryService<super::FetchTaskOutputRequest>
+                        for FetchTaskOutputSvc<T>
                     {
-                        type Response = super::QueryOnCompletionResponse;
-                        type ResponseStream = T::QueryOnCompletionStream;
+                        type Response = super::FetchTaskOutputResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::FetchTaskOutputRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as TasksService>::fetch_task_output(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = FetchTaskOutputSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.redap_tasks.v1alpha1.TasksService/QueryTasksOnCompletion" => {
+                    #[allow(non_camel_case_types)]
+                    struct QueryTasksOnCompletionSvc<T: TasksService>(pub Arc<T>);
+                    impl<T: TasksService>
+                        tonic::server::ServerStreamingService<super::QueryTasksOnCompletionRequest>
+                        for QueryTasksOnCompletionSvc<T>
+                    {
+                        type Response = super::QueryTasksOnCompletionResponse;
+                        type ResponseStream = T::QueryTasksOnCompletionStream;
                         type Future =
                             BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::QueryOnCompletionRequest>,
+                            request: tonic::Request<super::QueryTasksOnCompletionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as TasksService>::query_on_completion(&inner, request).await
+                                <T as TasksService>::query_tasks_on_completion(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -592,7 +597,7 @@ pub mod tasks_service_server {
                     let max_encoding_message_size = self.max_encoding_message_size;
                     let inner = self.inner.clone();
                     let fut = async move {
-                        let method = QueryOnCompletionSvc(inner);
+                        let method = QueryTasksOnCompletionSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(


### PR DESCRIPTION
When exposed from the dataplatform forntend, it became clare that methods like `Query` would not work well :) Renaming to clearer `QueryTasks` etc..

### Related

* https://github.com/rerun-io/dataplatform/pull/583
