### PR TITLE
Enable missing-f-string-syntax in ruff (`RUF027`)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -26419,7 +26419,7 @@ packages:
 - pypi: rerun_py
   name: rerun-sdk
   version: 0.24.0a1+dev
-  sha256: 696545b61e1058f4d03c83ea8f17d06c6dabb8b332e7b1d04c47a4d7a3e50da3
+  sha256: bee557d69aa460307a5b55658b8b969997d2cadef691f4cb5f178f7663a1242b
   requires_dist:
   - attrs>=23.1.0
   - numpy>=1.23

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -41,7 +41,7 @@ if ASSET_ENV is None:
     if "RERUN_DEV_ENVIRONMENT" in os.environ:
         ASSET_ENV = "serve-local"
     else:
-        ASSET_ENV = "https://app.rerun.io/version/{__version__}/widget.js"
+        ASSET_ENV = f"https://app.rerun.io/version/{__version__}/widget.js"
 
 if ASSET_ENV == ASSET_MAGIC_SERVE:
     from .asset_server import serve_assets

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -151,6 +151,7 @@ lint.select = [
   "PIE",     # flake8-pic: various idomatic python lints
   "PLW1514", # Force setting `encoding` for open calls. This is in order to prevent issues when opening utf8 files on windows where the default encoding may depend on the active locale. https://docs.astral.sh/ruff/rules/unspecified-encoding/
   "YTT",     # Various checks on the use of `sys.version_info` and related.
+  "RUF027",  # Ensure that strings which look like format-strings have the `f` prefix
 ]
 
 lint.unfixable = [

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -88,7 +88,7 @@ class TimeColumn(TimeColumnLike):
         """
         if sum(x is not None for x in (sequence, duration, timestamp)) != 1:
             raise ValueError(
-                "TimeColumn: Exactly one of `sequence`, `duration`, and `timestamp` must be set (timeline='{timeline}')",
+                f"TimeColumn: Exactly one of `sequence`, `duration`, and `timestamp` must be set (timeline='{timeline}')",
             )
 
         self.timeline = timeline

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -365,7 +365,7 @@ class Viewer:
 
         if sum(x is not None for x in (sequence, duration, timestamp)) > 1:
             raise ValueError(
-                "set_time_ctrl: Exactly one of `sequence`, `duration`, and `timestamp` must be set (timeline='{timeline}')",
+                f"set_time_ctrl: Exactly one of `sequence`, `duration`, and `timestamp` must be set (timeline='{timeline}')",
             )
 
         if sequence is not None:

--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -83,7 +83,7 @@ def set_time(
     """
     if sum(x is not None for x in (sequence, duration, timestamp)) != 1:
         raise ValueError(
-            "set_time: Exactly one of `sequence`, `duration`, and `timestamp` must be set (timeline='{timeline}')",
+            f"set_time: Exactly one of `sequence`, `duration`, and `timestamp` must be set (timeline='{timeline}')",
         )
 
     if sequence is not None:

--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -160,7 +160,7 @@ def get_sorted_publishable_crates(ctx: Context, crates: dict[str, Crate]) -> dic
     ) -> None:
         crate = crates[name]
         for dependency in crate_deps(crate.manifest):
-            assert dependency.name != name, "Crate {name} had itself as a dependency"
+            assert dependency.name != name, f"Crate {name} had itself as a dependency"
             if dependency.name not in crates:
                 continue
             if dependency.name in visited:

--- a/scripts/upload_rrd.py
+++ b/scripts/upload_rrd.py
@@ -132,7 +132,7 @@ def main() -> None:
         # Check if user put `v0.15.0` instead of `0.15.0`:
         if m := re.match(r"v(\d+\.\d+\..*)", version):
             version = m.group(1)
-            raise RuntimeError("Version should be in the format '{version}', without a leading 'v'")
+            raise RuntimeError(f"Version should be in the format '{version}', without a leading 'v'")
 
         file_data = file_path.read_bytes()
         digest = data_hash(file_data)


### PR DESCRIPTION
Ensures that `"{thing}"` is `f"{thing}"`. Seems to have found a few bugs, including the one that got into the release.