### PR TITLE
C++: Emit warnings when using deprecated Rerun types

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -832,8 +832,6 @@ impl QuotedObject {
                 template<typename T>
                 struct AsComponents;
 
-                #deprecation_ignore_start
-
                 #doc_hide_comment
                 template<>
                 struct AsComponents<#quoted_namespace::#archetype_type_ident> {

--- a/rerun_cpp/src/rerun/archetypes/scalar.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalar.hpp
@@ -158,8 +158,6 @@ namespace rerun {
     /// \private
     template <typename T>
     struct AsComponents;
-    RR_PUSH_WARNINGS
-    RR_DISABLE_DEPRECATION_WARNING
 
     /// \private
     template <>

--- a/rerun_cpp/src/rerun/archetypes/series_line.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_line.hpp
@@ -261,8 +261,6 @@ namespace rerun {
     /// \private
     template <typename T>
     struct AsComponents;
-    RR_PUSH_WARNINGS
-    RR_DISABLE_DEPRECATION_WARNING
 
     /// \private
     template <>

--- a/rerun_cpp/src/rerun/archetypes/series_point.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_point.hpp
@@ -251,8 +251,6 @@ namespace rerun {
     /// \private
     template <typename T>
     struct AsComponents;
-    RR_PUSH_WARNINGS
-    RR_DISABLE_DEPRECATION_WARNING
 
     /// \private
     template <>


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/9406

### What
I've verified that this indeed closes the above issue. Using the deprecated `archetypes::Scalar` (not `s`) in snapshots and tests now leads to an error:

![image](https://github.com/user-attachments/assets/11a44328-775d-4e53-82f7-bf9bfdbdc42f)
