### PR TITLE
Re-introduce `Navigation` and lean into `DisplayMode`

### DIFF
--- a/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
@@ -9,7 +9,7 @@ use re_log_types::{
     ResolvedTimeRange, StoreKind, TimeType, Timeline, TimelineName, TimestampFormat,
 };
 use re_ui::{list_item, UiExt as _};
-use re_viewer_context::ViewerContext;
+use re_viewer_context::StoreContext;
 
 use crate::chunk_list_mode::{ChunkListMode, ChunkListQueryMode};
 use crate::chunk_ui::ChunkUi;
@@ -74,7 +74,7 @@ impl DatastoreUi {
     /// or `true` if the datastore UI should remain open.
     pub fn ui(
         &mut self,
-        ctx: &ViewerContext<'_>,
+        ctx: &StoreContext<'_>,
         ui: &mut egui::Ui,
         timestamp_format: TimestampFormat,
     ) -> bool {
@@ -91,8 +91,8 @@ impl DatastoreUi {
                 self.chunk_store_ui(
                     ui,
                     match self.store_kind {
-                        StoreKind::Recording => ctx.recording_engine(),
-                        StoreKind::Blueprint => ctx.blueprint_engine(),
+                        StoreKind::Recording => ctx.recording.storage_engine(),
+                        StoreKind::Blueprint => ctx.blueprint.storage_engine(),
                     }
                     .store(),
                     &mut datastore_ui_active,

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -873,7 +873,7 @@ pub fn table_id_button_ui(
     let mut list_item = ui
         .list_item()
         .selected(ctx.selection().contains_item(&item))
-        .active(ctx.storage_context.hub.active_table_id() == Some(table_id));
+        .active(ctx.active_table_id == Some(table_id));
 
     if ctx.hovered().contains_item(&item) {
         list_item = list_item.force_hovered(true);

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -264,9 +264,7 @@ impl EntryKind {
 
     fn is_active(&self, ctx: &ViewerContext<'_>) -> bool {
         match self {
-            Self::Remote { entry_id, .. } => {
-                matches!(ctx.global_context.display_mode, DisplayMode::RedapEntry(id) if id == entry_id)
-            }
+            Self::Remote { entry_id, .. } => ctx.active_redap_entry == Some(entry_id),
             // TODO(lucasmerlin): Update this when local datasets have a view like remote datasets
             Self::Local(_) => false,
         }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -2205,7 +2205,7 @@ impl eframe::App for App {
             );
 
             let app_blueprint = AppBlueprint::new(
-                store_context.as_ref(),
+                store_context.as_ref().map(|ctx| ctx.blueprint),
                 &blueprint_query,
                 egui_ctx,
                 self.panel_state_overrides_active

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -419,7 +419,7 @@ impl App {
     ) {
         match cmd {
             SystemCommand::ActivateApp(app_id) => {
-                self.state.display_mode = DisplayMode::LocalRecordings;
+                self.state.navigation.replace(DisplayMode::LocalRecordings);
                 store_hub.set_active_app(app_id);
             }
 
@@ -428,7 +428,7 @@ impl App {
             }
 
             SystemCommand::ActivateEntry(entry) => {
-                self.state.display_mode = DisplayMode::LocalRecordings;
+                self.state.navigation.replace(DisplayMode::LocalRecordings);
                 store_hub.set_active_entry(entry);
             }
 
@@ -468,7 +468,7 @@ impl App {
             }
 
             SystemCommand::ChangeDisplayMode(display_mode) => {
-                self.state.display_mode = display_mode;
+                self.state.navigation.replace(display_mode);
             }
             SystemCommand::AddRedapServer(origin) => {
                 self.state.redap_servers.add_server(origin.clone());
@@ -478,7 +478,9 @@ impl App {
                     .as_ref()
                     .is_none_or(|store_hub| store_hub.active_entry().is_none())
                 {
-                    self.state.display_mode = DisplayMode::RedapServer(origin);
+                    self.state
+                        .navigation
+                        .replace(DisplayMode::RedapServer(origin));
                 }
                 self.command_sender.send_ui(UICommand::ExpandBlueprintPanel);
             }
@@ -593,11 +595,15 @@ impl App {
             SystemCommand::SetSelection(item) => {
                 match &item {
                     Item::RedapEntry(entry_id) => {
-                        self.state.display_mode = DisplayMode::RedapEntry(*entry_id);
+                        self.state
+                            .navigation
+                            .replace(DisplayMode::RedapEntry(*entry_id));
                     }
 
                     Item::RedapServer(origin) => {
-                        self.state.display_mode = DisplayMode::RedapServer(origin.clone());
+                        self.state
+                            .navigation
+                            .replace(DisplayMode::RedapServer(origin.clone()));
                     }
 
                     Item::AppId(_)
@@ -609,7 +615,7 @@ impl App {
                     | Item::Container(_)
                     | Item::View(_)
                     | Item::DataResult(_, _) => {
-                        self.state.display_mode = DisplayMode::LocalRecordings;
+                        self.state.navigation.replace(DisplayMode::LocalRecordings);
                     }
                 }
 
@@ -905,14 +911,22 @@ impl App {
             }
             UICommand::ToggleTimePanel => app_blueprint.toggle_time_panel(&self.command_sender),
 
-            UICommand::ToggleChunkStoreBrowser => match self.state.display_mode {
+            UICommand::ToggleChunkStoreBrowser => match self.state.navigation.peek() {
                 DisplayMode::LocalRecordings
                 | DisplayMode::RedapEntry(_)
                 | DisplayMode::RedapServer(_) => {
-                    self.state.display_mode = DisplayMode::ChunkStoreBrowser;
+                    self.state.navigation.push(DisplayMode::ChunkStoreBrowser);
                 }
+
                 DisplayMode::ChunkStoreBrowser => {
-                    self.state.display_mode = DisplayMode::LocalRecordings;
+                    self.state.navigation.pop();
+                }
+
+                DisplayMode::Settings => {
+                    re_log::debug!(
+                        "Cannot toggle chunk store browser from current display mode: {:?}",
+                        self.state.navigation.peek()
+                    );
                 }
             },
 
@@ -931,7 +945,7 @@ impl App {
             }
 
             UICommand::Settings => {
-                self.state.show_settings_ui = true;
+                self.state.navigation.push(DisplayMode::Settings);
             }
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -23,6 +23,7 @@ use re_viewport_blueprint::ViewportBlueprint;
 
 use crate::{
     app_blueprint::AppBlueprint,
+    navigation::Navigation,
     ui::{recordings_panel_ui, settings_screen_ui},
 };
 
@@ -56,16 +57,9 @@ pub struct AppState {
     /// Redap server catalogs and browser UI
     pub(crate) redap_servers: RedapServers,
 
-    /// The current display mode.
+    /// A stack of display modes that represents tab-like navigation of the user.
     #[serde(skip)]
-    pub(crate) display_mode: DisplayMode,
-
-    /// Display the settings UI.
-    ///
-    /// If both `show_datastore_ui` and `show_settings_ui` are true, the settings UI takes
-    /// precedence.
-    #[serde(skip)]
-    pub(crate) show_settings_ui: bool,
+    pub(crate) navigation: Navigation,
 
     /// Storage for the state of each `View`
     ///
@@ -99,8 +93,7 @@ impl Default for AppState {
             welcome_screen: Default::default(),
             datastore_ui: Default::default(),
             redap_servers: Default::default(),
-            display_mode: DisplayMode::RedapServer(re_redap_browser::EXAMPLES_ORIGIN.clone()),
-            show_settings_ui: false,
+            navigation: Default::default(),
             view_states: Default::default(),
             selection_state: Default::default(),
             focused_item: Default::default(),
@@ -177,356 +170,389 @@ impl AppState {
     ) {
         re_tracing::profile_function!();
 
-        let blueprint_query = self.blueprint_query_for_viewer(store_context.blueprint);
-
-        let Self {
-            app_options,
-            recording_configs,
-            blueprint_undo_state,
-            blueprint_cfg,
-            selection_panel,
-            time_panel,
-            blueprint_time_panel,
-            blueprint_tree,
-            welcome_screen,
-            datastore_ui,
-            redap_servers,
-            display_mode,
-            show_settings_ui,
-            view_states,
-            selection_state,
-            focused_item,
-        } = self;
-
         // check state early, before the UI has a chance to close these popups
         let is_any_popup_open = ui.memory(|m| m.any_popup_open());
 
-        blueprint_undo_state
-            .entry(store_context.blueprint.store_id().clone())
-            .or_default()
-            .update(ui.ctx(), store_context.blueprint);
-
-        let viewport_blueprint =
-            ViewportBlueprint::try_from_db(store_context.blueprint, &blueprint_query);
-        let viewport_ui = ViewportUi::new(viewport_blueprint);
-
-        // If the blueprint is invalid, reset it.
-        if viewport_ui.blueprint.is_invalid() {
-            re_log::warn!("Incompatible blueprint detected. Resetting to default.");
-            command_sender.send_system(re_viewer_context::SystemCommand::ClearActiveBlueprint);
-
-            // The blueprint isn't valid so nothing past this is going to work properly.
-            // we might as well return and it will get fixed on the next frame.
-
-            // TODO(jleibs): If we move viewport loading up to a context where the EntityDb is mutable
-            // we can run the clear and re-load.
-            return;
-        }
-
-        let selection_change = selection_state.on_frame_start(
-            |item| {
-                if let Item::StoreId(store_id) = item {
-                    if store_id.is_empty_recording() {
-                        return false;
-                    }
-                }
-
-                viewport_ui.blueprint.is_item_valid(storage_context, item)
-            },
-            Some(Item::StoreId(store_context.recording.store_id().clone())),
-        );
-
-        if let SelectionChange::SelectionChanged(selection) = selection_change {
-            if let Some(callbacks) = callbacks {
-                callbacks.on_selection_change(selection, &viewport_ui.blueprint);
-            }
-        }
-
-        // The root container cannot be dragged.
-        let drag_and_drop_manager =
-            DragAndDropManager::new(Item::Container(viewport_ui.blueprint.root_container));
-
-        let recording = store_context.recording;
-
-        let maybe_visualizable_entities_per_visualizer = view_class_registry
-            .maybe_visualizable_entities_for_visualizer_systems(&recording.store_id());
-        let indicated_entities_per_visualizer =
-            view_class_registry.indicated_entities_per_visualizer(&recording.store_id());
-
-        // Execute the queries for every `View`
-        let mut query_results = {
-            re_tracing::profile_scope!("query_results");
-            viewport_ui
-                .blueprint
-                .views
-                .values()
-                .map(|view| {
-                    // TODO(andreas): This needs to be done in a store subscriber that exists per view (instance, not class!).
-                    // Note that right now we determine *all* visualizable entities, not just the queried ones.
-                    // In a store subscriber set this is fine, but on a per-frame basis it's wasteful.
-                    let visualizable_entities = view
-                        .class(view_class_registry)
-                        .determine_visualizable_entities(
-                            &maybe_visualizable_entities_per_visualizer,
-                            recording,
-                            &view_class_registry.new_visualizer_collection(view.class_identifier()),
-                            &view.space_origin,
-                        );
-
-                    (
-                        view.id,
-                        view.contents.execute_query(
-                            store_context,
-                            view_class_registry,
-                            &blueprint_query,
-                            &visualizable_entities,
-                        ),
-                    )
-                })
-                .collect::<_>()
-        };
-
-        let rec_cfg = recording_config_entry(recording_configs, recording);
-        let egui_ctx = ui.ctx().clone();
-        let ctx = ViewerContext {
-            global_context: GlobalContext {
-                app_options,
-                reflection,
-                component_ui_registry,
-                view_class_registry,
-                egui_ctx: &egui_ctx,
-                render_ctx,
-                command_sender,
-                display_mode,
-            },
-            store_context,
-            storage_context,
-            maybe_visualizable_entities_per_visualizer: &maybe_visualizable_entities_per_visualizer,
-            indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
-            query_results: &query_results,
-            rec_cfg,
-            blueprint_cfg,
-            selection_state,
-            blueprint_query: &blueprint_query,
-            focused_item,
-            drag_and_drop_manager: &drag_and_drop_manager,
-        };
-
-        // enable the heuristics if we must this frame
-        if store_context.should_enable_heuristics {
-            viewport_ui.blueprint.set_auto_layout(true, &ctx);
-            viewport_ui.blueprint.set_auto_views(true, &ctx);
-            egui_ctx.request_repaint();
-        }
-
-        // We move the time at the very start of the frame,
-        // so that we always show the latest data when we're in "follow" mode.
-        move_time(&ctx, recording, rx_log, callbacks);
-
-        // Update the viewport. May spawn new views and handle queued requests (like screenshots).
-        viewport_ui.on_frame_start(&ctx);
-
-        {
-            re_tracing::profile_scope!("updated_query_results");
-
-            for view in viewport_ui.blueprint.views.values() {
-                if let Some(query_result) = query_results.get_mut(&view.id) {
-                    // TODO(andreas): This needs to be done in a store subscriber that exists per view (instance, not class!).
-                    // Note that right now we determine *all* visualizable entities, not just the queried ones.
-                    // In a store subscriber set this is fine, but on a per-frame basis it's wasteful.
-                    let visualizable_entities = view
-                        .class(view_class_registry)
-                        .determine_visualizable_entities(
-                            &maybe_visualizable_entities_per_visualizer,
-                            recording,
-                            &view_class_registry.new_visualizer_collection(view.class_identifier()),
-                            &view.space_origin,
-                        );
-
-                    let resolver = re_viewport_blueprint::DataQueryPropertyResolver::new(
-                        view,
-                        view_class_registry,
-                        &maybe_visualizable_entities_per_visualizer,
-                        &visualizable_entities,
-                        &indicated_entities_per_visualizer,
-                    );
-
-                    resolver.update_overrides(
-                        store_context.blueprint,
-                        &blueprint_query,
-                        rec_cfg.time_ctrl.read().timeline(),
-                        view_class_registry,
-                        query_result,
-                        view_states,
-                    );
+        #[expect(clippy::single_match_else)]
+        match self.navigation.peek() {
+            DisplayMode::Settings => {
+                let mut show_settings_ui = true;
+                settings_screen_ui(ui, &mut self.app_options, &mut show_settings_ui);
+                if !show_settings_ui {
+                    self.navigation.pop();
                 }
             }
-        };
 
-        // must happen before we recreate the view context as we mutably borrow the app options
-        if *show_settings_ui {
-            settings_screen_ui(ui, app_options, show_settings_ui);
-        }
+            _ => {
+                let blueprint_query = self.blueprint_query_for_viewer(store_context.blueprint);
 
-        // We need to recreate the context to appease the borrow checker. It is a bit annoying, but
-        // it's just a bunch of refs so not really that big of a deal in practice.
-        let ctx = ViewerContext {
-            global_context: GlobalContext {
-                app_options,
-                reflection,
-                component_ui_registry,
-                view_class_registry,
-                egui_ctx: &egui_ctx,
-                render_ctx,
-                command_sender,
-                display_mode: &display_mode.clone(),
-            },
-            store_context,
-            storage_context,
-            maybe_visualizable_entities_per_visualizer: &maybe_visualizable_entities_per_visualizer,
-            indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
-            query_results: &query_results,
-            rec_cfg,
-            blueprint_cfg,
-            selection_state,
-            blueprint_query: &blueprint_query,
-            focused_item,
-            drag_and_drop_manager: &drag_and_drop_manager,
-        };
-
-        if *show_settings_ui {
-            // nothing: this is already handled above
-        } else if *display_mode == DisplayMode::ChunkStoreBrowser {
-            let should_datastore_ui_remain_active =
-                datastore_ui.ui(&ctx, ui, app_options.timestamp_format);
-            if !should_datastore_ui_remain_active {
-                *display_mode = DisplayMode::LocalRecordings;
-            }
-        } else {
-            //
-            // Blueprint time panel
-            //
-
-            if app_options.inspect_blueprint_timeline
-                && *display_mode == DisplayMode::LocalRecordings
-            {
-                let blueprint_db = ctx.store_context.blueprint;
-
-                let undo_state = self
-                    .blueprint_undo_state
-                    .entry(ctx.store_context.blueprint.store_id().clone())
-                    .or_default();
-
-                {
-                    // Copy time from undo-state to the blueprint time control struct:
-                    let mut time_ctrl = blueprint_cfg.time_ctrl.write();
-                    if let Some(redo_time) = undo_state.redo_time() {
-                        time_ctrl
-                            .set_play_state(blueprint_db.times_per_timeline(), PlayState::Paused);
-                        time_ctrl.set_time(redo_time);
-                    } else {
-                        time_ctrl.set_play_state(
-                            blueprint_db.times_per_timeline(),
-                            PlayState::Following,
-                        );
-                    }
-                }
-
-                blueprint_time_panel.show_panel(
-                    &ctx,
-                    &viewport_ui.blueprint,
-                    blueprint_db,
+                let Self {
+                    app_options,
+                    recording_configs,
+                    blueprint_undo_state,
                     blueprint_cfg,
-                    ui,
-                    PanelState::Expanded,
-                    // Give the blueprint time panel a distinct color from the normal time panel:
-                    DesignTokens::bottom_panel_frame().fill(egui::hex_color!("#141326")),
+                    selection_panel,
+                    time_panel,
+                    blueprint_time_panel,
+                    blueprint_tree,
+                    welcome_screen,
+                    datastore_ui,
+                    redap_servers,
+                    navigation,
+                    view_states,
+                    selection_state,
+                    focused_item,
+                } = self;
+
+                blueprint_undo_state
+                    .entry(store_context.blueprint.store_id().clone())
+                    .or_default()
+                    .update(ui.ctx(), store_context.blueprint);
+
+                let viewport_blueprint =
+                    ViewportBlueprint::try_from_db(store_context.blueprint, &blueprint_query);
+                let viewport_ui = ViewportUi::new(viewport_blueprint);
+
+                // If the blueprint is invalid, reset it.
+                if viewport_ui.blueprint.is_invalid() {
+                    re_log::warn!("Incompatible blueprint detected. Resetting to default.");
+                    command_sender
+                        .send_system(re_viewer_context::SystemCommand::ClearActiveBlueprint);
+
+                    // The blueprint isn't valid so nothing past this is going to work properly.
+                    // we might as well return and it will get fixed on the next frame.
+
+                    // TODO(jleibs): If we move viewport loading up to a context where the EntityDb is mutable
+                    // we can run the clear and re-load.
+                    return;
+                }
+
+                let selection_change = selection_state.on_frame_start(
+                    |item| {
+                        if let Item::StoreId(store_id) = item {
+                            if store_id.is_empty_recording() {
+                                return false;
+                            }
+                        }
+
+                        viewport_ui.blueprint.is_item_valid(storage_context, item)
+                    },
+                    Some(Item::StoreId(store_context.recording.store_id().clone())),
                 );
 
-                {
-                    // Apply changes to the blueprint time to the undo-state:
-                    let time_ctrl = blueprint_cfg.time_ctrl.read();
-                    if time_ctrl.play_state() == PlayState::Following {
-                        undo_state.redo_all();
-                    } else if let Some(time) = time_ctrl.time_int() {
-                        undo_state.set_redo_time(time);
+                if let SelectionChange::SelectionChanged(selection) = selection_change {
+                    if let Some(callbacks) = callbacks {
+                        callbacks.on_selection_change(selection, &viewport_ui.blueprint);
                     }
                 }
-            }
 
-            //
-            // Time panel
-            //
+                // The root container cannot be dragged.
+                let drag_and_drop_manager =
+                    DragAndDropManager::new(Item::Container(viewport_ui.blueprint.root_container));
 
-            if *display_mode == DisplayMode::LocalRecordings {
-                time_panel.show_panel(
-                    &ctx,
-                    &viewport_ui.blueprint,
-                    ctx.recording(),
-                    ctx.rec_cfg,
-                    ui,
-                    app_blueprint.time_panel_state(),
-                    DesignTokens::bottom_panel_frame(),
-                );
-            }
+                let recording = store_context.recording;
 
-            //
-            // Selection Panel
-            //
+                let maybe_visualizable_entities_per_visualizer = view_class_registry
+                    .maybe_visualizable_entities_for_visualizer_systems(&recording.store_id());
+                let indicated_entities_per_visualizer =
+                    view_class_registry.indicated_entities_per_visualizer(&recording.store_id());
 
-            if *display_mode == DisplayMode::LocalRecordings {
-                selection_panel.show_panel(
-                    &ctx,
-                    &viewport_ui.blueprint,
-                    view_states,
-                    ui,
-                    app_blueprint.selection_panel_state().is_expanded(),
-                );
-            }
+                // Execute the queries for every `View`
+                let mut query_results = {
+                    re_tracing::profile_scope!("query_results");
+                    viewport_ui
+                        .blueprint
+                        .views
+                        .values()
+                        .map(|view| {
+                            // TODO(andreas): This needs to be done in a store subscriber that exists per view (instance, not class!).
+                            // Note that right now we determine *all* visualizable entities, not just the queried ones.
+                            // In a store subscriber set this is fine, but on a per-frame basis it's wasteful.
+                            let visualizable_entities = view
+                                .class(view_class_registry)
+                                .determine_visualizable_entities(
+                                    &maybe_visualizable_entities_per_visualizer,
+                                    recording,
+                                    &view_class_registry
+                                        .new_visualizer_collection(view.class_identifier()),
+                                    &view.space_origin,
+                                );
 
-            //
-            // Left panel (recordings and blueprint)
-            //
+                            (
+                                view.id,
+                                view.contents.execute_query(
+                                    store_context,
+                                    view_class_registry,
+                                    &blueprint_query,
+                                    &visualizable_entities,
+                                ),
+                            )
+                        })
+                        .collect::<_>()
+                };
 
-            let left_panel = egui::SidePanel::left("blueprint_panel")
-                .resizable(true)
-                .frame(egui::Frame {
-                    fill: ui.visuals().panel_fill,
-                    ..Default::default()
-                })
-                .min_width(120.0)
-                .default_width(default_blueprint_panel_width(
-                    ui.ctx().screen_rect().width(),
-                ));
+                let rec_cfg = recording_config_entry(recording_configs, recording);
+                let egui_ctx = ui.ctx().clone();
+                let ctx = ViewerContext {
+                    global_context: GlobalContext {
+                        app_options,
+                        reflection,
+                        component_ui_registry,
+                        view_class_registry,
+                        egui_ctx: &egui_ctx,
+                        render_ctx,
+                        command_sender,
+                    },
+                    store_context,
+                    storage_context,
+                    maybe_visualizable_entities_per_visualizer:
+                        &maybe_visualizable_entities_per_visualizer,
+                    indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
+                    query_results: &query_results,
+                    rec_cfg,
+                    blueprint_cfg,
+                    selection_state,
+                    blueprint_query: &blueprint_query,
+                    focused_item,
+                    drag_and_drop_manager: &drag_and_drop_manager,
+                    active_redap_entry: match navigation.peek() {
+                        DisplayMode::RedapEntry(id) => Some(id),
+                        _ => None,
+                    },
+                };
 
-            left_panel.show_animated_inside(
-                ui,
-                app_blueprint.blueprint_panel_state().is_expanded(),
-                |ui: &mut egui::Ui| {
-                    // ListItem don't need vertical spacing so we disable it, but restore it
-                    // before drawing the blueprint panel.
-                    ui.spacing_mut().item_spacing.y = 0.0;
+                // enable the heuristics if we must this frame
+                if store_context.should_enable_heuristics {
+                    viewport_ui.blueprint.set_auto_layout(true, &ctx);
+                    viewport_ui.blueprint.set_auto_views(true, &ctx);
+                    egui_ctx.request_repaint();
+                }
 
-                    match display_mode {
-                        DisplayMode::LocalRecordings
-                        | DisplayMode::RedapEntry(..)
-                        | DisplayMode::RedapServer(..) => {
-                            let show_blueprints = *display_mode == DisplayMode::LocalRecordings;
-                            let resizable = ctx.storage_context.bundle.recordings().count() > 3
-                                && show_blueprints;
+                // We move the time at the very start of the frame,
+                // so that we always show the latest data when we're in "follow" mode.
+                move_time(&ctx, recording, rx_log, callbacks);
 
-                            if resizable {
-                                // Don't shrink either recordings panel or blueprint panel below this height
-                                let min_height_each = 90.0_f32.at_most(ui.available_height() / 2.0);
+                // Update the viewport. May spawn new views and handle queued requests (like screenshots).
+                viewport_ui.on_frame_start(&ctx);
 
-                                egui::TopBottomPanel::top("recording_panel")
-                                    .frame(egui::Frame::new())
-                                    .resizable(resizable)
-                                    .show_separator_line(false)
-                                    .min_height(min_height_each)
-                                    .default_height(210.0)
-                                    .max_height(ui.available_height() - min_height_each)
-                                    .show_inside(ui, |ui| {
+                {
+                    re_tracing::profile_scope!("updated_query_results");
+
+                    for view in viewport_ui.blueprint.views.values() {
+                        if let Some(query_result) = query_results.get_mut(&view.id) {
+                            // TODO(andreas): This needs to be done in a store subscriber that exists per view (instance, not class!).
+                            // Note that right now we determine *all* visualizable entities, not just the queried ones.
+                            // In a store subscriber set this is fine, but on a per-frame basis it's wasteful.
+                            let visualizable_entities = view
+                                .class(view_class_registry)
+                                .determine_visualizable_entities(
+                                    &maybe_visualizable_entities_per_visualizer,
+                                    recording,
+                                    &view_class_registry
+                                        .new_visualizer_collection(view.class_identifier()),
+                                    &view.space_origin,
+                                );
+
+                            let resolver = re_viewport_blueprint::DataQueryPropertyResolver::new(
+                                view,
+                                view_class_registry,
+                                &maybe_visualizable_entities_per_visualizer,
+                                &visualizable_entities,
+                                &indicated_entities_per_visualizer,
+                            );
+
+                            resolver.update_overrides(
+                                store_context.blueprint,
+                                &blueprint_query,
+                                rec_cfg.time_ctrl.read().timeline(),
+                                view_class_registry,
+                                query_result,
+                                view_states,
+                            );
+                        }
+                    }
+                };
+
+                // We need to recreate the context to appease the borrow checker. It is a bit annoying, but
+                // it's just a bunch of refs so not really that big of a deal in practice.
+                let ctx = ViewerContext {
+                    global_context: GlobalContext {
+                        app_options,
+                        reflection,
+                        component_ui_registry,
+                        view_class_registry,
+                        egui_ctx: &egui_ctx,
+                        render_ctx,
+                        command_sender,
+                    },
+                    store_context,
+                    storage_context,
+                    maybe_visualizable_entities_per_visualizer:
+                        &maybe_visualizable_entities_per_visualizer,
+                    indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
+                    query_results: &query_results,
+                    rec_cfg,
+                    blueprint_cfg,
+                    selection_state,
+                    blueprint_query: &blueprint_query,
+                    focused_item,
+                    drag_and_drop_manager: &drag_and_drop_manager,
+                    active_redap_entry: match self.navigation.peek() {
+                        DisplayMode::RedapEntry(id) => Some(id),
+                        _ => None,
+                    },
+                };
+
+                if self.navigation.peek() == &DisplayMode::ChunkStoreBrowser {
+                    let should_datastore_ui_remain_active =
+                        datastore_ui.ui(&ctx, ui, app_options.timestamp_format);
+                    if !should_datastore_ui_remain_active {
+                        // TODO(grtlr): This will change, when datastore will become its own display mode.            }
+                        command_sender.send_system(SystemCommand::ChangeDisplayMode(
+                            DisplayMode::LocalRecordings,
+                        ));
+                    }
+                } else {
+                    //
+                    // Blueprint time panel
+                    //
+
+                    let display_mode = self.navigation.peek();
+
+                    if app_options.inspect_blueprint_timeline
+                        && *display_mode == DisplayMode::LocalRecordings
+                    {
+                        let blueprint_db = ctx.store_context.blueprint;
+
+                        let undo_state = self
+                            .blueprint_undo_state
+                            .entry(ctx.store_context.blueprint.store_id().clone())
+                            .or_default();
+
+                        {
+                            // Copy time from undo-state to the blueprint time control struct:
+                            let mut time_ctrl = blueprint_cfg.time_ctrl.write();
+                            if let Some(redo_time) = undo_state.redo_time() {
+                                time_ctrl.set_play_state(
+                                    blueprint_db.times_per_timeline(),
+                                    PlayState::Paused,
+                                );
+                                time_ctrl.set_time(redo_time);
+                            } else {
+                                time_ctrl.set_play_state(
+                                    blueprint_db.times_per_timeline(),
+                                    PlayState::Following,
+                                );
+                            }
+                        }
+
+                        blueprint_time_panel.show_panel(
+                            &ctx,
+                            &viewport_ui.blueprint,
+                            blueprint_db,
+                            blueprint_cfg,
+                            ui,
+                            PanelState::Expanded,
+                            // Give the blueprint time panel a distinct color from the normal time panel:
+                            DesignTokens::bottom_panel_frame().fill(egui::hex_color!("#141326")),
+                        );
+
+                        {
+                            // Apply changes to the blueprint time to the undo-state:
+                            let time_ctrl = blueprint_cfg.time_ctrl.read();
+                            if time_ctrl.play_state() == PlayState::Following {
+                                undo_state.redo_all();
+                            } else if let Some(time) = time_ctrl.time_int() {
+                                undo_state.set_redo_time(time);
+                            }
+                        }
+                    }
+
+                    //
+                    // Time panel
+                    //
+
+                    if *display_mode == DisplayMode::LocalRecordings {
+                        time_panel.show_panel(
+                            &ctx,
+                            &viewport_ui.blueprint,
+                            ctx.recording(),
+                            ctx.rec_cfg,
+                            ui,
+                            app_blueprint.time_panel_state(),
+                            DesignTokens::bottom_panel_frame(),
+                        );
+                    }
+
+                    //
+                    // Selection Panel
+                    //
+
+                    if *display_mode == DisplayMode::LocalRecordings {
+                        selection_panel.show_panel(
+                            &ctx,
+                            &viewport_ui.blueprint,
+                            view_states,
+                            ui,
+                            app_blueprint.selection_panel_state().is_expanded(),
+                        );
+                    }
+
+                    //
+                    // Left panel (recordings and blueprint)
+                    //
+
+                    let left_panel = egui::SidePanel::left("blueprint_panel")
+                        .resizable(true)
+                        .frame(egui::Frame {
+                            fill: ui.visuals().panel_fill,
+                            ..Default::default()
+                        })
+                        .min_width(120.0)
+                        .default_width(default_blueprint_panel_width(
+                            ui.ctx().screen_rect().width(),
+                        ));
+
+                    left_panel.show_animated_inside(
+                        ui,
+                        app_blueprint.blueprint_panel_state().is_expanded(),
+                        |ui: &mut egui::Ui| {
+                            // ListItem don't need vertical spacing so we disable it, but restore it
+                            // before drawing the blueprint panel.
+                            ui.spacing_mut().item_spacing.y = 0.0;
+
+                            match display_mode {
+                                DisplayMode::LocalRecordings
+                                | DisplayMode::RedapEntry(..)
+                                | DisplayMode::RedapServer(..) => {
+                                    let show_blueprints =
+                                        *display_mode == DisplayMode::LocalRecordings;
+                                    let resizable = ctx.storage_context.bundle.recordings().count()
+                                        > 3
+                                        && show_blueprints;
+
+                                    if resizable {
+                                        // Don't shrink either recordings panel or blueprint panel below this height
+                                        let min_height_each =
+                                            90.0_f32.at_most(ui.available_height() / 2.0);
+
+                                        egui::TopBottomPanel::top("recording_panel")
+                                            .frame(egui::Frame::new())
+                                            .resizable(resizable)
+                                            .show_separator_line(false)
+                                            .min_height(min_height_each)
+                                            .default_height(210.0)
+                                            .max_height(ui.available_height() - min_height_each)
+                                            .show_inside(ui, |ui| {
+                                                recordings_panel_ui(
+                                                    &ctx,
+                                                    rx_log,
+                                                    ui,
+                                                    welcome_screen_state,
+                                                    redap_servers,
+                                                );
+                                            });
+                                    } else {
                                         recordings_panel_ui(
                                             &ctx,
                                             rx_log,
@@ -534,110 +560,111 @@ impl AppState {
                                             welcome_screen_state,
                                             redap_servers,
                                         );
-                                    });
-                            } else {
-                                recordings_panel_ui(
-                                    &ctx,
-                                    rx_log,
-                                    ui,
-                                    welcome_screen_state,
-                                    redap_servers,
-                                );
-                            }
+                                    }
 
-                            ui.add_space(4.0);
+                                    ui.add_space(4.0);
 
-                            if show_blueprints {
-                                blueprint_tree.show(&ctx, &viewport_ui.blueprint, ui);
-                            }
-                        }
+                                    if show_blueprints {
+                                        blueprint_tree.show(&ctx, &viewport_ui.blueprint, ui);
+                                    }
+                                }
 
-                        DisplayMode::ChunkStoreBrowser => {} // handled above
+                                DisplayMode::ChunkStoreBrowser | DisplayMode::Settings => {} // handled above
+                            };
+                        },
+                    );
+
+                    //
+                    // Viewport
+                    //
+
+                    let viewport_frame = egui::Frame {
+                        fill: ui.style().visuals.panel_fill,
+                        ..Default::default()
                     };
-                },
-            );
 
-            //
-            // Viewport
-            //
-
-            let viewport_frame = egui::Frame {
-                fill: ui.style().visuals.panel_fill,
-                ..Default::default()
-            };
-
-            egui::CentralPanel::default()
-                .frame(viewport_frame)
-                .show_inside(ui, |ui| {
-                    match display_mode {
-                        DisplayMode::LocalRecordings => {
-                            if let Some(table_id) = ctx.storage_context.hub.active_table_id() {
-                                if let Some(store) = ctx.storage_context.tables.get(table_id) {
-                                    let context = TableContext {
-                                        table_id: table_id.clone(),
-                                        store,
-                                    };
-                                    crate::ui::table_ui(&ctx, ui, &context);
-                                } else {
-                                    re_log::error_once!(
-                                        "Could not find batch store for table id {}",
-                                        table_id
-                                    );
+                    egui::CentralPanel::default()
+                        .frame(viewport_frame)
+                        .show_inside(ui, |ui| {
+                            match display_mode {
+                                DisplayMode::LocalRecordings => {
+                                    if let Some(table_id) =
+                                        ctx.storage_context.hub.active_table_id()
+                                    {
+                                        if let Some(store) =
+                                            ctx.storage_context.tables.get(table_id)
+                                        {
+                                            let context = TableContext {
+                                                table_id: table_id.clone(),
+                                                store,
+                                            };
+                                            crate::ui::table_ui(&ctx, ui, &context);
+                                        } else {
+                                            re_log::error_once!(
+                                                "Could not find batch store for table id {}",
+                                                table_id
+                                            );
+                                        }
+                                    } else {
+                                        // If we are here and the "default" app id is selected,
+                                        // we should instead switch to the welcome screen.
+                                        if ctx.store_context.app_id
+                                            == StoreHub::welcome_screen_app_id()
+                                        {
+                                            ctx.command_sender().send_system(
+                                                SystemCommand::ChangeDisplayMode(
+                                                    DisplayMode::RedapServer(
+                                                        re_redap_browser::EXAMPLES_ORIGIN.clone(),
+                                                    ),
+                                                ),
+                                            );
+                                        }
+                                        viewport_ui.viewport_ui(ui, &ctx, view_states);
+                                    }
                                 }
-                            } else {
-                                // If we are here and the "default" app id is selected,
-                                // we should instead switch to the welcome screen.
-                                if ctx.store_context.app_id == StoreHub::welcome_screen_app_id() {
-                                    ctx.command_sender().send_system(
-                                        SystemCommand::ChangeDisplayMode(DisplayMode::RedapServer(
-                                            re_redap_browser::EXAMPLES_ORIGIN.clone(),
-                                        )),
-                                    );
+
+                                DisplayMode::RedapEntry(entry) => {
+                                    redap_servers.entry_ui(&ctx, ui, *entry);
                                 }
-                                viewport_ui.viewport_ui(ui, &ctx, view_states);
+
+                                DisplayMode::RedapServer(origin) => {
+                                    if origin == &*re_redap_browser::EXAMPLES_ORIGIN {
+                                        welcome_screen.ui(
+                                            ui,
+                                            command_sender,
+                                            welcome_screen_state,
+                                            is_history_enabled,
+                                        );
+                                    } else {
+                                        redap_servers.server_central_panel_ui(&ctx, ui, origin);
+                                    }
+                                }
+
+                                DisplayMode::ChunkStoreBrowser | DisplayMode::Settings => {} // Handled above
                             }
-                        }
+                        });
 
-                        DisplayMode::RedapEntry(entry) => {
-                            redap_servers.entry_ui(&ctx, ui, *entry);
-                        }
+                    add_view_or_container_modal_ui(&ctx, &viewport_ui.blueprint, ui);
+                    drag_and_drop_manager.payload_cursor_ui(ctx.egui_ctx());
 
-                        DisplayMode::RedapServer(origin) => {
-                            if origin == &*re_redap_browser::EXAMPLES_ORIGIN {
-                                welcome_screen.ui(
-                                    ui,
-                                    command_sender,
-                                    welcome_screen_state,
-                                    is_history_enabled,
-                                );
-                            } else {
-                                redap_servers.server_central_panel_ui(&ctx, ui, origin);
-                            }
-                        }
-
-                        DisplayMode::ChunkStoreBrowser => {} // Handled above
-                    }
-                });
+                    // Process deferred layout operations and apply updates back to blueprint:
+                    viewport_ui.save_to_blueprint_store(&ctx);
+                }
+            }
         }
 
         //
         // Other UI things
         //
 
-        redap_servers.modals_ui(ui);
-
-        add_view_or_container_modal_ui(&ctx, &viewport_ui.blueprint, ui);
-        drag_and_drop_manager.payload_cursor_ui(ctx.egui_ctx());
-
-        // Process deferred layout operations and apply updates back to blueprint:
-        viewport_ui.save_to_blueprint_store(&ctx);
+        self.redap_servers.modals_ui(ui);
 
         if WATERMARK {
             ui.ctx().paint_watermark();
         }
 
         // This must run after any ui code, or other code that tells egui to open an url:
-        check_for_clicked_hyperlinks(&ctx);
+        check_for_clicked_hyperlinks(ui.ctx(), command_sender, &self.selection_state);
 
         // Deselect on ESC. Must happen after all other UI code to let them capture ESC if needed.
         if ui.input(|i| i.key_pressed(egui::Key::Escape)) && !is_any_popup_open {
@@ -825,27 +852,29 @@ pub(crate) fn recording_config_entry<'cfgs>(
 /// Must run after any ui code, or other code that tells egui to open an url.
 ///
 /// See [`re_ui::UiExt::re_hyperlink`] for displaying hyperlinks in the UI.
-fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
+fn check_for_clicked_hyperlinks(
+    egui_ctx: &egui::Context,
+    command_sender: &CommandSender,
+    selection_state: &ApplicationSelectionState,
+) {
     let recording_scheme = "recording://";
 
     let mut recording_path = None;
 
-    ctx.egui_ctx().output_mut(|o| {
+    egui_ctx.output_mut(|o| {
         o.commands.retain_mut(|command| {
             if let egui::OutputCommand::OpenUrl(open_url) = command {
                 if let Ok(uri) = open_url.url.parse::<re_uri::RedapUri>() {
                     let is_dataset_uri = matches!(uri, re_uri::RedapUri::DatasetData { .. });
 
-                    ctx.command_sender()
-                        .send_system(SystemCommand::LoadDataSource(
-                            re_data_source::DataSource::RerunGrpcStream(uri),
-                        ));
+                    command_sender.send_system(SystemCommand::LoadDataSource(
+                        re_data_source::DataSource::RerunGrpcStream(uri),
+                    ));
 
                     if is_dataset_uri && !open_url.new_tab {
-                        ctx.command_sender()
-                            .send_system(SystemCommand::ChangeDisplayMode(
-                                DisplayMode::LocalRecordings,
-                            ));
+                        command_sender.send_system(SystemCommand::ChangeDisplayMode(
+                            DisplayMode::LocalRecordings,
+                        ));
                     }
                     return false;
                 } else if let Some(path_str) = open_url.url.strip_prefix(recording_scheme) {
@@ -863,7 +892,7 @@ fn check_for_clicked_hyperlinks(ctx: &ViewerContext<'_>) {
     if let Some(path) = recording_path {
         match path.parse::<Item>() {
             Ok(item) => {
-                ctx.selection_state.set_selection(item);
+                selection_state.set_selection(item);
             }
             Err(err) => {
                 re_log::warn!("Failed to parse entity path {path:?}: {err}");

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -9,6 +9,7 @@ mod app_state;
 mod background_tasks;
 mod callback;
 pub mod env_vars;
+mod navigation;
 mod saving;
 mod screenshotter;
 mod startup_options;

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -1,0 +1,46 @@
+use re_viewer_context::DisplayMode;
+
+/// The navigation history of the viewer.
+///
+/// This object should never be exposed to directly via contexts. Instead,
+/// we retrieve the display mode and pass that around.
+pub(crate) struct Navigation {
+    history: Vec<DisplayMode>,
+    default: DisplayMode,
+}
+
+impl Default for Navigation {
+    fn default() -> Self {
+        Self {
+            history: Default::default(),
+            default: DisplayMode::RedapServer(re_redap_browser::EXAMPLES_ORIGIN.clone()),
+        }
+    }
+}
+
+impl Navigation {
+    // TODO(grtlr): In the future we should have something like `push_unique`, but for
+    // this we first need all display modes to contain more information.
+
+    pub fn push(&mut self, display_mode: DisplayMode) {
+        re_log::debug!("Pushed display mode `{:?}`", display_mode);
+        self.history.push(display_mode);
+    }
+
+    pub fn replace(&mut self, display_mode: DisplayMode) -> Option<DisplayMode> {
+        let previous = self.history.pop();
+        re_log::debug!("Replaced `{:?}` with `{:?}`", previous, display_mode);
+        self.history.push(display_mode);
+        previous
+    }
+
+    pub fn pop(&mut self) -> Option<DisplayMode> {
+        let previous = self.history.pop();
+        re_log::debug!("Popped display mode `{:?}`", previous);
+        previous
+    }
+
+    pub fn peek(&self) -> &DisplayMode {
+        self.history.last().unwrap_or(&self.default)
+    }
+}

--- a/crates/viewer/re_viewer_context/src/global_context/mod.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/mod.rs
@@ -50,13 +50,14 @@ pub struct GlobalContext<'a> {
 
     /// Interface for sending commands back to the app
     pub command_sender: &'a CommandSender,
-
-    pub display_mode: &'a DisplayMode,
 }
 
 /// Which display mode are we currently in?
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DisplayMode {
+    /// The settings dialog for application-wide configuration.
+    Settings,
+
     /// Regular view of the local recordings, including the current recording's viewport.
     LocalRecordings,
 

--- a/crates/viewer/re_viewer_context/src/global_context/mod.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/mod.rs
@@ -21,6 +21,7 @@ pub use self::{
 use crate::ViewClassRegistry;
 
 pub(crate) use item::resolve_mono_instance_path_item;
+use re_log_types::TableId;
 
 /// Application context that is shared across all parts of the viewer.
 pub struct GlobalContext<'a> {
@@ -60,6 +61,8 @@ pub enum DisplayMode {
 
     /// Regular view of the local recordings, including the current recording's viewport.
     LocalRecordings,
+
+    LocalTable(TableId),
 
     /// The Redap server/catalog/collection browser.
     RedapEntry(re_log_types::EntryId),

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -17,7 +17,7 @@ use crate::{
     BlueprintUndoState, Caches, StorageContext, StoreBundle, StoreContext, TableStore, TableStores,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum StoreHubEntry {
     Recording {
         store_id: StoreId,
@@ -139,11 +139,6 @@ impl StoreHub {
     /// App ID used as a marker to display the welcome screen.
     pub fn welcome_screen_app_id() -> ApplicationId {
         "Welcome screen".into()
-    }
-
-    /// App ID used as a marker to display tables.
-    pub fn table_app_id() -> ApplicationId {
-        "table".into()
     }
 
     /// Blueprint ID used for the default welcome screen blueprint
@@ -416,10 +411,6 @@ impl StoreHub {
             .retain(|store_id, _| store_ids_retained.contains(store_id));
 
         self.table_stores.clear();
-
-        if self.active_table_id().is_none() {
-            self.active_entry = None;
-        }
         self.active_application_id = Some(Self::welcome_screen_app_id());
     }
 
@@ -447,9 +438,7 @@ impl StoreHub {
         // If this is the welcome screen, or we didn't have any app id at all so far,
         // we set the active application_id even if we don't find a matching recording.
         // (otherwise we don't, because we don't want to leave towards a state without any recording if we don't have to)
-        if Self::welcome_screen_app_id() == app_id
-            || (self.active_application_id.is_none() && self.active_table_id().is_none())
-        {
+        if Self::welcome_screen_app_id() == app_id || self.active_application_id.is_none() {
             self.active_application_id = Some(app_id.clone());
             self.active_entry = None;
         }
@@ -490,9 +479,6 @@ impl StoreHub {
 
         if self.active_application_id.as_ref() == Some(app_id) {
             self.active_application_id = None;
-            if self.active_table_id().is_none() {
-                self.active_entry = None;
-            }
         }
 
         self.default_blueprint_by_app_id.remove(app_id);
@@ -520,12 +506,6 @@ impl StoreHub {
             Some(StoreHubEntry::Recording { store_id }) => self.store_bundle.get(store_id),
             _ => None,
         }
-    }
-
-    /// The table id for the active table.
-    #[inline]
-    pub fn active_table_id(&self) -> Option<&TableId> {
-        self.active_entry.as_ref().and_then(|e| e.table_ref())
     }
 
     /// Currently active entry if any.
@@ -576,14 +556,6 @@ impl StoreHub {
         _ = self.caches_per_recording.entry(recording_id).or_default();
     }
 
-    /// Activate an [`StoreHubEntry`]
-    pub fn set_active_entry(&mut self, entry: StoreHubEntry) {
-        match entry {
-            StoreHubEntry::Recording { store_id } => self.set_activate_recording(store_id),
-            StoreHubEntry::Table { table_id } => self.set_activate_table(table_id),
-        }
-    }
-
     /// Activate a recording by its [`StoreId`].
     pub fn set_activate_recording(&mut self, store_id: StoreId) {
         match store_id.kind {
@@ -592,12 +564,6 @@ impl StoreHub {
                 re_log::debug!("Tried to activate the blueprint {store_id} as a recording.");
             }
         }
-    }
-
-    /// Activate a recording by its [`TableId`].
-    fn set_activate_table(&mut self, table_id: TableId) {
-        self.active_entry = Some(StoreHubEntry::Table { table_id });
-        self.active_application_id = Some(Self::table_app_id());
     }
 
     // ---------------------

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -8,9 +8,9 @@ use parking_lot::Mutex;
 
 use crate::{
     blueprint_timeline, command_channel, ApplicationSelectionState, CommandReceiver, CommandSender,
-    ComponentUiRegistry, DataQueryResult, DisplayMode, GlobalContext, ItemCollection,
-    RecordingConfig, StorageContext, StoreContext, SystemCommand, ViewClass, ViewClassRegistry,
-    ViewId, ViewStates, ViewerContext,
+    ComponentUiRegistry, DataQueryResult, GlobalContext, ItemCollection, RecordingConfig,
+    StorageContext, StoreContext, SystemCommand, ViewClass, ViewClassRegistry, ViewId, ViewStates,
+    ViewerContext,
 };
 use re_chunk::{Chunk, ChunkBuilder};
 use re_chunk_store::LatestAtQuery;
@@ -342,9 +342,9 @@ impl TestContext {
                 egui_ctx,
                 command_sender: &self.command_sender,
                 render_ctx,
-                display_mode: &DisplayMode::LocalRecordings,
             },
             store_context: &store_context,
+            active_redap_entry: None,
             storage_context: &StorageContext {
                 hub: &Default::default(),
                 bundle: &Default::default(),

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -345,6 +345,7 @@ impl TestContext {
             },
             store_context: &store_context,
             active_redap_entry: None,
+            active_table_id: None,
             storage_context: &StorageContext {
                 hub: &Default::default(),
                 bundle: &Default::default(),

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -4,7 +4,7 @@ use parking_lot::RwLock;
 
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::entity_db::EntityDb;
-use re_log_types::EntryId;
+use re_log_types::{EntryId, TableId};
 use re_query::StorageEngineReadGuard;
 
 use crate::drag_and_drop::DragAndDropPayload;
@@ -58,9 +58,12 @@ pub struct ViewerContext<'a> {
     /// Helper object to manage drag-and-drop operations.
     pub drag_and_drop_manager: &'a DragAndDropManager,
 
-    // --
+    // -- Everything that is concerned with the current active recording/table.
     /// The current active Redap entry id, if any.
     pub active_redap_entry: Option<&'a EntryId>,
+
+    /// The current active local table, if any.
+    pub active_table_id: Option<&'a TableId>,
 
     pub store_context: &'a StoreContext<'a>,
 }
@@ -302,10 +305,9 @@ impl ViewerContext<'_> {
     ///
     /// It excludes the globally hardcoded welcome screen app ID.
     pub fn has_active_recording(&self) -> bool {
-        self.recording().app_id().is_some_and(|active_app_id| {
-            active_app_id != &StoreHub::welcome_screen_app_id()
-                && active_app_id != &StoreHub::table_app_id()
-        })
+        self.recording()
+            .app_id()
+            .is_some_and(|active_app_id| active_app_id != &StoreHub::welcome_screen_app_id())
     }
 }
 

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -4,6 +4,7 @@ use parking_lot::RwLock;
 
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::entity_db::EntityDb;
+use re_log_types::EntryId;
 use re_query::StorageEngineReadGuard;
 
 use crate::drag_and_drop::DragAndDropPayload;
@@ -20,7 +21,6 @@ pub struct ViewerContext<'a> {
     /// Global context shared across all parts of the viewer.
     pub global_context: GlobalContext<'a>,
 
-    pub store_context: &'a StoreContext<'a>,
     pub storage_context: &'a StorageContext<'a>,
 
     /// Mapping from class and system to entities for the store
@@ -57,6 +57,12 @@ pub struct ViewerContext<'a> {
 
     /// Helper object to manage drag-and-drop operations.
     pub drag_and_drop_manager: &'a DragAndDropManager,
+
+    // --
+    /// The current active Redap entry id, if any.
+    pub active_redap_entry: Option<&'a EntryId>,
+
+    pub store_context: &'a StoreContext<'a>,
 }
 
 // Forwarding of `GlobalContext` methods to `ViewerContext`. Leaving this as a


### PR DESCRIPTION
### Related

* Brings back `Navigation` from #9586,
* which was reverted in #9735

### What

This PR basically brings back a more robust version of the `Navigation` mechanism and leans into the concept of _display modes_ to manage the state of the Rerun viewer.
