### PR TITLE
Add `Tasks.status_table()` to expose to the tasks status and metadata

### DIFF
--- a/crates/store/re_log_types/src/hash.rs
+++ b/crates/store/re_log_types/src/hash.rs
@@ -17,7 +17,7 @@ impl re_byte_size::SizeBytes for Hash64 {
 impl Hash64 {
     pub const ZERO: Self = Self(0);
 
-    pub fn hash(value: impl std::hash::Hash + Copy) -> Self {
+    pub fn hash(value: impl std::hash::Hash) -> Self {
         Self(hash(value))
     }
 

--- a/crates/store/re_protos/src/lib.rs
+++ b/crates/store/re_protos/src/lib.rs
@@ -49,6 +49,9 @@ mod v1alpha1 {
 
     #[path = "./rerun.redap_tasks.v1alpha1.rs"]
     pub mod rerun_redap_tasks_v1alpha1;
+
+    #[path = "./rerun.redap_tasks.v1alpha1.ext.rs"]
+    pub mod rerun_redap_tasks_v1alpha1_ext;
 }
 
 pub mod common {

--- a/crates/store/re_protos/src/v1alpha1/rerun.redap_tasks.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.redap_tasks.v1alpha1.ext.rs
@@ -1,0 +1,12 @@
+use crate::common::v1alpha1::DataframePart;
+use crate::v1alpha1::rerun_redap_tasks_v1alpha1::QueryTasksResponse;
+use crate::{missing_field, TypeConversionError};
+
+impl QueryTasksResponse {
+    pub fn dataframe_part(&self) -> Result<&DataframePart, TypeConversionError> {
+        Ok(self
+            .data
+            .as_ref()
+            .ok_or_else(|| missing_field!(QueryTasksResponse, "data"))?)
+    }
+}

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1357,6 +1357,9 @@ class Tasks:
         A `TimeoutError` is raised if the timeout is reached.
         """
 
+    def status_table(self) -> DataFusionTable:
+        """Return a table with the status of all tasks."""
+
     def __len__(self) -> int:
         """Return the number of tasks."""
 

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-
+use arrow::array::RecordBatch;
 use arrow::datatypes::Schema as ArrowSchema;
 use pyo3::exceptions::PyValueError;
 use pyo3::{
@@ -8,6 +7,7 @@ use pyo3::{
 };
 use re_log_encoding::codec::wire::decoder::Decode as _;
 use re_protos::manifest_registry::v1alpha1::RegisterWithDatasetResponse;
+use std::collections::BTreeMap;
 use tokio_stream::StreamExt as _;
 
 use re_arrow_util::ArrowArrayDowncastRef as _;
@@ -216,6 +216,27 @@ impl ConnectionHandle {
                         })
                 })
                 .ok_or_else(|| PyValueError::new_err("bug: invalid response schema"))
+        })
+    }
+
+    pub fn query_tasks(&mut self, py: Python<'_>, task_ids: &[TaskId]) -> PyResult<RecordBatch> {
+        wait_for_future(py, async {
+            let request = re_protos::redap_tasks::v1alpha1::QueryTasksRequest {
+                ids: task_ids.to_vec(),
+            };
+
+            let status_table = self
+                .client
+                .query_tasks(request)
+                .await
+                .map_err(to_py_err)?
+                .into_inner()
+                .dataframe_part()
+                .map_err(to_py_err)?
+                .decode()
+                .map_err(to_py_err)?;
+
+            Ok(status_table)
         })
     }
 

--- a/rerun_py/src/catalog/errors.rs
+++ b/rerun_py/src/catalog/errors.rs
@@ -66,6 +66,9 @@ enum ExternalError {
 
     #[error(transparent)]
     ColumnSelectorResolveError(#[from] re_sorbet::ColumnSelectorResolveError),
+
+    #[error(transparent)]
+    TypeConversionError(#[from] re_protos::TypeConversionError),
 }
 
 impl From<re_protos::manifest_registry::v1alpha1::ext::GetDatasetSchemaResponseError>
@@ -137,6 +140,10 @@ impl From<ExternalError> for PyErr {
 
             ExternalError::ColumnSelectorResolveError(err) => {
                 PyValueError::new_err(format!("{err}"))
+            }
+
+            ExternalError::TypeConversionError(err) => {
+                PyValueError::new_err(format!("Could not convert gRPC message: {err}"))
             }
         }
     }

--- a/rerun_py/src/catalog/task.rs
+++ b/rerun_py/src/catalog/task.rs
@@ -68,6 +68,7 @@ impl PyTasks {
         Ok(())
     }
 
+    /// Return a table with the status of all tasks.
     pub fn status_table(&self, py: Python<'_>) -> PyResult<PyDataFusionTable> {
         let mut connection = self.client.borrow(py).connection().clone();
 

--- a/rerun_py/src/catalog/task.rs
+++ b/rerun_py/src/catalog/task.rs
@@ -1,9 +1,14 @@
+use std::sync::Arc;
+
+use datafusion::datasource::MemTable;
 use pyo3::exceptions::PyIndexError;
 use pyo3::{pyclass, pymethods, Py, PyRef, PyResult, Python};
 
+use re_log_types::hash::Hash64;
 use re_protos::common::v1alpha1::TaskId;
 
-use crate::catalog::PyCatalogClient;
+use crate::catalog::{to_py_err, PyCatalogClient};
+use crate::dataframe::PyDataFusionTable;
 
 /// A handle on a remote task.
 #[pyclass(name = "Task")]
@@ -63,7 +68,23 @@ impl PyTasks {
         Ok(())
     }
 
-    //TODO(ab): add method to poll about status (how many are done, etc.)
+    pub fn status_table(&self, py: Python<'_>) -> PyResult<PyDataFusionTable> {
+        let mut connection = self.client.borrow(py).connection().clone();
+
+        // TODO(dataplatform/issues#709): we'd use `OperationId` here if we had it.
+        let hash = Hash64::hash(self.ids.iter().map(|id| id.id.as_str()).collect::<Vec<_>>());
+        let name = format!("__tasks_{:x}__", hash.hash64());
+
+        let task_status_table = connection.query_tasks(py, &self.ids)?;
+        let provider = MemTable::try_new(task_status_table.schema(), vec![vec![task_status_table]])
+            .map_err(to_py_err)?;
+
+        Ok(PyDataFusionTable {
+            provider: Arc::new(provider),
+            name,
+            client: self.client.clone_ref(py),
+        })
+    }
 
     //
     // Sequence methods


### PR DESCRIPTION
### Related

- follow-up to #9895

### What

This exposes `tasks.status_table()` to return a datafusion table containing the current status of the underlying tasks. 

Basically so you can do things like this:

<img width="894" alt="image" src="https://github.com/user-attachments/assets/49295f36-40ba-405e-9a45-403dcff5da25" />
