### PR TITLE
Require descriptor for all calls to `RangeResultsExt::iter_as`

### DIFF
--- a/crates/viewer/re_view/src/results_ext.rs
+++ b/crates/viewer/re_view/src/results_ext.rs
@@ -243,13 +243,12 @@ pub trait RangeResultsExt {
     /// Call one of the following methods on the returned [`HybridResultsChunkIter`]:
     /// * [`HybridResultsChunkIter::slice`]
     /// * [`HybridResultsChunkIter::slice_from_struct_field`]
-    // TODO(#6889): Take descriptor instead of name.
     fn iter_as(
         &self,
         timeline: TimelineName,
-        component_descriptor: impl Into<MaybeTagged>,
+        component_descriptor: ComponentDescriptor,
     ) -> HybridResultsChunkIter<'_> {
-        let component_descriptor = component_descriptor.into();
+        let component_descriptor = MaybeTagged::Descriptor(component_descriptor);
         let chunks = self.get_optional_chunks(component_descriptor.clone());
         HybridResultsChunkIter {
             chunks,

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -304,7 +304,12 @@ impl SeriesLineSystem {
                 }
             }
 
-            let series_visibility = collect_series_visibility(&query, &results, num_series);
+            let series_visibility = collect_series_visibility(
+                &query,
+                &results,
+                num_series,
+                archetypes::SeriesLines::descriptor_visible_series(),
+            );
             let series_names = collect_series_name(self, &query_ctx, &results, num_series);
 
             debug_assert_eq!(points_per_series.len(), series_names.len());
@@ -360,7 +365,7 @@ fn collect_recursive_clears(
 
         cleared_indices.extend(
             results
-                .iter_as(*query.timeline(), clear_descriptor.component_name) // TODO(#6889): Pass descriptor on.
+                .iter_as(*query.timeline(), clear_descriptor.clone())
                 .slice::<bool>()
                 .filter_map(|(index, is_recursive_buffer)| {
                     let is_recursive =

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -338,7 +338,12 @@ impl SeriesPointSystem {
                 }
             }
 
-            let series_visibility = collect_series_visibility(&query, &results, num_series);
+            let series_visibility = collect_series_visibility(
+                &query,
+                &results,
+                num_series,
+                archetypes::SeriesPoints::descriptor_visible_series(),
+            );
             let series_names = collect_series_name(self, &query_ctx, &results, num_series);
 
             debug_assert_eq!(points_per_series.len(), series_names.len());

--- a/crates/viewer/re_view_time_series/src/series_query.rs
+++ b/crates/viewer/re_view_time_series/src/series_query.rs
@@ -5,7 +5,9 @@ use itertools::Itertools as _;
 use re_chunk_store::RangeQuery;
 use re_log_types::{EntityPath, TimeInt};
 use re_types::external::arrow::datatypes::DataType as ArrowDatatype;
-use re_types::{components, Component as _, ComponentName, Loggable as _, RowId};
+use re_types::{
+    components, Component as _, ComponentDescriptor, ComponentName, Loggable as _, RowId,
+};
 use re_view::{clamped_or_nothing, ChunksWithDescriptor, HybridRangeResults, RangeResultsExt as _};
 use re_viewer_context::{auto_color_egui, QueryContext, TypedComponentFallbackProvider};
 
@@ -33,9 +35,10 @@ pub fn collect_series_visibility(
     query: &RangeQuery,
     results: &HybridRangeResults<'_>,
     num_series: usize,
+    visibility_descriptor: ComponentDescriptor,
 ) -> Vec<bool> {
     results
-        .iter_as(*query.timeline(), components::SeriesVisible::name())
+        .iter_as(*query.timeline(), visibility_descriptor)
         .slice::<bool>()
         .next()
         .map_or_else(


### PR DESCRIPTION
### Related

* Part of #6889.
* Requires #9892.

### What

Title. Internally we still use `MaybeTagged` but we're slowly moving the chains here.
