### PR TITLE
Fix graph view heuristic always recommending no views

### DIFF
--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -105,9 +105,11 @@ impl ViewClass for GraphView {
             .get(&NodeVisualizer::identifier())
         {
             ViewSpawnHeuristics::new(maybe_visualizable.iter().cloned().filter_map(|entity| {
-                suggested_filter
-                    .matches(&entity)
-                    .then_some(RecommendedView::new_single_entity(entity))
+                if !suggested_filter.matches(&entity) {
+                    Some(RecommendedView::new_single_entity(entity))
+                } else {
+                    None
+                }
             }))
         } else {
             ViewSpawnHeuristics::empty()

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -105,10 +105,10 @@ impl ViewClass for GraphView {
             .get(&NodeVisualizer::identifier())
         {
             ViewSpawnHeuristics::new(maybe_visualizable.iter().cloned().filter_map(|entity| {
-                if !suggested_filter.matches(&entity) {
-                    Some(RecommendedView::new_single_entity(entity))
-                } else {
+                if suggested_filter.matches(&entity) {
                     None
+                } else {
+                    Some(RecommendedView::new_single_entity(entity))
                 }
             }))
         } else {


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/9781

The filter contains entities which _should not_ create views, but the filter was used to determine which entities _should_ turn into views. It only contains `+ /__properties/**`, so it could never match anything.

I believe `then_some` as a concept is at fault here, this should've been an `if` from the start :grimacing: