### PR TITLE
Do not output empty vec from `BinaryStream::read`

### DIFF
--- a/crates/top/re_sdk/src/binary_stream_sink.rs
+++ b/crates/top/re_sdk/src/binary_stream_sink.rs
@@ -34,17 +34,15 @@ impl BinaryStreamStorage {
     /// Use [`BinaryStreamStorage::flush`] if you want to guarantee that all
     /// logged messages have been written to the stream before you read them.
     #[inline]
-    pub fn read(&self) -> Vec<u8> {
+    pub fn read(&self) -> Option<Vec<u8>> {
         let mut inner = self.inner.lock();
 
         // if there's no messages to send, do not include the RRD headers.
         if inner.is_empty() {
-            Vec::default()
-        } else {
-            encode_as_bytes_local(inner.drain(..).map(Ok))
-                .ok_or_log_error()
-                .unwrap_or_default()
+            return None;
         }
+
+        encode_as_bytes_local(inner.drain(..).map(Ok)).ok_or_log_error()
     }
 
     /// Flush the batcher and log encoder to guarantee that all logged messages
@@ -62,7 +60,7 @@ impl Drop for BinaryStreamStorage {
         self.flush();
         let bytes = self.read();
 
-        if !bytes.is_empty() {
+        if let Some(bytes) = bytes {
             re_log::warn!(
                 "Dropping data in BinaryStreamStorage ({} bytes)",
                 bytes.len()

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -595,7 +595,7 @@ class PyMemorySinkStorage:
         """
 
 class PyBinarySinkStorage:
-    def read(self, *, flush: bool = True) -> bytes:
+    def read(self, *, flush: bool = True) -> bytes | None:
         """
         Read the bytes from the binary sink.
 

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -1329,7 +1329,7 @@ class BinaryStream:
     def __init__(self, storage: bindings.PyBinarySinkStorage) -> None:
         self.storage = storage
 
-    def read(self, *, flush: bool = True) -> bytes:
+    def read(self, *, flush: bool = True) -> bytes | None:
         """
         Reads the available bytes from the stream.
 


### PR DESCRIPTION
This results in downstream consumers (gradio) getting "data source left unexpectedly", caused by the yielded bytes being empty, and thus also without a header. Doesn't cause any trouble, but produces an annoying and unnecessary warning.

