### PR TITLE
Introduce new `re_dataframe_ui` crate and move `DisplayRecordBatch` to it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,11 +98,11 @@ Of course, this will only take us so far. In the future we plan on caching queri
 Here is an overview of the crates included in the project:
 
 <picture>
-  <img src="https://static.rerun.io/crates/14f73cb8584737c66aa79f9404b202ae8d0748cb/full.png" alt="">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/crates/14f73cb8584737c66aa79f9404b202ae8d0748cb/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/crates/14f73cb8584737c66aa79f9404b202ae8d0748cb/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/crates/14f73cb8584737c66aa79f9404b202ae8d0748cb/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/crates/14f73cb8584737c66aa79f9404b202ae8d0748cb/1200w.png">
+  <img src="https://static.rerun.io/crates/a0fc732f2e6a79a7dc8b4ef5232e969d5bcccb22/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/crates/a0fc732f2e6a79a7dc8b4ef5232e969d5bcccb22/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/crates/a0fc732f2e6a79a7dc8b4ef5232e969d5bcccb22/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/crates/a0fc732f2e6a79a7dc8b4ef5232e969d5bcccb22/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/crates/a0fc732f2e6a79a7dc8b4ef5232e969d5bcccb22/1200w.png">
 </picture>
 
 <!-- !!! IMPORTANT!!!
@@ -134,11 +134,12 @@ Update instructions:
 ##### UI crates
 
 | Crate                 | Description                                                                                                |
-| --------------------- | ---------------------------------------------------------------------------------------------------------- |
+|-----------------------|------------------------------------------------------------------------------------------------------------|
 | re_blueprint_tree     | The UI for the blueprint tree in the left panel.                                                           |
 | re_redap_browser      | The UI and communication to implement the in-viewer redap server browser.                                  |
 | re_chunk_store_ui     | A chunk store browser UI.                                                                                  |
 | re_component_ui       | Provides UI editors for Rerun component data for registration with the Rerun Viewer component UI registry. |
+| re_dataframe_ui       | Rich table widget over DataFusion.                                                                         |
 | re_selection_panel    | The UI for the selection panel.                                                                            |
 | re_view               | Types & utilities for defining View classes and communicating with the Viewport.                           |
 | re_view_bar_chart     | A View that shows a single bar chart.                                                                      |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6947,7 +6947,6 @@ dependencies = [
  "re_arrow_util",
  "re_chunk_store",
  "re_dataframe",
- "re_log",
  "re_log_types",
  "re_sorbet",
  "re_tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6938,6 +6938,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_dataframe_ui"
+version = "0.23.0-alpha.3+dev"
+dependencies = [
+ "ahash",
+ "arrow",
+ "egui",
+ "re_arrow_util",
+ "re_chunk_store",
+ "re_dataframe",
+ "re_log",
+ "re_log_types",
+ "re_sorbet",
+ "re_tracing",
+ "re_types",
+ "re_types_core",
+ "re_ui",
+ "re_viewer_context",
+ "thiserror 1.0.65",
+]
+
+[[package]]
 name = "re_datafusion"
 version = "0.23.0-alpha.3+dev"
 dependencies = [
@@ -7333,6 +7354,7 @@ dependencies = [
  "once_cell",
  "re_arrow_util",
  "re_data_ui",
+ "re_dataframe_ui",
  "re_grpc_client",
  "re_log",
  "re_log_encoding",
@@ -7344,7 +7366,6 @@ dependencies = [
  "re_types_core",
  "re_ui",
  "re_uri",
- "re_view_dataframe",
  "re_viewer_context",
  "serde",
  "thiserror 1.0.65",
@@ -7810,22 +7831,20 @@ dependencies = [
 name = "re_view_dataframe"
 version = "0.23.0-alpha.3+dev"
 dependencies = [
- "ahash",
  "anyhow",
  "arrow",
  "egui",
  "egui_table",
  "itertools 0.14.0",
- "re_arrow_util",
  "re_chunk_store",
  "re_component_ui",
  "re_dataframe",
+ "re_dataframe_ui",
  "re_error",
  "re_format",
  "re_log",
  "re_log_types",
  "re_renderer",
- "re_sorbet",
  "re_tracing",
  "re_types",
  "re_types_core",
@@ -7833,7 +7852,6 @@ dependencies = [
  "re_viewer_context",
  "re_viewport",
  "re_viewport_blueprint",
- "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -8051,6 +8069,7 @@ dependencies = [
  "re_data_loader",
  "re_data_source",
  "re_data_ui",
+ "re_dataframe_ui",
  "re_entity_db",
  "re_error",
  "re_format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ re_redap_browser = { path = "crates/viewer/re_redap_browser", version = "=0.23.0
 re_component_ui = { path = "crates/viewer/re_component_ui", version = "=0.23.0-alpha.3", default-features = false }
 re_context_menu = { path = "crates/viewer/re_context_menu", version = "=0.23.0-alpha.3", default-features = false }
 re_chunk_store_ui = { path = "crates/viewer/re_chunk_store_ui", version = "=0.23.0-alpha.3", default-features = false }
+re_dataframe_ui = { path = "crates/viewer/re_dataframe_ui", version = "=0.23.0-alpha.3", default-features = false }
 re_data_ui = { path = "crates/viewer/re_data_ui", version = "=0.23.0-alpha.3", default-features = false }
 re_renderer = { path = "crates/viewer/re_renderer", version = "=0.23.0-alpha.3", default-features = false }
 re_renderer_examples = { path = "crates/viewer/re_renderer_examples", version = "=0.23.0-alpha.3", default-features = false }

--- a/crates/viewer/re_dataframe_ui/Cargo.toml
+++ b/crates/viewer/re_dataframe_ui/Cargo.toml
@@ -22,7 +22,6 @@ all-features = true
 re_arrow_util.workspace = true
 re_chunk_store.workspace = true
 re_dataframe.workspace = true
-re_log.workspace = true
 re_log_types.workspace = true
 re_sorbet.workspace = true
 re_tracing.workspace = true

--- a/crates/viewer/re_dataframe_ui/Cargo.toml
+++ b/crates/viewer/re_dataframe_ui/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+authors.workspace = true
+description = "Rich table widget over DataFusion."
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "re_dataframe_ui"
+publish = true
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+include.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+re_arrow_util.workspace = true
+re_chunk_store.workspace = true
+re_dataframe.workspace = true
+re_log.workspace = true
+re_log_types.workspace = true
+re_sorbet.workspace = true
+re_tracing.workspace = true
+re_types.workspace = true
+re_types_core.workspace = true
+re_ui.workspace = true
+re_viewer_context.workspace = true
+
+
+ahash.workspace = true
+arrow.workspace = true
+egui.workspace = true
+thiserror.workspace = true
+
+

--- a/crates/viewer/re_dataframe_ui/Cargo.toml
+++ b/crates/viewer/re_dataframe_ui/Cargo.toml
@@ -35,5 +35,3 @@ ahash.workspace = true
 arrow.workspace = true
 egui.workspace = true
 thiserror.workspace = true
-
-

--- a/crates/viewer/re_dataframe_ui/README.md
+++ b/crates/viewer/re_dataframe_ui/README.md
@@ -1,0 +1,10 @@
+# re_dataframe_ui
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_dataframe_ui.svg)](https://crates.io/crates/re_dataframe_ui?speculative-link)
+[![Documentation](https://docs.rs/re_dataframe_ui/badge.svg)](https://docs.rs/re_dataframe_ui?speculative-link)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+Rich table widget over DataFusion.

--- a/crates/viewer/re_dataframe_ui/src/display_record_batch.rs
+++ b/crates/viewer/re_dataframe_ui/src/display_record_batch.rs
@@ -1,6 +1,8 @@
 //! Intermediate data structures to make `re_datastore`'s row data more amenable to displaying in a
 //! table.
 
+use std::sync::Arc;
+
 use arrow::{
     array::{
         Array as _, ArrayRef as ArrowArrayRef, Int32DictionaryArray as ArrowInt32DictionaryArray,
@@ -10,7 +12,6 @@ use arrow::{
     buffer::ScalarBuffer as ArrowScalarBuffer,
     datatypes::DataType as ArrowDataType,
 };
-use std::sync::Arc;
 use thiserror::Error;
 
 use re_arrow_util::ArrowArrayDowncastRef as _;

--- a/crates/viewer/re_dataframe_ui/src/lib.rs
+++ b/crates/viewer/re_dataframe_ui/src/lib.rs
@@ -1,0 +1,5 @@
+//! Rich table widget over `datafusion`.
+
+mod display_record_batch;
+
+pub use display_record_batch::{DisplayColumn, DisplayRecordBatch, DisplayRecordBatchError};

--- a/crates/viewer/re_redap_browser/Cargo.toml
+++ b/crates/viewer/re_redap_browser/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 [dependencies]
 re_arrow_util.workspace = true
 re_data_ui.workspace = true
+re_dataframe_ui.workspace = true
 re_grpc_client.workspace = true
 re_log.workspace = true
 re_log_encoding.workspace = true
@@ -29,13 +30,11 @@ re_log_types.workspace = true
 re_protos.workspace = true
 re_smart_channel.workspace = true
 re_sorbet.workspace = true
-re_types_core.workspace = true
 re_types.workspace = true
+re_types_core.workspace = true
 re_ui.workspace = true
-re_viewer_context.workspace = true
-#TODO(ab): for `DisplayRecordBatch`, should be moved elsewhere.
-re_view_dataframe.workspace = true
 re_uri.workspace = true
+re_viewer_context.workspace = true
 
 ahash.workspace = true
 arrow.workspace = true

--- a/crates/viewer/re_redap_browser/src/dataset_ui.rs
+++ b/crates/viewer/re_redap_browser/src/dataset_ui.rs
@@ -8,12 +8,12 @@ use egui::{Frame, Id, Margin, RichText};
 use egui_table::{CellInfo, HeaderCellInfo};
 
 use re_arrow_util::ArrowArrayDowncastRef as _;
+use re_dataframe_ui::{DisplayRecordBatch, DisplayRecordBatchError};
 use re_log_types::{EntityPath, EntryId, TimelineName};
 use re_protos::manifest_registry::v1alpha1::DATASET_MANIFEST_ID_FIELD_NAME;
 use re_sorbet::{ColumnDescriptorRef, ComponentColumnDescriptor, SorbetBatch};
 use re_types_core::arrow_helpers::as_array_ref;
 use re_ui::{icons, UiExt as _};
-use re_view_dataframe::display_record_batch::{DisplayRecordBatch, DisplayRecordBatchError};
 use re_viewer_context::ViewerContext;
 
 use super::servers::Command;

--- a/crates/viewer/re_view_dataframe/Cargo.toml
+++ b/crates/viewer/re_view_dataframe/Cargo.toml
@@ -23,15 +23,14 @@ default = []
 testing = ["re_viewer_context/testing", "re_viewport_blueprint/testing"]
 
 [dependencies]
-re_arrow_util.workspace = true
 re_chunk_store.workspace = true
 re_dataframe.workspace = true
+re_dataframe_ui.workspace = true
 re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
 re_renderer.workspace = true
-re_sorbet.workspace = true
 re_tracing.workspace = true
 re_types_core.workspace = true
 re_types.workspace = true
@@ -39,13 +38,11 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 
-ahash.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
 egui_table.workspace = true
 egui.workspace = true
 itertools.workspace = true
-thiserror.workspace = true
 
 [dev-dependencies]
 re_chunk_store.workspace = true

--- a/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
@@ -9,12 +9,12 @@ use itertools::Itertools as _;
 use re_chunk_store::{ColumnDescriptor, LatestAtQuery};
 use re_dataframe::external::re_query::StorageEngineArcReadGuard;
 use re_dataframe::QueryHandle;
+use re_dataframe_ui::{DisplayRecordBatch, DisplayRecordBatchError};
 use re_log_types::{EntityPath, TimeInt, TimelineName};
 use re_types_core::ComponentName;
 use re_ui::UiExt as _;
 use re_viewer_context::{SystemCommandSender as _, ViewId, ViewerContext};
 
-use crate::display_record_batch::{DisplayRecordBatch, DisplayRecordBatchError};
 use crate::expanded_rows::{ExpandedRows, ExpandedRowsCache};
 
 /// Ui actions triggered by the dataframe UI to be handled by the calling code.

--- a/crates/viewer/re_view_dataframe/src/lib.rs
+++ b/crates/viewer/re_view_dataframe/src/lib.rs
@@ -3,8 +3,7 @@
 //! A View that shows the data contained in entities in a table.
 
 mod dataframe_ui;
-//TODO(ab): this should be moved somewhere else
-pub mod display_record_batch;
+
 mod expanded_rows;
 mod view_class;
 mod view_query;

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -52,6 +52,7 @@ re_redap_browser.workspace = true
 re_chunk.workspace = true
 re_chunk_store.workspace = true
 re_component_ui.workspace = true
+re_dataframe_ui.workspace = true
 re_data_loader.workspace = true
 re_data_source.workspace = true
 re_data_ui.workspace = true

--- a/crates/viewer/re_viewer/src/ui/table/mod.rs
+++ b/crates/viewer/re_viewer/src/ui/table/mod.rs
@@ -2,13 +2,13 @@ use eframe::epaint::Margin;
 use egui::{Frame, Id, RichText};
 use egui_table::{CellInfo, HeaderCellInfo};
 
+use re_dataframe_ui::{DisplayRecordBatch, DisplayRecordBatchError};
 use re_log_types::TimelineName;
 use re_redap_browser::table_utils::{
     apply_table_style_fixes, cell_ui, header_title, ColumnConfig, TableConfig, CELL_MARGIN,
 };
 use re_sorbet::{ColumnDescriptorRef, SorbetBatch};
 use re_ui::UiExt as _;
-use re_view_dataframe::display_record_batch::{DisplayRecordBatch, DisplayRecordBatchError};
 use re_viewer_context::{TableContext, ViewerContext};
 
 pub fn table_ui(viewer_ctx: &ViewerContext<'_>, ui: &mut egui::Ui, context: &TableContext<'_>) {


### PR DESCRIPTION
This crate will host the new datafusion table widget. For now this PR just moves the existing `DisplayRecordBatch` (previously in `re_view_dataframe`, which was a weird crate to depend on if you needed this helper).