### PR TITLE
Visualizers' data queries take component tags into account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8142,6 +8142,7 @@ dependencies = [
  "image",
  "indexmap 2.8.0",
  "itertools 0.14.0",
+ "linked-hash-map",
  "ndarray",
  "nohash-hasher",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8142,7 +8142,6 @@ dependencies = [
  "image",
  "indexmap 2.8.0",
  "itertools 0.14.0",
- "linked-hash-map",
  "ndarray",
  "nohash-hasher",
  "once_cell",

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -51,16 +51,6 @@ impl ChunkStore {
 
         let mut chunk = Arc::clone(chunk);
 
-        // We're in a transition period during which the Rerun ecosystem is slowly moving over to tagged data.
-        //
-        // During that time, it is common to end up in situations where the blueprint intermixes both tagged
-        // and untagged components, which invariably leads to undefined behavior.
-        // To prevent that, we just always hot-patch it to untagged, for now.
-        //
-        // Examples:
-        // * An SDK logs a blueprint (tagged), which is then updated by the viewer (which uses untagged log calls).
-        // * Somebody loads an old .rbl from somewhere and starts logging new blueprint data to it.
-        // * Etc.
         if self.id.kind == re_log_types::StoreKind::Blueprint {
             let patched = chunk.patched_for_blueprint_021_compat();
             chunk = Arc::new(patched);

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -164,13 +164,27 @@ impl EntityDb {
             })
     }
 
-    /// Queries for the given `component_names` using latest-at semantics.
+    /// Queries for the given components using latest-at semantics.
     ///
     /// See [`re_query::LatestAtResults`] for more information about how to handle the results.
     ///
     /// This is a cached API -- data will be lazily cached upon access.
     #[inline]
-    pub fn latest_at(
+    pub fn latest_at<'a>(
+        &self,
+        query: &re_chunk_store::LatestAtQuery,
+        entity_path: &EntityPath,
+        component_descr: impl IntoIterator<Item = &'a re_types_core::ComponentDescriptor>,
+    ) -> re_query::LatestAtResults {
+        self.storage_engine
+            .read()
+            .cache()
+            .latest_at(query, entity_path, component_descr)
+    }
+
+    // TODO(#6889): Remove.
+    #[inline]
+    pub fn latest_at_by_name(
         &self,
         query: &re_chunk_store::LatestAtQuery,
         entity_path: &EntityPath,

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -64,7 +64,7 @@ impl QueryCache {
                 // TODO(#6889): As an interim step we ignore the descriptor here for the moment.
                 let component_descr = match maybe_component_descr.into() {
                     MaybeTagged::Descriptor(component_descr) => {
-                        debug_assert!(component_descr.archetype_name.is_some() || component_descr.component_name.is_indicator_component(),
+                        debug_assert!(component_descr.archetype_name.is_some() || component_descr.component_name.is_indicator_component() || component_descr.component_name == "rerun.blueprint.components.VisualizerOverride",
                          "TODO(#6889): Got full descriptor for query but archetype name was None, this hints at an incorrectly patched query callsite. Descr: {component_descr}");
 
                         if component_descr.archetype_name.is_none_or(|archetype_name| archetype_name.as_str().starts_with("rerun.blueprint.") ) {
@@ -376,9 +376,7 @@ impl LatestAtResults {
 
     /// Returns the `RowId` for the specified component.
     #[inline]
-    pub fn component_row_id(&self, component_name: &ComponentName) -> Option<RowId> {
-        let component_descr = self.find_component_descriptor(*component_name)?;
-
+    pub fn component_row_id(&self, component_descr: &ComponentDescriptor) -> Option<RowId> {
         self.components
             .get(component_descr)
             .and_then(|unit| unit.row_id())

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -64,8 +64,12 @@ impl QueryCache {
                 // TODO(#6889): As an interim step we ignore the descriptor here for the moment.
                 let component_descr = match maybe_component_descr.into() {
                     MaybeTagged::Descriptor(component_descr) => {
-                        debug_assert!(component_descr.archetype_name.is_some() || component_descr.component_name.is_indicator_component() || component_descr.component_name == "rerun.blueprint.components.VisualizerOverride",
-                         "TODO(#6889): Got full descriptor for query but archetype name was None, this hints at an incorrectly patched query callsite. Descr: {component_descr}");
+                        debug_assert!(component_descr.archetype_name.is_some() ||
+                                        component_descr.component_name.is_indicator_component() ||
+                                        component_descr.component_name == "rerun.blueprint.components.VisualizerOverride" ||
+                                        entity_path.iter().any(|p| p.unescaped_str() == "overrides") ||
+                                        entity_path.iter().any(|p| p.unescaped_str() == "defaults"),
+                         "TODO(#6889): Got full descriptor for query but archetype name was None, this hints at an incorrectly patched query callsite. Descr: {component_descr}. Path: {entity_path:?}");
 
                         if component_descr.archetype_name.is_none_or(|archetype_name| archetype_name.as_str().starts_with("rerun.blueprint.") ) {
                             // TODO(#6889): ALWAYS ignore tags on blueprint right now because some writes & reads are tagged and others aren't.

--- a/crates/store/re_query/src/range.rs
+++ b/crates/store/re_query/src/range.rs
@@ -44,7 +44,9 @@ impl QueryCache {
                         debug_assert!(component_descr.archetype_name.is_some() || component_descr.component_name.is_indicator_component(),
                          "TODO(#6889): Got full descriptor for query but archetype name was None, this hints at an incorrectly patched query callsite. Descr: {component_descr}");
 
-                        if component_descr.archetype_name.is_none_or(|archetype_name| archetype_name.as_str().starts_with("rerun.blueprint.") ) {
+                        if component_descr.archetype_name.is_none_or(|archetype_name| {
+                            archetype_name.as_str().starts_with("rerun.blueprint.")
+                        }) {
                             // TODO(#6889): ALWAYS ignore tags on blueprint right now because some writes & reads are tagged and others aren't.
                             // See https://github.com/rerun-io/rerun/blob/8fb5aadcb8f4f35c8e22603c85beda6fb18d791b/crates/store/re_chunk_store/src/writes.rs#L54-L67
                             store
@@ -69,7 +71,8 @@ impl QueryCache {
                         query.timeline(),
                         entity_path,
                         &component_descr,
-                    ).then_some(component_descr)
+                    )
+                    .then_some(component_descr)
             });
 
         for component_descr in component_descrs {

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate provides ui elements for Rerun component data for the Rerun Viewer.
 
 use re_log_types::{hash::Hash64, EntityPath};
-use re_types::{ComponentDescriptor, ComponentName};
+use re_types::ComponentDescriptor;
 use re_viewer_context::{UiLayout, ViewerContext};
 
 mod annotation_context;
@@ -27,19 +27,6 @@ pub mod item_ui;
 pub use crate::tensor::tensor_summary_ui_grid_contents;
 pub use component::ComponentPathLatestAtResults;
 pub use component_ui_registry::{add_to_registry, register_component_uis};
-
-/// Sort components for display in the UI.
-pub fn sorted_component_name_list_for_ui<'a>(
-    iter: impl IntoIterator<Item = &'a ComponentName> + 'a,
-) -> Vec<ComponentName> {
-    let mut components: Vec<ComponentName> = iter.into_iter().copied().collect();
-
-    // Put indicator components first.
-    // We then sort by the short name, as that is what is shown in the UI.
-    components.sort_by_key(|c| (!c.is_indicator_component(), c.short_name()));
-
-    components
-}
 
 /// Sort components for display in the UI.
 pub fn sorted_component_list_for_ui<'a>(

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -157,7 +157,7 @@ fn active_default_ui(
                         .value_fn(|ui, _| value_fn(ui)),
                 )
                 .on_hover_ui(|ui| {
-                    // TODO: data ui for component descr!
+                    // TODO(andreas): Add data ui for component descr?
                     component_descr.component_name.data_ui_recording(
                         ctx.viewer_ctx,
                         ui,
@@ -285,7 +285,7 @@ fn add_popup_ui(
         if ui
             .button(component_descr.syntax_highlighted(ui.style()))
             .on_hover_ui(|ui| {
-                // TODO: data ui for component descr!
+                // TODO(andreas): Add data ui for component descr?
                 component_descr.component_name.data_ui_recording(
                     ctx.viewer_ctx,
                     ui,

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -241,7 +241,7 @@ fn active_defaults(
 fn components_to_show_in_add_menu(
     ctx: &ViewContext<'_>,
     visualized_components_by_archetype: &BTreeMap<ArchetypeName, Vec<DefaultOverrideEntry>>,
-    active_defaults: &IntMap<ComponentDescriptor, ArrayRef>,
+    active_defaults: &BTreeMap<ComponentDescriptor, ArrayRef>,
 ) -> Result<BTreeMap<ArchetypeName, Vec<DefaultOverrideEntry>>, String> {
     if visualized_components_by_archetype.is_empty() {
         return Err("No components to visualize".to_owned());

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -188,6 +188,11 @@ fn visualized_components_by_archetype(
             else {
                 // TODO(andreas): In theory this is perfectly valid: A visualizer may be interested in an untagged component!
                 // Practically this never happens and we don't handle this in the ui here yet.
+                re_log::warn_once!(
+                    "Visualizer {} queried untagged component {}. It won't show in the defaults ui.",
+                    id,
+                    descr.component_name
+                );
                 continue;
             };
 
@@ -201,9 +206,6 @@ fn visualized_components_by_archetype(
                 });
         }
     }
-
-    // It should be near-impossible, but just in case two visualizers use the exact same (tagged) component,
-    // make the first one win.
 
     visualized_components_by_visualizer
 }

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeMap;
 
+use arrow::array::ArrayRef;
 use itertools::Itertools as _;
 
-use re_chunk::{Chunk, RowId};
+use nohash_hasher::IntMap;
+use re_chunk::{ArchetypeFieldName, ArchetypeName, Chunk, ComponentName, RowId};
 use re_chunk_store::LatestAtQuery;
-use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
-use re_log_types::hash::Hash64;
+use re_data_ui::DataUi as _;
 use re_log_types::EntityPath;
-use re_types::ComponentDescriptorSet;
 use re_types_core::ComponentDescriptor;
 use re_ui::{list_item::LabelContent, SyntaxHighlighting as _, UiExt as _};
 use re_viewer_context::{
@@ -15,6 +15,26 @@ use re_viewer_context::{
     UiLayout, ViewContext, ViewSystemIdentifier,
 };
 use re_viewport_blueprint::ViewBlueprint;
+
+/// Entry that we can show in the defaults ui.
+#[derive(Clone, Debug)]
+struct DefaultOverrideEntry {
+    component_name: ComponentName,
+    archetype_field_name: ArchetypeFieldName,
+
+    /// Visualizer identifier that provides the fallback value for this component.
+    visualizer_identifier: ViewSystemIdentifier,
+}
+
+impl DefaultOverrideEntry {
+    fn descriptor(&self, archetype_name: ArchetypeName) -> ComponentDescriptor {
+        ComponentDescriptor {
+            component_name: self.component_name,
+            archetype_field_name: Some(self.archetype_field_name),
+            archetype_name: Some(archetype_name),
+        }
+    }
+}
 
 pub fn view_components_defaults_section_ui(
     ctx: &ViewContext<'_>,
@@ -25,16 +45,16 @@ pub fn view_components_defaults_section_ui(
     let query = ctx.viewer_ctx.blueprint_query;
 
     let active_defaults = active_defaults(ctx, view, db, query);
-    let component_to_vis = component_to_vis(ctx);
+    let visualized_components_by_archetype = visualized_components_by_archetype(ctx);
 
     // If there is nothing set by the user and nothing to be possibly added, we skip the section
     // entirely.
-    if active_defaults.is_empty() && component_to_vis.is_empty() {
+    if active_defaults.is_empty() && visualized_components_by_archetype.is_empty() {
         return;
     }
 
     let components_to_show_in_add_menu =
-        components_to_show_in_add_menu(ctx, &component_to_vis, &active_defaults);
+        components_to_show_in_add_menu(ctx, &visualized_components_by_archetype, &active_defaults);
     let reason_we_cannot_add_more = components_to_show_in_add_menu.as_ref().err().cloned();
 
     let mut add_button_is_open = false;
@@ -62,15 +82,7 @@ override is specified.\n
 Click on the `+` button to add a new default value.";
 
     let body = |ui: &mut egui::Ui| {
-        active_default_ui(
-            ctx,
-            ui,
-            &active_defaults,
-            &component_to_vis,
-            view,
-            query,
-            db,
-        );
+        active_default_ui(ctx, ui, &active_defaults, view, query, db);
     };
     ui.section_collapsing_header("Component defaults")
         .button(add_button)
@@ -81,14 +93,11 @@ Click on the `+` button to add a new default value.";
 fn active_default_ui(
     ctx: &ViewContext<'_>,
     ui: &mut egui::Ui,
-    active_defaults: &ComponentDescriptorSet,
-    component_to_vis: &BTreeMap<ComponentDescriptor, ViewSystemIdentifier>,
+    active_defaults: &IntMap<ComponentDescriptor, ArrayRef>,
     view: &ViewBlueprint,
     query: &LatestAtQuery,
     db: &re_entity_db::EntityDb,
 ) {
-    let sorted_overrides = sorted_component_list_for_ui(active_defaults.iter());
-
     let query_context = QueryContext {
         viewer_ctx: ctx.viewer_ctx,
         target_entity_path: &view.defaults_path,
@@ -101,91 +110,102 @@ fn active_default_ui(
     re_ui::list_item::list_item_scope(ui, "defaults", |ui| {
         ui.spacing_mut().item_spacing.y = 0.0;
 
-        if sorted_overrides.is_empty() {
+        if active_defaults.is_empty() {
             ui.list_item_flat_noninteractive(LabelContent::new("none").weak(true).italics(true));
         }
 
-        for component_descr in sorted_overrides {
-            let Some(visualizer_identifier) = component_to_vis.get(&component_descr) else {
-                continue;
-            };
-            let Ok(visualizer) = ctx
-                .visualizer_collection
-                .get_by_identifier(*visualizer_identifier)
-            else {
-                re_log::warn!(
-                    "Failed to resolve visualizer identifier {visualizer_identifier}, to a \
-                    visualizer implementation"
-                );
-                continue;
-            };
+        let mut previous_archetype_name = None;
 
-            // TODO(jleibs): We're already doing this query above as part of the filter. This is kind of silly to do it again.
-            // Change the structure to avoid this.
-            let (row_id, component_array) = {
-                let results = db.latest_at(query, &view.defaults_path, [&component_descr]);
-                (
-                    results.component_row_id(&component_descr),
-                    results.component_batch_raw_by_descr(&component_descr),
-                )
-            };
-
-            if let Some(component_array) = component_array {
-                let value_fn = |ui: &mut egui::Ui| {
-                    ctx.viewer_ctx.component_ui_registry().singleline_edit_ui(
-                        &query_context,
-                        ui,
-                        db,
-                        &view.defaults_path,
-                        component_descr.component_name,
-                        row_id.map(Hash64::hash),
-                        Some(&*component_array),
-                        visualizer.fallback_provider(),
-                    );
-                };
-
-                ui.list_item_flat_noninteractive(
-                    re_ui::list_item::PropertyContent::new(component_descr.short_name())
-                        .min_desired_width(150.0)
-                        .action_button(&re_ui::icons::CLOSE, || {
-                            ctx.clear_blueprint_component_by_name(
-                                &view.defaults_path,
-                                // TODO(#6889): Use descriptor directly.
-                                component_descr.component_name,
-                            );
-                        })
-                        .value_fn(|ui, _| value_fn(ui)),
-                )
-                .on_hover_ui(|ui| {
-                    // TODO(andreas): Add data ui for component descr?
-                    component_descr.component_name.data_ui_recording(
-                        ctx.viewer_ctx,
-                        ui,
-                        re_viewer_context::UiLayout::Tooltip,
-                    );
-                });
+        for (component_descr, default_value) in active_defaults {
+            if previous_archetype_name != component_descr.archetype_name {
+                if let Some(archetype_name) = component_descr.archetype_name {
+                    ui.add_space(4.0);
+                    ui.label(archetype_name.syntax_highlighted(ui.style()));
+                    previous_archetype_name = Some(archetype_name);
+                }
             }
+
+            let value_fn = |ui: &mut egui::Ui| {
+                let allow_multiline = false;
+                ctx.viewer_ctx.component_ui_registry().edit_ui_raw(
+                    &query_context,
+                    ui,
+                    db,
+                    &view.defaults_path,
+                    component_descr.component_name,
+                    None, // No cache key.
+                    default_value,
+                    allow_multiline,
+                );
+            };
+
+            ui.list_item_flat_noninteractive(
+                re_ui::list_item::PropertyContent::new(
+                    if let Some(archetype_field_name) = component_descr.archetype_field_name {
+                        archetype_field_name.syntax_highlighted(ui.style())
+                    } else {
+                        component_descr
+                            .component_name
+                            .syntax_highlighted(ui.style())
+                    },
+                )
+                .min_desired_width(150.0)
+                .action_button(&re_ui::icons::CLOSE, || {
+                    ctx.clear_blueprint_component_by_name(
+                        &view.defaults_path,
+                        // TODO(#6889): Use descriptor directly.
+                        component_descr.component_name,
+                    );
+                })
+                .value_fn(|ui, _| value_fn(ui)),
+            )
+            .on_hover_ui(|ui| {
+                component_descr.component_name.data_ui_recording(
+                    ctx.viewer_ctx,
+                    ui,
+                    re_viewer_context::UiLayout::Tooltip,
+                );
+            });
         }
     });
 }
 
-fn component_to_vis(ctx: &ViewContext<'_>) -> BTreeMap<ComponentDescriptor, ViewSystemIdentifier> {
-    // It only makes sense to set defaults for components that are used by a system in the view.
-    let mut component_to_vis: BTreeMap<ComponentDescriptor, ViewSystemIdentifier> =
-        Default::default();
+fn visualized_components_by_archetype(
+    ctx: &ViewContext<'_>,
+) -> BTreeMap<ArchetypeName, Vec<DefaultOverrideEntry>> {
+    let mut visualized_components_by_visualizer: BTreeMap<
+        ArchetypeName,
+        Vec<DefaultOverrideEntry>,
+    > = Default::default();
 
+    // It only makes sense to set defaults for components that are used by a system in the view.
     // Accumulate the components across all visualizers and track which visualizer
     // each component came from so we can use it for fallbacks later.
-    //
-    // If two visualizers have the same component, the first one wins.
-    // TODO(jleibs): We can do something fancier in the future such as presenting both
-    // options once we have a motivating use-case.
     for (id, vis) in ctx.visualizer_collection.iter_with_identifiers() {
-        for descr in vis.visualizer_query_info().queried.iter().cloned() {
-            component_to_vis.entry(descr).or_insert_with(|| id);
+        for descr in &vis.visualizer_query_info().queried {
+            let (Some(archetype_name), Some(archetype_field_name)) =
+                (descr.archetype_name, descr.archetype_field_name)
+            else {
+                // TODO(andreas): In theory this is perfectly valid: A visualizer may be interested in an untagged component!
+                // Practically this never happens and we don't handle this in the ui here yet.
+                continue;
+            };
+
+            visualized_components_by_visualizer
+                .entry(archetype_name)
+                .or_default()
+                .push(DefaultOverrideEntry {
+                    component_name: descr.component_name,
+                    archetype_field_name,
+                    visualizer_identifier: id,
+                });
         }
     }
-    component_to_vis
+
+    // It should be near-impossible, but just in case two visualizers use the exact same (tagged) component,
+    // make the first one win.
+
+    visualized_components_by_visualizer
 }
 
 fn active_defaults(
@@ -193,7 +213,7 @@ fn active_defaults(
     view: &ViewBlueprint,
     db: &re_entity_db::EntityDb,
     query: &LatestAtQuery,
-) -> ComponentDescriptorSet {
+) -> IntMap<ComponentDescriptor, ArrayRef> {
     // Cleared components should act as unset, so we filter out everything that's empty,
     // even if they are listed in `all_components`.
     ctx.blueprint_db()
@@ -202,56 +222,63 @@ fn active_defaults(
         .all_components_on_timeline(&blueprint_timeline(), &view.defaults_path)
         .unwrap_or_default()
         .into_iter()
-        .filter(|c| {
+        .filter_map(|component_descr| {
             db.storage_engine()
                 .cache()
-                .latest_at(query, &view.defaults_path, [c])
-                .component_batch_raw_by_descr(c)
-                .is_some_and(|data| !data.is_empty())
+                .latest_at(query, &view.defaults_path, [&component_descr])
+                .component_batch_raw_by_descr(&component_descr)
+                .and_then(|data| (!data.is_empty()).then_some((component_descr, data)))
         })
         .collect()
 }
 
 fn components_to_show_in_add_menu(
     ctx: &ViewContext<'_>,
-    component_to_vis: &BTreeMap<ComponentDescriptor, ViewSystemIdentifier>,
-    active_defaults: &ComponentDescriptorSet,
-) -> Result<Vec<(ComponentDescriptor, ViewSystemIdentifier)>, String> {
-    if component_to_vis.is_empty() {
+    visualized_components_by_archetype: &BTreeMap<ArchetypeName, Vec<DefaultOverrideEntry>>,
+    active_defaults: &IntMap<ComponentDescriptor, ArrayRef>,
+) -> Result<BTreeMap<ArchetypeName, Vec<DefaultOverrideEntry>>, String> {
+    if visualized_components_by_archetype.is_empty() {
         return Err("No components to visualize".to_owned());
     }
 
-    let mut component_to_vis = component_to_vis
-        .iter()
-        .filter(|(component, _)| !active_defaults.contains(*component))
-        .map(|(c, v)| (c.clone(), *v))
-        .collect::<Vec<_>>();
+    let mut components_to_show_in_add_menu = visualized_components_by_archetype.clone();
 
-    if component_to_vis.is_empty() {
-        return Err("All components already have active defaults".to_owned());
+    {
+        // Filter out all components that already have an active default.
+        for (archetype_name, components) in &mut components_to_show_in_add_menu {
+            components
+                .retain(|entry| !active_defaults.contains_key(&entry.descriptor(*archetype_name)));
+        }
+        components_to_show_in_add_menu.retain(|_, components| !components.is_empty());
+
+        if components_to_show_in_add_menu.is_empty() {
+            return Err("All components already have active defaults".to_owned());
+        }
     }
-
     {
         // Make sure we have editors. If we don't, explain to the user.
         let mut missing_editors = vec![];
 
-        component_to_vis.retain(|(component_descr, _)| {
-            // If there is no registered editor, don't let the user create an override
-            // TODO(andreas): Can only handle single line editors right now.
-            let types = ctx
-                .viewer_ctx
-                .component_ui_registry()
-                .registered_ui_types(component_descr.component_name);
+        for (archetype_name, components) in &mut components_to_show_in_add_menu {
+            components.retain(|entry| {
+                // If there is no registered editor, don't let the user create an override
+                // TODO(andreas): Can only handle single line editors right now.
+                let types = ctx
+                    .viewer_ctx
+                    .component_ui_registry()
+                    .registered_ui_types(entry.component_name);
 
-            if types.contains(ComponentUiTypes::SingleLineEditor) {
-                true // show it
-            } else {
-                missing_editors.push(component_descr.clone());
-                false // don't show
-            }
-        });
+                if types.contains(ComponentUiTypes::SingleLineEditor) {
+                    true // show it
+                } else {
+                    missing_editors.push(entry.descriptor(*archetype_name));
+                    false // don't show
+                }
+            });
+        }
+        components_to_show_in_add_menu.retain(|_, components| !components.is_empty());
 
-        if component_to_vis.is_empty() {
+        if components_to_show_in_add_menu.is_empty() {
             return Err(format!(
                 "Rerun lacks edit UI for: {}",
                 missing_editors.iter().map(|c| c.short_name()).join(", ")
@@ -259,7 +286,7 @@ fn components_to_show_in_add_menu(
         }
     }
 
-    Ok(component_to_vis)
+    Ok(components_to_show_in_add_menu)
 }
 
 fn add_popup_ui(
@@ -267,7 +294,7 @@ fn add_popup_ui(
     ui: &mut egui::Ui,
     defaults_path: &EntityPath,
     query: &LatestAtQuery,
-    component_to_vis: Vec<(ComponentDescriptor, ViewSystemIdentifier)>,
+    components_to_show_in_add_menu: BTreeMap<ArchetypeName, Vec<DefaultOverrideEntry>>,
 ) {
     let query_context = QueryContext {
         viewer_ctx: ctx.viewer_ctx,
@@ -280,56 +307,77 @@ fn add_popup_ui(
 
     // Present the option to add new components for each component that doesn't
     // already have an active override.
-    for (component_descr, viz) in component_to_vis {
-        #[allow(clippy::blocks_in_conditions)]
-        if ui
-            .button(component_descr.syntax_highlighted(ui.style()))
-            .on_hover_ui(|ui| {
-                // TODO(andreas): Add data ui for component descr?
-                component_descr.component_name.data_ui_recording(
-                    ctx.viewer_ctx,
-                    ui,
-                    UiLayout::Tooltip,
-                );
-            })
-            .clicked()
-        {
-            // We are creating a new override. We need to decide what initial value to give it.
-            // - First see if there's an existing splat in the recording.
-            // - Next see if visualizer system wants to provide a value.
-            // - Finally, fall back on the default value from the component registry.
-
-            // TODO(jleibs): Is this the right place for fallbacks to come from?
-            let Ok(visualizer) = ctx.visualizer_collection.get_by_identifier(viz) else {
-                re_log::warn!("Could not find visualizer for: {}", viz);
-                return;
-            };
-            let initial_data = visualizer
-                .fallback_provider()
-                .fallback_for(&query_context, component_descr.component_name);
-
-            match Chunk::builder(defaults_path.clone())
-                .with_row(
-                    RowId::new(),
-                    ctx.blueprint_timepoint_for_writes(),
-                    [(component_descr, initial_data)],
-                )
-                .build()
-            {
-                Ok(chunk) => {
-                    ctx.viewer_ctx
-                        .command_sender()
-                        .send_system(SystemCommand::UpdateBlueprint(
-                            ctx.blueprint_db().store_id().clone(),
-                            vec![chunk],
-                        ));
-                }
-                Err(err) => {
-                    re_log::warn!("Failed to create Chunk for blueprint component: {}", err);
+    for (archetype_name, components) in components_to_show_in_add_menu {
+        ui.menu_button(archetype_name.syntax_highlighted(ui.style()), |ui| {
+            for entry in components {
+                if ui
+                    .button(entry.archetype_field_name.syntax_highlighted(ui.style()))
+                    .on_hover_ui(|ui| {
+                        entry.component_name.data_ui_recording(
+                            ctx.viewer_ctx,
+                            ui,
+                            UiLayout::Tooltip,
+                        );
+                    })
+                    .clicked()
+                {
+                    add_new_default(
+                        ctx,
+                        defaults_path,
+                        &query_context,
+                        &entry.descriptor(archetype_name),
+                        entry.visualizer_identifier,
+                    );
+                    ui.close_menu();
                 }
             }
+        });
+    }
+}
 
-            ui.close_menu();
+fn add_new_default(
+    ctx: &ViewContext<'_>,
+    defaults_path: &EntityPath,
+    query_context: &QueryContext<'_>,
+    component_descr: &ComponentDescriptor,
+    visualizer: ViewSystemIdentifier,
+) {
+    // We are creating a new override. We need to decide what initial value to give it.
+    // - First see if there's an existing splat in the recording.
+    // - Next see if visualizer system wants to provide a value.
+    // - Finally, fall back on the default value from the component registry.
+
+    // TODO(jleibs): Is this the right place for fallbacks to come from?
+    let Ok(visualizer) = ctx.visualizer_collection.get_by_identifier(visualizer) else {
+        re_log::warn!("Could not find visualizer for: {}", visualizer);
+        return;
+    };
+    let initial_data = visualizer
+        .fallback_provider()
+        .fallback_for(query_context, component_descr.component_name);
+
+    match Chunk::builder(defaults_path.clone())
+        .with_row(
+            RowId::new(),
+            ctx.blueprint_timepoint_for_writes(),
+            [(
+                // TODO(#6889): Use descriptor directly.
+                ComponentDescriptor::new(component_descr.component_name),
+                initial_data,
+            )],
+        )
+        .build()
+    {
+        Ok(chunk) => {
+            ctx.viewer_ctx
+                .command_sender()
+                .send_system(SystemCommand::UpdateBlueprint(
+                    ctx.blueprint_db().store_id().clone(),
+                    vec![chunk],
+                ));
+        }
+        Err(err) => {
+            re_log::warn!("Failed to create Chunk for blueprint component: {}", err);
         }
     }
 }

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use arrow::array::ArrayRef;
 use itertools::Itertools as _;
 
-use nohash_hasher::IntMap;
 use re_chunk::{ArchetypeFieldName, ArchetypeName, Chunk, ComponentName, RowId};
 use re_chunk_store::LatestAtQuery;
 use re_data_ui::DataUi as _;
@@ -192,11 +191,13 @@ fn visualized_components_by_archetype(
             else {
                 // TODO(andreas): In theory this is perfectly valid: A visualizer may be interested in an untagged component!
                 // Practically this never happens and we don't handle this in the ui here yet.
-                re_log::warn_once!(
-                    "Visualizer {} queried untagged component {}. It won't show in the defaults ui.",
-                    id,
-                    descr.component_name
-                );
+                if !descr.component_name.is_indicator_component() {
+                    re_log::warn_once!(
+                        "Visualizer {} queried untagged component {}. It won't show in the defaults ui.",
+                        id,
+                        descr.component_name
+                    );
+                }
                 continue;
             };
 

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -182,7 +182,7 @@ fn visualized_components_by_archetype(
     // Accumulate the components across all visualizers and track which visualizer
     // each component came from so we can use it for fallbacks later.
     for (id, vis) in ctx.visualizer_collection.iter_with_identifiers() {
-        for descr in &vis.visualizer_query_info().queried {
+        for descr in vis.visualizer_query_info().queried.iter() {
             let (Some(archetype_name), Some(archetype_field_name)) =
                 (descr.archetype_name, descr.archetype_field_name)
             else {

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -44,6 +44,8 @@ pub fn view_components_defaults_section_ui(
     let db = ctx.viewer_ctx.blueprint_db();
     let query = ctx.viewer_ctx.blueprint_query;
 
+    // TODO(andreas): Components in `active_defaults` should be sorted by field order within each archetype.
+    // Right now, they're just sorted by descriptor, which is not the same.
     let active_defaults = active_defaults(ctx, view, db, query);
     let visualized_components_by_archetype = visualized_components_by_archetype(ctx);
 
@@ -93,7 +95,7 @@ Click on the `+` button to add a new default value.";
 fn active_default_ui(
     ctx: &ViewContext<'_>,
     ui: &mut egui::Ui,
-    active_defaults: &IntMap<ComponentDescriptor, ArrayRef>,
+    active_defaults: &BTreeMap<ComponentDescriptor, ArrayRef>,
     view: &ViewBlueprint,
     query: &LatestAtQuery,
     db: &re_entity_db::EntityDb,
@@ -118,6 +120,8 @@ fn active_default_ui(
 
         for (component_descr, default_value) in active_defaults {
             if previous_archetype_name != component_descr.archetype_name {
+                // `active_defaults` is sorted by descriptor which in turn sorts by archetype name,
+                // so we can just check if the previous archetype name is different from the current one.
                 if let Some(archetype_name) = component_descr.archetype_name {
                     ui.add_space(4.0);
                     ui.label(archetype_name.syntax_highlighted(ui.style()));
@@ -215,7 +219,7 @@ fn active_defaults(
     view: &ViewBlueprint,
     db: &re_entity_db::EntityDb,
     query: &LatestAtQuery,
-) -> IntMap<ComponentDescriptor, ArrayRef> {
+) -> BTreeMap<ComponentDescriptor, ArrayRef> {
     // Cleared components should act as unset, so we filter out everything that's empty,
     // even if they are listed in `all_components`.
     ctx.blueprint_db()

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -62,7 +62,7 @@ fn visible_time_range_ui(
 
     let visible_time_ranges = ctx
         .blueprint_db()
-        .latest_at(
+        .latest_at_by_name(
             ctx.blueprint_query,
             time_range_override_path,
             std::iter::once(VisibleTimeRange::name()),

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -170,6 +170,7 @@ fn visualizer_components(
             Some((unit.row_id(), batch))
         }
     }
+
     fn non_empty_component_batch_raw(
         unit: Option<&UnitChunkShared>,
         component_descr: &ComponentDescriptor,

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -206,6 +206,8 @@ fn visualizer_components(
             continue;
         }
 
+        // TODO(andreas): What about annotation context?
+
         // Query all the sources for our value.
         // (technically we only need to query those that are shown, but rolling this out makes things easier).
         let result_override = query_result

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -430,7 +430,7 @@ fn visualizer_components(
             )
             .item_response
             .on_hover_ui(|ui| {
-                // TODO: need data ui for component_descr?
+                // TODO(andreas): Add data ui for component descr?
                 component_descr.component_name.data_ui_recording(
                     ctx.viewer_ctx,
                     ui,

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools as _;
 
 use re_chunk::{ComponentName, RowId, UnitChunkShared};
-use re_data_ui::{sorted_component_name_list_for_ui, DataUi as _};
+use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
 use re_entity_db::EntityDb;
 use re_log_types::hash::Hash64;
 use re_log_types::{ComponentPath, EntityPath};
@@ -157,13 +157,25 @@ fn visualizer_components(
     data_result: &DataResult,
     visualizer: &dyn VisualizerSystem,
 ) {
-    // Helper for code below
-    fn non_empty_component_batch_raw(
+    // TODO(#6889): remove in favor of `non_empty_component_batch_raw`
+    fn non_empty_component_batch_raw_by_name(
         unit: Option<&UnitChunkShared>,
-        component_name: &ComponentName,
+        component_name: ComponentName,
     ) -> Option<(Option<RowId>, ArrayRef)> {
         let unit = unit?;
-        let batch = unit.component_batch_raw_by_component_name(*component_name)?;
+        let batch = unit.component_batch_raw_by_component_name(component_name)?;
+        if batch.is_empty() {
+            None
+        } else {
+            Some((unit.row_id(), batch))
+        }
+    }
+    fn non_empty_component_batch_raw(
+        unit: Option<&UnitChunkShared>,
+        component_descr: &ComponentDescriptor,
+    ) -> Option<(Option<RowId>, ArrayRef)> {
+        let unit = unit?;
+        let batch = unit.component_batch_raw(component_descr)?;
         if batch.is_empty() {
             None
         } else {
@@ -183,39 +195,36 @@ fn visualizer_components(
         None, // TODO(andreas): Figure out how to deal with annotation context here.
         &store_query,
         data_result,
-        query_info
-            .queried
-            .iter()
-            .copied()
-            // TODO: can't ship this ,this breaks the ui.
-            .map(|c| ComponentDescriptor::new(c))
-            .collect_vec()
-            .iter(),
+        query_info.queried.iter(),
         query_shadowed_defaults,
     );
 
     // TODO(andreas): Should we show required components in a special way?
-    for component_name in sorted_component_name_list_for_ui(query_info.queried.iter()) {
-        if component_name.is_indicator_component() {
+    for component_descr in sorted_component_list_for_ui(query_info.queried.iter()) {
+        if component_descr.component_name.is_indicator_component() {
             continue;
         }
 
-        // TODO(andreas): What about annotation context?
-
         // Query all the sources for our value.
         // (technically we only need to query those that are shown, but rolling this out makes things easier).
-        let result_override = query_result.overrides.get_by_name(&component_name);
-        let raw_override = non_empty_component_batch_raw(result_override, &component_name);
+        let result_override = query_result
+            .overrides
+            .get_by_name(&component_descr.component_name); // TODO(#6889): Use component_descr directly.
+        let raw_override =
+            non_empty_component_batch_raw_by_name(result_override, component_descr.component_name);
 
-        let result_store = query_result.results.get_by_name(&component_name);
-        let raw_store = non_empty_component_batch_raw(result_store, &component_name);
+        let result_store = query_result.results.get(&component_descr);
+        let raw_store = non_empty_component_batch_raw(result_store, &component_descr);
 
-        let result_default = query_result.defaults.get_by_name(&component_name);
-        let raw_default = non_empty_component_batch_raw(result_default, &component_name);
+        let result_default = query_result
+            .defaults
+            .get_by_name(&component_descr.component_name); // TODO(#6889): Use component_descr directly.
+        let raw_default =
+            non_empty_component_batch_raw_by_name(result_default, component_descr.component_name);
 
         let raw_fallback = visualizer
             .fallback_provider()
-            .fallback_for(&query_ctx, component_name);
+            .fallback_for(&query_ctx, component_descr.component_name);
 
         // Determine where the final value comes from.
         // Putting this into an enum makes it easier to reason about the next steps.
@@ -240,9 +249,9 @@ fn visualizer_components(
                 || !ctx.viewer_ctx.component_ui_registry().try_show_edit_ui(
                     ctx.viewer_ctx,
                     ui,
-                    raw_current_value.as_ref()                    ,
+                    raw_current_value.as_ref(),
                     override_path,
-                    component_name,
+                    component_descr.component_name,
                     multiline,
                 )
             {
@@ -279,7 +288,7 @@ fn visualizer_components(
                             &store_query,
                             ctx.recording(),
                             &data_result.entity_path,
-                            component_name,
+                            component_descr.component_name,
                             current_value_row_id.map(Hash64::hash),
                             raw_current_value.as_ref(),
                         );
@@ -287,22 +296,8 @@ fn visualizer_components(
                     }
                 };
 
-                // TODO(#6889): query results should already operate on full descriptors
-                let component_descr = db
-                    .storage_engine()
-                    .store()
-                    .entity_component_descriptors_with_name(&entity_path, component_name)
-                    .into_iter()
-                    .next()
-                    .unwrap_or_else(|| {
-                        re_log::warn_once!(
-                            "{component_name} was logged untagged. This is unexpected and may indicate a bug."
-                        );
-                        ComponentDescriptor::new(component_name)
-                    });
-
                 re_data_ui::ComponentPathLatestAtResults {
-                    component_path: ComponentPath::new(entity_path, component_descr),
+                    component_path: ComponentPath::new(entity_path, component_descr.clone()),
                     unit: latest_at_unit,
                 }
                 .data_ui(ctx.viewer_ctx, ui, UiLayout::List, query, db);
@@ -322,7 +317,7 @@ fn visualizer_components(
                         ui,
                         "Override",
                         override_path,
-                        component_name,
+                        &component_descr,
                         *row_id,
                         raw_override.as_ref(),
                     )
@@ -335,28 +330,10 @@ fn visualizer_components(
                 ui.push_id("store", |ui| {
                     ui.list_item_flat_noninteractive(
                         list_item::PropertyContent::new("Store").value_fn(|ui, _style| {
-                            // TODO(#6889): query results should already operate on full descriptors
-                            let component_descr = ctx
-                                .recording()
-                                .storage_engine()
-                                .store()
-                                .entity_component_descriptors_with_name(
-                                    &data_result.entity_path,
-                                    component_name,
-                                )
-                                .into_iter()
-                                .next()
-                                .unwrap_or_else(|| {
-                                    re_log::warn_once!(
-                                        "{component_name} was logged untagged. This is unexpected and may indicate a bug."
-                                    );
-                                    ComponentDescriptor::new(component_name)
-                                });
-
                             re_data_ui::ComponentPathLatestAtResults {
                                 component_path: ComponentPath::new(
                                     data_result.entity_path.clone(),
-                                    component_descr,
+                                    component_descr.clone(),
                                 ),
                                 unit,
                             }
@@ -381,7 +358,7 @@ fn visualizer_components(
                         ui,
                         "Default",
                         &ViewBlueprint::defaults_path(ctx.view_id),
-                        component_name,
+                        &component_descr,
                         *row_id,
                         raw_default.as_ref(),
                     )
@@ -404,7 +381,7 @@ fn visualizer_components(
                                 &store_query,
                                 ctx.recording(),
                                 &data_result.entity_path,
-                                component_name,
+                                component_descr.component_name,
                                 None,
                                 raw_fallback.as_ref(),
                             );
@@ -424,28 +401,41 @@ fn visualizer_components(
             .interactive(false)
             .show_hierarchical_with_children(
                 ui,
-                ui.make_persistent_id(component_name),
+                ui.make_persistent_id(&component_descr),
                 default_open,
-                list_item::PropertyContent::new(component_name.short_name())
-                    .value_fn(value_fn)
-                    .show_only_when_collapsed(false)
-                    .menu_button(&re_ui::icons::MORE, |ui: &mut egui::Ui| {
-                        menu_more(
-                            ctx,
-                            ui,
-                            component_name,
-                            override_path,
-                            &raw_override.clone().map(|(_, raw_override)| raw_override),
-                            raw_default.clone().map(|(_, raw_override)| raw_override),
-                            raw_fallback.clone(),
-                            raw_current_value.clone(),
-                        );
-                    }),
+                list_item::PropertyContent::new(
+                    // We're in the context of a visualizer, so we don't have to print the archetype name
+                    // since usually archetypes match 1:1 with visualizers.
+                    component_descr
+                        .archetype_field_name
+                        .map_or(component_descr.component_name.as_str(), |field| {
+                            field.as_str()
+                        }),
+                )
+                .value_fn(value_fn)
+                .show_only_when_collapsed(false)
+                .menu_button(&re_ui::icons::MORE, |ui: &mut egui::Ui| {
+                    menu_more(
+                        ctx,
+                        ui,
+                        &component_descr,
+                        override_path,
+                        &raw_override.clone().map(|(_, raw_override)| raw_override),
+                        raw_default.clone().map(|(_, raw_override)| raw_override),
+                        raw_fallback.clone(),
+                        raw_current_value.clone(),
+                    );
+                }),
                 add_children,
             )
             .item_response
             .on_hover_ui(|ui| {
-                component_name.data_ui_recording(ctx.viewer_ctx, ui, UiLayout::Tooltip);
+                // TODO: need data ui for component_descr?
+                component_descr.component_name.data_ui_recording(
+                    ctx.viewer_ctx,
+                    ui,
+                    UiLayout::Tooltip,
+                );
             });
     }
 }
@@ -455,7 +445,7 @@ fn editable_blueprint_component_list_item(
     ui: &mut egui::Ui,
     name: &'static str,
     blueprint_path: &EntityPath,
-    component: re_types::ComponentName,
+    component_descr: &re_types::ComponentDescriptor,
     row_id: Option<RowId>,
     raw_override: &dyn arrow::array::Array,
 ) -> egui::Response {
@@ -468,7 +458,7 @@ fn editable_blueprint_component_list_item(
                     ui,
                     query_ctx.viewer_ctx.blueprint_db(),
                     blueprint_path,
-                    component,
+                    component_descr.component_name,
                     row_id.map(Hash64::hash),
                     raw_override,
                     allow_multiline,
@@ -477,7 +467,11 @@ fn editable_blueprint_component_list_item(
             .action_button(&re_ui::icons::CLOSE, || {
                 query_ctx
                     .viewer_ctx
-                    .clear_blueprint_component_by_name(blueprint_path, component);
+                    // TODO(#6889): Use component_descr directly.
+                    .clear_blueprint_component_by_name(
+                        blueprint_path,
+                        component_descr.component_name,
+                    );
             }),
     )
 }
@@ -487,18 +481,22 @@ fn editable_blueprint_component_list_item(
 fn menu_more(
     ctx: &ViewContext<'_>,
     ui: &mut egui::Ui,
-    component_name: re_types::ComponentName,
+    component_descr: &re_types::ComponentDescriptor,
     override_path: &EntityPath,
     raw_override: &Option<ArrayRef>,
     raw_default: Option<ArrayRef>,
     raw_fallback: arrow::array::ArrayRef,
     raw_current_value: arrow::array::ArrayRef,
 ) {
+    // TODO(#6889): Use component_descr directly on all of the usages here.
+    let component_name = component_descr.component_name;
+
     if ui
         .add_enabled(raw_override.is_some(), egui::Button::new("Remove override"))
         .on_disabled_hover_text("There's no override active")
         .clicked()
     {
+        // TODO(#6889): Use component_descr directly.
         ctx.clear_blueprint_component_by_name(override_path, component_name);
         ui.close_menu();
     }

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -183,7 +183,14 @@ fn visualizer_components(
         None, // TODO(andreas): Figure out how to deal with annotation context here.
         &store_query,
         data_result,
-        query_info.queried.iter().copied(),
+        query_info
+            .queried
+            .iter()
+            .copied()
+            // TODO: can't ship this ,this breaks the ui.
+            .map(|c| ComponentDescriptor::new(c))
+            .collect_vec()
+            .iter(),
         query_shadowed_defaults,
     );
 

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -229,11 +229,11 @@ pub trait DataResultQuery {
         latest_at_query: &'a LatestAtQuery,
     ) -> HybridLatestAtResults<'a>;
 
-    fn latest_at_with_blueprint_resolved_data_for_component<'a, 'b>(
+    fn latest_at_with_blueprint_resolved_data_for_component<'a>(
         &'a self,
         ctx: &'a ViewContext<'a>,
         latest_at_query: &'a LatestAtQuery,
-        component_descr: &'b ComponentDescriptor,
+        component_descr: &ComponentDescriptor,
     ) -> HybridLatestAtResults<'a>;
 
     fn query_archetype_with_history<'a, A: re_types_core::Archetype>(
@@ -267,11 +267,11 @@ impl DataResultQuery for DataResult {
         )
     }
 
-    fn latest_at_with_blueprint_resolved_data_for_component<'a, 'b>(
+    fn latest_at_with_blueprint_resolved_data_for_component<'a>(
         &'a self,
         ctx: &'a ViewContext<'a>,
         latest_at_query: &'a LatestAtQuery,
-        component_descr: &'b ComponentDescriptor,
+        component_descr: &ComponentDescriptor,
     ) -> HybridLatestAtResults<'a> {
         let query_shadowed_components = false;
         latest_at_with_blueprint_resolved_data(
@@ -311,7 +311,12 @@ impl DataResultQuery for DataResult {
                 continue;
             };
 
-            if vis.visualizer_query_info().queried.contains(&component) {
+            if vis
+                .visualizer_query_info()
+                .queried
+                .iter()
+                .any(|c| c.component_name == component)
+            {
                 return vis.fallback_provider().fallback_for(query_ctx, component);
             }
         }

--- a/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
@@ -79,12 +79,25 @@ fn collect_draw_order_per_visualizer(
     let latest_at_query = ctx.current_query();
     for data_result in query.iter_visible_data_results(visualizer_identifier) {
         let query_shadowed_components = false;
+
+        // TODO(#6889): We want to query with the correct descriptor here for each visualizer in its `VisualizerQueryInfo`.
+        // To do so, we have to look up the descriptor that the visualizer advertises for `DrawOrder` here.
+        let Some(draw_order_descriptor) = ctx
+            .recording_engine()
+            .store()
+            .entity_component_descriptors_with_name(&data_result.entity_path, DrawOrder::name())
+            .into_iter()
+            .next()
+        else {
+            continue;
+        };
+
         let draw_order = latest_at_with_blueprint_resolved_data(
             ctx,
             None,
             &latest_at_query,
             data_result,
-            std::iter::once(DrawOrder::name()),
+            [&draw_order_descriptor],
             query_shadowed_components,
         )
         .get_mono_with_fallback::<DrawOrder>();

--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -4,7 +4,7 @@ use re_chunk_store::LatestAtQuery;
 use re_entity_db::{EntityPath, EntityTree};
 use re_log_types::EntityPathHash;
 use re_types::{
-    archetypes::{InstancePoses3D, Transform3D},
+    archetypes::{self, InstancePoses3D, Transform3D},
     components::{ImagePlaneDistance, PinholeProjection},
     Archetype as _, Component as _, ComponentNameSet,
 };
@@ -369,8 +369,10 @@ fn lookup_image_plane_distance(
         .cloned()
         .map(|data_result| {
             data_result
-                .latest_at_with_blueprint_resolved_data_for_component::<ImagePlaneDistance>(
-                    ctx, query,
+                .latest_at_with_blueprint_resolved_data_for_component(
+                    ctx,
+                    query,
+                    &archetypes::Pinhole::descriptor_image_plane_distance(),
                 )
                 .get_mono_with_fallback::<ImagePlaneDistance>()
         })

--- a/crates/viewer/re_view_spatial/src/pinhole.rs
+++ b/crates/viewer/re_view_spatial/src/pinhole.rs
@@ -97,9 +97,9 @@ pub fn query_pinhole_and_view_coordinates_from_store_without_blueprint(
         query,
         entity_path,
         [
-            archetypes::Pinhole::descriptor_image_from_camera().component_name,
-            archetypes::Pinhole::descriptor_resolution().component_name,
-            archetypes::Pinhole::descriptor_camera_xyz().component_name,
+            &archetypes::Pinhole::descriptor_image_from_camera(),
+            &archetypes::Pinhole::descriptor_resolution(),
+            &archetypes::Pinhole::descriptor_camera_xyz(),
         ],
     );
 

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -766,9 +766,11 @@ fn query_and_resolve_tree_transform_at_entity(
     query: &LatestAtQuery,
 ) -> Option<Affine3A> {
     // TODO(andreas): Filter out styling components.
-    let components = archetypes::Transform3D::all_components();
-    let component_names = components.iter().map(|descr| descr.component_name);
-    let results = entity_db.latest_at(query, entity_path, component_names);
+    let results = entity_db.latest_at(
+        query,
+        entity_path,
+        archetypes::Transform3D::all_components().iter(),
+    );
     if results.components.is_empty() {
         return None;
     }
@@ -850,9 +852,11 @@ fn query_and_resolve_instance_poses_at_entity(
     query: &LatestAtQuery,
 ) -> Vec<Affine3A> {
     // TODO(andreas): Filter out styling components.
-    let components = archetypes::InstancePoses3D::all_components();
-    let component_names = components.iter().map(|descr| descr.component_name);
-    let result = entity_db.latest_at(query, entity_path, component_names);
+    let result = entity_db.latest_at(
+        query,
+        entity_path,
+        archetypes::InstancePoses3D::all_components().iter(),
+    );
 
     let max_num_instances = result
         .components

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -852,10 +852,13 @@ fn query_and_resolve_instance_poses_at_entity(
     query: &LatestAtQuery,
 ) -> Vec<Affine3A> {
     // TODO(andreas): Filter out styling components.
-    let result = entity_db.latest_at(
+    // TODO(#9889): Boxes & ellipsoids depend on differently tagged instance pose right now.
+    let result = entity_db.latest_at_by_name(
         query,
         entity_path,
-        archetypes::InstancePoses3D::all_components().iter(),
+        archetypes::InstancePoses3D::all_components()
+            .iter()
+            .map(|c| c.component_name),
     );
 
     let max_num_instances = result

--- a/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
@@ -245,9 +245,7 @@ impl VisualizerSystem for CamerasVisualizer {
                 None,
                 &time_query,
                 data_result,
-                Pinhole::all_components()
-                    .iter()
-                    .map(|desc| desc.component_name),
+                Pinhole::all_components().iter(),
                 query_shadowed_components,
             );
 

--- a/crates/viewer/re_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/mod.rs
@@ -23,6 +23,7 @@ mod videos;
 
 pub use cameras::CamerasVisualizer;
 pub use depth_images::DepthImageVisualizer;
+use re_types::{archetypes, ComponentDescriptor};
 pub use transform3d_arrows::{add_axis_arrows, AxisLengthDetector, Transform3DArrowsVisualizer};
 pub use utilities::{
     entity_iterator, process_labels_3d, textured_rect_from_image, SpatialViewVisualizerData,
@@ -116,18 +117,43 @@ pub fn register_3d_spatial_visualizers(
     Ok(())
 }
 
-/// List of all visualizers that read [`re_types::components::DrawOrder`].
+/// List of all visualizers that read [`re_types::components::DrawOrder`] and the exact draw order component descriptor they use.
 // TODO(jan, andreas): consider adding DrawOrder to video
-pub fn visualizers_processing_draw_order() -> impl Iterator<Item = ViewSystemIdentifier> {
+pub fn visualizers_processing_draw_order(
+) -> impl Iterator<Item = (ViewSystemIdentifier, ComponentDescriptor)> {
     [
-        arrows2d::Arrows2DVisualizer::identifier(),
-        boxes2d::Boxes2DVisualizer::identifier(),
-        depth_images::DepthImageVisualizer::identifier(),
-        encoded_image::EncodedImageVisualizer::identifier(),
-        images::ImageVisualizer::identifier(),
-        lines2d::Lines2DVisualizer::identifier(),
-        points2d::Points2DVisualizer::identifier(),
-        segmentation_images::SegmentationImageVisualizer::identifier(),
+        (
+            arrows2d::Arrows2DVisualizer::identifier(),
+            archetypes::Arrows2D::descriptor_draw_order(),
+        ),
+        (
+            boxes2d::Boxes2DVisualizer::identifier(),
+            archetypes::Boxes2D::descriptor_draw_order(),
+        ),
+        (
+            depth_images::DepthImageVisualizer::identifier(),
+            archetypes::DepthImage::descriptor_draw_order(),
+        ),
+        (
+            encoded_image::EncodedImageVisualizer::identifier(),
+            archetypes::EncodedImage::descriptor_draw_order(),
+        ),
+        (
+            images::ImageVisualizer::identifier(),
+            archetypes::Image::descriptor_draw_order(),
+        ),
+        (
+            lines2d::Lines2DVisualizer::identifier(),
+            archetypes::LineStrips2D::descriptor_draw_order(),
+        ),
+        (
+            points2d::Points2DVisualizer::identifier(),
+            archetypes::Points2D::descriptor_draw_order(),
+        ),
+        (
+            segmentation_images::SegmentationImageVisualizer::identifier(),
+            archetypes::SegmentationImage::descriptor_draw_order(),
+        ),
     ]
     .into_iter()
 }

--- a/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -124,7 +124,7 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
                 None,
                 &latest_at_query,
                 data_result,
-                std::iter::once(AxisLength::name()),
+                [&Transform3D::descriptor_axis_length()],
                 false,
             );
 

--- a/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -286,6 +286,10 @@ impl VisualizerSystem for AxisLengthDetector {
         query_info.indicators = Default::default();
 
         query_info
+            .required
+            .insert(Transform3D::descriptor_axis_length());
+
+        query_info
     }
 
     fn execute(

--- a/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -4,7 +4,7 @@ use re_log_types::{EntityPath, Instance};
 use re_types::{
     archetypes::{Pinhole, Transform3D},
     components::{AxisLength, ImagePlaneDistance},
-    Archetype as _, Component as _, ComponentName,
+    Archetype as _, ComponentName,
 };
 use re_view::{latest_at_with_blueprint_resolved_data, DataResultQuery as _};
 use re_viewer_context::{
@@ -283,8 +283,6 @@ impl IdentifiedViewSystem for AxisLengthDetector {
 impl VisualizerSystem for AxisLengthDetector {
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
         let mut query_info = VisualizerQueryInfo::from_archetype::<Transform3D>();
-
-        query_info.required.insert(AxisLength::name());
         query_info.indicators = Default::default();
 
         query_info

--- a/crates/viewer/re_view_spatial/src/visualizers/utilities/labels.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/utilities/labels.rs
@@ -111,9 +111,11 @@ const MAX_NUM_LABELS_PER_ENTITY: usize = 30;
 /// This function is normally used to implement the [`ComponentFallbackProvider`]
 /// that will be used in a [`LabeledBatch`].
 pub fn show_labels_fallback<C: Component>(ctx: &re_viewer_context::QueryContext<'_>) -> ShowLabels {
-    let results =
-        ctx.recording()
-            .latest_at(ctx.query, ctx.target_entity_path, [C::name(), Text::name()]);
+    let results = ctx.recording().latest_at_by_name(
+        ctx.query,
+        ctx.target_entity_path,
+        [C::name(), Text::name()],
+    );
     let num_instances = results
         .component_batch_raw(&C::name())
         .map_or(0, |array| array.len());

--- a/crates/viewer/re_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/videos.rs
@@ -397,7 +397,7 @@ fn latest_at_query_video_from_datastore(
         AssetVideo::all_components().iter(),
     );
 
-    let blob_row_id = results.component_row_id(&Blob::name())?;
+    let blob_row_id = results.component_row_id(&AssetVideo::descriptor_blob())?;
     let blob = results.component_instance::<Blob>(0)?;
     let media_type = results.component_instance::<MediaType>(0);
 

--- a/crates/viewer/re_view_tensor/src/visualizer_system.rs
+++ b/crates/viewer/re_view_tensor/src/visualizer_system.rs
@@ -3,7 +3,7 @@ use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::Tensor,
     components::{TensorData, ValueRange},
-    Archetype, Component as _,
+    Archetype as _, Component as _,
 };
 use re_view::{latest_at_with_blueprint_resolved_data, RangeResultsExt as _};
 use re_viewer_context::{

--- a/crates/viewer/re_view_tensor/src/visualizer_system.rs
+++ b/crates/viewer/re_view_tensor/src/visualizer_system.rs
@@ -3,7 +3,7 @@ use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::Tensor,
     components::{TensorData, ValueRange},
-    Component as _,
+    Archetype, Component as _,
 };
 use re_view::{latest_at_with_blueprint_resolved_data, RangeResultsExt as _};
 use re_viewer_context::{
@@ -53,7 +53,7 @@ impl VisualizerSystem for TensorSystem {
                 annotations,
                 &timeline_query,
                 data_result,
-                [TensorData::name(), ValueRange::name()].into_iter(),
+                Tensor::all_components().iter(),
                 query_shadowed_defaults,
             );
 

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -4,6 +4,7 @@ use re_entity_db::EntityPath;
 use re_log_types::TimeInt;
 use re_log_types::TimePoint;
 use re_query::{clamped_zip_1x2, range_zip_1x2};
+use re_types::Archetype as _;
 use re_types::{
     archetypes::TextLog,
     components::{Color, Text, TextLogLevel},
@@ -90,7 +91,7 @@ impl TextLogSystem {
             None,
             query,
             data_result,
-            [Text::name(), TextLogLevel::name(), Color::name()],
+            TextLog::all_components().iter(),
         );
 
         let Some(all_text_chunks) = results.get_required_chunks(&Text::name()) else {

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -40,11 +40,9 @@ const DEFAULT_STROKE_WIDTH: f32 = 0.75;
 impl VisualizerSystem for SeriesLineSystem {
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
         let mut query_info = VisualizerQueryInfo::from_archetype::<archetypes::Scalars>();
-        query_info.queried.extend(
-            archetypes::SeriesLines::all_components()
-                .iter()
-                .map(|descr| descr.component_name),
-        );
+        query_info
+            .queried
+            .extend(archetypes::SeriesLines::all_components().iter().cloned());
 
         query_info.indicators =
             [archetypes::SeriesLines::descriptor_indicator().component_name].into();

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -200,14 +200,9 @@ impl SeriesLineSystem {
                 None,
                 &query,
                 data_result,
-                [
-                    Scalar::name(),
-                    Color::name(),
-                    StrokeWidth::name(),
-                    Name::name(),
-                    AggregationPolicy::name(),
-                    SeriesVisible::name(),
-                ],
+                archetypes::Scalars::all_components()
+                    .iter()
+                    .chain(archetypes::SeriesLines::all_components().iter()),
             );
 
             // If we have no scalars, we can't do anything.

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -41,11 +41,9 @@ const DEFAULT_MARKER_SIZE: f32 = 3.0;
 impl VisualizerSystem for SeriesPointSystem {
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
         let mut query_info = VisualizerQueryInfo::from_archetype::<archetypes::Scalars>();
-        query_info.queried.extend(
-            archetypes::SeriesPoints::all_components()
-                .iter()
-                .map(|descr| descr.component_name),
-        );
+        query_info
+            .queried
+            .extend(archetypes::SeriesPoints::all_components().iter().cloned());
 
         query_info.indicators =
             [archetypes::SeriesPoints::descriptor_indicator().component_name].into();

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -204,14 +204,9 @@ impl SeriesPointSystem {
                 None,
                 &query,
                 data_result,
-                [
-                    Color::name(),
-                    MarkerShape::name(),
-                    MarkerSize::name(),
-                    Name::name(),
-                    Scalar::name(),
-                    SeriesVisible::name(),
-                ],
+                archetypes::Scalars::all_components()
+                    .iter()
+                    .chain(archetypes::SeriesLines::all_components().iter()),
             );
 
             // If we have no scalars, we can't do anything.

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -204,7 +204,7 @@ impl SeriesPointSystem {
                 data_result,
                 archetypes::Scalars::all_components()
                     .iter()
-                    .chain(archetypes::SeriesLines::all_components().iter()),
+                    .chain(archetypes::SeriesPoints::all_components().iter()),
             );
 
             // If we have no scalars, we can't do anything.

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -66,6 +66,7 @@ half.workspace = true
 image = { workspace = true, features = ["jpeg", "png"] }
 indexmap = { workspace = true, features = ["std", "serde"] }
 itertools.workspace = true
+linked-hash-map.workspace = true
 ndarray.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -66,7 +66,6 @@ half.workspace = true
 image = { workspace = true, features = ["jpeg", "png"] }
 indexmap = { workspace = true, features = ["std", "serde"] }
 itertools.workspace = true
-linked-hash-map.workspace = true
 ndarray.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true

--- a/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
@@ -147,7 +147,7 @@ impl ViewerContext<'_> {
             .default_blueprint
             .and_then(|default_blueprint| {
                 default_blueprint
-                    .latest_at(self.blueprint_query, entity_path, [component_name])
+                    .latest_at_by_name(self.blueprint_query, entity_path, [component_name])
                     .get_by_name(&component_name)
                     .and_then(|default_value| {
                         default_value.component_batch_raw_by_component_name(component_name)
@@ -179,7 +179,7 @@ impl ViewerContext<'_> {
         let blueprint = &self.store_context.blueprint;
 
         let Some(datatype) = blueprint
-            .latest_at(self.blueprint_query, entity_path, [component_name])
+            .latest_at_by_name(self.blueprint_query, entity_path, [component_name])
             .get_by_name(&component_name)
             .and_then(|unit| {
                 unit.component_batch_raw_by_component_name(component_name)

--- a/crates/viewer/re_viewer_context/src/view/visualizer_entity_subscriber.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_entity_subscriber.rs
@@ -4,7 +4,7 @@ use nohash_hasher::IntMap;
 
 use re_chunk_store::{ChunkStoreDiffKind, ChunkStoreEvent, ChunkStoreSubscriber};
 use re_log_types::{EntityPathHash, StoreId};
-use re_types::{ComponentName, ComponentNameSet};
+use re_types::{ComponentDescriptor, ComponentNameSet};
 
 use crate::{
     IdentifiedViewSystem, IndicatedEntities, MaybeVisualizableEntities, ViewSystemIdentifier,
@@ -33,7 +33,7 @@ pub struct VisualizerEntitySubscriber {
     indicator_components: ComponentNameSet,
 
     /// Assigns each required component an index.
-    required_components_indices: IntMap<ComponentName, usize>,
+    required_components_indices: IntMap<ComponentDescriptor, usize>,
 
     per_store_mapping: HashMap<StoreId, VisualizerEntityMapping>,
 
@@ -200,10 +200,7 @@ impl ChunkStoreSubscriber for VisualizerEntitySubscriber {
             }
 
             for (component_desc, list_array) in event.diff.chunk.components().iter() {
-                if let Some(index) = self
-                    .required_components_indices
-                    .get(&component_desc.component_name)
-                {
+                if let Some(index) = self.required_components_indices.get(component_desc) {
                     // The component might be present, but logged completely empty.
                     // That shouldn't count towards filling "having the required component present"!
                     // (Note: This happens frequently now with `Transform3D`'s component which always get logged, thus tripping of the `AxisLengthDetector`!)` )

--- a/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
@@ -23,6 +23,7 @@ pub struct VisualizerQueryInfo {
     ///
     /// Must include required, usually excludes indicators.
     /// Order should reflect order in archetype docs & user code as well as possible.
+    // TODO: violated order. bring it back.
     pub queried: ComponentDescriptorSet,
 }
 

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -315,13 +315,14 @@ impl ViewContents {
                 let Ok(visualizer) = visualizer_collection.get_by_identifier(*visualizer) else {
                     continue;
                 };
-                components_for_defaults.extend(visualizer.visualizer_query_info().queried.iter());
+                components_for_defaults
+                    .extend(visualizer.visualizer_query_info().queried.iter().cloned());
             }
 
             ctx.blueprint.latest_at(
                 blueprint_query,
                 &ViewBlueprint::defaults_path(self.view_id),
-                components_for_defaults,
+                components_for_defaults.iter(),
             )
         };
 
@@ -481,7 +482,8 @@ impl<'a> DataQueryPropertyResolver<'a> {
                 .latest_at(
                     blueprint_query,
                     override_path,
-                    [blueprint_components::VisualizerOverride::name()],
+                    // TODO(andreas): Should there be any tags on this one? We don't have an archetype for it yet.
+                    [&blueprint_components::VisualizerOverride::descriptor()],
                 )
                 .component_batch::<blueprint_components::VisualizerOverride>()
             {

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -74,7 +74,7 @@ impl ViewProperty {
         let blueprint_store_path =
             entity_path_for_view_property(view_id, blueprint_db.tree(), archetype_name);
 
-        let query_results = blueprint_db.latest_at(
+        let query_results = blueprint_db.latest_at_by_name(
             &blueprint_query,
             &blueprint_store_path,
             component_descrs.iter().map(|descr| descr.component_name),


### PR DESCRIPTION
### Related

* yet another step towards #6889 

### What

All blueprint overridable queries now use tags when accessing the data store (not the blueprint store yet) -> visualizer queries take now tags into account!

<img width="2581" alt="image" src="https://github.com/user-attachments/assets/eda5575a-b641-4788-a05a-e4ef9be2a27b" />


Also slipped in because of cascade effects:
* visualizer ui shows now tagged value for data
* default ui partially distinguishes tags

Notably missing on the other hand:
* blueprint queries (default and overrides) aren't tagged yet
* accesses on query results are untagged - that requires lotsa per visualizer updates

Default ui had to be re-done (not final, but mostly workable). Defaults are still saved without tags which is why the list doesn't show them yet, but the menu for adding them already distinguishes
<img width="466" alt="image" src="https://github.com/user-attachments/assets/b81922f4-948e-448b-9c16-31be0b30b515" />