### PR TITLE
Fix shape inference for non fixed size list array types

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2691,7 +2691,7 @@ fn quote_columnar_methods(reporter: &Reporter, obj: &Object, objects: &Objects) 
                         # (This should have been already validated by conversion to the arrow_array)
                         batch_length = 1
                     else:
-                        batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                        batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                     num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                     sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -185,7 +185,7 @@ class AnnotationContext(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -255,7 +255,7 @@ class Arrows2D(Arrows2DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -241,7 +241,7 @@ class Arrows3D(Arrows3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -204,7 +204,7 @@ class Asset3D(Asset3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -236,7 +236,7 @@ class AssetVideo(AssetVideoExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -179,7 +179,7 @@ class BarChart(BarChartExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -240,7 +240,7 @@ class Boxes2D(Boxes2DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -288,7 +288,7 @@ class Boxes3D(Boxes3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
@@ -286,7 +286,7 @@ class Capsules3D(Capsules3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -154,7 +154,7 @@ class Clear(ClearExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -282,7 +282,7 @@ class DepthImage(DepthImageExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
@@ -289,7 +289,7 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/encoded_image.py
@@ -199,7 +199,7 @@ class EncodedImage(EncodedImageExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -195,7 +195,7 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
@@ -198,7 +198,7 @@ class GeoPoints(GeoPointsExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
@@ -195,7 +195,7 @@ class GraphEdges(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
@@ -252,7 +252,7 @@ class GraphNodes(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -233,7 +233,7 @@ class Image(ImageExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -257,7 +257,7 @@ class InstancePoses3D(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -331,7 +331,7 @@ class LineStrips2D(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -321,7 +321,7 @@ class LineStrips3D(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -304,7 +304,7 @@ class Mesh3D(Mesh3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -281,7 +281,7 @@ class Pinhole(PinholeExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -310,7 +310,7 @@ class Points2D(Points2DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -356,7 +356,7 @@ class Points3D(Points3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/recording_properties.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/recording_properties.py
@@ -162,7 +162,7 @@ class RecordingProperties(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -215,7 +215,7 @@ class Scalar(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalars.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalars.py
@@ -209,7 +209,7 @@ class Scalars(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -201,7 +201,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -284,7 +284,7 @@ class SeriesLine(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_lines.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_lines.py
@@ -304,7 +304,7 @@ class SeriesLines(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -287,7 +287,7 @@ class SeriesPoint(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_points.py
@@ -307,7 +307,7 @@ class SeriesPoints(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -187,7 +187,7 @@ class Tensor(TensorExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -239,7 +239,7 @@ class TextDocument(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -208,7 +208,7 @@ class TextLog(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -455,7 +455,7 @@ class Transform3D(Transform3DExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -252,7 +252,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -187,7 +187,7 @@ class ViewCoordinates(ViewCoordinatesExt, Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -292,7 +292,7 @@ class AffixFuzzer1(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -268,7 +268,7 @@ class AffixFuzzer2(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -261,7 +261,7 @@ class AffixFuzzer3(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -261,7 +261,7 @@ class AffixFuzzer4(Archetype):
                     # (This should have been already validated by conversion to the arrow_array)
                     batch_length = 1
                 else:
-                    batch_length = int(np.prod(shape[1:])) if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
+                    batch_length = shape[1] if len(shape) > 1 else 1  # type: ignore[redundant-expr,misc]
 
                 num_rows = shape[0] if len(shape) >= 1 else 1  # type: ignore[redundant-expr,misc]
                 sizes = batch_length * np.ones(num_rows)

--- a/rerun_py/tests/unit/test_arrows3d.py
+++ b/rerun_py/tests/unit/test_arrows3d.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 import itertools
 from typing import Optional, cast
 
+import numpy as np
 import rerun as rr
 from rerun.components import Position3DBatch, Vector3DBatch
-from rerun.datatypes import ClassIdArrayLike, Float32ArrayLike, Rgba32ArrayLike, Utf8ArrayLike, Vec3DArrayLike
+from rerun.datatypes import (
+    ClassIdArrayLike,
+    Float32ArrayLike,
+    Float64ArrayLike,
+    Rgba32ArrayLike,
+    Utf8ArrayLike,
+    Vec3DArrayLike,
+)
 
 from .common_arrays import (
     class_ids_arrays,
@@ -72,6 +80,29 @@ def test_arrows3d() -> None:
         assert arch.colors == colors_expected(colors)
         assert arch.labels == labels_expected(labels)
         assert arch.class_ids == class_ids_expected(class_ids)
+
+
+CASES: list[tuple[Float64ArrayLike, Float64ArrayLike]] = [
+    (
+        [],
+        [],
+    ),
+    (
+        [[1.0, 1.0, 1.0]],
+        [[[1.0, 1.0, 1.0]]],
+    ),
+    ([[[1.0, 1.0, 1.0]] for _ in range(3)], [[[1.0, 1.0, 1.0]] for _ in range(3)]),
+    ([[2.1, 3.2, 4.3] for _ in range(333)], [[[2.1, 3.2, 4.3]] for _ in range(333)]),
+    (np.ones((30, 3)), np.ones((30, 1, 3)).tolist()),
+    (np.ones((3, 1, 3)), np.ones((3, 1, 3)).tolist()),
+    (np.ones((1, 3)), np.ones((1, 1, 3)).tolist()),
+]
+
+
+def test_arrows3d_columnar() -> None:
+    for input, expected in CASES:
+        data = [*rr.Arrows3D.columns(vectors=input, origins=np.zeros_like(input))]
+        assert np.allclose(np.asarray(data[1].as_arrow_array().to_pylist()), np.asarray(expected))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Related

* Fixes regression from #9569 

### What

The partitioning shape was assumed to be the product of the outer dimensions of the input tensor, however this is incorrect and slipped through. It should default to the second dimension or 1 instead.