### PR TITLE
Properly resolve component selectors in dataset index creation and search APIs

### DIFF
--- a/crates/store/re_log_types/src/path/mod.rs
+++ b/crates/store/re_log_types/src/path/mod.rs
@@ -19,7 +19,7 @@ pub use entity_path_filter::{
     ResolvedEntityPathFilter, ResolvedEntityPathRule, RuleEffect,
 };
 pub use entity_path_part::EntityPathPart;
-pub use parse_path::PathParseError;
+pub use parse_path::{tokenize_by, PathParseError};
 
 // ----------------------------------------------------------------------------
 

--- a/crates/store/re_log_types/src/path/parse_path.rs
+++ b/crates/store/re_log_types/src/path/parse_path.rs
@@ -286,7 +286,7 @@ fn tokenize_data_path(path: &str) -> Vec<&str> {
     tokenize_by(path, b"/[]:")
 }
 
-fn tokenize_by<'s>(path: &'s str, special_chars: &[u8]) -> Vec<&'s str> {
+pub fn tokenize_by<'s>(path: &'s str, special_chars: &[u8]) -> Vec<&'s str> {
     #![allow(clippy::unwrap_used)]
 
     // We parse on bytes, and take care to only split on either side of a one-byte ASCII,

--- a/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
+use crate::{invalid_field, missing_field, TypeConversionError};
 use arrow::{datatypes::Schema as ArrowSchema, error::ArrowError};
 use re_log_types::{external::re_types_core::ComponentDescriptor, TableId};
-
-use crate::{invalid_field, missing_field, TypeConversionError};
 
 // --- Arrow ---
 

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -6,15 +6,15 @@ use arrow::{
     error::ArrowError,
 };
 
-use re_chunk::TimelineName;
-use re_log_types::EntityPath;
-
+use super::rerun_manifest_registry_v1alpha1::VectorDistanceMetric;
+use crate::common::v1alpha1::ComponentDescriptor;
 use crate::manifest_registry::v1alpha1::{
     CreatePartitionManifestsResponse, DataSourceKind, GetDatasetSchemaResponse,
 };
 use crate::{invalid_field, missing_field, TypeConversionError};
-
-use super::rerun_manifest_registry_v1alpha1::VectorDistanceMetric;
+use re_chunk::TimelineName;
+use re_log_types::EntityPath;
+use re_sorbet::ComponentColumnDescriptor;
 
 // --- QueryDataset ---
 
@@ -506,6 +506,22 @@ impl From<IndexProperties> for crate::manifest_registry::v1alpha1::IndexProperti
                     ),
                 ),
             },
+        }
+    }
+}
+
+// ---
+
+impl From<ComponentColumnDescriptor> for crate::manifest_registry::v1alpha1::IndexColumn {
+    fn from(value: ComponentColumnDescriptor) -> Self {
+        Self {
+            entity_path: Some(value.entity_path.into()),
+
+            component: Some(ComponentDescriptor {
+                archetype_name: value.archetype_name.map(|n| n.full_name().to_owned()),
+                archetype_field_name: value.archetype_field_name.map(|n| n.to_string()),
+                component_name: Some(value.component_name.full_name().to_owned()),
+            }),
         }
     }
 }

--- a/crates/store/re_sorbet/src/column_descriptor_ref.rs
+++ b/crates/store/re_sorbet/src/column_descriptor_ref.rs
@@ -5,6 +5,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ColumnDescriptorRef<'a> {
     RowId(&'a RowIdColumnDescriptor),
+    //TODO(ab): this should be renamed Index!
     Time(&'a IndexColumnDescriptor),
     Component(&'a ComponentColumnDescriptor),
 }

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -48,9 +48,11 @@ pub use self::{
     },
     migration::migrate_record_batch,
     row_id_column_descriptor::{RowIdColumnDescriptor, WrongDatatypeError},
-    selectors::{ColumnSelector, ComponentColumnSelector, TimeColumnSelector},
+    selectors::{
+        ColumnSelector, ColumnSelectorParseError, ComponentColumnSelector, TimeColumnSelector,
+    },
     sorbet_batch::SorbetBatch,
-    sorbet_columns::SorbetColumnDescriptors,
+    sorbet_columns::{ColumnSelectorResolveError, SorbetColumnDescriptors},
     sorbet_schema::SorbetSchema,
 };
 

--- a/crates/store/re_sorbet/src/selectors.rs
+++ b/crates/store/re_sorbet/src/selectors.rs
@@ -132,7 +132,7 @@ impl std::str::FromStr for ComponentColumnSelector {
     /// Parses a string in the form of `entity_path:component_name`.
     ///
     /// Note that no attempt is made to interpret `component_name`. In particular, we don't attempt
-    /// to prepend a `rerun.components.` prefix like [`ComponentPath::from_str`] does.
+    /// to prepend a `rerun.components.` prefix like `ComponentPath::from_str` does.
     fn from_str(selector: &str) -> Result<Self, Self::Err> {
         if selector.is_empty() {
             return Err(ColumnSelectorParseError::EmptyString);

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -180,6 +180,24 @@ class Schema:
 
         """
 
+    def column_for_selector(self, selector: str | ComponentColumnSelector | ComponentColumnDescriptor) -> ComponentColumnDescriptor:
+        """
+        Look up the column descriptor for a specific selector.
+
+        Parameters
+        ----------
+        selector: str | ComponentColumnDescriptor | ComponentColumnSelector
+           The selector to look up.
+
+           String arguments are expected to follow the following format:
+           `"<entity_path>:<component_name>"`
+
+        Returns
+        -------
+        ComponentColumnDescriptor
+            The column descriptor, if it exists. Raise an exception otherwise.
+        """
+
 class RecordingView:
     """
     A view of a recording restricted to a given index, containing a specific set of entities and components.
@@ -1037,7 +1055,7 @@ class Dataset(Entry):
     def create_fts_index(
         self,
         *,
-        column: ComponentColumnSelector,
+        column: str | ComponentColumnSelector | ComponentColumnDescriptor,
         time_index: IndexColumnSelector,
         store_position: bool = False,
         base_tokenizer: str = "simple",
@@ -1047,7 +1065,7 @@ class Dataset(Entry):
     def create_vector_index(
         self,
         *,
-        column: ComponentColumnSelector,
+        column: str | ComponentColumnSelector | ComponentColumnDescriptor,
         time_index: IndexColumnSelector,
         num_partitions: int = 5,
         num_sub_vectors: int = 16,
@@ -1058,14 +1076,14 @@ class Dataset(Entry):
     def search_fts(
         self,
         query: str,
-        column: ComponentColumnSelector,
+        column: str | ComponentColumnSelector | ComponentColumnDescriptor,
     ) -> DataFusionTable:
         """Search the dataset using a full-text search query."""
 
     def search_vector(
         self,
         query: Any,  # VectorLike
-        column: ComponentColumnSelector,
+        column: str | ComponentColumnSelector | ComponentColumnDescriptor,
         top_k: int,
     ) -> DataFusionTable:
         """Search the dataset using a vector search query."""

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -436,8 +436,11 @@ impl PyDataset {
 
     fn fetch_schema(self_: &PyRef<'_, Self>) -> PyResult<PySchema> {
         Self::fetch_arrow_schema(self_).and_then(|arrow_schema| {
-            let descs = SorbetColumnDescriptors::try_from_arrow_fields(None, arrow_schema.fields())
-                .map_err(to_py_err)?;
+            let descs = SorbetColumnDescriptors::try_from_arrow_fields_forgiving(
+                None,
+                arrow_schema.fields(),
+            )
+            .map_err(to_py_err)?;
 
             Ok(PySchema { schema: descs })
         })

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -16,17 +16,15 @@ use re_protos::common::v1alpha1::IfDuplicateBehavior;
 use re_protos::frontend::v1alpha1::{CreateIndexRequest, GetChunksRequest, SearchDatasetRequest};
 use re_protos::manifest_registry::v1alpha1::ext::IndexProperties;
 use re_protos::manifest_registry::v1alpha1::{
-    index_query_properties, IndexColumn, IndexConfig, IndexQueryProperties, InvertedIndexQuery,
-    VectorIndexQuery,
+    index_query_properties, IndexConfig, IndexQueryProperties, InvertedIndexQuery, VectorIndexQuery,
 };
-use re_sdk::{ComponentDescriptor, ComponentName};
-use re_sorbet::{ComponentColumnSelector, TimeColumnSelector};
+use re_sorbet::{SorbetColumnDescriptors, TimeColumnSelector};
 
 use crate::catalog::{
     dataframe_query::PyDataframeQueryView, to_py_err, PyEntry, VectorDistanceMetricLike, VectorLike,
 };
 use crate::dataframe::{
-    PyComponentColumnSelector, PyDataFusionTable, PyIndexColumnSelector, PyRecording,
+    PyComponentColumnSelector, PyDataFusionTable, PyIndexColumnSelector, PyRecording, PySchema,
 };
 use crate::utils::wait_for_future;
 
@@ -48,12 +46,14 @@ impl PyDataset {
     /// Return the Arrow schema of the data contained in the dataset.
     //TODO(#9457): there should be another `schema` method which returns a `PySchema`
     fn arrow_schema(self_: PyRef<'_, Self>) -> PyResult<PyArrowType<ArrowSchema>> {
-        let super_ = self_.as_super();
-        let mut connection = super_.client.borrow_mut(self_.py()).connection().clone();
+        let arrow_schema = Self::fetch_arrow_schema(&self_)?;
 
-        let schema = connection.get_dataset_schema(self_.py(), super_.details.id)?;
+        Ok(arrow_schema.into())
+    }
 
-        Ok(schema.into())
+    /// Return the schema of the data contained in the dataset.
+    fn schema(self_: PyRef<'_, Self>) -> PyResult<PySchema> {
+        Self::fetch_schema(&self_)
     }
 
     /// Return the partition table as a Datafusion table provider.
@@ -218,18 +218,10 @@ impl PyDataset {
         let super_ = self_.as_super();
         let connection = super_.client.borrow(self_.py()).connection().clone();
         let dataset_id = super_.details.id;
-
         let time_selector: TimeColumnSelector = time_index.into();
-        let column_selector: ComponentColumnSelector = column.into();
-        let mut component_descriptor =
-            ComponentDescriptor::new(column_selector.component_name.clone());
 
-        // TODO(jleibs): get rid of this hack
-        if component_descriptor.component_name == ComponentName::from("rerun.components.Text") {
-            component_descriptor = component_descriptor
-                .or_with_archetype_name(|| "rerun.archetypes.TextLog".into())
-                .or_with_archetype_field_name(|| "text".into());
-        }
+        let schema = Self::fetch_schema(&self_)?;
+        let component_descriptor = schema.resolve_component_column_selector(&column)?;
 
         let properties = IndexProperties::Inverted {
             store_position,
@@ -243,10 +235,7 @@ impl PyDataset {
 
             config: Some(IndexConfig {
                 properties: Some(properties.into()),
-                column: Some(IndexColumn {
-                    entity_path: Some(column_selector.entity_path.into()),
-                    component: Some(component_descriptor.into()),
-                }),
+                column: Some(component_descriptor.0.into()),
                 time_index: Some(time_selector.timeline.into()),
             }),
 
@@ -286,8 +275,9 @@ impl PyDataset {
         let dataset_id = super_.details.id;
 
         let time_selector: TimeColumnSelector = time_index.into();
-        let column_selector: ComponentColumnSelector = column.into();
-        let component_descriptor = ComponentDescriptor::new(column_selector.component_name.clone());
+
+        let schema = Self::fetch_schema(&self_)?;
+        let component_descriptor = schema.resolve_component_column_selector(&column)?;
 
         let distance_metric: re_protos::manifest_registry::v1alpha1::VectorDistanceMetric =
             distance_metric.try_into()?;
@@ -305,10 +295,7 @@ impl PyDataset {
 
             config: Some(IndexConfig {
                 properties: Some(properties.into()),
-                column: Some(IndexColumn {
-                    entity_path: Some(column_selector.entity_path.into()),
-                    component: Some(component_descriptor.into()),
-                }),
+                column: Some(component_descriptor.0.into()),
                 time_index: Some(time_selector.timeline.into()),
             }),
 
@@ -336,8 +323,8 @@ impl PyDataset {
         let connection = super_.client.borrow(self_.py()).connection().clone();
         let dataset_id = super_.details.id;
 
-        let column_selector: ComponentColumnSelector = column.into();
-        let component_descriptor = ComponentDescriptor::new(column_selector.component_name.clone());
+        let schema = Self::fetch_schema(&self_)?;
+        let component_descriptor = schema.resolve_component_column_selector(&column)?;
 
         let schema = arrow::datatypes::Schema::new_with_metadata(
             vec![Field::new("items", arrow::datatypes::DataType::Utf8, false)],
@@ -352,10 +339,7 @@ impl PyDataset {
 
         let request = SearchDatasetRequest {
             dataset_id: Some(dataset_id.into()),
-            column: Some(IndexColumn {
-                entity_path: Some(column_selector.entity_path.into()),
-                component: Some(component_descriptor.into()),
-            }),
+            column: Some(component_descriptor.0.into()),
             properties: Some(IndexQueryProperties {
                 props: Some(
                     re_protos::manifest_registry::v1alpha1::index_query_properties::Props::Inverted(
@@ -400,17 +384,14 @@ impl PyDataset {
         let connection = super_.client.borrow(self_.py()).connection().clone();
         let dataset_id = super_.details.id;
 
-        let column_selector: ComponentColumnSelector = column.into();
-        let component_descriptor = ComponentDescriptor::new(column_selector.component_name.clone());
+        let schema = Self::fetch_schema(&self_)?;
+        let component_descriptor = schema.resolve_component_column_selector(&column)?;
 
         let query = query.to_record_batch()?;
 
         let request = SearchDatasetRequest {
             dataset_id: Some(dataset_id.into()),
-            column: Some(IndexColumn {
-                entity_path: Some(column_selector.entity_path.into()),
-                component: Some(component_descriptor.into()),
-            }),
+            column: Some(component_descriptor.0.into()),
             properties: Some(IndexQueryProperties {
                 props: Some(index_query_properties::Props::Vector(VectorIndexQuery {
                     top_k: Some(top_k),
@@ -439,6 +420,26 @@ impl PyDataset {
             client: super_.client.clone_ref(self_.py()),
             name,
             provider,
+        })
+    }
+}
+
+impl PyDataset {
+    fn fetch_arrow_schema(self_: &PyRef<'_, Self>) -> PyResult<ArrowSchema> {
+        let super_ = self_.as_super();
+        let mut connection = super_.client.borrow_mut(self_.py()).connection().clone();
+
+        let schema = connection.get_dataset_schema(self_.py(), super_.details.id)?;
+
+        Ok(schema)
+    }
+
+    fn fetch_schema(self_: &PyRef<'_, Self>) -> PyResult<PySchema> {
+        Self::fetch_arrow_schema(self_).and_then(|arrow_schema| {
+            let descs = SorbetColumnDescriptors::try_from_arrow_fields(None, arrow_schema.fields())
+                .map_err(to_py_err)?;
+
+            Ok(PySchema { schema: descs })
         })
     }
 }

--- a/rerun_py/src/catalog/errors.rs
+++ b/rerun_py/src/catalog/errors.rs
@@ -58,6 +58,12 @@ enum ExternalError {
 
     #[error(transparent)]
     SorbetError(#[from] re_sorbet::SorbetError),
+
+    #[error(transparent)]
+    ColumnSelectorParseError(#[from] re_sorbet::ColumnSelectorParseError),
+
+    #[error(transparent)]
+    ColumnSelectorResolveError(#[from] re_sorbet::ColumnSelectorResolveError),
 }
 
 impl From<re_protos::manifest_registry::v1alpha1::ext::GetDatasetSchemaResponseError>
@@ -118,6 +124,12 @@ impl From<ExternalError> for PyErr {
 
             ExternalError::SorbetError(err) => {
                 PyValueError::new_err(format!("Sorbet error: {err}"))
+            }
+
+            ExternalError::ColumnSelectorParseError(err) => PyValueError::new_err(format!("{err}")),
+
+            ExternalError::ColumnSelectorResolveError(err) => {
+                PyValueError::new_err(format!("{err}"))
             }
         }
     }

--- a/rerun_py/src/catalog/errors.rs
+++ b/rerun_py/src/catalog/errors.rs
@@ -55,6 +55,9 @@ enum ExternalError {
 
     #[error(transparent)]
     CodecError(#[from] re_log_encoding::codec::CodecError),
+
+    #[error(transparent)]
+    SorbetError(#[from] re_sorbet::SorbetError),
 }
 
 impl From<re_protos::manifest_registry::v1alpha1::ext::GetDatasetSchemaResponseError>
@@ -112,6 +115,10 @@ impl From<ExternalError> for PyErr {
             }
 
             ExternalError::CodecError(err) => PyValueError::new_err(format!("Codec error: {err}")),
+
+            ExternalError::SorbetError(err) => {
+                PyValueError::new_err(format!("Sorbet error: {err}"))
+            }
         }
     }
 }

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -567,16 +567,21 @@ impl PySchema {
     ///
     /// Parameters
     /// ----------
-    /// component_column_selector: str | ComponentColumnDescriptor | ComponentColumnSelector
+    /// selector: str | ComponentColumnDescriptor | ComponentColumnSelector
     ///    The selector to look up.
     ///
     ///    String arguments are expected to follow the following format:
     ///    `"<entity_path>:<component_name>"`
+    ///
+    /// Returns
+    /// -------
+    /// ComponentColumnDescriptor
+    ///     The column descriptor, if it exists. Raise an exception otherwise.
     pub fn column_for_selector(
         &self,
-        component_column_selector: AnyComponentColumn,
+        selector: AnyComponentColumn,
     ) -> PyResult<PyComponentColumnDescriptor> {
-        match component_column_selector {
+        match selector {
             AnyComponentColumn::Name(name) => self.resolve_component_column_selector(
                 &ComponentColumnSelector::from_str(&name).map_err(to_py_err)?,
             ),


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/9837
* Further issue to address:
  * https://github.com/rerun-io/rerun/issues/9853
  * #9855 

### What

Initial attempt to formalise component column selector, how they are matched against a schema, and how they are expressed in our Python API. Applied on dataset index creation/search APIs.

TODO:
- [x] use `AnyComponentColumn` in APIs
- [x] cleanup and fix type stubs