### PR TITLE
Use descriptors when accessing components of `ViewProperty`

### DIFF
--- a/crates/store/re_query/examples/latest_at.rs
+++ b/crates/store/re_query/examples/latest_at.rs
@@ -62,8 +62,8 @@ fn main() -> anyhow::Result<()> {
         // * `get_required` returns an error if the chunk is missing.
         // * `get` returns an option.
         let points = results.get_required(&MyPoint::name())?;
-        let colors = results.get(&MyColor::name());
-        let labels = results.get(&MyLabel::name());
+        let colors = results.get_by_name(&MyColor::name());
+        let labels = results.get_by_name(&MyLabel::name());
 
         // You can always use the standard deserialization path:
         let points = points

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -300,7 +300,7 @@ impl LatestAtResults {
 impl LatestAtResults {
     /// Returns the [`UnitChunkShared`] for the specified [`Component`].
     #[inline]
-    pub fn get(&self, component_name: &ComponentName) -> Option<&UnitChunkShared> {
+    pub fn get_by_name(&self, component_name: &ComponentName) -> Option<&UnitChunkShared> {
         let component_descr = self.find_component_descriptor(*component_name)?;
         self.components.get(component_descr)
     }
@@ -310,7 +310,7 @@ impl LatestAtResults {
     /// Returns an error if the component is not present.
     #[inline]
     pub fn get_required(&self, component_name: &ComponentName) -> crate::Result<&UnitChunkShared> {
-        if let Some(component) = self.get(component_name) {
+        if let Some(component) = self.get_by_name(component_name) {
             Ok(component)
         } else {
             Err(QueryError::PrimaryNotFound(*component_name))

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -300,6 +300,13 @@ impl LatestAtResults {
 impl LatestAtResults {
     /// Returns the [`UnitChunkShared`] for the specified [`Component`].
     #[inline]
+    pub fn get(&self, component_descr: &ComponentDescriptor) -> Option<&UnitChunkShared> {
+        self.components.get(component_descr)
+    }
+
+    // TODO(#6889): Going forward, we should avoid querying by name.
+    /// Returns the [`UnitChunkShared`] for the specified [`Component`].
+    #[inline]
     pub fn get_by_name(&self, component_name: &ComponentName) -> Option<&UnitChunkShared> {
         let component_descr = self.find_component_descriptor(*component_name)?;
         self.components.get(component_descr)

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -197,13 +197,13 @@ fn visualizer_components(
 
         // Query all the sources for our value.
         // (technically we only need to query those that are shown, but rolling this out makes things easier).
-        let result_override = query_result.overrides.get(&component_name);
+        let result_override = query_result.overrides.get_by_name(&component_name);
         let raw_override = non_empty_component_batch_raw(result_override, &component_name);
 
-        let result_store = query_result.results.get(&component_name);
+        let result_store = query_result.results.get_by_name(&component_name);
         let raw_store = non_empty_component_batch_raw(result_store, &component_name);
 
-        let result_default = query_result.defaults.get(&component_name);
+        let result_default = query_result.defaults.get_by_name(&component_name);
         let raw_default = non_empty_component_batch_raw(result_default, &component_name);
 
         let raw_fallback = visualizer

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -41,7 +41,7 @@ pub fn range_with_blueprint_resolved_data<'a>(
     let overrides = query_overrides(ctx.viewer_ctx, data_result, component_name_set.iter());
 
     // No need to query for components that have overrides.
-    component_name_set.retain(|component_name| overrides.get(component_name).is_none());
+    component_name_set.retain(|component_name| overrides.get_by_name(component_name).is_none());
 
     let results = ctx.recording_engine().cache().range(
         range_query,
@@ -85,7 +85,7 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
 
     // No need to query for components that have overrides unless opted in!
     if !query_shadowed_components {
-        component_set.retain(|component_name| overrides.get(component_name).is_none());
+        component_set.retain(|component_name| overrides.get_by_name(component_name).is_none());
     }
 
     let results = ctx.viewer_ctx.recording_engine().cache().latest_at(
@@ -195,7 +195,7 @@ fn query_overrides<'a>(
             //
             // This is extra tricky since the promise hasn't been resolved yet so we can't
             // actually look at the data.
-            if let Some(value) = component_override_result.get(component_name) {
+            if let Some(value) = component_override_result.get_by_name(component_name) {
                 let index = value.index(&current_query.timeline());
 
                 // NOTE: This can never happen, but I'd rather it happens than an unwrap.

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -87,13 +87,12 @@ pub fn view_property_component_ui(
     ctx: &QueryContext<'_>,
     ui: &mut egui::Ui,
     property: &ViewProperty,
-    // TODO: Why this no `ArchetypeName`
     display_name: &str,
     field: &ArchetypeFieldReflection,
     fallback_provider: &dyn ComponentFallbackProvider,
 ) {
     let component_descr = ComponentDescriptor {
-        archetype_name: Some(display_name.into()),
+        archetype_name: Some(property.archetype_name),
         archetype_field_name: Some(field.name.into()),
         component_name: field.component_name,
     };

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -1,4 +1,5 @@
 use re_log_types::hash::Hash64;
+use re_types::ComponentDescriptor;
 use re_types_core::{
     reflection::ArchetypeFieldReflection, Archetype, ArchetypeReflectionMarker, ComponentName,
 };
@@ -86,11 +87,18 @@ pub fn view_property_component_ui(
     ctx: &QueryContext<'_>,
     ui: &mut egui::Ui,
     property: &ViewProperty,
+    // TODO: Why this no `ArchetypeName`
     display_name: &str,
     field: &ArchetypeFieldReflection,
     fallback_provider: &dyn ComponentFallbackProvider,
 ) {
-    let component_array = property.component_raw(field.component_name);
+    let component_descr = ComponentDescriptor {
+        archetype_name: Some(display_name.into()),
+        archetype_field_name: Some(field.name.into()),
+        component_name: field.component_name,
+    };
+
+    let component_array = property.component_raw(&component_descr);
     let cache_key = property
         .component_row_id(field.component_name)
         .map(Hash64::hash);
@@ -196,7 +204,9 @@ fn menu_more(
     property: &ViewProperty,
     component_name: ComponentName,
 ) {
-    let component_array = property.component_raw(component_name);
+    // TODO(#6889): Use proper `ComponentDescriptor`.
+    let component_descr = ComponentDescriptor::new(component_name);
+    let component_array = property.component_raw(&component_descr);
 
     let property_differs_from_default = component_array
         != ctx.raw_latest_at_in_default_blueprint(&property.blueprint_store_path, component_name);

--- a/crates/viewer/re_view_bar_chart/src/view_class.rs
+++ b/crates/viewer/re_view_bar_chart/src/view_class.rs
@@ -148,8 +148,18 @@ impl ViewClass for BarChartView {
 
         let plot_legend =
             ViewProperty::from_archetype::<PlotLegend>(blueprint_db, ctx.blueprint_query, view_id);
-        let legend_visible = plot_legend.component_or_fallback::<Visible>(ctx, self, state)?;
-        let legend_corner = plot_legend.component_or_fallback::<Corner2D>(ctx, self, state)?;
+        let legend_visible: Visible = plot_legend.component_or_fallback(
+            ctx,
+            self,
+            state,
+            &PlotLegend::descriptor_visible(),
+        )?;
+        let legend_corner: Corner2D = plot_legend.component_or_fallback(
+            ctx,
+            self,
+            state,
+            &PlotLegend::descriptor_corner(),
+        )?;
 
         ui.scope(|ui| {
             let mut plot = Plot::new("bar_chart_plot")

--- a/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
@@ -3,7 +3,9 @@ use std::collections::HashSet;
 use re_chunk_store::ColumnDescriptor;
 use re_log_types::{EntityPath, ResolvedTimeRange, Timeline, TimelineName};
 use re_sorbet::{ColumnSelector, ComponentColumnSelector};
+use re_types::blueprint::archetypes::DataframeQuery;
 use re_types::blueprint::{components, datatypes};
+use re_types::Archetype;
 use re_viewer_context::{ViewSystemExecutionError, ViewerContext};
 
 use crate::dataframe_ui::HideColumnAction;
@@ -20,7 +22,9 @@ impl Query {
     ) -> Result<re_log_types::TimelineName, ViewSystemExecutionError> {
         let timeline_name = self
             .query_property
-            .component_or_empty::<components::TimelineName>()?;
+            .component_or_empty::<components::TimelineName>(
+                &DataframeQuery::descriptor_timeline(),
+            )?;
 
         // if the timeline is unset, we "freeze" it to the current time panel timeline
         if let Some(timeline_name) = timeline_name {
@@ -61,7 +65,9 @@ impl Query {
     pub fn filter_by_range(&self) -> Result<ResolvedTimeRange, ViewSystemExecutionError> {
         Ok(self
             .query_property
-            .component_or_empty::<components::FilterByRange>()?
+            .component_or_empty::<components::FilterByRange>(
+                &DataframeQuery::descriptor_filter_by_range(),
+            )?
             .map(|range_filter| (ResolvedTimeRange::new(range_filter.start, range_filter.end)))
             .unwrap_or(ResolvedTimeRange::EVERYTHING))
     }
@@ -99,7 +105,9 @@ impl Query {
     ) -> Result<Option<components::FilterIsNotNull>, ViewSystemExecutionError> {
         Ok(self
             .query_property
-            .component_or_empty::<components::FilterIsNotNull>()?)
+            .component_or_empty::<components::FilterIsNotNull>(
+                &DataframeQuery::descriptor_filter_is_not_null(),
+            )?)
     }
 
     pub fn save_filter_is_not_null(
@@ -114,7 +122,9 @@ impl Query {
     pub fn latest_at_enabled(&self) -> Result<bool, ViewSystemExecutionError> {
         Ok(self
             .query_property
-            .component_or_empty::<components::ApplyLatestAt>()?
+            .component_or_empty::<components::ApplyLatestAt>(
+                &DataframeQuery::descriptor_apply_latest_at(),
+            )?
             .is_some_and(|comp| *comp.0))
     }
 
@@ -178,7 +188,9 @@ impl Query {
     ) -> Result<Option<Vec<ColumnSelector>>, ViewSystemExecutionError> {
         let selected_columns = self
             .query_property
-            .component_or_empty::<components::SelectedColumns>()?;
+            .component_or_empty::<components::SelectedColumns>(
+                &DataframeQuery::descriptor_select(),
+            )?;
 
         // no selected columns means all columns are visible
         let Some(datatypes::SelectedColumns {

--- a/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
@@ -5,7 +5,7 @@ use re_log_types::{EntityPath, ResolvedTimeRange, Timeline, TimelineName};
 use re_sorbet::{ColumnSelector, ComponentColumnSelector};
 use re_types::blueprint::archetypes::DataframeQuery;
 use re_types::blueprint::{components, datatypes};
-use re_types::Archetype;
+use re_types::Archetype as _;
 use re_viewer_context::{ViewSystemExecutionError, ViewerContext};
 
 use crate::dataframe_ui::HideColumnAction;

--- a/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
@@ -5,7 +5,6 @@ use re_log_types::{EntityPath, ResolvedTimeRange, Timeline, TimelineName};
 use re_sorbet::{ColumnSelector, ComponentColumnSelector};
 use re_types::blueprint::archetypes::DataframeQuery;
 use re_types::blueprint::{components, datatypes};
-use re_types::Archetype as _;
 use re_viewer_context::{ViewSystemExecutionError, ViewerContext};
 
 use crate::dataframe_ui::HideColumnAction;

--- a/crates/viewer/re_view_graph/src/layout/params.rs
+++ b/crates/viewer/re_view_graph/src/layout/params.rs
@@ -4,7 +4,7 @@ use re_types::{
         components::{Enabled, ForceDistance, ForceIterations, ForceStrength},
     },
     components::Position2D,
-    Archetype, Component,
+    Archetype, Component, ComponentDescriptor,
 };
 use re_viewer_context::{ComponentFallbackProvider, ViewQuery, ViewState, ViewerContext};
 use re_viewport_blueprint::{ViewProperty, ViewPropertyQueryError};
@@ -61,12 +61,16 @@ impl<'a, T: Archetype> QueryArchetype<'a, T> {
         }
     }
 
-    fn get<R>(&self) -> Result<R, ViewPropertyQueryError>
+    fn get<R>(&self, component_descr: &ComponentDescriptor) -> Result<R, ViewPropertyQueryError>
     where
         R: Component + Default,
     {
-        self.property
-            .component_or_fallback(self.ctx, self.provider, self.view_state)
+        self.property.component_or_fallback(
+            self.ctx,
+            self.provider,
+            self.view_state,
+            component_descr,
+        )
     }
 }
 
@@ -87,23 +91,26 @@ impl ForceLayoutParams {
 
         Ok(Self {
             // Link
-            force_link_enabled: force_link.get()?,
-            force_link_distance: force_link.get()?,
-            force_link_iterations: force_link.get()?,
+            force_link_enabled: force_link.get(&ForceLink::descriptor_enabled())?,
+            force_link_distance: force_link.get(&ForceLink::descriptor_distance())?,
+            force_link_iterations: force_link.get(&ForceLink::descriptor_iterations())?,
             // Many body
-            force_many_body_enabled: force_many.get()?,
-            force_many_body_strength: force_many.get()?,
+            force_many_body_enabled: force_many.get(&ForceManyBody::descriptor_enabled())?,
+            force_many_body_strength: force_many.get(&ForceManyBody::descriptor_strength())?,
             // Position
-            force_position_enabled: force_position.get()?,
-            force_position_strength: force_position.get()?,
-            force_position_pos: force_position.get()?,
+            force_position_enabled: force_position.get(&ForcePosition::descriptor_enabled())?,
+            force_position_strength: force_position.get(&ForcePosition::descriptor_strength())?,
+            force_position_pos: force_position.get(&ForcePosition::descriptor_position())?,
             // Center
-            force_center_enabled: force_center.get()?,
-            force_center_strength: force_center.get()?,
+            force_center_enabled: force_center.get(&ForceCenter::descriptor_enabled())?,
+            force_center_strength: force_center.get(&ForceCenter::descriptor_strength())?,
             // Collision
-            force_collision_enabled: force_collision.get()?,
-            force_collision_strength: force_collision.get()?,
-            force_collision_iterations: force_collision.get()?,
+            force_collision_enabled: force_collision
+                .get(&ForceCollisionRadius::descriptor_enabled())?,
+            force_collision_strength: force_collision
+                .get(&ForceCollisionRadius::descriptor_strength())?,
+            force_collision_iterations: force_collision
+                .get(&ForceCollisionRadius::descriptor_iterations())?,
         })
     }
 }

--- a/crates/viewer/re_view_graph/src/ui/selection.rs
+++ b/crates/viewer/re_view_graph/src/ui/selection.rs
@@ -64,7 +64,7 @@ pub fn view_property_force_ui<A: Archetype + ArchetypeReflectionMarker>(
             .expect("forces are required to have an `Enabled` component");
 
         let component_descr = ComponentDescriptor {
-            archetype_name: Some(reflection.display_name.into()),
+            archetype_name: Some(property.archetype_name),
             archetype_field_name: Some(field.name.into()),
             component_name: field.component_name,
         };

--- a/crates/viewer/re_view_graph/src/ui/selection.rs
+++ b/crates/viewer/re_view_graph/src/ui/selection.rs
@@ -1,6 +1,7 @@
 use re_log_types::hash::Hash64;
 use re_types::{
     blueprint::components::Enabled, Archetype, ArchetypeReflectionMarker, Component as _,
+    ComponentDescriptor,
 };
 use re_view::{view_property_component_ui, view_property_component_ui_custom};
 use re_viewer_context::{ComponentFallbackProvider, ViewId, ViewState, ViewerContext};
@@ -62,7 +63,13 @@ pub fn view_property_force_ui<A: Archetype + ArchetypeReflectionMarker>(
             .find(|field| field.component_name == Enabled::name())
             .expect("forces are required to have an `Enabled` component");
 
-        let component_array = property.component_raw(field.component_name);
+        let component_descr = ComponentDescriptor {
+            archetype_name: Some(reflection.display_name.into()),
+            archetype_field_name: Some(field.name.into()),
+            component_name: field.component_name,
+        };
+
+        let component_array = property.component_raw(&component_descr);
         let row_id = property.component_row_id(field.component_name);
 
         let singleline_ui: &dyn Fn(&mut egui::Ui) = &|ui| {

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -175,8 +175,8 @@ impl ViewClass for GraphView {
             ctx.blueprint_query,
             query.view_id,
         );
-        let rect_in_scene: blueprint::components::VisualBounds2D =
-            bounds_property.component_or_fallback(ctx, self, state)?;
+        let rect_in_scene: blueprint::components::VisualBounds2D = bounds_property
+            .component_or_fallback(ctx, self, state, &VisualBounds2D::descriptor_range())?;
 
         // Perform all layout-related tasks.
         let request = LayoutRequest::from_graphs(graphs.iter());

--- a/crates/viewer/re_view_map/src/map_view.rs
+++ b/crates/viewer/re_view_map/src/map_view.rs
@@ -8,7 +8,7 @@ use re_log_types::EntityPath;
 use re_renderer::{RenderContext, ViewBuilder};
 use re_types::{
     blueprint::{
-        archetypes::{Background, MapBackground, MapZoom},
+        archetypes::{MapBackground, MapZoom},
         components::{MapProvider, ZoomLevel},
     },
     View as _, ViewClassIdentifier,

--- a/crates/viewer/re_view_map/src/map_view.rs
+++ b/crates/viewer/re_view_map/src/map_view.rs
@@ -8,9 +8,8 @@ use re_log_types::EntityPath;
 use re_renderer::{RenderContext, ViewBuilder};
 use re_types::{
     blueprint::{
-        archetypes::{MapBackground, MapZoom},
-        components::MapProvider,
-        components::ZoomLevel,
+        archetypes::{Background, MapBackground, MapZoom},
+        components::{MapProvider, ZoomLevel},
     },
     View as _, ViewClassIdentifier,
 };
@@ -252,7 +251,7 @@ impl ViewClass for MapView {
         let default_center_position = state.last_center_position;
 
         let blueprint_zoom_level = map_zoom
-            .component_or_empty::<ZoomLevel>()?
+            .component_or_empty::<ZoomLevel>(&MapZoom::descriptor_zoom())?
             .map(|zoom| **zoom);
         let default_zoom_level = span.and_then(|span| {
             span.zoom_for_screen_size(

--- a/crates/viewer/re_view_map/src/map_view.rs
+++ b/crates/viewer/re_view_map/src/map_view.rs
@@ -215,7 +215,12 @@ impl ViewClass for MapView {
         // Map Provider
         //
 
-        let map_provider = map_background.component_or_fallback::<MapProvider>(ctx, self, state)?;
+        let map_provider = map_background.component_or_fallback::<MapProvider>(
+            ctx,
+            self,
+            state,
+            &MapBackground::descriptor_provider(),
+        )?;
         if state.selected_provider != map_provider {
             state.tiles = None;
             state.selected_provider = map_provider;

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -45,7 +45,7 @@ use re_log_types::debug_assert_archetype_has_components;
 use re_log_types::hash::Hash64;
 use re_renderer::RenderContext;
 use re_types::{
-    blueprint::components::BackgroundKind,
+    blueprint::{archetypes::Background, components::BackgroundKind},
     components::{Color, ImageFormat, MediaType, Resolution},
 };
 use re_viewport_blueprint::{ViewProperty, ViewPropertyQueryError};
@@ -108,7 +108,12 @@ pub(crate) fn configure_background(
 ) -> Result<(Option<re_renderer::QueueableDrawData>, re_renderer::Rgba), ViewPropertyQueryError> {
     use re_renderer::renderer;
 
-    let kind: BackgroundKind = background.component_or_fallback(ctx, view_system, state)?;
+    let kind: BackgroundKind = background.component_or_fallback(
+        ctx,
+        view_system,
+        state,
+        &Background::descriptor_kind(),
+    )?;
 
     match kind {
         BackgroundKind::GradientDark => Ok((
@@ -134,7 +139,12 @@ pub(crate) fn configure_background(
         )),
 
         BackgroundKind::SolidColor => {
-            let color: Color = background.component_or_fallback(ctx, view_system, state)?;
+            let color: Color = background.component_or_fallback(
+                ctx,
+                view_system,
+                state,
+                &Background::descriptor_color(),
+            )?;
             Ok((None, color.into()))
         }
     }

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -32,7 +32,12 @@ fn ui_from_scene(
     bounds_property: &ViewProperty,
 ) -> RectTransform {
     let bounds: blueprint_components::VisualBounds2D = bounds_property
-        .component_or_fallback(ctx, view_class, view_state)
+        .component_or_fallback(
+            ctx,
+            view_class,
+            view_state,
+            &VisualBounds2D::descriptor_range(),
+        )
         .ok_or_log_error()
         .unwrap_or_default();
     view_state.visual_bounds_2d = Some(bounds);
@@ -177,7 +182,12 @@ impl SpatialView2D {
         let scene_from_ui = ui_from_scene.inverse();
 
         let near_clip_plane: blueprint_components::NearClipPlane = clip_property
-            .component_or_fallback(ctx, self, state)
+            .component_or_fallback(
+                ctx,
+                self,
+                state,
+                &NearClipPlane::descriptor_near_clip_plane(),
+            )
             .ok_or_log_error()
             .unwrap_or_default();
 

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -1,4 +1,3 @@
-
 use egui::{emath::RectTransform, NumExt as _};
 use glam::{Affine3A, Quat, Vec3};
 use web_time::Instant;

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -1,4 +1,3 @@
-use std::fmt::Debug;
 
 use egui::{emath::RectTransform, NumExt as _};
 use glam::{Affine3A, Quat, Vec3};

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use egui::{emath::RectTransform, NumExt as _};
 use glam::{Affine3A, Quat, Vec3};
 use web_time::Instant;
@@ -725,17 +727,40 @@ impl SpatialView3D {
         grid_config: &ViewProperty,
         state: &SpatialViewState,
     ) -> Result<Option<re_renderer::renderer::WorldGridDrawData>, ViewSystemExecutionError> {
-        if !**grid_config.component_or_fallback::<Visible>(ctx, self, state)? {
+        if !**grid_config.component_or_fallback::<Visible>(
+            ctx,
+            self,
+            state,
+            &LineGrid3D::descriptor_visible(),
+        )? {
             return Ok(None);
         }
 
-        let spacing = **grid_config.component_or_fallback::<GridSpacing>(ctx, self, state)?;
+        let spacing = **grid_config.component_or_fallback::<GridSpacing>(
+            ctx,
+            self,
+            state,
+            &LineGrid3D::descriptor_spacing(),
+        )?;
         let thickness_ui = **grid_config
-            .component_or_fallback::<re_types::components::StrokeWidth>(ctx, self, state)?;
-        let color =
-            grid_config.component_or_fallback::<re_types::components::Color>(ctx, self, state)?;
-        let plane =
-            grid_config.component_or_fallback::<re_types::components::Plane3D>(ctx, self, state)?;
+            .component_or_fallback::<re_types::components::StrokeWidth>(
+                ctx,
+                self,
+                state,
+                &LineGrid3D::descriptor_stroke_width(),
+            )?;
+        let color = grid_config.component_or_fallback::<re_types::components::Color>(
+            ctx,
+            self,
+            state,
+            &LineGrid3D::descriptor_color(),
+        )?;
+        let plane = grid_config.component_or_fallback::<re_types::components::Plane3D>(
+            ctx,
+            self,
+            state,
+            &LineGrid3D::descriptor_plane(),
+        )?;
 
         Ok(Some(re_renderer::renderer::WorldGridDrawData::new(
             ctx.render_ctx(),

--- a/crates/viewer/re_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_view_spatial/src/view_3d.rs
@@ -490,6 +490,7 @@ fn view_property_ui_grid3d(
                                 ctx,
                                 fallback_provider,
                                 view_state,
+                                &LineGrid3D::descriptor_color(),
                             )
                         else {
                             ui.error_label("Failed to query color component");

--- a/crates/viewer/re_view_tensor/src/dimension_mapping.rs
+++ b/crates/viewer/re_view_tensor/src/dimension_mapping.rs
@@ -1,7 +1,7 @@
 use egui::NumExt as _;
 
 use re_types::{
-    blueprint::components::TensorDimensionIndexSlider,
+    blueprint::{archetypes, components::TensorDimensionIndexSlider},
     components::{TensorDimensionIndexSelection, TensorHeightDimension, TensorWidthDimension},
     datatypes::TensorDimensionSelection,
 };
@@ -37,11 +37,19 @@ impl TensorSliceSelection {
     ) -> Result<Self, re_types::DeserializationError> {
         re_tracing::profile_function!();
 
-        let mut width = slice_selection.component_or_empty::<TensorWidthDimension>()?;
-        let mut height = slice_selection.component_or_empty::<TensorHeightDimension>()?;
-        let mut indices =
-            slice_selection.component_array_or_empty::<TensorDimensionIndexSelection>()?;
-        let mut slider = slice_selection.component_array::<TensorDimensionIndexSlider>()?;
+        let mut width = slice_selection.component_or_empty::<TensorWidthDimension>(
+            &archetypes::TensorSliceSelection::descriptor_width(),
+        )?;
+        let mut height = slice_selection.component_or_empty::<TensorHeightDimension>(
+            &archetypes::TensorSliceSelection::descriptor_height(),
+        )?;
+        let mut indices = slice_selection
+            .component_array_or_empty::<TensorDimensionIndexSelection>(
+                &archetypes::TensorSliceSelection::descriptor_indices(),
+            )?;
+        let mut slider = slice_selection.component_array::<TensorDimensionIndexSlider>(
+            &archetypes::TensorSliceSelection::descriptor_slider(),
+        )?;
 
         make_width_height_valid(shape, &mut width, &mut height);
         make_indices_valid(shape, &mut indices, width, height);

--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 
 use egui::{epaint::TextShape, Align2, NumExt as _, Vec2};
 use ndarray::Axis;

--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -1,4 +1,3 @@
-
 use egui::{epaint::TextShape, Align2, NumExt as _, Vec2};
 use ndarray::Axis;
 

--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use egui::{epaint::TextShape, Align2, NumExt as _, Vec2};
 use ndarray::Axis;
 
@@ -367,10 +369,24 @@ impl TensorView {
             ctx.blueprint_query,
             view_id,
         );
-        let colormap: Colormap = scalar_mapping.component_or_fallback(ctx, self, state)?;
-        let gamma: GammaCorrection = scalar_mapping.component_or_fallback(ctx, self, state)?;
-        let mag_filter: MagnificationFilter =
-            scalar_mapping.component_or_fallback(ctx, self, state)?;
+        let colormap: Colormap = scalar_mapping.component_or_fallback(
+            ctx,
+            self,
+            state,
+            &TensorScalarMapping::descriptor_colormap(),
+        )?;
+        let gamma: GammaCorrection = scalar_mapping.component_or_fallback(
+            ctx,
+            self,
+            state,
+            &TensorScalarMapping::descriptor_gamma(),
+        )?;
+        let mag_filter: MagnificationFilter = scalar_mapping.component_or_fallback(
+            ctx,
+            self,
+            state,
+            &TensorScalarMapping::descriptor_mag_filter(),
+        )?;
 
         let colormap = ColormapWithRange {
             colormap,
@@ -391,7 +407,7 @@ impl TensorView {
             ctx.blueprint_query,
             view_id,
         )
-        .component_or_fallback(ctx, self, state)?;
+        .component_or_fallback(ctx, self, state, &TensorViewFit::descriptor_scaling())?;
 
         let img_size = egui::vec2(width as _, height as _);
         let img_size = Vec2::max(Vec2::splat(1.0), img_size); // better safe than sorry

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -338,16 +338,35 @@ impl ViewClass for TimeSeriesView {
 
         let plot_legend =
             ViewProperty::from_archetype::<PlotLegend>(blueprint_db, ctx.blueprint_query, view_id);
-        let legend_visible = plot_legend.component_or_fallback::<Visible>(ctx, self, state)?;
-        let legend_corner = plot_legend.component_or_fallback::<Corner2D>(ctx, self, state)?;
+        let legend_visible = plot_legend.component_or_fallback::<Visible>(
+            ctx,
+            self,
+            state,
+            &PlotLegend::descriptor_visible(),
+        )?;
+        let legend_corner = plot_legend.component_or_fallback::<Corner2D>(
+            ctx,
+            self,
+            state,
+            &PlotLegend::descriptor_corner(),
+        )?;
 
         let scalar_axis =
             ViewProperty::from_archetype::<ScalarAxis>(blueprint_db, ctx.blueprint_query, view_id);
-        let y_range = scalar_axis.component_or_fallback::<Range1D>(ctx, self, state)?;
+        let y_range = scalar_axis.component_or_fallback::<Range1D>(
+            ctx,
+            self,
+            state,
+            &ScalarAxis::descriptor_range(),
+        )?;
         let y_range = make_range_sane(y_range);
 
-        let y_zoom_lock =
-            scalar_axis.component_or_fallback::<LockRangeDuringZoom>(ctx, self, state)?;
+        let y_zoom_lock = scalar_axis.component_or_fallback::<LockRangeDuringZoom>(
+            ctx,
+            self,
+            state,
+            &ScalarAxis::descriptor_zoom_lock(),
+        )?;
         let y_zoom_lock = y_zoom_lock.0 .0;
 
         let (current_time, time_type, timeline) = {

--- a/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
@@ -148,7 +148,7 @@ impl ViewerContext<'_> {
             .and_then(|default_blueprint| {
                 default_blueprint
                     .latest_at(self.blueprint_query, entity_path, [component_name])
-                    .get(&component_name)
+                    .get_by_name(&component_name)
                     .and_then(|default_value| {
                         default_value.component_batch_raw_by_component_name(component_name)
                     })
@@ -180,7 +180,7 @@ impl ViewerContext<'_> {
 
         let Some(datatype) = blueprint
             .latest_at(self.blueprint_query, entity_path, [component_name])
-            .get(&component_name)
+            .get_by_name(&component_name)
             .and_then(|unit| {
                 unit.component_batch_raw_by_component_name(component_name)
                     .map(|array| array.data_type().clone())

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -377,7 +377,9 @@ impl ViewBlueprint {
             blueprint_query,
             self.id,
         );
-        let ranges = property.component_array::<blueprint_components::VisibleTimeRange>();
+        let ranges = property.component_array::<blueprint_components::VisibleTimeRange>(
+            &blueprint_archetypes::VisibleTimeRanges::descriptor_ranges(),
+        );
 
         let time_range = ranges.ok().flatten().and_then(|ranges| {
             ranges

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -135,7 +135,9 @@ impl ViewContents {
             query,
             view_id,
         );
-        let expressions = match property.component_array_or_empty::<QueryExpression>() {
+        let expressions = match property.component_array_or_empty::<QueryExpression>(
+            &blueprint_archetypes::ViewContents::descriptor_query(),
+        ) {
             Ok(expressions) => expressions,
 
             Err(err) => {

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -162,8 +162,10 @@ impl ViewProperty {
         component_descr: &ComponentDescriptor,
     ) -> Option<arrow::array::ArrayRef> {
         self.query_results
-            .get(component_descr)
-            .and_then(|unit| unit.component_batch_raw(component_descr))
+            .get_by_name(&component_descr.component_name)
+            .and_then(|unit| {
+                unit.component_batch_raw_by_component_name(component_descr.component_name)
+            })
     }
 
     fn component_or_fallback_raw(

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -1,7 +1,10 @@
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::{external::re_query::LatestAtResults, EntityDb};
 use re_log_types::EntityPath;
-use re_types::{Archetype, ArchetypeName, ComponentBatch, ComponentName, DeserializationError};
+use re_types::{
+    Archetype, ArchetypeName, ComponentBatch, ComponentDescriptor, ComponentName,
+    DeserializationError,
+};
 use re_viewer_context::{
     external::re_entity_db::EntityTree, ComponentFallbackError, ComponentFallbackProvider,
     QueryContext, ViewId, ViewSystemExecutionError, ViewerContext,
@@ -36,7 +39,7 @@ pub struct ViewProperty {
     pub archetype_name: ArchetypeName,
 
     /// List of all components in this property.
-    pub component_names: Vec<ComponentName>,
+    pub component_descrs: Vec<ComponentDescriptor>,
 
     /// Query results for all queries of this property.
     pub query_results: LatestAtResults,
@@ -57,10 +60,7 @@ impl ViewProperty {
             blueprint_query.clone(),
             view_id,
             A::name(),
-            A::all_components()
-                .iter()
-                .map(|descr| descr.component_name)
-                .collect(),
+            A::all_components().iter().cloned().collect(),
         )
     }
 
@@ -69,7 +69,7 @@ impl ViewProperty {
         blueprint_query: LatestAtQuery,
         view_id: ViewId,
         archetype_name: ArchetypeName,
-        component_names: Vec<ComponentName>,
+        component_descrs: Vec<ComponentDescriptor>,
     ) -> Self {
         let blueprint_store_path =
             entity_path_for_view_property(view_id, blueprint_db.tree(), archetype_name);
@@ -77,14 +77,14 @@ impl ViewProperty {
         let query_results = blueprint_db.latest_at(
             &blueprint_query,
             &blueprint_store_path,
-            component_names.iter().copied(),
+            component_descrs.iter().map(|descr| descr.component_name),
         );
 
         Self {
             blueprint_store_path,
             archetype_name,
             query_results,
-            component_names,
+            component_descrs,
             blueprint_query,
         }
     }
@@ -195,8 +195,11 @@ impl ViewProperty {
     /// Resets all components to the values they had in the default blueprint.
     pub fn reset_all_components(&self, ctx: &ViewerContext<'_>) {
         // Don't use `self.query_results.components.keys()` since it may already have some components missing since they didn't show up in the query.
-        for &component_name in &self.component_names {
-            ctx.reset_blueprint_component_by_name(&self.blueprint_store_path, component_name);
+        for component_descr in &self.component_descrs {
+            ctx.reset_blueprint_component_by_name(
+                &self.blueprint_store_path,
+                component_descr.component_name,
+            );
         }
     }
 

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -161,11 +161,9 @@ impl ViewProperty {
         &self,
         component_descr: &ComponentDescriptor,
     ) -> Option<arrow::array::ArrayRef> {
-        // TODO(#6889): Tagged components should go all the way.
-        let component_name = component_descr.component_name;
         self.query_results
-            .get_by_name(&component_name)
-            .and_then(|unit| unit.component_batch_raw_by_component_name(component_name))
+            .get(component_descr)
+            .and_then(|unit| unit.component_batch_raw(component_descr))
     }
 
     fn component_or_fallback_raw(


### PR DESCRIPTION
### Related

* Part of #6889.

### What

This changes the views to query the data using `ComponentDescriptor` instead of `ComponentName`. Important to note: under the hood we still use the `ComponentName` to perform the actual lookup in the blueprint store.

When doing the review, please pay close attention that we always use the correct `blueprint::archetype` to get the descriptor, because this seems quite error prone. 🙏 
