### PR TITLE
Fix incorrectly advertised numpy 1.x support (numpy2 is required now)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -11470,19 +11470,6 @@ packages:
   version: 1.2.5
   sha256: 74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d
   requires_dist:
-  - grpclib
-  - stringcase
-  - dataclasses ; python_full_version < '3.7'
-  - backports-datetime-fromisoformat ; python_full_version < '3.7'
-  - black ; extra == 'compiler'
-  - jinja2 ; extra == 'compiler'
-  - protobuf ; extra == 'compiler'
-  requires_python: '>=3.6'
-- pypi: https://files.pythonhosted.org/packages/ff/2e/abfed7a721928e14aeb900182ff695be474c4ee5f07ef0874cc5ecd5b0b1/betterproto-1.2.5.tar.gz
-  name: betterproto
-  version: 1.2.5
-  sha256: 74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d
-  requires_dist:
   - dataclasses ; python_full_version < '3.7'
   - backports-datetime-fromisoformat ; python_full_version < '3.7'
   - grpclib
@@ -25592,15 +25579,6 @@ packages:
   version: 1.16.2
   sha256: 4f9481f5841b0b8fb7b271b0414b394b503405260a6ee0cf2c330a5420d19b64
   requires_dist:
-  - dataclasses-json>=0.0.25
-  - deprecated
-  - dataclasses ; python_full_version == '3.6.*'
-  requires_python: '>=3.6'
-- pypi: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
-  name: pygltflib
-  version: 1.16.2
-  sha256: 4f9481f5841b0b8fb7b271b0414b394b503405260a6ee0cf2c330a5420d19b64
-  requires_dist:
   - dataclasses ; python_full_version == '3.6.*'
   - dataclasses-json>=0.0.25
   - deprecated
@@ -26441,10 +26419,10 @@ packages:
 - pypi: rerun_py
   name: rerun-sdk
   version: 0.24.0a1+dev
-  sha256: 69ec6b0db03d0911c625900d20065ccef1fc62fe243300565c05c41d6e1e0272
+  sha256: b9daa6c2b4c0a3451a73e1bc2c75322443da1f074406d2a93d3d975f08222be4
   requires_dist:
   - attrs>=23.1.0
-  - numpy>=1.23
+  - numpy>=2
   - pillow>=8.0.0
   - pyarrow>=18.0.0
   - typing-extensions>=4.5

--- a/pixi.toml
+++ b/pixi.toml
@@ -507,7 +507,7 @@ jinja2 = ">=3.1.3,<3.2"           # For `build_screenshot_compare.py` and other 
 mypy = "1.14.1.*"
 nasm = ">=2.16"                   # Required by https://github.com/memorysafety/rav1d for native video support
 ninja = "1.11.1.*"
-numpy = ">=2"
+numpy = ">=2"                     # Whenever upgrading here, also make sure to upgrade in `rerun_py/pyproject.toml`
 prettier = "3.2.5.*"
 pyarrow = "18.0.0.*"              # Whenever upgrading here, also make sure to upgrade in `rerun_py/pyproject.toml`
 pytest = ">=7"

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -11,10 +11,12 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Scientific/Engineering :: Visualization",
 ]
+# Keep in mind that tested dependencies are usually goverend by `pixi.toml`
+# which means that any changes to the dependencies here should be reflected there as well.
 dependencies = [
   # Must match list in `.github/workflows/reusable_test_wheels.yml`
   "attrs>=23.1.0",
-  "numpy>=1.23",
+  "numpy>=2",
   "pillow>=8.0.0",          # Used for JPEG encoding. 8.0.0 added the `format` arguments to `Image.open`
   "pyarrow>=18.0.0",
   "typing_extensions>=4.5", # Used for PEP-702 deprecated decorator


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/9862

### What

The rerun python sdk incorrectly advertised being compatible with numpy 1.x when in actuallity we unintentionally made numpy 2 mandatory in 0.23.0. This changes make numpy 2.0.0 the minimum requirement.

(The only _known_ piece that introduced the dependency is that we started using the `copy` parameter of `asarray` which is only available in numpy 2)