### PR TITLE
Centralize `RedapClient` configuration/initialization/etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6973,6 +6973,7 @@ dependencies = [
  "futures-util",
  "itertools 0.14.0",
  "re_dataframe",
+ "re_grpc_client",
  "re_log_encoding",
  "re_log_types",
  "re_protos",
@@ -7085,6 +7086,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-web-wasm-client",
+ "tower 0.5.2",
  "url",
  "wasm-bindgen-futures",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,7 @@ tonic = { version = "0.12.3", default-features = false }
 tonic-build = { version = "0.12.3", default-features = false }
 tonic-web = "0.12"
 tonic-web-wasm-client = "0.6"
+tower = "0.5"
 tower-http = "0.5"
 tracing = { version = "0.1", default-features = false }
 type-map = "0.5"

--- a/crates/store/re_datafusion/Cargo.toml
+++ b/crates/store/re_datafusion/Cargo.toml
@@ -27,6 +27,7 @@ default = []
 [dependencies]
 # Rerun dependencies:
 re_dataframe.workspace = true
+re_grpc_client.workspace = true
 re_log_encoding.workspace = true
 re_log_types.workspace = true
 re_protos.workspace = true

--- a/crates/store/re_datafusion/examples/catalog.rs
+++ b/crates/store/re_datafusion/examples/catalog.rs
@@ -10,11 +10,7 @@ use re_tuid::Tuid;
 async fn main() -> anyhow::Result<()> {
     let local_addr = "127.0.0.1:51234";
 
-    let conn = tonic::transport::Endpoint::new(format!("http://{local_addr}"))?
-        .connect()
-        .await?;
-
-    let mut df_connector = DataFusionConnector::new(&conn);
+    let mut df_connector = DataFusionConnector::new(&format!("http://{local_addr}")).await?;
 
     let ctx = SessionContext::default();
 

--- a/crates/store/re_datafusion/src/datafusion_connector.rs
+++ b/crates/store/re_datafusion/src/datafusion_connector.rs
@@ -1,25 +1,24 @@
 use std::sync::Arc;
 
 use datafusion::{catalog::TableProvider, error::DataFusionError};
-use tonic::transport::Channel;
 
+use re_grpc_client::redap::RedapClient;
 use re_log_types::{external::re_tuid::Tuid, EntryId};
-use re_protos::{
-    catalog::v1alpha1::{ext::EntryDetails, DatasetEntry, EntryFilter, ReadDatasetEntryRequest},
-    frontend::v1alpha1::frontend_service_client::FrontendServiceClient,
+use re_protos::catalog::v1alpha1::{
+    ext::EntryDetails, DatasetEntry, EntryFilter, ReadDatasetEntryRequest,
 };
 
 use crate::partition_table::PartitionTableProvider;
 use crate::table_entry_provider::TableEntryTableProvider;
 
 pub struct DataFusionConnector {
-    catalog: FrontendServiceClient<Channel>,
+    catalog: RedapClient,
 }
 
 impl DataFusionConnector {
-    pub fn new(channel: &Channel) -> Self {
-        let catalog = FrontendServiceClient::new(channel.clone());
-        Self { catalog }
+    pub async fn new(origin: &str) -> anyhow::Result<Self> {
+        let catalog = re_grpc_client::redap::client(origin.parse()?).await?;
+        Ok(Self { catalog })
     }
 }
 

--- a/crates/store/re_datafusion/src/partition_table.rs
+++ b/crates/store/re_datafusion/src/partition_table.rs
@@ -6,15 +6,13 @@ use datafusion::{
     catalog::TableProvider,
     error::{DataFusionError, Result as DataFusionResult},
 };
-use tonic::transport::Channel;
 
+use re_grpc_client::redap::RedapClient;
 use re_log_encoding::codec::wire::decoder::Decode as _;
 use re_log_types::EntryId;
 use re_protos::frontend::v1alpha1::GetPartitionTableSchemaRequest;
 use re_protos::{
-    frontend::v1alpha1::{
-        frontend_service_client::FrontendServiceClient, ScanPartitionTableRequest,
-    },
+    frontend::v1alpha1::ScanPartitionTableRequest,
     manifest_registry::v1alpha1::ScanPartitionTableResponse,
 };
 
@@ -22,12 +20,12 @@ use crate::grpc_streaming_provider::{GrpcStreamProvider, GrpcStreamToTable};
 
 #[derive(Debug, Clone)]
 pub struct PartitionTableProvider {
-    client: FrontendServiceClient<Channel>,
+    client: RedapClient,
     dataset_id: EntryId,
 }
 
 impl PartitionTableProvider {
-    pub fn new(client: FrontendServiceClient<Channel>, dataset_id: EntryId) -> Self {
+    pub fn new(client: RedapClient, dataset_id: EntryId) -> Self {
         Self { client, dataset_id }
     }
 

--- a/crates/store/re_datafusion/src/search_provider.rs
+++ b/crates/store/re_datafusion/src/search_provider.rs
@@ -7,12 +7,11 @@ use datafusion::{
     error::{DataFusionError, Result as DataFusionResult},
 };
 use tokio_stream::StreamExt as _;
-use tonic::transport::Channel;
 
+use re_grpc_client::redap::RedapClient;
 use re_log_encoding::codec::wire::decoder::Decode as _;
 use re_protos::{
-    common::v1alpha1::ScanParameters,
-    frontend::v1alpha1::{frontend_service_client::FrontendServiceClient, SearchDatasetRequest},
+    common::v1alpha1::ScanParameters, frontend::v1alpha1::SearchDatasetRequest,
     manifest_registry::v1alpha1::SearchDatasetResponse,
 };
 
@@ -20,13 +19,13 @@ use crate::grpc_streaming_provider::{GrpcStreamProvider, GrpcStreamToTable};
 
 #[derive(Debug, Clone)]
 pub struct SearchResultsTableProvider {
-    client: FrontendServiceClient<Channel>,
+    client: RedapClient,
     request: SearchDatasetRequest,
 }
 
 impl SearchResultsTableProvider {
     pub fn new(
-        client: FrontendServiceClient<Channel>,
+        client: RedapClient,
         request: SearchDatasetRequest,
     ) -> Result<Self, DataFusionError> {
         if request.scan_parameters.is_some() {

--- a/crates/store/re_datafusion/src/table_entry_provider.rs
+++ b/crates/store/re_datafusion/src/table_entry_provider.rs
@@ -7,22 +7,19 @@ use datafusion::{
     catalog::TableProvider,
     error::{DataFusionError, Result as DataFusionResult},
 };
-use tonic::transport::Channel;
 
+use re_grpc_client::redap::RedapClient;
 use re_log_encoding::codec::wire::decoder::Decode as _;
 use re_log_types::{EntryId, EntryIdOrName};
 use re_protos::catalog::v1alpha1::ext::EntryDetails;
 use re_protos::catalog::v1alpha1::{EntryFilter, EntryKind, FindEntriesRequest};
-use re_protos::frontend::v1alpha1::{
-    frontend_service_client::FrontendServiceClient, GetTableSchemaRequest, ScanTableRequest,
-    ScanTableResponse,
-};
+use re_protos::frontend::v1alpha1::{GetTableSchemaRequest, ScanTableRequest, ScanTableResponse};
 
 use crate::grpc_streaming_provider::{GrpcStreamProvider, GrpcStreamToTable};
 
 #[derive(Debug, Clone)]
 pub struct TableEntryTableProvider {
-    client: FrontendServiceClient<Channel>,
+    client: RedapClient,
     table: EntryIdOrName,
 
     // cache the table id when resolved
@@ -30,7 +27,7 @@ pub struct TableEntryTableProvider {
 }
 
 impl TableEntryTableProvider {
-    pub fn new(client: FrontendServiceClient<Channel>, table: impl Into<EntryIdOrName>) -> Self {
+    pub fn new(client: RedapClient, table: impl Into<EntryIdOrName>) -> Self {
         Self {
             client,
             table: table.into(),

--- a/crates/store/re_grpc_client/Cargo.toml
+++ b/crates/store/re_grpc_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "re_grpc_client"
 authors.workspace = true
-description = "gRCP client for the Rerun Data Platform gRPC protocol"
+description = "gRPC client for the Rerun Data Platform gRPC protocol"
 edition.workspace = true
 homepage.workspace = true
 include.workspace = true
@@ -42,6 +42,7 @@ tonic = { workspace = true, default-features = false, features = [
   "tls",
   "tls-native-roots",
 ] }
+tower.workspace = true
 
 # Web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -116,7 +116,7 @@ pub async fn channel(origin: Origin) -> Result<tonic::transport::Channel, Connec
 }
 
 #[cfg(target_arch = "wasm32")]
-pub type Client = FrontendServiceClient<tonic_web_wasm_client::Client>;
+pub type RedapClient = FrontendServiceClient<tonic_web_wasm_client::Client>;
 
 #[cfg(target_arch = "wasm32")]
 pub async fn client(
@@ -127,31 +127,33 @@ pub async fn client(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub type Client = FrontendServiceClient<tonic::transport::Channel>;
+pub type RedapClient = FrontendServiceClient<tonic::transport::Channel>;
+// TODO(cmc): figure out how we integrate redap_telemetry in mainline Rerun
+// pub type RedapClient = FrontendServiceClient<
+//     tower_http::trace::Trace<
+//         tonic::service::interceptor::InterceptedService<
+//             tonic::transport::Channel,
+//             redap_telemetry::TracingInjectorInterceptor,
+//         >,
+//         tower_http::classify::SharedClassifier<tower_http::classify::GrpcErrorsAsFailures>,
+//     >,
+// >;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub async fn client(
-    origin: Origin,
-) -> Result<FrontendServiceClient<tonic::transport::Channel>, ConnectionError> {
+pub async fn client(origin: Origin) -> Result<RedapClient, ConnectionError> {
     let channel = channel(origin).await?;
-    Ok(FrontendServiceClient::new(channel).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE))
-}
 
-#[cfg(not(target_arch = "wasm32"))]
-pub async fn client_with_interceptor<I: tonic::service::Interceptor>(
-    origin: Origin,
-    interceptor: I,
-) -> Result<
-    FrontendServiceClient<
-        tonic::service::interceptor::InterceptedService<tonic::transport::Channel, I>,
-    >,
-    ConnectionError,
-> {
-    let channel = channel(origin).await?;
-    Ok(
-        FrontendServiceClient::with_interceptor(channel, interceptor)
-            .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
-    )
+    let middlewares = tower::ServiceBuilder::new()
+        // TODO(cmc): figure out how we integrate redap_telemetry in mainline Rerun
+        // .layer(redap_telemetry::new_grpc_tracing_layer())
+        // .layer(redap_telemetry::TracingInjectorInterceptor::new_layer())
+        .into_inner();
+
+    let svc = tower::ServiceBuilder::new()
+        .layer(middlewares)
+        .service(channel);
+
+    Ok(FrontendServiceClient::new(svc).max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE))
 }
 
 /// Converts a `FetchPartitionResponse` stream into a stream of `Chunk`s.

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -408,7 +408,7 @@ async fn fetch_dataset_entries(
 }
 
 async fn fetch_partition_table(
-    client: &mut redap::Client,
+    client: &mut redap::RedapClient,
     entry_id: EntryId,
 ) -> Result<Vec<SorbetBatch>, EntryError> {
     let mut response = client


### PR DESCRIPTION
This is basically my telemetry branch, but without the telemetry.

It refactors the Redap client construction to allow for arbitrary chains of middlewares, and more importantly makes sure that this exact client is used _everywhere_. This will become very important as soon as we introduce more middlewares (including auth -- apparently we've never set up auth here!).