### PR TITLE
All queries to the query cache are now guaranteed to use tagged components

### DIFF
--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -58,7 +58,8 @@ fn all_components() -> anyhow::Result<()> {
         |store: &ChunkStore, entity_path: &EntityPath, expected: Option<&[ComponentDescriptor]>| {
             let timeline = TimelineName::new("frame_nr");
 
-            let component_names = store.all_components_on_timeline_sorted(&timeline, entity_path);
+            let component_names =
+                store.all_components_on_timeline_sorted_by_name(&timeline, entity_path);
 
             let expected_component_names = expected.map(|expected| {
                 let expected: ComponentNameSet =

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -343,13 +343,17 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                         let query =
                             re_chunk::LatestAtQuery::new(TimelineName::new(""), TimeInt::STATIC);
 
-                        let results = cache.latest_at(
-                            &query,
-                            &descr.entity_path,
-                            // TODO(#6889): We don't allow passing in full descriptors to dataframe queries yet. Everything works via component name.
-                            //[ComponentDescriptor::from(descr.clone())],
-                            [descr.component_name],
-                        );
+                        // TODO(#6889): We don't allow passing in full descriptors to dataframe queries yet. Everything works via component name.
+                        let component_descriptor = store
+                            .entity_component_descriptors_with_name(
+                                &descr.entity_path,
+                                descr.component_name,
+                            )
+                            .into_iter()
+                            .next()?;
+
+                        let results =
+                            cache.latest_at(&query, &descr.entity_path, [&component_descriptor]);
 
                         results.components.into_values().next()
                     }
@@ -1054,12 +1058,19 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                     let query =
                         re_chunk::LatestAtQuery::new(state.filtered_index, *cur_index_value);
 
+                    // TODO(#6889): We don't allow passing in full descriptors to dataframe queries yet. Everything works via component name.
+                    let component_descriptor = store
+                        .entity_component_descriptors_with_name(
+                            &descr.entity_path,
+                            descr.component_name,
+                        )
+                        .into_iter()
+                        .next()?;
+
                     let results = cache.latest_at(
                         &query,
                         &descr.entity_path.clone(),
-                        // TODO(#6889): We don't allow passing in full descriptors to dataframe queries yet. Everything works via component name.
-                        //[ComponentDescriptor::from(descr.clone())],
-                        [descr.component_name],
+                        [&component_descriptor],
                     );
 
                     *streaming_state = results

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -27,7 +27,7 @@ fn query_latest_component<C: re_types_core::Component>(
     let results = db
         .storage_engine()
         .cache()
-        // This test uses explicitely untagged components for the most part.
+        // This test uses explicitly untagged components for the most part.
         .latest_at(query, entity_path, [&C::descriptor()]);
 
     let (data_time, row_id) = results.index();

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -12,7 +12,6 @@ use re_log_types::{
 };
 use re_types_core::{
     archetypes::Clear, components::ClearIsRecursive, AsComponents as _, ComponentBatch as _,
-    ComponentDescriptor,
 };
 
 // ---

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -12,6 +12,7 @@ use re_log_types::{
 };
 use re_types_core::{
     archetypes::Clear, components::ClearIsRecursive, AsComponents as _, ComponentBatch as _,
+    ComponentDescriptor,
 };
 
 // ---
@@ -26,10 +27,30 @@ fn query_latest_component<C: re_types_core::Component>(
     let results = db
         .storage_engine()
         .cache()
-        .latest_at(query, entity_path, [C::name()]);
+        // This test uses explicitely untagged components for the most part.
+        .latest_at(query, entity_path, [&C::descriptor()]);
 
     let (data_time, row_id) = results.index();
     let data = results.component_mono::<C>()?;
+
+    Some((data_time, row_id, data))
+}
+
+fn query_latest_component_clear(
+    db: &EntityDb,
+    entity_path: &EntityPath,
+    query: &LatestAtQuery,
+) -> Option<(TimeInt, RowId, ClearIsRecursive)> {
+    re_tracing::profile_function!();
+
+    let results = db.storage_engine().cache().latest_at(
+        query,
+        entity_path,
+        [&Clear::descriptor_is_recursive()],
+    );
+
+    let (data_time, row_id) = results.index();
+    let data = results.component_mono::<ClearIsRecursive>()?;
 
     Some((data_time, row_id, data))
 }
@@ -137,8 +158,7 @@ fn clears() -> anyhow::Result<()> {
             assert!(query_latest_component::<MyColor>(&db, &entity_path_parent, &query).is_none());
             // the `Clear` component itself doesn't get cleared!
             let (_, _, got_clear) =
-                query_latest_component::<ClearIsRecursive>(&db, &entity_path_parent, &query)
-                    .unwrap();
+                query_latest_component_clear(&db, &entity_path_parent, &query).unwrap();
             similar_asserts::assert_eq!(
                 clear.is_recursive.map(|batch| batch.array),
                 got_clear.serialized().map(|batch| batch.array)
@@ -174,8 +194,7 @@ fn clears() -> anyhow::Result<()> {
             assert!(query_latest_component::<MyColor>(&db, &entity_path_parent, &query).is_none());
             // the `Clear` component itself doesn't get cleared!
             let (_, _, got_clear) =
-                query_latest_component::<ClearIsRecursive>(&db, &entity_path_parent, &query)
-                    .unwrap();
+                query_latest_component_clear(&db, &entity_path_parent, &query).unwrap();
             similar_asserts::assert_eq!(
                 clear.is_recursive.map(|batch| batch.array),
                 got_clear.serialized().map(|batch| batch.array)
@@ -362,8 +381,7 @@ fn clears_respect_index_order() -> anyhow::Result<()> {
         similar_asserts::assert_eq!(point, got_point);
 
         // the `Clear` component itself doesn't get cleared!
-        let (_, _, got_clear) =
-            query_latest_component::<ClearIsRecursive>(&db, &entity_path, &query).unwrap();
+        let (_, _, got_clear) = query_latest_component_clear(&db, &entity_path, &query).unwrap();
         similar_asserts::assert_eq!(
             clear.is_recursive.map(|batch| batch.array),
             got_clear.serialized().map(|batch| batch.array)
@@ -387,8 +405,7 @@ fn clears_respect_index_order() -> anyhow::Result<()> {
         assert!(query_latest_component::<MyPoint>(&db, &entity_path, &query).is_none());
 
         // the `Clear` component itself doesn't get cleared!
-        let (_, _, got_clear) =
-            query_latest_component::<ClearIsRecursive>(&db, &entity_path, &query).unwrap();
+        let (_, _, got_clear) = query_latest_component_clear(&db, &entity_path, &query).unwrap();
         similar_asserts::assert_eq!(
             clear.is_recursive.map(|batch| batch.array),
             got_clear.serialized().map(|batch| batch.array)

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -100,7 +100,7 @@ fn annotation_info(
 
     // TODO(#6889): If there's several class ids we have no idea which one to use.
     // This code uses the first one that shows up.
-    // We should instead for a class id that is likely a sibling of the keypoint id.
+    // We should search instead for a class id that is likely a sibling of the keypoint id.
     let storage_engine = ctx.recording().storage_engine();
     let possible_class_id_descriptors = storage_engine
         .store()

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -2,16 +2,19 @@ use egui::{color_picker, Vec2};
 use itertools::Itertools as _;
 use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
-use re_types::components::AnnotationContext;
-use re_types::datatypes::{
-    AnnotationInfo, ClassDescription, ClassDescriptionMapElem, KeypointId, KeypointPair,
+use re_types::{
+    components::{self, AnnotationContext},
+    datatypes::{
+        AnnotationInfo, ClassDescription, ClassDescriptionMapElem, KeypointId, KeypointPair,
+    },
+    Component as _,
 };
 use re_ui::{DesignTokens, UiExt as _};
 use re_viewer_context::{auto_color_egui, UiLayout, ViewerContext};
 
 use super::DataUi;
 
-impl crate::EntityDataUi for re_types::components::ClassId {
+impl crate::EntityDataUi for components::ClassId {
     fn entity_data_ui(
         &self,
         ctx: &ViewerContext<'_>,
@@ -57,7 +60,7 @@ impl crate::EntityDataUi for re_types::components::ClassId {
     }
 }
 
-impl crate::EntityDataUi for re_types::components::KeypointId {
+impl crate::EntityDataUi for components::KeypointId {
     fn entity_data_ui(
         &self,
         ctx: &ViewerContext<'_>,
@@ -94,9 +97,23 @@ fn annotation_info(
 ) -> Option<AnnotationInfo> {
     // TODO(#3168): this needs to use the index of the keypoint to look up the correct
     // class_id. For now we use `latest_at_component_quiet` to avoid the warning spam.
+
+    // TODO(#6889): If there's several class ids we have no idea which one to use.
+    // This code uses the first one that shows up.
+    // We should instead for a class id that is likely a sibling of the keypoint id.
+    let storage_engine = ctx.recording().storage_engine();
+    let possible_class_id_descriptors = storage_engine
+        .store()
+        .entity_component_descriptors_with_name(entity_path, components::ClassId::name());
+    let picked_class_id_descriptors = possible_class_id_descriptors.iter().next()?;
+
     let (_, class_id) = ctx
         .recording()
-        .latest_at_component_quiet::<re_types::components::ClassId>(entity_path, query)?;
+        .latest_at_component_quiet::<components::ClassId>(
+            entity_path,
+            query,
+            picked_class_id_descriptors,
+        )?;
 
     let annotations = crate::annotations(ctx, query, entity_path);
     let class = annotations.resolved_class_description(Some(class_id));

--- a/crates/viewer/re_data_ui/src/app_id.rs
+++ b/crates/viewer/re_data_ui/src/app_id.rs
@@ -2,7 +2,7 @@ use itertools::Itertools as _;
 
 use re_entity_db::EntityDb;
 use re_log_types::ApplicationId;
-use re_types::components::Timestamp;
+use re_types::{archetypes::RecordingProperties, components::Timestamp};
 use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::item_ui::entity_db_button_ui;
@@ -41,7 +41,10 @@ impl crate::DataUi for ApplicationId {
             .bundle
             .recordings()
             .filter(|db| db.app_id() == Some(self))
-            .sorted_by_key(|entity_db| entity_db.recording_property::<Timestamp>())
+            .sorted_by_key(|entity_db| {
+                entity_db
+                    .recording_property::<Timestamp>(&RecordingProperties::descriptor_start_time())
+            })
             .collect();
 
         // Using the same content ui also for tooltips even if it can't be interacted with.

--- a/crates/viewer/re_data_ui/src/data_source.rs
+++ b/crates/viewer/re_data_ui/src/data_source.rs
@@ -1,5 +1,5 @@
 use re_log_types::StoreKind;
-use re_types::components::Timestamp;
+use re_types::{archetypes::RecordingProperties, components::Timestamp};
 use re_viewer_context::{UiLayout, ViewerContext};
 
 use crate::item_ui::entity_db_button_ui;
@@ -48,9 +48,12 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
             }
         }
 
-        recordings.sort_by_key(|entity_db| entity_db.recording_property::<Timestamp>());
+        let start_time_descr = RecordingProperties::descriptor_start_time();
+        recordings
+            .sort_by_key(|entity_db| entity_db.recording_property::<Timestamp>(&start_time_descr));
         // TODO(grtlr): Blueprints don't have a time yet. But do we even need that?
-        blueprints.sort_by_key(|entity_db| entity_db.recording_property::<Timestamp>());
+        blueprints
+            .sort_by_key(|entity_db| entity_db.recording_property::<Timestamp>(&start_time_descr));
 
         ui.scope(|ui| {
             ui.spacing_mut().item_spacing.y = 0.0;

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -5,7 +5,10 @@
 use re_entity_db::{EntityTree, InstancePath};
 use re_format::format_uint;
 use re_log_types::{ApplicationId, EntityPath, TableId, TimeInt, TimeType, Timeline, TimelineName};
-use re_types::components::{Name, Timestamp};
+use re_types::{
+    archetypes::RecordingProperties,
+    components::{Name, Timestamp},
+};
 use re_ui::{icons, list_item, SyntaxHighlighting as _, UiExt as _};
 use re_viewer_context::{
     HoverHighlight, Item, SystemCommand, SystemCommandSender as _, UiLayout, ViewId, ViewerContext,
@@ -689,15 +692,19 @@ pub fn entity_db_button_ui(
         String::default()
     };
 
-    let recording_name = if let Some(recording_name) = entity_db.recording_property::<Name>() {
+    let recording_name = if let Some(recording_name) =
+        entity_db.recording_property::<Name>(&RecordingProperties::descriptor_name())
+    {
         Some(recording_name.to_string())
     } else {
-        entity_db.recording_property::<Timestamp>().map(|started| {
-            re_log_types::Timestamp::from(started.0)
-                .to_jiff_zoned(ctx.app_options().timestamp_format)
-                .strftime("%H:%M:%S")
-                .to_string()
-        })
+        entity_db
+            .recording_property::<Timestamp>(&RecordingProperties::descriptor_start_time())
+            .map(|started| {
+                re_log_types::Timestamp::from(started.0)
+                    .to_jiff_zoned(ctx.app_options().timestamp_format)
+                    .strftime("%H:%M:%S")
+                    .to_string()
+            })
     }
     .unwrap_or("<unknown>".to_owned());
 

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -17,6 +17,7 @@ use re_protos::catalog::v1alpha1::{
 use re_protos::TypeConversionError;
 use re_smart_channel::SmartChannelSource;
 use re_sorbet::SorbetError;
+use re_types::archetypes::RecordingProperties;
 use re_types::components::{Name, Timestamp};
 use re_ui::{icons, list_item, UiExt as _, UiLayout};
 use re_viewer_context::{
@@ -293,9 +294,10 @@ pub fn dataset_and_its_recordings_ui(
     entity_dbs.sort_by_cached_key(|entity_db| {
         (
             entity_db
-                .recording_property::<Name>()
+                .recording_property::<Name>(&RecordingProperties::descriptor_name())
                 .map(|s| natural_ordering::OrderedString(s.to_string())),
-            entity_db.recording_property::<Timestamp>(),
+            entity_db
+                .recording_property::<Timestamp>(&RecordingProperties::descriptor_start_time()),
         )
     });
 

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -229,7 +229,7 @@ fn active_defaults(
             db.storage_engine()
                 .cache()
                 .latest_at(query, &view.defaults_path, [&component_descr])
-                .component_batch_raw_by_descr(&component_descr)
+                .component_batch_raw(&component_descr)
                 .and_then(|data| (!data.is_empty()).then_some((component_descr, data)))
         })
         .collect()

--- a/crates/viewer/re_selection_panel/src/item_title.rs
+++ b/crates/viewer/re_selection_panel/src/item_title.rs
@@ -4,7 +4,7 @@ use re_chunk::EntityPath;
 use re_data_ui::item_ui::{guess_instance_path_icon, guess_query_and_db_for_selected_entity};
 use re_entity_db::InstancePath;
 use re_log_types::{ComponentPath, TableId};
-use re_types::components::Timestamp;
+use re_types::{archetypes::RecordingProperties, components::Timestamp};
 use re_ui::{
     icons,
     syntax_highlighting::{InstanceInBrackets as InstanceWithBrackets, SyntaxHighlightedBuilder},
@@ -90,7 +90,8 @@ impl ItemTitle {
         let title = if let Some(entity_db) = ctx.storage_context.bundle.get(store_id) {
             match (
                 entity_db.app_id(),
-                entity_db.recording_property::<Timestamp>(),
+                entity_db
+                    .recording_property::<Timestamp>(&RecordingProperties::descriptor_start_time()),
             ) {
                 (Some(application_id), Some(started)) => {
                     let time = re_log_types::Timestamp::from(started.0)

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -58,14 +58,12 @@ fn visible_time_range_ui(
     time_range_override_path: &EntityPath,
     is_view: bool,
 ) {
-    use re_types::Component as _;
-
     let visible_time_ranges = ctx
         .blueprint_db()
-        .latest_at_by_name(
+        .latest_at(
             ctx.blueprint_query,
             time_range_override_path,
-            std::iter::once(VisibleTimeRange::name()),
+            [&blueprint_archetypes::VisibleTimeRanges::descriptor_ranges()],
         )
         .component_batch::<VisibleTimeRange>()
         .unwrap_or_default();

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -226,7 +226,7 @@ impl Query {
         let all_components = ctx
             .recording_engine()
             .store()
-            .all_components_on_timeline_sorted(timeline, &filter_entity)
+            .all_components_on_timeline_sorted_by_name(timeline, &filter_entity)
             .unwrap_or_default();
 
         // The list of suggested components is built as follows:

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -41,10 +41,10 @@ pub(crate) use pinhole::Pinhole;
 
 use re_viewer_context::{ImageDecodeCache, ViewerContext};
 
-use re_log_types::debug_assert_archetype_has_components;
 use re_log_types::hash::Hash64;
 use re_renderer::RenderContext;
 use re_types::{
+    archetypes,
     blueprint::{archetypes::Background, components::BackgroundKind},
     components::{Color, ImageFormat, MediaType, Resolution},
 };
@@ -63,25 +63,44 @@ fn resolution_of_image_at(
     query: &re_chunk_store::LatestAtQuery,
     entity_path: &re_log_types::EntityPath,
 ) -> Option<Resolution> {
-    // First check assumptions:
-    debug_assert_archetype_has_components!(re_types::archetypes::Image, format: re_types::components::ImageFormat);
-    debug_assert_archetype_has_components!(re_types::archetypes::EncodedImage, blob: re_types::components::Blob);
+    let entity_db = ctx.recording();
+    let storage_engine = entity_db.storage_engine();
 
-    let db = ctx.recording();
+    // Check what kind of non-encoded were logged here if any.
+    // TODO(andreas): can we do this more efficiently?
+    // TODO(andreas): doesn't take blueprint into account!
+    let all_components = storage_engine
+        .store()
+        .all_components_for_entity(entity_path)?;
+    let image_format_descr = all_components
+        .get(&archetypes::Image::descriptor_format())
+        .or_else(|| all_components.get(&archetypes::DepthImage::descriptor_format()))
+        .or_else(|| all_components.get(&archetypes::SegmentationImage::descriptor_format()));
 
-    if let Some((_, image_format)) = db.latest_at_component::<ImageFormat>(entity_path, query) {
+    if let Some((_, image_format)) = image_format_descr
+        .and_then(|desc| entity_db.latest_at_component::<ImageFormat>(entity_path, query, desc))
+    {
         // Normal `Image` archetype
         return Some(Resolution::from([
             image_format.width as f32,
             image_format.height as f32,
         ]));
-    } else if let Some(((_time, row_id), blob)) =
-        db.latest_at_component::<re_types::components::Blob>(entity_path, query)
-    {
-        // `archetypes.EncodedImage`
+    }
 
-        let media_type = db
-            .latest_at_component::<MediaType>(entity_path, query)
+    // Check for an encoded image.
+    if let Some(((_time, row_id), blob)) = entity_db
+        .latest_at_component::<re_types::components::Blob>(
+            entity_path,
+            query,
+            &archetypes::EncodedImage::descriptor_blob(),
+        )
+    {
+        let media_type = entity_db
+            .latest_at_component::<MediaType>(
+                entity_path,
+                query,
+                &archetypes::EncodedImage::descriptor_media_type(),
+            )
             .map(|(_, c)| c);
 
         let image = ctx.store_context.caches.entry(|c: &mut ImageDecodeCache| {

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -66,7 +66,7 @@ fn resolution_of_image_at(
     let entity_db = ctx.recording();
     let storage_engine = entity_db.storage_engine();
 
-    // Check what kind of non-encoded were logged here if any.
+    // Check what kind of non-encoded images were logged here, if any.
     // TODO(andreas): can we do this more efficiently?
     // TODO(andreas): doesn't take blueprint into account!
     let all_components = storage_engine

--- a/crates/viewer/re_view_spatial/src/transform_cache.rs
+++ b/crates/viewer/re_view_spatial/src/transform_cache.rs
@@ -851,14 +851,23 @@ fn query_and_resolve_instance_poses_at_entity(
     entity_db: &EntityDb,
     query: &LatestAtQuery,
 ) -> Vec<Affine3A> {
-    // TODO(andreas): Filter out styling components.
-    // TODO(#9889): Boxes & ellipsoids depend on differently tagged instance pose right now.
-    let result = entity_db.latest_at_by_name(
+    let result = entity_db.latest_at(
         query,
         entity_path,
+        // TODO(#9889): Boxes, ellipsoids and capsules depend on differently tagged instance pose right now.
         archetypes::InstancePoses3D::all_components()
             .iter()
-            .map(|c| c.component_name),
+            .chain(&[
+                archetypes::Boxes3D::descriptor_centers(), // PoseTranslation3D
+                archetypes::Boxes3D::descriptor_quaternions(), // PoseRotationQuat
+                archetypes::Boxes3D::descriptor_rotation_axis_angles(), // PoseRotationAxisAngle
+                archetypes::Ellipsoids3D::descriptor_centers(), // PoseTranslation3D
+                archetypes::Ellipsoids3D::descriptor_quaternions(), // PoseRotationQuat
+                archetypes::Ellipsoids3D::descriptor_rotation_axis_angles(), // PoseRotationAxisAngle
+                archetypes::Capsules3D::descriptor_translations(),           // PoseTranslation3D
+                archetypes::Capsules3D::descriptor_quaternions(),            // PoseRotationQuat
+                archetypes::Capsules3D::descriptor_rotation_axis_angles(), // PoseRotationAxisAngle
+            ]),
     );
 
     let max_num_instances = result
@@ -959,13 +968,69 @@ fn query_and_resolve_pinhole_projection_at_entity(
     query: &LatestAtQuery,
 ) -> Option<ResolvedPinholeProjection> {
     entity_db
-        .latest_at_component::<components::PinholeProjection>(entity_path, query)
+        .latest_at_component::<components::PinholeProjection>(
+            entity_path,
+            query,
+            &archetypes::Pinhole::descriptor_image_from_camera(),
+        )
         .map(|(_index, image_from_camera)| ResolvedPinholeProjection {
             image_from_camera,
-            view_coordinates: entity_db
-                .latest_at_component::<components::ViewCoordinates>(entity_path, query)
-                .map_or(archetypes::Pinhole::DEFAULT_CAMERA_XYZ, |(_index, res)| res),
+            view_coordinates: {
+                query_view_coordinates(entity_path, entity_db, query)
+                    .unwrap_or(archetypes::Pinhole::DEFAULT_CAMERA_XYZ)
+            },
         })
+}
+
+/// Queries view coordinates from either the [`archetypes::Pinhole`] or [`archetypes::ViewCoordinates`] archetype.
+///
+/// Gives precedence to the `Pinhole` archetype.
+// TODO(#9917): This is confusing and should be cleaned up.
+pub fn query_view_coordinates(
+    entity_path: &EntityPath,
+    entity_db: &EntityDb,
+    query: &LatestAtQuery,
+) -> Option<components::ViewCoordinates> {
+    entity_db
+        .latest_at_component::<components::ViewCoordinates>(
+            entity_path,
+            query,
+            &archetypes::Pinhole::descriptor_camera_xyz(),
+        )
+        .or_else(|| {
+            entity_db.latest_at_component::<components::ViewCoordinates>(
+                entity_path,
+                query,
+                &archetypes::ViewCoordinates::descriptor_xyz(),
+            )
+        })
+        .map(|(_index, view_coordinates)| view_coordinates)
+}
+
+/// Queries view coordinates from either the [`archetypes::Pinhole`] or [`archetypes::ViewCoordinates`] archetype
+/// at the closest ancestor of the given entity path.
+///
+/// Gives precedence to the `Pinhole` archetype.
+// TODO(#9917): This is confusing and should be cleaned up.
+pub fn query_view_coordinates_at_closest_ancestor(
+    entity_path: &EntityPath,
+    entity_db: &EntityDb,
+    query: &LatestAtQuery,
+) -> Option<components::ViewCoordinates> {
+    entity_db
+        .latest_at_component_at_closest_ancestor::<components::ViewCoordinates>(
+            entity_path,
+            query,
+            &archetypes::Pinhole::descriptor_camera_xyz(),
+        )
+        .or_else(|| {
+            entity_db.latest_at_component_at_closest_ancestor::<components::ViewCoordinates>(
+                entity_path,
+                query,
+                &archetypes::ViewCoordinates::descriptor_xyz(),
+            )
+        })
+        .map(|(_path, _index, view_coordinates)| view_coordinates)
 }
 
 #[cfg(test)]

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -31,6 +31,7 @@ use re_viewport_blueprint::ViewProperty;
 use crate::{
     scene_bounding_boxes::SceneBoundingBoxes,
     space_camera_3d::SpaceCamera3D,
+    transform_cache::query_view_coordinates_at_closest_ancestor,
     ui::{create_labels, SpatialViewState},
     view_kind::SpatialViewKind,
     visualizers::{collect_ui_labels, image_view_coordinates, CamerasVisualizer},
@@ -443,12 +444,11 @@ impl SpatialView3D {
             .view_systems
             .get::<CamerasVisualizer>()?
             .space_cameras;
-        let scene_view_coordinates = ctx
-            .recording()
-            // Allow logging view-coordinates to `/` and have it apply to `/world` etc.
-            // See https://github.com/rerun-io/rerun/issues/3538
-            .latest_at_component_at_closest_ancestor(query.space_origin, &ctx.current_query())
-            .map(|(_, _index, c)| c);
+        let scene_view_coordinates = query_view_coordinates_at_closest_ancestor(
+            query.space_origin,
+            ctx.recording(),
+            &ctx.current_query(),
+        );
 
         let (ui_rect, mut response) =
             ui.allocate_at_least(ui.available_size(), egui::Sense::click_and_drag());

--- a/crates/viewer/re_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/arrows2d.rs
@@ -292,7 +292,11 @@ impl TypedComponentFallbackProvider<DrawOrder> for Arrows2DVisualizer {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Arrows2DVisualizer {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<Vector2D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Arrows2D::descriptor_vectors(),
+            &Arrows2D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/arrows3d.rs
@@ -287,7 +287,11 @@ impl TypedComponentFallbackProvider<Color> for Arrows3DVisualizer {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Arrows3DVisualizer {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<Vector3D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Arrows3D::descriptor_vectors(),
+            &Arrows3D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/boxes2d.rs
@@ -303,7 +303,11 @@ impl TypedComponentFallbackProvider<DrawOrder> for Boxes2DVisualizer {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Boxes2DVisualizer {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<HalfSize2D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Boxes2D::descriptor_half_sizes(),
+            &Boxes2D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/boxes3d.rs
@@ -234,7 +234,11 @@ impl TypedComponentFallbackProvider<Color> for Fallback {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Fallback {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<HalfSize3D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Boxes3D::descriptor_half_sizes(),
+            &Boxes3D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/capsules3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/capsules3d.rs
@@ -243,7 +243,11 @@ impl TypedComponentFallbackProvider<Color> for Fallback {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Fallback {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<HalfSize3D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Capsules3D::descriptor_radii(),
+            &Capsules3D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/ellipsoids.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/ellipsoids.rs
@@ -244,7 +244,11 @@ impl TypedComponentFallbackProvider<Color> for Fallback {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Fallback {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<HalfSize3D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Ellipsoids3D::descriptor_half_sizes(),
+            &Ellipsoids3D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/lines2d.rs
@@ -2,7 +2,7 @@ use re_log_types::Instance;
 use re_renderer::{renderer::LineStripFlags, LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::LineStrips2D,
-    components::{ClassId, Color, DrawOrder, LineStrip2D, Radius, ShowLabels},
+    components::{ClassId, Color, DrawOrder, Radius, ShowLabels},
     ArrowString,
 };
 use re_view::{process_annotation_slices, process_color_slice};
@@ -279,7 +279,11 @@ impl TypedComponentFallbackProvider<DrawOrder> for Lines2DVisualizer {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Lines2DVisualizer {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<LineStrip2D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &LineStrips2D::descriptor_strips(),
+            &LineStrips2D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/lines3d.rs
@@ -2,7 +2,7 @@ use re_log_types::Instance;
 use re_renderer::{renderer::LineStripFlags, PickingLayerInstanceId};
 use re_types::{
     archetypes::LineStrips3D,
-    components::{ClassId, Color, LineStrip3D, Radius, ShowLabels},
+    components::{ClassId, Color, Radius, ShowLabels},
     ArrowString,
 };
 use re_view::{process_annotation_slices, process_color_slice};
@@ -282,7 +282,11 @@ impl TypedComponentFallbackProvider<Color> for Lines3DVisualizer {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Lines3DVisualizer {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<LineStrip3D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &LineStrips3D::descriptor_strips(),
+            &LineStrips3D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/points2d.rs
@@ -318,7 +318,11 @@ impl TypedComponentFallbackProvider<DrawOrder> for Points2DVisualizer {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Points2DVisualizer {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<Position2D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Points2D::descriptor_positions(),
+            &Points2D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
@@ -303,7 +303,11 @@ impl TypedComponentFallbackProvider<Color> for Points3DVisualizer {
 
 impl TypedComponentFallbackProvider<ShowLabels> for Points3DVisualizer {
     fn fallback_for(&self, ctx: &QueryContext<'_>) -> ShowLabels {
-        super::utilities::show_labels_fallback::<Position3D>(ctx)
+        super::utilities::show_labels_fallback(
+            ctx,
+            &Points3D::descriptor_positions(),
+            &Points3D::descriptor_labels(),
+        )
     }
 }
 

--- a/crates/viewer/re_view_tensor/src/visualizer_system.rs
+++ b/crates/viewer/re_view_tensor/src/visualizer_system.rs
@@ -141,10 +141,11 @@ impl TypedComponentFallbackProvider<re_types::components::ValueRange> for Tensor
         &self,
         ctx: &re_viewer_context::QueryContext<'_>,
     ) -> re_types::components::ValueRange {
-        if let Some(((_time, row_id), tensor)) = ctx
-            .recording()
-            .latest_at_component::<TensorData>(ctx.target_entity_path, ctx.query)
-        {
+        if let Some(((_time, row_id), tensor)) = ctx.recording().latest_at_component::<TensorData>(
+            ctx.target_entity_path,
+            ctx.query,
+            &Tensor::descriptor_data(),
+        ) {
             let tensor_stats = ctx
                 .viewer_ctx
                 .store_context

--- a/crates/viewer/re_viewer/src/app_blueprint.rs
+++ b/crates/viewer/re_viewer/src/app_blueprint.rs
@@ -4,7 +4,10 @@ use re_chunk::{Chunk, RowId};
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
 use re_log_types::EntityPath;
-use re_types::{blueprint::components::PanelState, ComponentBatch};
+use re_types::{
+    blueprint::{archetypes::PanelBlueprint, components::PanelState},
+    ComponentBatch,
+};
 use re_viewer_context::{
     blueprint_timepoint_for_writes, CommandSender, SystemCommand, SystemCommandSender as _,
 };
@@ -246,6 +249,6 @@ fn load_panel_state(
 ) -> Option<PanelState> {
     re_tracing::profile_function!();
     blueprint_db
-        .latest_at_component_quiet::<PanelState>(path, query)
+        .latest_at_component_quiet::<PanelState>(path, query, &PanelBlueprint::descriptor_state())
         .map(|(_index, p)| p)
 }

--- a/crates/viewer/re_viewer/src/blueprint/validation.rs
+++ b/crates/viewer/re_viewer/src/blueprint/validation.rs
@@ -1,5 +1,3 @@
-use re_chunk::TimelineName;
-use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
 use re_types_core::Component;
 
@@ -15,27 +13,6 @@ pub(crate) fn validate_component<C: Component>(blueprint: &EntityDb) -> bool {
                 C::arrow_datatype()
             );
             return false;
-        } else {
-            // Otherwise, our usage of serde-fields means we still might have a problem
-            // this can go away once we stop using serde-fields.
-            // Walk the blueprint and see if any cells fail to deserialize for this component type.
-            let query = LatestAtQuery::latest(TimelineName::new(""));
-            for path in blueprint.entity_paths() {
-                if let Some(array) = engine
-                    .cache()
-                    .latest_at(&query, path, [C::name()])
-                    .component_batch_raw(&C::name())
-                {
-                    if let Err(err) = C::from_arrow_opt(&*array) {
-                        re_log::debug!(
-                            "Failed to deserialize component {:?}: {:?}",
-                            C::name(),
-                            err
-                        );
-                        return false;
-                    }
-                }
-            }
         }
     }
 

--- a/crates/viewer/re_viewer_context/src/annotations.rs
+++ b/crates/viewer/re_viewer_context/src/annotations.rs
@@ -6,6 +6,7 @@ use nohash_hasher::IntSet;
 use re_chunk::RowId;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityPath;
+use re_types::archetypes;
 use re_types::components::AnnotationContext;
 use re_types::datatypes::{AnnotationInfo, ClassDescription, ClassId, KeypointId, Utf8};
 
@@ -248,9 +249,12 @@ impl AnnotationMap {
                     // Otherwise check the obj_store for the field.
                     // If we find one, insert it and then we can break.
                     std::collections::btree_map::Entry::Vacant(entry) => {
-                        if let Some(((_time, row_id), ann_ctx)) = ctx
-                            .recording()
-                            .latest_at_component::<AnnotationContext>(&parent, time_query)
+                        if let Some(((_time, row_id), ann_ctx)) =
+                            ctx.recording().latest_at_component::<AnnotationContext>(
+                                &parent,
+                                time_query,
+                                &archetypes::AnnotationContext::descriptor_context(),
+                            )
                         {
                             let annotations = Annotations {
                                 row_id,

--- a/crates/viewer/re_viewer_context/src/global_context/item.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/item.rs
@@ -227,7 +227,7 @@ pub fn resolve_mono_instance_path(
             if let Some(array) = engine
                 .cache()
                 .latest_at(query, &instance.entity_path, [component_descr])
-                .component_batch_raw_by_descr(component_descr)
+                .component_batch_raw(component_descr)
             {
                 if array.len() > 1 {
                     return instance.clone();

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -11,7 +11,7 @@ use re_chunk_store::{
 use re_entity_db::EntityDb;
 use re_log_types::{ApplicationId, ResolvedTimeRange, StoreId, StoreKind, TableId};
 use re_query::CachesStats;
-use re_types::components::Timestamp;
+use re_types::{archetypes, components::Timestamp};
 
 use crate::{
     BlueprintUndoState, Caches, StorageContext, StoreBundle, StoreContext, TableStore, TableStores,
@@ -444,11 +444,11 @@ impl StoreHub {
         }
 
         // Find any matching recording and activate it
-        for rec in self
-            .store_bundle
-            .recordings()
-            .sorted_by_key(|entity_db| entity_db.recording_property::<Timestamp>())
-        {
+        for rec in self.store_bundle.recordings().sorted_by_key(|entity_db| {
+            entity_db.recording_property::<Timestamp>(
+                &archetypes::RecordingProperties::descriptor_start_time(),
+            )
+        }) {
             if rec.app_id() == Some(&app_id) {
                 self.active_application_id = Some(app_id.clone());
                 self.active_entry = Some(StoreHubEntry::Recording {

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -270,7 +270,7 @@ impl ViewBlueprint {
                                 let array = blueprint_engine
                                     .cache()
                                     .latest_at(query, path, [&component_descr])
-                                    .component_batch_raw_by_descr(&component_descr);
+                                    .component_batch_raw(&component_descr);
                                 array.map(|array| (component_descr, array))
                             }),
                     )

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -518,7 +518,7 @@ impl<'a> DataQueryPropertyResolver<'a> {
                     .storage_engine()
                     .cache()
                     .latest_at(blueprint_query, override_path, [&component_descr])
-                    .component_batch_raw_by_descr(&component_descr)
+                    .component_batch_raw(&component_descr)
                 {
                     // We regard empty overrides as non-existent. This is important because there is no other way of doing component-clears.
                     if !component_data.is_empty() {

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -74,10 +74,10 @@ impl ViewProperty {
         let blueprint_store_path =
             entity_path_for_view_property(view_id, blueprint_db.tree(), archetype_name);
 
-        let query_results = blueprint_db.latest_at_by_name(
+        let query_results = blueprint_db.latest_at(
             &blueprint_query,
             &blueprint_store_path,
-            component_descrs.iter().map(|descr| descr.component_name),
+            component_descrs.iter(),
         );
 
         Self {

--- a/examples/rust/custom_view/src/color_coordinates_visualizer_system.rs
+++ b/examples/rust/custom_view/src/color_coordinates_visualizer_system.rs
@@ -42,7 +42,7 @@ impl VisualizerSystem for InstanceColorSystem {
     ) -> Result<Vec<re_renderer::QueueableDrawData>, ViewSystemExecutionError> {
         // For each entity in the view that should be displayed with the `InstanceColorSystem`…
         for data_result in query.iter_visible_data_results(Self::identifier()) {
-            // TODO(#6889): This is an _interesting_ but really really strange example.
+            // TODO(#6889): This is an _interesting_ but really strange example.
             // UI doesn't play nicely with it as it won't show anything when one of these color points is selected.
 
             // First gather all kinds of colors that are logged on this path.

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -140,7 +140,7 @@ fn entity_ui(
         .store()
         .all_components_on_timeline_sorted(&timeline, entity_path)
     {
-        for component in components {
+        for component in &components {
             ui.collapsing(component.to_string(), |ui| {
                 component_ui(ui, entity_db, timeline, entity_path, component);
             });
@@ -153,7 +153,7 @@ fn component_ui(
     entity_db: &re_entity_db::EntityDb,
     timeline: re_log_types::TimelineName,
     entity_path: &re_log_types::EntityPath,
-    component_name: re_types::ComponentName,
+    component_descriptor: &re_types::ComponentDescriptor,
 ) {
     // You can query the data for any time point, but for now
     // just show the last value logged for each component:
@@ -163,9 +163,9 @@ fn component_ui(
         entity_db
             .storage_engine()
             .cache()
-            .latest_at(&query, entity_path, [component_name]);
+            .latest_at(&query, entity_path, [component_descriptor]);
 
-    if let Some(data) = results.component_batch_raw(&component_name) {
+    if let Some(data) = results.component_batch_raw(component_descriptor) {
         egui::ScrollArea::vertical()
             .auto_shrink([false, true])
             .show(ui, |ui| {


### PR DESCRIPTION
### Related

* #6889 

### What

Major milestone: While not all indexing into chunks and query results is tagged yet, all queries themselves are now guaranteed to be tagged (ignoring some remaining workaround where we gather descriptors/tags in a dubious way).

Unfortunately it escalated a bit all over the codebase and a few places needed surprisingly elaborate fixes.