### PR TITLE
Deduplicate task ids in `PyTasks`

### DIFF
--- a/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
@@ -1,9 +1,10 @@
+use std::hash::Hasher;
 use std::sync::Arc;
 
+use crate::v1alpha1::rerun_common_v1alpha1::TaskId;
 use crate::{invalid_field, missing_field, TypeConversionError};
 use arrow::{datatypes::Schema as ArrowSchema, error::ArrowError};
 use re_log_types::{external::re_types_core::ComponentDescriptor, TableId};
-
 // --- Arrow ---
 
 impl TryFrom<&crate::common::v1alpha1::Schema> for ArrowSchema {
@@ -889,7 +890,17 @@ impl TryFrom<crate::common::v1alpha1::ComponentDescriptor> for ComponentDescript
     }
 }
 
-// --
+// ---
+
+impl Eq for TaskId {}
+
+impl std::hash::Hash for TaskId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.as_str().hash(state)
+    }
+}
+
+// ---
 
 #[cfg(test)]
 mod tests {

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -162,6 +162,11 @@ impl ConnectionHandle {
         })
     }
 
+    /// Initiate registration of the provided recording URIs with a dataset and return the
+    /// corresponding task IDs.
+    ///
+    /// NOTE: The server may pool multiple registrations into a single task. The result always has
+    /// the same length as the output, so task ids may be duplicated.
     pub fn register_with_dataset(
         &mut self,
         py: Python<'_>,

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -137,10 +137,7 @@ impl PyDataset {
 
         let task_ids = connection.register_with_dataset(self_.py(), dataset_id, recording_uris)?;
 
-        Ok(PyTasks {
-            client: super_.client.clone_ref(self_.py()),
-            ids: task_ids,
-        })
+        Ok(PyTasks::new(super_.client.clone_ref(self_.py()), task_ids))
     }
 
     /// Download a partition from the dataset.


### PR DESCRIPTION
### Related

* follow up to https://github.com/rerun-io/rerun/pull/9899

### What

Turns out task ids may be duplicated when returned from `register_with_dataset`. This PR changes `PyTasks` such that it deduplicate tasks.