### PR TITLE
Remove component name indirection from `ChunkComponents`

### DIFF
--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -752,7 +752,7 @@ impl PendingRow {
         for (component_desc, array) in components {
             let list_array = arrays_to_list_array_opt(&[Some(&*array as _)]);
             if let Some(list_array) = list_array {
-                per_name.insert_descriptor(component_desc, list_array);
+                per_name.insert(component_desc, list_array);
             }
         }
 
@@ -901,7 +901,7 @@ impl PendingRow {
                                     {
                                         let list_array = arrays_to_list_array_opt(&arrays);
                                         if let Some(list_array) = list_array {
-                                            per_name.insert_descriptor(component_desc, list_array);
+                                            per_name.insert(component_desc, list_array);
                                         }
                                     }
                                     per_name
@@ -946,7 +946,7 @@ impl PendingRow {
                         for (component_desc, arrays) in components {
                             let list_array = arrays_to_list_array_opt(&arrays);
                             if let Some(list_array) = list_array {
-                                per_name.insert_descriptor(component_desc, list_array);
+                                per_name.insert(component_desc, list_array);
                             }
                         }
                         per_name

--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -748,11 +748,11 @@ impl PendingRow {
             })
             .collect();
 
-        let mut per_name = ChunkComponents::default();
+        let mut per_desc = ChunkComponents::default();
         for (component_desc, array) in components {
             let list_array = arrays_to_list_array_opt(&[Some(&*array as _)]);
             if let Some(list_array) = list_array {
-                per_name.insert(component_desc, list_array);
+                per_desc.insert(component_desc, list_array);
             }
         }
 
@@ -762,7 +762,7 @@ impl PendingRow {
             Some(true),
             &[row_id],
             timelines,
-            per_name,
+            per_desc,
         )
     }
 
@@ -896,15 +896,15 @@ impl PendingRow {
                                     .map(|(name, time_column)| (name, time_column.finish()))
                                     .collect(),
                                 {
-                                    let mut per_name = ChunkComponents::default();
+                                    let mut per_desc = ChunkComponents::default();
                                     for (component_desc, arrays) in std::mem::take(&mut components)
                                     {
                                         let list_array = arrays_to_list_array_opt(&arrays);
                                         if let Some(list_array) = list_array {
-                                            per_name.insert(component_desc, list_array);
+                                            per_desc.insert(component_desc, list_array);
                                         }
                                     }
-                                    per_name
+                                    per_desc
                                 },
                             ));
 
@@ -942,14 +942,14 @@ impl PendingRow {
                         .map(|(timeline, time_column)| (timeline, time_column.finish()))
                         .collect(),
                     {
-                        let mut per_name = ChunkComponents::default();
+                        let mut per_desc = ChunkComponents::default();
                         for (component_desc, arrays) in components {
                             let list_array = arrays_to_list_array_opt(&arrays);
                             if let Some(list_array) = list_array {
-                                per_name.insert(component_desc, list_array);
+                                per_desc.insert(component_desc, list_array);
                             }
                         }
-                        per_name
+                        per_desc
                     },
                 ));
 

--- a/crates/store/re_chunk/src/builder.rs
+++ b/crates/store/re_chunk/src/builder.rs
@@ -273,8 +273,7 @@ impl ChunkBuilder {
 
         let components = {
             re_tracing::profile_scope!("components");
-            let mut per_name = ChunkComponents::default();
-            for (component_desc, list_array) in
+            ChunkComponents(
                 components
                     .into_iter()
                     .filter_map(|(component_desc, arrays)| {
@@ -282,10 +281,8 @@ impl ChunkBuilder {
                         re_arrow_util::arrays_to_list_array_opt(&arrays)
                             .map(|list_array| (component_desc, list_array))
                     })
-            {
-                per_name.insert(component_desc, list_array);
-            }
-            per_name
+                    .collect(),
+            )
         };
 
         Chunk::from_native_row_ids(id, entity_path, None, &row_ids, timelines, components)
@@ -329,8 +326,7 @@ impl ChunkBuilder {
                 .map(|(timeline, time_column)| (timeline, time_column.build()))
                 .collect(),
             {
-                let mut per_name = ChunkComponents::default();
-                for (component_desc, list_array) in
+                ChunkComponents(
                     components
                         .into_iter()
                         .filter_map(|(component_desc, arrays)| {
@@ -345,10 +341,8 @@ impl ChunkBuilder {
                                     .map(|list_array| (component_desc, list_array))
                             }
                         })
-                {
-                    per_name.insert(component_desc, list_array);
-                }
-                per_name
+                        .collect(),
+                )
             },
         )
     }

--- a/crates/store/re_chunk/src/builder.rs
+++ b/crates/store/re_chunk/src/builder.rs
@@ -283,7 +283,7 @@ impl ChunkBuilder {
                             .map(|list_array| (component_desc, list_array))
                     })
             {
-                per_name.insert_descriptor(component_desc, list_array);
+                per_name.insert(component_desc, list_array);
             }
             per_name
         };
@@ -346,7 +346,7 @@ impl ChunkBuilder {
                             }
                         })
                 {
-                    per_name.insert_descriptor(component_desc, list_array);
+                    per_name.insert(component_desc, list_array);
                 }
                 per_name
             },

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -66,70 +66,20 @@ pub type ChunkResult<T> = Result<T, ChunkError>;
 // ---
 
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct ChunkComponents(
-    // TODO(#6576): support non-list based columns?
-    //
-    // NOTE: The extra `ComponentName` layer is needed because it is very common to want to look
-    // for anything matching a `ComponentName`, without any further tags specified.
-    pub IntMap<ComponentName, IntMap<ComponentDescriptor, ArrowListArray>>,
-);
+pub struct ChunkComponents(pub IntMap<ComponentDescriptor, ArrowListArray>);
 
 impl ChunkComponents {
-    /// Like `Self::insert`, but automatically infers the [`ComponentName`] layer.
-    #[inline]
-    pub fn insert_descriptor(
-        &mut self,
-        component_desc: ComponentDescriptor,
-        list_array: ArrowListArray,
-    ) -> Option<ArrowListArray> {
-        self.0
-            .entry(component_desc.component_name)
-            .or_default()
-            .insert(component_desc, list_array)
-    }
-
     /// Returns all list arrays for the given component name.
     ///
     /// I.e semantically equivalent to `get("MyComponent:*.*")`
     #[inline]
-    pub fn get_by_component_name<'a>(
-        &'a self,
-        component_name: &ComponentName,
-    ) -> impl Iterator<Item = &'a ArrowListArray> {
-        self.get(component_name).map_or_else(
-            || itertools::Either::Left(std::iter::empty()),
-            |per_desc| itertools::Either::Right(per_desc.values()),
-        )
-    }
-
-    #[inline]
-    pub fn get_by_descriptor(
+    pub fn get_by_component_name(
         &self,
-        component_desc: &ComponentDescriptor,
-    ) -> Option<&ArrowListArray> {
-        self.get(&component_desc.component_name)
-            .and_then(|per_desc| per_desc.get(component_desc))
-    }
-
-    #[inline]
-    pub fn get_by_descriptor_mut(
-        &mut self,
-        component_desc: &ComponentDescriptor,
-    ) -> Option<&mut ArrowListArray> {
-        self.get_mut(&component_desc.component_name)
-            .and_then(|per_desc| per_desc.get_mut(component_desc))
-    }
-
-    #[inline]
-    pub fn iter_flattened(&self) -> impl Iterator<Item = (&ComponentDescriptor, &ArrowListArray)> {
-        self.0.values().flatten()
-    }
-
-    #[inline]
-    pub fn into_iter_flattened(
-        self,
-    ) -> impl Iterator<Item = (ComponentDescriptor, ArrowListArray)> {
-        self.0.into_values().flatten()
+        component_name: ComponentName,
+    ) -> impl Iterator<Item = &ArrowListArray> {
+        self.0.iter().filter_map(move |(desc, array)| {
+            (desc.component_name == component_name).then_some(array)
+        })
     }
 
     /// Approximate equal, that ignores small numeric differences.
@@ -141,24 +91,26 @@ impl ChunkComponents {
     /// Useful for tests.
     pub fn ensure_similar(left: &Self, right: &Self) -> anyhow::Result<()> {
         anyhow::ensure!(left.len() == right.len());
-        for (comp_name, left_comp_map) in left.iter() {
-            let Some(right_map) = right.get(comp_name) else {
-                anyhow::bail!("rhs is missing {comp_name:?}");
+        for (descr, left_array) in left.iter() {
+            let Some(right_array) = right.get(descr) else {
+                anyhow::bail!("rhs is missing {descr:?}");
             };
-            for (descr, left_array) in left_comp_map {
-                let Some(right_array) = right_map.get(descr) else {
-                    anyhow::bail!("rhs {comp_name:?} is missing {descr:?}");
-                };
-                re_arrow_util::ensure_similar(&left_array.to_data(), &right_array.to_data())
-                    .with_context(|| format!("Component {comp_name:?}"))?;
-            }
+            re_arrow_util::ensure_similar(&left_array.to_data(), &right_array.to_data())
+                .with_context(|| format!("Component {descr:?}"))?;
         }
         Ok(())
+    }
+
+    /// Whether any of the components in this chunk has the given name.
+    pub fn contains_component_name(&self, component_name: ComponentName) -> bool {
+        self.0
+            .keys()
+            .any(|desc| desc.component_name == component_name)
     }
 }
 
 impl std::ops::Deref for ChunkComponents {
-    type Target = IntMap<ComponentName, IntMap<ComponentDescriptor, ArrowListArray>>;
+    type Target = IntMap<ComponentDescriptor, ArrowListArray>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -179,7 +131,7 @@ impl FromIterator<(ComponentDescriptor, ArrowListArray)> for ChunkComponents {
         let mut this = Self::default();
         {
             for (component_desc, list_array) in iter {
-                this.insert_descriptor(component_desc, list_array);
+                this.insert(component_desc, list_array);
             }
         }
         this
@@ -272,10 +224,10 @@ impl Chunk {
     // TODO(cmc): Kinda disgusting but it makes our lives easier during the interim, as long as we're
     // in this weird halfway in-between state where we still have a bunch of things indexed by name only.
     #[inline]
-    pub fn get_first_component(&self, component_name: &ComponentName) -> Option<&ArrowListArray> {
-        self.components
-            .get(component_name)
-            .and_then(|per_desc| per_desc.values().next())
+    pub fn get_first_component(&self, component_name: ComponentName) -> Option<&ArrowListArray> {
+        self.components.iter().find_map(move |(descr, array)| {
+            (descr.component_name == component_name).then_some(array)
+        })
     }
 }
 
@@ -348,23 +300,15 @@ impl Chunk {
 
             // Filter out the recording time component from both lhs and rhs.
             let lhs_components = components
-                .values() // `keys` is `ComponentName`, don't care since we use full descriptors directly.
-                .cloned()
-                .flat_map(|per_desc| {
-                    per_desc
-                        .into_iter()
-                        .filter(|(desc, _)| desc != &recording_time_descriptor)
-                })
+                .iter()
+                .filter(|&(desc, _list_array)| (desc != &recording_time_descriptor))
+                .map(|(desc, list_array)| (desc.clone(), list_array.clone()))
                 .collect::<IntMap<_, _>>();
             let rhs_components = rhs
                 .components
-                .values() // `keys` is `ComponentName`, don't care since we use full descriptors directly.
-                .cloned()
-                .flat_map(|per_desc| {
-                    per_desc
-                        .into_iter()
-                        .filter(|(desc, _)| desc != &recording_time_descriptor)
-                })
+                .iter()
+                .filter(|&(desc, _list_array)| (desc != &recording_time_descriptor))
+                .map(|(desc, list_array)| (desc.clone(), list_array.clone()))
                 .collect::<IntMap<_, _>>();
 
             anyhow::ensure!(lhs_components == rhs_components);
@@ -387,22 +331,14 @@ impl Chunk {
         } = self;
 
         let my_components: IntMap<_, _> = components
-            .values()
-            .flat_map(|per_desc| {
-                per_desc
-                    .iter()
-                    .map(|(descr, list_array)| (descr.clone(), list_array))
-            })
+            .iter()
+            .map(|(descr, list_array)| (descr.clone(), list_array))
             .collect();
 
         let other_components: IntMap<_, _> = other
             .components
-            .values()
-            .flat_map(|per_desc| {
-                per_desc
-                    .iter()
-                    .map(|(descr, list_array)| (descr.clone(), list_array))
-            })
+            .iter()
+            .map(|(descr, list_array)| (descr.clone(), list_array))
             .collect();
 
         *id == other.id
@@ -483,8 +419,7 @@ impl Chunk {
     #[inline]
     pub fn time_range_per_component(
         &self,
-    ) -> IntMap<TimelineName, IntMap<ComponentName, IntMap<ComponentDescriptor, ResolvedTimeRange>>>
-    {
+    ) -> IntMap<TimelineName, IntMap<ComponentDescriptor, ResolvedTimeRange>> {
         re_tracing::profile_function!();
 
         self.timelines
@@ -508,7 +443,6 @@ impl Chunk {
         // Reminder: component columns are sparse, we must take a look at the validity bitmaps.
         self.components
             .values()
-            .flat_map(|per_desc| per_desc.values())
             .map(|list_array| {
                 list_array.nulls().map_or_else(
                     || list_array.len() as u64,
@@ -572,19 +506,16 @@ impl Chunk {
         // Raw, potentially duplicated counts (because timestamps aren't necessarily unique).
         let mut counts_raw = vec![0u64; self.num_rows()];
         {
-            self.components
-                .values()
-                .flat_map(|per_desc| per_desc.values())
-                .for_each(|list_array| {
-                    if let Some(validity) = list_array.nulls() {
-                        validity
-                            .iter()
-                            .enumerate()
-                            .for_each(|(i, is_valid)| counts_raw[i] += is_valid as u64);
-                    } else {
-                        counts_raw.iter_mut().for_each(|count| *count += 1);
-                    }
-                });
+            self.components.values().for_each(|list_array| {
+                if let Some(validity) = list_array.nulls() {
+                    validity
+                        .iter()
+                        .enumerate()
+                        .for_each(|(i, is_valid)| counts_raw[i] += is_valid as u64);
+                } else {
+                    counts_raw.iter_mut().for_each(|count| *count += 1);
+                }
+            });
         }
 
         let mut counts = Vec::with_capacity(counts_raw.len());
@@ -620,26 +551,25 @@ impl Chunk {
 
         // NOTE: This is used on some very hot paths (time panel rendering).
 
-        let result_unordered = self
-            .components
-            .values()
-            .flat_map(|per_desc| per_desc.values())
-            .fold(HashMap::default(), |acc, list_array| {
-                if let Some(validity) = list_array.nulls() {
-                    time_column.times().zip(validity.iter()).fold(
-                        acc,
-                        |mut acc, (time, is_valid)| {
-                            *acc.entry(time).or_default() += is_valid as u64;
+        let result_unordered =
+            self.components
+                .values()
+                .fold(HashMap::default(), |acc, list_array| {
+                    if let Some(validity) = list_array.nulls() {
+                        time_column.times().zip(validity.iter()).fold(
+                            acc,
+                            |mut acc, (time, is_valid)| {
+                                *acc.entry(time).or_default() += is_valid as u64;
+                                acc
+                            },
+                        )
+                    } else {
+                        time_column.times().fold(acc, |mut acc, time| {
+                            *acc.entry(time).or_default() += 1;
                             acc
-                        },
-                    )
-                } else {
-                    time_column.times().fold(acc, |mut acc, time| {
-                        *acc.entry(time).or_default() += 1;
-                        acc
-                    })
-                }
-            });
+                        })
+                    }
+                });
 
         let mut result = result_unordered.into_iter().collect_vec();
         result.sort_by_key(|val| val.0);
@@ -654,7 +584,7 @@ impl Chunk {
     #[inline]
     pub fn num_events_for_component(&self, component_name: ComponentName) -> Option<u64> {
         // Reminder: component columns are sparse, we must check validity bitmap.
-        self.get_first_component(&component_name).map(|list_array| {
+        self.get_first_component(component_name).map(|list_array| {
             list_array.nulls().map_or_else(
                 || list_array.len() as u64,
                 |validity| validity.len() as u64 - validity.null_count() as u64,
@@ -670,9 +600,7 @@ impl Chunk {
     /// This is crucial for indexing and queries to work properly.
     //
     // TODO(cmc): This needs to be stored in chunk metadata and transported across IPC.
-    pub fn row_id_range_per_component(
-        &self,
-    ) -> IntMap<ComponentName, IntMap<ComponentDescriptor, (RowId, RowId)>> {
+    pub fn row_id_range_per_component(&self) -> IntMap<ComponentDescriptor, (RowId, RowId)> {
         re_tracing::profile_function!();
 
         let row_ids = self.row_ids().collect_vec();
@@ -680,59 +608,43 @@ impl Chunk {
         if self.is_sorted() {
             self.components
                 .iter()
-                .map(|(component_name, per_desc)| {
-                    (
-                        *component_name,
-                        per_desc
-                            .iter()
-                            .filter_map(|(component_desc, list_array)| {
-                                let mut row_id_min = None;
-                                let mut row_id_max = None;
+                .filter_map(|(component_desc, list_array)| {
+                    let mut row_id_min = None;
+                    let mut row_id_max = None;
 
-                                for (i, &row_id) in row_ids.iter().enumerate() {
-                                    if list_array.is_valid(i) {
-                                        row_id_min = Some(row_id);
-                                    }
-                                }
-                                for (i, &row_id) in row_ids.iter().enumerate().rev() {
-                                    if list_array.is_valid(i) {
-                                        row_id_max = Some(row_id);
-                                    }
-                                }
+                    for (i, &row_id) in row_ids.iter().enumerate() {
+                        if list_array.is_valid(i) {
+                            row_id_min = Some(row_id);
+                        }
+                    }
+                    for (i, &row_id) in row_ids.iter().enumerate().rev() {
+                        if list_array.is_valid(i) {
+                            row_id_max = Some(row_id);
+                        }
+                    }
 
-                                Some((component_desc.clone(), (row_id_min?, row_id_max?)))
-                            })
-                            .collect(),
-                    )
+                    Some((component_desc.clone(), (row_id_min?, row_id_max?)))
                 })
                 .collect()
         } else {
             self.components
                 .iter()
-                .map(|(component_name, per_desc)| {
-                    (
-                        *component_name,
-                        per_desc
-                            .iter()
-                            .filter_map(|(component_desc, list_array)| {
-                                let mut row_id_min = Some(RowId::MAX);
-                                let mut row_id_max = Some(RowId::ZERO);
+                .filter_map(|(component_desc, list_array)| {
+                    let mut row_id_min = Some(RowId::MAX);
+                    let mut row_id_max = Some(RowId::ZERO);
 
-                                for (i, &row_id) in row_ids.iter().enumerate() {
-                                    if list_array.is_valid(i) && Some(row_id) > row_id_min {
-                                        row_id_min = Some(row_id);
-                                    }
-                                }
-                                for (i, &row_id) in row_ids.iter().enumerate().rev() {
-                                    if list_array.is_valid(i) && Some(row_id) < row_id_max {
-                                        row_id_max = Some(row_id);
-                                    }
-                                }
+                    for (i, &row_id) in row_ids.iter().enumerate() {
+                        if list_array.is_valid(i) && Some(row_id) > row_id_min {
+                            row_id_min = Some(row_id);
+                        }
+                    }
+                    for (i, &row_id) in row_ids.iter().enumerate().rev() {
+                        if list_array.is_valid(i) && Some(row_id) < row_id_max {
+                            row_id_max = Some(row_id);
+                        }
+                    }
 
-                                Some((component_desc.clone(), (row_id_min?, row_id_max?)))
-                            })
-                            .collect(),
-                    )
+                    Some((component_desc.clone(), (row_id_min?, row_id_max?)))
                 })
                 .collect()
         }
@@ -850,7 +762,7 @@ impl Chunk {
         components: ChunkComponents,
     ) -> ChunkResult<Self> {
         let count = components
-            .iter_flattened()
+            .iter()
             .next()
             .map_or(0, |(_, list_array)| list_array.len());
 
@@ -914,8 +826,7 @@ impl Chunk {
         component_desc: ComponentDescriptor,
         list_array: ArrowListArray,
     ) -> ChunkResult<()> {
-        self.components
-            .insert_descriptor(component_desc, list_array);
+        self.components.insert(component_desc, list_array);
         self.sanity_check()
     }
 
@@ -1262,7 +1173,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = RowId> + '_ {
-        let Some(list_array) = self.get_first_component(component_name) else {
+        let Some(list_array) = self.get_first_component(*component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -1318,15 +1229,15 @@ impl Chunk {
 
     #[inline]
     pub fn component_names(&self) -> impl Iterator<Item = ComponentName> + '_ {
-        self.components.keys().copied()
+        self.components
+            .keys()
+            .map(|desc| desc.component_name)
+            .unique()
     }
 
     #[inline]
     pub fn component_descriptors(&self) -> impl Iterator<Item = ComponentDescriptor> + '_ {
-        self.components
-            .values()
-            .flat_map(|per_desc| per_desc.keys())
-            .cloned()
+        self.components.keys().cloned()
     }
 
     #[inline]
@@ -1426,56 +1337,48 @@ impl TimeColumn {
     pub fn time_range_per_component(
         &self,
         components: &ChunkComponents,
-    ) -> IntMap<ComponentName, IntMap<ComponentDescriptor, ResolvedTimeRange>> {
+    ) -> IntMap<ComponentDescriptor, ResolvedTimeRange> {
         let times = self.times_raw();
         components
             .iter()
-            .map(|(component_name, per_desc)| {
-                (
-                    *component_name,
-                    per_desc
-                        .iter()
-                        .filter_map(|(component_desc, list_array)| {
-                            if let Some(validity) = list_array.nulls() {
-                                // Potentially sparse
+            .filter_map(|(component_desc, list_array)| {
+                if let Some(validity) = list_array.nulls() {
+                    // Potentially sparse
 
-                                if validity.is_empty() {
-                                    return None;
-                                }
+                    if validity.is_empty() {
+                        return None;
+                    }
 
-                                let is_dense = validity.null_count() == 0;
-                                if is_dense {
-                                    return Some((component_desc.clone(), self.time_range));
-                                }
+                    let is_dense = validity.null_count() == 0;
+                    if is_dense {
+                        return Some((component_desc.clone(), self.time_range));
+                    }
 
-                                let mut time_min = TimeInt::MAX;
-                                for (i, time) in times.iter().copied().enumerate() {
-                                    if validity.is_valid(i) {
-                                        time_min = TimeInt::new_temporal(time);
-                                        break;
-                                    }
-                                }
+                    let mut time_min = TimeInt::MAX;
+                    for (i, time) in times.iter().copied().enumerate() {
+                        if validity.is_valid(i) {
+                            time_min = TimeInt::new_temporal(time);
+                            break;
+                        }
+                    }
 
-                                let mut time_max = TimeInt::MIN;
-                                for (i, time) in times.iter().copied().enumerate().rev() {
-                                    if validity.is_valid(i) {
-                                        time_max = TimeInt::new_temporal(time);
-                                        break;
-                                    }
-                                }
+                    let mut time_max = TimeInt::MIN;
+                    for (i, time) in times.iter().copied().enumerate().rev() {
+                        if validity.is_valid(i) {
+                            time_max = TimeInt::new_temporal(time);
+                            break;
+                        }
+                    }
 
-                                Some((
-                                    component_desc.clone(),
-                                    ResolvedTimeRange::new(time_min, time_max),
-                                ))
-                            } else {
-                                // Dense
+                    Some((
+                        component_desc.clone(),
+                        ResolvedTimeRange::new(time_min, time_max),
+                    ))
+                } else {
+                    // Dense
 
-                                Some((component_desc.clone(), self.time_range))
-                            }
-                        })
-                        .collect(),
-                )
+                    Some((component_desc.clone(), self.time_range))
+                }
             })
             .collect()
     }
@@ -1604,25 +1507,24 @@ impl Chunk {
         }
 
         // Components
-        for (component_name, per_desc) in components.iter() {
-            component_name.sanity_check();
-            for (component_desc, list_array) in per_desc {
-                component_desc.component_name.sanity_check();
-                // Ensure that each cell is a list (we don't support mono-components yet).
-                if let arrow::datatypes::DataType::List(_field) = list_array.data_type() {
-                    // We don't check `field.is_nullable()` here because we support both.
-                    // TODO(#6819): Remove support for inner nullability.
-                } else {
-                    return Err(ChunkError::Malformed {
-                        reason: format!(
-                            "The inner array in a chunked component batch must be a list, got {:?}",
-                            list_array.data_type(),
-                        ),
-                    });
-                }
 
-                if list_array.len() != row_ids.len() {
-                    return Err(ChunkError::Malformed {
+        for (component_desc, list_array) in components.iter() {
+            component_desc.component_name.sanity_check();
+            // Ensure that each cell is a list (we don't support mono-components yet).
+            if let arrow::datatypes::DataType::List(_field) = list_array.data_type() {
+                // We don't check `field.is_nullable()` here because we support both.
+                // TODO(#6819): Remove support for inner nullability.
+            } else {
+                return Err(ChunkError::Malformed {
+                    reason: format!(
+                        "The inner array in a chunked component batch must be a list, got {:?}",
+                        list_array.data_type(),
+                    ),
+                });
+            }
+
+            if list_array.len() != row_ids.len() {
+                return Err(ChunkError::Malformed {
                         reason: format!(
                             "All component batches in a chunk must have the same number of rows, matching the number of row IDs. \
                              Found {} row IDs but {} rows for component batch {component_desc}",
@@ -1630,19 +1532,18 @@ impl Chunk {
                             list_array.len(),
                         ),
                     });
-                }
+            }
 
-                let validity_is_empty = list_array
-                    .nulls()
-                    .is_some_and(|validity| validity.is_empty());
-                if !self.is_empty() && validity_is_empty {
-                    return Err(ChunkError::Malformed {
+            let validity_is_empty = list_array
+                .nulls()
+                .is_some_and(|validity| validity.is_empty());
+            if !self.is_empty() && validity_is_empty {
+                return Err(ChunkError::Malformed {
                         reason: format!(
                             "All component batches in a chunk must contain at least one non-null entry.\
                              Found a completely empty column for {component_desc}",
                         ),
                     });
-                }
             }
         }
 

--- a/crates/store/re_chunk/src/helpers.rs
+++ b/crates/store/re_chunk/src/helpers.rs
@@ -22,7 +22,7 @@ impl Chunk {
         component_name: &ComponentName,
         row_index: usize,
     ) -> Option<ChunkResult<ArrowArrayRef>> {
-        self.get_first_component(component_name)
+        self.get_first_component(*component_name)
             .and_then(|list_array| {
                 if list_array.len() > row_index {
                     list_array
@@ -239,12 +239,9 @@ impl UnitChunkShared {
     pub fn num_instances(&self, component_name: &ComponentName) -> u64 {
         debug_assert!(self.num_rows() == 1);
         self.components
-            .values()
-            .flat_map(|per_desc| per_desc.iter())
-            .filter_map(|(descr, list_array)| {
-                (descr.component_name == *component_name).then_some(list_array)
-            })
-            .map(|list_array| {
+            .iter()
+            .filter(|&(descr, _list_array)| (descr.component_name == *component_name))
+            .map(|(_descr, list_array)| {
                 let array = list_array.value(0);
                 array.nulls().map_or_else(
                     || array.len(),
@@ -265,7 +262,7 @@ impl UnitChunkShared {
     #[inline]
     pub fn component_batch_raw(&self, component_name: &ComponentName) -> Option<ArrowArrayRef> {
         debug_assert!(self.num_rows() == 1);
-        self.get_first_component(component_name)
+        self.get_first_component(*component_name)
             .and_then(|list_array| list_array.is_valid(0).then(|| list_array.value(0)))
     }
 

--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -68,7 +68,7 @@ impl Chunk {
         timeline: &TimelineName,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = (TimeInt, RowId)> + '_ {
-        let Some(list_array) = self.get_first_component(component_name) else {
+        let Some(list_array) = self.get_first_component(*component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -134,7 +134,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = TimePoint> + '_ {
-        let Some(list_array) = self.get_first_component(component_name) else {
+        let Some(list_array) = self.get_first_component(*component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -187,7 +187,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = (usize, usize)> + '_ {
-        let Some(list_array) = self.get_first_component(component_name) else {
+        let Some(list_array) = self.get_first_component(*component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -220,7 +220,7 @@ impl Chunk {
         &'a self,
         component_name: ComponentName,
     ) -> impl Iterator<Item = S::Item<'a>> + 'a {
-        let Some(list_array) = self.get_first_component(&component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -248,7 +248,7 @@ impl Chunk {
         component_name: ComponentName,
         field_name: &'a str,
     ) -> impl Iterator<Item = S::Item<'a>> + 'a {
-        let Some(list_array) = self.get_first_component(&component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -849,7 +849,7 @@ impl Chunk {
     pub fn iter_component<C: Component>(
         &self,
     ) -> ChunkComponentIter<C, impl Iterator<Item = (usize, usize)> + '_> {
-        let Some(list_array) = self.get_first_component(&C::name()) else {
+        let Some(list_array) = self.get_first_component(C::name()) else {
             return ChunkComponentIter {
                 values: Arc::new(vec![]),
                 offsets: Either::Left(std::iter::empty()),

--- a/crates/store/re_chunk/src/latest_at.rs
+++ b/crates/store/re_chunk/src/latest_at.rs
@@ -78,7 +78,7 @@ impl Chunk {
 
         re_tracing::profile_function!(format!("{query:?}"));
 
-        let Some(component_list_array) = self.get_first_component(&component_name) else {
+        let Some(component_list_array) = self.get_first_component(component_name) else {
             return self.emptied();
         };
 

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -242,10 +242,13 @@ impl Chunk {
     #[inline]
     pub fn same_descriptors(&self, rhs: &Self) -> bool {
         self.components.keys().all(|lhs_desc| {
-            if let Some(rhs_desc) = rhs.components.keys().next() {
-                lhs_desc == rhs_desc
+            if rhs.components.contains_key(lhs_desc) {
+                return true;
             } else {
-                true
+                rhs.components
+                    .get_by_component_name(lhs_desc.component_name)
+                    .next()
+                    .is_none()
             }
         })
     }

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -243,7 +243,7 @@ impl Chunk {
     pub fn same_descriptors(&self, rhs: &Self) -> bool {
         self.components.keys().all(|lhs_desc| {
             if rhs.components.contains_key(lhs_desc) {
-                return true;
+                true
             } else {
                 rhs.components
                     .get_by_component_name(lhs_desc.component_name)

--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -246,10 +246,7 @@ impl Chunk {
         // Reminder: these are all `ListArray`s.
         re_tracing::profile_scope!("components (offsets & data)");
         {
-            for original in components
-                .values_mut()
-                .flat_map(|per_desc| per_desc.values_mut())
-            {
+            for original in components.values_mut() {
                 let sorted_arrays = swaps
                     .iter()
                     .copied()

--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -82,8 +82,7 @@ impl Chunk {
             re_tracing::profile_scope!("components");
 
             let mut components = components
-                .values()
-                .flat_map(|per_desc| per_desc.iter())
+                .iter()
                 .map(|(component_desc, list_array)| {
                     let list_array = ArrowListArray::from(list_array.clone());
                     let ComponentDescriptor {
@@ -203,10 +202,7 @@ impl Chunk {
                     component_name: schema.component_name,
                 };
 
-                if components
-                    .insert_descriptor(component_desc, column.clone())
-                    .is_some()
-                {
+                if components.insert(component_desc, column.clone()).is_some() {
                     return Err(ChunkError::Malformed {
                         reason: format!(
                             "component column '{schema:?}' was specified more than once"

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -262,7 +262,7 @@ mod tests {
                     .entry(event.chunk.entity_path().clone())
                     .or_default() += delta_chunks;
 
-                for (component_desc, list_array) in event.chunk.components().iter_flattened() {
+                for (component_desc, list_array) in event.chunk.components().iter() {
                     let delta = event.delta() * list_array.iter().flatten().count() as i64;
                     *self
                         .component_names

--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -473,20 +473,19 @@ impl ChunkStore {
             for (timeline, time_range_per_component) in chunk.time_range_per_component() {
                 let chunk_ids_to_be_removed = chunk_ids_to_be_removed.entry(timeline).or_default();
 
-                for (component_name, per_desc) in time_range_per_component {
-                    for (_component_desc, time_range) in per_desc {
-                        let chunk_ids_to_be_removed =
-                            chunk_ids_to_be_removed.entry(component_name).or_default();
+                for (component_desc, time_range) in time_range_per_component {
+                    let chunk_ids_to_be_removed = chunk_ids_to_be_removed
+                        .entry(component_desc.component_name)
+                        .or_default();
 
-                        chunk_ids_to_be_removed
-                            .entry(time_range.min())
-                            .or_default()
-                            .push(chunk.id());
-                        chunk_ids_to_be_removed
-                            .entry(time_range.max())
-                            .or_default()
-                            .push(chunk.id());
-                    }
+                    chunk_ids_to_be_removed
+                        .entry(time_range.min())
+                        .or_default()
+                        .push(chunk.id());
+                    chunk_ids_to_be_removed
+                        .entry(time_range.max())
+                        .or_default()
+                        .push(chunk.id());
                 }
             }
         }

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -771,8 +771,10 @@ impl ChunkStore {
                     .is_some_and(|time_column| {
                         time_column
                             .time_range_per_component(chunk.components())
-                            .get(&component_name)
-                            .and_then(|per_desc| per_desc.values().next())
+                            .iter()
+                            .find_map(|(desc, time_range)| {
+                                (desc.component_name == component_name).then_some(time_range)
+                            })
                             .is_some_and(|time_range| time_range.intersects(query.range()))
                     })
             })

--- a/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
@@ -8,7 +8,7 @@ ChunkStore {
     config: ChunkStoreConfig { enable_changelog: true, chunk_max_bytes: 393216, chunk_max_rows: 4096, chunk_max_rows_if_unsorted: 1024 }
     stats: {
         num_chunks: 1
-        total_size_bytes: 1.2 KiB
+        total_size_bytes: 1.1 KiB
         num_rows: 1
         num_events: 2
     }
@@ -16,7 +16,7 @@ ChunkStore {
         ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
         │ METADATA:                                                                                                                                                        │
         │ * entity_path: /this/that                                                                                                                                        │
-        │ * heap_size_bytes: 1056                                                                                                                                          │
+        │ * heap_size_bytes: 944                                                                                                                                           │
         │ * id: chunk_0000000000661EFDf2e3b19f7c045f15                                                                                                                     │
         │ * version: 1                                                                                                                                                     │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -522,9 +522,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
         /// Returns `None` if the chunk either doesn't contain a `ClearIsRecursive` column or if
         /// the end result is an empty chunk.
         fn chunk_filter_recursive_only(chunk: &Chunk) -> Option<Chunk> {
-            let list_array = chunk
-                .components()
-                .get_by_descriptor(&ClearIsRecursive::descriptor())?;
+            let list_array = chunk.components().get(&ClearIsRecursive::descriptor())?;
 
             let values = list_array
                 .values()
@@ -1152,13 +1150,13 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                     let list_array = match streaming_state {
                         StreamingJoinState::StreamingJoinState(s) => {
                             debug_assert!(
-                                s.chunk.components().iter_flattened().count() <= 1,
+                                s.chunk.components().iter().count() <= 1,
                                 "cannot possibly get more than one component with this query"
                             );
 
                             s.chunk
                                 .components()
-                                .iter_flattened()
+                                .iter()
                                 .next()
                                 .map(|(_, list_array)| list_array.slice(s.cursor as usize, 1))
 
@@ -1176,7 +1174,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                                 },
                                 ColumnDescriptor::Time(_) => None,
                             })?;
-                            unit.components().get_by_descriptor(&component_desc).cloned()
+                            unit.components().get(&component_desc).cloned()
                         }
                     };
 

--- a/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
@@ -76,7 +76,7 @@ impl ChunkUi {
 
         let components = chunk
             .components()
-            .iter_flattened()
+            .iter()
             .map(|(component_desc, list_array)| {
                 (
                     component_desc.clone(),

--- a/crates/viewer/re_view/src/lib.rs
+++ b/crates/viewer/re_view/src/lib.rs
@@ -52,7 +52,7 @@ pub fn diff_component_filter<T: re_types_core::Component>(
         .diff
         .chunk
         .components()
-        .get_by_component_name(&T::descriptor().component_name)
+        .get_by_component_name(T::descriptor().component_name)
         .any(|list_array| {
             list_array
                 .iter()

--- a/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
@@ -91,22 +91,29 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
                     max_dim.height = max_dim.height.max(new_dim.height);
                 }
             }
+
             // TODO(andreas): this should be part of the ImageFormat component's tag instead.
-            if components.contains_key(&archetypes::Image::descriptor_indicator()) {
+            if components
+                .contains_component_name(archetypes::Image::descriptor_indicator().component_name)
+            {
                 self.max_dimensions
                     .entry(event.diff.chunk.entity_path().clone())
                     .or_default()
                     .image_types
                     .insert(ImageTypes::IMAGE);
             }
-            if components.contains_key(&archetypes::SegmentationImage::descriptor_indicator()) {
+            if components.contains_component_name(
+                archetypes::SegmentationImage::descriptor_indicator().component_name,
+            ) {
                 self.max_dimensions
                     .entry(event.diff.chunk.entity_path().clone())
                     .or_default()
                     .image_types
                     .insert(ImageTypes::SEGMENTATION_IMAGE);
             }
-            if components.contains_key(&archetypes::DepthImage::descriptor_indicator()) {
+            if components.contains_component_name(
+                archetypes::DepthImage::descriptor_indicator().component_name,
+            ) {
                 self.max_dimensions
                     .entry(event.diff.chunk.entity_path().clone())
                     .or_default()

--- a/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
@@ -75,11 +75,8 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
 
             // Handle `Image`, `DepthImage`, `SegmentationImage`…
             let components = event.diff.chunk.components();
-            if let Some(all_dimensions) = components
-                .get(&ImageFormat::name())
-                .and_then(|per_desc| per_desc.values().next())
-            {
-                for new_dim in all_dimensions.iter().filter_map(|array| {
+            for image_format_list_array in components.get_by_component_name(ImageFormat::name()) {
+                for new_dim in image_format_list_array.iter().filter_map(|array| {
                     array.and_then(|array| {
                         let array = arrow::array::ArrayRef::from(array);
                         ImageFormat::from_arrow(&array).ok()?.into_iter().next()
@@ -95,25 +92,21 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
                 }
             }
             // TODO(andreas): this should be part of the ImageFormat component's tag instead.
-            if components.contains_key(&archetypes::Image::descriptor_indicator().component_name) {
+            if components.contains_key(&archetypes::Image::descriptor_indicator()) {
                 self.max_dimensions
                     .entry(event.diff.chunk.entity_path().clone())
                     .or_default()
                     .image_types
                     .insert(ImageTypes::IMAGE);
             }
-            if components
-                .contains_key(&archetypes::SegmentationImage::descriptor_indicator().component_name)
-            {
+            if components.contains_key(&archetypes::SegmentationImage::descriptor_indicator()) {
                 self.max_dimensions
                     .entry(event.diff.chunk.entity_path().clone())
                     .or_default()
                     .image_types
                     .insert(ImageTypes::SEGMENTATION_IMAGE);
             }
-            if components
-                .contains_key(&archetypes::DepthImage::descriptor_indicator().component_name)
-            {
+            if components.contains_key(&archetypes::DepthImage::descriptor_indicator()) {
                 self.max_dimensions
                     .entry(event.diff.chunk.entity_path().clone())
                     .or_default()

--- a/crates/viewer/re_view_spatial/src/mesh_cache.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_cache.rs
@@ -93,12 +93,12 @@ impl Cache for MeshCache {
                     let contains_asset_blob = event
                         .chunk
                         .components()
-                        .contains_key(&re_types::components::Blob::name());
+                        .contains_component_name(re_types::components::Blob::name());
 
                     let contains_vertex_positions = event
                         .chunk
                         .components()
-                        .contains_key(&re_types::components::Position3D::name());
+                        .contains_component_name(re_types::components::Position3D::name());
 
                     contains_asset_blob || contains_vertex_positions
                 };

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -159,7 +159,7 @@ impl Cache for ImageDecodeCache {
                     event
                         .chunk
                         .components()
-                        .contains_key(&re_types::components::Blob::name())
+                        .contains_component_name(re_types::components::Blob::name())
                 };
 
                 if is_deletion() && contains_image_blob() {

--- a/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
@@ -39,7 +39,7 @@ impl Cache for ImageStatsCache {
                     event
                         .chunk
                         .components()
-                        .contains_key(&re_types::components::Blob::name())
+                        .contains_component_name(re_types::components::Blob::name())
                 };
 
                 if is_deletion() && contains_image_blob() {

--- a/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
@@ -41,7 +41,7 @@ impl Cache for TensorStatsCache {
                     event
                         .chunk
                         .components()
-                        .contains_key(&re_types::components::TensorData::name())
+                        .contains_component_name(re_types::components::TensorData::name())
                 };
 
                 if is_deletion() && contains_tensor_data() {

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -117,7 +117,7 @@ impl Cache for VideoCache {
                     event
                         .chunk
                         .components()
-                        .contains_key(&re_types::components::Blob::name())
+                        .contains_component_name(re_types::components::Blob::name())
                 };
 
                 if is_deletion() && contains_video_blob() {

--- a/crates/viewer/re_viewer_context/src/view/visualizer_entity_subscriber.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_entity_subscriber.rs
@@ -173,7 +173,11 @@ impl ChunkStoreSubscriber for VisualizerEntitySubscriber {
             // Update indicator component tracking:
             if self.indicator_components.is_empty()
                 || self.indicator_components.iter().any(|component_name| {
-                    event.diff.chunk.components().contains_key(component_name)
+                    event
+                        .diff
+                        .chunk
+                        .components()
+                        .contains_component_name(*component_name)
                 })
             {
                 store_mapping
@@ -195,7 +199,7 @@ impl ChunkStoreSubscriber for VisualizerEntitySubscriber {
                 continue;
             }
 
-            for (component_desc, list_array) in event.diff.chunk.components().iter_flattened() {
+            for (component_desc, list_array) in event.diff.chunk.components().iter() {
                 if let Some(index) = self
                     .required_components_indices
                     .get(&component_desc.component_name)

--- a/docs/snippets/all/descriptors/descr_builtin_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_archetype.rs
@@ -46,12 +46,7 @@ fn check_tags(rec: &rerun::RecordingStream) {
         {
             let chunk = &chunks[0];
 
-            let mut descriptors = chunk
-                .components()
-                .values()
-                .flat_map(|per_desc| per_desc.keys())
-                .cloned()
-                .collect::<Vec<_>>();
+            let mut descriptors = chunk.components().keys().cloned().collect::<Vec<_>>();
             descriptors.sort();
 
             let expected = vec![
@@ -73,12 +68,7 @@ fn check_tags(rec: &rerun::RecordingStream) {
         {
             let chunk = &chunks[1];
 
-            let mut descriptors = chunk
-                .components()
-                .values()
-                .flat_map(|per_desc| per_desc.keys())
-                .cloned()
-                .collect::<Vec<_>>();
+            let mut descriptors = chunk.components().keys().cloned().collect::<Vec<_>>();
             descriptors.sort();
 
             let expected = vec![ComponentDescriptor {

--- a/docs/snippets/all/descriptors/descr_builtin_component.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_component.rs
@@ -46,12 +46,7 @@ fn check_tags(rec: &rerun::RecordingStream) {
 
         let chunk = chunks.into_iter().next().unwrap();
 
-        let mut descriptors = chunk
-            .components()
-            .values()
-            .flat_map(|per_desc| per_desc.keys())
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut descriptors = chunk.components().keys().cloned().collect::<Vec<_>>();
         descriptors.sort();
 
         let expected = vec![

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -88,12 +88,7 @@ fn check_tags(rec: &rerun::RecordingStream) {
 
         let chunk = chunks.into_iter().next().unwrap();
 
-        let mut descriptors = chunk
-            .components()
-            .values()
-            .flat_map(|per_desc| per_desc.keys())
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut descriptors = chunk.components().keys().cloned().collect::<Vec<_>>();
         descriptors.sort();
 
         let expected = vec![

--- a/docs/snippets/all/descriptors/descr_custom_component.rs
+++ b/docs/snippets/all/descriptors/descr_custom_component.rs
@@ -49,12 +49,7 @@ fn check_tags(rec: &rerun::RecordingStream) {
 
         let chunk = chunks.into_iter().next().unwrap();
 
-        let mut descriptors = chunk
-            .components()
-            .values()
-            .flat_map(|per_desc| per_desc.keys())
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut descriptors = chunk.components().keys().cloned().collect::<Vec<_>>();
         descriptors.sort();
 
         let expected = vec![


### PR DESCRIPTION
### Related

* Tiny prep piece for the next step on https://github.com/rerun-io/rerun/issues/6889

### What

After talking with @teh-cmc a bit we decided that we want to do Desc -> data/etc. maps everywhere instead of adding an indirection for component names. The latter has advantages since there are plenty situations where we want to make statements about all columns with a given component name. However, it makes a lot of things a lot more complex and the indirection is likely harmful for small numbers of columns per chunk, i.e. it becomes a bit of a muddy tradeoff.

This also happens to be a great sightseeing task for me to get started with getting queries and the viewer at large over to be working with fully tagged components.