### PR TITLE
Fix size check for NV12 & YUY2 formats in C++ and Rust

### DIFF
--- a/crates/store/re_types/src/datatypes/pixel_format_ext.rs
+++ b/crates/store/re_types/src/datatypes/pixel_format_ext.rs
@@ -46,12 +46,12 @@ impl PixelFormat {
             Self::Y_U_V24_FullRange | Self::Y_U_V24_LimitedRange => num_pixels * 4,
 
             // 422 formats.
-            Self::Y_U_V16_FullRange | Self::Y_U_V16_LimitedRange | Self::NV12 => {
+            Self::Y_U_V16_FullRange | Self::Y_U_V16_LimitedRange | Self::YUY2 => {
                 16 * num_pixels / 8
             }
 
             // 420 formats.
-            Self::Y_U_V12_FullRange | Self::Y_U_V12_LimitedRange | Self::YUY2 => {
+            Self::Y_U_V12_FullRange | Self::Y_U_V12_LimitedRange | Self::NV12 => {
                 12 * num_pixels / 8
             }
 

--- a/rerun_cpp/src/rerun/image_utils.hpp
+++ b/rerun_cpp/src/rerun/image_utils.hpp
@@ -165,13 +165,13 @@ namespace rerun {
             // 422 formats.
             case datatypes::PixelFormat::Y_U_V16_FullRange:
             case datatypes::PixelFormat::Y_U_V16_LimitedRange:
-            case datatypes::PixelFormat::NV12:
+            case datatypes::PixelFormat::YUY2:
                 return 16 * num_pixels / 8;
 
             // 420 formats.
             case datatypes::PixelFormat::Y_U_V12_FullRange:
             case datatypes::PixelFormat::Y_U_V12_LimitedRange:
-            case datatypes::PixelFormat::YUY2:
+            case datatypes::PixelFormat::NV12:
                 return 12 * num_pixels / 8;
 
             // Monochrome formats.


### PR DESCRIPTION
### Related

* Fixes #9885


### What

NV12 & YUY2 each reported the wrong bytes size in C++ and Python, causing checks on log/serialization to fail incorrectly.