### PR TITLE
Relax `SorbetColumnDescriptors` and add `ChunkColumnDescriptors`

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -15,7 +15,7 @@ use re_chunk::{LatestAtQuery, RangeQuery, TimelineName};
 use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, Timeline};
 use re_sorbet::{
     ChunkColumnDescriptors, ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor,
-    ComponentColumnSelector, IndexColumnDescriptor,  TimeColumnSelector,
+    ComponentColumnSelector, IndexColumnDescriptor, TimeColumnSelector,
 };
 use re_types_core::{ComponentDescriptor, ComponentName};
 use tap::Tap as _;

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -14,8 +14,8 @@ use itertools::Itertools as _;
 use re_chunk::{LatestAtQuery, RangeQuery, TimelineName};
 use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, Timeline};
 use re_sorbet::{
-    ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor, ComponentColumnSelector,
-    IndexColumnDescriptor, SorbetColumnDescriptors, TimeColumnSelector,
+    ChunkColumnDescriptors, ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor,
+    ComponentColumnSelector, IndexColumnDescriptor,  TimeColumnSelector,
 };
 use re_types_core::{ComponentDescriptor, ComponentName};
 use tap::Tap as _;
@@ -306,7 +306,7 @@ impl ChunkStore {
     /// The order of the columns is guaranteed to be in a specific order:
     /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
     /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
-    pub fn schema(&self) -> SorbetColumnDescriptors {
+    pub fn schema(&self) -> ChunkColumnDescriptors {
         re_tracing::profile_function!();
 
         let indices = self
@@ -360,8 +360,8 @@ impl ChunkStore {
             .collect_vec()
             .tap_mut(|components| components.sort());
 
-        SorbetColumnDescriptors {
-            row_id: Some(self.row_id_descriptor()),
+        ChunkColumnDescriptors {
+            row_id: self.row_id_descriptor(),
             indices,
             components,
         }
@@ -483,7 +483,7 @@ impl ChunkStore {
     /// The order of the columns is guaranteed to be in a specific order:
     /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
     /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
-    pub fn schema_for_query(&self, query: &QueryExpression) -> SorbetColumnDescriptors {
+    pub fn schema_for_query(&self, query: &QueryExpression) -> ChunkColumnDescriptors {
         re_tracing::profile_function!();
 
         let QueryExpression {

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -4,7 +4,7 @@ use re_chunk::EntityPath;
 use re_chunk_store::{ChunkStore, ChunkStoreConfig, ChunkStoreHandle, QueryExpression};
 use re_log_types::{EntityPathFilter, StoreId};
 use re_query::{QueryCache, QueryCacheHandle, StorageEngine, StorageEngineLike};
-use re_sorbet::SorbetColumnDescriptors;
+use re_sorbet::ChunkColumnDescriptors;
 
 use crate::QueryHandle;
 
@@ -69,7 +69,7 @@ impl<E: StorageEngineLike + Clone> QueryEngine<E> {
     /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
     /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
     #[inline]
-    pub fn schema(&self) -> SorbetColumnDescriptors {
+    pub fn schema(&self) -> ChunkColumnDescriptors {
         self.engine.with(|store, _cache| store.schema())
     }
 
@@ -79,7 +79,7 @@ impl<E: StorageEngineLike + Clone> QueryEngine<E> {
     /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
     /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
     #[inline]
-    pub fn schema_for_query(&self, query: &QueryExpression) -> SorbetColumnDescriptors {
+    pub fn schema_for_query(&self, query: &QueryExpression) -> ChunkColumnDescriptors {
         self.engine
             .with(|store, _cache| store.schema_for_query(query))
     }

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -32,7 +32,7 @@ use re_chunk_store::{
 use re_log_types::ResolvedTimeRange;
 use re_query::{QueryCache, StorageEngineLike};
 use re_sorbet::{
-    ColumnSelector, ComponentColumnSelector, RowIdColumnDescriptor, SorbetColumnDescriptors,
+    ChunkColumnDescriptors, ColumnSelector, ComponentColumnSelector, RowIdColumnDescriptor,
     TimeColumnSelector,
 };
 use re_types_core::{archetypes, arrow_helpers::as_array_ref, ComponentDescriptor, Loggable as _};
@@ -79,7 +79,7 @@ struct QueryHandleState {
     /// Describes the columns that make up this view.
     ///
     /// See [`QueryExpression::view_contents`].
-    view_contents: SorbetColumnDescriptors,
+    view_contents: ChunkColumnDescriptors,
 
     /// Describes the columns specifically selected to be returned from this view.
     ///
@@ -683,7 +683,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
     ///
     /// See [`QueryExpression::view_contents`].
     #[inline]
-    pub fn view_contents(&self) -> &SorbetColumnDescriptors {
+    pub fn view_contents(&self) -> &ChunkColumnDescriptors {
         &self.init().view_contents
     }
 

--- a/crates/store/re_sorbet/src/chunk_columns.rs
+++ b/crates/store/re_sorbet/src/chunk_columns.rs
@@ -1,0 +1,183 @@
+use arrow::datatypes::Fields as ArrowFields;
+use nohash_hasher::IntSet;
+
+use re_log_types::EntityPath;
+
+use crate::{
+    ColumnDescriptor, ComponentColumnDescriptor, IndexColumnDescriptor, RowIdColumnDescriptor,
+    SorbetColumnDescriptors, SorbetError,
+};
+
+/// Requires a specific ordering of the columns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChunkColumnDescriptors {
+    /// The primary row id column.
+    pub row_id: RowIdColumnDescriptor,
+
+    /// Index columns (timelines).
+    pub indices: Vec<IndexColumnDescriptor>,
+
+    /// The actual component data
+    pub components: Vec<ComponentColumnDescriptor>,
+}
+
+impl ChunkColumnDescriptors {
+    /// Debug-only sanity check.
+    #[inline]
+    #[track_caller]
+    pub fn sanity_check(&self) {
+        for component in &self.components {
+            component.sanity_check();
+        }
+    }
+
+    /// Total number of columns in this chunk,
+    /// including the row id column, the index columns,
+    /// and the data columns.
+    pub fn num_columns(&self) -> usize {
+        let Self {
+            row_id: _,
+            indices,
+            components,
+        } = self;
+        1 + indices.len() + components.len()
+    }
+
+    /// All unique entity paths present in the view contents.
+    pub fn entity_paths(&self) -> IntSet<EntityPath> {
+        self.components
+            .iter()
+            .map(|col| col.entity_path.clone())
+            .collect()
+    }
+
+    /// Returns all indices and then all components;
+    /// skipping the `row_id` column.
+    ///
+    /// See also [`Self::get_index_or_component`].
+    pub fn indices_and_components(&self) -> Vec<ColumnDescriptor> {
+        itertools::chain!(
+            self.indices.iter().cloned().map(ColumnDescriptor::Time),
+            self.components
+                .iter()
+                .cloned()
+                .map(ColumnDescriptor::Component),
+        )
+        .collect()
+    }
+
+    /// Index the index- and component columns, ignoring the `row_id` column completely.
+    ///
+    /// That is, `get_index_or_component(0)` will return the first index column (if any; otherwise
+    /// the first component column).
+    ///
+    /// See also [`Self::indices_and_components`].
+    pub fn get_index_or_component(&self, index_ignoring_row_id: usize) -> Option<ColumnDescriptor> {
+        if index_ignoring_row_id < self.indices.len() {
+            Some(ColumnDescriptor::Time(
+                self.indices[index_ignoring_row_id].clone(),
+            ))
+        } else {
+            self.components
+                .get(index_ignoring_row_id - self.indices.len())
+                .cloned()
+                .map(ColumnDescriptor::Component)
+        }
+    }
+
+    /// Keep only the component columns that satisfy the given predicate.
+    #[must_use]
+    #[inline]
+    pub fn filter_components(mut self, keep: impl Fn(&ComponentColumnDescriptor) -> bool) -> Self {
+        self.components.retain(keep);
+        self
+    }
+}
+
+impl ChunkColumnDescriptors {
+    pub fn try_from_arrow_fields(
+        chunk_entity_path: Option<&EntityPath>,
+        fields: &ArrowFields,
+    ) -> Result<Self, SorbetError> {
+        Self::try_from(SorbetColumnDescriptors::try_from_arrow_fields(
+            chunk_entity_path,
+            fields,
+        )?)
+    }
+}
+
+impl TryFrom<SorbetColumnDescriptors> for ChunkColumnDescriptors {
+    type Error = SorbetError;
+
+    fn try_from(columns: SorbetColumnDescriptors) -> Result<Self, Self::Error> {
+        let SorbetColumnDescriptors { columns } = columns;
+
+        let mut row_ids = Vec::new();
+        let mut indices = Vec::new();
+        let mut components = Vec::new();
+
+        for column in &columns {
+            match column.clone() {
+                ColumnDescriptor::RowId(descr) => {
+                    if indices.is_empty() && components.is_empty() {
+                        row_ids.push(descr);
+                    } else {
+                        let err = format!(
+                            "RowId column must be the first column; but the columns were: {columns:?}"
+                        );
+                        return Err(SorbetError::custom(err));
+                    }
+                }
+
+                ColumnDescriptor::Time(descr) => {
+                    if components.is_empty() {
+                        indices.push(descr);
+                    } else {
+                        return Err(SorbetError::custom(
+                            "Index columns must come before any data columns",
+                        ));
+                    }
+                }
+
+                ColumnDescriptor::Component(descr) => {
+                    components.push(descr);
+                }
+            }
+        }
+
+        if row_ids.len() > 1 {
+            return Err(SorbetError::custom(
+                "Multiple RowId columns are not supported",
+            ));
+        }
+
+        let row_id = row_ids
+            .pop()
+            .ok_or_else(|| SorbetError::custom("Missing RowId column"))?;
+
+        Ok(Self {
+            row_id,
+            indices,
+            components,
+        })
+    }
+}
+
+impl From<ChunkColumnDescriptors> for SorbetColumnDescriptors {
+    fn from(columns: ChunkColumnDescriptors) -> Self {
+        let ChunkColumnDescriptors {
+            row_id,
+            indices,
+            components,
+        } = columns;
+
+        let columns = itertools::chain!(
+            std::iter::once(ColumnDescriptor::RowId(row_id.clone())),
+            indices.iter().cloned().map(ColumnDescriptor::Time),
+            components.iter().cloned().map(ColumnDescriptor::Component),
+        )
+        .collect();
+
+        Self { columns }
+    }
+}

--- a/crates/store/re_sorbet/src/chunk_columns.rs
+++ b/crates/store/re_sorbet/src/chunk_columns.rs
@@ -106,7 +106,7 @@ impl TryFrom<SorbetColumnDescriptors> for ChunkColumnDescriptors {
                         let err = format!(
                             "RowId column must be the first column; but the columns were: {columns:?}"
                         );
-                        return Err(SorbetError::custom(err));
+                        return Err(SorbetError::InvalidColumnOrder(err));
                     }
                 }
 
@@ -114,8 +114,8 @@ impl TryFrom<SorbetColumnDescriptors> for ChunkColumnDescriptors {
                     if components.is_empty() {
                         indices.push(descr);
                     } else {
-                        return Err(SorbetError::custom(
-                            "Index columns must come before any data columns",
+                        return Err(SorbetError::InvalidColumnOrder(
+                            "Index columns must come before any data columns".to_owned(),
                         ));
                     }
                 }
@@ -127,15 +127,10 @@ impl TryFrom<SorbetColumnDescriptors> for ChunkColumnDescriptors {
         }
 
         if row_ids.len() > 1 {
-            return Err(SorbetError::custom(format!(
-                "Found {} RowId columns in Chunk",
-                row_ids.len()
-            )));
+            return Err(SorbetError::MultipleRowIdColumns(row_ids.len()));
         }
 
-        let row_id = row_ids
-            .pop()
-            .ok_or_else(|| SorbetError::custom("Missing RowId column"))?;
+        let row_id = row_ids.pop().ok_or(SorbetError::MissingRowIdColumn)?;
 
         Ok(Self {
             row_id,

--- a/crates/store/re_sorbet/src/chunk_columns.rs
+++ b/crates/store/re_sorbet/src/chunk_columns.rs
@@ -31,26 +31,6 @@ impl ChunkColumnDescriptors {
         }
     }
 
-    /// Total number of columns in this chunk,
-    /// including the row id column, the index columns,
-    /// and the data columns.
-    pub fn num_columns(&self) -> usize {
-        let Self {
-            row_id: _,
-            indices,
-            components,
-        } = self;
-        1 + indices.len() + components.len()
-    }
-
-    /// All unique entity paths present in the view contents.
-    pub fn entity_paths(&self) -> IntSet<EntityPath> {
-        self.components
-            .iter()
-            .map(|col| col.entity_path.clone())
-            .collect()
-    }
-
     /// Returns all indices and then all components;
     /// skipping the `row_id` column.
     ///
@@ -146,9 +126,10 @@ impl TryFrom<SorbetColumnDescriptors> for ChunkColumnDescriptors {
         }
 
         if row_ids.len() > 1 {
-            return Err(SorbetError::custom(
-                "Multiple RowId columns are not supported",
-            ));
+            return Err(SorbetError::custom(format!(
+                "Found {} RowId columns in Chunk",
+                row_ids.len()
+            )));
         }
 
         let row_id = row_ids

--- a/crates/store/re_sorbet/src/chunk_columns.rs
+++ b/crates/store/re_sorbet/src/chunk_columns.rs
@@ -34,6 +34,7 @@ impl ChunkColumnDescriptors {
     /// skipping the `row_id` column.
     ///
     /// See also [`Self::get_index_or_component`].
+    // TODO(#9922): stop ignoring row_id
     pub fn indices_and_components(&self) -> Vec<ColumnDescriptor> {
         itertools::chain!(
             self.indices.iter().cloned().map(ColumnDescriptor::Time),
@@ -51,6 +52,7 @@ impl ChunkColumnDescriptors {
     /// the first component column).
     ///
     /// See also [`Self::indices_and_components`].
+    // TODO(#9922): stop ignoring row_id
     pub fn get_index_or_component(&self, index_ignoring_row_id: usize) -> Option<ColumnDescriptor> {
         if index_ignoring_row_id < self.indices.len() {
             Some(ColumnDescriptor::Time(

--- a/crates/store/re_sorbet/src/chunk_columns.rs
+++ b/crates/store/re_sorbet/src/chunk_columns.rs
@@ -1,5 +1,4 @@
 use arrow::datatypes::Fields as ArrowFields;
-use nohash_hasher::IntSet;
 
 use re_log_types::EntityPath;
 

--- a/crates/store/re_sorbet/src/chunk_schema.rs
+++ b/crates/store/re_sorbet/src/chunk_schema.rs
@@ -150,13 +150,11 @@ impl TryFrom<SorbetSchema> for ChunkSchema {
 
             chunk_columns: ChunkColumnDescriptors::try_from(sorbet_schema.columns.clone())?,
 
-            chunk_id: sorbet_schema
-                .chunk_id
-                .ok_or_else(|| SorbetError::custom("Missing chunk_id"))?,
+            chunk_id: sorbet_schema.chunk_id.ok_or(SorbetError::MissingChunkId)?,
 
             entity_path: sorbet_schema
                 .entity_path
-                .ok_or_else(|| SorbetError::custom("Missing entity_path"))?,
+                .ok_or(SorbetError::MissingEntityPath)?,
         })
     }
 }

--- a/crates/store/re_sorbet/src/chunk_schema.rs
+++ b/crates/store/re_sorbet/src/chunk_schema.rs
@@ -6,7 +6,8 @@ use re_log_types::EntityPath;
 use re_types_core::ChunkId;
 
 use crate::{
-    ArrowBatchMetadata, ComponentColumnDescriptor, IndexColumnDescriptor, RowIdColumnDescriptor,
+    chunk_columns::ChunkColumnDescriptors, ArrowBatchMetadata, ColumnDescriptor,
+    ComponentColumnDescriptor, IndexColumnDescriptor, RowIdColumnDescriptor,
     SorbetColumnDescriptors, SorbetError, SorbetSchema,
 };
 
@@ -19,8 +20,8 @@ pub struct ChunkSchema {
     sorbet: SorbetSchema,
 
     // Some things here are also in [`SorbetSchema]`, but are duplicated
-    // here because they are non-optional:
-    row_id: RowIdColumnDescriptor,
+    // here because they have additional constraints (e.g. ordering, non-optional):
+    chunk_columns: ChunkColumnDescriptors,
     chunk_id: ChunkId,
     entity_path: EntityPath,
 }
@@ -53,15 +54,22 @@ impl ChunkSchema {
         Self {
             sorbet: SorbetSchema {
                 columns: SorbetColumnDescriptors {
-                    row_id: Some(row_id.clone()),
-                    indices,
-                    components,
+                    columns: itertools::chain!(
+                        std::iter::once(ColumnDescriptor::RowId(row_id.clone())),
+                        indices.iter().cloned().map(ColumnDescriptor::Time),
+                        components.iter().cloned().map(ColumnDescriptor::Component),
+                    )
+                    .collect(),
                 },
                 chunk_id: Some(chunk_id),
                 entity_path: Some(entity_path.clone()),
                 heap_size_bytes: None,
             },
-            row_id,
+            chunk_columns: ChunkColumnDescriptors {
+                row_id,
+                indices,
+                components,
+            },
             chunk_id,
             entity_path,
         }
@@ -103,17 +111,7 @@ impl ChunkSchema {
 
     #[inline]
     pub fn row_id_column(&self) -> &RowIdColumnDescriptor {
-        &self.row_id
-    }
-
-    #[inline]
-    pub fn index_columns(&self) -> &[IndexColumnDescriptor] {
-        &self.sorbet.columns.indices
-    }
-
-    #[inline]
-    pub fn component_columns(&self) -> &[ComponentColumnDescriptor] {
-        &self.sorbet.columns.components
+        &self.chunk_columns.row_id
     }
 
     pub fn arrow_batch_metadata(&self) -> ArrowBatchMetadata {
@@ -148,20 +146,17 @@ impl TryFrom<SorbetSchema> for ChunkSchema {
 
     fn try_from(sorbet_schema: SorbetSchema) -> Result<Self, Self::Error> {
         Ok(Self {
-            row_id: sorbet_schema
-                .columns
-                .row_id
-                .clone()
-                .ok_or_else(|| SorbetError::custom("Missing row_id column"))?,
+            sorbet: sorbet_schema.clone(),
+
+            chunk_columns: ChunkColumnDescriptors::try_from(sorbet_schema.columns.clone())?,
+
             chunk_id: sorbet_schema
                 .chunk_id
                 .ok_or_else(|| SorbetError::custom("Missing chunk_id"))?,
+
             entity_path: sorbet_schema
                 .entity_path
-                .clone()
                 .ok_or_else(|| SorbetError::custom("Missing entity_path"))?,
-
-            sorbet: sorbet_schema,
         })
     }
 }

--- a/crates/store/re_sorbet/src/column_descriptor.rs
+++ b/crates/store/re_sorbet/src/column_descriptor.rs
@@ -27,16 +27,23 @@ pub enum ColumnError {
     UnsupportedTimeType(#[from] crate::UnsupportedTimeType),
 }
 
-// Describes any kind of column.
-//
-// See:
-// * [`IndexColumnDescriptor`]
-// * [`ComponentColumnDescriptor`]
-//TODO(#9034): This should support RowId as well, but this has ramifications on the dataframe API.
+/// Describes any kind of column.
+///
+/// See:
+/// * [`RowIdColumnDescriptor`]
+/// * [`IndexColumnDescriptor`]
+/// * [`ComponentColumnDescriptor`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ColumnDescriptor {
+    /// The primary row id column.
+    ///
+    /// There should usually only be one of these.
     RowId(RowIdColumnDescriptor),
+
+    /// Index columns (timelines).
     Time(IndexColumnDescriptor),
+
+    /// The actual component data
     Component(ComponentColumnDescriptor),
 }
 

--- a/crates/store/re_sorbet/src/column_descriptor_ref.rs
+++ b/crates/store/re_sorbet/src/column_descriptor_ref.rs
@@ -3,6 +3,7 @@ use crate::{
     RowIdColumnDescriptor,
 };
 
+// TODO: deprecate and replace with `&ColumnDescriptor`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ColumnDescriptorRef<'a> {
     RowId(&'a RowIdColumnDescriptor),

--- a/crates/store/re_sorbet/src/column_descriptor_ref.rs
+++ b/crates/store/re_sorbet/src/column_descriptor_ref.rs
@@ -3,7 +3,6 @@ use crate::{
     RowIdColumnDescriptor,
 };
 
-// TODO: deprecate and replace with `&ColumnDescriptor`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ColumnDescriptorRef<'a> {
     RowId(&'a RowIdColumnDescriptor),

--- a/crates/store/re_sorbet/src/error.rs
+++ b/crates/store/re_sorbet/src/error.rs
@@ -20,14 +20,21 @@ pub enum SorbetError {
     #[error(transparent)]
     ArrowError(#[from] ArrowError),
 
-    #[error("Bad chunk schema: {reason}")]
-    Custom { reason: String },
-}
+    #[error("Missing chunk ID")]
+    MissingChunkId,
 
-impl SorbetError {
-    pub fn custom(reason: impl Into<String>) -> Self {
-        Self::Custom {
-            reason: reason.into(),
-        }
-    }
+    #[error("Missing entity path")]
+    MissingEntityPath,
+
+    #[error("Missing RowId column")]
+    MissingRowIdColumn,
+
+    #[error("Invalid column order: {0}")]
+    InvalidColumnOrder(String),
+
+    #[error("Multiple RowId columns found: {0}")]
+    MultipleRowIdColumns(usize),
+
+    #[error("Failed to deserialize chunk ID: {0}")]
+    ChunkIdDeserializationError(String),
 }

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -16,6 +16,7 @@
 //! * `DataframeBatch` will have a `DataframeSchema`
 
 mod chunk_batch;
+mod chunk_columns;
 mod chunk_schema;
 mod column_descriptor;
 mod column_descriptor_ref;
@@ -34,6 +35,7 @@ mod sorbet_schema;
 
 pub use self::{
     chunk_batch::{ChunkBatch, MismatchedChunkSchemaError},
+    chunk_columns::ChunkColumnDescriptors,
     chunk_schema::ChunkSchema,
     column_descriptor::{ColumnDescriptor, ColumnError},
     column_descriptor_ref::ColumnDescriptorRef,

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -4,16 +4,12 @@
 //!
 //! An arrow record batch that follows a specific schema is called a [`SorbetBatch`].
 //!
-//! Some [`SorbetBatch`]es has even more constrained requirements, such as [`ChunkBatch`] and `DataframeBatch`.
-//! * Every [`ChunkBatch`] is a [`SorbetBatch`].
-//! * Every `DataframeBatch` is a [`SorbetBatch`].
-//!
-//! NOTE: `DataframeBatch` has not yet been implemented.
+//! There is also [`ChunkBatch`], which is a has even more constrained requirements.
+//! Every [`ChunkBatch`] is a [`SorbetBatch`], but the opposite does not hold.
 //!
 //! Each batch type has a matching schema type:
-//! * [`SorbetBatch`] has a [`SorbetSchema`]
-//! * [`ChunkBatch`] has a [`ChunkSchema`]
-//! * `DataframeBatch` will have a `DataframeSchema`
+//! * [`SorbetBatch`] has a [`SorbetSchema`] with [`SorbetColumnDescriptors`]
+//! * [`ChunkBatch`] has a [`ChunkSchema`] with [`ChunkColumnDescriptors`]
 
 mod chunk_batch;
 mod chunk_columns;

--- a/crates/store/re_sorbet/src/sorbet_batch.rs
+++ b/crates/store/re_sorbet/src/sorbet_batch.rs
@@ -159,9 +159,9 @@ impl From<&SorbetBatch> for ArrowRecordBatch {
 }
 
 impl SorbetBatch {
-    /// Will automatically wrap data columns in `ListArrays` if they are not already.
-    ///
-    /// Will also migrate old types to new types.
+    /// Will perform some transformations:
+    /// * Will automatically wrap data columns in `ListArrays` if they are not already
+    /// * Will migrate legacy data to more modern form
     pub fn try_from_record_batch(
         batch: &ArrowRecordBatch,
         batch_type: crate::BatchType,
@@ -169,7 +169,6 @@ impl SorbetBatch {
         re_tracing::profile_function!();
 
         let batch = make_all_data_columns_list_arrays(batch);
-        let batch = crate::migration::reorder_columns(&batch);
         let batch = crate::migration::migrate_tuids(&batch);
         let batch = crate::migration::migrate_record_batch(&batch);
 

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -72,14 +72,6 @@ impl SorbetColumnDescriptors {
             .collect()
     }
 
-    /// Returns all columns, including the `row_id` column.
-    ///
-    /// See also [`Self::indices_and_components`].
-    #[deprecated] // TODO: remove
-    pub fn descriptors(&self) -> impl Iterator<Item = &ColumnDescriptor> {
-        self.columns.iter()
-    }
-
     pub fn row_id_columns(&self) -> impl Iterator<Item = &RowIdColumnDescriptor> {
         self.columns.iter().filter_map(|descr| {
             if let ColumnDescriptor::RowId(descr) = descr {

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -5,15 +5,12 @@ use re_log_types::{EntityPath, TimelineName};
 
 use crate::{
     ColumnDescriptor, ColumnKind, ComponentColumnDescriptor, ComponentColumnSelector,
-    IndexColumnDescriptor, RowIdColumnDescriptor, SorbetError,
+    IndexColumnDescriptor, RowIdColumnDescriptor, SorbetError, TimeColumnSelector,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 #[expect(clippy::enum_variant_names)]
 pub enum ColumnSelectorResolveError {
-    #[error("There is no RowId column")]
-    RowIdNotFound,
-
     #[error("Column for component '{0}' not found")]
     ComponentNotFound(String),
 
@@ -111,6 +108,19 @@ impl SorbetColumnDescriptors {
                 None
             }
         })
+    }
+
+    /// Resolve the provided index column selector. Returns `None` if no corresponding column was
+    /// found.
+    pub fn resolve_index_column_selector(
+        &self,
+        index_column_selector: &TimeColumnSelector,
+    ) -> Result<&IndexColumnDescriptor, ColumnSelectorResolveError> {
+        self.index_columns()
+            .find(|column| column.timeline_name() == index_column_selector.timeline)
+            .ok_or(ColumnSelectorResolveError::TimelineNotFound(
+                index_column_selector.timeline,
+            ))
     }
 
     /// Resolve the provided component column selector. Returns `None` if no corresponding column

--- a/crates/store/re_sorbet/src/sorbet_columns.rs
+++ b/crates/store/re_sorbet/src/sorbet_columns.rs
@@ -1,14 +1,11 @@
 use arrow::datatypes::{Field as ArrowField, Fields as ArrowFields};
-
-use itertools::Itertools as _;
 use nohash_hasher::IntSet;
 
 use re_log_types::{EntityPath, TimelineName};
 
 use crate::{
-    ColumnDescriptor, ColumnDescriptorRef, ColumnKind, ColumnSelector, ComponentColumnDescriptor,
-    ComponentColumnSelector, IndexColumnDescriptor, RowIdColumnDescriptor, SorbetError,
-    TimeColumnSelector,
+    ColumnDescriptor, ColumnKind, ComponentColumnDescriptor, ComponentColumnSelector,
+    IndexColumnDescriptor, RowIdColumnDescriptor, SorbetError,
 };
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
@@ -31,15 +28,26 @@ pub enum ColumnSelectorResolveError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SorbetColumnDescriptors {
-    /// The primary row id column.
-    /// If present, it is always the first column.
-    pub row_id: Option<RowIdColumnDescriptor>,
+    pub columns: Vec<ColumnDescriptor>,
+}
 
-    /// Index columns (timelines).
-    pub indices: Vec<IndexColumnDescriptor>,
+impl std::ops::Deref for SorbetColumnDescriptors {
+    type Target = [ColumnDescriptor];
 
-    /// The actual component data
-    pub components: Vec<ComponentColumnDescriptor>,
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.columns
+    }
+}
+
+impl IntoIterator for SorbetColumnDescriptors {
+    type Item = ColumnDescriptor;
+    type IntoIter = std::vec::IntoIter<ColumnDescriptor>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.columns.into_iter()
+    }
 }
 
 impl SorbetColumnDescriptors {
@@ -47,8 +55,8 @@ impl SorbetColumnDescriptors {
     #[inline]
     #[track_caller]
     pub fn sanity_check(&self) {
-        for component in &self.components {
-            component.sanity_check();
+        for column in &self.columns {
+            column.sanity_check();
         }
     }
 
@@ -56,101 +64,53 @@ impl SorbetColumnDescriptors {
     /// including the row id column, the index columns,
     /// and the data columns.
     pub fn num_columns(&self) -> usize {
-        let Self {
-            row_id,
-            indices,
-            components,
-        } = self;
-        row_id.is_some() as usize + indices.len() + components.len()
+        self.columns.len()
     }
 
     /// All unique entity paths present in the view contents.
     pub fn entity_paths(&self) -> IntSet<EntityPath> {
-        self.components
+        self.columns
             .iter()
-            .map(|col| col.entity_path.clone())
+            .filter_map(|col| col.entity_path().cloned())
             .collect()
     }
 
     /// Returns all columns, including the `row_id` column.
     ///
     /// See also [`Self::indices_and_components`].
-    pub fn descriptors(&self) -> impl Iterator<Item = ColumnDescriptorRef<'_>> + '_ {
-        self.row_id
-            .iter()
-            .map(ColumnDescriptorRef::from)
-            .chain(self.indices.iter().map(ColumnDescriptorRef::from))
-            .chain(self.components.iter().map(ColumnDescriptorRef::from))
+    #[deprecated] // TODO: remove
+    pub fn descriptors(&self) -> impl Iterator<Item = &ColumnDescriptor> {
+        self.columns.iter()
     }
 
-    /// Returns all indices and then all components;
-    /// skipping the `row_id` column.
-    ///
-    /// See also [`Self::get_index_or_component`].
-    pub fn indices_and_components(&self) -> Vec<ColumnDescriptor> {
-        itertools::chain!(
-            self.indices.iter().cloned().map(ColumnDescriptor::Time),
-            self.components
-                .iter()
-                .cloned()
-                .map(ColumnDescriptor::Component),
-        )
-        .collect()
+    pub fn row_id_columns(&self) -> impl Iterator<Item = &RowIdColumnDescriptor> {
+        self.columns.iter().filter_map(|descr| {
+            if let ColumnDescriptor::RowId(descr) = descr {
+                Some(descr)
+            } else {
+                None
+            }
+        })
     }
 
-    /// Index the index- and component columns, ignoring the `row_id` column completely.
-    ///
-    /// That is, `get_index_or_component(0)` will return the first index column (if any; otherwise
-    /// the first component column).
-    ///
-    /// See also [`Self::indices_and_components`].
-    pub fn get_index_or_component(&self, index_ignoring_row_id: usize) -> Option<ColumnDescriptor> {
-        if index_ignoring_row_id < self.indices.len() {
-            Some(ColumnDescriptor::Time(
-                self.indices[index_ignoring_row_id].clone(),
-            ))
-        } else {
-            self.components
-                .get(index_ignoring_row_id - self.indices.len())
-                .cloned()
-                .map(ColumnDescriptor::Component)
-        }
+    pub fn index_columns(&self) -> impl Iterator<Item = &IndexColumnDescriptor> {
+        self.columns.iter().filter_map(|descr| {
+            if let ColumnDescriptor::Time(descr) = descr {
+                Some(descr)
+            } else {
+                None
+            }
+        })
     }
 
-    /// Resolve the provided column selector. Returns `None` if no corresponding column was found.
-    pub fn resolve_selector(
-        &self,
-        column_selector: &ColumnSelector,
-    ) -> Result<ColumnDescriptorRef<'_>, ColumnSelectorResolveError> {
-        match column_selector {
-            ColumnSelector::RowId => self
-                .row_id
-                .as_ref()
-                .map(ColumnDescriptorRef::RowId)
-                .ok_or(ColumnSelectorResolveError::RowIdNotFound),
-
-            ColumnSelector::Time(selector) => self
-                .resolve_index_column_selector(selector)
-                .map(ColumnDescriptorRef::Time),
-
-            ColumnSelector::Component(selector) => self
-                .resolve_component_column_selector(selector)
-                .map(ColumnDescriptorRef::Component),
-        }
-    }
-
-    /// Resolve the provided index column selector. Returns `None` if no corresponding column was
-    /// found.
-    pub fn resolve_index_column_selector(
-        &self,
-        index_column_selector: &TimeColumnSelector,
-    ) -> Result<&IndexColumnDescriptor, ColumnSelectorResolveError> {
-        self.indices
-            .iter()
-            .find(|column| column.timeline_name() == index_column_selector.timeline)
-            .ok_or(ColumnSelectorResolveError::TimelineNotFound(
-                index_column_selector.timeline,
-            ))
+    pub fn component_columns(&self) -> impl Iterator<Item = &ComponentColumnDescriptor> {
+        self.columns.iter().filter_map(|descr| {
+            if let ColumnDescriptor::Component(descr) = descr {
+                Some(descr)
+            } else {
+                None
+            }
+        })
     }
 
     /// Resolve the provided component column selector. Returns `None` if no corresponding column
@@ -175,7 +135,7 @@ impl SorbetColumnDescriptors {
         } = component_column_selector;
 
         // happy path: exact component name match
-        let exact_match = self.components.iter().find(|column| {
+        let exact_match = self.component_columns().find(|column| {
             column.component_name.as_str() == component_name && &column.entity_path == entity_path
         });
 
@@ -184,7 +144,7 @@ impl SorbetColumnDescriptors {
         }
 
         // fallback: use `ComponentName::match` and check that we have a single result
-        let mut partial_match = self.components.iter().filter(|column| {
+        let mut partial_match = self.component_columns().filter(|column| {
             column.component_name.matches(component_name) && &column.entity_path == entity_path
         });
 
@@ -204,30 +164,10 @@ impl SorbetColumnDescriptors {
     }
 
     pub fn arrow_fields(&self, batch_type: crate::BatchType) -> Vec<ArrowField> {
-        let Self {
-            row_id,
-            indices,
-            components,
-        } = self;
-        let mut fields: Vec<ArrowField> = Vec::with_capacity(self.num_columns());
-        if let Some(row_id) = row_id {
-            fields.push(row_id.to_arrow_field());
-        }
-        fields.extend(indices.iter().map(|column| column.to_arrow_field()));
-        fields.extend(
-            components
-                .iter()
-                .map(|column| column.to_arrow_field(batch_type)),
-        );
-        fields
-    }
-
-    /// Keep only the component columns that satisfy the given predicate.
-    #[must_use]
-    #[inline]
-    pub fn filter_components(mut self, keep: impl Fn(&ComponentColumnDescriptor) -> bool) -> Self {
-        self.components.retain(keep);
-        self
+        self.columns
+            .iter()
+            .map(|c| c.to_arrow_field(batch_type))
+            .collect()
     }
 }
 
@@ -236,92 +176,29 @@ impl SorbetColumnDescriptors {
         chunk_entity_path: Option<&EntityPath>,
         fields: &ArrowFields,
     ) -> Result<Self, SorbetError> {
-        let mut row_ids = Vec::new();
-        let mut indices = Vec::new();
-        let mut components = Vec::new();
+        let mut columns = Vec::with_capacity(fields.len());
 
         for field in fields {
             let field = field.as_ref();
             let column_kind = ColumnKind::try_from(field)?;
-            match column_kind {
+
+            let descr = match column_kind {
                 ColumnKind::RowId => {
-                    if indices.is_empty() && components.is_empty() {
-                        row_ids.push(RowIdColumnDescriptor::try_from(field)?);
-                    } else {
-                        let err = format!(
-                            "RowId column must be the first column; but the columns were: {:?}",
-                            fields.iter().map(|f| f.name()).collect_vec()
-                        );
-                        return Err(SorbetError::custom(err));
-                    }
+                    ColumnDescriptor::RowId(RowIdColumnDescriptor::try_from(field)?)
                 }
 
                 ColumnKind::Index => {
-                    if components.is_empty() {
-                        indices.push(IndexColumnDescriptor::try_from(field)?);
-                    } else {
-                        return Err(SorbetError::custom(
-                            "Index columns must come before any data columns",
-                        ));
-                    }
+                    ColumnDescriptor::Time(IndexColumnDescriptor::try_from(field)?)
                 }
 
-                ColumnKind::Component => {
-                    components.push(ComponentColumnDescriptor::from_arrow_field(
-                        chunk_entity_path,
-                        field,
-                    ));
-                }
-            }
+                ColumnKind::Component => ColumnDescriptor::Component(
+                    ComponentColumnDescriptor::from_arrow_field(chunk_entity_path, field),
+                ),
+            };
+
+            columns.push(descr);
         }
 
-        if row_ids.len() > 1 {
-            return Err(SorbetError::custom(
-                "Multiple row_id columns are not supported",
-            ));
-        }
-
-        Ok(Self {
-            row_id: row_ids.pop(),
-            indices,
-            components,
-        })
-    }
-
-    // TODO(#9855): Reconcile this with the above.
-    pub fn try_from_arrow_fields_forgiving(
-        chunk_entity_path: Option<&EntityPath>,
-        fields: &ArrowFields,
-    ) -> Result<Self, SorbetError> {
-        let mut row_ids = Vec::new();
-        let mut indices = Vec::new();
-        let mut components = Vec::new();
-
-        for field in fields {
-            let field = field.as_ref();
-            let column_kind = ColumnKind::try_from(field)?;
-            match column_kind {
-                ColumnKind::RowId => {
-                    row_ids.push(RowIdColumnDescriptor::try_from(field)?);
-                }
-
-                ColumnKind::Index => {
-                    indices.push(IndexColumnDescriptor::try_from(field)?);
-                }
-
-                ColumnKind::Component => {
-                    components.push(ComponentColumnDescriptor::from_arrow_field(
-                        chunk_entity_path,
-                        field,
-                    ));
-                }
-            }
-        }
-
-        Ok(Self {
-            row_id: row_ids.pop(),
-            indices,
-            components,
-        })
+        Ok(Self { columns })
     }
 }

--- a/crates/store/re_sorbet/src/sorbet_schema.rs
+++ b/crates/store/re_sorbet/src/sorbet_schema.rs
@@ -108,7 +108,7 @@ impl TryFrom<&ArrowSchema> for SorbetSchema {
 
         let chunk_id = if let Some(chunk_id_str) = metadata.get("rerun.id") {
             Some(chunk_id_str.parse().map_err(|err| {
-                SorbetError::custom(format!(
+                SorbetError::ChunkIdDeserializationError(format!(
                     "Failed to deserialize chunk id {chunk_id_str:?}: {err}"
                 ))
             })?)

--- a/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
@@ -289,7 +289,7 @@ impl ChunkUi {
                 }
                 Err(err) => {
                     ui.error_with_details_on_hover(format!(
-                        "Failed to convert to tqransport: {err}"
+                        "Failed to convert to transport: {err}"
                     ));
                 }
             }

--- a/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
@@ -31,9 +31,9 @@ impl<'a> Columns<'a> {
     fn from(sorbet_schema: &'a SorbetSchema) -> Self {
         let inner = sorbet_schema
             .columns
-            .descriptors()
+            .iter()
             .enumerate()
-            .map(|(index, desc)| (egui::Id::new(&desc), (index, desc)))
+            .map(|(index, desc)| (egui::Id::new(desc), (index, desc.into())))
             .collect::<IntMap<_, _>>();
 
         Self { inner }
@@ -238,7 +238,7 @@ impl<'a> DataFusionTableWidget<'a> {
             .map(|sorbet_batch| {
                 DisplayRecordBatch::try_new(
                     sorbet_batch
-                        .all_columns()
+                        .all_columns_ref()
                         .map(|(desc, array)| (desc, array.clone())),
                 )
             })

--- a/rerun_py/src/catalog/dataset.rs
+++ b/rerun_py/src/catalog/dataset.rs
@@ -464,13 +464,11 @@ impl PyDataset {
 
     fn fetch_schema(self_: &PyRef<'_, Self>) -> PyResult<PySchema> {
         Self::fetch_arrow_schema(self_).and_then(|arrow_schema| {
-            let descs = SorbetColumnDescriptors::try_from_arrow_fields_forgiving(
-                None,
-                arrow_schema.fields(),
-            )
-            .map_err(to_py_err)?;
+            let schema =
+                SorbetColumnDescriptors::try_from_arrow_fields(None, arrow_schema.fields())
+                    .map_err(to_py_err)?;
 
-            Ok(PySchema { schema: descs })
+            Ok(PySchema { schema })
         })
     }
 }


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/9855


### What
`SorbetColumnDescriptors` no longer enforces the order of columns. Instead there is a new `ChunkColumnDescriptors` that enforces this.