### PR TITLE
Improve PR number parsing resiliency

### DIFF
--- a/.github/workflows/auto_docs.yml
+++ b/.github/workflows/auto_docs.yml
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
         run: |
           commit_message=$(git log --pretty=format:%s -n 1 ${{ github.sha }})
-          pr_number=$(echo $commit_message | grep -oP '(?<=#)\d+')
+          pr_number=$(python3 scripts/ci/parse_pr_number.py "$commit_message")
 
           result=$(gh pr view $pr_number --json labels | jq -r 'any(.labels[].name; . == "deploy docs")')
           echo "result=$result" >> $GITHUB_OUTPUT

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 rerun_cpp/docs/**/*
 
 rerun_py/docs/templates/**
+rerun_py/site/**
 
 rerun_js/web-viewer/re_viewer_bg.js
 rerun_js/web-viewer/re_viewer.js

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -180,7 +180,9 @@ class Schema:
 
         """
 
-    def column_for_selector(self, selector: str | ComponentColumnSelector | ComponentColumnDescriptor) -> ComponentColumnDescriptor:
+    def column_for_selector(
+        self, selector: str | ComponentColumnSelector | ComponentColumnDescriptor
+    ) -> ComponentColumnDescriptor:
         """
         Look up the column descriptor for a specific selector.
 

--- a/scripts/ci/parse_pr_number.py
+++ b/scripts/ci/parse_pr_number.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def parse_pr_number(commit_message: str) -> int:
+    first_line = commit_message.splitlines()[0]
+    start_idx = first_line.rfind("(#")
+    if start_idx == -1:
+        raise Exception("failed to parse PR number: no PR number in commit message, expected to find '(#1234)'")
+    start_idx += 2  # trim '(#'
+
+    end_idx = first_line.find(")", start_idx)
+    if end_idx == -1:
+        raise Exception("failed to parse PR number: unclosed parenthesis, expected to find '(#1234)'")
+    # end idx is exclusive, no need to trim
+
+    digits = first_line[start_idx:end_idx]
+    return int(digits)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("commit_message", type=str)
+
+    args, unknown = parser.parse_known_args()
+    for arg in unknown:
+        print(f"Unknown argument: {arg}")
+
+    pr_number = parse_pr_number(args.commit_message)
+    sys.stdout.write(str(pr_number))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This sort of thing failed before, because there were two PR numbers in the title:
* [Fix lint error from #9854 (#9856)](https://github.com/rerun-io/rerun/commit/fba7990af2f22d98dcbbb9e7a51a6e1af7c0fc8b)

Now it won't