### PR TITLE
Fix notification popup instantly closing

### DIFF
--- a/crates/viewer/re_ui/src/notifications.rs
+++ b/crates/viewer/re_ui/src/notifications.rs
@@ -159,8 +159,13 @@ impl NotificationUi {
     }
 
     fn ui(&mut self, egui_ctx: &egui::Context, button_response: &egui::Response) {
-        let is_panel_visible =
-            egui_ctx.memory(|mem| mem.is_popup_open(notification_panel_popup_id()));
+        let is_panel_visible = egui_ctx.memory_mut(|mem| {
+            let is_open = mem.is_popup_open(notification_panel_popup_id());
+            if is_open {
+                mem.keep_popup_open(notification_panel_popup_id());
+            }
+            is_open
+        });
         if is_panel_visible {
             // Dismiss all toasts when opening panel
             self.unread_notification_level = None;

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -318,7 +318,13 @@ pub trait UiExt {
     ) -> Option<R> {
         let ui = self.ui();
 
-        if !ui.memory(|mem| mem.is_popup_open(popup_id)) {
+        if !ui.memory_mut(|mem| {
+            let is_open = mem.is_popup_open(popup_id);
+            if is_open {
+                mem.keep_popup_open(popup_id);
+            }
+            is_open
+        }) {
             return None;
         }
 


### PR DESCRIPTION
### What

#9103 broke the notification popup, this is the fix. Seems like `view_space_origin_widget_editing_ui` was also broken, but I'm not sure where that ui is.