### PR TITLE
Fix missing feature for `custom_view`

### DIFF
--- a/examples/rust/custom_view/Cargo.toml
+++ b/examples/rust/custom_view/Cargo.toml
@@ -15,6 +15,7 @@ analytics = ["rerun/analytics"]
 [dependencies]
 rerun = { path = "../../../crates/top/rerun", default-features = false, features = [
   "native_viewer",
+  "sdk",
   "server",
 ] }
 


### PR DESCRIPTION
Caused `cargo check --no-default-features -p custom_view` to fail, regressed in #9825