### PR TITLE
create partition manifests now requires storage url and partition type

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -456,9 +456,13 @@ message CreatePartitionManifestsRequest {
   // created if left unspecified (empty list)
   repeated rerun.common.v1alpha1.PartitionId partition_ids = 2;
 
+  // types of partitions and their storage location (same order
+  // as partition ids above)
+  repeated DataSource data_sources = 3;
+
   // Define what happens if create is called multiple times for the same
   // Dataset / partitions
-  rerun.common.v1alpha1.IfDuplicateBehavior on_duplicate = 3;
+  rerun.common.v1alpha1.IfDuplicateBehavior on_duplicate = 4;
 }
 
 message CreatePartitionManifestsResponse {

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -748,11 +748,15 @@ pub struct CreatePartitionManifestsRequest {
     /// created if left unspecified (empty list)
     #[prost(message, repeated, tag = "2")]
     pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::PartitionId>,
+    /// types of partitions and their storage location (same order
+    /// as partition ids above)
+    #[prost(message, repeated, tag = "3")]
+    pub data_sources: ::prost::alloc::vec::Vec<DataSource>,
     /// Define what happens if create is called multiple times for the same
     /// Dataset / partitions
     #[prost(
         enumeration = "super::super::common::v1alpha1::IfDuplicateBehavior",
-        tag = "3"
+        tag = "4"
     )]
     pub on_duplicate: i32,
 }


### PR DESCRIPTION
Small prep for moving partition type and storage url from Dataset manifest to Partition manifest.