### PR TITLE
Fix world grid not scaling correctly when camera is below the grid

### DIFF
--- a/crates/viewer/re_renderer/shader/utils/plane.wgsl
+++ b/crates/viewer/re_renderer/shader/utils/plane.wgsl
@@ -9,6 +9,8 @@ struct Plane {
 }
 
 /// How far away is a given point from the plane?
+///
+/// Returns a *signed* distance! Positive, when the point is above the plane, negative when below.
 fn distance_to_plane(plane: Plane, point: vec3f) -> f32 {
     return dot(plane.normal, point) - plane.distance;
 }

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -39,7 +39,7 @@ struct VertexOutput {
 @vertex
 fn main_vs(@builtin(vertex_index) v_idx: u32) -> VertexOutput {
     var out: VertexOutput;
-    let camera_plane_distance_world = distance_to_plane(config.plane, frame.camera_position);
+    let camera_plane_distance_world = abs(distance_to_plane(config.plane, frame.camera_position));
 
     // Scale the plane geometry based on the distance to the camera.
     // This preserves relative precision MUCH better than a fixed scale.


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/9866


### What

Before:
![image](https://github.com/user-attachments/assets/f4149e74-0dc9-4afb-ab79-ddb071167a51)


After:
![image](https://github.com/user-attachments/assets/7705758e-73ed-4476-a19f-a4338eef03e1)
