### PR TITLE
Do not hide all entities when the search is active but empty

### DIFF
--- a/crates/viewer/re_blueprint_tree/src/data.rs
+++ b/crates/viewer/re_blueprint_tree/src/data.rs
@@ -374,11 +374,6 @@ impl DataResultData {
     ) -> Option<Self> {
         re_tracing::profile_function!();
 
-        // Early out.
-        if filter_matcher.matches_nothing() {
-            return None;
-        }
-
         let entity_path = data_result_or_path.path().clone();
         let data_result_node = data_result_or_path.data_result_node();
         let visible = data_result_node.is_some_and(|node| node.data_result.is_visible());

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/empty.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/empty.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4173d8f02a5dd16c14aa1283f37f9ce968b372b8b8494d91e9b4dded71b46ab
+size 14636

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/empty.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/empty.snap
@@ -1,0 +1,26 @@
+---
+source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+expression: blueprint_tree_data
+---
+root_container:
+  name:
+    Placeholder: Grid
+  kind: Grid
+  visible: true
+  default_open: true
+  children:
+    - View:
+        class_identifier: 3D
+        name:
+          Placeholder: /
+        visible: true
+        default_open: true
+        origin_tree:
+          kind: EmptyOriginPlaceholder
+          entity_path: []
+          visible: false
+          label: / (root)
+          highlight_sections: []
+          default_open: false
+          children: []
+        projection_trees: []

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/multiple_proj.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/multiple_proj.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5192b94f3380ead029841d4c8da804295292635fb868feced1f28262274ae10e
+size 21525

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/multiple_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/multiple_proj.snap
@@ -1,0 +1,59 @@
+---
+source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+expression: blueprint_tree_data
+---
+root_container:
+  name:
+    Placeholder: Grid
+  kind: Grid
+  visible: true
+  default_open: true
+  children:
+    - View:
+        class_identifier: 3D
+        name:
+          Placeholder: center/way
+        visible: true
+        default_open: true
+        origin_tree:
+          kind: EntityPart
+          entity_path:
+            - center
+            - way
+          visible: true
+          label: way
+          highlight_sections: []
+          default_open: true
+          children: []
+        projection_trees:
+          - kind: EntityPart
+            entity_path:
+              - path
+              - to
+              - right
+            visible: true
+            label: right
+            highlight_sections: []
+            default_open: true
+            children: []
+          - kind: EntityPart
+            entity_path:
+              - path
+              - to
+              - the
+            visible: true
+            label: the
+            highlight_sections: []
+            default_open: true
+            children:
+              - kind: EntityPart
+                entity_path:
+                  - path
+                  - to
+                  - the
+                  - void
+                visible: true
+                label: void
+                highlight_sections: []
+                default_open: true
+                children: []

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/non_root_origin.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/non_root_origin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b85f23fc506f8bbb60b74597dd5c8c67261e3cc82f6bfdab480133af48866b7
+size 19530

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/non_root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/non_root_origin.snap
@@ -1,0 +1,69 @@
+---
+source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+expression: blueprint_tree_data
+---
+root_container:
+  name:
+    Placeholder: Grid
+  kind: Grid
+  visible: true
+  default_open: true
+  children:
+    - View:
+        class_identifier: 3D
+        name:
+          Placeholder: path/to
+        visible: true
+        default_open: true
+        origin_tree:
+          kind: EntityPart
+          entity_path:
+            - path
+            - to
+          visible: true
+          label: to
+          highlight_sections: []
+          default_open: true
+          children:
+            - kind: EntityPart
+              entity_path:
+                - path
+                - to
+                - left
+              visible: true
+              label: left
+              highlight_sections: []
+              default_open: true
+              children: []
+            - kind: EntityPart
+              entity_path:
+                - path
+                - to
+                - right
+              visible: true
+              label: right
+              highlight_sections: []
+              default_open: true
+              children: []
+            - kind: EntityPart
+              entity_path:
+                - path
+                - to
+                - the
+              visible: true
+              label: the
+              highlight_sections: []
+              default_open: true
+              children:
+                - kind: EntityPart
+                  entity_path:
+                    - path
+                    - to
+                    - the
+                    - void
+                  visible: true
+                  label: void
+                  highlight_sections: []
+                  default_open: true
+                  children: []
+        projection_trees: []

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/proj_with_placeholder.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/proj_with_placeholder.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85f0f40cfb7f3e00ab8eebd601fce8edc260d915276e700c704c4b6e10dbf63a
+size 32007

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/proj_with_placeholder.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/proj_with_placeholder.snap
@@ -1,0 +1,140 @@
+---
+source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+expression: blueprint_tree_data
+---
+root_container:
+  name:
+    Placeholder: Grid
+  kind: Grid
+  visible: true
+  default_open: true
+  children:
+    - View:
+        class_identifier: 3D
+        name:
+          Placeholder: path/to
+        visible: true
+        default_open: true
+        origin_tree:
+          kind: EntityPart
+          entity_path:
+            - path
+            - to
+          visible: true
+          label: to
+          highlight_sections: []
+          default_open: true
+          children:
+            - kind: EntityPart
+              entity_path:
+                - path
+                - to
+                - left
+              visible: true
+              label: left
+              highlight_sections: []
+              default_open: true
+              children: []
+            - kind: EntityPart
+              entity_path:
+                - path
+                - to
+                - right
+              visible: true
+              label: right
+              highlight_sections: []
+              default_open: true
+              children: []
+            - kind: EntityPart
+              entity_path:
+                - path
+                - to
+                - the
+              visible: true
+              label: the
+              highlight_sections: []
+              default_open: true
+              children:
+                - kind: EntityPart
+                  entity_path:
+                    - path
+                    - to
+                    - the
+                    - void
+                  visible: true
+                  label: void
+                  highlight_sections: []
+                  default_open: true
+                  children: []
+        projection_trees:
+          - kind: EntityPart
+            entity_path: []
+            visible: true
+            label: / (root)
+            highlight_sections: []
+            default_open: true
+            children:
+              - kind: EntityPart
+                entity_path:
+                  - center
+                visible: true
+                label: center
+                highlight_sections: []
+                default_open: true
+                children:
+                  - kind: EntityPart
+                    entity_path:
+                      - center
+                      - way
+                    visible: true
+                    label: way
+                    highlight_sections: []
+                    default_open: true
+                    children: []
+              - kind: EntityPart
+                entity_path:
+                  - path
+                visible: true
+                label: path
+                highlight_sections: []
+                default_open: true
+                children:
+                  - kind: EntityPart
+                    entity_path:
+                      - path
+                      - onto
+                    visible: true
+                    label: onto
+                    highlight_sections: []
+                    default_open: true
+                    children:
+                      - kind: EntityPart
+                        entity_path:
+                          - path
+                          - onto
+                          - their
+                        visible: true
+                        label: their
+                        highlight_sections: []
+                        default_open: true
+                        children:
+                          - kind: EntityPart
+                            entity_path:
+                              - path
+                              - onto
+                              - their
+                              - coils
+                            visible: true
+                            label: coils
+                            highlight_sections: []
+                            default_open: true
+                            children: []
+                  - kind: OriginProjectionPlaceholder
+                    entity_path:
+                      - path
+                      - to
+                    visible: true
+                    label: to
+                    highlight_sections: []
+                    default_open: false
+                    children: []

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/root_origin.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/root_origin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba479120078773fcb58c6d52864db2b9b73a780f0f44dbc9f42a71c15d0fefd3
+size 26868

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/root_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/root_origin.snap
@@ -1,0 +1,131 @@
+---
+source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+expression: blueprint_tree_data
+---
+root_container:
+  name:
+    Placeholder: Grid
+  kind: Grid
+  visible: true
+  default_open: true
+  children:
+    - View:
+        class_identifier: 3D
+        name:
+          Placeholder: /
+        visible: true
+        default_open: true
+        origin_tree:
+          kind: EntityPart
+          entity_path: []
+          visible: true
+          label: / (root)
+          highlight_sections: []
+          default_open: true
+          children:
+            - kind: EntityPart
+              entity_path:
+                - center
+              visible: true
+              label: center
+              highlight_sections: []
+              default_open: true
+              children:
+                - kind: EntityPart
+                  entity_path:
+                    - center
+                    - way
+                  visible: true
+                  label: way
+                  highlight_sections: []
+                  default_open: true
+                  children: []
+            - kind: EntityPart
+              entity_path:
+                - path
+              visible: true
+              label: path
+              highlight_sections: []
+              default_open: true
+              children:
+                - kind: EntityPart
+                  entity_path:
+                    - path
+                    - onto
+                  visible: true
+                  label: onto
+                  highlight_sections: []
+                  default_open: true
+                  children:
+                    - kind: EntityPart
+                      entity_path:
+                        - path
+                        - onto
+                        - their
+                      visible: true
+                      label: their
+                      highlight_sections: []
+                      default_open: true
+                      children:
+                        - kind: EntityPart
+                          entity_path:
+                            - path
+                            - onto
+                            - their
+                            - coils
+                          visible: true
+                          label: coils
+                          highlight_sections: []
+                          default_open: true
+                          children: []
+                - kind: EntityPart
+                  entity_path:
+                    - path
+                    - to
+                  visible: true
+                  label: to
+                  highlight_sections: []
+                  default_open: true
+                  children:
+                    - kind: EntityPart
+                      entity_path:
+                        - path
+                        - to
+                        - left
+                      visible: true
+                      label: left
+                      highlight_sections: []
+                      default_open: true
+                      children: []
+                    - kind: EntityPart
+                      entity_path:
+                        - path
+                        - to
+                        - right
+                      visible: true
+                      label: right
+                      highlight_sections: []
+                      default_open: true
+                      children: []
+                    - kind: EntityPart
+                      entity_path:
+                        - path
+                        - to
+                        - the
+                      visible: true
+                      label: the
+                      highlight_sections: []
+                      default_open: true
+                      children:
+                        - kind: EntityPart
+                          entity_path:
+                            - path
+                            - to
+                            - the
+                            - void
+                          visible: true
+                          label: void
+                          highlight_sections: []
+                          default_open: true
+                          children: []
+        projection_trees: []

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/single_proj.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/single_proj.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6248ba79a8293d595f8d3d22fc3596d34e36081f33fcb67046522547c8464008
+size 23266

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/single_proj.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/single_proj.snap
@@ -1,0 +1,78 @@
+---
+source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+expression: blueprint_tree_data
+---
+root_container:
+  name:
+    Placeholder: Grid
+  kind: Grid
+  visible: true
+  default_open: true
+  children:
+    - View:
+        class_identifier: 3D
+        name:
+          Placeholder: center/way
+        visible: true
+        default_open: true
+        origin_tree:
+          kind: EntityPart
+          entity_path:
+            - center
+            - way
+          visible: true
+          label: way
+          highlight_sections: []
+          default_open: true
+          children: []
+        projection_trees:
+          - kind: EntityPart
+            entity_path:
+              - path
+              - to
+            visible: true
+            label: to
+            highlight_sections: []
+            default_open: true
+            children:
+              - kind: EntityPart
+                entity_path:
+                  - path
+                  - to
+                  - left
+                visible: true
+                label: left
+                highlight_sections: []
+                default_open: true
+                children: []
+              - kind: EntityPart
+                entity_path:
+                  - path
+                  - to
+                  - right
+                visible: true
+                label: right
+                highlight_sections: []
+                default_open: true
+                children: []
+              - kind: EntityPart
+                entity_path:
+                  - path
+                  - to
+                  - the
+                visible: true
+                label: the
+                highlight_sections: []
+                default_open: true
+                children:
+                  - kind: EntityPart
+                    entity_path:
+                      - path
+                      - to
+                      - the
+                      - void
+                    visible: true
+                    label: void
+                    highlight_sections: []
+                    default_open: true
+                    children: []

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/unknown_origin.png
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/unknown_origin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:031d5639778b4be73ea6dbf4d436391cb8805125cb5e091743bbf3449ef9030b
+size 16274

--- a/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/unknown_origin.snap
+++ b/crates/viewer/re_blueprint_tree/tests/snapshots/view_structure_test/query-/unknown_origin.snap
@@ -1,0 +1,28 @@
+---
+source: crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+expression: blueprint_tree_data
+---
+root_container:
+  name:
+    Placeholder: Grid
+  kind: Grid
+  visible: true
+  default_open: true
+  children:
+    - View:
+        class_identifier: 3D
+        name:
+          Placeholder: wrong/path
+        visible: true
+        default_open: true
+        origin_tree:
+          kind: EmptyOriginPlaceholder
+          entity_path:
+            - wrong
+            - path
+          visible: false
+          label: path
+          highlight_sections: []
+          default_open: false
+          children: []
+        projection_trees: []

--- a/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
@@ -91,6 +91,7 @@ fn base_test_cases() -> impl Iterator<Item = TestCase> {
 fn filter_queries() -> impl Iterator<Item = Option<&'static str>> {
     [
         None,
+        Some(""),
         Some("t"),
         Some("void"),
         Some("path"),

--- a/crates/viewer/re_selection_panel/src/view_entity_picker.rs
+++ b/crates/viewer/re_selection_panel/src/view_entity_picker.rs
@@ -337,11 +337,6 @@ impl EntityPickerEntryData {
         hierarchy: &mut Vec<String>,
         hierarchy_highlights: &mut PathRanges,
     ) -> Option<Self> {
-        // Early out
-        if filter_matcher.matches_nothing() {
-            return None;
-        }
-
         let entity_part_ui_string = entity_tree
             .path
             .last()

--- a/crates/viewer/re_time_panel/src/streams_tree_data.rs
+++ b/crates/viewer/re_time_panel/src/streams_tree_data.rs
@@ -106,11 +106,6 @@ impl EntityData {
         hierarchy: &mut Vec<String>,
         hierarchy_highlights: &mut PathRanges,
     ) -> Option<Self> {
-        // Early out
-        if filter_matcher.matches_nothing() {
-            return None;
-        }
-
         let entity_part_ui_string = entity_tree
             .path
             .last()

--- a/crates/viewer/re_time_panel/tests/snapshots/time_panel_filter_test_active_no_query.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/time_panel_filter_test_active_no_query.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:50709d736409f20e233ec37d12359ec391eafee856727ada1a48e980c25d1c9b
-size 17422
+oid sha256:b39c2a9325705efea2c8bf948187df59ddfdce17cab7284162ea74c1e8264960
+size 24678


### PR DESCRIPTION
### Related

* closes https://github.com/rerun-io/rerun/issues/9520

### What

This PR changes the behaviours of the entity search filter when the search is activated but the query is still empty. Now, the displayed content is unchanged compared to when the search is inactive. Previously, nothing would be displayed in that situation. This required subtle change of when a session id is returned, such that the collapse state used in the active-but-empty-query state is the same as in the inactive state.