### PR TITLE
Check `.pyi` files in PRs

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -69,6 +69,7 @@ jobs:
               - pixi.toml # maybe our build commands have changed
               - scripts/ci/*
               - '**/*.py'
+              - '**/*.pyi'
               - '**/requirements.txt'
               - '**/pyproject.toml'
 


### PR DESCRIPTION
It wasn't part of the path filter, so python checks would not run if it was the only changed filetype, even though it could then fail on `main` due to e.g. bad formatting.