### PR TITLE
Selection ui now handles different images on the same entity path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6860,7 +6860,6 @@ dependencies = [
  "egui_extras",
  "egui_plot",
  "itertools 0.14.0",
- "nohash-hasher",
  "re_byte_size",
  "re_capabilities",
  "re_chunk_store",

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -810,49 +810,6 @@ impl SizeBytes for LogMsg {
 
 // ----------------------------------------------------------------------------
 
-/// Runtime asserts that an archetype has the given components.
-///
-/// In particular, this is useful to statically check that an archetype
-/// has a specific component.
-///
-/// ```
-/// # #[macro_use] extern crate re_log_types;
-/// # use re_log_types::example_components::*;
-/// debug_assert_archetype_has_components!(MyPoints, colors: MyColor);
-/// ```
-///
-/// This will panic because the type is wrong:
-///
-/// ```should_panic
-/// # #[macro_use] extern crate re_log_types;
-/// # use re_log_types::example_components::*;
-/// debug_assert_archetype_has_components!(MyPoints, colors: MyPoint);
-/// ```
-///
-/// This will fail to compile because the field is missing:
-///
-/// ```compile_fail
-/// # #[macro_use] extern crate re_log_types;
-/// # use re_log_types::example_components::*;
-/// debug_assert_archetype_has_components!(MyPoints, colours: MyColor);
-/// ```
-///
-#[macro_export]
-macro_rules! debug_assert_archetype_has_components {
-    ($arch:ty, $($field:ident: $field_typ:ty),+ $(,)?) => {
-        #[cfg(debug_assertions)]
-        {
-            use re_log_types::external::re_types_core::{Component as _};
-            let archetype = <$arch>::clear_fields();
-            $(
-                assert_eq!(archetype.$field.map(|batch| batch.descriptor.component_name), Some(<$field_typ>::name()));
-            )+
-        }
-    };
-}
-
-// ----------------------------------------------------------------------------
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -98,23 +98,19 @@ impl Ord for ComponentColumnDescriptor {
 
 impl std::fmt::Display for ComponentColumnDescriptor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let descriptor = self.component_descriptor();
+
         let Self {
             entity_path,
-            archetype_name,
-            archetype_field_name,
-            component_name,
+            archetype_name: _,
+            archetype_field_name: _,
+            component_name: _,
             store_datatype: _,
             is_static,
             is_indicator: _,
             is_tombstone: _,
             is_semantically_empty: _,
         } = self;
-
-        let descriptor = ComponentDescriptor {
-            archetype_name: *archetype_name,
-            archetype_field_name: *archetype_field_name,
-            component_name: *component_name,
-        };
 
         let s = format!("{entity_path}@{}", descriptor.short_name());
 

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -93,8 +93,6 @@ pub mod external {
 
 /// Useful macro for statically asserting that a `struct` contains some specific fields.
 ///
-/// For asserting that an archetype has a specific component use `re_log_types::debug_assert_archetype_has_components`
-///
 ///  ```
 /// # #[macro_use] extern crate re_types_core;
 /// struct Data {

--- a/crates/viewer/re_component_ui/src/fallback_ui.rs
+++ b/crates/viewer/re_component_ui/src/fallback_ui.rs
@@ -1,4 +1,4 @@
-use re_log_types::hash::Hash64;
+use re_types::{ComponentDescriptor, RowId};
 use re_viewer_context::{
     external::{re_chunk_store::LatestAtQuery, re_entity_db::EntityDb, re_log_types::EntityPath},
     UiLayout, ViewerContext,
@@ -12,7 +12,8 @@ pub fn fallback_component_ui(
     _query: &LatestAtQuery,
     _db: &EntityDb,
     _entity_path: &EntityPath,
-    _cache_key: Option<Hash64>,
+    _component_descriptor: &ComponentDescriptor,
+    _row_id: Option<RowId>,
     component: &dyn arrow::array::Array,
 ) {
     re_ui::arrow_ui(ui, ui_layout, component);

--- a/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
+++ b/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
@@ -14,6 +14,7 @@ use re_types::{
     blueprint::components::{ComponentColumnSelector, QueryExpression},
     components::{self, GraphEdge, GraphNode, ImageFormat, Text},
     datatypes::{ChannelDatatype, PixelFormat},
+    ComponentDescriptor,
 };
 use re_types_core::{reflection::Reflection, Component, ComponentName, LoggableBatch};
 use re_ui::{list_item, UiExt as _};
@@ -242,7 +243,9 @@ fn test_single_component_ui_as_list_item(
                     &LatestAtQuery::latest(TimelineName::log_time()),
                     ctx.recording(),
                     &EntityPath::root(),
-                    test_case.component_name,
+                    // As of writing, `ComponentDescriptor` the descriptor part is only used for
+                    // caching and actual lookup of uis is only done via `ComponentName`.
+                    &ComponentDescriptor::new(test_case.component_name),
                     None,
                     &*test_case.component_data,
                 );

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -44,6 +44,5 @@ egui_extras.workspace = true
 egui_plot.workspace = true
 egui.workspace = true
 itertools.workspace = true
-nohash-hasher.workspace = true
 rexif.workspace = true
 unindent.workspace = true

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -1,13 +1,12 @@
 use egui::{color_picker, Vec2};
 use itertools::Itertools as _;
-use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
 use re_types::{
     components::{self, AnnotationContext},
     datatypes::{
         AnnotationInfo, ClassDescription, ClassDescriptionMapElem, KeypointId, KeypointPair,
     },
-    Component as _,
+    Component as _, ComponentDescriptor, RowId,
 };
 use re_ui::{DesignTokens, UiExt as _};
 use re_viewer_context::{auto_color_egui, UiLayout, ViewerContext};
@@ -21,7 +20,8 @@ impl crate::EntityDataUi for components::ClassId {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        _cache_key: Option<Hash64>,
+        _component_descriptor: &ComponentDescriptor,
+        _row_id: Option<RowId>,
         query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -67,7 +67,8 @@ impl crate::EntityDataUi for components::KeypointId {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        _cache_key: Option<Hash64>,
+        _component_descriptor: &ComponentDescriptor,
+        _row_id: Option<RowId>,
         query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
-use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
-use re_types::components::{Blob, MediaType, VideoTimestamp};
+use re_types::{
+    components::{Blob, MediaType, VideoTimestamp},
+    ComponentDescriptor, RowId,
+};
 use re_ui::{
     list_item::{self, PropertyContent},
     UiExt as _,
 };
-use re_viewer_context::{UiLayout, ViewerContext};
+use re_viewer_context::{StoredBlobCacheKey, UiLayout, ViewerContext};
 
 use crate::{
     image::image_preview_ui,
@@ -22,7 +24,8 @@ impl EntityDataUi for Blob {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        cache_key: Option<Hash64>,
+        component_descriptor: &ComponentDescriptor,
+        row_id: Option<RowId>,
         query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -44,7 +47,8 @@ impl EntityDataUi for Blob {
                     ui_layout,
                     query,
                     entity_path,
-                    cache_key,
+                    component_descriptor,
+                    row_id,
                     self,
                     media_type.as_ref(),
                     None,
@@ -88,7 +92,8 @@ impl EntityDataUi for Blob {
                     ui_layout,
                     query,
                     entity_path,
-                    cache_key,
+                    component_descriptor,
+                    row_id,
                     self,
                     media_type.as_ref(),
                     None,
@@ -105,7 +110,8 @@ pub fn blob_preview_and_save_ui(
     ui_layout: UiLayout,
     query: &re_chunk_store::LatestAtQuery,
     entity_path: &re_log_types::EntityPath,
-    blob_cache_key: Option<Hash64>,
+    blob_component_descriptor: &ComponentDescriptor,
+    blob_row_id: Option<RowId>,
     blob: &re_types::datatypes::Blob,
     media_type: Option<&MediaType>,
     video_timestamp: Option<VideoTimestamp>,
@@ -114,9 +120,13 @@ pub fn blob_preview_and_save_ui(
     let mut image = None;
     let mut video_result_for_frame_preview = None;
 
-    if let Some(blob_cache_key) = blob_cache_key {
+    if let Some(blob_row_id) = blob_row_id {
         if !ui_layout.is_single_line() && ui_layout != UiLayout::Tooltip {
-            exif_ui(ui, blob_cache_key, blob);
+            exif_ui(
+                ui,
+                StoredBlobCacheKey::new(blob_row_id, blob_component_descriptor),
+                blob,
+            );
         }
 
         // Try to treat it as an image:
@@ -124,7 +134,7 @@ pub fn blob_preview_and_save_ui(
             .store_context
             .caches
             .entry(|c: &mut re_viewer_context::ImageDecodeCache| {
-                c.entry(blob_cache_key, blob, media_type)
+                c.entry(blob_row_id, blob_component_descriptor, blob, media_type)
             })
             .ok();
 
@@ -146,7 +156,8 @@ pub fn blob_preview_and_save_ui(
                         let debug_name = entity_path.to_string();
                         c.entry(
                             debug_name,
-                            blob_cache_key,
+                            blob_row_id,
+                            blob_component_descriptor,
                             blob,
                             media_type,
                             ctx.app_options().video_decoder_settings(),
@@ -216,13 +227,13 @@ pub fn blob_preview_and_save_ui(
 }
 
 /// Show EXIF data about the given blob (image), if possible.
-fn exif_ui(ui: &mut egui::Ui, key: Hash64, blob: &re_types::datatypes::Blob) {
+fn exif_ui(ui: &mut egui::Ui, key: StoredBlobCacheKey, blob: &re_types::datatypes::Blob) {
     let exif_result = ui.ctx().memory_mut(|mem| {
         // Cache EXIF parsing to avoid re-parsing every frame.
         // The parsing is really fast, so this is not really needed.
         let cache = mem
             .caches
-            .cache::<egui::cache::FramePublisher<Hash64, Arc<rexif::ExifResult>>>();
+            .cache::<egui::cache::FramePublisher<StoredBlobCacheKey, Arc<rexif::ExifResult>>>();
         cache.get(&key).cloned().unwrap_or_else(|| {
             re_tracing::profile_scope!("exif-parse");
             let (result, _warnings) = rexif::parse_buffer_quiet(blob);

--- a/crates/viewer/re_data_ui/src/component_ui_registry.rs
+++ b/crates/viewer/re_data_ui/src/component_ui_registry.rs
@@ -39,7 +39,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
                             ui,
                             ui_layout,
                             entity_path,
-                            &component_descriptor,
+                            component_descriptor,
                             row_id,
                             query,
                             db,

--- a/crates/viewer/re_data_ui/src/component_ui_registry.rs
+++ b/crates/viewer/re_data_ui/src/component_ui_registry.rs
@@ -23,9 +23,15 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
     registry.add_legacy_display_ui(
         C::name(),
         Box::new(
-            |ctx, ui, ui_layout, query, db, entity_path, row_id, component_raw| match C::from_arrow(
-                component_raw,
-            ) {
+            |ctx,
+             ui,
+             ui_layout,
+             query,
+             db,
+             entity_path,
+             component_descriptor,
+             row_id,
+             component_raw| match C::from_arrow(component_raw) {
                 Ok(components) => match components.len() {
                     1 => {
                         components[0].entity_data_ui(
@@ -33,6 +39,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
                             ui,
                             ui_layout,
                             entity_path,
+                            &component_descriptor,
                             row_id,
                             query,
                             db,

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -1,17 +1,17 @@
+use std::collections::BTreeMap;
+
 use egui::Rangef;
-use nohash_hasher::IntMap;
 
 use re_chunk_store::UnitChunkShared;
 use re_entity_db::InstancePath;
 use re_log_types::hash::Hash64;
-use re_log_types::{debug_assert_archetype_has_components, ComponentPath};
-use re_types::ComponentDescriptor;
+use re_log_types::ComponentPath;
 use re_types::{
     archetypes, components,
     datatypes::{ChannelDatatype, ColorModel},
     image::ImageKind,
-    Component as _, ComponentName,
 };
+use re_types::{Archetype as _, ArchetypeName, Component, ComponentDescriptor};
 use re_ui::UiExt as _;
 use re_viewer_context::{
     gpu_bridge::image_data_range_heuristic, ColormapWithRange, HoverHighlight, ImageInfo,
@@ -69,7 +69,15 @@ impl DataUi for InstancePath {
             .filter(|c| c.component_name.is_indicator_component())
             .count();
 
-        let mut components = latest_at(db, query, entity_path, &components);
+        let mut components: BTreeMap<ComponentDescriptor, UnitChunkShared> = db
+            .storage_engine()
+            .cache()
+            .latest_at(query, entity_path, &components)
+            .components
+            // Use descriptor order.
+            // TODO(andreas): Even better would be to use the order of components as they show on archetypes.
+            .into_iter()
+            .collect();
 
         if components.is_empty() {
             let typ = db.timeline_type(&query.timeline());
@@ -106,7 +114,7 @@ impl DataUi for InstancePath {
             // In order to work around the GraphEdges showing up associated with random nodes, we just hide them here.
             // (this is obviously a hack and these relationships should be formalized such that they are accessible to the UI, see ticket link above)
             if !self.is_all() {
-                components.retain(|(component, _chunk)| {
+                components.retain(|component, _chunk| {
                     component.component_name != components::GraphEdge::name()
                 });
             }
@@ -124,40 +132,10 @@ impl DataUi for InstancePath {
         }
 
         if instance.is_all() {
-            let component_map = components
-                .into_iter()
-                // TODO(#6889): Below methods aren't handling multiple images yet.
-                .map(|(descr, chunk)| (descr.component_name, chunk))
-                .collect();
-
-            preview_if_image_ui(ctx, ui, ui_layout, query, entity_path, &component_map);
-            preview_if_blob_ui(ctx, ui, ui_layout, query, entity_path, &component_map);
+            preview_if_image_ui(ctx, ui, ui_layout, query, entity_path, &components);
+            preview_if_blob_ui(ctx, ui, ui_layout, query, entity_path, &components);
         }
     }
-}
-
-fn latest_at(
-    db: &re_entity_db::EntityDb,
-    query: &re_chunk_store::LatestAtQuery,
-    entity_path: &re_log_types::EntityPath,
-    components: &[ComponentDescriptor],
-) -> Vec<(ComponentDescriptor, UnitChunkShared)> {
-    let components: Vec<(ComponentDescriptor, UnitChunkShared)> = components
-        .iter()
-        .filter_map(|component_descr| {
-            let mut results =
-                db.storage_engine()
-                    .cache()
-                    .latest_at(query, entity_path, [component_descr]);
-
-            // We ignore components that are unset at this point in time
-            results
-                .components
-                .remove(component_descr)
-                .map(|unit| (component_descr.clone(), unit))
-        })
-        .collect();
-    components
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -169,7 +147,7 @@ fn component_list_ui(
     db: &re_entity_db::EntityDb,
     entity_path: &re_log_types::EntityPath,
     instance: &re_log_types::Instance,
-    components: &[(ComponentDescriptor, UnitChunkShared)],
+    components: &BTreeMap<ComponentDescriptor, UnitChunkShared>,
 ) {
     let indicator_count = components
         .iter()
@@ -288,61 +266,60 @@ fn preview_if_image_ui(
     ui_layout: UiLayout,
     query: &re_chunk_store::LatestAtQuery,
     entity_path: &re_log_types::EntityPath,
-    component_map: &IntMap<ComponentName, UnitChunkShared>,
+    components: &BTreeMap<ComponentDescriptor, UnitChunkShared>,
+) {
+    // There might be several image buffers!
+    for (image_buffer_descr, image_buffer_chunk) in components
+        .iter()
+        .filter(|(descr, _chunk)| descr.component_name == components::ImageBuffer::name())
+    {
+        preview_single_image(
+            ctx,
+            ui,
+            ui_layout,
+            query,
+            entity_path,
+            components,
+            image_buffer_descr,
+            image_buffer_chunk,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn preview_single_image(
+    ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    ui_layout: UiLayout,
+    query: &re_chunk_store::LatestAtQuery,
+    entity_path: &re_log_types::EntityPath,
+    components: &BTreeMap<ComponentDescriptor, UnitChunkShared>,
+    image_buffer_descr: &ComponentDescriptor,
+    image_buffer_chunk: &UnitChunkShared,
 ) -> Option<()> {
-    // First check assumptions:
-    debug_assert_archetype_has_components!(
-        archetypes::Image,
-        buffer: components::ImageBuffer,
-        format: components::ImageFormat
-    );
-    debug_assert_archetype_has_components!(
-        archetypes::DepthImage,
-        buffer: components::ImageBuffer,
-        format: components::ImageFormat
-    );
-    debug_assert_archetype_has_components!(
-        archetypes::SegmentationImage,
-        buffer: components::ImageBuffer,
-        format: components::ImageFormat
-    );
-
-    let image_buffer = component_map.get(&components::ImageBuffer::name())?;
-    let buffer_cache_key = Hash64::hash(image_buffer.row_id()?);
-
-    // TODO(andreas): why does this not use the query cache like other queries?
-    // Use first buffer that we find, but then use the same tags for the format.
-    // TODO(andreas): Handle multiple types of images.
-    let image_buffer_desc =
-        image_buffer.get_first_component_descriptor(components::ImageBuffer::name())?;
-    let image_format_desc = ComponentDescriptor {
-        component_name: components::ImageFormat::name(),
-        ..image_buffer_desc.clone()
-    };
-
-    let image_buffer = image_buffer
-        .component_mono::<components::ImageBuffer>(image_buffer_desc)?
-        .ok()?;
-    let image_format = component_map
-        .get(&components::ImageFormat::name())?
-        .component_mono::<components::ImageFormat>(&image_format_desc)?
+    let row_id = image_buffer_chunk.row_id()?;
+    let image_buffer = image_buffer_chunk
+        .component_mono::<components::ImageBuffer>(image_buffer_descr)?
         .ok()?;
 
-    // TODO(#8129): it's ugly but indicators are going away next anyway.
-    let kind = if component_map
-        .contains_key(&archetypes::DepthImage::descriptor_indicator().component_name)
-    {
+    let (image_format_descr, image_format_chunk) = components.iter().find(|(descr, _chunk)| {
+        descr.component_name == components::ImageFormat::name()
+            && descr.archetype_name == image_buffer_descr.archetype_name
+    })?;
+    let image_format = image_format_chunk
+        .component_mono::<components::ImageFormat>(image_format_descr)?
+        .ok()?;
+
+    let kind = if image_format_descr.archetype_name == Some(archetypes::DepthImage::name()) {
         ImageKind::Depth
-    } else if component_map
-        .contains_key(&archetypes::SegmentationImage::descriptor_indicator().component_name)
-    {
+    } else if image_format_descr.archetype_name == Some(archetypes::SegmentationImage::name()) {
         ImageKind::Segmentation
     } else {
         ImageKind::Color
     };
 
     let image = ImageInfo {
-        buffer_cache_key,
+        buffer_cache_key: Hash64::hash(row_id),
         buffer: image_buffer.0,
         format: image_format.0,
         kind,
@@ -352,26 +329,15 @@ fn preview_if_image_ui(
         .caches
         .entry(|c: &mut ImageStatsCache| c.entry(&image));
 
-    let colormap = component_map
-        .get(&components::Colormap::name())
-        .and_then(|colormap| {
-            colormap
-                .component_mono::<components::Colormap>(&ComponentDescriptor {
-                    component_name: components::Colormap::name(),
-                    ..image_buffer_desc.clone()
-                })?
-                .ok()
-        });
-    let value_range = component_map
-        .get(&components::Range1D::name())
-        .and_then(|colormap| {
-            colormap
-                .component_mono::<components::ValueRange>(&ComponentDescriptor {
-                    component_name: components::ValueRange::name(),
-                    ..image_buffer_desc.clone()
-                })?
-                .ok()
-        });
+    let colormap = find_and_deserialize_archetype_mono_component::<components::Colormap>(
+        components,
+        image_buffer_descr.archetype_name,
+    );
+    let value_range = find_and_deserialize_archetype_mono_component::<components::ValueRange>(
+        components,
+        image_buffer_descr.archetype_name,
+    );
+
     let colormap_with_range = colormap.map(|colormap| ColormapWithRange {
         colormap,
         value_range: value_range
@@ -397,7 +363,7 @@ fn preview_if_image_ui(
     );
 
     if ui_layout.is_single_line() || ui_layout == UiLayout::Tooltip {
-        return Some(()); // no more ui
+        return Some(());
     }
 
     let data_range = value_range.map_or_else(
@@ -528,41 +494,51 @@ fn preview_if_blob_ui(
     ui_layout: UiLayout,
     query: &re_chunk_store::LatestAtQuery,
     entity_path: &re_log_types::EntityPath,
-    component_map: &IntMap<ComponentName, UnitChunkShared>,
+    components: &BTreeMap<ComponentDescriptor, UnitChunkShared>,
+) {
+    // There might be several blobs, all with different meanings.
+    for (blob_descr, blob_chunk) in components
+        .iter()
+        .filter(|(descr, _chunk)| descr.component_name == components::Blob::name())
+    {
+        preview_single_blob(
+            ctx,
+            ui,
+            ui_layout,
+            query,
+            entity_path,
+            components,
+            blob_descr,
+            blob_chunk,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn preview_single_blob(
+    ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    ui_layout: UiLayout,
+    query: &re_chunk_store::LatestAtQuery,
+    entity_path: &re_log_types::EntityPath,
+    components: &BTreeMap<ComponentDescriptor, UnitChunkShared>,
+    blob_descr: &ComponentDescriptor,
+    blob_chunk: &UnitChunkShared,
 ) -> Option<()> {
-    let blob_chunk = component_map.get(&components::Blob::name())?;
-    let blob_row_id = blob_chunk.row_id();
-
-    // TODO(andreas): why does this not use the query cache like other queries?
-    // Pick the first blob component we find but have other types be consistent with those tags.
-    // TODO(andreas): Handle multiple types of blobs.
-    let blob_desc = blob_chunk.get_first_component_descriptor(components::Blob::name())?;
-    let media_type_desc = ComponentDescriptor {
-        component_name: components::MediaType::name(),
-        ..blob_desc.clone()
-    };
-    let video_stamp_desc = ComponentDescriptor {
-        component_name: components::VideoTimestamp::name(),
-        ..blob_desc.clone()
-    };
-
     let blob = blob_chunk
-        .component_mono::<components::Blob>(blob_desc)?
+        .component_mono::<components::Blob>(blob_descr)?
         .ok()?;
-    let media_type = component_map
-        .get(&components::MediaType::name())
-        .and_then(|unit| {
-            unit.component_mono::<components::MediaType>(&media_type_desc)?
-                .ok()
-        })
-        .or_else(|| components::MediaType::guess_from_data(&blob));
 
-    let video_timestamp = component_map
-        .get(&components::VideoTimestamp::name())
-        .and_then(|unit| {
-            unit.component_mono::<components::VideoTimestamp>(&video_stamp_desc)?
-                .ok()
-        });
+    let media_type = find_and_deserialize_archetype_mono_component::<components::MediaType>(
+        components,
+        blob_descr.archetype_name,
+    )
+    .or_else(|| components::MediaType::guess_from_data(&blob));
+
+    let video_timestamp = find_and_deserialize_archetype_mono_component::<components::VideoTimestamp>(
+        components,
+        blob_descr.archetype_name,
+    );
 
     blob_preview_and_save_ui(
         ctx,
@@ -570,11 +546,23 @@ fn preview_if_blob_ui(
         ui_layout,
         query,
         entity_path,
-        blob_row_id.map(Hash64::hash),
+        blob_chunk.row_id().map(Hash64::hash),
         &blob,
         media_type.as_ref(),
         video_timestamp,
     );
 
     Some(())
+}
+
+/// Finds and deserializes the given component type if its descriptor matches the given archetype name.
+fn find_and_deserialize_archetype_mono_component<C: Component>(
+    components: &BTreeMap<ComponentDescriptor, UnitChunkShared>,
+    archetype_name: Option<ArchetypeName>,
+) -> Option<C> {
+    components.iter().find_map(|(descr, chunk)| {
+        (descr.component_name == C::name() && descr.archetype_name == archetype_name)
+            .then(|| chunk.component_mono::<C>(descr).and_then(|r| r.ok()))
+            .flatten()
+    })
 }

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! This crate provides ui elements for Rerun component data for the Rerun Viewer.
 
-use re_log_types::{hash::Hash64, EntityPath};
-use re_types::ComponentDescriptor;
+use re_log_types::EntityPath;
+use re_types::{ComponentDescriptor, RowId};
 use re_viewer_context::{UiLayout, ViewerContext};
 
 mod annotation_context;
@@ -71,7 +71,8 @@ pub trait EntityDataUi {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        cache_key: Option<Hash64>,
+        component_descriptor: &ComponentDescriptor,
+        row_id: Option<RowId>,
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     );
@@ -87,7 +88,8 @@ where
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
-        _cache_key: Option<Hash64>,
+        _component_descriptor: &ComponentDescriptor,
+        _row_id: Option<RowId>,
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {

--- a/crates/viewer/re_data_ui/src/tensor.rs
+++ b/crates/viewer/re_data_ui/src/tensor.rs
@@ -2,7 +2,7 @@ use itertools::Itertools as _;
 
 use re_log_types::hash::Hash64;
 use re_log_types::EntityPath;
-use re_types::datatypes::TensorData;
+use re_types::{datatypes::TensorData, ComponentDescriptor, RowId};
 use re_ui::UiExt as _;
 use re_viewer_context::{TensorStats, TensorStatsCache, UiLayout, ViewerContext};
 
@@ -39,13 +39,14 @@ impl EntityDataUi for re_types::components::TensorData {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         _entity_path: &EntityPath,
-        cache_key: Option<Hash64>,
+        _component_descriptor: &ComponentDescriptor,
+        row_id: Option<RowId>,
         _query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         re_tracing::profile_function!();
-
-        let tensor_cache_key = cache_key.unwrap_or(Hash64::ZERO);
+        // RowId is enough for cache keying the tensor stats right now since you can't have more than one per row.
+        let tensor_cache_key = row_id.map_or(Hash64::ZERO, Hash64::hash);
         tensor_ui(ctx, ui, ui_layout, tensor_cache_key, &self.0);
     }
 }

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -3,7 +3,6 @@ use itertools::Itertools as _;
 use re_chunk::{RowId, UnitChunkShared};
 use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
 use re_entity_db::EntityDb;
-use re_log_types::hash::Hash64;
 use re_log_types::{ComponentPath, EntityPath};
 use re_types::blueprint::archetypes::VisualizerOverrides;
 use re_types::ComponentDescriptor;
@@ -271,8 +270,8 @@ fn visualizer_components(
                             &store_query,
                             ctx.recording(),
                             &data_result.entity_path,
-                            component_descr.component_name,
-                            current_value_row_id.map(Hash64::hash),
+                            &component_descr,
+                            current_value_row_id,
                             raw_current_value.as_ref(),
                         );
                         return;
@@ -364,7 +363,7 @@ fn visualizer_components(
                                 &store_query,
                                 ctx.recording(),
                                 &data_result.entity_path,
-                                component_descr.component_name,
+                                &component_descr,
                                 None,
                                 raw_fallback.as_ref(),
                             );
@@ -442,7 +441,7 @@ fn editable_blueprint_component_list_item(
                     query_ctx.viewer_ctx.blueprint_db(),
                     blueprint_path,
                     component_descr,
-                    row_id.map(Hash64::hash),
+                    row_id,
                     raw_override,
                     allow_multiline,
                 );

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -1,4 +1,3 @@
-use re_log_types::hash::Hash64;
 use re_types::ComponentDescriptor;
 use re_types_core::{reflection::ArchetypeFieldReflection, Archetype, ArchetypeReflectionMarker};
 use re_ui::{list_item, UiExt as _};
@@ -92,9 +91,7 @@ pub fn view_property_component_ui(
     let component_descr = field.component_descriptor(property.archetype_name);
 
     let component_array = property.component_raw(&component_descr);
-    let cache_key = property
-        .component_row_id(field.component_name)
-        .map(Hash64::hash);
+    let row_id = property.component_row_id(field.component_name);
 
     let ui_types = ctx
         .viewer_ctx
@@ -108,7 +105,7 @@ pub fn view_property_component_ui(
             ctx.viewer_ctx.blueprint_db(),
             ctx.target_entity_path,
             &component_descr,
-            cache_key,
+            row_id,
             component_array.as_deref(),
             fallback_provider,
         );
@@ -121,7 +118,7 @@ pub fn view_property_component_ui(
             ctx.viewer_ctx.blueprint_db(),
             ctx.target_entity_path,
             &component_descr,
-            cache_key,
+            row_id,
             component_array.as_deref(),
             fallback_provider,
         );

--- a/crates/viewer/re_view_graph/src/ui/selection.rs
+++ b/crates/viewer/re_view_graph/src/ui/selection.rs
@@ -1,4 +1,3 @@
-use re_log_types::hash::Hash64;
 use re_types::{
     blueprint::components::Enabled, Archetype, ArchetypeReflectionMarker, Component as _,
 };
@@ -73,7 +72,7 @@ pub fn view_property_force_ui<A: Archetype + ArchetypeReflectionMarker>(
                 ctx.blueprint_db(),
                 query_ctx.target_entity_path,
                 &component_descr,
-                row_id.map(Hash64::hash),
+                row_id,
                 component_array.as_deref(),
                 fallback_provider,
             );

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -41,7 +41,6 @@ pub(crate) use pinhole::Pinhole;
 
 use re_viewer_context::{ImageDecodeCache, ViewerContext};
 
-use re_log_types::hash::Hash64;
 use re_renderer::RenderContext;
 use re_types::{
     archetypes,
@@ -104,7 +103,12 @@ fn resolution_of_image_at(
             .map(|(_, c)| c);
 
         let image = ctx.store_context.caches.entry(|c: &mut ImageDecodeCache| {
-            c.entry(Hash64::hash(row_id), &blob, media_type.as_ref())
+            c.entry(
+                row_id,
+                &archetypes::EncodedImage::descriptor_blob(),
+                &blob,
+                media_type.as_ref(),
+            )
         });
 
         if let Ok(image) = image {

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools as _;
 
-use re_log_types::hash::Hash64;
 use re_renderer::{mesh::GpuMesh, RenderContext};
 use re_types::{components::MediaType, datatypes};
 use re_viewer_context::{
@@ -232,8 +231,8 @@ fn try_get_or_create_albedo_texture(
     re_tracing::profile_function!();
 
     let image_info = ImageInfo {
-        buffer_content_hash: StoredBlobCacheKey(Hash64::ZERO), // unused
-        buffer: albedo_texture_buffer.clone(),                 // shallow clone
+        buffer_content_hash: StoredBlobCacheKey::ZERO, // unused
+        buffer: albedo_texture_buffer.clone(),         // shallow clone
         format: *albedo_texture_format,
         kind: re_types::image::ImageKind::Color,
     };

--- a/crates/viewer/re_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_loader.rs
@@ -3,7 +3,9 @@ use itertools::Itertools as _;
 use re_log_types::hash::Hash64;
 use re_renderer::{mesh::GpuMesh, RenderContext};
 use re_types::{components::MediaType, datatypes};
-use re_viewer_context::{gpu_bridge::texture_creation_desc_from_color_image, ImageInfo};
+use re_viewer_context::{
+    gpu_bridge::texture_creation_desc_from_color_image, ImageInfo, StoredBlobCacheKey,
+};
 
 use crate::{mesh_cache::AnyMesh, visualizers::entity_iterator::clamped_vec_or};
 
@@ -230,8 +232,8 @@ fn try_get_or_create_albedo_texture(
     re_tracing::profile_function!();
 
     let image_info = ImageInfo {
-        buffer_cache_key: Hash64::ZERO,        // unused
-        buffer: albedo_texture_buffer.clone(), // shallow clone
+        buffer_content_hash: StoredBlobCacheKey(Hash64::ZERO), // unused
+        buffer: albedo_texture_buffer.clone(),                 // shallow clone
         format: *albedo_texture_format,
         kind: re_types::image::ImageKind::Color,
     };

--- a/crates/viewer/re_view_spatial/src/visualizers/encoded_image.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/encoded_image.rs
@@ -1,4 +1,3 @@
-use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::EncodedImage,
     components::{DrawOrder, MediaType, Opacity},
@@ -161,7 +160,12 @@ impl EncodedImageVisualizer {
                 .store_context
                 .caches
                 .entry(|c: &mut ImageDecodeCache| {
-                    c.entry(Hash64::hash(tensor_data_row_id), blob, media_type.as_ref())
+                    c.entry(
+                        tensor_data_row_id,
+                        &EncodedImage::descriptor_blob(),
+                        blob,
+                        media_type.as_ref(),
+                    )
                 });
 
             let image = match image {

--- a/crates/viewer/re_view_spatial/src/visualizers/images.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/images.rs
@@ -1,4 +1,3 @@
-use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::Image,
     components::{DrawOrder, ImageFormat, Opacity},
@@ -138,16 +137,17 @@ impl ImageVisualizer {
             all_formats_indexed,
             all_opacities.slice::<f32>(),
         )
-        .filter_map(|(index, buffers, formats, opacities)| {
+        .filter_map(|((_time, row_id), buffers, formats, opacities)| {
             let buffer = buffers.first()?;
 
             Some(ImageComponentData {
-                image: ImageInfo {
-                    buffer_cache_key: Hash64::hash(index.1),
-                    buffer: buffer.clone().into(),
-                    format: first_copied(formats.as_deref())?.0,
-                    kind: ImageKind::Color,
-                },
+                image: ImageInfo::from_stored_blob(
+                    row_id,
+                    &Image::descriptor_buffer(),
+                    buffer.clone().into(),
+                    first_copied(formats.as_deref())?.0,
+                    ImageKind::Color,
+                ),
                 opacity: first_copied(opacities).map(Into::into),
             })
         });

--- a/crates/viewer/re_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/segmentation_images.rs
@@ -1,4 +1,3 @@
-use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::SegmentationImage,
     components::{DrawOrder, ImageFormat, Opacity},
@@ -96,15 +95,16 @@ impl VisualizerSystem for SegmentationImageVisualizer {
                     all_formats_indexed,
                     all_opacities.slice::<f32>(),
                 )
-                .filter_map(|(index, buffers, formats, opacity)| {
+                .filter_map(|((_time, row_id), buffers, formats, opacity)| {
                     let buffer = buffers.first()?;
                     Some(SegmentationImageComponentData {
-                        image: ImageInfo {
-                            buffer_cache_key: Hash64::hash(index.1),
-                            buffer: buffer.clone().into(),
-                            format: first_copied(formats.as_deref())?.0,
-                            kind: ImageKind::Segmentation,
-                        },
+                        image: ImageInfo::from_stored_blob(
+                            row_id,
+                            &SegmentationImage::descriptor_buffer(),
+                            buffer.clone().into(),
+                            first_copied(formats.as_deref())?.0,
+                            ImageKind::Segmentation,
+                        ),
                         opacity: first_copied(opacity).map(Into::into),
                     })
                 });

--- a/crates/viewer/re_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/videos.rs
@@ -401,7 +401,8 @@ fn latest_at_query_video_from_datastore(
         let debug_name = entity_path.to_string();
         c.entry(
             debug_name,
-            Hash64::hash(blob_row_id),
+            blob_row_id,
+            &AssetVideo::descriptor_blob(),
             &blob,
             media_type.as_ref(),
             ctx.app_options().video_decoder_settings(),

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -1,15 +1,16 @@
 use ahash::{HashMap, HashSet};
 use itertools::Either;
 
+use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_types::{
-    components::{ImageBuffer, MediaType},
+    components::{self, ImageBuffer, MediaType},
     image::{ImageKind, ImageLoadError},
-    Component as _,
+    Component as _, ComponentDescriptor,
 };
 
-use crate::{Cache, ImageInfo};
+use crate::{image_info::StoredBlobCacheKey, Cache, ImageInfo};
 
 struct DecodedImageResult {
     /// Cached `Result` from decoding the image
@@ -25,7 +26,7 @@ struct DecodedImageResult {
 /// Caches the results of decoding [`re_types::archetypes::EncodedImage`].
 #[derive(Default)]
 pub struct ImageDecodeCache {
-    cache: HashMap<Hash64, HashMap<Hash64, DecodedImageResult>>,
+    cache: HashMap<StoredBlobCacheKey, HashMap<Hash64, DecodedImageResult>>,
     memory_used: u64,
     generation: u64,
 }
@@ -39,7 +40,8 @@ impl ImageDecodeCache {
     /// so we don't need the instance id here.
     pub fn entry(
         &mut self,
-        blob_cache_key: Hash64,
+        blob_row_id: RowId,
+        blob_component_descriptor: &ComponentDescriptor,
         image_bytes: &[u8],
         media_type: Option<&MediaType>,
     ) -> Result<ImageInfo, ImageLoadError> {
@@ -57,13 +59,22 @@ impl ImageDecodeCache {
 
         let inner_key = Hash64::hash(&media_type);
 
+        // The descriptor should always be the one in the encoded image archetype, but in the future
+        // we may allow overrides such that it is sourced from somewhere else.
+        let blob_cache_key = StoredBlobCacheKey::new(blob_row_id, blob_component_descriptor);
+
         let lookup = self
             .cache
             .entry(blob_cache_key)
             .or_default()
             .entry(inner_key)
             .or_insert_with(|| {
-                let result = decode_image(blob_cache_key, image_bytes, media_type.as_str());
+                let result = decode_image(
+                    blob_row_id,
+                    blob_component_descriptor,
+                    image_bytes,
+                    media_type.as_str(),
+                );
                 let memory_used = result.as_ref().map_or(0, |image| image.buffer.len() as u64);
                 self.memory_used += memory_used;
                 DecodedImageResult {
@@ -78,7 +89,8 @@ impl ImageDecodeCache {
 }
 
 fn decode_image(
-    blob_cache_key: Hash64,
+    blob_row_id: RowId,
+    blob_component_descriptor: &ComponentDescriptor,
     image_bytes: &[u8],
     media_type: &str,
 ) -> Result<ImageInfo, ImageLoadError> {
@@ -96,12 +108,13 @@ fn decode_image(
 
     let (buffer, format) = ImageBuffer::from_dynamic_image(dynamic_image)?;
 
-    Ok(ImageInfo {
-        buffer_cache_key: blob_cache_key,
-        buffer: buffer.0,
-        format: format.0,
-        kind: ImageKind::Color,
-    })
+    Ok(ImageInfo::from_stored_blob(
+        blob_row_id,
+        blob_component_descriptor,
+        buffer.0,
+        format.0,
+        ImageKind::Color,
+    ))
 }
 
 impl Cache for ImageDecodeCache {
@@ -151,19 +164,22 @@ impl Cache for ImageDecodeCache {
     fn on_store_events(&mut self, events: &[ChunkStoreEvent]) {
         re_tracing::profile_function!();
 
-        let cache_key_removed: HashSet<Hash64> = events
+        let cache_key_removed: HashSet<StoredBlobCacheKey> = events
             .iter()
             .flat_map(|event| {
-                let is_deletion = || event.kind == re_chunk_store::ChunkStoreDiffKind::Deletion;
-                let contains_image_blob = || {
-                    event
-                        .chunk
-                        .components()
-                        .contains_component_name(re_types::components::Blob::name())
-                };
-
-                if is_deletion() && contains_image_blob() {
-                    Either::Left(event.chunk.row_ids().map(Hash64::hash))
+                if event.kind == re_chunk_store::ChunkStoreDiffKind::Deletion {
+                    Either::Left(
+                        event
+                            .chunk
+                            .component_descriptors()
+                            .filter(|descr| descr.component_name == components::Blob::name())
+                            .flat_map(|descr| {
+                                event
+                                    .chunk
+                                    .row_ids()
+                                    .map(move |row_id| StoredBlobCacheKey::new(row_id, &descr))
+                            }),
+                    )
                 } else {
                     Either::Right(std::iter::empty())
                 }

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
@@ -34,14 +34,14 @@ use super::get_or_create_texture;
 fn generate_texture_key(image: &ImageInfo) -> u64 {
     // We need to inclde anything that, if changes, should result in a new texture being uploaded.
     let ImageInfo {
-        buffer_cache_key,
+        buffer_content_hash,
         buffer: _, // we hash `blob_row_id` instead; much faster!
 
         format,
         kind,
     } = image;
 
-    hash((buffer_cache_key, format, kind))
+    hash((buffer_content_hash, format, kind))
 }
 
 /// `colormap` is currently only used for depth images.

--- a/crates/viewer/re_viewer_context/src/image_info.rs
+++ b/crates/viewer/re_viewer_context/src/image_info.rs
@@ -42,6 +42,8 @@ impl ColormapWithRange {
 pub struct StoredBlobCacheKey(pub Hash64);
 
 impl StoredBlobCacheKey {
+    pub const ZERO: Self = Self(Hash64::ZERO);
+
     pub fn new(blob_row_id: RowId, component_descriptor: &ComponentDescriptor) -> Self {
         // Row ID + component descriptor is enough because in a single row & column there
         // can currently only be a single blob since blobs are internally stored as transparent dynamic byte arrays.
@@ -79,7 +81,10 @@ impl ImageInfo {
         // we need to make sure that the descriptor is the one used for _querying_ the blob.
         // This also means that the `ImageKind` may change!
         // But until then, image kind and descriptor should be in sync.
-        debug_assert!(ImageKind::from_archetype_name(component_descriptor.archetype_name) == kind);
+        debug_assert_eq!(
+            ImageKind::from_archetype_name(component_descriptor.archetype_name),
+            kind
+        );
 
         Self {
             buffer_content_hash: StoredBlobCacheKey::new(blob_row_id, component_descriptor),

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::{
         command_channel, AppOptions, CommandReceiver, CommandSender, ComponentUiRegistry,
         ComponentUiTypes, DisplayMode, GlobalContext, Item, SystemCommand, SystemCommandSender,
     },
-    image_info::{ColormapWithRange, ImageInfo},
+    image_info::{ColormapWithRange, ImageInfo, StoredBlobCacheKey},
     maybe_mut_ref::MaybeMutRef,
     query_context::{
         DataQueryResult, DataResultHandle, DataResultNode, DataResultTree, QueryContext,

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -138,7 +138,15 @@ impl Default for TestContext {
         let blueprint_query = LatestAtQuery::latest(blueprint_timeline());
 
         let component_ui_registry = ComponentUiRegistry::new(Box::new(
-            |_ctx, _ui, _ui_layout, _query, _db, _entity_path, _row_id, _component| {},
+            |_ctx,
+             _ui,
+             _ui_layout,
+             _query,
+             _db,
+             _entity_path,
+             _row_id,
+             _component_descriptor,
+             _component| {},
         ));
 
         let reflection =


### PR DESCRIPTION
### Related

* Part of #6889.

### What

Previously, data ui for blobs/images was very poorly ported to tagged component world. Causing various issues. This rewrite now allows graceful handling of several images side by side.

Here's an example with both a segmentation image and a regular image _on the same entity path_:
<img width="315" alt="image" src="https://github.com/user-attachments/assets/6eb6a4ff-e33d-43a5-b03b-45555c704b63" />

Test code:

```py
import rerun as rr
import numpy as np

rr.init("rerun_example_tags", spawn=True)

# Create an image with numpy
col_image = np.zeros((200, 300, 3), dtype=np.uint8)
col_image[:, :, 0] = 255
col_image[50:150, 50:150] = (0, 255, 0)
rr.log("image", rr.Image(col_image))

# Create a segmentation image
seg_image = np.zeros((8, 12), dtype=np.uint8)
seg_image[0:4, 0:6] = 1
seg_image[4:8, 6:12] = 2
rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
rr.log("image", rr.SegmentationImage(seg_image))

```

(ideally I'd make this an image comparision test, but can't find the time for that right now unfortunately)
