### PR TITLE
Fix doclinks to archetypes

### DIFF
--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -206,13 +206,15 @@ impl ComponentName {
     }
 
     /// If this is an indicator component, for which archetype?
-    pub fn indicator_component_archetype(&self) -> Option<String> {
-        self.strip_suffix("Indicator").map(|name| name.to_owned())
+    pub fn indicator_component_archetype_short_name(&self) -> Option<String> {
+        self.short_name()
+            .strip_suffix("Indicator")
+            .map(|name| name.to_owned())
     }
 
     /// Web URL to the Rerun documentation for this component.
     pub fn doc_url(&self) -> Option<String> {
-        if let Some(archetype_name_pascal_case) = self.indicator_component_archetype() {
+        if let Some(archetype_name_pascal_case) = self.indicator_component_archetype_short_name() {
             // Link indicator components to their archetype.
             // This code should be correct as long as this url passes our link checker:
             // https://rerun.io/docs/reference/types/archetypes/line_strips3d

--- a/crates/viewer/re_data_ui/src/component_path.rs
+++ b/crates/viewer/re_data_ui/src/component_path.rs
@@ -20,7 +20,7 @@ impl DataUi for ComponentPath {
 
         let engine = db.storage_engine();
 
-        if let Some(archetype_name) = component_name.indicator_component_archetype() {
+        if let Some(archetype_name) = component_name.indicator_component_archetype_short_name() {
             ui.label(format!(
                 "Indicator component for the {archetype_name} archetype"
             ));

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -228,7 +228,7 @@ impl Query {
             .all_components_on_timeline_sorted(timeline, &filter_entity)
             .unwrap_or_default();
 
-        // The list of suggested components is build as follows:
+        // The list of suggested components is built as follows:
         // - consider all indicator components
         // - for the matching archetypes, take all required components
         // - keep those that are actually present
@@ -236,7 +236,7 @@ impl Query {
             all_components
                 .iter()
                 .filter_map(|c| {
-                    c.indicator_component_archetype()
+                    c.indicator_component_archetype_short_name()
                         .and_then(|archetype_short_name| {
                             ctx.reflection()
                                 .archetype_reflection_from_short_name(&archetype_short_name)

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1564,10 +1564,12 @@ impl App {
         for event in store_events {
             let chunk = &event.diff.chunk;
             for component in chunk.component_names() {
-                if let Some(archetype_name) = component.indicator_component_archetype() {
+                if let Some(short_archetype_name) =
+                    component.indicator_component_archetype_short_name()
+                {
                     if let Some(archetype) = self
                         .reflection
-                        .archetype_reflection_from_short_name(&archetype_name)
+                        .archetype_reflection_from_short_name(&short_archetype_name)
                     {
                         for &view_type in archetype.view_types {
                             if !cfg!(feature = "map_view") && view_type == "MapView" {
@@ -1577,7 +1579,7 @@ impl App {
                             }
                         }
                     } else {
-                        re_log::debug_once!("Unknown archetype: {archetype_name}");
+                        re_log::debug_once!("Unknown archetype: {short_archetype_name}");
                     }
                 }
             }


### PR DESCRIPTION
### Related
* Broke in https://github.com/rerun-io/rerun/pull/9755

### What
The above PR:
* broke doclinks to archetypes
* broke something in `re_view_dataframe` (not sure what)
* Caused `debug` log spam on startup