### PR TITLE
Remove warning/error on loading .rrd from older Rerun version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6927,7 +6927,6 @@ dependencies = [
  "re_chunk_store",
  "re_format_arrow",
  "re_log",
- "re_log_encoding",
  "re_log_types",
  "re_query",
  "re_sorbet",

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -717,7 +717,6 @@ impl ChunkStore {
     pub fn from_rrd_filepath(
         store_config: &ChunkStoreConfig,
         path_to_rrd: impl AsRef<std::path::Path>,
-        version_policy: re_log_encoding::VersionPolicy,
     ) -> anyhow::Result<BTreeMap<StoreId, Self>> {
         let path_to_rrd = path_to_rrd.as_ref();
 
@@ -730,7 +729,7 @@ impl ChunkStore {
         let rrd_file = std::fs::File::open(path_to_rrd)
             .with_context(|| format!("couldn't open {path_to_rrd:?}"))?;
 
-        let mut decoder = re_log_encoding::decoder::Decoder::new(version_policy, rrd_file)
+        let mut decoder = re_log_encoding::decoder::Decoder::new(rrd_file)
             .with_context(|| format!("couldn't decode {path_to_rrd:?}"))?;
 
         // TODO(cmc): offload the decoding to a background thread.
@@ -824,13 +823,10 @@ impl ChunkStore {
     pub fn handle_from_rrd_filepath(
         store_config: &ChunkStoreConfig,
         path_to_rrd: impl AsRef<std::path::Path>,
-        version_policy: re_log_encoding::VersionPolicy,
     ) -> anyhow::Result<BTreeMap<StoreId, ChunkStoreHandle>> {
-        Ok(
-            Self::from_rrd_filepath(store_config, path_to_rrd, version_policy)?
-                .into_iter()
-                .map(|(store_id, store)| (store_id, ChunkStoreHandle::new(store)))
-                .collect(),
-        )
+        Ok(Self::from_rrd_filepath(store_config, path_to_rrd)?
+            .into_iter()
+            .map(|(store_id, store)| (store_id, ChunkStoreHandle::new(store)))
+            .collect())
     }
 }

--- a/crates/store/re_data_loader/src/loader_external.rs
+++ b/crates/store/re_data_loader/src/loader_external.rs
@@ -182,9 +182,9 @@ impl crate::DataLoader for ExternalLoader {
                 // streaming data to stdout.
                 let is_sending_data = Arc::new(AtomicBool::new(false));
 
-                let version_policy = re_log_encoding::VersionPolicy::Warn;
+
                 let stdout = std::io::BufReader::new(stdout);
-                match re_log_encoding::decoder::Decoder::new(version_policy, stdout) {
+                match re_log_encoding::decoder::Decoder::new(stdout) {
                     Ok(decoder) => {
                         let filepath = filepath.clone();
                         let tx = tx.clone();

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -40,8 +40,6 @@ impl crate::DataLoader for RrdLoader {
             "Loading rrd data from filesystem…",
         );
 
-        let version_policy = re_log_encoding::VersionPolicy::Warn;
-
         match extension.as_str() {
             "rbl" => {
                 // We assume .rbl is not streamed and no retrying after seeing EOF is needed.
@@ -52,7 +50,7 @@ impl crate::DataLoader for RrdLoader {
                     .with_context(|| format!("Failed to open file {filepath:?}"))?;
                 let file = std::io::BufReader::new(file);
 
-                let decoder = Decoder::new(version_policy, file)?;
+                let decoder = Decoder::new(file)?;
 
                 // NOTE: This is IO bound, it must run on a dedicated thread, not the shared rayon thread pool.
                 std::thread::Builder::new()
@@ -80,7 +78,7 @@ impl crate::DataLoader for RrdLoader {
                 let retryable_reader = RetryableFileReader::new(&filepath).with_context(|| {
                     format!("failed to create retryable file reader for {filepath:?}")
                 })?;
-                let decoder = Decoder::new(version_policy, retryable_reader)?;
+                let decoder = Decoder::new(retryable_reader)?;
 
                 // NOTE: This is IO bound, it must run on a dedicated thread, not the shared rayon thread pool.
                 std::thread::Builder::new()
@@ -118,9 +116,8 @@ impl crate::DataLoader for RrdLoader {
             return Err(crate::DataLoaderError::Incompatible(filepath));
         }
 
-        let version_policy = re_log_encoding::VersionPolicy::Warn;
         let contents = std::io::Cursor::new(contents);
-        let decoder = match re_log_encoding::decoder::Decoder::new(version_policy, contents) {
+        let decoder = match re_log_encoding::decoder::Decoder::new(contents) {
             Ok(decoder) => decoder,
             Err(err) => match err {
                 // simply not interested
@@ -308,7 +305,7 @@ impl RetryableFileReader {
 mod tests {
     use re_build_info::CrateVersion;
     use re_chunk::RowId;
-    use re_log_encoding::{encoder::DroppableEncoder, VersionPolicy};
+    use re_log_encoding::encoder::DroppableEncoder;
     use re_log_types::{
         ApplicationId, LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource,
     };
@@ -370,7 +367,7 @@ mod tests {
         encoder.flush_blocking().expect("failed to flush messages");
 
         let reader = RetryableFileReader::new(&rrd_file_path).unwrap();
-        let mut decoder = Decoder::new(VersionPolicy::Warn, reader).unwrap();
+        let mut decoder = Decoder::new(reader).unwrap();
 
         // we should be able to read 5 messages that we wrote
         let decoded_messages = (0..5)

--- a/crates/store/re_data_source/src/load_stdin.rs
+++ b/crates/store/re_data_source/src/load_stdin.rs
@@ -6,10 +6,8 @@ use re_smart_channel::Sender;
 /// This fails synchronously iff the standard input stream could not be opened, otherwise errors
 /// are handled asynchronously (as in: they're logged).
 pub fn load_stdin(tx: Sender<LogMsg>) -> anyhow::Result<()> {
-    let version_policy = re_log_encoding::VersionPolicy::Warn;
-
     let stdin = std::io::BufReader::new(std::io::stdin());
-    let decoder = re_log_encoding::decoder::Decoder::new_concatenated(version_policy, stdin)?;
+    let decoder = re_log_encoding::decoder::Decoder::new_concatenated(stdin)?;
 
     rayon::spawn(move || {
         re_tracing::profile_scope!("stdin");

--- a/crates/store/re_dataframe/Cargo.toml
+++ b/crates/store/re_dataframe/Cargo.toml
@@ -31,7 +31,6 @@ re_chunk.workspace = true
 re_chunk_store.workspace = true
 re_format_arrow.workspace = true
 re_log.workspace = true
-re_log_encoding.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
 re_sorbet.workspace = true

--- a/crates/store/re_dataframe/examples/query.rs
+++ b/crates/store/re_dataframe/examples/query.rs
@@ -7,7 +7,6 @@ use re_dataframe::{
     SparseFillStrategy, StoreKind, TimeInt,
 };
 use re_format_arrow::format_record_batch;
-use re_log_encoding::VersionPolicy;
 
 fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect_vec();
@@ -34,11 +33,7 @@ fn main() -> anyhow::Result<()> {
     let entity_path_filter =
         EntityPathFilter::parse_strict(args.get(5).map_or("/**", |s| s.as_str()))?;
 
-    let engines = QueryEngine::from_rrd_filepath(
-        &ChunkStoreConfig::DEFAULT,
-        path_to_rrd,
-        VersionPolicy::Warn,
-    )?;
+    let engines = QueryEngine::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, path_to_rrd)?;
 
     for (store_id, engine) in &engines {
         if store_id.kind != StoreKind::Recording {

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -49,10 +49,9 @@ impl QueryEngine<StorageEngine> {
     pub fn from_rrd_filepath(
         store_config: &ChunkStoreConfig,
         path_to_rrd: impl AsRef<std::path::Path>,
-        version_policy: re_log_encoding::VersionPolicy,
     ) -> anyhow::Result<BTreeMap<StoreId, Self>> {
         Ok(
-            ChunkStore::handle_from_rrd_filepath(store_config, path_to_rrd, version_policy)?
+            ChunkStore::handle_from_rrd_filepath(store_config, path_to_rrd)?
                 .into_iter()
                 .map(|(store_id, store)| (store_id, Self::from_store(store)))
                 .collect(),

--- a/crates/store/re_entity_db/examples/memory_usage.rs
+++ b/crates/store/re_entity_db/examples/memory_usage.rs
@@ -78,8 +78,7 @@ fn log_messages() {
     }
 
     fn decode_log_msg(mut bytes: &[u8]) -> LogMsg {
-        let version_policy = re_log_encoding::VersionPolicy::Error;
-        let mut messages = re_log_encoding::decoder::Decoder::new(version_policy, &mut bytes)
+        let mut messages = re_log_encoding::decoder::Decoder::new(&mut bytes)
             .unwrap()
             .collect::<Result<Vec<LogMsg>, _>>()
             .unwrap();

--- a/crates/store/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/store/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -51,8 +51,7 @@ fn encode_log_msgs(
 }
 
 fn decode_log_msgs(mut bytes: &[u8]) -> Vec<LogMsg> {
-    let version_policy = re_log_encoding::VersionPolicy::Error;
-    let messages = re_log_encoding::decoder::Decoder::new(version_policy, &mut bytes)
+    let messages = re_log_encoding::decoder::Decoder::new(&mut bytes)
         .unwrap()
         .collect::<Result<Vec<LogMsg>, _>>()
         .unwrap();

--- a/crates/store/re_log_encoding/src/decoder/stream.rs
+++ b/crates/store/re_log_encoding/src/decoder/stream.rs
@@ -10,7 +10,7 @@ use crate::EncodingOptions;
 use crate::FileHeader;
 use crate::Serializer;
 
-use super::{DecodeError, VersionPolicy};
+use super::DecodeError;
 
 /// The stream decoder is a state machine which ingests byte chunks
 /// and outputs messages once it has enough data to deserialize one.
@@ -22,9 +22,6 @@ pub struct StreamDecoder {
     ///
     /// `None` until a Rerun header has been processed.
     version: Option<CrateVersion>,
-
-    /// How to handle version mismatches
-    version_policy: VersionPolicy,
 
     options: EncodingOptions,
 
@@ -67,10 +64,10 @@ enum State {
 }
 
 impl StreamDecoder {
-    pub fn new(version_policy: VersionPolicy) -> Self {
+    #[expect(clippy::new_without_default)]
+    pub fn new() -> Self {
         Self {
             version: None,
-            version_policy,
             // Note: `options` are filled in once we read `FileHeader`,
             // so this value does not matter.
             options: EncodingOptions::PROTOBUF_UNCOMPRESSED,
@@ -88,7 +85,7 @@ impl StreamDecoder {
             State::StreamHeader => {
                 if let Some(header) = self.chunks.try_read(FileHeader::SIZE) {
                     // header contains version and compression options
-                    let (version, options) = options_from_bytes(self.version_policy, header)?;
+                    let (version, options) = options_from_bytes(header)?;
                     self.version = Some(version);
                     self.options = options;
 
@@ -296,7 +293,7 @@ mod tests {
     fn stream_whole_chunks_uncompressed_protobuf() {
         let (input, data) = test_data(EncodingOptions::PROTOBUF_UNCOMPRESSED, 16);
 
-        let mut decoder = StreamDecoder::new(VersionPolicy::Error);
+        let mut decoder = StreamDecoder::new();
 
         assert_message_incomplete!(decoder.try_read());
 
@@ -313,7 +310,7 @@ mod tests {
     fn stream_byte_chunks_uncompressed_protobuf() {
         let (input, data) = test_data(EncodingOptions::PROTOBUF_UNCOMPRESSED, 16);
 
-        let mut decoder = StreamDecoder::new(VersionPolicy::Error);
+        let mut decoder = StreamDecoder::new();
 
         assert_message_incomplete!(decoder.try_read());
 
@@ -334,7 +331,7 @@ mod tests {
         let (input2, data2) = test_data(EncodingOptions::PROTOBUF_UNCOMPRESSED, 16);
         let input = input1.into_iter().chain(input2).collect::<Vec<_>>();
 
-        let mut decoder = StreamDecoder::new(VersionPolicy::Error);
+        let mut decoder = StreamDecoder::new();
 
         assert_message_incomplete!(decoder.try_read());
 
@@ -352,7 +349,7 @@ mod tests {
     fn stream_whole_chunks_compressed_protobuf() {
         let (input, data) = test_data(EncodingOptions::PROTOBUF_COMPRESSED, 16);
 
-        let mut decoder = StreamDecoder::new(VersionPolicy::Error);
+        let mut decoder = StreamDecoder::new();
 
         assert_message_incomplete!(decoder.try_read());
 
@@ -369,7 +366,7 @@ mod tests {
     fn stream_byte_chunks_compressed_protobuf() {
         let (input, data) = test_data(EncodingOptions::PROTOBUF_COMPRESSED, 16);
 
-        let mut decoder = StreamDecoder::new(VersionPolicy::Error);
+        let mut decoder = StreamDecoder::new();
 
         assert_message_incomplete!(decoder.try_read());
 
@@ -388,7 +385,7 @@ mod tests {
     fn stream_3x16_chunks_protobuf() {
         let (input, data) = test_data(EncodingOptions::PROTOBUF_COMPRESSED, 16);
 
-        let mut decoder = StreamDecoder::new(VersionPolicy::Error);
+        let mut decoder = StreamDecoder::new();
         let mut decoded_messages = vec![];
 
         // keep pushing 3 chunks of 16 bytes at a time, and attempting to read messages
@@ -418,7 +415,7 @@ mod tests {
         let (input, data) = test_data(EncodingOptions::PROTOBUF_COMPRESSED, 16);
         let mut data = Cursor::new(data);
 
-        let mut decoder = StreamDecoder::new(VersionPolicy::Error);
+        let mut decoder = StreamDecoder::new();
         let mut decoded_messages = vec![];
 
         // read chunks 2xN bytes at a time, where `N` comes from a regular pattern

--- a/crates/store/re_log_encoding/src/decoder/streaming.rs
+++ b/crates/store/re_log_encoding/src/decoder/streaming.rs
@@ -9,7 +9,7 @@ use tokio_stream::Stream;
 
 use crate::{
     codec::file::{self},
-    EncodingOptions, VersionPolicy,
+    EncodingOptions,
 };
 
 use super::{options_from_bytes, DecodeError, FileHeader};
@@ -66,7 +66,7 @@ pub struct StreamingDecoder<R: AsyncBufRead> {
 }
 
 impl<R: AsyncBufRead + Unpin> StreamingDecoder<R> {
-    pub async fn new(version_policy: VersionPolicy, mut reader: R) -> Result<Self, DecodeError> {
+    pub async fn new(mut reader: R) -> Result<Self, DecodeError> {
         let mut data = [0_u8; FileHeader::SIZE];
 
         reader
@@ -74,7 +74,7 @@ impl<R: AsyncBufRead + Unpin> StreamingDecoder<R> {
             .await
             .map_err(DecodeError::Read)?;
 
-        let (version, options) = options_from_bytes(version_policy, &data)?;
+        let (version, options) = options_from_bytes(&data)?;
 
         Ok(Self {
             version,
@@ -162,7 +162,7 @@ impl<R: AsyncBufRead + Unpin> Stream for StreamingDecoder<R> {
                 let data = &unprocessed_bytes[..FileHeader::SIZE];
                 // We've found another file header in the middle of the stream, it's time to switch
                 // gears and start over on this new file.
-                match options_from_bytes(VersionPolicy::Warn, data) {
+                match options_from_bytes(data) {
                     Ok((version, options)) => {
                         self.version = CrateVersion::max(self.version, version);
                         self.options = options;
@@ -257,7 +257,7 @@ mod tests {
 
     use crate::{
         decoder::{streaming::StreamingDecoder, tests::fake_log_messages},
-        Compression, EncodingOptions, Serializer, VersionPolicy,
+        Compression, EncodingOptions, Serializer,
     };
 
     #[tokio::test]
@@ -288,9 +288,7 @@ mod tests {
 
             let buf_reader = tokio::io::BufReader::new(std::io::Cursor::new(data));
 
-            let decoder = StreamingDecoder::new(VersionPolicy::Error, buf_reader)
-                .await
-                .unwrap();
+            let decoder = StreamingDecoder::new(buf_reader).await.unwrap();
 
             let decoded_messages = decoder
                 .map(|res| res.map(|msg| msg.inner))
@@ -326,9 +324,7 @@ mod tests {
 
             let buf_reader = tokio::io::BufReader::new(std::io::Cursor::new(data));
 
-            let decoder = StreamingDecoder::new(VersionPolicy::Error, buf_reader)
-                .await
-                .unwrap();
+            let decoder = StreamingDecoder::new(buf_reader).await.unwrap();
 
             let decoded_messages = decoder
                 .map(|res| res.map(|msg| msg.inner))
@@ -364,9 +360,7 @@ mod tests {
 
             let buf_reader = tokio::io::BufReader::new(std::io::Cursor::new(data.clone()));
 
-            let decoder = StreamingDecoder::new(VersionPolicy::Error, buf_reader)
-                .await
-                .unwrap();
+            let decoder = StreamingDecoder::new(buf_reader).await.unwrap();
 
             let decoded_messages = decoder.collect::<Result<Vec<_>, _>>().await.unwrap();
 

--- a/crates/store/re_log_encoding/src/lib.rs
+++ b/crates/store/re_log_encoding/src/lib.rs
@@ -17,20 +17,6 @@ mod file_sink;
 #[cfg(feature = "stream_from_http")]
 pub mod stream_rrd_from_http;
 
-/// How to handle version mismatches during decoding.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum VersionPolicy {
-    /// Warn if the versions don't match, but continue loading.
-    ///
-    /// We usually use this for loading `.rrd` recordings.
-    Warn,
-
-    /// Return an error if the versions aren't compatible.
-    ///
-    /// We usually use this for tests, and for loading `.rbl` blueprint files.
-    Error,
-}
-
 // ---------------------------------------------------------------------
 
 #[cfg(feature = "encoder")]

--- a/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
+++ b/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
@@ -71,8 +71,7 @@ pub fn stream_rrd_from_http(url: String, on_msg: Arc<HttpMessageCallback>) {
     re_log::debug!("Downloading .rrd file from {url:?}…");
 
     ehttp::streaming::fetch(ehttp::Request::get(&url), {
-        let version_policy = crate::VersionPolicy::Warn;
-        let decoder = RefCell::new(StreamDecoder::new(version_policy));
+        let decoder = RefCell::new(StreamDecoder::new());
         move |part| match part {
             Ok(part) => match part {
                 ehttp::streaming::Part::Response(ehttp::PartialResponse {
@@ -184,8 +183,7 @@ pub mod web_decode {
     async fn decode_rrd_async(rrd_bytes: Vec<u8>, on_msg: Arc<HttpMessageCallback>) {
         let mut last_yield = web_time::Instant::now();
 
-        let version_policy = crate::VersionPolicy::Warn;
-        match crate::decoder::Decoder::new(version_policy, rrd_bytes.as_slice()) {
+        match crate::decoder::Decoder::new(rrd_bytes.as_slice()) {
             Ok(decoder) => {
                 for msg in decoder {
                     match msg {

--- a/crates/store/re_log_encoding/tests/arrow_encode_roundtrip.rs
+++ b/crates/store/re_log_encoding/tests/arrow_encode_roundtrip.rs
@@ -2,9 +2,7 @@ use similar_asserts::assert_eq;
 
 use re_build_info::CrateVersion;
 use re_chunk::{Chunk, RowId, TimePoint, Timeline};
-use re_log_encoding::{
-    decoder::decode_bytes, encoder::encode_as_bytes, EncodingOptions, VersionPolicy,
-};
+use re_log_encoding::{decoder::decode_bytes, encoder::encode_as_bytes, EncodingOptions};
 use re_log_types::{LogMsg, StoreId};
 use re_types::archetypes::Points3D;
 
@@ -44,7 +42,7 @@ fn encode_roundtrip() {
     let option = EncodingOptions::PROTOBUF_COMPRESSED;
     let crate_version = CrateVersion::LOCAL;
     let encoded = encode_as_bytes(crate_version, option, messages.iter().cloned().map(Ok)).unwrap();
-    let decoded = decode_bytes(VersionPolicy::Error, &encoded).unwrap();
+    let decoded = decode_bytes(&encoded).unwrap();
     similar_asserts::assert_eq!(
         decoded,
         messages,

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -142,8 +142,7 @@ fn compute_uber_table(
     let rrd_file = std::io::BufReader::new(rrd_file);
 
     let mut stores: std::collections::HashMap<StoreId, EntityDb> = Default::default();
-    let version_policy = re_log_encoding::VersionPolicy::Error;
-    let decoder = re_log_encoding::decoder::Decoder::new(version_policy, rrd_file)?;
+    let decoder = re_log_encoding::decoder::Decoder::new(rrd_file)?;
     for msg in decoder {
         let msg = msg.context("decode rrd message")?;
         stores

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -65,9 +65,8 @@ impl FilterCommand {
             .collect();
 
         // TODO(cmc): might want to make this configurable at some point.
-        let version_policy = re_log_encoding::VersionPolicy::Warn;
-        let (rx_decoder, rx_size_bytes) =
-            read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+
+        let (rx_decoder, rx_size_bytes) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
         // TODO(cmc): might want to make this configurable at some point.
         let (tx_encoder, rx_encoder) = crossbeam::channel::bounded(100);

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -64,8 +64,6 @@ impl FilterCommand {
             .map(|s| EntityPath::parse_forgiving(s))
             .collect();
 
-        // TODO(cmc): might want to make this configurable at some point.
-
         let (rx_decoder, rx_size_bytes) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
         // TODO(cmc): might want to make this configurable at some point.

--- a/crates/top/rerun/src/commands/rrd/merge_compact.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_compact.rs
@@ -156,8 +156,6 @@ fn merge_and_compact(
         "merge/compaction started"
     );
 
-    // TODO(cmc): might want to make this configurable at some point.
-
     let (rx, rx_size_bytes) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
     let mut entity_dbs: std::collections::HashMap<StoreId, EntityDb> = Default::default();

--- a/crates/top/rerun/src/commands/rrd/merge_compact.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_compact.rs
@@ -157,9 +157,8 @@ fn merge_and_compact(
     );
 
     // TODO(cmc): might want to make this configurable at some point.
-    let version_policy = re_log_encoding::VersionPolicy::Warn;
-    let (rx, rx_size_bytes) =
-        read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+
+    let (rx, rx_size_bytes) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
     let mut entity_dbs: std::collections::HashMap<StoreId, EntityDb> = Default::default();
 

--- a/crates/top/rerun/src/commands/rrd/print.rs
+++ b/crates/top/rerun/src/commands/rrd/print.rs
@@ -40,8 +40,6 @@ impl PrintCommand {
             continue_on_error,
         } = self;
 
-        // TODO(cmc): might want to make this configurable at some point.
-
         let (rx, _) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
         for (_source, res) in rx {

--- a/crates/top/rerun/src/commands/rrd/print.rs
+++ b/crates/top/rerun/src/commands/rrd/print.rs
@@ -41,8 +41,8 @@ impl PrintCommand {
         } = self;
 
         // TODO(cmc): might want to make this configurable at some point.
-        let version_policy = re_log_encoding::VersionPolicy::Warn;
-        let (rx, _) = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+
+        let (rx, _) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
         for (_source, res) in rx {
             let mut is_success = true;

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -23,8 +23,8 @@ impl VerifyCommand {
         let Self { path_to_input_rrds } = self;
 
         // TODO(cmc): might want to make this configurable at some point.
-        let version_policy = re_log_encoding::VersionPolicy::Warn;
-        let (rx, _) = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+
+        let (rx, _) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
         let mut seen_files = std::collections::HashSet::new();
 

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -22,8 +22,6 @@ impl VerifyCommand {
 
         let Self { path_to_input_rrds } = self;
 
-        // TODO(cmc): might want to make this configurable at some point.
-
         let (rx, _) = read_rrd_streams_from_file_or_stdin(path_to_input_rrds);
 
         let mut seen_files = std::collections::HashSet::new();

--- a/crates/top/rerun/src/lib.rs
+++ b/crates/top/rerun/src/lib.rs
@@ -132,8 +132,6 @@ pub use log_integration::Logger;
 #[cfg(feature = "run")]
 pub use commands::{run, CallSource};
 
-pub use re_log_encoding::VersionPolicy;
-
 #[cfg(feature = "sdk")]
 pub use sdk::*;
 

--- a/crates/viewer/re_viewer/src/loading.rs
+++ b/crates/viewer/re_viewer/src/loading.rs
@@ -20,11 +20,7 @@ pub fn load_blueprint_file(path: &std::path::Path) -> Option<StoreBundle> {
         let file = std::fs::File::open(path)?;
         let file = std::io::BufReader::new(file);
 
-        // Blueprint files change often. Be strict about the version, and then ignore any errors.
-        // See https://github.com/rerun-io/rerun/issues/2830
-        let version_policy = re_log_encoding::VersionPolicy::Error;
-
-        Ok(StoreBundle::from_rrd(version_policy, file)?)
+        Ok(StoreBundle::from_rrd(file)?)
     }
 
     match load_file_path_impl(path) {

--- a/crates/viewer/re_viewer_context/src/store_bundle.rs
+++ b/crates/viewer/re_viewer_context/src/store_bundle.rs
@@ -1,7 +1,6 @@
 use itertools::Itertools as _;
 
 use re_entity_db::EntityDb;
-use re_log_encoding::VersionPolicy;
 use re_log_types::{StoreId, StoreKind};
 
 #[derive(thiserror::Error, Debug)]
@@ -22,13 +21,10 @@ pub struct StoreBundle {
 impl StoreBundle {
     /// Decode an rrd stream.
     /// It can theoretically contain multiple recordings, and blueprints.
-    pub fn from_rrd(
-        version_policy: VersionPolicy,
-        read: impl std::io::Read,
-    ) -> Result<Self, StoreLoadError> {
+    pub fn from_rrd(read: impl std::io::Read) -> Result<Self, StoreLoadError> {
         re_tracing::profile_function!();
 
-        let decoder = re_log_encoding::decoder::Decoder::new(version_policy, read)?;
+        let decoder = re_log_encoding::decoder::Decoder::new(read)?;
 
         let mut slf = Self::default();
 

--- a/docs/snippets/all/concepts/send_recording.rs
+++ b/docs/snippets/all/concepts/send_recording.rs
@@ -1,18 +1,16 @@
 //! Send a `.rrd` to a new recording stream.
 
 use rerun::external::re_chunk_store::{ChunkStore, ChunkStoreConfig};
-use rerun::VersionPolicy;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get the filename from the command-line args.
     let filename = std::env::args().nth(2).ok_or("Missing filename argument")?;
 
     // Load the chunk store from the file.
-    let (store_id, store) =
-        ChunkStore::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, filename, VersionPolicy::Warn)?
-            .into_iter()
-            .next()
-            .ok_or("Expected exactly one recording in the archive")?;
+    let (store_id, store) = ChunkStore::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, filename)?
+        .into_iter()
+        .next()
+        .ok_or("Expected exactly one recording in the archive")?;
 
     // Use the same app and recording IDs as the original.
     if let Some(info) = store.info().cloned() {

--- a/docs/snippets/all/descriptors/descr_builtin_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_archetype.rs
@@ -1,4 +1,4 @@
-use rerun::{ChunkStore, ChunkStoreConfig, ComponentDescriptor, VersionPolicy};
+use rerun::{ChunkStore, ChunkStoreConfig, ComponentDescriptor};
 
 fn example(rec: &rerun::RecordingStream) -> Result<(), Box<dyn std::error::Error>> {
     rec.log_static(
@@ -34,12 +34,8 @@ fn check_tags(rec: &rerun::RecordingStream) {
     if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
         rec.flush_blocking();
 
-        let stores = ChunkStore::from_rrd_filepath(
-            &ChunkStoreConfig::ALL_DISABLED,
-            path_to_rrd,
-            VersionPolicy::Warn,
-        )
-        .unwrap();
+        let stores =
+            ChunkStore::from_rrd_filepath(&ChunkStoreConfig::ALL_DISABLED, path_to_rrd).unwrap();
         assert_eq!(1, stores.len());
 
         let store = stores.into_values().next().unwrap();

--- a/docs/snippets/all/descriptors/descr_builtin_component.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_component.rs
@@ -1,4 +1,4 @@
-use rerun::{ChunkStore, ChunkStoreConfig, Component as _, ComponentDescriptor, VersionPolicy};
+use rerun::{ChunkStore, ChunkStoreConfig, Component as _, ComponentDescriptor};
 
 fn example(rec: &rerun::RecordingStream) -> Result<(), Box<dyn std::error::Error>> {
     use rerun::ComponentBatch as _;
@@ -35,12 +35,8 @@ fn check_tags(rec: &rerun::RecordingStream) {
     if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
         rec.flush_blocking();
 
-        let stores = ChunkStore::from_rrd_filepath(
-            &ChunkStoreConfig::ALL_DISABLED,
-            path_to_rrd,
-            VersionPolicy::Warn,
-        )
-        .unwrap();
+        let stores =
+            ChunkStore::from_rrd_filepath(&ChunkStoreConfig::ALL_DISABLED, path_to_rrd).unwrap();
         assert_eq!(1, stores.len());
 
         let store = stores.into_values().next().unwrap();

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -1,6 +1,4 @@
-use rerun::{
-    ChunkStore, ChunkStoreConfig, ComponentBatch as _, ComponentDescriptor, VersionPolicy,
-};
+use rerun::{ChunkStore, ChunkStoreConfig, ComponentBatch as _, ComponentDescriptor};
 
 struct CustomPoints3D {
     positions: Vec<rerun::components::Position3D>,
@@ -79,12 +77,8 @@ fn check_tags(rec: &rerun::RecordingStream) {
     if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
         rec.flush_blocking();
 
-        let stores = ChunkStore::from_rrd_filepath(
-            &ChunkStoreConfig::ALL_DISABLED,
-            path_to_rrd,
-            VersionPolicy::Warn,
-        )
-        .unwrap();
+        let stores =
+            ChunkStore::from_rrd_filepath(&ChunkStoreConfig::ALL_DISABLED, path_to_rrd).unwrap();
         assert_eq!(1, stores.len());
 
         let store = stores.into_values().next().unwrap();

--- a/docs/snippets/all/descriptors/descr_custom_component.rs
+++ b/docs/snippets/all/descriptors/descr_custom_component.rs
@@ -1,6 +1,4 @@
-use rerun::{
-    ChunkStore, ChunkStoreConfig, ComponentBatch as _, ComponentDescriptor, VersionPolicy,
-};
+use rerun::{ChunkStore, ChunkStoreConfig, ComponentBatch as _, ComponentDescriptor};
 
 fn example(rec: &rerun::RecordingStream) -> Result<(), Box<dyn std::error::Error>> {
     let positions = rerun::components::Position3D::new(1.0, 2.0, 3.0)
@@ -40,12 +38,8 @@ fn check_tags(rec: &rerun::RecordingStream) {
     if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
         rec.flush_blocking();
 
-        let stores = ChunkStore::from_rrd_filepath(
-            &ChunkStoreConfig::ALL_DISABLED,
-            path_to_rrd,
-            VersionPolicy::Warn,
-        )
-        .unwrap();
+        let stores =
+            ChunkStore::from_rrd_filepath(&ChunkStoreConfig::ALL_DISABLED, path_to_rrd).unwrap();
         assert_eq!(1, stores.len());
 
         let store = stores.into_values().next().unwrap();

--- a/docs/snippets/all/reference/dataframe_query.rs
+++ b/docs/snippets/all/reference/dataframe_query.rs
@@ -3,7 +3,7 @@
 use rerun::{
     dataframe::{QueryEngine, QueryExpression, SparseFillStrategy, TimelineName},
     external::re_format_arrow::format_record_batch,
-    ChunkStoreConfig, VersionPolicy,
+    ChunkStoreConfig,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,11 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path_to_rrd = &args[1];
     let timeline = TimelineName::log_time();
 
-    let engines = QueryEngine::from_rrd_filepath(
-        &ChunkStoreConfig::DEFAULT,
-        path_to_rrd,
-        VersionPolicy::Warn,
-    )?;
+    let engines = QueryEngine::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, path_to_rrd)?;
 
     let Some((_, engine)) = engines.first_key_value() else {
         return Ok(());

--- a/examples/rust/dataframe_query/src/main.rs
+++ b/examples/rust/dataframe_query/src/main.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use rerun::{
     dataframe::{QueryEngine, QueryExpression, SparseFillStrategy, TimelineName},
     external::{arrow, re_format_arrow::format_record_batch},
-    ChunkStoreConfig, StoreKind, VersionPolicy,
+    ChunkStoreConfig, StoreKind,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -40,11 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let entity_path_filter = args.get(2).map_or("/**", |s| s.as_str()).parse()?;
     let timeline = TimelineName::log_time();
 
-    let engines = QueryEngine::from_rrd_filepath(
-        &ChunkStoreConfig::DEFAULT,
-        path_to_rrd,
-        VersionPolicy::Warn,
-    )?;
+    let engines = QueryEngine::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, path_to_rrd)?;
 
     for (store_id, engine) in engines {
         if store_id.kind != StoreKind::Recording {

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -30,7 +30,6 @@ use re_chunk_store::{
     SparseFillStrategy, TimeColumnSelector, ViewContentsSelector,
 };
 use re_dataframe::{QueryEngine, StorageEngine};
-use re_log_encoding::VersionPolicy;
 use re_log_types::{EntityPathFilter, ResolvedTimeRange};
 use re_sdk::{ComponentName, EntityPath, StoreId, StoreKind};
 use re_sorbet::SorbetColumnDescriptors;
@@ -1458,12 +1457,11 @@ pub fn load_recording(path_to_rrd: std::path::PathBuf) -> PyResult<PyRecording> 
 ///     The loaded archive.
 #[pyfunction]
 pub fn load_archive(path_to_rrd: std::path::PathBuf) -> PyResult<PyRRDArchive> {
-    let stores =
-        ChunkStore::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, path_to_rrd, VersionPolicy::Warn)
-            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
-            .into_iter()
-            .map(|(store_id, store)| (store_id, ChunkStoreHandle::new(store)))
-            .collect();
+    let stores = ChunkStore::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, path_to_rrd)
+        .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
+        .into_iter()
+        .map(|(store_id, store)| (store_id, ChunkStoreHandle::new(store)))
+        .collect();
 
     let archive = PyRRDArchive { datasets: stores };
 


### PR DESCRIPTION
It is no longer a problem loading old .rrd files, unless they are pre 0.23.

It _may_ be a problem loading data from a future Rerun version, but we log a warning and try anyway.