### PR TITLE
Fix handling of custom indicator components

### DIFF
--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -202,18 +202,12 @@ impl ComponentName {
 
     /// Is this an indicator component for an archetype?
     pub fn is_indicator_component(&self) -> bool {
-        (self.starts_with("rerun.components.") || self.starts_with("rerun.blueprint.components."))
-            && self.ends_with("Indicator")
+        self.ends_with("Indicator")
     }
 
     /// If this is an indicator component, for which archetype?
     pub fn indicator_component_archetype(&self) -> Option<String> {
-        if let Some(name) = self.strip_prefix("rerun.components.") {
-            if let Some(name) = name.strip_suffix("Indicator") {
-                return Some(name.to_owned());
-            }
-        }
-        None
+        self.strip_suffix("Indicator").map(|name| name.to_owned())
     }
 
     /// Web URL to the Rerun documentation for this component.

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -263,7 +263,9 @@ impl ViewerContext<'_> {
                 .lookup_datatype(&component)
                 .or_else(|| self.blueprint_engine().store().lookup_datatype(&component))
                 .unwrap_or_else(|| {
-                    re_log::error_once!("Could not find datatype for component {component}. Using null array as placeholder.");
+                    if !component.is_indicator_component() {
+                        re_log::error_once!("Could not find datatype for component {component}. Using null array as placeholder.");
+                    }
                     arrow::datatypes::DataType::Null
                 })
         };


### PR DESCRIPTION
### Related

* part of https://github.com/rerun-io/rerun/issues/9183

### What

User defined indicators like in the custom view example weren't detected as indicators, causing them to show up in edit ui and leading to needless (and confusing!) inclusion in some queries.

Note that indicators should soon ™️  go away as we start reading out component tags (which contain archetype information!) in the viewer.