### PR TITLE
Adapt remaining calls to `iter_as` with component descriptors

### DIFF
--- a/crates/viewer/re_view_graph/src/visualizers/edges.rs
+++ b/crates/viewer/re_view_graph/src/visualizers/edges.rs
@@ -1,6 +1,10 @@
 use re_chunk::LatestAtQuery;
 use re_log_types::{EntityPath, Instance};
-use re_types::{self, archetypes, components, datatypes, Component as _};
+use re_types::{
+    self,
+    archetypes::{self, GraphEdges},
+    components, datatypes, Component as _,
+};
 use re_view::{DataResultQuery as _, RangeResultsExt as _};
 use re_viewer_context::{
     self, IdentifiedViewSystem, ViewContext, ViewContextCollection, ViewQuery,
@@ -64,7 +68,8 @@ impl VisualizerSystem for EdgesVisualizer {
                     &timeline_query,
                 );
 
-            let all_edges = results.iter_as(query.timeline, components::GraphEdge::name());
+            let all_edges = results.iter_as(query.timeline, GraphEdges::descriptor_edges());
+            // TODO(#6889): This still uses an untagged query.
             let graph_type = results.get_mono_with_fallback::<components::GraphType>();
 
             let sources = all_edges

--- a/crates/viewer/re_view_graph/src/visualizers/nodes.rs
+++ b/crates/viewer/re_view_graph/src/visualizers/nodes.rs
@@ -2,6 +2,7 @@ use egui::Color32;
 use re_chunk::LatestAtQuery;
 use re_log_types::{EntityPath, Instance};
 use re_query::{clamped_zip_2x4, range_zip_1x4};
+use re_types::archetypes::GraphNodes;
 use re_types::components::{Color, Radius, ShowLabels};
 use re_types::{
     self, archetypes,
@@ -78,11 +79,11 @@ impl VisualizerSystem for NodeVisualizer {
                     &timeline_query,
                 );
 
-            let all_nodes = results.iter_as(query.timeline, components::GraphNode::name());
-            let all_colors = results.iter_as(query.timeline, components::Color::name());
-            let all_positions = results.iter_as(query.timeline, components::Position2D::name());
-            let all_labels = results.iter_as(query.timeline, components::Text::name());
-            let all_radii = results.iter_as(query.timeline, components::Radius::name());
+            let all_nodes = results.iter_as(query.timeline, GraphNodes::descriptor_node_ids());
+            let all_colors = results.iter_as(query.timeline, GraphNodes::descriptor_colors());
+            let all_positions = results.iter_as(query.timeline, GraphNodes::descriptor_positions());
+            let all_labels = results.iter_as(query.timeline, GraphNodes::descriptor_labels());
+            let all_radii = results.iter_as(query.timeline, GraphNodes::descriptor_radii());
             let show_label = results
                 .get_mono::<components::ShowLabels>()
                 .is_none_or(bool::from);

--- a/crates/viewer/re_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/boxes3d.rs
@@ -155,7 +155,7 @@ impl VisualizerSystem for Boxes3DVisualizer {
                 let all_show_labels = results.iter_as(timeline, Boxes3D::descriptor_show_labels());
 
                 // Deserialized because it's a union.
-                let all_fill_modes = results.iter_as(timeline, FillMode::name());
+                let all_fill_modes = results.iter_as(timeline, Boxes3D::descriptor_fill_mode());
                 // fill mode is currently a non-repeated component
                 let fill_mode: FillMode = all_fill_modes
                     .slice::<u8>()

--- a/crates/viewer/re_view_tensor/src/visualizer_system.rs
+++ b/crates/viewer/re_view_tensor/src/visualizer_system.rs
@@ -68,7 +68,7 @@ impl VisualizerSystem for TensorSystem {
                     .iter_component_indices(&timeline)
                     .zip(chunk.iter_component::<TensorData>())
             });
-            let all_ranges = results.iter_as(timeline, ValueRange::name());
+            let all_ranges = results.iter_as(timeline, Tensor::descriptor_value_range());
 
             for ((_, tensor_row_id), tensors, data_ranges) in
                 re_query::range_zip_1x1(all_tensors_indexed, all_ranges.slice::<[f64; 2]>())

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -104,9 +104,9 @@ impl TextLogSystem {
             .flat_map(|chunk| chunk.iter_component_timepoints());
 
         let timeline = *query.timeline();
-        let all_texts = results.iter_as(timeline, Text::name());
-        let all_levels = results.iter_as(timeline, TextLogLevel::name());
-        let all_colors = results.iter_as(timeline, Color::name());
+        let all_texts = results.iter_as(timeline, TextLog::descriptor_text());
+        let all_levels = results.iter_as(timeline, TextLog::descriptor_level());
+        let all_colors = results.iter_as(timeline, TextLog::descriptor_color());
 
         let all_frames = range_zip_1x2(
             all_texts.slice::<String>(),


### PR DESCRIPTION
### Related

* Part of #6889.
* Follow up of #9915.

### What

Title.
