### PR TITLE
Propagate `re_grpc_server` TCP error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7095,6 +7095,7 @@ dependencies = [
 name = "re_grpc_server"
 version = "0.24.0-alpha.1+dev"
 dependencies = [
+ "anyhow",
  "crossbeam",
  "parking_lot",
  "re_build_info",

--- a/crates/store/re_grpc_server/Cargo.toml
+++ b/crates/store/re_grpc_server/Cargo.toml
@@ -35,6 +35,7 @@ re_types.workspace = true
 re_uri.workspace = true
 
 # External
+anyhow.workspace = true
 crossbeam.workspace = true
 parking_lot.workspace = true
 tonic = { workspace = true, default-features = false, features = ["transport"] }

--- a/crates/store/re_grpc_server/src/main.rs
+++ b/crates/store/re_grpc_server/src/main.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddrV4;
 use re_grpc_server::{serve, shutdown, DEFAULT_MEMORY_LIMIT, DEFAULT_SERVER_PORT};
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), tonic::transport::Error> {
+async fn main() -> anyhow::Result<()> {
     re_log::setup_logging();
 
     serve(
@@ -16,5 +16,7 @@ async fn main() -> Result<(), tonic::transport::Error> {
         DEFAULT_MEMORY_LIMIT,
         shutdown::never(),
     )
-    .await
+    .await?;
+
+    Ok(())
 }


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/9829

Using `anyhow`, because these errors are not inspectable anyway