### PR TITLE
redap: support REDAP_TOKEN env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7048,6 +7048,7 @@ name = "re_grpc_client"
 version = "0.24.0-alpha.1+dev"
 dependencies = [
  "async-stream",
+ "re_auth",
  "re_chunk",
  "re_error",
  "re_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ rerun-cli = { path = "crates/top/rerun-cli", version = "=0.24.0-alpha.1", defaul
 # crates/utils:
 re_analytics = { path = "crates/utils/re_analytics", version = "=0.24.0-alpha.1", default-features = false }
 re_arrow_util = { path = "crates/utils/re_arrow_util", version = "=0.24.0-alpha.1", default-features = false }
+re_auth = { path = "crates/utils/re_auth", version = "=0.24.0-alpha.1", default-features = false }
 re_byte_size = { path = "crates/utils/re_byte_size", version = "=0.24.0-alpha.1", default-features = false }
 re_capabilities = { path = "crates/utils/re_capabilities", version = "=0.24.0-alpha.1", default-features = false }
 re_case = { path = "crates/utils/re_case", version = "=0.24.0-alpha.1", default-features = false }

--- a/crates/store/re_grpc_client/Cargo.toml
+++ b/crates/store/re_grpc_client/Cargo.toml
@@ -36,6 +36,7 @@ url.workspace = true
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+re_auth.workspace = true
 tokio.workspace = true
 tonic = { workspace = true, default-features = false, features = [
   "transport",

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -130,7 +130,6 @@ pub async fn client(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-// pub type RedapClient = FrontendServiceClient<tonic::transport::Channel>;
 pub type RedapClient = FrontendServiceClient<
     tonic::service::interceptor::InterceptedService<tonic::transport::Channel, AuthDecorator>,
 >;
@@ -151,18 +150,20 @@ pub async fn client(origin: Origin) -> Result<RedapClient, ConnectionError> {
 
     // Use the token from the env var if available, logging any error
     //
-    // TODO(#721): we should support configuring the token from
+    // TODO(rerun-io/dataplatform#721): we should support configuring the token from
     // the UI and/or API too
     let maybe_token = std::env::var("REDAP_TOKEN")
         .map_err(|err| match err {
             std::env::VarError::NotPresent => {}
             std::env::VarError::NotUnicode(..) => {
-                re_log::warn!("REDAP_TOKEN env var is malformed: {err}");
+                re_log::warn_once!("REDAP_TOKEN env var is malformed: {err}");
             }
         })
         .and_then(|t| {
             Jwt::try_from(t).map_err(|err| {
-                re_log::warn!("REDAP_TOKEN env var is present, but the token is invalid: {err}");
+                re_log::warn_once!(
+                    "REDAP_TOKEN env var is present, but the token is invalid: {err}"
+                );
             })
         })
         .ok();

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -1,5 +1,8 @@
 use tokio_stream::{Stream, StreamExt as _};
 
+#[cfg(not(target_arch = "wasm32"))]
+use re_auth::{client::AuthDecorator, Jwt};
+
 use re_chunk::Chunk;
 use re_log_encoding::codec::wire::decoder::Decode as _;
 use re_log_types::{LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource};
@@ -127,7 +130,10 @@ pub async fn client(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub type RedapClient = FrontendServiceClient<tonic::transport::Channel>;
+// pub type RedapClient = FrontendServiceClient<tonic::transport::Channel>;
+pub type RedapClient = FrontendServiceClient<
+    tonic::service::interceptor::InterceptedService<tonic::transport::Channel, AuthDecorator>,
+>;
 // TODO(cmc): figure out how we integrate redap_telemetry in mainline Rerun
 // pub type RedapClient = FrontendServiceClient<
 //     tower_http::trace::Trace<
@@ -143,7 +149,28 @@ pub type RedapClient = FrontendServiceClient<tonic::transport::Channel>;
 pub async fn client(origin: Origin) -> Result<RedapClient, ConnectionError> {
     let channel = channel(origin).await?;
 
+    // Use the token from the env var if available, logging any error
+    //
+    // TODO(#721): we should support configuring the token from
+    // the UI and/or API too
+    let maybe_token = std::env::var("REDAP_TOKEN")
+        .map_err(|err| match err {
+            std::env::VarError::NotPresent => {}
+            std::env::VarError::NotUnicode(..) => {
+                re_log::warn!("REDAP_TOKEN env var is malformed: {err}");
+            }
+        })
+        .and_then(|t| {
+            Jwt::try_from(t).map_err(|err| {
+                re_log::warn!("REDAP_TOKEN env var is present, but the token is invalid: {err}");
+            })
+        })
+        .ok();
+
+    let auth = AuthDecorator::new(maybe_token);
+
     let middlewares = tower::ServiceBuilder::new()
+        .layer(tonic::service::interceptor::interceptor(auth))
         // TODO(cmc): figure out how we integrate redap_telemetry in mainline Rerun
         // .layer(redap_telemetry::new_grpc_tracing_layer())
         // .layer(redap_telemetry::TracingInjectorInterceptor::new_layer())


### PR DESCRIPTION
### What
To access redap endpoints that require authentication (such as `sandbox.redap.rerun.io`) we need ways to pass the auth token to the GRPC client.

This is the simplest most naive way, that unblocks us.

We may consider to have explicit SDK params and even UI elements in the viewer for that.

### Notable miss
This won't work with with the `wasm` build because `re_auth` is not friendly with it. I have not had the time to dig into it, and I will likely need help with that. Created an issue in https://github.com/rerun-io/dataplatform/issues/726

### Issues
* Closes: https://github.com/rerun-io/dataplatform/issues/722
* Opens :sweat_smile: : https://github.com/rerun-io/dataplatform/issues/726
