### PR TITLE
Fix incorrectly advertised minimum supported `pyarrow` version (18.0.0 is required)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11478,6 +11478,19 @@ packages:
   - jinja2 ; extra == 'compiler'
   - protobuf ; extra == 'compiler'
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/ff/2e/abfed7a721928e14aeb900182ff695be474c4ee5f07ef0874cc5ecd5b0b1/betterproto-1.2.5.tar.gz
+  name: betterproto
+  version: 1.2.5
+  sha256: 74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d
+  requires_dist:
+  - dataclasses ; python_full_version < '3.7'
+  - backports-datetime-fromisoformat ; python_full_version < '3.7'
+  - grpclib
+  - stringcase
+  - black ; extra == 'compiler'
+  - jinja2 ; extra == 'compiler'
+  - protobuf ; extra == 'compiler'
+  requires_python: '>=3.6'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binaryen-117-h59595ed_0.conda
   sha256: f6d7f876c514d2d138fd8b06e485b042598cf3dcda40a8a346252bb7e1adf8d7
   md5: 58aea5eaef8cb663104654734d432ba3
@@ -25583,6 +25596,15 @@ packages:
   - deprecated
   - dataclasses ; python_full_version == '3.6.*'
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
+  name: pygltflib
+  version: 1.16.2
+  sha256: 4f9481f5841b0b8fb7b271b0414b394b503405260a6ee0cf2c330a5420d19b64
+  requires_dist:
+  - dataclasses ; python_full_version == '3.6.*'
+  - dataclasses-json>=0.0.25
+  - deprecated
+  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
   name: pygments
   version: 2.18.0
@@ -26419,12 +26441,12 @@ packages:
 - pypi: rerun_py
   name: rerun-sdk
   version: 0.24.0a1+dev
-  sha256: bee557d69aa460307a5b55658b8b969997d2cadef691f4cb5f178f7663a1242b
+  sha256: 69ec6b0db03d0911c625900d20065ccef1fc62fe243300565c05c41d6e1e0272
   requires_dist:
   - attrs>=23.1.0
   - numpy>=1.23
   - pillow>=8.0.0
-  - pyarrow>=14.0.2
+  - pyarrow>=18.0.0
   - typing-extensions>=4.5
   - pytest==7.1.2 ; extra == 'tests'
   - rerun-notebook==0.24.0a1+dev ; extra == 'notebook'

--- a/pixi.toml
+++ b/pixi.toml
@@ -509,7 +509,7 @@ nasm = ">=2.16"                   # Required by https://github.com/memorysafety/
 ninja = "1.11.1.*"
 numpy = ">=2"
 prettier = "3.2.5.*"
-pyarrow = "18.0.0.*"
+pyarrow = "18.0.0.*"              # Whenever upgrading here, also make sure to upgrade in `rerun_py/pyproject.toml`
 pytest = ">=7"
 pytest-benchmark = ">=4.0.0,<4.1"
 python = "=3.11"                  # We use the latest Python version here, so we get the latest mypy etc, EXCEPT 3.12 is too new for some of our examples. We run our CI tests on ALL supported versions though.

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "attrs>=23.1.0",
   "numpy>=1.23",
   "pillow>=8.0.0",          # Used for JPEG encoding. 8.0.0 added the `format` arguments to `Image.open`
-  "pyarrow>=14.0.2",
+  "pyarrow>=18.0.0",
   "typing_extensions>=4.5", # Used for PEP-702 deprecated decorator
 ]
 description = "The Rerun Logging SDK"


### PR DESCRIPTION
### Related

* fixes https://github.com/rerun-io/rerun/issues/9843
* replaces https://github.com/rerun-io/rerun/pull/9876

### What

The rerun python sdk incorrectly advertised being compatible with pyarrow 14.0.2, when in actuality we require 18.0.0.
(This is the oldest version that seems to be working with our current codebase and is what we previously tested locally & ci via the pixi environment setting)