### PR TITLE
Use approximate equals when comparing floats in snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ Makes sure all of the snippets in the [snippets/](./docs/snippets/) folder are w
 ### "Roundtrip" tests
 
 ```sh
-pixi run ./tests/roundtrips.py
+pixi run -e py ./tests/roundtrips.py
 ```
 
 A set of cross SDK language tests that makes sure that the same logging commands for a select group of archetypes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6601,6 +6601,7 @@ dependencies = [
 name = "re_arrow_util"
 version = "0.23.0-alpha.3+dev"
 dependencies = [
+ "anyhow",
  "arrow",
  "half",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6602,6 +6602,7 @@ name = "re_arrow_util"
 version = "0.23.0-alpha.3+dev"
 dependencies = [
  "arrow",
+ "half",
  "insta",
  "itertools 0.14.0",
  "re_log",

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -130,6 +130,136 @@ impl ChunkComponents {
     ) -> impl Iterator<Item = (ComponentDescriptor, ArrowListArray)> {
         self.0.into_values().flatten()
     }
+
+    /// Approximate equal, that ignores small numeric differences.
+    ///
+    /// Useful for tests.
+    pub fn are_similar(left: &Self, right: &Self) -> bool {
+        if left.len() != right.len() {
+            return false;
+        }
+        for (comp_name, left_comp_map) in left.iter() {
+            let Some(right_map) = right.get(comp_name) else {
+                return false;
+            };
+            for (descr, left_array) in left_comp_map {
+                let Some(right_array) = right_map.get(descr) else {
+                    return false;
+                };
+                if !approximate_equals(&left_array.to_data(), &right_array.to_data()) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+// TODO: move to arrow utils
+fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::ArrayData) -> bool {
+    if left.data_type() != right.data_type()
+        || left.len() != right.len()
+        || left.offset() != right.offset()
+    {
+        return false;
+    }
+
+    let data_type = left.data_type();
+
+    if left.null_count() != right.null_count() {
+        return false;
+    }
+
+    let left_buffers = left.buffers();
+    let right_buffers = right.buffers();
+
+    if left_buffers.len() != right_buffers.len() {
+        return false;
+    }
+
+    for (i, (left_buff, right_buff)) in izip!(left_buffers, right_buffers).enumerate() {
+        if left_buff.len() != right_buff.len() {
+            return false;
+        }
+
+        if data_type == &arrow::datatypes::DataType::Float32 {
+            // Approximate compare to accommodate differences in snippet output from Python/C++/Rust
+            let left_floats = left_buff.typed_data::<f32>();
+            let right_floats = right_buff.typed_data::<f32>();
+            for (&l, &r) in izip!(left_floats, right_floats) {
+                if !almost_equal_f32(l, r, 1e-5) {
+                    re_log::debug!("Significant float difference: {l} vs {r}");
+                    return false;
+                }
+            }
+        } else if left_buff != right_buff {
+            re_log::debug!("Difference in buffer {i} of array of datatype {data_type:?}");
+            return false;
+        }
+    }
+
+    let left_children = left.child_data();
+    let right_children = right.child_data();
+
+    if left_children.len() != right_children.len() {
+        return false;
+    }
+
+    for (left_child, right_child) in izip!(left_children, right_children) {
+        if !approximate_equals(left_child, right_child) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Return true when arguments are the same within some rounding error.
+///
+/// For instance `almost_equal(x, x.to_degrees().to_radians(), f32::EPSILON)` should hold true for all x.
+/// The `epsilon`  can be `f32::EPSILON` to handle simple transforms (like degrees -> radians)
+/// but should be higher to handle more complex transformations.
+pub fn almost_equal_f32(a: f32, b: f32, epsilon: f32) -> bool {
+    if a == b {
+        true // handle infinites
+    } else {
+        let abs_max = a.abs().max(b.abs());
+        abs_max <= epsilon || ((a - b).abs() / abs_max) <= epsilon
+    }
+}
+
+#[test]
+fn test_almost_equal() {
+    for &x in &[
+        0.0_f32,
+        f32::MIN_POSITIVE,
+        1e-20,
+        1e-10,
+        f32::EPSILON,
+        0.1,
+        0.99,
+        1.0,
+        1.001,
+        1e10,
+        f32::MAX / 100.0,
+        // f32::MAX, // overflows in rad<->deg test
+        f32::INFINITY,
+    ] {
+        for &x in &[-x, x] {
+            for roundtrip in &[
+                |x: f32| x.to_degrees().to_radians(),
+                |x: f32| x.to_radians().to_degrees(),
+            ] {
+                let epsilon = f32::EPSILON;
+                assert!(
+                    almost_equal_f32(x, roundtrip(x), epsilon),
+                    "{} vs {}",
+                    x,
+                    roundtrip(x)
+                );
+            }
+        }
+    }
 }
 
 impl std::ops::Deref for ChunkComponents {
@@ -342,14 +472,10 @@ impl Chunk {
                 })
                 .collect::<IntMap<_, _>>();
 
-            if lhs_components != rhs_components {
-                return false;
-            }
-        } else if *components != rhs.components {
-            return false;
+            lhs_components == rhs_components
+        } else {
+            ChunkComponents::are_similar(components, &rhs.components)
         }
-
-        true
     }
 
     // Only used for tests atm

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -146,119 +146,13 @@ impl ChunkComponents {
                 let Some(right_array) = right_map.get(descr) else {
                     return false;
                 };
-                if !approximate_equals(&left_array.to_data(), &right_array.to_data()) {
+                if !re_arrow_util::approximate_equals(&left_array.to_data(), &right_array.to_data())
+                {
                     return false;
                 }
             }
         }
         true
-    }
-}
-
-// TODO: move to arrow utils
-fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::ArrayData) -> bool {
-    if left.data_type() != right.data_type()
-        || left.len() != right.len()
-        || left.offset() != right.offset()
-    {
-        return false;
-    }
-
-    let data_type = left.data_type();
-
-    if left.null_count() != right.null_count() {
-        return false;
-    }
-
-    let left_buffers = left.buffers();
-    let right_buffers = right.buffers();
-
-    if left_buffers.len() != right_buffers.len() {
-        return false;
-    }
-
-    for (i, (left_buff, right_buff)) in izip!(left_buffers, right_buffers).enumerate() {
-        if left_buff.len() != right_buff.len() {
-            return false;
-        }
-
-        if data_type == &arrow::datatypes::DataType::Float32 {
-            // Approximate compare to accommodate differences in snippet output from Python/C++/Rust
-            let left_floats = left_buff.typed_data::<f32>();
-            let right_floats = right_buff.typed_data::<f32>();
-            for (&l, &r) in izip!(left_floats, right_floats) {
-                if !almost_equal_f32(l, r, 1e-5) {
-                    re_log::debug!("Significant float difference: {l} vs {r}");
-                    return false;
-                }
-            }
-        } else if left_buff != right_buff {
-            re_log::debug!("Difference in buffer {i} of array of datatype {data_type:?}");
-            return false;
-        }
-    }
-
-    let left_children = left.child_data();
-    let right_children = right.child_data();
-
-    if left_children.len() != right_children.len() {
-        return false;
-    }
-
-    for (left_child, right_child) in izip!(left_children, right_children) {
-        if !approximate_equals(left_child, right_child) {
-            return false;
-        }
-    }
-
-    true
-}
-
-/// Return true when arguments are the same within some rounding error.
-///
-/// For instance `almost_equal(x, x.to_degrees().to_radians(), f32::EPSILON)` should hold true for all x.
-/// The `epsilon`  can be `f32::EPSILON` to handle simple transforms (like degrees -> radians)
-/// but should be higher to handle more complex transformations.
-pub fn almost_equal_f32(a: f32, b: f32, epsilon: f32) -> bool {
-    if a == b {
-        true // handle infinites
-    } else {
-        let abs_max = a.abs().max(b.abs());
-        abs_max <= epsilon || ((a - b).abs() / abs_max) <= epsilon
-    }
-}
-
-#[test]
-fn test_almost_equal() {
-    for &x in &[
-        0.0_f32,
-        f32::MIN_POSITIVE,
-        1e-20,
-        1e-10,
-        f32::EPSILON,
-        0.1,
-        0.99,
-        1.0,
-        1.001,
-        1e10,
-        f32::MAX / 100.0,
-        // f32::MAX, // overflows in rad<->deg test
-        f32::INFINITY,
-    ] {
-        for &x in &[-x, x] {
-            for roundtrip in &[
-                |x: f32| x.to_degrees().to_radians(),
-                |x: f32| x.to_radians().to_degrees(),
-            ] {
-                let epsilon = f32::EPSILON;
-                assert!(
-                    almost_equal_f32(x, roundtrip(x), epsilon),
-                    "{} vs {}",
-                    x,
-                    roundtrip(x)
-                );
-            }
-        }
     }
 }
 

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use ahash::HashMap;
+use anyhow::Context as _;
 use arrow::{
     array::{
         Array as ArrowArray, ArrayRef as ArrowArrayRef, FixedSizeBinaryArray,
@@ -148,10 +149,8 @@ impl ChunkComponents {
                 let Some(right_array) = right_map.get(descr) else {
                     anyhow::bail!("rhs {comp_name:?} is missing {descr:?}");
                 };
-                if !re_arrow_util::approximate_equals(&left_array.to_data(), &right_array.to_data())
-                {
-                    anyhow::bail!("Difference in {comp_name:?} {descr:?}");
-                }
+                re_arrow_util::ensure_similar(&left_array.to_data(), &right_array.to_data())
+                    .with_context(|| format!("Component {comp_name:?}"))?;
             }
         }
         Ok(())

--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -14,6 +14,7 @@ impl Chunk {
     /// Prepare the [`Chunk`] for transport.
     ///
     /// It is probably a good idea to sort the chunk first.
+    // TODO(#8744): this is infallible, so we should not return a `Result` here.
     pub fn to_record_batch(&self) -> ChunkResult<ArrowRecordBatch> {
         re_tracing::profile_function!();
         Ok(self.to_chunk_batch()?.into())
@@ -22,6 +23,7 @@ impl Chunk {
     /// Prepare the [`Chunk`] for transport.
     ///
     /// It is probably a good idea to sort the chunk first.
+    // TODO(#8744): this is infallible, so we should not return a `Result` here.
     pub fn to_chunk_batch(&self) -> ChunkResult<re_sorbet::ChunkBatch> {
         re_tracing::profile_function!();
         self.sanity_check()?;

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -4,13 +4,13 @@ use std::fmt::Formatter;
 
 use arrow::{
     array::{Array, ArrayRef, ListArray},
-    datatypes::{DataType, Field, Fields, IntervalUnit, TimeUnit},
+    datatypes::{DataType, Field, Fields},
     util::display::{ArrayFormatter, FormatOptions},
 };
 use comfy_table::{presets, Cell, Row, Table};
 use itertools::{Either, Itertools as _};
 
-use re_arrow_util::ArrowArrayDowncastRef as _;
+use re_arrow_util::{format_data_type, ArrowArrayDowncastRef as _};
 use re_tuid::Tuid;
 use re_types_core::Loggable as _;
 
@@ -75,122 +75,6 @@ fn parse_tuid(array: &dyn Array, index: usize) -> Option<Tuid> {
 }
 
 // ---
-
-// arrow has `ToString` implemented, but it is way too verbose.
-#[repr(transparent)]
-struct DisplayTimeUnit(TimeUnit);
-
-impl std::fmt::Display for DisplayTimeUnit {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let s = match self.0 {
-            TimeUnit::Second => "s",
-            TimeUnit::Millisecond => "ms",
-            TimeUnit::Microsecond => "us",
-            TimeUnit::Nanosecond => "ns",
-        };
-        f.write_str(s)
-    }
-}
-
-// arrow has `ToString` implemented, but it is way too verbose.
-#[repr(transparent)]
-struct DisplayIntervalUnit(IntervalUnit);
-
-impl std::fmt::Display for DisplayIntervalUnit {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let s = match self.0 {
-            IntervalUnit::YearMonth => "year/month",
-            IntervalUnit::DayTime => "day/time",
-            IntervalUnit::MonthDayNano => "month/day/nano",
-        };
-        f.write_str(s)
-    }
-}
-
-// arrow has `ToString` implemented, but it is way too verbose.
-#[repr(transparent)]
-struct DisplayDatatype<'a>(&'a DataType);
-
-impl std::fmt::Display for DisplayDatatype<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let s = match &self.0 {
-            DataType::Null => "null",
-            DataType::Boolean => "bool",
-            DataType::Int8 => "i8",
-            DataType::Int16 => "i16",
-            DataType::Int32 => "i32",
-            DataType::Int64 => "i64",
-            DataType::UInt8 => "u8",
-            DataType::UInt16 => "u16",
-            DataType::UInt32 => "u32",
-            DataType::UInt64 => "u64",
-            DataType::Float16 => "f16",
-            DataType::Float32 => "f32",
-            DataType::Float64 => "f64",
-            DataType::Timestamp(unit, timezone) => {
-                let s = if let Some(tz) = timezone {
-                    format!("Timestamp({}, {tz})", DisplayTimeUnit(*unit))
-                } else {
-                    format!("Timestamp({})", DisplayTimeUnit(*unit))
-                };
-                return f.write_str(&s);
-            }
-            DataType::Date32 => "Date32",
-            DataType::Date64 => "Date64",
-            DataType::Time32(unit) => {
-                let s = format!("Time32({})", DisplayTimeUnit(*unit));
-                return f.write_str(&s);
-            }
-            DataType::Time64(unit) => {
-                let s = format!("Time64({})", DisplayTimeUnit(*unit));
-                return f.write_str(&s);
-            }
-            DataType::Duration(unit) => {
-                let s = format!("Duration({})", DisplayTimeUnit(*unit));
-                return f.write_str(&s);
-            }
-            DataType::Interval(unit) => {
-                let s = format!("Interval({})", DisplayIntervalUnit(*unit));
-                return f.write_str(&s);
-            }
-            DataType::Binary => "Binary",
-            DataType::FixedSizeBinary(size) => return write!(f, "FixedSizeBinary[{size}]"),
-            DataType::LargeBinary => "LargeBinary",
-            DataType::Utf8 => "Utf8",
-            DataType::LargeUtf8 => "LargeUtf8",
-            DataType::List(ref field) => {
-                let s = format!("List[{}]", Self(field.data_type()));
-                return f.write_str(&s);
-            }
-            DataType::FixedSizeList(field, len) => {
-                let s = format!("FixedSizeList[{}; {len}]", Self(field.data_type()));
-                return f.write_str(&s);
-            }
-            DataType::LargeList(field) => {
-                let s = format!("LargeList[{}]", Self(field.data_type()));
-                return f.write_str(&s);
-            }
-            DataType::Struct(fields) => return write!(f, "Struct[{}]", fields.len()),
-            DataType::Union(fields, _) => return write!(f, "Union[{}]", fields.len()),
-            DataType::Map(field, _) => return write!(f, "Map[{}]", Self(field.data_type())),
-            DataType::Dictionary(key, value) => {
-                return write!(f, "Dictionary{{{}: {}}}", Self(key), Self(value));
-            }
-            DataType::Decimal128(_, _) => "Decimal128",
-            DataType::Decimal256(_, _) => "Decimal256",
-            DataType::BinaryView => "BinaryView",
-            DataType::Utf8View => "Utf8View",
-            DataType::ListView(field) => return write!(f, "ListView[{}]", Self(field.data_type())),
-            DataType::LargeListView(field) => {
-                return write!(f, "LargeListView[{}]", Self(field.data_type()));
-            }
-            DataType::RunEndEncoded(_run_ends, values) => {
-                return write!(f, "RunEndEncoded[{}]", Self(values.data_type()));
-            }
-        };
-        f.write_str(s)
-    }
-}
 
 struct DisplayMetadata {
     prefix: &'static str,
@@ -422,13 +306,13 @@ fn format_dataframe_without_metadata(
                     Cell::new(format!(
                         "{}\n---\ntype: {}",
                         trim_name(field.name()),
-                        DisplayDatatype(field.data_type()),
+                        format_data_type(field.data_type()),
                     ))
                 } else {
                     Cell::new(format!(
                         "{}\n---\ntype: {}\n{}",
                         trim_name(field.name()),
-                        DisplayDatatype(field.data_type()),
+                        format_data_type(field.data_type()),
                         DisplayMetadata {
                             prefix: "",
                             metadata: field.metadata().clone().into_iter().collect()

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -36,27 +36,30 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     rec.log(
 ///         "capsules",
-///         &rerun::Capsules3D::from_lengths_and_radii([0., 2., 4., 6., 8.], [1., 0.5, 0.5, 0.5, 1.])
-///             .with_colors([
-///                 rerun::Color::from_rgb(255, 0, 0),
-///                 rerun::Color::from_rgb(188, 188, 0),
-///                 rerun::Color::from_rgb(0, 255, 0),
-///                 rerun::Color::from_rgb(0, 188, 188),
-///                 rerun::Color::from_rgb(0, 0, 255),
-///             ])
-///             .with_translations([
-///                 vec3(0., 0., 0.),
-///                 vec3(2., 0., 0.),
-///                 vec3(4., 0., 0.),
-///                 vec3(6., 0., 0.),
-///                 vec3(8., 0., 0.),
-///             ])
-///             .with_rotation_axis_angles((0..5).map(|i| {
-///                 rerun::RotationAxisAngle::new(
-///                     [1.0, 0.0, 0.0],
-///                     rerun::Angle::from_degrees(i as f32 * -22.5),
-///                 )
-///             })),
+///         &rerun::Capsules3D::from_lengths_and_radii(
+///             [0.0, 2.0, 4.0, 6.0, 8.0],
+///             [1.0, 0.5, 0.5, 0.5, 1.0],
+///         )
+///         .with_colors([
+///             rerun::Color::from_rgb(255, 0, 0),
+///             rerun::Color::from_rgb(188, 188, 0),
+///             rerun::Color::from_rgb(0, 255, 0),
+///             rerun::Color::from_rgb(0, 188, 188),
+///             rerun::Color::from_rgb(0, 0, 255),
+///         ])
+///         .with_translations([
+///             vec3(0., 0., 0.),
+///             vec3(2., 0., 0.),
+///             vec3(4., 0., 0.),
+///             vec3(6., 0., 0.),
+///             vec3(8., 0., 0.),
+///         ])
+///         .with_rotation_axis_angles((0..5).map(|i| {
+///             rerun::RotationAxisAngle::new(
+///                 [1.0, 0.0, 0.0],
+///                 rerun::Angle::from_degrees(i as f32 * -22.5),
+///             )
+///         })),
 ///     )?;
 ///
 ///     Ok(())

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -97,7 +97,7 @@ impl CompareCommand {
             re_format_arrow::format_record_batch_opts(
                 &chunk.to_record_batch().expect("Cannot fail in practice"),
                 &re_format_arrow::RecordBatchFormatOpts {
-                    transposed: false,
+                    transposed: true,
                     width: None,
                     include_metadata: true,
                     include_column_metadata: false,

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -93,14 +93,27 @@ impl CompareCommand {
             }
         }
 
+        fn format_chunk(chunk: &Chunk) -> String {
+            re_format_arrow::format_record_batch_opts(
+                &chunk.to_record_batch().unwrap(),
+                &re_format_arrow::RecordBatchFormatOpts {
+                    transposed: true,
+                    width: None,
+                    include_metadata: true,
+                    include_column_metadata: false,
+                },
+            )
+            .to_string()
+        }
+
         if !*unordered || unordered_failed {
             for (chunk1, chunk2) in izip!(chunks1, chunks2) {
                 anyhow::ensure!(
                     re_chunk::Chunk::are_similar(&chunk1, &chunk2),
                     "Chunks do not match:\n{}",
                     similar_asserts::SimpleDiff::from_str(
-                        &format!("{chunk1}"),
-                        &format!("{chunk2}"),
+                        &format_chunk(&chunk1),
+                        &format_chunk(&chunk2),
                         "got",
                         "expected",
                     ),

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -97,10 +97,10 @@ impl CompareCommand {
             re_format_arrow::format_record_batch_opts(
                 &chunk.to_record_batch().expect("Cannot fail in practice"),
                 &re_format_arrow::RecordBatchFormatOpts {
-                    transposed: true,
-                    width: None,
+                    transposed: false,
+                    width: Some(800),
                     include_metadata: true,
-                    include_column_metadata: false,
+                    include_column_metadata: true,
                 },
             )
             .to_string()

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -83,7 +83,7 @@ impl CompareCommand {
             'outer: for chunk1 in &chunks1 {
                 for chunk2 in chunks2_opt.iter_mut().filter(|c| c.is_some()) {
                     #[allow(clippy::unwrap_used)]
-                    if re_chunk::Chunk::are_similar(chunk1, chunk2.as_ref().unwrap()) {
+                    if re_chunk::Chunk::ensure_similar(chunk1, chunk2.as_ref().unwrap()).is_ok() {
                         *chunk2 = None;
                         continue 'outer;
                     }
@@ -93,31 +93,32 @@ impl CompareCommand {
             }
         }
 
-        fn format_chunk(chunk: &Chunk) -> anyhow::Result<String> {
-            Ok(re_format_arrow::format_record_batch_opts(
-                &chunk.to_record_batch()?,
+        fn format_chunk(chunk: &Chunk) -> String {
+            re_format_arrow::format_record_batch_opts(
+                &chunk.to_record_batch().expect("Cannot fail in practice"),
                 &re_format_arrow::RecordBatchFormatOpts {
-                    transposed: true,
+                    transposed: false,
                     width: None,
                     include_metadata: true,
                     include_column_metadata: false,
                 },
             )
-            .to_string())
+            .to_string()
         }
 
         if !*unordered || unordered_failed {
             for (chunk1, chunk2) in izip!(chunks1, chunks2) {
-                anyhow::ensure!(
-                    re_chunk::Chunk::are_similar(&chunk1, &chunk2),
-                    "Chunks do not match:\n{}",
-                    similar_asserts::SimpleDiff::from_str(
-                        &format_chunk(&chunk1)?,
-                        &format_chunk(&chunk2)?,
-                        "got",
-                        "expected",
-                    ),
-                );
+                re_chunk::Chunk::ensure_similar(&chunk1, &chunk2).with_context(|| {
+                    format!(
+                        "Chunks diff:\n{}",
+                        similar_asserts::SimpleDiff::from_str(
+                            &format_chunk(&chunk1),
+                            &format_chunk(&chunk2),
+                            "got",
+                            "expected",
+                        ),
+                    )
+                })?;
             }
         }
 

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -93,9 +93,9 @@ impl CompareCommand {
             }
         }
 
-        fn format_chunk(chunk: &Chunk) -> String {
-            re_format_arrow::format_record_batch_opts(
-                &chunk.to_record_batch().unwrap(),
+        fn format_chunk(chunk: &Chunk) -> anyhow::Result<String> {
+            Ok(re_format_arrow::format_record_batch_opts(
+                &chunk.to_record_batch()?,
                 &re_format_arrow::RecordBatchFormatOpts {
                     transposed: true,
                     width: None,
@@ -103,7 +103,7 @@ impl CompareCommand {
                     include_column_metadata: false,
                 },
             )
-            .to_string()
+            .to_string())
         }
 
         if !*unordered || unordered_failed {
@@ -112,8 +112,8 @@ impl CompareCommand {
                     re_chunk::Chunk::are_similar(&chunk1, &chunk2),
                     "Chunks do not match:\n{}",
                     similar_asserts::SimpleDiff::from_str(
-                        &format_chunk(&chunk1),
-                        &format_chunk(&chunk2),
+                        &format_chunk(&chunk1)?,
+                        &format_chunk(&chunk2)?,
                         "got",
                         "expected",
                     ),

--- a/crates/utils/re_arrow_util/Cargo.toml
+++ b/crates/utils/re_arrow_util/Cargo.toml
@@ -26,6 +26,7 @@ all-features = true
 re_log.workspace = true
 re_tracing.workspace = true
 
+anyhow.workspace = true
 arrow.workspace = true
 half.workspace = true
 itertools.workspace = true

--- a/crates/utils/re_arrow_util/Cargo.toml
+++ b/crates/utils/re_arrow_util/Cargo.toml
@@ -27,6 +27,7 @@ re_log.workspace = true
 re_tracing.workspace = true
 
 arrow.workspace = true
+half.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]

--- a/crates/utils/re_arrow_util/src/compare.rs
+++ b/crates/utils/re_arrow_util/src/compare.rs
@@ -48,7 +48,7 @@ pub fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::
                 let left_floats = left_buff.typed_data::<f32>();
                 let right_floats = right_buff.typed_data::<f32>();
                 for (&l, &r) in izip!(left_floats, right_floats) {
-                    if !almost_equal_f32(l, r, 1e-5) {
+                    if !almost_equal_f32(l, r, 1e-3) {
                         re_log::debug!("Significant f32 difference: {l} vs {r}");
                         return false;
                     }

--- a/crates/utils/re_arrow_util/src/compare.rs
+++ b/crates/utils/re_arrow_util/src/compare.rs
@@ -38,7 +38,7 @@ pub fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::
                 let left_floats = left_buff.typed_data::<f16>();
                 let right_floats = right_buff.typed_data::<f16>();
                 for (&l, &r) in izip!(left_floats, right_floats) {
-                    if !almost_equal_f32(l.to_f32(), r.to_f32(), 1e-3) {
+                    if !almost_equal_f64(l.to_f64(), r.to_f64(), 1e-3) {
                         re_log::debug!("Significant f16 difference: {l} vs {r}");
                         return false;
                     }
@@ -48,7 +48,7 @@ pub fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::
                 let left_floats = left_buff.typed_data::<f32>();
                 let right_floats = right_buff.typed_data::<f32>();
                 for (&l, &r) in izip!(left_floats, right_floats) {
-                    if !almost_equal_f32(l, r, 1e-3) {
+                    if !almost_equal_f64(l as f64, r as f64, 1e-3) {
                         re_log::debug!("Significant f32 difference: {l} vs {r}");
                         return false;
                     }
@@ -58,7 +58,7 @@ pub fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::
                 let left_floats = left_buff.typed_data::<f64>();
                 let right_floats = right_buff.typed_data::<f64>();
                 for (&l, &r) in izip!(left_floats, right_floats) {
-                    if !almost_equal_f32(l as f32, r as f32, 1e-5) {
+                    if !almost_equal_f64(l, r, 1e-8) {
                         re_log::debug!("Significant f64 difference: {l} vs {r}");
                         return false;
                     }
@@ -91,10 +91,10 @@ pub fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::
 
 /// Return true when arguments are the same within some rounding error.
 ///
-/// For instance `almost_equal(x, x.to_degrees().to_radians(), f32::EPSILON)` should hold true for all x.
-/// The `epsilon`  can be `f32::EPSILON` to handle simple transforms (like degrees -> radians)
+/// For instance `almost_equal(x, x.to_degrees().to_radians(), f64::EPSILON)` should hold true for all x.
+/// The `epsilon`  can be `f64::EPSILON` to handle simple transforms (like degrees -> radians)
 /// but should be higher to handle more complex transformations.
-pub fn almost_equal_f32(a: f32, b: f32, epsilon: f32) -> bool {
+pub fn almost_equal_f64(a: f64, b: f64, epsilon: f64) -> bool {
     if a == b {
         true // handle infinites
     } else {
@@ -106,28 +106,28 @@ pub fn almost_equal_f32(a: f32, b: f32, epsilon: f32) -> bool {
 #[test]
 fn test_almost_equal() {
     for &x in &[
-        0.0_f32,
-        f32::MIN_POSITIVE,
+        0.0_f64,
+        f64::MIN_POSITIVE,
         1e-20,
         1e-10,
-        f32::EPSILON,
+        f64::EPSILON,
         0.1,
         0.99,
         1.0,
         1.001,
         1e10,
-        f32::MAX / 100.0,
-        // f32::MAX, // overflows in rad<->deg test
-        f32::INFINITY,
+        f64::MAX / 100.0,
+        // f64::MAX, // overflows in rad<->deg test
+        f64::INFINITY,
     ] {
         for &x in &[-x, x] {
             for roundtrip in &[
-                |x: f32| x.to_degrees().to_radians(),
-                |x: f32| x.to_radians().to_degrees(),
+                |x: f64| x.to_degrees().to_radians(),
+                |x: f64| x.to_radians().to_degrees(),
             ] {
-                let epsilon = f32::EPSILON;
+                let epsilon = f64::EPSILON;
                 assert!(
-                    almost_equal_f32(x, roundtrip(x), epsilon),
+                    almost_equal_f64(x, roundtrip(x), epsilon),
                     "{} vs {}",
                     x,
                     roundtrip(x)

--- a/crates/utils/re_arrow_util/src/compare.rs
+++ b/crates/utils/re_arrow_util/src/compare.rs
@@ -17,6 +17,13 @@ pub fn ensure_similar(
 
     let data_type = left.data_type();
 
+    if matches!(data_type, arrow::datatypes::DataType::Union { .. }) {
+        // We encode arrow unions slightly different in Python and Rust.
+        // TODO(#6388): Remove this hack once we have stopped using arrow unions.
+        ensure!(left == right);
+        return Ok(());
+    }
+
     ensure!(left.len() == right.len());
     ensure!(left.offset() == right.offset());
     ensure!(left.null_count() == right.null_count());

--- a/crates/utils/re_arrow_util/src/compare.rs
+++ b/crates/utils/re_arrow_util/src/compare.rs
@@ -1,0 +1,127 @@
+use itertools::izip;
+
+/// Are two arrays equal, ignoring small numeric differences?
+pub fn approximate_equals(left: &arrow::array::ArrayData, right: &arrow::array::ArrayData) -> bool {
+    if left.data_type() != right.data_type()
+        || left.len() != right.len()
+        || left.offset() != right.offset()
+    {
+        return false;
+    }
+
+    let data_type = left.data_type();
+
+    if left.null_count() != right.null_count() {
+        return false;
+    }
+    if left.nulls() != right.nulls() {
+        return false;
+    }
+
+    {
+        // Compare buffers:
+        let left_buffers = left.buffers();
+        let right_buffers = right.buffers();
+
+        if left_buffers.len() != right_buffers.len() {
+            return false;
+        }
+
+        for (i, (left_buff, right_buff)) in izip!(left_buffers, right_buffers).enumerate() {
+            if left_buff.len() != right_buff.len() {
+                return false;
+            }
+
+            if data_type == &arrow::datatypes::DataType::Float32 {
+                // Approximate compare to accommodate differences in snippet output from Python/C++/Rust
+                let left_floats = left_buff.typed_data::<f32>();
+                let right_floats = right_buff.typed_data::<f32>();
+                for (&l, &r) in izip!(left_floats, right_floats) {
+                    if !almost_equal_f32(l, r, 1e-5) {
+                        re_log::debug!("Significant f32 difference: {l} vs {r}");
+                        return false;
+                    }
+                }
+            } else if data_type == &arrow::datatypes::DataType::Float64 {
+                // Approximate compare to accommodate differences in snippet output from Python/C++/Rust
+                let left_floats = left_buff.typed_data::<f64>();
+                let right_floats = right_buff.typed_data::<f64>();
+                for (&l, &r) in izip!(left_floats, right_floats) {
+                    if !almost_equal_f32(l as f32, r as f32, 1e-5) {
+                        re_log::debug!("Significant f64 difference: {l} vs {r}");
+                        return false;
+                    }
+                }
+            } else if left_buff != right_buff {
+                re_log::debug!("Difference in buffer {i} of array of datatype {data_type:?}");
+                return false;
+            }
+        }
+    }
+
+    {
+        // Compare children:
+        let left_children = left.child_data();
+        let right_children = right.child_data();
+
+        if left_children.len() != right_children.len() {
+            return false;
+        }
+
+        for (left_child, right_child) in izip!(left_children, right_children) {
+            if !approximate_equals(left_child, right_child) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+/// Return true when arguments are the same within some rounding error.
+///
+/// For instance `almost_equal(x, x.to_degrees().to_radians(), f32::EPSILON)` should hold true for all x.
+/// The `epsilon`  can be `f32::EPSILON` to handle simple transforms (like degrees -> radians)
+/// but should be higher to handle more complex transformations.
+pub fn almost_equal_f32(a: f32, b: f32, epsilon: f32) -> bool {
+    if a == b {
+        true // handle infinites
+    } else {
+        let abs_max = a.abs().max(b.abs());
+        abs_max <= epsilon || ((a - b).abs() / abs_max) <= epsilon
+    }
+}
+
+#[test]
+fn test_almost_equal() {
+    for &x in &[
+        0.0_f32,
+        f32::MIN_POSITIVE,
+        1e-20,
+        1e-10,
+        f32::EPSILON,
+        0.1,
+        0.99,
+        1.0,
+        1.001,
+        1e10,
+        f32::MAX / 100.0,
+        // f32::MAX, // overflows in rad<->deg test
+        f32::INFINITY,
+    ] {
+        for &x in &[-x, x] {
+            for roundtrip in &[
+                |x: f32| x.to_degrees().to_radians(),
+                |x: f32| x.to_radians().to_degrees(),
+            ] {
+                let epsilon = f32::EPSILON;
+                assert!(
+                    almost_equal_f32(x, roundtrip(x), epsilon),
+                    "{} vs {}",
+                    x,
+                    roundtrip(x)
+                );
+            }
+        }
+    }
+}

--- a/crates/utils/re_arrow_util/src/format_data_type.rs
+++ b/crates/utils/re_arrow_util/src/format_data_type.rs
@@ -1,0 +1,125 @@
+//! `arrow` has `ToString` implemented, but it is way too verbose.
+
+use std::fmt::Formatter;
+
+use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
+
+/// Compact format of an arrow data type.
+pub fn format_data_type(data_type: &DataType) -> String {
+    DisplayDatatype(data_type).to_string()
+}
+
+#[repr(transparent)]
+struct DisplayTimeUnit(TimeUnit);
+
+impl std::fmt::Display for DisplayTimeUnit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self.0 {
+            TimeUnit::Second => "s",
+            TimeUnit::Millisecond => "ms",
+            TimeUnit::Microsecond => "us",
+            TimeUnit::Nanosecond => "ns",
+        };
+        f.write_str(s)
+    }
+}
+
+// arrow has `ToString` implemented, but it is way too verbose.
+#[repr(transparent)]
+struct DisplayIntervalUnit(IntervalUnit);
+
+impl std::fmt::Display for DisplayIntervalUnit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match self.0 {
+            IntervalUnit::YearMonth => "year/month",
+            IntervalUnit::DayTime => "day/time",
+            IntervalUnit::MonthDayNano => "month/day/nano",
+        };
+        f.write_str(s)
+    }
+}
+
+// arrow has `ToString` implemented, but it is way too verbose.
+#[repr(transparent)]
+struct DisplayDatatype<'a>(&'a DataType);
+
+impl std::fmt::Display for DisplayDatatype<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let s = match &self.0 {
+            DataType::Null => "null",
+            DataType::Boolean => "bool",
+            DataType::Int8 => "i8",
+            DataType::Int16 => "i16",
+            DataType::Int32 => "i32",
+            DataType::Int64 => "i64",
+            DataType::UInt8 => "u8",
+            DataType::UInt16 => "u16",
+            DataType::UInt32 => "u32",
+            DataType::UInt64 => "u64",
+            DataType::Float16 => "f16",
+            DataType::Float32 => "f32",
+            DataType::Float64 => "f64",
+            DataType::Timestamp(unit, timezone) => {
+                let s = if let Some(tz) = timezone {
+                    format!("Timestamp({}, {tz})", DisplayTimeUnit(*unit))
+                } else {
+                    format!("Timestamp({})", DisplayTimeUnit(*unit))
+                };
+                return f.write_str(&s);
+            }
+            DataType::Date32 => "Date32",
+            DataType::Date64 => "Date64",
+            DataType::Time32(unit) => {
+                let s = format!("Time32({})", DisplayTimeUnit(*unit));
+                return f.write_str(&s);
+            }
+            DataType::Time64(unit) => {
+                let s = format!("Time64({})", DisplayTimeUnit(*unit));
+                return f.write_str(&s);
+            }
+            DataType::Duration(unit) => {
+                let s = format!("Duration({})", DisplayTimeUnit(*unit));
+                return f.write_str(&s);
+            }
+            DataType::Interval(unit) => {
+                let s = format!("Interval({})", DisplayIntervalUnit(*unit));
+                return f.write_str(&s);
+            }
+            DataType::Binary => "Binary",
+            DataType::FixedSizeBinary(size) => return write!(f, "FixedSizeBinary[{size}]"),
+            DataType::LargeBinary => "LargeBinary",
+            DataType::Utf8 => "Utf8",
+            DataType::LargeUtf8 => "LargeUtf8",
+            DataType::List(ref field) => {
+                let s = format!("List[{}]", Self(field.data_type()));
+                return f.write_str(&s);
+            }
+            DataType::FixedSizeList(field, len) => {
+                let s = format!("FixedSizeList[{}; {len}]", Self(field.data_type()));
+                return f.write_str(&s);
+            }
+            DataType::LargeList(field) => {
+                let s = format!("LargeList[{}]", Self(field.data_type()));
+                return f.write_str(&s);
+            }
+            DataType::Struct(fields) => return write!(f, "Struct[{}]", fields.len()),
+            DataType::Union(fields, _) => return write!(f, "Union[{}]", fields.len()),
+            DataType::Map(field, _) => return write!(f, "Map[{}]", Self(field.data_type())),
+            DataType::Dictionary(key, value) => {
+                return write!(f, "Dictionary{{{}: {}}}", Self(key), Self(value));
+            }
+            DataType::Decimal128(_, _) => "Decimal128",
+            DataType::Decimal256(_, _) => "Decimal256",
+            DataType::BinaryView => "BinaryView",
+            DataType::Utf8View => "Utf8View",
+            DataType::ListView(field) => return write!(f, "ListView[{}]", Self(field.data_type())),
+            DataType::LargeListView(field) => {
+                return write!(f, "LargeListView[{}]", Self(field.data_type()));
+            }
+            DataType::RunEndEncoded(_run_ends, values) => {
+                return write!(f, "RunEndEncoded[{}]", Self(values.data_type()));
+            }
+        };
+        f.write_str(s)
+    }
+}

--- a/crates/utils/re_arrow_util/src/lib.rs
+++ b/crates/utils/re_arrow_util/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod arrays;
 mod batches;
+mod compare;
 
 pub use self::arrays::*;
 pub use self::batches::*;
+pub use self::compare::*;

--- a/crates/utils/re_arrow_util/src/lib.rs
+++ b/crates/utils/re_arrow_util/src/lib.rs
@@ -3,7 +3,9 @@
 mod arrays;
 mod batches;
 mod compare;
+mod format_data_type;
 
 pub use self::arrays::*;
 pub use self::batches::*;
 pub use self::compare::*;
+pub use self::format_data_type::*;

--- a/docs/snippets/all/archetypes/capsules3d_batch.cpp
+++ b/docs/snippets/all/archetypes/capsules3d_batch.cpp
@@ -27,7 +27,7 @@ int main() {
                 {8.0f, 0.0f, 0.0f},
             })
             .with_rotation_axis_angles({
-                rerun::RotationAxisAngle(),
+                rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(0.0)),
                 rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(-22.5)),
                 rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(-45.0)),
                 rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(-67.5)),

--- a/docs/snippets/all/archetypes/capsules3d_batch.rs
+++ b/docs/snippets/all/archetypes/capsules3d_batch.rs
@@ -7,27 +7,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log(
         "capsules",
-        &rerun::Capsules3D::from_lengths_and_radii([0., 2., 4., 6., 8.], [1., 0.5, 0.5, 0.5, 1.])
-            .with_colors([
-                rerun::Color::from_rgb(255, 0, 0),
-                rerun::Color::from_rgb(188, 188, 0),
-                rerun::Color::from_rgb(0, 255, 0),
-                rerun::Color::from_rgb(0, 188, 188),
-                rerun::Color::from_rgb(0, 0, 255),
-            ])
-            .with_translations([
-                vec3(0., 0., 0.),
-                vec3(2., 0., 0.),
-                vec3(4., 0., 0.),
-                vec3(6., 0., 0.),
-                vec3(8., 0., 0.),
-            ])
-            .with_rotation_axis_angles((0..5).map(|i| {
-                rerun::RotationAxisAngle::new(
-                    [1.0, 0.0, 0.0],
-                    rerun::Angle::from_degrees(i as f32 * -22.5),
-                )
-            })),
+        &rerun::Capsules3D::from_lengths_and_radii(
+            [0.0, 2.0, 4.0, 6.0, 8.0],
+            [1.0, 0.5, 0.5, 0.5, 1.0],
+        )
+        .with_colors([
+            rerun::Color::from_rgb(255, 0, 0),
+            rerun::Color::from_rgb(188, 188, 0),
+            rerun::Color::from_rgb(0, 255, 0),
+            rerun::Color::from_rgb(0, 188, 188),
+            rerun::Color::from_rgb(0, 0, 255),
+        ])
+        .with_translations([
+            vec3(0., 0., 0.),
+            vec3(2., 0., 0.),
+            vec3(4., 0., 0.),
+            vec3(6., 0., 0.),
+            vec3(8., 0., 0.),
+        ])
+        .with_rotation_axis_angles((0..5).map(|i| {
+            rerun::RotationAxisAngle::new(
+                [1.0, 0.0, 0.0],
+                rerun::Angle::from_degrees(i as f32 * -22.5),
+            )
+        })),
     )?;
 
     Ok(())

--- a/docs/snippets/all/archetypes/instance_poses3d_combined.py
+++ b/docs/snippets/all/archetypes/instance_poses3d_combined.py
@@ -9,7 +9,10 @@ rr.set_time("frame", sequence=0)
 
 # Log a box and points further down in the hierarchy.
 rr.log("world/box", rr.Boxes3D(half_sizes=[[1.0, 1.0, 1.0]]))
-rr.log("world/box/points", rr.Points3D(np.vstack([xyz.ravel() for xyz in np.mgrid[3 * [slice(-10, 10, 10j)]]]).T))
+lin = np.linspace(-10, 10, 10)
+z, y, x = np.meshgrid(lin, lin, lin, indexing="ij")
+point_grid = np.vstack([x.flatten(), y.flatten(), z.flatten()]).T
+rr.log("world/box/points", rr.Points3D(point_grid))
 
 for i in range(180):
     rr.set_time("frame", sequence=i)

--- a/docs/snippets/all/archetypes/mesh3d_partial_updates.py
+++ b/docs/snippets/all/archetypes/mesh3d_partial_updates.py
@@ -18,8 +18,8 @@ rr.log(
     ),
 )
 
-# Only update its vertices' positions each frame
-factors = np.abs(np.sin(np.arange(1, 300, dtype=np.float32) * 0.04))
-for i, factor in enumerate(factors):
+# Only update its vertices' positions each frame:
+for i in range(1, 300):
+    factor = np.abs(np.sin(i * 0.04))
     rr.set_time("frame", sequence=i)
     rr.log("triangle", rr.Mesh3D.from_fields(vertex_positions=vertex_positions * factor))

--- a/docs/snippets/all/archetypes/transform3d_axes.cpp
+++ b/docs/snippets/all/archetypes/transform3d_axes.cpp
@@ -17,7 +17,7 @@ int main() {
 
         rec.log(
             "base/rotated",
-            rerun::Transform3D().with_axis_length(0.5).with_rotation_axis_angle(
+            rerun::Transform3D::clear_fields().with_axis_length(0.5).with_rotation_axis_angle(
                 rerun::RotationAxisAngle(
                     {1.0f, 1.0f, 1.0f},
                     rerun::Angle::degrees(static_cast<float>(deg))
@@ -27,7 +27,9 @@ int main() {
 
         rec.log(
             "base/rotated/translated",
-            rerun::Transform3D().with_axis_length(0.5).with_translation({2.0f, 0.0f, 0.0f})
+            rerun::Transform3D::clear_fields().with_axis_length(0.5).with_translation(
+                {2.0f, 0.0f, 0.0f}
+            )
         );
     }
 }

--- a/docs/snippets/all/archetypes/transform3d_axes.cpp
+++ b/docs/snippets/all/archetypes/transform3d_axes.cpp
@@ -6,7 +6,7 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_transform3d_axes");
     rec.spawn().exit_on_failure();
 
-    auto base_axes = rerun::Transform3D().with_axis_length(1.0);
+    auto base_axes = rerun::Transform3D::clear_fields().with_axis_length(1.0);
 
     rec.set_time_sequence("step", 0);
 

--- a/docs/snippets/all/archetypes/transform3d_axes.py
+++ b/docs/snippets/all/archetypes/transform3d_axes.py
@@ -14,8 +14,9 @@ for deg in range(360):
     rr.set_time("step", sequence=deg)
     rr.log(
         "base/rotated",
-        rr.Transform3D(
-            rotation=rr.RotationAxisAngle(
+        rr.Transform3D.from_fields(
+            clear_unset=True,
+            rotation_axis_angle=rr.RotationAxisAngle(
                 axis=[1.0, 1.0, 1.0],
                 degrees=deg,
             ),
@@ -24,7 +25,8 @@ for deg in range(360):
     )
     rr.log(
         "base/rotated/translated",
-        rr.Transform3D(
+        rr.Transform3D.from_fields(
+            clear_unset=True,
             translation=[2.0, 0, 0],
             axis_length=0.5,
         ),

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.py
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.py
@@ -6,10 +6,12 @@ import rerun.blueprint as rrb
 
 rr.init("rerun_example_transform3d_hierarchy", spawn=True)
 
-# One space with the sun in the center, and another one with the planet.
-rr.send_blueprint(
-    rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**")),
-)
+if False:
+    # One space with the sun in the center, and another one with the planet.
+    #TODO(#5521): enable this once we have it in Rust too, so that the snippets compare equally
+    rr.send_blueprint(
+        rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**")),
+    )
 
 rr.set_time("sim_time", duration=0)
 

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.py
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.py
@@ -8,7 +8,7 @@ rr.init("rerun_example_transform3d_hierarchy", spawn=True)
 
 if False:
     # One space with the sun in the center, and another one with the planet.
-    #TODO(#5521): enable this once we have it in Rust too, so that the snippets compare equally
+    # TODO(#5521): enable this once we have it in Rust too, so that the snippets compare equally
     rr.send_blueprint(
         rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**")),
     )

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -280,7 +280,7 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "rust",
 ]
 "archetypes/arrows3d_simple" = [
-  "py",  # Python has different colors. TODO(emilk): fix that
+  "py", # Python has different colors. TODO(emilk): fix that
 ]
 "archetypes/bar_chart" = [ # On Windows this logs f64 instead of u64 unless a numpy array with explicit type is used.
   "py",

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -286,11 +286,6 @@ quick_start = [ # These examples don't have exactly the same implementation.
 "archetypes/bar_chart" = [ # On Windows this logs f64 instead of u64 unless a numpy array with explicit type is used.
   "py",
 ]
-"archetypes/capsules3d_batch" = [ # TODO(#3235): Degree to radian conversion is slightly different.
-  "cpp",
-  "py",
-  "rust",
-]
 "archetypes/ellipsoids3d_simple" = [ # TODO(#3206): examples use different RNGs
   "cpp",
   "py",
@@ -327,19 +322,10 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "py",
   "rust",
 ]
-"archetypes/transform3d_axes" = [ # TODO(#3235): Degree to radian conversion is slightly different.
-  "cpp",
-  "py",
-  "rust",
-]
 "archetypes/transform3d_hierarchy" = [ # Uses a lot of trigonometry which is surprisingly easy to get the same on Rust & C++, but not on Python/Numpy
   "py",
 ]
-"archetypes/instance_poses3d_combined" = [ # TODO(#3235): Slight floating point differences in point grid.
-  "cpp",
-  "py",
-  "rust",
-]
+
 "archetypes/mesh3d_instancing" = [ # Python uses doubles
   "py",
 ]
@@ -348,22 +334,6 @@ quick_start = [ # These examples don't have exactly the same implementation.
 ]
 "archetypes/series_point_style" = [
   "cpp", # somehow, C++ yields a different result, see <https://github.com/rerun-io/rerun/pull/8851>
-]
-
-"archetypes/scalars_multiple_plots" = [ # TODO(#3235): Slight floating point differences
-  "cpp",
-  "py",
-  "rust",
-]
-"archetypes/series_lines_style" = [ # TODO(#3235): Slight floating point differences
-  "cpp",
-  "py",
-  "rust",
-]
-"archetypes/series_points_style" = [ # TODO(#3235): Slight floating point differences
-  "cpp",
-  "py",
-  "rust",
 ]
 
 

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -280,8 +280,7 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "rust",
 ]
 "archetypes/arrows3d_simple" = [
-  "py",  # Python uses doubles
-  "cpp", # Trigonometry doesn't work out the same with all C++ toolchains (*some* Windows machines yield a different result)
+  "py",  # Python has different colors. TODO(emilk): fix that
 ]
 "archetypes/bar_chart" = [ # On Windows this logs f64 instead of u64 unless a numpy array with explicit type is used.
   "py",
@@ -290,9 +289,6 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "cpp",
   "py",
   "rust",
-]
-"archetypes/mesh3d_partial_updates" = [ # Python uses doubles
-  "py",
 ]
 "archetypes/pinhole_simple" = [ # TODO(#3206): examples use different RNGs
   "cpp",
@@ -309,9 +305,6 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "py",
   "rust",
 ]
-"archetypes/scalar_multiple_plots" = [ # trigonometric functions have slightly different outcomes
-  "cpp",
-]
 "archetypes/tensor_simple" = [ # TODO(#3206): examples use different RNGs
   "cpp",
   "py",
@@ -322,20 +315,6 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "py",
   "rust",
 ]
-"archetypes/transform3d_hierarchy" = [ # Uses a lot of trigonometry which is surprisingly easy to get the same on Rust & C++, but not on Python/Numpy
-  "py",
-]
-
-"archetypes/mesh3d_instancing" = [ # Python uses doubles
-  "py",
-]
-"archetypes/series_line_style" = [
-  "cpp", # somehow, C++ yields a different result, see <https://github.com/rerun-io/rerun/pull/8851>
-]
-"archetypes/series_point_style" = [
-  "cpp", # somehow, C++ yields a different result, see <https://github.com/rerun-io/rerun/pull/8851>
-]
-
 
 # -----------------------------------------------------------------------------
 

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
@@ -64,7 +64,7 @@ namespace rerun::archetypes {
     ///                 {8.0f, 0.0f, 0.0f},
     ///             })
     ///             .with_rotation_axis_angles({
-    ///                 rerun::RotationAxisAngle(),
+    ///                 rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(0.0)),
     ///                 rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(-22.5)),
     ///                 rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(-45.0)),
     ///                 rerun::RotationAxisAngle({1.0f, 0.0f, 0.0f}, rerun::Angle::degrees(-67.5)),

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -52,7 +52,10 @@ class InstancePoses3D(Archetype):
 
     # Log a box and points further down in the hierarchy.
     rr.log("world/box", rr.Boxes3D(half_sizes=[[1.0, 1.0, 1.0]]))
-    rr.log("world/box/points", rr.Points3D(np.vstack([xyz.ravel() for xyz in np.mgrid[3 * [slice(-10, 10, 10j)]]]).T))
+    lin = np.linspace(-10, 10, 10)
+    z, y, x = np.meshgrid(lin, lin, lin, indexing="ij")
+    point_grid = np.vstack([x.flatten(), y.flatten(), z.flatten()]).T
+    rr.log("world/box/points", rr.Points3D(point_grid))
 
     for i in range(180):
         rr.set_time("frame", sequence=i)

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -81,10 +81,12 @@ class Transform3D(Transform3DExt, Archetype):
 
     rr.init("rerun_example_transform3d_hierarchy", spawn=True)
 
-    # One space with the sun in the center, and another one with the planet.
-    rr.send_blueprint(
-        rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**")),
-    )
+    if False:
+        # One space with the sun in the center, and another one with the planet.
+        # TODO(#5521): enable this once we have it in Rust too, so that the snippets compare equally
+        rr.send_blueprint(
+            rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**")),
+        )
 
     rr.set_time("sim_time", duration=0)
 


### PR DESCRIPTION
### Related
* Closes #3235
* Part of https://github.com/rerun-io/rerun/issues/9110
* Unblocks https://github.com/rerun-io/rerun/pull/9751
* Unblocks https://github.com/rerun-io/rerun/issues/9588

### What
In our snippet comparisons, ignore small numeric differences (that often occur because of differences in programming language, or compiler/interpreter version)