### PR TITLE
Move migration guide to the top

### DIFF
--- a/docs/content/reference/migration/migration-0-23.md
+++ b/docs/content/reference/migration/migration-0-23.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from 0.22 to 0.23
-order: 989
+order: 987
 ---
 
 ## Reserved namespaces


### PR DESCRIPTION
Fixes this:

<img width="277" alt="image" src="https://github.com/user-attachments/assets/585a5e40-f75f-4308-ac93-27acb186395f" />
