### PR TITLE
Tensor view improvements

### DIFF
--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -297,7 +297,7 @@ impl TensorView {
             }),
         ];
 
-        egui::ScrollArea::both().show(ui, |ui| {
+        egui::ScrollArea::both().auto_shrink(false).show(ui, |ui| {
             if let Err(err) =
                 self.tensor_slice_ui(ctx, ui, state, view_id, dimension_labels, &slice_selection)
             {
@@ -317,12 +317,12 @@ impl TensorView {
         dimension_labels: [Option<(String, bool)>; 2],
         slice_selection: &TensorSliceSelection,
     ) -> anyhow::Result<()> {
-        let (response, painter, image_rect) =
+        let (response, image_rect) =
             self.paint_tensor_slice(ctx, ui, state, view_id, slice_selection)?;
 
         if !response.hovered() {
             let font_id = egui::TextStyle::Body.resolve(ui.style());
-            paint_axis_names(ui, &painter, image_rect, font_id, dimension_labels);
+            paint_axis_names(ui, image_rect, font_id, dimension_labels);
         }
 
         Ok(())
@@ -335,7 +335,7 @@ impl TensorView {
         state: &ViewTensorState,
         view_id: ViewId,
         slice_selection: &TensorSliceSelection,
-    ) -> anyhow::Result<(egui::Response, egui::Painter, egui::Rect)> {
+    ) -> anyhow::Result<(egui::Response, egui::Rect)> {
         re_tracing::profile_function!();
 
         let Some(tensor_view) = state.tensor.as_ref() else {
@@ -411,7 +411,7 @@ impl TensorView {
             re_renderer::DebugLabel::from("tensor_slice"),
         )?;
 
-        Ok((response, painter, image_rect))
+        Ok((response, image_rect))
     }
 }
 
@@ -484,11 +484,12 @@ fn dimension_name(shape: &[TensorDimension], dim_idx: u32) -> String {
 
 fn paint_axis_names(
     ui: &egui::Ui,
-    painter: &egui::Painter,
     rect: egui::Rect,
     font_id: egui::FontId,
     dimension_labels: [Option<(String, bool)>; 2],
 ) {
+    let painter = ui.painter();
+
     let [width, height] = dimension_labels;
     let (width_name, invert_width) =
         width.map_or((None, false), |(label, invert)| (Some(label), invert));

--- a/tests/python/release_checklist/check_1d_tensor_data.py
+++ b/tests/python/release_checklist/check_1d_tensor_data.py
@@ -21,9 +21,6 @@ You should see:
 * an image view with a 1D image
 * a bar chart
 
-Known bugs:
-* TODO(#6695): When hovering over a the tensor view, a thin, black, rounded cutout appears.
-
 Bonus actions:
 * use the ui to create a tensor/bar-chart with each of the entities no matter how it was logged
     * TODO(#5847): Right now tensors & bar charts can not be reinterpreted as 2D images.


### PR DESCRIPTION
### Related

- Fixes https://github.com/rerun-io/rerun/issues/6695

### What

Small improvement to the tensor view:
- do not crop the axes label to the area of the tensor itself
- expand the scroll area to the entire view
- make the view hoverable and clickable


#### Before


<img width="220" alt="image" src="https://github.com/user-attachments/assets/34d4c7e5-f5c1-4960-899a-da3d364f7111" />


<img width="285" alt="image" src="https://github.com/user-attachments/assets/6d48ce48-4f96-46c8-97cc-8a05512e761f" />


#### After


<img width="220" alt="image" src="https://github.com/user-attachments/assets/83d00ef4-89f0-4d32-b290-ed1ca429e2c8" />


<img width="325" alt="image" src="https://github.com/user-attachments/assets/3d34913c-0124-45de-8b77-1cde7bd38c33" />
