### PR TITLE
Correct deprecation warnings in c++ headers when using a deprecated type

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -839,6 +839,8 @@ impl QuotedObject {
                 struct AsComponents<#quoted_namespace::#archetype_type_ident> {
                     #serialize_hpp
                 };
+
+                #deprecation_ignore_end
             }
 
             #deprecation_ignore_end

--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -784,7 +784,7 @@ impl QuotedObject {
         //   -> this means that there's no non-move constructors/assignments
         // * we really want to make sure that the object is movable, therefore creating a move ctor
         //   -> this means that there's no implicit move assignment.
-        // Therefore, we have to define all five move/copy  constructors/assignments.
+        // Therefore, we have to define all five move/copy constructors/assignments.
         let hpp = quote! {
             #hpp_includes
 

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -167,6 +167,8 @@ namespace rerun {
         /// Serialize all set component batches.
         static Result<Collection<ComponentBatch>> as_batches(const archetypes::Scalar& archetype);
     };
+
+    RR_POP_WARNINGS
 } // namespace rerun
 
 RR_POP_WARNINGS

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -271,6 +271,8 @@ namespace rerun {
         static Result<Collection<ComponentBatch>> as_batches(const archetypes::SeriesLine& archetype
         );
     };
+
+    RR_POP_WARNINGS
 } // namespace rerun
 
 RR_POP_WARNINGS

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -262,6 +262,8 @@ namespace rerun {
             const archetypes::SeriesPoint& archetype
         );
     };
+
+    RR_POP_WARNINGS
 } // namespace rerun
 
 RR_POP_WARNINGS


### PR DESCRIPTION
### Related

Part of #9406

### What

We have a mismatched set of push/pop operations for disabling deprecation warnings. We need to keep these warnings in so that we can include our entire C++ header set but still create a warning when one of these deprecated types is used.

This PR addresses the bug of the mismatched push/pop operations that was leading to not generating any deprecation warnings.