### PR TITLE
Store and query overrides & defaults with full `ComponentDescriptor`

### DIFF
--- a/crates/store/re_types_core/src/reflection.rs
+++ b/crates/store/re_types_core/src/reflection.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use arrow::array::{Array as _, ArrayRef};
 
-use crate::{ArchetypeFieldName, ArchetypeName, ComponentName};
+use crate::{ArchetypeFieldName, ArchetypeName, ComponentDescriptor, ComponentName};
 
 /// A trait for code-generated enums.
 pub trait Enum:
@@ -303,4 +303,16 @@ pub struct ArchetypeFieldReflection {
 
     /// Is this a required component?
     pub is_required: bool,
+}
+
+impl ArchetypeFieldReflection {
+    /// Returns the component descriptor for this field.
+    #[inline]
+    pub fn component_descriptor(&self, archetype_name: ArchetypeName) -> ComponentDescriptor {
+        ComponentDescriptor {
+            component_name: self.component_name,
+            archetype_field_name: Some(self.name),
+            archetype_name: Some(archetype_name),
+        }
+    }
 }

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -41,11 +41,7 @@ pub fn range_with_blueprint_resolved_data<'a, 'b>(
     let overrides = query_overrides(ctx.viewer_ctx, data_result, component_descrs.iter());
 
     // No need to query for components that have overrides.
-    component_descrs.retain(|component_descr| {
-        overrides
-            .get_by_name(&component_descr.component_name)
-            .is_none()
-    }); // TODO(#6889): use descriptor directly (overrides aren't saved with descriptors yet)
+    component_descrs.retain(|component_descr| overrides.get(&component_descr).is_none());
 
     let results = ctx.recording_engine().cache().range(
         range_query,

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -41,7 +41,7 @@ pub fn range_with_blueprint_resolved_data<'a, 'b>(
     let overrides = query_overrides(ctx.viewer_ctx, data_result, component_descrs.iter());
 
     // No need to query for components that have overrides.
-    component_descrs.retain(|component_descr| overrides.get(&component_descr).is_none());
+    component_descrs.retain(|component_descr| overrides.get(component_descr).is_none());
 
     let results = ctx.recording_engine().cache().range(
         range_query,

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -89,7 +89,7 @@ pub fn latest_at_with_blueprint_resolved_data<'a, 'b>(
 
     // No need to query for components that have overrides unless opted in!
     if !query_shadowed_components {
-        component_descrs.retain(|component_descr| overrides.get(&component_descr).is_none());
+        component_descrs.retain(|component_descr| overrides.get(component_descr).is_none());
     }
 
     let results = ctx.viewer_ctx.recording_engine().cache().latest_at(

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -1,8 +1,6 @@
 use re_log_types::hash::Hash64;
 use re_types::ComponentDescriptor;
-use re_types_core::{
-    reflection::ArchetypeFieldReflection, Archetype, ArchetypeReflectionMarker, ComponentName,
-};
+use re_types_core::{reflection::ArchetypeFieldReflection, Archetype, ArchetypeReflectionMarker};
 use re_ui::{list_item, UiExt as _};
 use re_viewer_context::{
     ComponentFallbackProvider, ComponentUiTypes, QueryContext, ViewId, ViewState, ViewerContext,
@@ -91,11 +89,7 @@ pub fn view_property_component_ui(
     field: &ArchetypeFieldReflection,
     fallback_provider: &dyn ComponentFallbackProvider,
 ) {
-    let component_descr = ComponentDescriptor {
-        archetype_name: Some(property.archetype_name),
-        archetype_field_name: Some(field.name),
-        component_name: field.component_name,
-    };
+    let component_descr = field.component_descriptor(property.archetype_name);
 
     let component_array = property.component_raw(&component_descr);
     let cache_key = property
@@ -113,7 +107,7 @@ pub fn view_property_component_ui(
             ui,
             ctx.viewer_ctx.blueprint_db(),
             ctx.target_entity_path,
-            field.component_name,
+            &component_descr,
             cache_key,
             component_array.as_deref(),
             fallback_provider,
@@ -126,7 +120,7 @@ pub fn view_property_component_ui(
             ui,
             ctx.viewer_ctx.blueprint_db(),
             ctx.target_entity_path,
-            field.component_name,
+            &component_descr,
             cache_key,
             component_array.as_deref(),
             fallback_provider,
@@ -164,15 +158,17 @@ pub fn view_property_component_ui_custom(
     singleline_ui: &dyn Fn(&mut egui::Ui),
     multiline_ui: Option<&dyn Fn(&mut egui::Ui)>,
 ) {
+    let component_descr = field.component_descriptor(property.archetype_name);
+
     let singleline_list_item_content = list_item::PropertyContent::new(display_name)
         .menu_button(&re_ui::icons::MORE, |ui| {
-            menu_more(ctx.viewer_ctx, ui, property, field.component_name);
+            menu_more(ctx.viewer_ctx, ui, property, &component_descr);
         })
         .value_fn(move |ui, _| singleline_ui(ui));
 
     let list_item_response = if let Some(multiline_ui) = multiline_ui {
         let default_open = false;
-        let id = egui::Id::new((ctx.target_entity_path.hash(), field.component_name));
+        let id = egui::Id::new((ctx.target_entity_path.hash(), component_descr.full_name()));
         ui.list_item()
             .interactive(false)
             .show_hierarchical_with_children(
@@ -201,14 +197,12 @@ fn menu_more(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     property: &ViewProperty,
-    component_name: ComponentName,
+    component_descr: &ComponentDescriptor,
 ) {
-    // TODO(#6889): Use proper `ComponentDescriptor`.
-    let component_descr = ComponentDescriptor::new(component_name);
-    let component_array = property.component_raw(&component_descr);
+    let component_array = property.component_raw(component_descr);
 
     let property_differs_from_default = component_array
-        != ctx.raw_latest_at_in_default_blueprint(&property.blueprint_store_path, component_name);
+        != ctx.raw_latest_at_in_default_blueprint(&property.blueprint_store_path, component_descr);
 
     let response = ui
         .add_enabled(
@@ -223,7 +217,7 @@ If no default blueprint was set or it didn't set any value for this field, this 
             "The property is already set to the same value it has in the default blueprint",
         );
     if response.clicked() {
-        ctx.reset_blueprint_component_by_name(&property.blueprint_store_path, component_name);
+        ctx.reset_blueprint_component(&property.blueprint_store_path, component_descr.clone());
         ui.close_menu();
     }
 
@@ -238,7 +232,7 @@ This has the same effect as not setting the value in the blueprint at all."
         )
         .on_disabled_hover_text("The property is already unset.");
     if response.clicked() {
-        ctx.clear_blueprint_component_by_name(&property.blueprint_store_path, component_name);
+        ctx.clear_blueprint_component(&property.blueprint_store_path, component_descr.clone());
         ui.close_menu();
     }
 

--- a/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/blueprint.rs
@@ -58,7 +58,7 @@ impl Query {
 
         // clearing the range filter is equivalent to setting it to the default -inf/+inf
         self.query_property
-            .clear_blueprint_component::<components::FilterByRange>(ctx);
+            .clear_blueprint_component_by_name::<components::FilterByRange>(ctx);
     }
 
     pub fn filter_by_range(&self) -> Result<ResolvedTimeRange, ViewSystemExecutionError> {
@@ -74,7 +74,7 @@ impl Query {
     pub fn save_filter_by_range(&self, ctx: &ViewerContext<'_>, range: ResolvedTimeRange) {
         if range == ResolvedTimeRange::EVERYTHING {
             self.query_property
-                .clear_blueprint_component::<components::FilterByRange>(ctx);
+                .clear_blueprint_component_by_name::<components::FilterByRange>(ctx);
         } else {
             self.query_property.save_blueprint_component(
                 ctx,
@@ -165,7 +165,7 @@ impl Query {
 
     pub fn save_all_columns_selected(&self, ctx: &ViewerContext<'_>) {
         self.query_property
-            .clear_blueprint_component::<components::SelectedColumns>(ctx);
+            .clear_blueprint_component_by_name::<components::SelectedColumns>(ctx);
     }
 
     pub fn save_all_columns_unselected(&self, ctx: &ViewerContext<'_>) {

--- a/crates/viewer/re_view_graph/src/ui/selection.rs
+++ b/crates/viewer/re_view_graph/src/ui/selection.rs
@@ -1,7 +1,6 @@
 use re_log_types::hash::Hash64;
 use re_types::{
     blueprint::components::Enabled, Archetype, ArchetypeReflectionMarker, Component as _,
-    ComponentDescriptor,
 };
 use re_view::{view_property_component_ui, view_property_component_ui_custom};
 use re_viewer_context::{ComponentFallbackProvider, ViewId, ViewState, ViewerContext};
@@ -63,12 +62,7 @@ pub fn view_property_force_ui<A: Archetype + ArchetypeReflectionMarker>(
             .find(|field| field.component_name == Enabled::name())
             .expect("forces are required to have an `Enabled` component");
 
-        let component_descr = ComponentDescriptor {
-            archetype_name: Some(property.archetype_name),
-            archetype_field_name: Some(field.name),
-            component_name: field.component_name,
-        };
-
+        let component_descr = field.component_descriptor(property.archetype_name);
         let component_array = property.component_raw(&component_descr);
         let row_id = property.component_row_id(field.component_name);
 
@@ -78,7 +72,7 @@ pub fn view_property_force_ui<A: Archetype + ArchetypeReflectionMarker>(
                 ui,
                 ctx.blueprint_db(),
                 query_ctx.target_entity_path,
-                field.component_name,
+                &component_descr,
                 row_id.map(Hash64::hash),
                 component_array.as_deref(),
                 fallback_provider,

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -225,7 +225,10 @@ impl ViewClass for GraphView {
         // Update blueprint if changed
         let updated_bounds = blueprint::components::VisualBounds2D::from(scene_rect);
         if resp.double_clicked() {
-            bounds_property.reset_blueprint_component::<blueprint::components::VisualBounds2D>(ctx);
+            bounds_property.reset_blueprint_component(
+                ctx,
+                blueprint::archetypes::VisualBounds2D::descriptor_range(),
+            );
         } else if scene_rect != scene_rect_ref {
             bounds_property.save_blueprint_component(ctx, &updated_bounds);
         }

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -101,7 +101,7 @@ fn ui_from_scene(
     // Update blueprint if changed
     let updated_bounds: blueprint_components::VisualBounds2D = bounds_rect.into();
     if response.double_clicked() {
-        bounds_property.reset_blueprint_component::<blueprint_components::VisualBounds2D>(ctx);
+        bounds_property.reset_blueprint_component(ctx, VisualBounds2D::descriptor_range());
     } else if bounds != updated_bounds {
         bounds_property.save_blueprint_component(ctx, &updated_bounds);
     }

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -580,7 +580,7 @@ impl ViewClass for TimeSeriesView {
         // Write new y_range if it has changed.
         let new_y_range = Range1D::new(transform.bounds().min()[1], transform.bounds().max()[1]);
         if is_resetting {
-            scalar_axis.reset_blueprint_component::<Range1D>(ctx);
+            scalar_axis.reset_blueprint_component(ctx, ScalarAxis::descriptor_range());
             state.reset_bounds_next_frame = true;
             ui.ctx().request_repaint(); // Make sure we get another frame with the reset actually applied.
         } else if new_y_range != y_range {

--- a/crates/viewer/re_viewer_context/src/view/view_context.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use re_chunk_store::LatestAtQuery;
 use re_log_types::{EntityPath, TimePoint};
 use re_query::StorageEngineReadGuard;
-use re_types::{AsComponents, ComponentBatch, ComponentName};
+use re_types::{AsComponents, ComponentBatch, ComponentDescriptor, ComponentName};
 
 use crate::{DataQueryResult, DataResult, QueryContext, ViewId};
 
@@ -95,11 +95,11 @@ impl<'a> ViewContext<'a> {
     pub fn save_blueprint_array(
         &self,
         entity_path: &EntityPath,
-        component_name: ComponentName,
+        component_descr: ComponentDescriptor,
         array: arrow::array::ArrayRef,
     ) {
         self.viewer_ctx
-            .save_blueprint_array(entity_path, component_name, array);
+            .save_blueprint_array(entity_path, component_descr, array);
     }
 
     #[inline]
@@ -132,16 +132,17 @@ impl<'a> ViewContext<'a> {
     }
 
     #[inline]
-    pub fn reset_blueprint_component_by_name(
+    pub fn reset_blueprint_component(
         &self,
         entity_path: &EntityPath,
-        component_name: ComponentName,
+        component_descr: ComponentDescriptor,
     ) {
         self.viewer_ctx
-            .reset_blueprint_component_by_name(entity_path, component_name);
+            .reset_blueprint_component(entity_path, component_descr);
     }
 
     /// Clears a component in the blueprint store by logging an empty array if it exists.
+    // TODO(#6889): Remove in favor of `clear_blueprint_component`.
     #[inline]
     pub fn clear_blueprint_component_by_name(
         &self,
@@ -150,6 +151,17 @@ impl<'a> ViewContext<'a> {
     ) {
         self.viewer_ctx
             .clear_blueprint_component_by_name(entity_path, component_name);
+    }
+
+    /// Clears a component in the blueprint store by logging an empty array if it exists.
+    #[inline]
+    pub fn clear_blueprint_component(
+        &self,
+        entity_path: &EntityPath,
+        component_descr: ComponentDescriptor,
+    ) {
+        self.viewer_ctx
+            .clear_blueprint_component(entity_path, component_descr);
     }
 
     #[inline]

--- a/crates/viewer/re_viewer_context/src/view/view_query.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_query.rs
@@ -8,7 +8,10 @@ use smallvec::SmallVec;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::{EntityPath, TimeInt};
 use re_log_types::StoreKind;
-use re_types::{blueprint::archetypes as blueprint_archetypes, components, ComponentName};
+use re_types::{
+    blueprint::archetypes::{self as blueprint_archetypes, EntityBehavior},
+    components, ComponentDescriptor,
+};
 
 use crate::{
     DataResultTree, QueryRange, ViewHighlights, ViewId, ViewSystemIdentifier, ViewerContext,
@@ -40,7 +43,7 @@ pub struct PropertyOverrides {
     /// like `Visible`, `Interactive` or transform components.
     // TODO(jleibs): Consider something like `tinymap` for this.
     // TODO(andreas): Should be a `Cow` to not do as many clones.
-    pub component_overrides: IntMap<ComponentName, OverridePath>,
+    pub component_overrides: IntMap<ComponentDescriptor, OverridePath>,
 
     /// Whether the entity is visible.
     ///
@@ -107,7 +110,7 @@ impl DataResult {
         new_value: bool,
     ) {
         // Check if we should instead clear an existing override.
-        if self.lookup_override::<components::Visible>(ctx).is_some() {
+        if self.has_override(ctx, &EntityBehavior::descriptor_visible()) {
             let parent_visibility = self
                 .entity_path
                 .parent()
@@ -142,10 +145,7 @@ impl DataResult {
         new_value: bool,
     ) {
         // Check if we should instead clear an existing override.
-        if self
-            .lookup_override::<components::Interactive>(ctx)
-            .is_some()
-        {
+        if self.has_override(ctx, &EntityBehavior::descriptor_interactive()) {
             let parent_interactivity = self
                 .entity_path
                 .parent()
@@ -153,7 +153,7 @@ impl DataResult {
                 .is_none_or(|data_result| data_result.is_interactive());
 
             if parent_interactivity == new_value {
-                // TODO(andreas): tagged empty component.
+                // TODO(#6889): tagged empty component.
                 ctx.save_empty_blueprint_component::<components::Interactive>(
                     &self.property_overrides.override_path,
                 );
@@ -167,66 +167,25 @@ impl DataResult {
         );
     }
 
-    fn lookup_override<C: 'static + re_types::Component>(
-        &self,
-        ctx: &ViewerContext<'_>,
-    ) -> Option<C> {
+    fn has_override(&self, ctx: &ViewerContext<'_>, component_descr: &ComponentDescriptor) -> bool {
         self.property_overrides
             .component_overrides
-            .get(&C::name())
-            .and_then(|OverridePath { store_kind, path }| match store_kind {
-                StoreKind::Blueprint => ctx
-                    .store_context
-                    .blueprint
-                    .latest_at_component::<C>(path, ctx.blueprint_query),
-                StoreKind::Recording => ctx
-                    .recording()
-                    .latest_at_component::<C>(path, &ctx.current_query()),
+            .get(&component_descr)
+            .is_some_and(|OverridePath { store_kind, path }| {
+                match store_kind {
+                    StoreKind::Blueprint => ctx.store_context.blueprint.latest_at(
+                        ctx.blueprint_query,
+                        path,
+                        [component_descr],
+                    ),
+                    StoreKind::Recording => {
+                        ctx.recording()
+                            .latest_at(&ctx.current_query(), path, [component_descr])
+                    }
+                }
+                .get(component_descr)
+                .is_some()
             })
-            .map(|(_index, value)| value)
-    }
-
-    /// Returns from which entity path an override originates from.
-    ///
-    /// Returns None if there was no override at all.
-    /// Note that if this returns the current path, the override might be either an individual or recursive override.
-    pub fn component_override_source(
-        &self,
-        result_tree: &DataResultTree,
-        component_name: ComponentName,
-    ) -> Option<EntityPath> {
-        re_tracing::profile_function!();
-
-        // If we don't have a resolved override, clearly nothing overrode this.
-        let active_override = self
-            .property_overrides
-            .component_overrides
-            .get(&component_name)?;
-
-        // Walk up the tree to find the highest ancestor which has a matching override.
-        // This must be the ancestor we inherited the override from. Note that `active_override`
-        // is a `(StoreKind, EntityPath)`, not a value.
-        let mut override_source = self.entity_path.clone();
-        while let Some(parent_path) = override_source.parent() {
-            if result_tree
-                .lookup_result_by_path(&parent_path)
-                .is_none_or(|data_result| {
-                    // TODO(andreas): Assumes all overrides are recursive which is not true,
-                    //                This should access `recursive_component_overrides` instead.
-                    data_result
-                        .property_overrides
-                        .component_overrides
-                        .get(&component_name)
-                        != Some(active_override)
-                })
-            {
-                break;
-            }
-
-            override_source = parent_path;
-        }
-
-        Some(override_source)
     }
 
     /// Shorthand for checking for visibility on data overrides.

--- a/crates/viewer/re_viewer_context/src/view/view_query.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_query.rs
@@ -170,7 +170,7 @@ impl DataResult {
     fn has_override(&self, ctx: &ViewerContext<'_>, component_descr: &ComponentDescriptor) -> bool {
         self.property_overrides
             .component_overrides
-            .get(&component_descr)
+            .get(component_descr)
             .is_some_and(|OverridePath { store_kind, path }| {
                 match store_kind {
                     StoreKind::Blueprint => ctx.store_context.blueprint.latest_at(

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -458,8 +458,7 @@ mod tests {
         example_components::{MyLabel, MyPoint, MyPoints},
         StoreId, StoreKind, TimePoint,
     };
-    use re_types::{blueprint::archetypes::EntityBehavior, components::Interactive};
-    use re_types::{Component as _, ComponentName};
+    use re_types::{blueprint::archetypes::EntityBehavior, ComponentDescriptor};
     use re_viewer_context::{
         test_context::TestContext, IndicatedEntities, MaybeVisualizableEntities, OverridePath,
         PerVisualizer, StoreContext, VisualizableEntities,
@@ -533,7 +532,7 @@ mod tests {
 
         struct Scenario {
             blueprint_overrides: Vec<(EntityPath, Box<dyn re_types_core::AsComponents>)>,
-            expected_overrides: HashMap<EntityPath, HashSet<ComponentName>>,
+            expected_overrides: HashMap<EntityPath, HashSet<ComponentDescriptor>>,
             expected_hidden: HashSet<EntityPath>,
             expected_non_interactive: HashSet<EntityPath>,
         }
@@ -556,7 +555,7 @@ mod tests {
                 )],
                 expected_overrides: HashMap::from([(
                     "parent".into(),
-                    std::iter::once(MyLabel::name()).collect(),
+                    std::iter::once(MyPoints::descriptor_labels()).collect(),
                 )]),
                 expected_hidden: HashSet::default(),
                 expected_non_interactive: HashSet::default(),
@@ -569,7 +568,7 @@ mod tests {
                 )],
                 expected_overrides: HashMap::from([(
                     "parent".into(),
-                    std::iter::once(Visible::name()).collect(),
+                    std::iter::once(EntityBehavior::descriptor_visible()).collect(),
                 )]),
                 expected_hidden: [
                     "parent/skipped/grandchild".into(),
@@ -594,10 +593,13 @@ mod tests {
                     ),
                 ],
                 expected_overrides: HashMap::from([
-                    ("parent".into(), std::iter::once(Visible::name()).collect()),
+                    (
+                        "parent".into(),
+                        std::iter::once(EntityBehavior::descriptor_visible()).collect(),
+                    ),
                     (
                         "parent/skipped".into(),
-                        std::iter::once(Visible::name()).collect(),
+                        std::iter::once(EntityBehavior::descriptor_visible()).collect(),
                     ),
                 ]),
                 expected_hidden: ["parent".into(), "parent/child".into()]
@@ -613,7 +615,7 @@ mod tests {
                 )],
                 expected_overrides: HashMap::from([(
                     "parent".into(),
-                    HashSet::from_iter([Interactive::name()]),
+                    HashSet::from_iter([EntityBehavior::descriptor_interactive()]),
                 )]),
                 expected_hidden: HashSet::default(),
                 expected_non_interactive: [
@@ -640,11 +642,11 @@ mod tests {
                 expected_overrides: HashMap::from([
                     (
                         "parent".into(),
-                        std::iter::once(Interactive::name()).collect(),
+                        std::iter::once(EntityBehavior::descriptor_interactive()).collect(),
                     ),
                     (
                         "parent/skipped".into(),
-                        std::iter::once(Interactive::name()).collect(),
+                        std::iter::once(EntityBehavior::descriptor_interactive()).collect(),
                     ),
                 ]),
                 expected_hidden: HashSet::default(),
@@ -697,21 +699,21 @@ mod tests {
                     .cloned()
                     .unwrap_or_default();
 
-                for (component_name, override_path) in component_overrides {
+                for (component_descr, override_path) in component_overrides {
                     assert_eq!(
                         override_path.store_kind,
                         StoreKind::Blueprint,
                         "Scenario {i}"
                     );
 
-                    if component_name.ends_with("Indicator") {
+                    if component_descr.component_name.ends_with("Indicator") {
                         // Ignore indicators for overrides.
                         continue;
                     }
 
                     assert!(
-                        expected_overrides.remove(component_name),
-                        "Scenario {i}: expected override for {component_name} at {override_path:?} but got none"
+                        expected_overrides.remove(component_descr),
+                        "Scenario {i}: expected override for {component_descr} at {override_path:?} but got none"
                     );
 
                     assert_eq!(

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -18,7 +18,7 @@ use re_types::{
     },
     Archetype as _, ViewClassIdentifier,
 };
-use re_types::{components, Component as _, Loggable as _};
+use re_types::{Component as _, Loggable as _};
 use re_viewer_context::{
     DataQueryResult, DataResult, DataResultHandle, DataResultNode, DataResultTree,
     IndicatedEntities, MaybeVisualizableEntities, OverridePath, PerVisualizer, PropertyOverrides,
@@ -514,26 +514,21 @@ impl<'a> DataQueryPropertyResolver<'a> {
                 .all_components_for_entity(&override_subtree.path)
                 .unwrap_or_default()
             {
-                let component_name = component_descr.component_name;
-
                 if let Some(component_data) = blueprint
                     .storage_engine()
                     .cache()
-                    .latest_at(blueprint_query, override_path, [component_name])
-                    .component_batch_raw(&component_name)
+                    .latest_at(blueprint_query, override_path, [&component_descr])
+                    .component_batch_raw_by_descr(&component_descr)
                 {
                     // We regard empty overrides as non-existent. This is important because there is no other way of doing component-clears.
                     if !component_data.is_empty() {
-                        // TODO(andreas): Why not keep the component data while we're here? Could speed up things a lot down the line.
-                        component_overrides.insert(
-                            component_name,
-                            OverridePath::blueprint_path(override_path.clone()),
-                        );
-
                         // Handle special overrides:
-
+                        //
                         // Visible time range override.
-                        if component_name == blueprint_components::VisibleTimeRange::name() {
+                        // TODO(#6889): What tag to use for visible time range?
+                        if component_descr.component_name
+                            == blueprint_components::VisibleTimeRange::name()
+                        {
                             if let Ok(visible_time_ranges) =
                                 blueprint_components::VisibleTimeRange::from_arrow(&component_data)
                             {
@@ -546,19 +541,29 @@ impl<'a> DataQueryPropertyResolver<'a> {
                             }
                         }
                         // Visible override.
-                        else if component_name == components::Visible::name() {
+                        else if component_descr
+                            == blueprint_archetypes::EntityBehavior::descriptor_visible()
+                        {
                             if let Some(visible_array) = component_data.as_boolean_opt() {
                                 // We already checked for non-empty above, so this should be safe.
                                 property_overrides.visible = visible_array.value(0);
                             }
                         }
                         // Interactive override.
-                        else if component_name == components::Interactive::name() {
+                        else if component_descr
+                            == blueprint_archetypes::EntityBehavior::descriptor_interactive()
+                        {
                             if let Some(interactive_array) = component_data.as_boolean_opt() {
                                 // We already checked for non-empty above, so this should be safe.
                                 property_overrides.interactive = interactive_array.value(0);
                             }
                         }
+
+                        // TODO(andreas): Why not keep the component data while we're here? Could speed up things a lot down the line.
+                        component_overrides.insert(
+                            component_descr,
+                            OverridePath::blueprint_path(override_path.clone()),
+                        );
                     }
                 }
             }

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -196,6 +196,7 @@ impl ViewProperty {
     }
 
     /// Clears a blueprint component.
+    // TODO(#6889): Blueprints should be cleared by descriptor only.
     pub fn clear_blueprint_component_by_name<C: re_types::Component>(
         &self,
         ctx: &ViewerContext<'_>,

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -196,33 +196,34 @@ impl ViewProperty {
     }
 
     /// Clears a blueprint component.
-    pub fn clear_blueprint_component<C: re_types::Component>(&self, ctx: &ViewerContext<'_>) {
+    pub fn clear_blueprint_component_by_name<C: re_types::Component>(
+        &self,
+        ctx: &ViewerContext<'_>,
+    ) {
         ctx.clear_blueprint_component_by_name(&self.blueprint_store_path, C::name());
     }
 
     /// Resets a blueprint component to the value it had in the default blueprint.
-    pub fn reset_blueprint_component<C: re_types::Component>(&self, ctx: &ViewerContext<'_>) {
-        ctx.reset_blueprint_component_by_name(&self.blueprint_store_path, C::name());
+    pub fn reset_blueprint_component(
+        &self,
+        ctx: &ViewerContext<'_>,
+        component_descr: ComponentDescriptor,
+    ) {
+        ctx.reset_blueprint_component(&self.blueprint_store_path, component_descr);
     }
 
     /// Resets all components to the values they had in the default blueprint.
     pub fn reset_all_components(&self, ctx: &ViewerContext<'_>) {
         // Don't use `self.query_results.components.keys()` since it may already have some components missing since they didn't show up in the query.
-        for component_descr in &self.component_descrs {
-            ctx.reset_blueprint_component_by_name(
-                &self.blueprint_store_path,
-                component_descr.component_name,
-            );
+        for component_descr in self.component_descrs.iter().cloned() {
+            ctx.reset_blueprint_component(&self.blueprint_store_path, component_descr);
         }
     }
 
     /// Resets all components to empty values, i.e. the fallback.
     pub fn reset_all_components_to_empty(&self, ctx: &ViewerContext<'_>) {
-        for component_descr in self.query_results.components.keys() {
-            ctx.clear_blueprint_component_by_name(
-                &self.blueprint_store_path,
-                component_descr.component_name,
-            );
+        for component_descr in self.query_results.components.keys().cloned() {
+            ctx.clear_blueprint_component(&self.blueprint_store_path, component_descr);
         }
     }
 


### PR DESCRIPTION
### Related

* tagging business #6889 


### What

Fixes component defaults again (were broken on `main`).

* component ui does read and store now with fully tagged components
* default & override creation now uses fully tagged components
* _some_ operations on `ViewProperty` now store tagged components
* initial query of overrides uses now tags (default already did, causing a regression  in the interim)

Note that since lookups into query results are still not tagged, `default` spill from one tag to the other at this point. This happens because we do a single query for all the defaults which in the latest-at-cache materializes as a single chunk containing all default values for a given view.

https://github.com/user-attachments/assets/2ef257ac-0134-4a47-b77d-c15834131c28

