### PR TITLE
Save `ViewProperty` components to blueprint store with descriptors

### DIFF
--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -231,7 +231,7 @@ fn load_video(
                         video_frame_reference_indicators_list_array,
                     ),
                     (
-                        video_timestamp_batch.descriptor().into_owned(),
+                        VideoFrameReference::descriptor_timestamp(),
                         video_timestamp_list_array,
                     ),
                 ]

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -421,7 +421,7 @@ fn load_episode_video(
                         video_frame_reference_indicators_list_array,
                     ),
                     (
-                        video_timestamp_batch.descriptor().into_owned(),
+                        VideoFrameReference::descriptor_timestamp(),
                         video_timestamp_list_array,
                     ),
                 ]

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -100,6 +100,7 @@ pub trait Component: Loggable {
     // * Users might still want to register Components with specific tags.
     // * In the future, `ComponentDescriptor`s will very likely cover more than Archetype-related tags
     //   (e.g. generics, metric units, etc).
+    // TODO(#6889): This method should be removed, or made dynamic.
     fn descriptor() -> ComponentDescriptor;
 
     /// The fully-qualified name of this component, e.g. `rerun.components.Position2D`.
@@ -111,9 +112,7 @@ pub trait Component: Loggable {
     /// `Self::name()` must exactly match the value returned by `Self::descriptor().component_name`,
     /// or undefined behavior ensues.
     //
-    // TODO(cmc): The only reason we keep this around is for convenience, and the only reason we need this
-    // convenience is because we're still in this weird half-way in-between state where some things
-    // are still indexed by name. Remove this entirely once we've ported everything to descriptors.
+    // TODO(#6889): This method should be removed.
     #[inline]
     fn name() -> ComponentName {
         Self::descriptor().component_name

--- a/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
@@ -53,8 +53,11 @@ impl Query {
     /// Note: this resets the range filter timestamps to -inf/+inf as any other value might be
     /// invalidated.
     pub fn save_timeline_name(&self, ctx: &ViewerContext<'_>, timeline_name: &TimelineName) {
-        self.query_property
-            .save_blueprint_component(ctx, &components::TimelineName::from(timeline_name.as_str()));
+        self.query_property.save_blueprint_component(
+            ctx,
+            &DataframeQuery::descriptor_timeline(),
+            &components::TimelineName::from(timeline_name.as_str()),
+        );
 
         // clearing the range filter is equivalent to setting it to the default -inf/+inf
         self.query_property
@@ -78,6 +81,7 @@ impl Query {
         } else {
             self.query_property.save_blueprint_component(
                 ctx,
+                &DataframeQuery::descriptor_filter_by_range(),
                 &components::FilterByRange::new(range.min(), range.max()),
             );
         }
@@ -114,8 +118,11 @@ impl Query {
         ctx: &ViewerContext<'_>,
         filter_is_not_null: &components::FilterIsNotNull,
     ) {
-        self.query_property
-            .save_blueprint_component(ctx, filter_is_not_null);
+        self.query_property.save_blueprint_component(
+            ctx,
+            &DataframeQuery::descriptor_filter_is_not_null(),
+            filter_is_not_null,
+        );
     }
 
     pub fn latest_at_enabled(&self) -> Result<bool, ViewSystemExecutionError> {
@@ -128,8 +135,11 @@ impl Query {
     }
 
     pub fn save_latest_at_enabled(&self, ctx: &ViewerContext<'_>, enabled: bool) {
-        self.query_property
-            .save_blueprint_component(ctx, &components::ApplyLatestAt(enabled.into()));
+        self.query_property.save_blueprint_component(
+            ctx,
+            &DataframeQuery::descriptor_apply_latest_at(),
+            &components::ApplyLatestAt(enabled.into()),
+        );
     }
 
     pub fn save_selected_columns(
@@ -159,8 +169,11 @@ impl Query {
             }
         }
 
-        self.query_property
-            .save_blueprint_component(ctx, &components::SelectedColumns(selected_columns));
+        self.query_property.save_blueprint_component(
+            ctx,
+            &DataframeQuery::descriptor_select(),
+            &components::SelectedColumns(selected_columns),
+        );
     }
 
     pub fn save_all_columns_selected(&self, ctx: &ViewerContext<'_>) {
@@ -169,8 +182,11 @@ impl Query {
     }
 
     pub fn save_all_columns_unselected(&self, ctx: &ViewerContext<'_>) {
-        self.query_property
-            .save_blueprint_component(ctx, &components::SelectedColumns::default());
+        self.query_property.save_blueprint_component(
+            ctx,
+            &DataframeQuery::descriptor_select(),
+            &components::SelectedColumns::default(),
+        );
     }
 
     /// Given some view columns, list the columns that should be visible (aka "selected columns"),

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -227,7 +227,11 @@ impl ViewClass for GraphView {
         if resp.double_clicked() {
             bounds_property.reset_blueprint_component::<blueprint::components::VisualBounds2D>(ctx);
         } else if scene_rect != scene_rect_ref {
-            bounds_property.save_blueprint_component(ctx, &updated_bounds);
+            bounds_property.save_blueprint_component(
+                ctx,
+                &VisualBounds2D::descriptor_range(),
+                &updated_bounds,
+            );
         }
         // Update stored bounds on the state, so visualizers see an up-to-date value.
         state.visual_bounds = Some(updated_bounds);

--- a/crates/viewer/re_view_map/src/map_view.rs
+++ b/crates/viewer/re_view_map/src/map_view.rs
@@ -299,6 +299,7 @@ impl ViewClass for MapView {
         if Some(map_memory.zoom()) != blueprint_zoom_level {
             map_zoom.save_blueprint_component(
                 ctx,
+                &MapZoom::descriptor_zoom(),
                 &ZoomLevel(re_types::datatypes::Float64(map_memory.zoom())),
             );
         }

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -103,7 +103,11 @@ fn ui_from_scene(
     if response.double_clicked() {
         bounds_property.reset_blueprint_component::<blueprint_components::VisualBounds2D>(ctx);
     } else if bounds != updated_bounds {
-        bounds_property.save_blueprint_component(ctx, &updated_bounds);
+        bounds_property.save_blueprint_component(
+            ctx,
+            &VisualBounds2D::descriptor_range(),
+            &updated_bounds,
+        );
     }
     // Update stored bounds on the state, so visualizers see an up-to-date value.
     view_state.visual_bounds_2d = Some(bounds);

--- a/crates/viewer/re_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_view_spatial/src/view_3d.rs
@@ -505,7 +505,11 @@ fn view_property_ui_grid3d(
                         .changed()
                         {
                             let color = re_types::components::Color::from(edit_color);
-                            property.save_blueprint_component(ctx, &[color]);
+                            property.save_blueprint_component(
+                                ctx,
+                                &LineGrid3D::descriptor_color(),
+                                &[color],
+                            );
                         }
                     },
                     None, // No multiline editor.

--- a/crates/viewer/re_view_tensor/src/tensor_dimension_mapper.rs
+++ b/crates/viewer/re_view_tensor/src/tensor_dimension_mapper.rs
@@ -1,4 +1,7 @@
-use re_types::datatypes::TensorDimensionIndexSelection;
+use re_types::{
+    blueprint::archetypes::{self},
+    datatypes::TensorDimensionIndexSelection,
+};
 use re_ui::UiExt as _;
 use re_viewer_context::ViewerContext;
 use re_viewport_blueprint::ViewProperty;
@@ -59,7 +62,11 @@ impl DragDropAddress {
                     width.dimension = new_selection.dimension;
                     width
                 });
-                slice_property.save_blueprint_component(ctx, &width);
+                slice_property.save_blueprint_component(
+                    ctx,
+                    &archetypes::TensorSliceSelection::descriptor_width(),
+                    &width,
+                );
             }
             Self::Height => {
                 let height = new_selection.map(|new_selection| {
@@ -67,7 +74,11 @@ impl DragDropAddress {
                     height.dimension = new_selection.dimension;
                     height
                 });
-                slice_property.save_blueprint_component(ctx, &height);
+                slice_property.save_blueprint_component(
+                    ctx,
+                    &archetypes::TensorSliceSelection::descriptor_height(),
+                    &height,
+                );
             }
             Self::Selector(selector_idx) => {
                 let mut indices = slice_selection.indices.clone();
@@ -80,8 +91,16 @@ impl DragDropAddress {
                     slider.retain(|s| s.dimension != removed_dim); // purge slider if there was any.
                     indices.remove(*selector_idx);
                 }
-                slice_property.save_blueprint_component(ctx, &indices);
-                slice_property.save_blueprint_component(ctx, &slider);
+                slice_property.save_blueprint_component(
+                    ctx,
+                    &archetypes::TensorSliceSelection::descriptor_indices(),
+                    &indices,
+                );
+                slice_property.save_blueprint_component(
+                    ctx,
+                    &archetypes::TensorSliceSelection::descriptor_slider(),
+                    &slider,
+                );
             }
             Self::NewSelector => {
                 // NewSelector can only be a drop *target*, therefore dim_idx can't be None!
@@ -90,8 +109,16 @@ impl DragDropAddress {
                     let mut slider = slice_selection.slider.clone().unwrap_or_default();
                     indices.push(new_selection.into());
                     slider.push(new_selection.dimension.into()); // Enable slider by default.
-                    slice_property.save_blueprint_component(ctx, &indices);
-                    slice_property.save_blueprint_component(ctx, &slider);
+                    slice_property.save_blueprint_component(
+                        ctx,
+                        &archetypes::TensorSliceSelection::descriptor_indices(),
+                        &indices,
+                    );
+                    slice_property.save_blueprint_component(
+                        ctx,
+                        &archetypes::TensorSliceSelection::descriptor_slider(),
+                        &slider,
+                    );
                 }
             }
         };
@@ -168,7 +195,11 @@ pub fn dimension_mapping_ui(
                 ui.horizontal(|ui| {
                     if let Some(mut width) = slice_selection.width {
                         if ui.toggle_value(&mut width.invert, "Flip").changed() {
-                            slice_property.save_blueprint_component(ctx, &width);
+                            slice_property.save_blueprint_component(
+                                ctx,
+                                &archetypes::TensorSliceSelection::descriptor_width(),
+                                &width,
+                            );
                         }
                     }
                     ui.label("width");
@@ -188,7 +219,11 @@ pub fn dimension_mapping_ui(
                 ui.horizontal(|ui| {
                     if let Some(mut height) = slice_selection.height {
                         if ui.toggle_value(&mut height.invert, "Flip").changed() {
-                            slice_property.save_blueprint_component(ctx, &height);
+                            slice_property.save_blueprint_component(
+                                ctx,
+                                &archetypes::TensorSliceSelection::descriptor_height(),
+                                &height,
+                            );
                         }
                     }
                     ui.label("height");
@@ -237,7 +272,11 @@ pub fn dimension_mapping_ui(
                             } else {
                                 slider.retain(|slider| slider.dimension != selector.dimension);
                             }
-                            slice_property.save_blueprint_component(ctx, &slider);
+                            slice_property.save_blueprint_component(
+                                ctx,
+                                &archetypes::TensorSliceSelection::descriptor_slider(),
+                                &slider,
+                            );
                         }
 
                         ui.end_row();

--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -6,7 +6,7 @@ use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
 use re_types::{
     blueprint::{
-        archetypes::{TensorScalarMapping, TensorViewFit},
+        archetypes::{self, TensorScalarMapping, TensorViewFit},
         components::ViewFit,
     },
     components::{Colormap, GammaCorrection, MagnificationFilter, TensorDimensionIndexSelection},
@@ -716,7 +716,11 @@ fn selectors_ui(
     }
 
     if changed_indices {
-        slice_property.save_blueprint_component(ctx, &indices);
+        slice_property.save_blueprint_component(
+            ctx,
+            &archetypes::TensorSliceSelection::descriptor_indices(),
+            &indices,
+        );
     }
 }
 

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -584,7 +584,11 @@ impl ViewClass for TimeSeriesView {
             state.reset_bounds_next_frame = true;
             ui.ctx().request_repaint(); // Make sure we get another frame with the reset actually applied.
         } else if new_y_range != y_range {
-            scalar_axis.save_blueprint_component(ctx, &new_y_range);
+            scalar_axis.save_blueprint_component(
+                ctx,
+                &ScalarAxis::descriptor_range(),
+                &new_y_range,
+            );
             ui.ctx().request_repaint(); // Make sure we get another frame with this new range applied.
         }
 

--- a/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
@@ -60,6 +60,7 @@ impl ViewerContext<'_> {
             ));
     }
 
+    // TODO(#6889): This saves a component without tags.
     pub fn save_blueprint_component(
         &self,
         entity_path: &EntityPath,

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -256,6 +256,7 @@ impl ViewContents {
         )
         .save_blueprint_component(
             ctx,
+            &blueprint_archetypes::ViewContents::descriptor_query(),
             &self
                 .new_entity_path_filter
                 .lock()

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -190,9 +190,18 @@ impl ViewProperty {
     pub fn save_blueprint_component(
         &self,
         ctx: &ViewerContext<'_>,
+        component_descr: &ComponentDescriptor,
         components: &dyn ComponentBatch,
     ) {
-        ctx.save_blueprint_component(&self.blueprint_store_path, components);
+        let Some(serialized) = components
+            .serialized()
+            .map(|b| b.with_descriptor_override(component_descr.clone()))
+        else {
+            re_log::warn!("could not serialize components with descriptor `{component_descr}`");
+            return;
+        };
+
+        ctx.save_serialized_blueprint_component(&self.blueprint_store_path, serialized);
     }
 
     /// Clears a blueprint component.


### PR DESCRIPTION
### Related

* Part of #6889.

### What

This ensures that all writes to the blueprint store from `ViewProperties` are tagged.
