### PR TITLE
Update mac runners to `macos-15` and use clang 18

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -47,6 +47,7 @@ runs:
       shell: bash
 
     - name: Check clang version
+      if: ${{ runner.os == 'macOS' }}
       run: |
         clang --version
         which clang

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -38,6 +38,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+
     - name: Set up GCP credentials
       uses: google-github-actions/auth@v2
       with:

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -38,6 +38,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Needed because the default is clang 15 and it fails to compile some dependencies for wasm, with "LLVM error:
+    # section too large".
+    - name: Use clang 18 (mac)
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+      shell: bash
+
+    - name: Check clang version
+      run: |
+        clang --version
+        which clang
+      shell: bash
 
     - name: Set up GCP credentials
       uses: google-github-actions/auth@v2

--- a/.github/workflows/cpp_matrix_full.json
+++ b/.github/workflows/cpp_matrix_full.json
@@ -21,7 +21,7 @@
         },
         {
             "name": "Mac aarch64",
-            "runs_on": "macos-latest-large",
+            "runs_on": "macos-15-large",
             "cache_key": "build-macos-arm64",
             "extra_env_vars": "RERUN_USE_ASAN=1 LSAN_OPTIONS=suppressions=.github/workflows/lsan_suppressions.supp"
         }

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,7 +56,7 @@ jobs:
     name: cargo build on clean container
     strategy:
       matrix:
-        os: [ubuntu-latest-16-cores, macos-latest, windows-latest-8-cores]
+        os: [ubuntu-latest-16-cores, macos-15, windows-latest-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Check clang version
         run: |
-           echo $PATH
-           clang --version
-           which clang
+          echo $PATH
+          clang --version
+          which clang
 
   checks:
     name: Checks

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -16,6 +16,21 @@ permissions: write-all
 
 # These jobs use fairly short names as they are a prefix in the display hierarchy
 jobs:
+  sandbox:
+    name: macsandbox
+    runs-on: macos-latest
+    steps:
+      - name: Setup llvm 8
+        run: |
+          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+          ls "$(brew --prefix llvm@18)/bin"
+
+      - name: Check clang version
+        run: |
+           echo $PATH
+           clang --version
+           which clang
+
   checks:
     name: Checks
     if: github.event.pull_request.head.repo.owner.login == 'rerun-io'

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -18,7 +18,7 @@ permissions: write-all
 jobs:
   sandbox:
     name: macsandbox
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Setup llvm 8
         run: |

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup llvm 8
         run: |
           echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
-          ls "$(brew --prefix llvm@18)/bin"
+          ls "/opt/homebrew/opt"
 
       - name: Check clang version
         run: |

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -16,21 +16,6 @@ permissions: write-all
 
 # These jobs use fairly short names as they are a prefix in the display hierarchy
 jobs:
-  sandbox:
-    name: macsandbox
-    runs-on: macos-15
-    steps:
-      - name: Setup llvm 8
-        run: |
-          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
-          ls "/opt/homebrew/opt"
-
-      - name: Check clang version
-        run: |
-          echo $PATH
-          clang --version
-          which clang
-
   checks:
     name: Checks
     if: github.event.pull_request.head.repo.owner.login == 'rerun-io'

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -105,13 +105,13 @@ jobs:
               lib_name="rerun_c.lib"
               ;;
             macos-arm64)
-              runner="macos-latest" # Small runners, because building rerun_c is fast
+              runner="macos-15" # Small runners, because building rerun_c is fast
               target="aarch64-apple-darwin"
               container="null"
               lib_name="librerun_c.a"
               ;;
             macos-x64)
-              runner="macos-latest" # Small runners, because building rerun_c is fast
+              runner="macos-15" # Small runners, because building rerun_c is fast
               target="x86_64-apple-darwin"
               container="null"
               lib_name="librerun_c.a"

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -106,13 +106,13 @@ jobs:
               bin_name="rerun.exe"
               ;;
             macos-arm64)
-              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               bin_name="rerun"
               ;;
             macos-x64)
-              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="x86_64-apple-darwin"
               container="null"
               bin_name="rerun"

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -129,13 +129,13 @@ jobs:
               compat="manylinux_2_31"
               ;;
             macos-arm64)
-              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               compat="manylinux_2_31"
               ;;
             macos-x64)
-              runner="macos-latest-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="x86_64-apple-darwin"
               container="null"
               compat="manylinux_2_31"

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -146,12 +146,13 @@ jobs:
         with:
           pixi-version: v0.41.4
 
+      # TODO
       # Needed because the default is clang 15 and it fails to compile some dependencies for wasm, with "LLVM error:
       # section too large".
       - name: Use clang 18 (mac)
         if: ${{ matrix.name == 'macos' }}
         run: |
-          echo "$(brew --prefix clang@18)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
           cat $GITHUB_PATH
 
       - name: Check clang version

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Use clang 18 (mac)
         if: ${{ matrix.name == 'macos' }}
         run: |
-          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix clang@18)/bin" >> $GITHUB_PATH
           cat $GITHUB_PATH
 
       - name: Check clang version

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: "macos-latest"
+          - os: "macos-15"
             name: "macos"
           - os: "windows-latest-8-cores"
             name: "windows"
@@ -146,20 +146,20 @@ jobs:
         with:
           pixi-version: v0.41.4
 
-      # TODO
-      # Needed because the default is clang 15 and it fails to compile some dependencies for wasm, with "LLVM error:
-      # section too large".
-      - name: Use clang 18 (mac)
-        if: ${{ matrix.name == 'macos' }}
-        run: |
-          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
-          cat $GITHUB_PATH
-
-      - name: Check clang version
-        run: |
-          echo $PATH
-          clang --version
-          which clang
+#      # TODO
+#      # Needed because the default is clang 15 and it fails to compile some dependencies for wasm, with "LLVM error:
+#      # section too large".
+#      - name: Use clang 18 (mac)
+#        if: ${{ matrix.name == 'macos' }}
+#        run: |
+#          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+#          cat $GITHUB_PATH
+#
+#      - name: Check clang version
+#        run: |
+#          echo $PATH
+#          clang --version
+#          which clang
 
       # Install the Vulkan SDK, so we can use the software rasterizer.
       # TODO(andreas): It would be nice if `setup_software_rasterizer.py` could do that for us as well (note though that this action here is very fast when cached!)

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -146,21 +146,6 @@ jobs:
         with:
           pixi-version: v0.41.4
 
-#      # TODO
-#      # Needed because the default is clang 15 and it fails to compile some dependencies for wasm, with "LLVM error:
-#      # section too large".
-#      - name: Use clang 18 (mac)
-#        if: ${{ matrix.name == 'macos' }}
-#        run: |
-#          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
-#          cat $GITHUB_PATH
-#
-#      - name: Check clang version
-#        run: |
-#          echo $PATH
-#          clang --version
-#          which clang
-
       # Install the Vulkan SDK, so we can use the software rasterizer.
       # TODO(andreas): It would be nice if `setup_software_rasterizer.py` could do that for us as well (note though that this action here is very fast when cached!)
       - name: Install Vulkan SDK

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -152,9 +152,11 @@ jobs:
         if: ${{ matrix.name == 'macos' }}
         run: |
           echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+          cat $GITHUB_PATH
 
       - name: Check clang version
         run: |
+          echo $PATH
           clang --version
           which clang
 

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -146,6 +146,18 @@ jobs:
         with:
           pixi-version: v0.41.4
 
+      # Needed because the default is clang 15 and it fails to compile some dependencies for wasm, with "LLVM error:
+      # section too large".
+      - name: Use clang 18 (mac)
+        if: ${{ matrix.name == 'macos' }}
+        run: |
+          echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
+
+      - name: Check clang version
+        run: |
+          clang --version
+          which clang
+
       # Install the Vulkan SDK, so we can use the software rasterizer.
       # TODO(andreas): It would be nice if `setup_software_rasterizer.py` could do that for us as well (note though that this action here is very fast when cached!)
       - name: Install Vulkan SDK


### PR DESCRIPTION
### Related

- Fix CI regression introduced by #9764 

### What

#9764 pulls DataFusion to the wasm target, and old clang version struggle to deal with it (LLVM error: section too large"). In particular, it fails with the mac runners, which default to clang 15. So this PR:
- updates mac runners to 15, which include (optional) llvm 18 (note that `macos-latest` points at `macos-14`, which isn't quite the latest)
- enables llvm 18 (the default is still 15)