### PR TITLE
Match legend colors with chart lines

### DIFF
--- a/crates/viewer/re_view_bar_chart/src/view_class.rs
+++ b/crates/viewer/re_view_bar_chart/src/view_class.rs
@@ -1,4 +1,5 @@
 use egui::ahash::HashMap;
+use egui_plot::ColorConflictHandling;
 use re_log_types::{EntityPath, ResolvedEntityPathFilter};
 use re_types::{
     blueprint::{archetypes::PlotLegend, components::Corner2D},
@@ -156,7 +157,11 @@ impl ViewClass for BarChartView {
                 .allow_zoom([true, zoom_both_axis]);
 
             if *legend_visible.0 {
-                plot = plot.legend(Legend::default().position(legend_corner.into()));
+                plot = plot.legend(
+                    Legend::default()
+                        .position(legend_corner.into())
+                        .color_conflict_handling(ColorConflictHandling::PickFirst),
+                );
             }
 
             let mut plot_item_id_to_entity_path = HashMap::default();

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -1,5 +1,5 @@
 use egui::ahash::{HashMap, HashSet};
-use egui_plot::{Legend, Line, Plot, PlotPoint, Points};
+use egui_plot::{ColorConflictHandling, Legend, Line, Plot, PlotPoint, Points};
 use nohash_hasher::IntSet;
 use smallvec::SmallVec;
 
@@ -462,7 +462,11 @@ impl ViewClass for TimeSeriesView {
             });
 
         if *legend_visible.0 {
-            plot = plot.legend(Legend::default().position(legend_corner.into()));
+            plot = plot.legend(
+                Legend::default()
+                    .position(legend_corner.into())
+                    .color_conflict_handling(ColorConflictHandling::PickFirst),
+            );
         }
 
         match timeline.typ() {

--- a/crates/viewer/re_view_time_series/tests/snapshots/line_properties_multiple_properties_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/line_properties_multiple_properties_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d3b8414873feba93e319599bd0582b2e50da88f2159e5c5cba3e1f96343a6f8
-size 34311
+oid sha256:9ef94afd81cf5d589cedecb78bb6ae0f9ab736aa6bc64ad3273ab6edba795898
+size 34357

--- a/crates/viewer/re_view_time_series/tests/snapshots/line_properties_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/line_properties_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a8c2ba06e997920200778b53cd7607a050d751126f294ae5d69e1b07f0d47e6
-size 39362
+oid sha256:0feb2beada00d91fcbe92e51a51706e79f98d1d0acf35ba16a7c3756ccf0162e
+size 39394

--- a/crates/viewer/re_view_time_series/tests/snapshots/point_properties_multiple_properties_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/point_properties_multiple_properties_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:03a656316afcb872bbd285aa6b12e97b26acf632a4281f4ec3c204337b0c28a0
-size 31203
+oid sha256:8b369b8bebf5a590446d4a1cc952e12d8904c9b038a54c491289060b55756020
+size 31225

--- a/crates/viewer/re_view_time_series/tests/snapshots/point_properties_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/point_properties_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:172781c932f28621084c38b9bac93a265bffc9f27c1d661bb52caf9e097ccba5
-size 37323
+oid sha256:d3c05d413ce80278e2cf67af5ffd9d4fdbba4c943ab96e09001f72a8784e4366
+size 37349


### PR DESCRIPTION
### Related

* Closes #9768 

### What

This sets the `ColorConflictHandling` of the plot legend to `PickFirst` instead of the default `RemoveColor`.
Changing this does change the behavior for plots with multiple colours, e.g. in the following time series, the `samples` plot has both green _and_ red points, but the toggle button is now green instead of gray.
![image](https://github.com/user-attachments/assets/7e16bd53-c46b-4088-81c5-1a8aab4822ad)

