### PR TITLE
Remove `MaybeTagged` accessor utility

### DIFF
--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -254,6 +254,7 @@ impl LatestAtResults {
         let component_descr = self.find_component_descriptor(*component_name)?;
         self.components.get(component_descr)
     }
+
     /// Returns the [`UnitChunkShared`] for the specified [`Component`].
     ///
     /// Returns an error if the component is not present.

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -16,7 +16,7 @@ use re_types_core::{
     ComponentDescriptor, ComponentName,
 };
 
-use crate::{MaybeTagged, QueryCache, QueryCacheKey, QueryError};
+use crate::{QueryCache, QueryCacheKey, QueryError};
 
 // --- Public API ---
 
@@ -247,14 +247,6 @@ impl LatestAtResults {
         self.components.get(component_descr)
     }
 
-    // TODO(#6889): remove this please!
-    pub fn get_by_maybe(&self, component_descriptor: &MaybeTagged) -> Option<&UnitChunkShared> {
-        match component_descriptor {
-            MaybeTagged::Descriptor(component_descriptor) => self.get(component_descriptor),
-            MaybeTagged::JustName(component_name) => self.get_by_name(component_name),
-        }
-    }
-
     // TODO(#6889): Going forward, we should avoid querying by name.
     /// Returns the [`UnitChunkShared`] for the specified [`Component`].
     #[inline]
@@ -262,28 +254,6 @@ impl LatestAtResults {
         let component_descr = self.find_component_descriptor(*component_name)?;
         self.components.get(component_descr)
     }
-
-    /// Returns the [`UnitChunkShared`] for the specified [`Component`].
-    ///
-    /// Returns an error if the component is not present.
-    // TODO(#6889): Remove this in favor or `get`
-    #[inline]
-    pub fn get_required_by_name(
-        &self,
-        component_name: &ComponentName,
-    ) -> crate::Result<&UnitChunkShared> {
-        let component_descr =
-            self.find_component_descriptor(*component_name)
-                .ok_or(QueryError::PrimaryNotFound(ComponentDescriptor::new(
-                    *component_name,
-                )))?;
-        if let Some(component) = self.components.get(component_descr) {
-            Ok(component)
-        } else {
-            Err(QueryError::PrimaryNotFound(component_descr.clone()))
-        }
-    }
-
     /// Returns the [`UnitChunkShared`] for the specified [`Component`].
     ///
     /// Returns an error if the component is not present.

--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -72,37 +72,3 @@ pub enum QueryError {
 }
 
 pub type Result<T> = std::result::Result<T, QueryError>;
-
-// ---
-
-use re_chunk::ComponentName;
-use re_types_core::ComponentDescriptor;
-
-// TODO(#6889): This is a temporary object until we use tagged components everywhere or have explicit untagged queries (?).
-
-#[derive(Debug, Clone)]
-pub enum MaybeTagged {
-    Descriptor(ComponentDescriptor),
-    JustName(ComponentName),
-}
-
-impl<'a> From<&'a ComponentDescriptor> for MaybeTagged {
-    #[inline]
-    fn from(descr: &'a ComponentDescriptor) -> Self {
-        Self::Descriptor(descr.clone())
-    }
-}
-
-impl From<ComponentDescriptor> for MaybeTagged {
-    #[inline]
-    fn from(descr: ComponentDescriptor) -> Self {
-        Self::Descriptor(descr)
-    }
-}
-
-impl From<ComponentName> for MaybeTagged {
-    #[inline]
-    fn from(name: ComponentName) -> Self {
-        Self::JustName(name)
-    }
-}

--- a/crates/viewer/re_view/src/results_ext.rs
+++ b/crates/viewer/re_view/src/results_ext.rs
@@ -4,7 +4,7 @@ use itertools::Itertools as _;
 
 use re_chunk_store::{Chunk, LatestAtQuery, RangeQuery, UnitChunkShared};
 use re_log_types::hash::Hash64;
-use re_query::{LatestAtResults, MaybeTagged, RangeResults};
+use re_query::{LatestAtResults, RangeResults};
 use re_types::ComponentDescriptor;
 use re_types_core::ComponentName;
 use re_viewer_context::{DataResult, QueryContext, ViewContext};
@@ -235,8 +235,7 @@ pub trait RangeResultsExt {
     /// For results that are aware of the blueprint, overrides, store results, and defaults will be
     /// considered.
     // TODO(#6889): Take descriptor instead of name.
-    fn get_optional_chunks(&self, component_descriptor: impl Into<MaybeTagged>)
-        -> Cow<'_, [Chunk]>;
+    fn get_optional_chunks(&self, component_descriptor: ComponentDescriptor) -> Cow<'_, [Chunk]>;
 
     /// Returns a zero-copy iterator over all the results for the given `(timeline, component)` pair.
     ///
@@ -248,7 +247,6 @@ pub trait RangeResultsExt {
         timeline: TimelineName,
         component_descriptor: ComponentDescriptor,
     ) -> HybridResultsChunkIter<'_> {
-        let component_descriptor = MaybeTagged::Descriptor(component_descriptor);
         let chunks = self.get_optional_chunks(component_descriptor.clone());
         HybridResultsChunkIter {
             chunks,
@@ -273,17 +271,11 @@ impl RangeResultsExt for LatestAtResults {
     }
 
     #[inline]
-    fn get_optional_chunks(
-        &self,
-        component_descriptor: impl Into<MaybeTagged>,
-    ) -> Cow<'_, [Chunk]> {
-        let component_descriptor = component_descriptor.into();
-        self.get_by_maybe(&component_descriptor)
-            .cloned()
-            .map_or_else(
-                || Cow::Owned(vec![]),
-                |chunk| Cow::Owned(vec![Arc::unwrap_or_clone(chunk.into_chunk())]),
-            )
+    fn get_optional_chunks(&self, component_descriptor: ComponentDescriptor) -> Cow<'_, [Chunk]> {
+        self.get(&component_descriptor).cloned().map_or_else(
+            || Cow::Owned(vec![]),
+            |chunk| Cow::Owned(vec![Arc::unwrap_or_clone(chunk.into_chunk())]),
+        )
     }
 }
 
@@ -302,12 +294,8 @@ impl RangeResultsExt for RangeResults {
     }
 
     #[inline]
-    fn get_optional_chunks(
-        &self,
-        component_descriptor: impl Into<MaybeTagged>,
-    ) -> Cow<'_, [Chunk]> {
-        let component_descriptor = component_descriptor.into();
-        Cow::Borrowed(self.get_by_maybe(&component_descriptor).unwrap_or_default())
+    fn get_optional_chunks(&self, component_descriptor: ComponentDescriptor) -> Cow<'_, [Chunk]> {
+        Cow::Borrowed(self.get(&component_descriptor).unwrap_or_default())
     }
 }
 
@@ -334,15 +322,10 @@ impl RangeResultsExt for HybridRangeResults<'_> {
     }
 
     #[inline]
-    fn get_optional_chunks(
-        &self,
-        component_descriptor: impl Into<MaybeTagged>,
-    ) -> Cow<'_, [Chunk]> {
+    fn get_optional_chunks(&self, component_descriptor: ComponentDescriptor) -> Cow<'_, [Chunk]> {
         re_tracing::profile_function!();
 
-        let component_descriptor = component_descriptor.into();
-
-        if let Some(unit) = self.overrides.get_by_maybe(&component_descriptor) {
+        if let Some(unit) = self.overrides.get(&component_descriptor) {
             // Because this is an override we always re-index the data as static
             let chunk = Arc::unwrap_or_clone(unit.clone().into_chunk())
                 .into_static()
@@ -353,15 +336,12 @@ impl RangeResultsExt for HybridRangeResults<'_> {
 
             // NOTE: Because this is a range query, we always need the defaults to come first,
             // since range queries don't have any state to bootstrap from.
-            let defaults = self
-                .defaults
-                .get_by_maybe(&component_descriptor)
-                .map(|unit| {
-                    // Because this is an default from the blueprint we always re-index the data as static
-                    Arc::unwrap_or_clone(unit.clone().into_chunk())
-                        .into_static()
-                        .zeroed()
-                });
+            let defaults = self.defaults.get(&component_descriptor).map(|unit| {
+                // Because this is an default from the blueprint we always re-index the data as static
+                Arc::unwrap_or_clone(unit.clone().into_chunk())
+                    .into_static()
+                    .zeroed()
+            });
 
             let chunks = self.results.get_optional_chunks(component_descriptor);
 
@@ -398,13 +378,8 @@ impl RangeResultsExt for HybridLatestAtResults<'_> {
     }
 
     #[inline]
-    fn get_optional_chunks(
-        &self,
-        component_descriptor: impl Into<MaybeTagged>,
-    ) -> Cow<'_, [Chunk]> {
-        let component_descriptor = component_descriptor.into();
-
-        if let Some(unit) = self.overrides.get_by_maybe(&component_descriptor) {
+    fn get_optional_chunks(&self, component_descriptor: ComponentDescriptor) -> Cow<'_, [Chunk]> {
+        if let Some(unit) = self.overrides.get(&component_descriptor) {
             // Because this is an override we always re-index the data as static
             let chunk = Arc::unwrap_or_clone(unit.clone().into_chunk())
                 .into_static()
@@ -428,7 +403,7 @@ impl RangeResultsExt for HybridLatestAtResults<'_> {
             }
 
             // Otherwise try to use the default data.
-            let Some(unit) = self.defaults.get_by_maybe(&component_descriptor) else {
+            let Some(unit) = self.defaults.get(&component_descriptor) else {
                 return Cow::Owned(Vec::new());
             };
             // Because this is an default from the blueprint we always re-index the data as static
@@ -453,10 +428,7 @@ impl RangeResultsExt for HybridResults<'_> {
     }
 
     #[inline]
-    fn get_optional_chunks(
-        &self,
-        component_descriptor: impl Into<MaybeTagged>,
-    ) -> Cow<'_, [Chunk]> {
+    fn get_optional_chunks(&self, component_descriptor: ComponentDescriptor) -> Cow<'_, [Chunk]> {
         match self {
             Self::LatestAt(_, results) => results.get_optional_chunks(component_descriptor),
             Self::Range(_, results) => results.get_optional_chunks(component_descriptor),
@@ -473,7 +445,7 @@ use re_chunk_store::external::re_chunk;
 pub struct HybridResultsChunkIter<'a> {
     chunks: Cow<'a, [Chunk]>,
     timeline: TimelineName,
-    component_descriptor: MaybeTagged,
+    component_descriptor: ComponentDescriptor,
 }
 
 impl<'a> HybridResultsChunkIter<'a> {
@@ -487,24 +459,12 @@ impl<'a> HybridResultsChunkIter<'a> {
     pub fn component_slow<C: re_types_core::Component>(
         &'a self,
     ) -> impl Iterator<Item = ((TimeInt, RowId), ChunkComponentIterItem<C>)> + 'a {
-        match &self.component_descriptor {
-            MaybeTagged::Descriptor(component_descriptor) => {
-                itertools::Either::Left(self.chunks.iter().flat_map(move |chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices(&self.timeline, component_descriptor),
-                        chunk.iter_component::<C>(component_descriptor),
-                    )
-                }))
-            }
-            MaybeTagged::JustName(component_name) => {
-                itertools::Either::Right(self.chunks.iter().flat_map(move |chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices_by_name(&self.timeline, component_name),
-                        chunk.iter_component_by_name::<C>(),
-                    )
-                }))
-            }
-        }
+        self.chunks.iter().flat_map(move |chunk| {
+            itertools::izip!(
+                chunk.iter_component_indices(&self.timeline, &self.component_descriptor),
+                chunk.iter_component::<C>(&self.component_descriptor),
+            )
+        })
     }
 
     /// Iterate as indexed, sliced, deserialized component batches.
@@ -513,25 +473,13 @@ impl<'a> HybridResultsChunkIter<'a> {
     pub fn slice<S: 'a + re_chunk::ChunkComponentSlicer>(
         &'a self,
     ) -> impl Iterator<Item = ((TimeInt, RowId), S::Item<'a>)> + 'a {
-        match &self.component_descriptor {
-            MaybeTagged::Descriptor(component_descriptor) => {
-                itertools::Either::Left(self.chunks.iter().flat_map(move |chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices(&self.timeline, component_descriptor),
-                        // TODO(#6889): Use descriptor instead of name.
-                        chunk.iter_slices::<S>(component_descriptor.component_name),
-                    )
-                }))
-            }
-            MaybeTagged::JustName(component_name) => {
-                itertools::Either::Right(self.chunks.iter().flat_map(move |chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices_by_name(&self.timeline, component_name),
-                        chunk.iter_slices::<S>(*component_name),
-                    )
-                }))
-            }
-        }
+        self.chunks.iter().flat_map(move |chunk| {
+            itertools::izip!(
+                chunk.iter_component_indices(&self.timeline, &self.component_descriptor),
+                // TODO(#6889): Use descriptor instead of name.
+                chunk.iter_slices::<S>(self.component_descriptor.component_name),
+            )
+        })
     }
 
     /// Iterate as indexed, sliced, deserialized component batches for a specific struct field.
@@ -541,27 +489,15 @@ impl<'a> HybridResultsChunkIter<'a> {
         &'a self,
         field_name: &'a str,
     ) -> impl Iterator<Item = ((TimeInt, RowId), S::Item<'a>)> + 'a {
-        match &self.component_descriptor {
-            MaybeTagged::Descriptor(component_descriptor) => {
-                itertools::Either::Left(self.chunks.iter().flat_map(move |chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices(&self.timeline, component_descriptor),
-                        chunk.iter_slices_from_struct_field::<S>(
-                            // TODO(#6889): Use descriptor instead of name.s
-                            component_descriptor.component_name,
-                            field_name,
-                        )
-                    )
-                }))
-            }
-            MaybeTagged::JustName(component_name) => {
-                itertools::Either::Right(self.chunks.iter().flat_map(move |chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices_by_name(&self.timeline, component_name),
-                        chunk.iter_slices_from_struct_field::<S>(*component_name, field_name)
-                    )
-                }))
-            }
-        }
+        self.chunks.iter().flat_map(move |chunk| {
+            itertools::izip!(
+                chunk.iter_component_indices(&self.timeline, &self.component_descriptor),
+                chunk.iter_slices_from_struct_field::<S>(
+                    // TODO(#6889): Use descriptor instead of name.s
+                    self.component_descriptor.component_name,
+                    field_name,
+                )
+            )
+        })
     }
 }

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -3,9 +3,9 @@ use itertools::Itertools as _;
 use re_chunk_store::{RangeQuery, RowId};
 use re_log_types::{EntityPath, TimeInt};
 use re_types::{
-    archetypes,
+    archetypes::{self},
     components::{AggregationPolicy, Color, Name, SeriesVisible, StrokeWidth},
-    Archetype as _, Component as _,
+    Archetype as _,
 };
 use re_view::{range_with_blueprint_resolved_data, RangeResultsExt as _};
 use re_viewer_context::external::re_entity_db::InstancePath;
@@ -235,19 +235,20 @@ impl SeriesLineSystem {
                 &results,
                 &all_scalar_chunks,
                 &mut points_per_series,
+                &archetypes::SeriesLines::descriptor_colors(),
             );
             collect_radius_ui(
                 &query,
                 &results,
                 &all_scalar_chunks,
                 &mut points_per_series,
-                StrokeWidth::name(),
+                &archetypes::SeriesLines::descriptor_widths(),
                 0.5,
             );
 
             // Now convert the `PlotPoints` into `Vec<PlotSeries>`
             let aggregator = results
-                .get_optional_chunks(AggregationPolicy::name())
+                .get_optional_chunks(archetypes::SeriesLines::descriptor_aggregation_policy())
                 .iter()
                 .find(|chunk| !chunk.is_empty())
                 .and_then(|chunk| chunk.component_mono::<AggregationPolicy>(0)?.ok())
@@ -310,7 +311,13 @@ impl SeriesLineSystem {
                 num_series,
                 archetypes::SeriesLines::descriptor_visible_series(),
             );
-            let series_names = collect_series_name(self, &query_ctx, &results, num_series);
+            let series_names = collect_series_name(
+                self,
+                &query_ctx,
+                &results,
+                num_series,
+                &archetypes::SeriesLines::descriptor_names(),
+            );
 
             debug_assert_eq!(points_per_series.len(), series_names.len());
             for (instance, (points, label, visible)) in itertools::izip!(

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -243,13 +243,14 @@ impl SeriesPointSystem {
                 &results,
                 &all_scalar_chunks,
                 &mut points_per_series,
+                &archetypes::SeriesPoints::descriptor_colors(),
             );
             collect_radius_ui(
                 &query,
                 &results,
                 &all_scalar_chunks,
                 &mut points_per_series,
-                MarkerSize::name(),
+                &archetypes::SeriesPoints::descriptor_marker_sizes(),
                 // `marker_size` is a radius, see NOTE above
                 1.0,
             );
@@ -259,7 +260,8 @@ impl SeriesPointSystem {
                 re_tracing::profile_scope!("fill marker shapes");
 
                 {
-                    let all_marker_shapes_chunks = results.get_optional_chunks(MarkerShape::name());
+                    let all_marker_shapes_chunks =
+                        results.get_optional_chunks(archetypes::SeriesPoints::descriptor_markers());
 
                     if all_marker_shapes_chunks.len() == 1
                         && all_marker_shapes_chunks[0].is_static()
@@ -267,7 +269,9 @@ impl SeriesPointSystem {
                         re_tracing::profile_scope!("override/default fast path");
 
                         if let Some(marker_shapes) = all_marker_shapes_chunks[0]
-                            .iter_component_by_name::<MarkerShape>()
+                            .iter_component::<MarkerShape>(
+                                &archetypes::SeriesPoints::descriptor_markers(),
+                            )
                             .next()
                         {
                             for (points, marker_shape) in points_per_series
@@ -344,7 +348,13 @@ impl SeriesPointSystem {
                 num_series,
                 archetypes::SeriesPoints::descriptor_visible_series(),
             );
-            let series_names = collect_series_name(self, &query_ctx, &results, num_series);
+            let series_names = collect_series_name(
+                self,
+                &query_ctx,
+                &results,
+                num_series,
+                &archetypes::SeriesPoints::descriptor_names(),
+            );
 
             debug_assert_eq!(points_per_series.len(), series_names.len());
             for (instance, (points, label, visible)) in itertools::izip!(

--- a/crates/viewer/re_view_time_series/src/series_query.rs
+++ b/crates/viewer/re_view_time_series/src/series_query.rs
@@ -5,9 +5,7 @@ use itertools::Itertools as _;
 use re_chunk_store::RangeQuery;
 use re_log_types::{EntityPath, TimeInt};
 use re_types::external::arrow::datatypes::DataType as ArrowDatatype;
-use re_types::{
-    components, Component as _, ComponentDescriptor, ComponentName, Loggable as _, RowId,
-};
+use re_types::{components, Component as _, ComponentDescriptor, Loggable as _, RowId};
 use re_view::{clamped_or_nothing, ChunksWithDescriptor, HybridRangeResults, RangeResultsExt as _};
 use re_viewer_context::{auto_color_egui, QueryContext, TypedComponentFallbackProvider};
 
@@ -123,6 +121,7 @@ pub fn collect_colors(
     results: &re_view::HybridRangeResults<'_>,
     all_scalar_chunks: &ChunksWithDescriptor<'_>,
     points_per_series: &mut smallvec::SmallVec<[Vec<PlotPoint>; 1]>,
+    color_descriptor: &ComponentDescriptor,
 ) {
     re_tracing::profile_function!();
 
@@ -134,12 +133,12 @@ pub fn collect_colors(
         let [a, b, g, r] = raw.to_le_bytes();
         re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
     }
-    let all_color_chunks = results.get_optional_chunks(components::Color::name());
+    let all_color_chunks = results.get_optional_chunks(color_descriptor.clone());
     if all_color_chunks.len() == 1 && all_color_chunks[0].is_static() {
         re_tracing::profile_scope!("override/default fast path");
 
         if let Some(colors) = all_color_chunks[0]
-            .iter_slices::<u32>(components::Color::name())
+            .iter_slices::<u32>(color_descriptor.component_name)
             .next()
         {
             for (points, color) in points_per_series
@@ -214,14 +213,19 @@ pub fn collect_series_name(
     query_ctx: &QueryContext<'_>,
     results: &re_view::HybridRangeResults<'_>,
     num_series: usize,
+    name_descriptor: &ComponentDescriptor,
 ) -> Vec<String> {
     re_tracing::profile_function!();
 
     let mut series_names: Vec<String> = results
-        .get_optional_chunks(components::Name::name())
+        .get_optional_chunks(name_descriptor.clone())
         .iter()
         .find(|chunk| !chunk.is_empty())
-        .and_then(|chunk| chunk.iter_slices::<String>(components::Name::name()).next())
+        .and_then(|chunk| {
+            chunk
+                .iter_slices::<String>(name_descriptor.component_name)
+                .next()
+        })
         .map(|slice| slice.into_iter().map(|s| s.to_string()).collect())
         .unwrap_or_default();
 
@@ -245,7 +249,7 @@ pub fn collect_radius_ui(
     results: &re_view::HybridRangeResults<'_>,
     all_scalar_chunks: &ChunksWithDescriptor<'_>,
     points_per_series: &mut smallvec::SmallVec<[Vec<PlotPoint>; 1]>,
-    radius_component_name: ComponentName,
+    radius_descriptor: &ComponentDescriptor,
     radius_multiplier: f32,
 ) {
     re_tracing::profile_function!();
@@ -253,13 +257,13 @@ pub fn collect_radius_ui(
     let num_series = points_per_series.len();
 
     {
-        let all_radius_chunks = results.get_optional_chunks(radius_component_name);
+        let all_radius_chunks = results.get_optional_chunks(radius_descriptor.clone());
 
         if all_radius_chunks.len() == 1 && all_radius_chunks[0].is_static() {
             re_tracing::profile_scope!("override/default fast path");
 
             if let Some(radius) = all_radius_chunks[0]
-                .iter_slices::<f32>(radius_component_name)
+                .iter_slices::<f32>(radius_descriptor.component_name)
                 .next()
             {
                 for (points, radius) in points_per_series
@@ -277,8 +281,8 @@ pub fn collect_radius_ui(
 
             let all_radii = all_radius_chunks.iter().flat_map(|chunk| {
                 itertools::izip!(
-                    chunk.iter_component_indices_by_name(query.timeline(), &radius_component_name),
-                    chunk.iter_slices::<f32>(radius_component_name)
+                    chunk.iter_component_indices(query.timeline(), radius_descriptor),
+                    chunk.iter_slices::<f32>(radius_descriptor.component_name)
                 )
             });
 


### PR DESCRIPTION
### Related

* #6889

### What

Removes the dreaded `MaybeTagged` crutch again. This makes `re_query_cache` _almost_ free of name based access (there's a few tiny holdouts, getting there very soon!)