### PR TITLE
Use `MaybeTagged` as an interim solution for porting view results lookups & port map view

### DIFF
--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -284,6 +284,14 @@ impl LatestAtResults {
         self.components.get(component_descr)
     }
 
+    // TODO(#6889): remove this please!
+    pub fn get_by_maybe(&self, component_descriptor: &MaybeTagged) -> Option<&UnitChunkShared> {
+        match component_descriptor {
+            MaybeTagged::Descriptor(component_descriptor) => self.get(component_descriptor),
+            MaybeTagged::JustName(component_name) => self.get_by_name(component_name),
+        }
+    }
+
     // TODO(#6889): Going forward, we should avoid querying by name.
     /// Returns the [`UnitChunkShared`] for the specified [`Component`].
     #[inline]

--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -79,6 +79,8 @@ use re_chunk::ComponentName;
 use re_types_core::ComponentDescriptor;
 
 // TODO(#6889): This is a temporary object until we use tagged components everywhere or have explicit untagged queries (?).
+
+#[derive(Debug, Clone)]
 pub enum MaybeTagged {
     Descriptor(ComponentDescriptor),
     JustName(ComponentName),

--- a/crates/store/re_query/src/range.rs
+++ b/crates/store/re_query/src/range.rs
@@ -165,6 +165,14 @@ impl RangeResults {
         )
     }
 
+    // TODO(#6889): remove this please!
+    pub fn get_by_maybe(&self, component_descriptor: &MaybeTagged) -> Option<&[Chunk]> {
+        match component_descriptor {
+            MaybeTagged::Descriptor(component_descriptor) => self.get(component_descriptor),
+            MaybeTagged::JustName(component_name) => self.get_by_name(component_name),
+        }
+    }
+
     /// Returns the [`Chunk`]s for the specified component.
     ///
     /// Returns an error if the component is not present.

--- a/crates/viewer/re_view_map/src/visualizers/geo_line_strings.rs
+++ b/crates/viewer/re_view_map/src/visualizers/geo_line_strings.rs
@@ -5,8 +5,7 @@ use re_renderer::{
 };
 use re_types::{
     archetypes::GeoLineStrings,
-    components::{Color, GeoLineString, Radius},
-    Component as _,
+    components::{Color, Radius},
 };
 use re_view::{DataResultQuery as _, RangeResultsExt as _};
 use re_viewer_context::{
@@ -54,9 +53,9 @@ impl VisualizerSystem for GeoLineStringsVisualizer {
 
             // gather all relevant chunks
             let timeline = view_query.timeline;
-            let all_lines = results.iter_as(timeline, GeoLineString::name());
-            let all_colors = results.iter_as(timeline, Color::name());
-            let all_radii = results.iter_as(timeline, Radius::name());
+            let all_lines = results.iter_as(timeline, GeoLineStrings::descriptor_line_strings());
+            let all_colors = results.iter_as(timeline, GeoLineStrings::descriptor_colors());
+            let all_radii = results.iter_as(timeline, GeoLineStrings::descriptor_radii());
 
             // fallback component values
             let fallback_color: Color =

--- a/crates/viewer/re_view_map/src/visualizers/geo_line_strings.rs
+++ b/crates/viewer/re_view_map/src/visualizers/geo_line_strings.rs
@@ -22,7 +22,7 @@ struct GeoLineStringsBatch {
     instance_id: Vec<PickingLayerInstanceId>,
 }
 
-/// Visualizer for [`GeoLineString`].
+/// Visualizer for [`GeoLineStrings`].
 #[derive(Default)]
 pub struct GeoLineStringsVisualizer {
     batches: Vec<(EntityPath, GeoLineStringsBatch)>,

--- a/crates/viewer/re_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_view_map/src/visualizers/geo_points.rs
@@ -2,8 +2,7 @@ use re_log_types::EntityPath;
 use re_renderer::{renderer::PointCloudDrawDataError, PickingLayerInstanceId};
 use re_types::{
     archetypes::GeoPoints,
-    components::{ClassId, Color, LatLon, Radius},
-    Component as _,
+    components::{Color, Radius},
 };
 use re_view::{
     process_annotation_slices, process_color_slice, AnnotationSceneContext, DataResultQuery as _,
@@ -57,10 +56,10 @@ impl VisualizerSystem for GeoPointsVisualizer {
 
             // gather all relevant chunks
             let timeline = view_query.timeline;
-            let all_positions = results.iter_as(timeline, LatLon::name());
-            let all_colors = results.iter_as(timeline, Color::name());
-            let all_radii = results.iter_as(timeline, Radius::name());
-            let all_class_ids = results.iter_as(timeline, ClassId::name());
+            let all_positions = results.iter_as(timeline, GeoPoints::descriptor_positions());
+            let all_colors = results.iter_as(timeline, GeoPoints::descriptor_colors());
+            let all_radii = results.iter_as(timeline, GeoPoints::descriptor_radii());
+            let all_class_ids = results.iter_as(timeline, GeoPoints::descriptor_class_ids());
 
             // fallback component values
             let query_context = ctx.query_context(data_result, &latest_at_query);

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -247,7 +247,7 @@ impl SeriesLineSystem {
 
             // Now convert the `PlotPoints` into `Vec<PlotSeries>`
             let aggregator = results
-                .get_optional_chunks(&AggregationPolicy::name())
+                .get_optional_chunks(AggregationPolicy::name())
                 .iter()
                 .find(|chunk| !chunk.is_empty())
                 .and_then(|chunk| chunk.component_mono::<AggregationPolicy>(0)?.ok())

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -259,8 +259,7 @@ impl SeriesPointSystem {
                 re_tracing::profile_scope!("fill marker shapes");
 
                 {
-                    let all_marker_shapes_chunks =
-                        results.get_optional_chunks(&MarkerShape::name());
+                    let all_marker_shapes_chunks = results.get_optional_chunks(MarkerShape::name());
 
                     if all_marker_shapes_chunks.len() == 1
                         && all_marker_shapes_chunks[0].is_static()

--- a/crates/viewer/re_view_time_series/src/series_query.rs
+++ b/crates/viewer/re_view_time_series/src/series_query.rs
@@ -131,7 +131,7 @@ pub fn collect_colors(
         let [a, b, g, r] = raw.to_le_bytes();
         re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
     }
-    let all_color_chunks = results.get_optional_chunks(&components::Color::name());
+    let all_color_chunks = results.get_optional_chunks(components::Color::name());
     if all_color_chunks.len() == 1 && all_color_chunks[0].is_static() {
         re_tracing::profile_scope!("override/default fast path");
 
@@ -215,7 +215,7 @@ pub fn collect_series_name(
     re_tracing::profile_function!();
 
     let mut series_names: Vec<String> = results
-        .get_optional_chunks(&components::Name::name())
+        .get_optional_chunks(components::Name::name())
         .iter()
         .find(|chunk| !chunk.is_empty())
         .and_then(|chunk| chunk.iter_slices::<String>(components::Name::name()).next())
@@ -250,7 +250,7 @@ pub fn collect_radius_ui(
     let num_series = points_per_series.len();
 
     {
-        let all_radius_chunks = results.get_optional_chunks(&radius_component_name);
+        let all_radius_chunks = results.get_optional_chunks(radius_component_name);
 
         if all_radius_chunks.len() == 1 && all_radius_chunks[0].is_static() {
             re_tracing::profile_scope!("override/default fast path");


### PR DESCRIPTION
### Related

* Part of #6889 

### What

See title. This allow us to switch lookups one by one and delay porting the chunk iter utilities until we're done on porting views!