### PR TITLE
Improve `set_time` error handling for large Python integers

### DIFF
--- a/rerun_py/rerun_sdk/rerun/time.py
+++ b/rerun_py/rerun_sdk/rerun/time.py
@@ -101,11 +101,18 @@ def set_time(
         )
     elif timestamp is not None:
         nanos = to_nanos_since_epoch(timestamp)
-        bindings.set_time_timestamp_nanos_since_epoch(
-            timeline,
-            nanos,
-            recording=recording.to_native() if recording is not None else None,
-        )
+        try:
+            bindings.set_time_timestamp_nanos_since_epoch(
+                timeline,
+                nanos,
+                recording=recording.to_native() if recording is not None else None,
+            )
+        except OverflowError as err:
+            raise ValueError(
+                f"set_time: `timestamp={timestamp!r}` is out of range; "
+                f"expected seconds since Unix epoch, datetime.datetime, or numpy.datetime64 "
+                f"(timeline='{timeline}')"
+            ) from err
 
 
 def to_nanos(duration: int | np.integer | float | np.float64 | timedelta | np.timedelta64) -> int:


### PR DESCRIPTION
### Related

* Closes #9822 

### What

Adds a clear error message when `set_time` receives an out-of-range timestamp.

