### PR TITLE
Fixed streams tree not focusing on the double-clicked item

### DIFF
--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -666,7 +666,8 @@ impl TimePanel {
             .as_ref()
             .and_then(|item| item.entity_path());
 
-        if focused_entity_path.is_some_and(|entity_path| entity_path.is_descendant_of(entity_path))
+        if focused_entity_path
+            .is_some_and(|focused_entity_path| focused_entity_path.is_descendant_of(entity_path))
         {
             collapse_scope
                 .entity(entity_path.clone())

--- a/crates/viewer/re_time_panel/tests/snapshots/focused_item_is_focused.png
+++ b/crates/viewer/re_time_panel/tests/snapshots/focused_item_is_focused.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bf994a37ab49d73bf19113f981d5da093b489884bc4d2b509a4061594e8dff3
+size 24546

--- a/crates/viewer/re_time_panel/tests/time_panel_tests.rs
+++ b/crates/viewer/re_time_panel/tests/time_panel_tests.rs
@@ -180,6 +180,28 @@ pub fn test_various_entity_kinds_in_time_panel() {
     }
 }
 
+#[test]
+pub fn test_focused_item_is_focused() {
+    TimePanel::ensure_registered_subscribers();
+
+    let mut test_context = TestContext::default();
+
+    log_data_for_various_entity_kinds_tests(&mut test_context);
+
+    *test_context.focused_item.lock() =
+        Some(EntityPath::from("/parent_with_data/of/entity").into());
+
+    let time_panel = TimePanel::default();
+
+    run_time_panel_and_save_snapshot(
+        test_context,
+        time_panel,
+        200.0,
+        false,
+        "focused_item_is_focused",
+    );
+}
+
 pub fn log_data_for_various_entity_kinds_tests(test_context: &mut TestContext) {
     let timeline_a = "timeline_a";
     let timeline_b = "timeline_b";


### PR DESCRIPTION
- Fixes #9778 

This PR fixes a regression where the streams tree would not longer scroll/expand to display the focused item (aka the double-clicked item).