### PR TITLE
Set wheels' min python version to 3.9

### DIFF
--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -80,9 +80,9 @@ numpy.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 pyo3 = { workspace = true, features = [
-  "abi3-py39",  # Require at least Python 3.9
-  "chrono",
-] } #TODO(#9317): migrate to jiff when upgrading to pyo3 0.24
+  "abi3-py39", # Require at least Python 3.9
+  "chrono",    #TODO(#9317): migrate to jiff when upgrading to pyo3 0.24
+] }
 rand = { workspace = true, features = ["std", "std_rng"] }
 uuid.workspace = true
 

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -80,7 +80,7 @@ numpy.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 pyo3 = { workspace = true, features = [
-  "abi3-py39",
+  "abi3-py39",  # Require at least Python 3.9
   "chrono",
 ] } #TODO(#9317): migrate to jiff when upgrading to pyo3 0.24
 rand = { workspace = true, features = ["std", "std_rng"] }

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -80,7 +80,7 @@ numpy.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 pyo3 = { workspace = true, features = [
-  "abi3-py38",
+  "abi3-py39",
   "chrono",
 ] } #TODO(#9317): migrate to jiff when upgrading to pyo3 0.24
 rand = { workspace = true, features = ["std", "std_rng"] }


### PR DESCRIPTION
Currently, our python package is advertised as >=3.9, but our wheels still specify 3.8:

<img width="968" alt="image" src="https://github.com/user-attachments/assets/b7d6e5c9-f6ab-44a7-b13f-a32dd655cfff" />


With this PR, our wheels should specify 3.9 as well.

related:
* #9182 