### PR TITLE
Migration guide: Add note about notebook import

### DIFF
--- a/docs/content/reference/migration/migration-0-23.md
+++ b/docs/content/reference/migration/migration-0-23.md
@@ -389,7 +389,7 @@ We've deprecated inconsistent constructors with following replacements:
     - `from_file` -> `from_file_path`
     - `from_bytes` -> `from_file_contents`
 
-## Notebooks
+## Jupyter notebooks
 
 ### Explicit `Viewer` imports
 

--- a/docs/content/reference/migration/migration-0-23.md
+++ b/docs/content/reference/migration/migration-0-23.md
@@ -388,3 +388,23 @@ We've deprecated inconsistent constructors with following replacements:
 - 🌊 C++:
     - `from_file` -> `from_file_path`
     - `from_bytes` -> `from_file_contents`
+
+## Notebooks
+
+### Explicit `Viewer` imports
+
+We've removed `notebook` from the root `rerun` namespace. `Viewer` must now be imported directly:
+
+Before:
+```python
+viewer = rr.notebook.Viewer(recording=rec)
+viewer.display()
+```
+
+After:
+```python
+from rerun.notebook import Viewer
+
+viewer = Viewer(recording=rec)
+display(viewer)
+```

--- a/docs/content/reference/migration/migration-0-23.md
+++ b/docs/content/reference/migration/migration-0-23.md
@@ -397,7 +397,7 @@ We've removed `notebook` from the root `rerun` namespace. `Viewer` must now be i
 
 Before:
 ```python
-viewer = rr.notebook.Viewer(recording=rec)
+viewer = rr.notebook.Viewer()
 viewer.display()
 ```
 
@@ -405,6 +405,8 @@ After:
 ```python
 from rerun.notebook import Viewer
 
-viewer = Viewer(recording=rec)
+viewer = Viewer()
 display(viewer)
 ```
+
+`rr.notebook_show` is still available in the root `rerun` namespace.

--- a/docs/content/reference/migration/migration-0-23.md
+++ b/docs/content/reference/migration/migration-0-23.md
@@ -406,7 +406,7 @@ After:
 from rerun.notebook import Viewer
 
 viewer = Viewer()
-display(viewer)
+viewer.display()
 ```
 
 `rr.notebook_show` is still available in the root `rerun` namespace.


### PR DESCRIPTION
This probably should've been in the migration guide from the start, but better late than never