### PR TITLE
Compare snippets to legacy rrds

### DIFF
--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -32,14 +32,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// ### Covariance ellipsoid
 /// ```ignore
-/// use rand::distributions::Distribution as _;
+/// use rand::prelude::*;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_ellipsoid_simple").spawn()?;
 ///
 ///     let sigmas: [f32; 3] = [5., 3., 1.];
 ///
-///     let mut rng = rand::thread_rng();
+///     let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
 ///     let normal = rand_distr::Normal::new(0.0, 1.0)?;
 ///
 ///     rec.log(

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -27,12 +27,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple pinhole camera
 /// ```ignore
 /// use ndarray::{Array, ShapeBuilder as _};
+/// use rand::prelude::*;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn()?;
 ///
 ///     let mut image = Array::<u8, _>::default((3, 3, 3).f());
-///     image.map_inplace(|x| *x = rand::random());
+///     let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+///     image.map_inplace(|x| *x = rng.gen());
 ///
 ///     rec.log(
 ///         "world/image",

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -24,13 +24,13 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// ### Randomly distributed 2D points with varying color and radius
 /// ```ignore
-/// use rand::{distributions::Uniform, Rng as _};
+/// use rand::prelude::*;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d_random").spawn()?;
 ///
-///     let mut rng = rand::thread_rng();
-///     let dist = Uniform::new(-3., 3.);
+///     let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+///     let dist = rand::distributions::Uniform::new(-3., 3.);
 ///
 ///     rec.log(
 ///         "random",

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -25,12 +25,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ### Simple tensor
 /// ```ignore
 /// use ndarray::{Array, ShapeBuilder as _};
+/// use rand::prelude::*;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor").spawn()?;
 ///
 ///     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
-///     data.map_inplace(|x| *x = rand::random());
+///     let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+///     data.map_inplace(|x| *x = rng.gen());
 ///
 ///     let tensor =
 ///         rerun::Tensor::try_from(data)?.with_dim_names(["width", "height", "channel", "batch"]);

--- a/crates/top/rerun/src/commands/stdio.rs
+++ b/crates/top/rerun/src/commands/stdio.rs
@@ -44,7 +44,11 @@ pub fn read_rrd_streams_from_file_or_stdin(
     channel::Receiver<(InputSource, anyhow::Result<LogMsg>)>,
     channel::Receiver<u64>,
 ) {
-    let path_to_input_rrds = paths.iter().map(PathBuf::from).collect_vec();
+    let path_to_input_rrds = paths
+        .iter()
+        .filter(|s| !s.is_empty()) // Avoid a problem with `pixi run check-backwards-compatibility`
+        .map(PathBuf::from)
+        .collect_vec();
 
     // TODO(cmc): might want to make this configurable at some point.
     let (tx, rx) = crossbeam::channel::bounded(100);

--- a/docs/snippets/all/archetypes/ellipsoids3d_simple.rs
+++ b/docs/snippets/all/archetypes/ellipsoids3d_simple.rs
@@ -1,13 +1,13 @@
 //! Log random points and the corresponding covariance ellipsoid.
 
-use rand::distributions::Distribution as _;
+use rand::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_ellipsoid_simple").spawn()?;
 
     let sigmas: [f32; 3] = [5., 3., 1.];
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
     let normal = rand_distr::Normal::new(0.0, 1.0)?;
 
     rec.log(

--- a/docs/snippets/all/archetypes/pinhole_simple.rs
+++ b/docs/snippets/all/archetypes/pinhole_simple.rs
@@ -1,12 +1,14 @@
 //! Log a pinhole and a random image.
 
 use ndarray::{Array, ShapeBuilder as _};
+use rand::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_pinhole").spawn()?;
 
     let mut image = Array::<u8, _>::default((3, 3, 3).f());
-    image.map_inplace(|x| *x = rand::random());
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+    image.map_inplace(|x| *x = rng.gen());
 
     rec.log(
         "world/image",

--- a/docs/snippets/all/archetypes/points2d_random.rs
+++ b/docs/snippets/all/archetypes/points2d_random.rs
@@ -1,12 +1,12 @@
 //! Log some random points with color and radii.
 
-use rand::{distributions::Uniform, Rng as _};
+use rand::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points2d_random").spawn()?;
 
-    let mut rng = rand::thread_rng();
-    let dist = Uniform::new(-3., 3.);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+    let dist = rand::distributions::Uniform::new(-3., 3.);
 
     rec.log(
         "random",

--- a/docs/snippets/all/archetypes/points3d_random.rs
+++ b/docs/snippets/all/archetypes/points3d_random.rs
@@ -1,12 +1,12 @@
 //! Log some random points with color and radii.
 
-use rand::{distributions::Uniform, Rng as _};
+use rand::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_points3d_random").spawn()?;
 
-    let mut rng = rand::thread_rng();
-    let dist = Uniform::new(-5., 5.);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+    let dist = rand::distributions::Uniform::new(-5., 5.);
 
     rec.log(
         "random",

--- a/docs/snippets/all/archetypes/tensor_simple.rs
+++ b/docs/snippets/all/archetypes/tensor_simple.rs
@@ -1,12 +1,14 @@
 //! Create and log a tensor.
 
 use ndarray::{Array, ShapeBuilder as _};
+use rand::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_tensor").spawn()?;
 
     let mut data = Array::<u8, _>::default((8, 6, 3, 5).f());
-    data.map_inplace(|x| *x = rand::random());
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
+    data.map_inplace(|x| *x = rng.gen());
 
     let tensor =
         rerun::Tensor::try_from(data)?.with_dim_names(["width", "height", "channel", "batch"]);

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import sys
 import time
+import subprocess
 from pathlib import Path
 from typing import Any, cast
 
@@ -198,8 +199,10 @@ def main() -> None:
 
         if args.write_missing_backward_assets:
             if not backwards_path.exists():
+                print(f"Writing new backwards-compatibility file to {backwards_path}…")
                 backwards_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(rust_output_path, backwards_path)
+                subprocess.call(["git", "add", "-f", backwards_path])
         else:
             try:
                 # Compare old snippet files checked in to git lfs, to the newly generated ones.

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -200,6 +200,13 @@ def main() -> None:
             if not backwards_path.exists():
                 backwards_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(rust_output_path, backwards_path)
+        else:
+            try:
+                # Compare old snippet files checked in to git lfs, to the newly generated ones.
+                # They should be the same!
+                run_comparison(backwards_path, rust_output_path, args.full_dump)
+            except Exception as e:
+                errors.append((example, e))
 
         if "cpp" in active_languages:
             if "cpp" in example_opt_out_entirely:

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -55,8 +55,8 @@ class Example:
                 ]
         return []
 
-    def output_path(self, language: str) -> Path:
-        return Path(f"docs/snippets/all/{self.subdir}/{self.name}_{language}.rrd")
+    def output_path(self, language: str) -> str:
+        return f"docs/snippets/all/{self.subdir}/{self.name}_{language}.rrd"
 
     def backwards_compatibility_path(self) -> Path:
         """

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -206,7 +206,7 @@ def main() -> None:
                 # They should be the same!
                 run_comparison(backwards_path, rust_output_path, args.full_dump)
             except Exception as e:
-                errors.append((example, e))
+                errors.append((example, "old-rrd-files", e))
 
         if "cpp" in active_languages:
             if "cpp" in example_opt_out_entirely:
@@ -217,7 +217,7 @@ def main() -> None:
                 try:
                     run_comparison(cpp_output_path, rust_output_path, args.full_dump)
                 except Exception as e:
-                    errors.append((example, e))
+                    errors.append((example, "C++", e))
 
         if "py" in active_languages:
             if "py" in example_opt_out_entirely:
@@ -228,18 +228,19 @@ def main() -> None:
                 try:
                     run_comparison(python_output_path, rust_output_path, args.full_dump)
                 except Exception as e:
-                    errors.append((example, e))
+                    errors.append((example, "Python", e))
 
     if len(errors) == 0:
         print("All tests passed!")
     else:
         print(f"{len(errors)} errors found:")
 
-        for example, _error in errors:
-            print(f"❌ {example}")
+        for example, comparison, _error in errors:
+            print(f"❌ {example} - {comparison} differs from Rust baseline")
 
-        for _example, error in errors:
+        for example, comparison, error in errors:
             print()
+            print(f"❌ {example} - {comparison} differs from Rust baseline:")
             print(error)
             print("--------------------------------------")
 
@@ -247,8 +248,8 @@ def main() -> None:
         print("----------------------------------------------------------")
         print()
 
-        for example, _error in errors:
-            print(f"❌ {example}")
+        for example, comparison, _error in errors:
+            print(f"❌ {example} - {comparison} differs from Rust baseline")
 
         sys.exit(1)
 

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -9,9 +9,9 @@ import glob
 import multiprocessing
 import os
 import shutil
+import subprocess
 import sys
 import time
-import subprocess
 from pathlib import Path
 from typing import Any, cast
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -206,7 +206,7 @@ rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/c
 
 # Check that old .rrd files can still be read and understood.
 # See tests/assets/rrd/README.md for more.
-check-backwards-compatibility = { cmd = "cargo run --package rerun-cli --no-default-features --quiet rrd verify tests/assets/rrd/*.rrd" }
+check-backwards-compatibility = { cmd = "find tests/assets/rrd -name '*.rrd' -type f -print0 | xargs -0 cargo run --package rerun-cli --no-default-features --quiet rrd verify" }
 
 rs-fmt = "cargo fmt --all"
 

--- a/tests/assets/rrd/annotation_context_connections_rust.rrd
+++ b/tests/assets/rrd/annotation_context_connections_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f430250f3c45331be5f9f60736ddc21549f78708afbc7dfbdc56e2b4f041262a
-size 4683

--- a/tests/assets/rrd/annotation_context_rects_rust.rrd
+++ b/tests/assets/rrd/annotation_context_rects_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf1ccc9f4391363e3bc719e2d8a93db77a60756298840929d0e933a025ec338
-size 4585

--- a/tests/assets/rrd/annotation_context_rust.rrd
+++ b/tests/assets/rrd/annotation_context_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3b624075070168cc21c54154f56edd3ea45433c3689c09c35716585e1fd1df4
-size 4567

--- a/tests/assets/rrd/annotation_context_segmentation_rust.rrd
+++ b/tests/assets/rrd/annotation_context_segmentation_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e4ff0f583b1920da6bb3fece9b0dcb40cc89494c072d95a064f02db2ab13871
-size 4969

--- a/tests/assets/rrd/any_batch_value_column_updates_rust.rrd
+++ b/tests/assets/rrd/any_batch_value_column_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c53825af896e0e37a90113e469f20113edd799f62f24b18585be6666143cc73b
-size 7828

--- a/tests/assets/rrd/any_values_column_updates_rust.rrd
+++ b/tests/assets/rrd/any_values_column_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c07ce163249d382fe161063e3152a7c4c2445d292ba9d2b17413f0d14d0e959b
-size 2922

--- a/tests/assets/rrd/any_values_row_updates_rust.rrd
+++ b/tests/assets/rrd/any_values_row_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7cfdd437eda7883de5780c734690addafc230169ce606aa124d39450e7b95ab3
-size 68157

--- a/tests/assets/rrd/any_values_rust.rrd
+++ b/tests/assets/rrd/any_values_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d932741841d784167b8dff61610dfb625ccf9866ef1470a3cfdd631caa75369
-size 1492

--- a/tests/assets/rrd/arkit_scenes.rrd
+++ b/tests/assets/rrd/arkit_scenes.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea9c6b0f0277cf6e7b763f591566c480a282c27be4c4c55dc151f8d029eda5ea
-size 41028893

--- a/tests/assets/rrd/arrows2d_simple_rust.rrd
+++ b/tests/assets/rrd/arrows2d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce4d7dddfd965d0e5b9a2a55feba92b26ad52b9f62d02e56a373a912094802c3
-size 2746

--- a/tests/assets/rrd/arrows3d_simple_rust.rrd
+++ b/tests/assets/rrd/arrows3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:10677880e61784bbdb75a47a064538476b44e3ceff51d9e2cfa36a39cc8ec9bc
-size 3803

--- a/tests/assets/rrd/asset3d_simple_rust.rrd
+++ b/tests/assets/rrd/asset3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b0e252eb0aafd15e9288bfda9bc603508078eb4a6324571a6563cebb13c4a48
-size 5078

--- a/tests/assets/rrd/bar_chart_rust.rrd
+++ b/tests/assets/rrd/bar_chart_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed6dae959fe3717363de798d540a4b48f5ef8e70c85a1b66c46a5601793c6625
-size 3001

--- a/tests/assets/rrd/boxes2d_simple_rust.rrd
+++ b/tests/assets/rrd/boxes2d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb41f5970f8e62ed372cd4b0f67c36241fc61fda985de9559fdf01f2e3410e15
-size 2312

--- a/tests/assets/rrd/boxes3d_batch_rust.rrd
+++ b/tests/assets/rrd/boxes3d_batch_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9e9f00fded5e1660d5b4a829671743f0d4a18f1c7f2fc5c2db32075acc68638
-size 3057

--- a/tests/assets/rrd/boxes3d_simple_rust.rrd
+++ b/tests/assets/rrd/boxes3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a04ea929626195e5875ccf0c5d0efff2216e64a8457aeacc4ad117972323152b
-size 2208

--- a/tests/assets/rrd/capsules3d_batch_rust.rrd
+++ b/tests/assets/rrd/capsules3d_batch_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23765e2bc0c5134418f5ae73ddae5b4529b1442131a85efdd813bcfde1d6180b
-size 2867

--- a/tests/assets/rrd/clear_recursive_rust.rrd
+++ b/tests/assets/rrd/clear_recursive_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eed1744530d487f4b9c0faac5775698cf542b03c25521f057896a4d963935592
-size 11112

--- a/tests/assets/rrd/clear_simple_rust.rrd
+++ b/tests/assets/rrd/clear_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:319f39546badaf491184738ae8c713b939f08df52df1b19c87658e79931cf206
-size 16931

--- a/tests/assets/rrd/custom_data_rust.rrd
+++ b/tests/assets/rrd/custom_data_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c31bbda21127930796c0a021552f672bb2aeb4b02dc26483ab74fe0ab91170b
-size 5026

--- a/tests/assets/rrd/depth_image_3d_rust.rrd
+++ b/tests/assets/rrd/depth_image_3d_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ad34b854bec4480b9ec77960a9d4374538bba6e47a14b1b8a8cc4660cc5caa6
-size 5542

--- a/tests/assets/rrd/depth_image_simple_rust.rrd
+++ b/tests/assets/rrd/depth_image_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee2a1856fd72c1ac6ff55f73b85d10b90032c93441bb4f0573a38bfec5929408
-size 3213

--- a/tests/assets/rrd/descr_builtin_archetype_rust.rrd
+++ b/tests/assets/rrd/descr_builtin_archetype_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fc63e9627a08dc2a5f911c63a5934f5d6f02919c504e7dfdba5fd684683a94f
-size 2008

--- a/tests/assets/rrd/descr_builtin_component_rust.rrd
+++ b/tests/assets/rrd/descr_builtin_component_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a6e2063cb22d799f88de134b87fc90f1c8f536ac084fc8d75582e015c55d0db
-size 1047

--- a/tests/assets/rrd/descr_custom_archetype_rust.rrd
+++ b/tests/assets/rrd/descr_custom_archetype_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37ad2eb74d6025185dbf420ae41cf40f089c19f6ec4c138adf123140321e6126
-size 1248

--- a/tests/assets/rrd/descr_custom_component_rust.rrd
+++ b/tests/assets/rrd/descr_custom_component_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6892ca351d1ff8e418736bfb4ab8fa354f428b3d92f79bcf991503e0b9b49ef3
-size 1126

--- a/tests/assets/rrd/dicom_mri.rrd
+++ b/tests/assets/rrd/dicom_mri.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:191e49bac5ba8898f4532a3be1c231e8d1bb557f538bce35752cfe6a819d4ed9
-size 66439590

--- a/tests/assets/rrd/different_data_per_timeline_rust.rrd
+++ b/tests/assets/rrd/different_data_per_timeline_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:677762ed5d013b85958470bd6fe7a2d8d9825c9d13d23817c5067ff151ca2575
-size 6708

--- a/tests/assets/rrd/dna.rrd
+++ b/tests/assets/rrd/dna.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee03a1dbb2b252ea343a63c4440b3d70eacfafba5a92002855b823d38ece7472
-size 633958

--- a/tests/assets/rrd/ellipsoids3d_batch_rust.rrd
+++ b/tests/assets/rrd/ellipsoids3d_batch_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07e27d97f204f666e9426b34d974037d570bdc45400d81a38f8e70d8eb4b6c7f
-size 2654

--- a/tests/assets/rrd/ellipsoids3d_simple_rust.rrd
+++ b/tests/assets/rrd/ellipsoids3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:174799db65b674d1b35ad5e112119b4240859990aae680298a052a78270d8d97
-size 607215

--- a/tests/assets/rrd/encoded_image_rust.rrd
+++ b/tests/assets/rrd/encoded_image_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e9755c87e10d903615cf283c839e363aa3d04c6322e585a4c582964da9e124
-size 48187

--- a/tests/assets/rrd/entity_path_rust.rrd
+++ b/tests/assets/rrd/entity_path_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a5c24984f46f4e9b4161856a58467571e185e0c73b62a8d514e4daab1bdb863
-size 4249

--- a/tests/assets/rrd/examples/arkit_scenes.rrd
+++ b/tests/assets/rrd/examples/arkit_scenes.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a6e5cd5bf6f906a6de3790594b051fff91c2b7f71bfe5e59c01c20a27c11cf0
+size 41032192

--- a/tests/assets/rrd/examples/dicom_mri.rrd
+++ b/tests/assets/rrd/examples/dicom_mri.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b50169867bff0c3dc338f7a28cb9f296476e00ef36e2553bae5b095c00346e02
+size 66467101

--- a/tests/assets/rrd/examples/dna.rrd
+++ b/tests/assets/rrd/examples/dna.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f26e55bb7c04a26cc3b34e29f097be02f43ed88a4a22938103c36255ec6f093
+size 635505

--- a/tests/assets/rrd/examples/graphs.rrd
+++ b/tests/assets/rrd/examples/graphs.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7b815929dfa542567060b3b11ea8e1d3bde0bad9799ea2529d52845420c7514
+size 115315

--- a/tests/assets/rrd/examples/human_pose_tracking.rrd
+++ b/tests/assets/rrd/examples/human_pose_tracking.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03ed35b2b0db09a39e3cfd7d03c21233da48045bba5ebf92e9513099b4a6a3c9
+size 57188211

--- a/tests/assets/rrd/examples/imu_signals.rrd
+++ b/tests/assets/rrd/examples/imu_signals.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54964c4ffcd975e774a4dd70712230072c179156b297429f0f2f9bbe4c099980
+size 59021813

--- a/tests/assets/rrd/examples/plots.rrd
+++ b/tests/assets/rrd/examples/plots.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9352d0f99a12664dec69a203cc13917d29eabf46a282cc03f2ae60277666c2ef
+size 257605

--- a/tests/assets/rrd/examples/rrt_star.rrd
+++ b/tests/assets/rrd/examples/rrt_star.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0486a7fd300692267eb33b79fc1da23021555e006fcf43b9237c1bc123375d0
+size 7443206

--- a/tests/assets/rrd/examples/structure_from_motion.rrd
+++ b/tests/assets/rrd/examples/structure_from_motion.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db9cd01dc6210dac8a38edc0188fd7bcd8c2060f60801c6925d884678fc5cdc0
+size 7025248

--- a/tests/assets/rrd/extra_values_rust.rrd
+++ b/tests/assets/rrd/extra_values_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53d5c16392982181de89e217243de2403579e72bb004de61afc35bc6924dea14
-size 2379

--- a/tests/assets/rrd/generate-compatibility-rrds.sh
+++ b/tests/assets/rrd/generate-compatibility-rrds.sh
@@ -3,28 +3,20 @@
 
 set -eux
 
-
-SOURCE_DIR="docs/snippets/all"
 DEST_DIR="tests/assets/rrd"
 
+# Uncomment if you want to update _ALL_ files (not recommended!)
+# echo "Removing old rrds…"
+# find "${DEST_DIR}" -type f -name "*.rrd" -delete
 
-echo "Removing old rrds…"
-rm -f "${DEST_DIR}/*.rrd"
-
-
+# TODO(emilk): only update missing files
 echo "Generating example .rrd files…"
-pixi run -e examples build-examples rrd --channel main ${DEST_DIR}
-
-
-echo "Removing old snippet output…"
-find "${SOURCE_DIR}" -type f -name "*.rrd" -exec rm -f {} +
+pixi run -e examples build-examples rrd --channel main ${DEST_DIR}/examples
 
 echo "Generating snippet .rrd files…"
-pixi run -e py docs/snippets/compare_snippet_output.py --no-py --no-cpp
-
-echo "Copying .rrd files to ${DEST_DIR}…"
-find "$SOURCE_DIR" -type f -name "*.rrd" -exec cp {} "${DEST_DIR}" \;
-
+pixi run -e py docs/snippets/compare_snippet_output.py --no-py --no-cpp --write-missing-backward-assets
 
 echo "Adding new .rrd files to git…"
-git add -f ${DEST_DIR}/*.rrd
+find "${DEST_DIR}" -type f -name "*.rrd" -exec git add -f {} \;
+
+echo "!!! It is recommended that you ONLY _add_ files, NEVER remove them"

--- a/tests/assets/rrd/geo_line_strings_simple_rust.rrd
+++ b/tests/assets/rrd/geo_line_strings_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27ef89fa2883bc61cf6930a67a7381039e7b95f8b49498ead2f9f5a6af899738
-size 2587

--- a/tests/assets/rrd/geo_points_simple_rust.rrd
+++ b/tests/assets/rrd/geo_points_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac2c580c356792a162f8c1664dd79bc4d73e8906850c7c060855fdfea9cacbed
-size 2479

--- a/tests/assets/rrd/graph_directed_rust.rrd
+++ b/tests/assets/rrd/graph_directed_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59af8edd53a27f619cd2a57e5c90789b5d20b42c58eeb6b378bdd45f5893b20f
-size 2899

--- a/tests/assets/rrd/graph_undirected_rust.rrd
+++ b/tests/assets/rrd/graph_undirected_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bdd2d95afcc91ac3749bee43e2b8bd9fc83a83dc540df54ca2bb843abd7bfb4
-size 2893

--- a/tests/assets/rrd/graphs.rrd
+++ b/tests/assets/rrd/graphs.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46581a9146194ca4d1c53f5c8b79ad07c4911765e0b9383a93993f9a73dde92c
-size 92968

--- a/tests/assets/rrd/human_pose_tracking.rrd
+++ b/tests/assets/rrd/human_pose_tracking.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2521ff77bac804fb74d5a78b8eda68be8cc1557acc1057d10eff4963b15b69e
-size 57057460

--- a/tests/assets/rrd/image_column_updates_rust.rrd
+++ b/tests/assets/rrd/image_column_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:09eaab88328853d00f8516602ec3940c0d133f5a6b72f2baf3bdd91c20c957b1
-size 18560

--- a/tests/assets/rrd/image_formats_rust.rrd
+++ b/tests/assets/rrd/image_formats_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c10d37f1e64a94cf040fb25f824221923e278cc5dd787e8fcc20bd4034f6371f
-size 408539

--- a/tests/assets/rrd/image_row_updates_rust.rrd
+++ b/tests/assets/rrd/image_row_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8ecb74e2eaf8fa12106ecea8d8918337b2d745acfe66eac33132cccecbd7dd0
-size 63520

--- a/tests/assets/rrd/image_simple_rust.rrd
+++ b/tests/assets/rrd/image_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:856e75b5b59e301a1b715aa36339ab767c06fcbf265fc544e7f963d7a5bffe2c
-size 3248

--- a/tests/assets/rrd/indices_rust.rrd
+++ b/tests/assets/rrd/indices_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebc160c609f40911bcf6553cdd18e3ecdd290b22ac3983ef668f9d79314e4ad1
-size 2688

--- a/tests/assets/rrd/instance_poses3d_combined_rust.rrd
+++ b/tests/assets/rrd/instance_poses3d_combined_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f63debd75ca7288fd8db7c171f78941e73adbaadc4815e2a5d2977e284bec150
-size 923429

--- a/tests/assets/rrd/line_strips2d_batch_rust.rrd
+++ b/tests/assets/rrd/line_strips2d_batch_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2ca55be1339757cf6f4bb6d1819a2798a6e4a6e4d59a6f2f8cbbd4ab65515b7e
-size 2740

--- a/tests/assets/rrd/line_strips2d_segments_simple_rust.rrd
+++ b/tests/assets/rrd/line_strips2d_segments_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07029dba2221949a28d44c2f2790613d00eebe29a09c56c62baca1260c4ef6fc
-size 2301

--- a/tests/assets/rrd/line_strips2d_simple_rust.rrd
+++ b/tests/assets/rrd/line_strips2d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f9af5a36a65953b951f8ca1cadd81efb6515ef46b8974f2109d8612c2856d7b
-size 2271

--- a/tests/assets/rrd/line_strips2d_ui_radius_rust.rrd
+++ b/tests/assets/rrd/line_strips2d_ui_radius_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2c00cd704471e034667135542fff63e9098aa380e7627e51dd8a597f24a8365
-size 4944

--- a/tests/assets/rrd/line_strips3d_batch_rust.rrd
+++ b/tests/assets/rrd/line_strips3d_batch_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86eb7940ee89f098306c2d19b7eced9d0cda9113fc315eecf27e8888401aad45
-size 2743

--- a/tests/assets/rrd/line_strips3d_segments_simple_rust.rrd
+++ b/tests/assets/rrd/line_strips3d_segments_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0f13c038b5276e9f9282ed06e159141de28d705a55acb3f65a85546d7c9cd58
-size 2316

--- a/tests/assets/rrd/line_strips3d_simple_rust.rrd
+++ b/tests/assets/rrd/line_strips3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:726331372a718c4bf91ccbf3061131b5400ab28f6268f522885bc38e3defae7c
-size 2287

--- a/tests/assets/rrd/line_strips3d_ui_radius_rust.rrd
+++ b/tests/assets/rrd/line_strips3d_ui_radius_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8197d2cddb5235d31d491a96ff7fefab4a5a9b049a475da2959ca54f30baff83
-size 4899

--- a/tests/assets/rrd/mesh3d_indexed_rust.rrd
+++ b/tests/assets/rrd/mesh3d_indexed_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d384343ccee9c4b92098c67b251b47fbbb2db09a294fc6570e7a9cec15664c44
-size 2670

--- a/tests/assets/rrd/mesh3d_instancing_rust.rrd
+++ b/tests/assets/rrd/mesh3d_instancing_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7dba45f131f7b98f49698d7d950d1f0169bb2291a6fcd62ab58204c289098b27
-size 247820

--- a/tests/assets/rrd/mesh3d_partial_updates_rust.rrd
+++ b/tests/assets/rrd/mesh3d_partial_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9fcfcc73229633ebb54a5a24ab0ebfb19a970537bc9dea13e31e7dc1ef3c5e0
-size 656527

--- a/tests/assets/rrd/mesh3d_simple_rust.rrd
+++ b/tests/assets/rrd/mesh3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88af2d2e829ce25c50ad9cf462c92361d4d5b75f7e68811b847dd1035ada2f6a
-size 2489

--- a/tests/assets/rrd/pinhole_perspective_rust.rrd
+++ b/tests/assets/rrd/pinhole_perspective_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ddf0089fbf8d89b8520e7ce681b7e7ddec1d983870bd747408af3b47431a20ba
-size 4915

--- a/tests/assets/rrd/pinhole_simple_rust.rrd
+++ b/tests/assets/rrd/pinhole_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:520ae6e07d18f14fd12cc2099ea2826ca227ce0d370ff6ee9022f23216052143
-size 4750

--- a/tests/assets/rrd/plots.rrd
+++ b/tests/assets/rrd/plots.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:973061fc6daa6167d667c843be7871a712da2db831359943884c9ae6078cf2cd
-size 236158

--- a/tests/assets/rrd/points2d_random_rust.rrd
+++ b/tests/assets/rrd/points2d_random_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78b5e3959ddd539b6b9ae55776d9c4b9685ddf82dfbd95b6401bccbfaa7a90e5
-size 2631

--- a/tests/assets/rrd/points2d_simple_rust.rrd
+++ b/tests/assets/rrd/points2d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d343ac12afa29a7a4d683dc59645e8432c0d92238f9796c73c87a0012e0cba6c
-size 2204

--- a/tests/assets/rrd/points2d_ui_radius_rust.rrd
+++ b/tests/assets/rrd/points2d_ui_radius_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a8a737d13862a155fd453e0716b68701b3622477ddb86c20f93838f27515c536
-size 4814

--- a/tests/assets/rrd/points3d_column_updates_rust.rrd
+++ b/tests/assets/rrd/points3d_column_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aefdf0a5b641760124018eedd3055d2952467ec096ae400692c860cd21d4edc4
-size 2548

--- a/tests/assets/rrd/points3d_partial_updates_rust.rrd
+++ b/tests/assets/rrd/points3d_partial_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9dbfe2bd66cd4a93cc662af2a518971ec9f05b40c9774bac9a64862433640d52
-size 27453

--- a/tests/assets/rrd/points3d_random_rust.rrd
+++ b/tests/assets/rrd/points3d_random_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f692945ee357a177c369b748032610b79dea3b85dcc07e42fefe655bf46df59c
-size 2656

--- a/tests/assets/rrd/points3d_row_updates_rust.rrd
+++ b/tests/assets/rrd/points3d_row_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fef99bd77f66dc4df5571bfa7b5c2c69e1d0da48b26398aaab3cdd1383928f0
-size 12282

--- a/tests/assets/rrd/points3d_simple_rust.rrd
+++ b/tests/assets/rrd/points3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5a539e0438a52c6b3054ca7cfd04cfaed50a7248b59fc270030eb6be4c863be
-size 2190

--- a/tests/assets/rrd/points3d_ui_radius_rust.rrd
+++ b/tests/assets/rrd/points3d_ui_radius_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76ef53b633fe96493f49f72e06202c46fda852487ca7c85bddb5241315bdbb52
-size 4789

--- a/tests/assets/rrd/quick_start_connect_rust.rrd
+++ b/tests/assets/rrd/quick_start_connect_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d93a2d64a431a66122a83ebeafd3abbe2de9d580a41ad15c63b186813bdfdfde
-size 12806

--- a/tests/assets/rrd/quick_start_spawn_rust.rrd
+++ b/tests/assets/rrd/quick_start_spawn_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81270d92e13f89d00faa35b6460049aeb433093fe91f37db8bae387adb74c3bb
-size 12801

--- a/tests/assets/rrd/rrt_star.rrd
+++ b/tests/assets/rrd/rrt_star.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e215890534e97f9ad02d49ae5e7e56ae5dd7703c649ffd3f309d8fbe89f2240
-size 7613266

--- a/tests/assets/rrd/scalar_column_updates_rust.rrd
+++ b/tests/assets/rrd/scalar_column_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9695a6583b13a494a2713e38e9f2e46d1e14610aca0d52a8bf6e1a698a3c57f0
-size 3293

--- a/tests/assets/rrd/scalar_multiple_plots_rust.rrd
+++ b/tests/assets/rrd/scalar_multiple_plots_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73b9a9d20d4142d2e809b0a311f5fa5e7105f34388299ba4a1c005e936196fe5
-size 7989838

--- a/tests/assets/rrd/scalar_row_updates_rust.rrd
+++ b/tests/assets/rrd/scalar_row_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81290e60e38ef5b8975982d010527feb57ce1933bbebd9da45660dffaeb9dbd4
-size 135195

--- a/tests/assets/rrd/scalar_simple_rust.rrd
+++ b/tests/assets/rrd/scalar_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:357289425dfbf4fd142ca405d3cc733e462fd26ebdba8b77812e02e1b9d8bf58
-size 134199

--- a/tests/assets/rrd/segmentation_image_simple_rust.rrd
+++ b/tests/assets/rrd/segmentation_image_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:93e83ebf8e34a31fe953b5ad5b5d312e4a15c456385d1389ea20de69b035b16d
-size 4670

--- a/tests/assets/rrd/series_line_style_rust.rrd
+++ b/tests/assets/rrd/series_line_style_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14bb83433dd4ac00398bc8e5ce91a62d31a1d80d709027c347b4c0e9204c8afb
-size 5325364

--- a/tests/assets/rrd/series_point_style_rust.rrd
+++ b/tests/assets/rrd/series_point_style_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:004d24042ecdacbce1ff5c67bccf7bf0077592dfee8823d703be92e58873a442
-size 533979

--- a/tests/assets/rrd/snippets/archetypes/annotation_context_connections.rrd
+++ b/tests/assets/rrd/snippets/archetypes/annotation_context_connections.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:016c9b27851a7118434154dd2e2fabea1d1bbb2390de156db40b2a145994c149
+size 7603

--- a/tests/assets/rrd/snippets/archetypes/annotation_context_rects.rrd
+++ b/tests/assets/rrd/snippets/archetypes/annotation_context_rects.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba57ff59cfa5746bbad0027356188001dd6b175e1156962f9a4f12453e3663bd
+size 7486

--- a/tests/assets/rrd/snippets/archetypes/annotation_context_segmentation.rrd
+++ b/tests/assets/rrd/snippets/archetypes/annotation_context_segmentation.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67d659289827c7f747f46db348947e6a13043a20c1a8ae707e86d640c3ab7b22
+size 7854

--- a/tests/assets/rrd/snippets/archetypes/arrows2d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/arrows2d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72422251c5091c993b87c75195fa5f2e9e880de1ab7c318165c1cd83e8545b81
+size 5362

--- a/tests/assets/rrd/snippets/archetypes/arrows3d_column_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/arrows3d_column_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1191b4c3bf91fc0de0fad8e694368888f866a6f5f08c9012e55bfb9a9a56073d
+size 4874

--- a/tests/assets/rrd/snippets/archetypes/arrows3d_row_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/arrows3d_row_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20bdaf0d3e24938a0e2e77c15b0eea1b8ab32666c4a336ec0acce162456032e
+size 17385

--- a/tests/assets/rrd/snippets/archetypes/arrows3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/arrows3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30118a14dc446d89a8bb863ce3ee4e656475cd0a651ef184cd2148d834f2b256
+size 6314

--- a/tests/assets/rrd/snippets/archetypes/asset3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/asset3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a1bf70c82bfb0a1ef2f597c1b99f04c7a3276954eae1f819a2532747e59c0f4
+size 7736

--- a/tests/assets/rrd/snippets/archetypes/bar_chart.rrd
+++ b/tests/assets/rrd/snippets/archetypes/bar_chart.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d824fe546da924b43da35655fdb9593eab49a31b8a7acfb57eda7ca2e4bb20
+size 5342

--- a/tests/assets/rrd/snippets/archetypes/boxes2d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/boxes2d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad92439854497eed21ee794da3147aa4f8c999ed98f09db6bd0f5e6856d6117a
+size 4733

--- a/tests/assets/rrd/snippets/archetypes/boxes3d_batch.rrd
+++ b/tests/assets/rrd/snippets/archetypes/boxes3d_batch.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ac154fc44c8b5fc2475865d3ddb5e308cb8951303d821f3d434a6a7fb77fd78
+size 5781

--- a/tests/assets/rrd/snippets/archetypes/boxes3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/boxes3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce6e5dcbee44e92c32d80e05319ae7695fb654358c1ca027235f8f7d716dfa68
+size 4552

--- a/tests/assets/rrd/snippets/archetypes/capsules3d_batch.rrd
+++ b/tests/assets/rrd/snippets/archetypes/capsules3d_batch.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfaf0e0ab7e4e867ec0f144e84412540884bba90c1fdf614320f49c52dc268dd
+size 5445

--- a/tests/assets/rrd/snippets/archetypes/clear_recursive.rrd
+++ b/tests/assets/rrd/snippets/archetypes/clear_recursive.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65269c746fc0bbe8d5a3cba17db29dc359587df479a330b893f399bc87d78675
+size 15755

--- a/tests/assets/rrd/snippets/archetypes/clear_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/clear_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf3bf6a4ed5fef2f7f8c0ff0e06a0ac469690437cba96c62c650a5c2f97b2521
+size 23013

--- a/tests/assets/rrd/snippets/archetypes/depth_image_3d.rrd
+++ b/tests/assets/rrd/snippets/archetypes/depth_image_3d.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed200c2406910a4b5f2506c06194e7fa1b42816cef76117e983457c33193e2be
+size 8588

--- a/tests/assets/rrd/snippets/archetypes/depth_image_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/depth_image_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5dab3f0bca1ba373f63a36292fe5ede9f36fe9f8df19f13994b2069ab4cc329
+size 5677

--- a/tests/assets/rrd/snippets/archetypes/ellipsoids3d_batch.rrd
+++ b/tests/assets/rrd/snippets/archetypes/ellipsoids3d_batch.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fd99fa1099118e9249afb9832b86e3394178ed59b7865129b33b99f5e38dee1
+size 5172

--- a/tests/assets/rrd/snippets/archetypes/ellipsoids3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/ellipsoids3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7324869b864425c0425efb9647f4a1fbee5e47a477a62ddfc1bab95af23cdef
+size 610346

--- a/tests/assets/rrd/snippets/archetypes/ellipsoids3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/ellipsoids3d_simple.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7324869b864425c0425efb9647f4a1fbee5e47a477a62ddfc1bab95af23cdef
-size 610346
+oid sha256:7a573cd4e71976315475db87dc310237b22c2f2857c148d4a48ef729acf3200b
+size 610383

--- a/tests/assets/rrd/snippets/archetypes/encoded_image.rrd
+++ b/tests/assets/rrd/snippets/archetypes/encoded_image.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f71c3743912626dc9e98874d450f68847c6895b8e64ffff100992daa459e7822
+size 50615

--- a/tests/assets/rrd/snippets/archetypes/entity_path.rrd
+++ b/tests/assets/rrd/snippets/archetypes/entity_path.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb173e2a58488df56f72d93bda84058211b8ff3f1ec89d7d0da7fab616aacade
+size 7022

--- a/tests/assets/rrd/snippets/archetypes/geo_line_strings_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/geo_line_strings_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0af34036c3f4e8e412a1950150aa89a8ec26e6f5774ba47d652eabe4532c42e
+size 5003

--- a/tests/assets/rrd/snippets/archetypes/geo_points_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/geo_points_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc498a1a9128a01ea4950e4ce5b6d10ec6ee8cbb2e1347b958ef69fd6f252891
+size 4912

--- a/tests/assets/rrd/snippets/archetypes/graph_directed.rrd
+++ b/tests/assets/rrd/snippets/archetypes/graph_directed.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2ab4c119484ea5c8b4396dd9694ae9d1cbd5bbc30357dc0d3729aa36e7f0fad
+size 5501

--- a/tests/assets/rrd/snippets/archetypes/graph_undirected.rrd
+++ b/tests/assets/rrd/snippets/archetypes/graph_undirected.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e41f384ae58d21d588ceaa956d7029722f8defd3e43bb7065783ab123aa9929
+size 5508

--- a/tests/assets/rrd/snippets/archetypes/image_column_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/image_column_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4d96f34685a668091759ed60652c3e38063dbd7d5d1260266c33f18769ca677
+size 22859

--- a/tests/assets/rrd/snippets/archetypes/image_formats.rrd
+++ b/tests/assets/rrd/snippets/archetypes/image_formats.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a11eb3607f92a798bdb967cf2475b407fd2e91a7d1f44cf749cd9c44e8398bc3
+size 412794

--- a/tests/assets/rrd/snippets/archetypes/image_row_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/image_row_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c900ba8ac63dd751716f465f82e95203e6f50c843d74004bfd92cfdd6103ff1
+size 78705

--- a/tests/assets/rrd/snippets/archetypes/image_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/image_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7b3b790c2d6904fde3e4957236e1ed85625da0e1fe42bd598dda76131319095
+size 5773

--- a/tests/assets/rrd/snippets/archetypes/instance_poses3d_combined.rrd
+++ b/tests/assets/rrd/snippets/archetypes/instance_poses3d_combined.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ea125a0a9ae5a153cd273e708994096ad2070e8dcc487e3643fafb51de97b47
+size 1179703

--- a/tests/assets/rrd/snippets/archetypes/line_strips2d_batch.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips2d_batch.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de53ed1e8e3c8f5f808decdef66212b136bad7ccb393522db5c422cb0b39747e
+size 5215

--- a/tests/assets/rrd/snippets/archetypes/line_strips2d_segments_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips2d_segments_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6516f5016e66119653167730c228a536ba69d523aac8aec0c55c6a819afdba5b
+size 4629

--- a/tests/assets/rrd/snippets/archetypes/line_strips2d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips2d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7fbb3e3cfd7d714ba384a194e730cdbe2cf1c1eff28f16a9fc330a39a1fe0ec
+size 4574

--- a/tests/assets/rrd/snippets/archetypes/line_strips2d_ui_radius.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips2d_ui_radius.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee62953cb54611409276b9cd1297556b93f97bd5fa8a7b2852cfc71ae91aa021
+size 7831

--- a/tests/assets/rrd/snippets/archetypes/line_strips3d_batch.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips3d_batch.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25aedc9c319cad5911a92fbb369cc8e33c84ff9d1ee03071d378e74969281217
+size 5264

--- a/tests/assets/rrd/snippets/archetypes/line_strips3d_segments_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips3d_segments_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6614524084f2a3cc1b5e80ca26186fd4701893a4d7a4da93ef5ad42967c2398
+size 4649

--- a/tests/assets/rrd/snippets/archetypes/line_strips3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:086031209ca17ba96cbb1424a11f6dc27c129e9277c16ef4e10a9fdbf9a37d3c
+size 4611

--- a/tests/assets/rrd/snippets/archetypes/line_strips3d_ui_radius.rrd
+++ b/tests/assets/rrd/snippets/archetypes/line_strips3d_ui_radius.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23163ed259493f9b452d0035350e999915cbc8295cd2e0ace02976ceef2ba1a
+size 7858

--- a/tests/assets/rrd/snippets/archetypes/mesh3d_indexed.rrd
+++ b/tests/assets/rrd/snippets/archetypes/mesh3d_indexed.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07f94396d96cb42209a914cc2364819e725c258463400c95f30446f848b1165b
+size 5145

--- a/tests/assets/rrd/snippets/archetypes/mesh3d_instancing.rrd
+++ b/tests/assets/rrd/snippets/archetypes/mesh3d_instancing.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a487f51d6602c20c1f9e3ae7fef301051b6d364c05b088cc354c254fc83fcf6b
+size 313778

--- a/tests/assets/rrd/snippets/archetypes/mesh3d_partial_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/mesh3d_partial_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e57697015cddce9d9bb0d67ed2c32159843beb4c62f5f8a673bca05d062885e2
+size 801790

--- a/tests/assets/rrd/snippets/archetypes/mesh3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/mesh3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72f442d7ca2c43a35c6d24229212c950eedeb3ffd4c17e32dca7ac744e043279
+size 4955

--- a/tests/assets/rrd/snippets/archetypes/pinhole_perspective.rrd
+++ b/tests/assets/rrd/snippets/archetypes/pinhole_perspective.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11e6178ec502f444a45c7a716f6e5916c660c0d248f19a6e98a9122ed1a54ad4
+size 7915

--- a/tests/assets/rrd/snippets/archetypes/pinhole_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/pinhole_simple.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a24c8ccfb7461bd0d1fe5daf64ec743dd1c8748b190f588b5612b7f93ba28f3f
-size 7765
+oid sha256:b93aa6beb5c4ebb43af97dca7bd4f89c34046f705b7d0afbed6650b51c811b9a
+size 7696

--- a/tests/assets/rrd/snippets/archetypes/pinhole_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/pinhole_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a24c8ccfb7461bd0d1fe5daf64ec743dd1c8748b190f588b5612b7f93ba28f3f
+size 7765

--- a/tests/assets/rrd/snippets/archetypes/points2d_random.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points2d_random.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93c34d00d150e759960a31506ed8b3360a070a2cc87f27d65e154a697e1d4e0b
-size 5063
+oid sha256:379379d8d8b7cfd9ef836e864a50c3712eb75c0f3e424296732ed23ea964329b
+size 5046

--- a/tests/assets/rrd/snippets/archetypes/points2d_random.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points2d_random.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93c34d00d150e759960a31506ed8b3360a070a2cc87f27d65e154a697e1d4e0b
+size 5063

--- a/tests/assets/rrd/snippets/archetypes/points2d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points2d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f9f8e73ea7cb4ddac45a4e00aff87822f3c3128e96dc627a5b2aec23b4d9a79
+size 4511

--- a/tests/assets/rrd/snippets/archetypes/points2d_ui_radius.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points2d_ui_radius.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab40cb11feab9c0069c2e212355d2d9c02e36a86fd97f9b0cb10d6d10163d97d
+size 7802

--- a/tests/assets/rrd/snippets/archetypes/points3d_column_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points3d_column_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af7a3e3ab6dd347f1a882c60f2f788e9515ef9c200150e9d48222620bf28a722
+size 4887

--- a/tests/assets/rrd/snippets/archetypes/points3d_partial_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points3d_partial_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41310da7c9a699976ffecc2a8eb8fb5f4ec59211f4857f43474eb3960f2ca853
+size 36788

--- a/tests/assets/rrd/snippets/archetypes/points3d_random.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points3d_random.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4299a9f612937109d4728ed0044bd3f5e977d236f3be0e573cabd0c43d87c546
+size 5101

--- a/tests/assets/rrd/snippets/archetypes/points3d_random.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points3d_random.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4299a9f612937109d4728ed0044bd3f5e977d236f3be0e573cabd0c43d87c546
+oid sha256:6b5ef123df44c1f292dc879b6eeea1a0d01db768c095e00fdb94aabfc1b52be1
 size 5101

--- a/tests/assets/rrd/snippets/archetypes/points3d_row_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points3d_row_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28e282ce9983d6a5867825c6402470551fd6aad5babb9e08bfda97901b33fbfc
+size 17413

--- a/tests/assets/rrd/snippets/archetypes/points3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ea875e8508e97dff726a4cd1f0c73516826285fd64f73afc0a48305862eee68
+size 4492

--- a/tests/assets/rrd/snippets/archetypes/points3d_ui_radius.rrd
+++ b/tests/assets/rrd/snippets/archetypes/points3d_ui_radius.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9e2e682deee96bbe4179dac55e3010828aeeca1557dce200f9f3db4c85b9a95
+size 7745

--- a/tests/assets/rrd/snippets/archetypes/scalars_column_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/scalars_column_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41ec1083f5c2cd19d1c10d48daec2c6c6ad024e281a3b42a7e9074c605997817
+size 5527

--- a/tests/assets/rrd/snippets/archetypes/scalars_multiple_plots.rrd
+++ b/tests/assets/rrd/snippets/archetypes/scalars_multiple_plots.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75a3bd34a43befc2fabbae62977a14ad2609d8178128c478f27b4fd0b5acc757
+size 9839319

--- a/tests/assets/rrd/snippets/archetypes/scalars_row_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/scalars_row_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbffef9955f6339a86bfa14766196a722c21fe525e94bb30916807543c7a85ca
+size 167199

--- a/tests/assets/rrd/snippets/archetypes/scalars_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/scalars_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ffc2574842279b71aa37fd905fbdcf0ccbb01b89d349d55318b39f2a49d8092
+size 166912

--- a/tests/assets/rrd/snippets/archetypes/segmentation_image_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/segmentation_image_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:234d290553b8c9343061cd4e2aa5d7472d5d7a036483e5e24fb90c1f331430f2
+size 7509

--- a/tests/assets/rrd/snippets/archetypes/series_lines_style.rrd
+++ b/tests/assets/rrd/snippets/archetypes/series_lines_style.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d12c04fce96a95573ef5a4cf27dc0794a3c2d73cd4b8a0017a9c095689ae26b8
+size 6558248

--- a/tests/assets/rrd/snippets/archetypes/series_points_style.rrd
+++ b/tests/assets/rrd/snippets/archetypes/series_points_style.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:621d148037392527d0b064a4b3028a1b73985e6bdaf67da07bea2c9fc2ec1017
+size 658865

--- a/tests/assets/rrd/snippets/archetypes/tensor_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/tensor_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdc1e75b26adf99b7440a1f5c8c1f4a0d2f547f627d87a63de9005ea363c7442
+size 6112

--- a/tests/assets/rrd/snippets/archetypes/tensor_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/tensor_simple.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdc1e75b26adf99b7440a1f5c8c1f4a0d2f547f627d87a63de9005ea363c7442
-size 6112
+oid sha256:09a492578153e1d7688795e69a027da29b0a529a3560d406f4a251d853a0d146
+size 6104

--- a/tests/assets/rrd/snippets/archetypes/text_document.rrd
+++ b/tests/assets/rrd/snippets/archetypes/text_document.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:859777c4a7e06cd9817277cc8a3ade9f588dcf7a2eb8b9249bbf046e4b5ab912
+size 7802

--- a/tests/assets/rrd/snippets/archetypes/text_log.rrd
+++ b/tests/assets/rrd/snippets/archetypes/text_log.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15bdd7764e47ecf7a71a1698a0be72fed2306a8f5438eba5ddffa8d8796d0f53
+size 4660

--- a/tests/assets/rrd/snippets/archetypes/text_log_integration.rrd
+++ b/tests/assets/rrd/snippets/archetypes/text_log_integration.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cf5b8e82efd0d8283509e14866782fe94830417714ffa45f7d24e74500cc097
+size 7406

--- a/tests/assets/rrd/snippets/archetypes/transform3d_axes.rrd
+++ b/tests/assets/rrd/snippets/archetypes/transform3d_axes.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d81d57f1ac0057d5847c80e9142d6958ef276142800a8ab1c647d55d1beab71
+size 2739802

--- a/tests/assets/rrd/snippets/archetypes/transform3d_column_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/transform3d_column_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0af51717fd9a907a7983725947ebf6bf23fa105b21da82b9252d9960a4f4bb6
+size 10108

--- a/tests/assets/rrd/snippets/archetypes/transform3d_hierarchy.rrd
+++ b/tests/assets/rrd/snippets/archetypes/transform3d_hierarchy.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33015ada3e79b9e6ed964dc270d0b58d3fe428f8785054f6d7754ebaad509d8e
+size 5487591

--- a/tests/assets/rrd/snippets/archetypes/transform3d_partial_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/transform3d_partial_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77926b5401429f52c3416ae5a5f8bc99512a7ef9901360d31a586d5a84ee4fd7
+size 367276

--- a/tests/assets/rrd/snippets/archetypes/transform3d_row_updates.rrd
+++ b/tests/assets/rrd/snippets/archetypes/transform3d_row_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5bb69edf797c82b6b81ea31eeb377c7e7828125173115366ad1cbec9449bd87
+size 303510

--- a/tests/assets/rrd/snippets/archetypes/transform3d_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/transform3d_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:128229ce69002131f058cb4541512a0007aebb231fb2f19d33a9a031c3bf3f4f
+size 17100

--- a/tests/assets/rrd/snippets/archetypes/video_auto_frames.rrd
+++ b/tests/assets/rrd/snippets/archetypes/video_auto_frames.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79677ca732db31d36b4e683a296cb106d8ad3c4e978b456545e4acb13c20e50d
+size 5285835

--- a/tests/assets/rrd/snippets/archetypes/video_manual_frames.rrd
+++ b/tests/assets/rrd/snippets/archetypes/video_manual_frames.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4457d9df5267908f35f96fb1fb5f3e07e63b8a6ba7cb9220e9c410ad160c142
+size 1071379

--- a/tests/assets/rrd/snippets/archetypes/view_coordinates_simple.rrd
+++ b/tests/assets/rrd/snippets/archetypes/view_coordinates_simple.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a11de9ccbdb63c623ef2d1706258085aa09bc685e9eeb00031eee73a9a25e69a
+size 6631

--- a/tests/assets/rrd/snippets/concepts/different_data_per_timeline.rrd
+++ b/tests/assets/rrd/snippets/concepts/different_data_per_timeline.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcfa30338d9541df8ca74c325aea5be0a4ee230781e96b2db28ee5590229916a
+size 10253

--- a/tests/assets/rrd/snippets/concepts/indices.rrd
+++ b/tests/assets/rrd/snippets/concepts/indices.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b6bc59743216de784a9200e52c70c40af68028beaa54dd94276f828be2a52b1
+size 5363

--- a/tests/assets/rrd/snippets/concepts/recording_properties.rrd
+++ b/tests/assets/rrd/snippets/concepts/recording_properties.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b8ed150ec45e9526c35093a21a95d8cda97725ea269efc6399c5bad6243ec64
+size 11087

--- a/tests/assets/rrd/snippets/descriptors/descr_builtin_archetype.rrd
+++ b/tests/assets/rrd/snippets/descriptors/descr_builtin_archetype.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:536045f95142f37fd74e75bd64420e333cdd6f73123f4708f8f8a257c8e62b9f
+size 4239

--- a/tests/assets/rrd/snippets/descriptors/descr_builtin_component.rrd
+++ b/tests/assets/rrd/snippets/descriptors/descr_builtin_component.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:538fc74cf75c407892f396a059ad8da4de01fa9acf704f8595886af9ed9843f4
+size 3075

--- a/tests/assets/rrd/snippets/descriptors/descr_custom_archetype.rrd
+++ b/tests/assets/rrd/snippets/descriptors/descr_custom_archetype.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f189c3e1c81a4e62eed5575d27d96fb5f1ee540bfaa104f78d39d653837a9ebf
+size 3368

--- a/tests/assets/rrd/snippets/descriptors/descr_custom_component.rrd
+++ b/tests/assets/rrd/snippets/descriptors/descr_custom_component.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05b534de6278edaa3164ff5af173fa4a2fcdda28426966c2e8ba66a003fc1c5c
+size 3149

--- a/tests/assets/rrd/snippets/howto/any_batch_value_column_updates.rrd
+++ b/tests/assets/rrd/snippets/howto/any_batch_value_column_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf9d2a2b9087b568c5e9eb503e3fb067b93b21669a99c561633cb7bad68caab4
+size 9977

--- a/tests/assets/rrd/snippets/howto/any_values_column_updates.rrd
+++ b/tests/assets/rrd/snippets/howto/any_values_column_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41bc8474bf1cf90d93f16f3e1ba140550e6c21df32a8766baadbffc9bb7ff20e
+size 5071

--- a/tests/assets/rrd/snippets/howto/any_values_row_updates.rrd
+++ b/tests/assets/rrd/snippets/howto/any_values_row_updates.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df7f19dda8d4b2d0b8102513ec1ded422b383de04ca9842e7e6f4be2c73d5f32
+size 90449

--- a/tests/assets/rrd/snippets/quick_start/quick_start_connect.rrd
+++ b/tests/assets/rrd/snippets/quick_start/quick_start_connect.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba1e12da16058eb17576937c26727f52dafec9d355ff995a33c3ef4b36cf958a
+size 15347

--- a/tests/assets/rrd/snippets/quick_start/quick_start_spawn.rrd
+++ b/tests/assets/rrd/snippets/quick_start/quick_start_spawn.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07d0455d09beb48060c7e260b805c5d1637c6bc9166e97d64f91ac3206a1bbfd
+size 15342

--- a/tests/assets/rrd/snippets/tutorials/annotation_context.rrd
+++ b/tests/assets/rrd/snippets/tutorials/annotation_context.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de5f425f6d897cdb2f9b8d8e4d5b0d84bee1b36c46fe569355ce64f12dd4ea03
+size 7378

--- a/tests/assets/rrd/snippets/tutorials/any_values.rrd
+++ b/tests/assets/rrd/snippets/tutorials/any_values.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02cc15ee33994478b3a1b66e14b7afab6b3dea58446d39c273936773f18ff29d
+size 3770

--- a/tests/assets/rrd/snippets/tutorials/custom_data.rrd
+++ b/tests/assets/rrd/snippets/tutorials/custom_data.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2d594831e47b3d7b8f9ee58c18fdd97181c5a2997446bdfab92a118cd01000a
+size 8007

--- a/tests/assets/rrd/snippets/tutorials/extra_values.rrd
+++ b/tests/assets/rrd/snippets/tutorials/extra_values.rrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa8bc4f2f27e64b4c254c77ead054971bb4b8ebc75596c999570b1ded607518a
+size 4716

--- a/tests/assets/rrd/structure_from_motion.rrd
+++ b/tests/assets/rrd/structure_from_motion.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b380c709d22fda9736f57e54a9a36b79fdc7cb960dd72c665faf551fe841790
-size 7035697

--- a/tests/assets/rrd/tensor_simple_rust.rrd
+++ b/tests/assets/rrd/tensor_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2238a5d270e04557e44f55bad615a031707774adc0a0909bb097350417d529bc
-size 3724

--- a/tests/assets/rrd/text_document_rust.rrd
+++ b/tests/assets/rrd/text_document_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:570d4e3feb46ddebe19c75c7952b02a5894a80726119636ed5bf7177688b89ea
-size 4940

--- a/tests/assets/rrd/text_log_integration_rust.rrd
+++ b/tests/assets/rrd/text_log_integration_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:492e42a71eb1e337076194b93d68b4ccaf8133410ce0c6d965d20460e9d15923
-size 4497

--- a/tests/assets/rrd/text_log_rust.rrd
+++ b/tests/assets/rrd/text_log_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c30a9ce07edc99fae64cdb2273729593131888e3118df296537c2c641f2256d
-size 2274

--- a/tests/assets/rrd/transform3d_axes_rust.rrd
+++ b/tests/assets/rrd/transform3d_axes_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a951f092107c723ec8d45b5e89fbf10f4a5ecf684a636be04dd309978510ec53
-size 2108069

--- a/tests/assets/rrd/transform3d_column_updates_rust.rrd
+++ b/tests/assets/rrd/transform3d_column_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0de1dd8217c8bdf67efc27483152ebc75bb7ed4c0c74ddebe1c531dc441af7cd
-size 7082

--- a/tests/assets/rrd/transform3d_hierarchy_rust.rrd
+++ b/tests/assets/rrd/transform3d_hierarchy_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bff13e0cb0227aca8bc5e1f7de0ae8de2ae501d2d64e8adecd89ea2d38f27300
-size 4126233

--- a/tests/assets/rrd/transform3d_partial_updates_rust.rrd
+++ b/tests/assets/rrd/transform3d_partial_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fee23fdb9eeceb5f2c20ad5fd4437847b6485689d8ca27bbb85aaaec195e8eaa
-size 302253

--- a/tests/assets/rrd/transform3d_row_updates_rust.rrd
+++ b/tests/assets/rrd/transform3d_row_updates_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:df9261506f911c52ec47e9b971e69552e322fb23616a3e058c6a00bc96d6f51b
-size 242660

--- a/tests/assets/rrd/transform3d_simple_rust.rrd
+++ b/tests/assets/rrd/transform3d_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d53b7873580faa4867f5682834aa6616848bba36fbefc61d87d99a203f0aded
-size 11971

--- a/tests/assets/rrd/video_auto_frames_rust.rrd
+++ b/tests/assets/rrd/video_auto_frames_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:753187083245365ff80639e72fbac70e780105704fa921c24be009437ae5f108
-size 5280549

--- a/tests/assets/rrd/video_manual_frames_rust.rrd
+++ b/tests/assets/rrd/video_manual_frames_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e7adb167671906cde54f540bdbde9cbc9bd59b0645c2d63e97071dcb39fb7bb
-size 1067544

--- a/tests/assets/rrd/view_coordinates_simple_rust.rrd
+++ b/tests/assets/rrd/view_coordinates_simple_rust.rrd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97d46d5b6ec0432ed79cc57d05431fe65ad478b04df546c4988f7442f8359ac9
-size 4004


### PR DESCRIPTION
## Related
* Requires https://github.com/rerun-io/rerun/pull/9750
* Part of #9110

## What
This restructures the folder of .rrds that we use for backwards-compatibility checks, so that it has a `snippets` folder, matching the structure of our snippets. These are then read by `compare_snippets_output.py` and are compared to the latest output of the snippets. They should be equal to each other (since the old .rrds should be migrated on ingestion).

### Consequences
If we add a new snippet, the CI will fail until the output .rrd of that snippet is checked in to CI (using `compare_snippets_output.py --write-missing-backward-assets`)

If we _change_ a snippet (so that it outputs something different), we need to either:
* Update the file on `git lfs`
* Add a _new_ file to `git lfs` alongside the old one
* Add an opt-out flag for comparing to the file on `git lfs` to `snippets.toml`

Since this should be a rather rare occurrence (our snippets tend to stay pretty stable), any one solution will do, and I have not decided on one yet. Maybe cross that bridge if and when we get to it?