### PR TITLE
Add component type to doc string of `ComponentDescriptor::descriptor_*`

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1102,14 +1102,31 @@ fn quote_trait_impls_for_archetype(reporter: &Reporter, obj: &Object) -> TokenSt
             let archetype_name = &obj.fqname;
             let archetype_field_name = field.snake_case_name();
 
-            let doc = format!(
-                "Returns the [`ComponentDescriptor`] for [`Self::{archetype_field_name}`]."
-            );
+            // Make the `#doc` string nice (avoids `/** */`).
+            let lines = [
+                format!(
+                    "Returns the [`ComponentDescriptor`] for [`Self::{archetype_field_name}`]."
+                ),
+                String::new(),
+                "The `descriptor` will have the following fields:".to_owned(),
+                "```".to_owned(),
+                "let descriptor = ComponentDescriptor {".to_owned(),
+                format!("    archetype_name: \"{archetype_name}\","),
+                format!("    component_name: \"{component_name}\","),
+                format!("    archetype_field_name: \"{archetype_field_name}\","),
+                "};".to_owned(),
+                "```".to_owned(),
+            ];
+
+            let doc_attrs = lines.iter().map(|line| {
+                quote! { #[doc = #line] }
+            });
+
             let fn_name = format_ident!("descriptor_{archetype_field_name}");
 
             quote! {
-                #[doc = #doc]
-                #[inline]
+            #(#doc_attrs)*
+            #[inline]
                 pub fn #fn_name() -> ComponentDescriptor {
                     ComponentDescriptor {
                         archetype_name: Some(#archetype_name.into()),

--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1101,6 +1101,7 @@ fn quote_trait_impls_for_archetype(reporter: &Reporter, obj: &Object) -> TokenSt
 
             let archetype_name = &obj.fqname;
             let archetype_field_name = field.snake_case_name();
+            let (typ, _) = quote_field_type_from_typ(&field.typ, true);
 
             // Make the `#doc` string nice (avoids `/** */`).
             let lines = [
@@ -1108,7 +1109,7 @@ fn quote_trait_impls_for_archetype(reporter: &Reporter, obj: &Object) -> TokenSt
                     "Returns the [`ComponentDescriptor`] for [`Self::{archetype_field_name}`]."
                 ),
                 String::new(),
-                format!("The `component_name` field will be set to `{component_name}`."),
+                format!("The corresponding component is [`{typ}`]."),
             ];
 
             let doc_attrs = lines.iter().map(|line| {

--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1108,7 +1108,7 @@ fn quote_trait_impls_for_archetype(reporter: &Reporter, obj: &Object) -> TokenSt
                     "Returns the [`ComponentDescriptor`] for [`Self::{archetype_field_name}`]."
                 ),
                 String::new(),
-                "The `descriptor` will have the following fields:".to_owned(),
+                "It will have the following fields:".to_owned(),
                 "```".to_owned(),
                 "let descriptor = ComponentDescriptor {".to_owned(),
                 format!("    archetype_name: \"{archetype_name}\","),

--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1108,14 +1108,7 @@ fn quote_trait_impls_for_archetype(reporter: &Reporter, obj: &Object) -> TokenSt
                     "Returns the [`ComponentDescriptor`] for [`Self::{archetype_field_name}`]."
                 ),
                 String::new(),
-                "It will have the following fields:".to_owned(),
-                "```".to_owned(),
-                "let descriptor = ComponentDescriptor {".to_owned(),
-                format!("    archetype_name: \"{archetype_name}\","),
-                format!("    component_name: \"{component_name}\","),
-                format!("    archetype_field_name: \"{archetype_field_name}\","),
-                "};".to_owned(),
-                "```".to_owned(),
+                format!("The `component_name` field will be set to `{component_name}`."),
             ];
 
             let doc_attrs = lines.iter().map(|line| {

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -80,7 +80,7 @@ pub struct AnnotationContext {
 impl AnnotationContext {
     /// Returns the [`ComponentDescriptor`] for [`Self::context`].
     ///
-    /// The `component_name` field will be set to `rerun.components.AnnotationContext`.
+    /// The corresponding component is [`crate::components::AnnotationContext`].
     #[inline]
     pub fn descriptor_context() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -79,6 +79,15 @@ pub struct AnnotationContext {
 
 impl AnnotationContext {
     /// Returns the [`ComponentDescriptor`] for [`Self::context`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.AnnotationContext",
+    ///    component_name: "rerun.components.AnnotationContext",
+    ///    archetype_field_name: "context",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_context() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -80,14 +80,7 @@ pub struct AnnotationContext {
 impl AnnotationContext {
     /// Returns the [`ComponentDescriptor`] for [`Self::context`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.AnnotationContext",
-    ///    component_name: "rerun.components.AnnotationContext",
-    ///    archetype_field_name: "context",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.AnnotationContext`.
     #[inline]
     pub fn descriptor_context() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -89,6 +89,15 @@ pub struct Arrows2D {
 
 impl Arrows2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.Vector2D",
+    ///    archetype_field_name: "vectors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_vectors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -99,6 +108,15 @@ impl Arrows2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.Position2D",
+    ///    archetype_field_name: "origins",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_origins() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -109,6 +127,15 @@ impl Arrows2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -119,6 +146,15 @@ impl Arrows2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -129,6 +165,15 @@ impl Arrows2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -139,6 +184,15 @@ impl Arrows2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -149,6 +203,15 @@ impl Arrows2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -159,6 +222,15 @@ impl Arrows2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows2D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -90,14 +90,7 @@ pub struct Arrows2D {
 impl Arrows2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.Vector2D",
-    ///    archetype_field_name: "vectors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Vector2D`.
     #[inline]
     pub fn descriptor_vectors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -109,14 +102,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.Position2D",
-    ///    archetype_field_name: "origins",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position2D`.
     #[inline]
     pub fn descriptor_origins() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -128,14 +114,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -147,14 +126,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -166,14 +138,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -185,14 +150,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -204,14 +162,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -223,14 +174,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows2D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -90,7 +90,7 @@ pub struct Arrows2D {
 impl Arrows2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Vector2D`.
+    /// The corresponding component is [`crate::components::Vector2D`].
     #[inline]
     pub fn descriptor_vectors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,7 +102,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position2D`.
+    /// The corresponding component is [`crate::components::Position2D`].
     #[inline]
     pub fn descriptor_origins() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -114,7 +114,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -126,7 +126,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -138,7 +138,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -150,7 +150,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -162,7 +162,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -174,7 +174,7 @@ impl Arrows2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -98,7 +98,7 @@ pub struct Arrows3D {
 impl Arrows3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Vector3D`.
+    /// The corresponding component is [`crate::components::Vector3D`].
     #[inline]
     pub fn descriptor_vectors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -110,7 +110,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position3D`.
+    /// The corresponding component is [`crate::components::Position3D`].
     #[inline]
     pub fn descriptor_origins() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,7 +122,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -134,7 +134,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -146,7 +146,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -158,7 +158,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -170,7 +170,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -97,6 +97,15 @@ pub struct Arrows3D {
 
 impl Arrows3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows3D",
+    ///    component_name: "rerun.components.Vector3D",
+    ///    archetype_field_name: "vectors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_vectors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -107,6 +116,15 @@ impl Arrows3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows3D",
+    ///    component_name: "rerun.components.Position3D",
+    ///    archetype_field_name: "origins",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_origins() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -117,6 +135,15 @@ impl Arrows3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows3D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -127,6 +154,15 @@ impl Arrows3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -137,6 +173,15 @@ impl Arrows3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows3D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -147,6 +192,15 @@ impl Arrows3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows3D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,6 +211,15 @@ impl Arrows3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Arrows3D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -98,14 +98,7 @@ pub struct Arrows3D {
 impl Arrows3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vectors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows3D",
-    ///    component_name: "rerun.components.Vector3D",
-    ///    archetype_field_name: "vectors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Vector3D`.
     #[inline]
     pub fn descriptor_vectors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -117,14 +110,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::origins`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows3D",
-    ///    component_name: "rerun.components.Position3D",
-    ///    archetype_field_name: "origins",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position3D`.
     #[inline]
     pub fn descriptor_origins() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,14 +122,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows3D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -155,14 +134,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -174,14 +146,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows3D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -193,14 +158,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows3D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -212,14 +170,7 @@ impl Arrows3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Arrows3D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -80,6 +80,15 @@ pub struct Asset3D {
 
 impl Asset3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Asset3D",
+    ///    component_name: "rerun.components.Blob",
+    ///    archetype_field_name: "blob",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -90,6 +99,15 @@ impl Asset3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Asset3D",
+    ///    component_name: "rerun.components.MediaType",
+    ///    archetype_field_name: "media_type",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -100,6 +118,15 @@ impl Asset3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Asset3D",
+    ///    component_name: "rerun.components.AlbedoFactor",
+    ///    archetype_field_name: "albedo_factor",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_albedo_factor() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -81,14 +81,7 @@ pub struct Asset3D {
 impl Asset3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Asset3D",
-    ///    component_name: "rerun.components.Blob",
-    ///    archetype_field_name: "blob",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Blob`.
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -100,14 +93,7 @@ impl Asset3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Asset3D",
-    ///    component_name: "rerun.components.MediaType",
-    ///    archetype_field_name: "media_type",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MediaType`.
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -119,14 +105,7 @@ impl Asset3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Asset3D",
-    ///    component_name: "rerun.components.AlbedoFactor",
-    ///    archetype_field_name: "albedo_factor",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.AlbedoFactor`.
     #[inline]
     pub fn descriptor_albedo_factor() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -81,7 +81,7 @@ pub struct Asset3D {
 impl Asset3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Blob`.
+    /// The corresponding component is [`crate::components::Blob`].
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -93,7 +93,7 @@ impl Asset3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MediaType`.
+    /// The corresponding component is [`crate::components::MediaType`].
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -105,7 +105,7 @@ impl Asset3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
     ///
-    /// The `component_name` field will be set to `rerun.components.AlbedoFactor`.
+    /// The corresponding component is [`crate::components::AlbedoFactor`].
     #[inline]
     pub fn descriptor_albedo_factor() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -141,14 +141,7 @@ pub struct AssetVideo {
 impl AssetVideo {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.AssetVideo",
-    ///    component_name: "rerun.components.Blob",
-    ///    archetype_field_name: "blob",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Blob`.
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -160,14 +153,7 @@ impl AssetVideo {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.AssetVideo",
-    ///    component_name: "rerun.components.MediaType",
-    ///    archetype_field_name: "media_type",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MediaType`.
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -141,7 +141,7 @@ pub struct AssetVideo {
 impl AssetVideo {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Blob`.
+    /// The corresponding component is [`crate::components::Blob`].
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -153,7 +153,7 @@ impl AssetVideo {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MediaType`.
+    /// The corresponding component is [`crate::components::MediaType`].
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -140,6 +140,15 @@ pub struct AssetVideo {
 
 impl AssetVideo {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.AssetVideo",
+    ///    component_name: "rerun.components.Blob",
+    ///    archetype_field_name: "blob",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -150,6 +159,15 @@ impl AssetVideo {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.AssetVideo",
+    ///    component_name: "rerun.components.MediaType",
+    ///    archetype_field_name: "media_type",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -58,7 +58,7 @@ pub struct BarChart {
 impl BarChart {
     /// Returns the [`ComponentDescriptor`] for [`Self::values`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TensorData`.
+    /// The corresponding component is [`crate::components::TensorData`].
     #[inline]
     pub fn descriptor_values() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -70,7 +70,7 @@ impl BarChart {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -58,14 +58,7 @@ pub struct BarChart {
 impl BarChart {
     /// Returns the [`ComponentDescriptor`] for [`Self::values`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.BarChart",
-    ///    component_name: "rerun.components.TensorData",
-    ///    archetype_field_name: "values",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TensorData`.
     #[inline]
     pub fn descriptor_values() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -77,14 +70,7 @@ impl BarChart {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.BarChart",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "color",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -57,6 +57,15 @@ pub struct BarChart {
 
 impl BarChart {
     /// Returns the [`ComponentDescriptor`] for [`Self::values`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.BarChart",
+    ///    component_name: "rerun.components.TensorData",
+    ///    archetype_field_name: "values",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_values() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -67,6 +76,15 @@ impl BarChart {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.BarChart",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "color",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -83,7 +83,7 @@ pub struct Boxes2D {
 impl Boxes2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
     ///
-    /// The `component_name` field will be set to `rerun.components.HalfSize2D`.
+    /// The corresponding component is [`crate::components::HalfSize2D`].
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -95,7 +95,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position2D`.
+    /// The corresponding component is [`crate::components::Position2D`].
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -107,7 +107,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -119,7 +119,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -131,7 +131,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -143,7 +143,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -155,7 +155,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,7 +167,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -82,6 +82,15 @@ pub struct Boxes2D {
 
 impl Boxes2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.HalfSize2D",
+    ///    archetype_field_name: "half_sizes",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,6 +101,15 @@ impl Boxes2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.Position2D",
+    ///    archetype_field_name: "centers",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,6 +120,15 @@ impl Boxes2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -112,6 +139,15 @@ impl Boxes2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,6 +158,15 @@ impl Boxes2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -132,6 +177,15 @@ impl Boxes2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -142,6 +196,15 @@ impl Boxes2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,6 +215,15 @@ impl Boxes2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes2D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -83,14 +83,7 @@ pub struct Boxes2D {
 impl Boxes2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.HalfSize2D",
-    ///    archetype_field_name: "half_sizes",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.HalfSize2D`.
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,14 +95,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.Position2D",
-    ///    archetype_field_name: "centers",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position2D`.
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -121,14 +107,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -140,14 +119,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -159,14 +131,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -178,14 +143,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -197,14 +155,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -216,14 +167,7 @@ impl Boxes2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes2D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -112,6 +112,15 @@ pub struct Boxes3D {
 
 impl Boxes3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.HalfSize3D",
+    ///    archetype_field_name: "half_sizes",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,6 +131,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.PoseTranslation3D",
+    ///    archetype_field_name: "centers",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -132,6 +150,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.PoseRotationAxisAngle",
+    ///    archetype_field_name: "rotation_axis_angles",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -142,6 +169,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.PoseRotationQuat",
+    ///    archetype_field_name: "quaternions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,6 +188,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -162,6 +207,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -172,6 +226,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.FillMode",
+    ///    archetype_field_name: "fill_mode",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fill_mode() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -182,6 +245,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -192,6 +264,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -202,6 +283,15 @@ impl Boxes3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Boxes3D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -113,14 +113,7 @@ pub struct Boxes3D {
 impl Boxes3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.HalfSize3D",
-    ///    archetype_field_name: "half_sizes",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.HalfSize3D`.
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -132,14 +125,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.PoseTranslation3D",
-    ///    archetype_field_name: "centers",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -151,14 +137,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.PoseRotationAxisAngle",
-    ///    archetype_field_name: "rotation_axis_angles",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -170,14 +149,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.PoseRotationQuat",
-    ///    archetype_field_name: "quaternions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -189,14 +161,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -208,14 +173,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -227,14 +185,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.FillMode",
-    ///    archetype_field_name: "fill_mode",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.FillMode`.
     #[inline]
     pub fn descriptor_fill_mode() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -246,14 +197,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -265,14 +209,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -284,14 +221,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Boxes3D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -113,7 +113,7 @@ pub struct Boxes3D {
 impl Boxes3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
     ///
-    /// The `component_name` field will be set to `rerun.components.HalfSize3D`.
+    /// The corresponding component is [`crate::components::HalfSize3D`].
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -125,7 +125,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
+    /// The corresponding component is [`crate::components::PoseTranslation3D`].
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -137,7 +137,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
+    /// The corresponding component is [`crate::components::PoseRotationAxisAngle`].
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -149,7 +149,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
+    /// The corresponding component is [`crate::components::PoseRotationQuat`].
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -161,7 +161,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -173,7 +173,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -185,7 +185,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
     ///
-    /// The `component_name` field will be set to `rerun.components.FillMode`.
+    /// The corresponding component is [`crate::components::FillMode`].
     #[inline]
     pub fn descriptor_fill_mode() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -197,7 +197,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -209,7 +209,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -221,7 +221,7 @@ impl Boxes3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -118,14 +118,7 @@ pub struct Capsules3D {
 impl Capsules3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::lengths`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.Length",
-    ///    archetype_field_name: "lengths",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Length`.
     #[inline]
     pub fn descriptor_lengths() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -137,14 +130,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -156,14 +142,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.PoseTranslation3D",
-    ///    archetype_field_name: "translations",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
     #[inline]
     pub fn descriptor_translations() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -175,14 +154,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.PoseRotationAxisAngle",
-    ///    archetype_field_name: "rotation_axis_angles",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -194,14 +166,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.PoseRotationQuat",
-    ///    archetype_field_name: "quaternions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -213,14 +178,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -232,14 +190,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -251,14 +202,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -270,14 +214,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Capsules3D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -118,7 +118,7 @@ pub struct Capsules3D {
 impl Capsules3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::lengths`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Length`.
+    /// The corresponding component is [`crate::components::Length`].
     #[inline]
     pub fn descriptor_lengths() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -130,7 +130,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -142,7 +142,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
+    /// The corresponding component is [`crate::components::PoseTranslation3D`].
     #[inline]
     pub fn descriptor_translations() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -154,7 +154,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
+    /// The corresponding component is [`crate::components::PoseRotationAxisAngle`].
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -166,7 +166,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
+    /// The corresponding component is [`crate::components::PoseRotationQuat`].
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -178,7 +178,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -190,7 +190,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -202,7 +202,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -214,7 +214,7 @@ impl Capsules3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -117,6 +117,15 @@ pub struct Capsules3D {
 
 impl Capsules3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::lengths`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.Length",
+    ///    archetype_field_name: "lengths",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_lengths() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -127,6 +136,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -137,6 +155,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.PoseTranslation3D",
+    ///    archetype_field_name: "translations",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_translations() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -147,6 +174,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.PoseRotationAxisAngle",
+    ///    archetype_field_name: "rotation_axis_angles",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,6 +193,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.PoseRotationQuat",
+    ///    archetype_field_name: "quaternions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,6 +212,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -177,6 +231,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -187,6 +250,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -197,6 +269,15 @@ impl Capsules3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Capsules3D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -116,6 +116,15 @@ pub struct DepthImage {
 
 impl DepthImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.DepthImage",
+    ///    component_name: "rerun.components.ImageBuffer",
+    ///    archetype_field_name: "buffer",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -126,6 +135,15 @@ impl DepthImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.DepthImage",
+    ///    component_name: "rerun.components.ImageFormat",
+    ///    archetype_field_name: "format",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,6 +154,15 @@ impl DepthImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::meter`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.DepthImage",
+    ///    component_name: "rerun.components.DepthMeter",
+    ///    archetype_field_name: "meter",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_meter() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -146,6 +173,15 @@ impl DepthImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.DepthImage",
+    ///    component_name: "rerun.components.Colormap",
+    ///    archetype_field_name: "colormap",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colormap() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -156,6 +192,15 @@ impl DepthImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::depth_range`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.DepthImage",
+    ///    component_name: "rerun.components.ValueRange",
+    ///    archetype_field_name: "depth_range",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_depth_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -166,6 +211,15 @@ impl DepthImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::point_fill_ratio`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.DepthImage",
+    ///    component_name: "rerun.components.FillRatio",
+    ///    archetype_field_name: "point_fill_ratio",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_point_fill_ratio() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,6 +230,15 @@ impl DepthImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.DepthImage",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -117,7 +117,7 @@ pub struct DepthImage {
 impl DepthImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
+    /// The corresponding component is [`crate::components::ImageBuffer`].
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -129,7 +129,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
+    /// The corresponding component is [`crate::components::ImageFormat`].
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -141,7 +141,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::meter`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DepthMeter`.
+    /// The corresponding component is [`crate::components::DepthMeter`].
     #[inline]
     pub fn descriptor_meter() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -153,7 +153,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Colormap`.
+    /// The corresponding component is [`crate::components::Colormap`].
     #[inline]
     pub fn descriptor_colormap() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -165,7 +165,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::depth_range`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ValueRange`.
+    /// The corresponding component is [`crate::components::ValueRange`].
     #[inline]
     pub fn descriptor_depth_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -177,7 +177,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::point_fill_ratio`].
     ///
-    /// The `component_name` field will be set to `rerun.components.FillRatio`.
+    /// The corresponding component is [`crate::components::FillRatio`].
     #[inline]
     pub fn descriptor_point_fill_ratio() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -189,7 +189,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -117,14 +117,7 @@ pub struct DepthImage {
 impl DepthImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.DepthImage",
-    ///    component_name: "rerun.components.ImageBuffer",
-    ///    archetype_field_name: "buffer",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,14 +129,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.DepthImage",
-    ///    component_name: "rerun.components.ImageFormat",
-    ///    archetype_field_name: "format",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -155,14 +141,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::meter`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.DepthImage",
-    ///    component_name: "rerun.components.DepthMeter",
-    ///    archetype_field_name: "meter",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DepthMeter`.
     #[inline]
     pub fn descriptor_meter() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -174,14 +153,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.DepthImage",
-    ///    component_name: "rerun.components.Colormap",
-    ///    archetype_field_name: "colormap",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Colormap`.
     #[inline]
     pub fn descriptor_colormap() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -193,14 +165,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::depth_range`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.DepthImage",
-    ///    component_name: "rerun.components.ValueRange",
-    ///    archetype_field_name: "depth_range",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ValueRange`.
     #[inline]
     pub fn descriptor_depth_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -212,14 +177,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::point_fill_ratio`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.DepthImage",
-    ///    component_name: "rerun.components.FillRatio",
-    ///    archetype_field_name: "point_fill_ratio",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.FillRatio`.
     #[inline]
     pub fn descriptor_point_fill_ratio() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -231,14 +189,7 @@ impl DepthImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.DepthImage",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -128,7 +128,7 @@ pub struct Ellipsoids3D {
 impl Ellipsoids3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
     ///
-    /// The `component_name` field will be set to `rerun.components.HalfSize3D`.
+    /// The corresponding component is [`crate::components::HalfSize3D`].
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -140,7 +140,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
+    /// The corresponding component is [`crate::components::PoseTranslation3D`].
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,7 +152,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
+    /// The corresponding component is [`crate::components::PoseRotationAxisAngle`].
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -164,7 +164,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
+    /// The corresponding component is [`crate::components::PoseRotationQuat`].
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,7 +176,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -188,7 +188,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::line_radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_line_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -200,7 +200,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
     ///
-    /// The `component_name` field will be set to `rerun.components.FillMode`.
+    /// The corresponding component is [`crate::components::FillMode`].
     #[inline]
     pub fn descriptor_fill_mode() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -212,7 +212,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -224,7 +224,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -236,7 +236,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -127,6 +127,15 @@ pub struct Ellipsoids3D {
 
 impl Ellipsoids3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.HalfSize3D",
+    ///    archetype_field_name: "half_sizes",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -137,6 +146,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.PoseTranslation3D",
+    ///    archetype_field_name: "centers",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -147,6 +165,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.PoseRotationAxisAngle",
+    ///    archetype_field_name: "rotation_axis_angles",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,6 +184,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.PoseRotationQuat",
+    ///    archetype_field_name: "quaternions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,6 +203,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -177,6 +222,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::line_radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "line_radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_line_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -187,6 +241,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.FillMode",
+    ///    archetype_field_name: "fill_mode",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fill_mode() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -197,6 +260,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -207,6 +279,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -217,6 +298,15 @@ impl Ellipsoids3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -128,14 +128,7 @@ pub struct Ellipsoids3D {
 impl Ellipsoids3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::half_sizes`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.HalfSize3D",
-    ///    archetype_field_name: "half_sizes",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.HalfSize3D`.
     #[inline]
     pub fn descriptor_half_sizes() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -147,14 +140,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::centers`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.PoseTranslation3D",
-    ///    archetype_field_name: "centers",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
     #[inline]
     pub fn descriptor_centers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -166,14 +152,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.PoseRotationAxisAngle",
-    ///    archetype_field_name: "rotation_axis_angles",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -185,14 +164,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.PoseRotationQuat",
-    ///    archetype_field_name: "quaternions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -204,14 +176,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -223,14 +188,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::line_radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "line_radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_line_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -242,14 +200,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.FillMode",
-    ///    archetype_field_name: "fill_mode",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.FillMode`.
     #[inline]
     pub fn descriptor_fill_mode() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -261,14 +212,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -280,14 +224,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -299,14 +236,7 @@ impl Ellipsoids3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Ellipsoids3D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -68,6 +68,15 @@ pub struct EncodedImage {
 
 impl EncodedImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.EncodedImage",
+    ///    component_name: "rerun.components.Blob",
+    ///    archetype_field_name: "blob",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -78,6 +87,15 @@ impl EncodedImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.EncodedImage",
+    ///    component_name: "rerun.components.MediaType",
+    ///    archetype_field_name: "media_type",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -88,6 +106,15 @@ impl EncodedImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.EncodedImage",
+    ///    component_name: "rerun.components.Opacity",
+    ///    archetype_field_name: "opacity",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -98,6 +125,15 @@ impl EncodedImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.EncodedImage",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -69,14 +69,7 @@ pub struct EncodedImage {
 impl EncodedImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.EncodedImage",
-    ///    component_name: "rerun.components.Blob",
-    ///    archetype_field_name: "blob",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Blob`.
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -88,14 +81,7 @@ impl EncodedImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.EncodedImage",
-    ///    component_name: "rerun.components.MediaType",
-    ///    archetype_field_name: "media_type",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MediaType`.
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -107,14 +93,7 @@ impl EncodedImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.EncodedImage",
-    ///    component_name: "rerun.components.Opacity",
-    ///    archetype_field_name: "opacity",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Opacity`.
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -126,14 +105,7 @@ impl EncodedImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.EncodedImage",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -69,7 +69,7 @@ pub struct EncodedImage {
 impl EncodedImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::blob`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Blob`.
+    /// The corresponding component is [`crate::components::Blob`].
     #[inline]
     pub fn descriptor_blob() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -81,7 +81,7 @@ impl EncodedImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MediaType`.
+    /// The corresponding component is [`crate::components::MediaType`].
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -93,7 +93,7 @@ impl EncodedImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Opacity`.
+    /// The corresponding component is [`crate::components::Opacity`].
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -105,7 +105,7 @@ impl EncodedImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -72,14 +72,7 @@ pub struct GeoLineStrings {
 impl GeoLineStrings {
     /// Returns the [`ComponentDescriptor`] for [`Self::line_strings`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GeoLineStrings",
-    ///    component_name: "rerun.components.GeoLineString",
-    ///    archetype_field_name: "line_strings",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.GeoLineString`.
     #[inline]
     pub fn descriptor_line_strings() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -91,14 +84,7 @@ impl GeoLineStrings {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GeoLineStrings",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -110,14 +96,7 @@ impl GeoLineStrings {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GeoLineStrings",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -72,7 +72,7 @@ pub struct GeoLineStrings {
 impl GeoLineStrings {
     /// Returns the [`ComponentDescriptor`] for [`Self::line_strings`].
     ///
-    /// The `component_name` field will be set to `rerun.components.GeoLineString`.
+    /// The corresponding component is [`crate::components::GeoLineString`].
     #[inline]
     pub fn descriptor_line_strings() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -84,7 +84,7 @@ impl GeoLineStrings {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -96,7 +96,7 @@ impl GeoLineStrings {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -71,6 +71,15 @@ pub struct GeoLineStrings {
 
 impl GeoLineStrings {
     /// Returns the [`ComponentDescriptor`] for [`Self::line_strings`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GeoLineStrings",
+    ///    component_name: "rerun.components.GeoLineString",
+    ///    archetype_field_name: "line_strings",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_line_strings() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -81,6 +90,15 @@ impl GeoLineStrings {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GeoLineStrings",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -91,6 +109,15 @@ impl GeoLineStrings {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GeoLineStrings",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -67,6 +67,15 @@ pub struct GeoPoints {
 
 impl GeoPoints {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GeoPoints",
+    ///    component_name: "rerun.components.LatLon",
+    ///    archetype_field_name: "positions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -77,6 +86,15 @@ impl GeoPoints {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GeoPoints",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -87,6 +105,15 @@ impl GeoPoints {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GeoPoints",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -97,6 +124,15 @@ impl GeoPoints {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GeoPoints",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -68,7 +68,7 @@ pub struct GeoPoints {
 impl GeoPoints {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.LatLon`.
+    /// The corresponding component is [`crate::components::LatLon`].
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -80,7 +80,7 @@ impl GeoPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,7 +92,7 @@ impl GeoPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -104,7 +104,7 @@ impl GeoPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -68,14 +68,7 @@ pub struct GeoPoints {
 impl GeoPoints {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GeoPoints",
-    ///    component_name: "rerun.components.LatLon",
-    ///    archetype_field_name: "positions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.LatLon`.
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -87,14 +80,7 @@ impl GeoPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GeoPoints",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -106,14 +92,7 @@ impl GeoPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GeoPoints",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -125,14 +104,7 @@ impl GeoPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GeoPoints",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -65,7 +65,7 @@ pub struct GraphEdges {
 impl GraphEdges {
     /// Returns the [`ComponentDescriptor`] for [`Self::edges`].
     ///
-    /// The `component_name` field will be set to `rerun.components.GraphEdge`.
+    /// The corresponding component is [`crate::components::GraphEdge`].
     #[inline]
     pub fn descriptor_edges() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -77,7 +77,7 @@ impl GraphEdges {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::graph_type`].
     ///
-    /// The `component_name` field will be set to `rerun.components.GraphType`.
+    /// The corresponding component is [`crate::components::GraphType`].
     #[inline]
     pub fn descriptor_graph_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -64,6 +64,15 @@ pub struct GraphEdges {
 
 impl GraphEdges {
     /// Returns the [`ComponentDescriptor`] for [`Self::edges`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphEdges",
+    ///    component_name: "rerun.components.GraphEdge",
+    ///    archetype_field_name: "edges",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_edges() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -74,6 +83,15 @@ impl GraphEdges {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::graph_type`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphEdges",
+    ///    component_name: "rerun.components.GraphType",
+    ///    archetype_field_name: "graph_type",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_graph_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -65,14 +65,7 @@ pub struct GraphEdges {
 impl GraphEdges {
     /// Returns the [`ComponentDescriptor`] for [`Self::edges`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphEdges",
-    ///    component_name: "rerun.components.GraphEdge",
-    ///    archetype_field_name: "edges",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.GraphEdge`.
     #[inline]
     pub fn descriptor_edges() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -84,14 +77,7 @@ impl GraphEdges {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::graph_type`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphEdges",
-    ///    component_name: "rerun.components.GraphType",
-    ///    archetype_field_name: "graph_type",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.GraphType`.
     #[inline]
     pub fn descriptor_graph_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -73,7 +73,7 @@ pub struct GraphNodes {
 impl GraphNodes {
     /// Returns the [`ComponentDescriptor`] for [`Self::node_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.GraphNode`.
+    /// The corresponding component is [`crate::components::GraphNode`].
     #[inline]
     pub fn descriptor_node_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -85,7 +85,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position2D`.
+    /// The corresponding component is [`crate::components::Position2D`].
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -97,7 +97,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -109,7 +109,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -121,7 +121,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -133,7 +133,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -73,14 +73,7 @@ pub struct GraphNodes {
 impl GraphNodes {
     /// Returns the [`ComponentDescriptor`] for [`Self::node_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphNodes",
-    ///    component_name: "rerun.components.GraphNode",
-    ///    archetype_field_name: "node_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.GraphNode`.
     #[inline]
     pub fn descriptor_node_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,14 +85,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphNodes",
-    ///    component_name: "rerun.components.Position2D",
-    ///    archetype_field_name: "positions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position2D`.
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -111,14 +97,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphNodes",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -130,14 +109,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphNodes",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -149,14 +121,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphNodes",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -168,14 +133,7 @@ impl GraphNodes {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.GraphNodes",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -72,6 +72,15 @@ pub struct GraphNodes {
 
 impl GraphNodes {
     /// Returns the [`ComponentDescriptor`] for [`Self::node_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphNodes",
+    ///    component_name: "rerun.components.GraphNode",
+    ///    archetype_field_name: "node_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_node_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -82,6 +91,15 @@ impl GraphNodes {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphNodes",
+    ///    component_name: "rerun.components.Position2D",
+    ///    archetype_field_name: "positions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,6 +110,15 @@ impl GraphNodes {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphNodes",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,6 +129,15 @@ impl GraphNodes {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphNodes",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -112,6 +148,15 @@ impl GraphNodes {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphNodes",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,6 +167,15 @@ impl GraphNodes {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.GraphNodes",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -152,7 +152,7 @@ pub struct Image {
 impl Image {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
+    /// The corresponding component is [`crate::components::ImageBuffer`].
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -164,7 +164,7 @@ impl Image {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
+    /// The corresponding component is [`crate::components::ImageFormat`].
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,7 +176,7 @@ impl Image {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Opacity`.
+    /// The corresponding component is [`crate::components::Opacity`].
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -188,7 +188,7 @@ impl Image {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -152,14 +152,7 @@ pub struct Image {
 impl Image {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Image",
-    ///    component_name: "rerun.components.ImageBuffer",
-    ///    archetype_field_name: "buffer",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -171,14 +164,7 @@ impl Image {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Image",
-    ///    component_name: "rerun.components.ImageFormat",
-    ///    archetype_field_name: "format",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -190,14 +176,7 @@ impl Image {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Image",
-    ///    component_name: "rerun.components.Opacity",
-    ///    archetype_field_name: "opacity",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Opacity`.
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -209,14 +188,7 @@ impl Image {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Image",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -151,6 +151,15 @@ pub struct Image {
 
 impl Image {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Image",
+    ///    component_name: "rerun.components.ImageBuffer",
+    ///    archetype_field_name: "buffer",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -161,6 +170,15 @@ impl Image {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Image",
+    ///    component_name: "rerun.components.ImageFormat",
+    ///    archetype_field_name: "format",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -171,6 +189,15 @@ impl Image {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Image",
+    ///    component_name: "rerun.components.Opacity",
+    ///    archetype_field_name: "opacity",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -181,6 +208,15 @@ impl Image {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Image",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -110,6 +110,15 @@ pub struct InstancePoses3D {
 
 impl InstancePoses3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
+    ///    component_name: "rerun.components.PoseTranslation3D",
+    ///    archetype_field_name: "translations",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_translations() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -120,6 +129,15 @@ impl InstancePoses3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
+    ///    component_name: "rerun.components.PoseRotationAxisAngle",
+    ///    archetype_field_name: "rotation_axis_angles",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -130,6 +148,15 @@ impl InstancePoses3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
+    ///    component_name: "rerun.components.PoseRotationQuat",
+    ///    archetype_field_name: "quaternions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -140,6 +167,15 @@ impl InstancePoses3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::scales`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
+    ///    component_name: "rerun.components.PoseScale3D",
+    ///    archetype_field_name: "scales",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_scales() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -150,6 +186,15 @@ impl InstancePoses3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
+    ///    component_name: "rerun.components.PoseTransformMat3x3",
+    ///    archetype_field_name: "mat3x3",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_mat3x3() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -111,14 +111,7 @@ pub struct InstancePoses3D {
 impl InstancePoses3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
-    ///    component_name: "rerun.components.PoseTranslation3D",
-    ///    archetype_field_name: "translations",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
     #[inline]
     pub fn descriptor_translations() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -130,14 +123,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
-    ///    component_name: "rerun.components.PoseRotationAxisAngle",
-    ///    archetype_field_name: "rotation_axis_angles",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -149,14 +135,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
-    ///    component_name: "rerun.components.PoseRotationQuat",
-    ///    archetype_field_name: "quaternions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -168,14 +147,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::scales`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
-    ///    component_name: "rerun.components.PoseScale3D",
-    ///    archetype_field_name: "scales",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseScale3D`.
     #[inline]
     pub fn descriptor_scales() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -187,14 +159,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.InstancePoses3D",
-    ///    component_name: "rerun.components.PoseTransformMat3x3",
-    ///    archetype_field_name: "mat3x3",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PoseTransformMat3x3`.
     #[inline]
     pub fn descriptor_mat3x3() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -111,7 +111,7 @@ pub struct InstancePoses3D {
 impl InstancePoses3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::translations`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseTranslation3D`.
+    /// The corresponding component is [`crate::components::PoseTranslation3D`].
     #[inline]
     pub fn descriptor_translations() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -123,7 +123,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angles`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationAxisAngle`.
+    /// The corresponding component is [`crate::components::PoseRotationAxisAngle`].
     #[inline]
     pub fn descriptor_rotation_axis_angles() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -135,7 +135,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseRotationQuat`.
+    /// The corresponding component is [`crate::components::PoseRotationQuat`].
     #[inline]
     pub fn descriptor_quaternions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -147,7 +147,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::scales`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseScale3D`.
+    /// The corresponding component is [`crate::components::PoseScale3D`].
     #[inline]
     pub fn descriptor_scales() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -159,7 +159,7 @@ impl InstancePoses3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PoseTransformMat3x3`.
+    /// The corresponding component is [`crate::components::PoseTransformMat3x3`].
     #[inline]
     pub fn descriptor_mat3x3() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -119,7 +119,7 @@ pub struct LineStrips2D {
 impl LineStrips2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
     ///
-    /// The `component_name` field will be set to `rerun.components.LineStrip2D`.
+    /// The corresponding component is [`crate::components::LineStrip2D`].
     #[inline]
     pub fn descriptor_strips() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -131,7 +131,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -143,7 +143,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -155,7 +155,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,7 +167,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -179,7 +179,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -191,7 +191,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -118,6 +118,15 @@ pub struct LineStrips2D {
 
 impl LineStrips2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips2D",
+    ///    component_name: "rerun.components.LineStrip2D",
+    ///    archetype_field_name: "strips",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_strips() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -128,6 +137,15 @@ impl LineStrips2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips2D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -138,6 +156,15 @@ impl LineStrips2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips2D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -148,6 +175,15 @@ impl LineStrips2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips2D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -158,6 +194,15 @@ impl LineStrips2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips2D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -168,6 +213,15 @@ impl LineStrips2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips2D",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -178,6 +232,15 @@ impl LineStrips2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips2D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -119,14 +119,7 @@ pub struct LineStrips2D {
 impl LineStrips2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips2D",
-    ///    component_name: "rerun.components.LineStrip2D",
-    ///    archetype_field_name: "strips",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.LineStrip2D`.
     #[inline]
     pub fn descriptor_strips() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -138,14 +131,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips2D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,14 +143,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips2D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,14 +155,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips2D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -195,14 +167,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips2D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -214,14 +179,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips2D",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -233,14 +191,7 @@ impl LineStrips2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips2D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -127,14 +127,7 @@ pub struct LineStrips3D {
 impl LineStrips3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips3D",
-    ///    component_name: "rerun.components.LineStrip3D",
-    ///    archetype_field_name: "strips",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.LineStrip3D`.
     #[inline]
     pub fn descriptor_strips() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -146,14 +139,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips3D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -165,14 +151,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -184,14 +163,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips3D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -203,14 +175,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips3D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -222,14 +187,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.LineStrips3D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -126,6 +126,15 @@ pub struct LineStrips3D {
 
 impl LineStrips3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips3D",
+    ///    component_name: "rerun.components.LineStrip3D",
+    ///    archetype_field_name: "strips",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_strips() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,6 +145,15 @@ impl LineStrips3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips3D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -146,6 +164,15 @@ impl LineStrips3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -156,6 +183,15 @@ impl LineStrips3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips3D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -166,6 +202,15 @@ impl LineStrips3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips3D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,6 +221,15 @@ impl LineStrips3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.LineStrips3D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -127,7 +127,7 @@ pub struct LineStrips3D {
 impl LineStrips3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::strips`].
     ///
-    /// The `component_name` field will be set to `rerun.components.LineStrip3D`.
+    /// The corresponding component is [`crate::components::LineStrip3D`].
     #[inline]
     pub fn descriptor_strips() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -139,7 +139,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -151,7 +151,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -163,7 +163,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -175,7 +175,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -187,7 +187,7 @@ impl LineStrips3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -148,14 +148,7 @@ pub struct Mesh3D {
 impl Mesh3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_positions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.Position3D",
-    ///    archetype_field_name: "vertex_positions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position3D`.
     #[inline]
     pub fn descriptor_vertex_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,14 +160,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::triangle_indices`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.TriangleIndices",
-    ///    archetype_field_name: "triangle_indices",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TriangleIndices`.
     #[inline]
     pub fn descriptor_triangle_indices() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -186,14 +172,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_normals`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.Vector3D",
-    ///    archetype_field_name: "vertex_normals",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Vector3D`.
     #[inline]
     pub fn descriptor_vertex_normals() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -205,14 +184,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "vertex_colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_vertex_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -224,14 +196,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_texcoords`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.Texcoord2D",
-    ///    archetype_field_name: "vertex_texcoords",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Texcoord2D`.
     #[inline]
     pub fn descriptor_vertex_texcoords() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -243,14 +208,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.AlbedoFactor",
-    ///    archetype_field_name: "albedo_factor",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.AlbedoFactor`.
     #[inline]
     pub fn descriptor_albedo_factor() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -262,14 +220,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_buffer`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.ImageBuffer",
-    ///    archetype_field_name: "albedo_texture_buffer",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
     #[inline]
     pub fn descriptor_albedo_texture_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -281,14 +232,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_format`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.ImageFormat",
-    ///    archetype_field_name: "albedo_texture_format",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
     #[inline]
     pub fn descriptor_albedo_texture_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -300,14 +244,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Mesh3D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -148,7 +148,7 @@ pub struct Mesh3D {
 impl Mesh3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_positions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position3D`.
+    /// The corresponding component is [`crate::components::Position3D`].
     #[inline]
     pub fn descriptor_vertex_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -160,7 +160,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::triangle_indices`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TriangleIndices`.
+    /// The corresponding component is [`crate::components::TriangleIndices`].
     #[inline]
     pub fn descriptor_triangle_indices() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -172,7 +172,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_normals`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Vector3D`.
+    /// The corresponding component is [`crate::components::Vector3D`].
     #[inline]
     pub fn descriptor_vertex_normals() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -184,7 +184,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_vertex_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -196,7 +196,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_texcoords`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Texcoord2D`.
+    /// The corresponding component is [`crate::components::Texcoord2D`].
     #[inline]
     pub fn descriptor_vertex_texcoords() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -208,7 +208,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
     ///
-    /// The `component_name` field will be set to `rerun.components.AlbedoFactor`.
+    /// The corresponding component is [`crate::components::AlbedoFactor`].
     #[inline]
     pub fn descriptor_albedo_factor() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -220,7 +220,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_buffer`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
+    /// The corresponding component is [`crate::components::ImageBuffer`].
     #[inline]
     pub fn descriptor_albedo_texture_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -232,7 +232,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_format`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
+    /// The corresponding component is [`crate::components::ImageFormat`].
     #[inline]
     pub fn descriptor_albedo_texture_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -244,7 +244,7 @@ impl Mesh3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -147,6 +147,15 @@ pub struct Mesh3D {
 
 impl Mesh3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_positions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.Position3D",
+    ///    archetype_field_name: "vertex_positions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_vertex_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,6 +166,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::triangle_indices`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.TriangleIndices",
+    ///    archetype_field_name: "triangle_indices",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_triangle_indices() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,6 +185,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_normals`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.Vector3D",
+    ///    archetype_field_name: "vertex_normals",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_vertex_normals() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -177,6 +204,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "vertex_colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_vertex_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -187,6 +223,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::vertex_texcoords`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.Texcoord2D",
+    ///    archetype_field_name: "vertex_texcoords",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_vertex_texcoords() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -197,6 +242,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_factor`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.AlbedoFactor",
+    ///    archetype_field_name: "albedo_factor",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_albedo_factor() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -207,6 +261,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_buffer`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.ImageBuffer",
+    ///    archetype_field_name: "albedo_texture_buffer",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_albedo_texture_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -217,6 +280,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::albedo_texture_format`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.ImageFormat",
+    ///    archetype_field_name: "albedo_texture_format",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_albedo_texture_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -227,6 +299,15 @@ impl Mesh3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Mesh3D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -142,6 +142,15 @@ pub struct Pinhole {
 
 impl Pinhole {
     /// Returns the [`ComponentDescriptor`] for [`Self::image_from_camera`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Pinhole",
+    ///    component_name: "rerun.components.PinholeProjection",
+    ///    archetype_field_name: "image_from_camera",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_image_from_camera() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,6 +161,15 @@ impl Pinhole {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::resolution`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Pinhole",
+    ///    component_name: "rerun.components.Resolution",
+    ///    archetype_field_name: "resolution",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_resolution() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -162,6 +180,15 @@ impl Pinhole {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::camera_xyz`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Pinhole",
+    ///    component_name: "rerun.components.ViewCoordinates",
+    ///    archetype_field_name: "camera_xyz",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_camera_xyz() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -172,6 +199,15 @@ impl Pinhole {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::image_plane_distance`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Pinhole",
+    ///    component_name: "rerun.components.ImagePlaneDistance",
+    ///    archetype_field_name: "image_plane_distance",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_image_plane_distance() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -143,14 +143,7 @@ pub struct Pinhole {
 impl Pinhole {
     /// Returns the [`ComponentDescriptor`] for [`Self::image_from_camera`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Pinhole",
-    ///    component_name: "rerun.components.PinholeProjection",
-    ///    archetype_field_name: "image_from_camera",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.PinholeProjection`.
     #[inline]
     pub fn descriptor_image_from_camera() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -162,14 +155,7 @@ impl Pinhole {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::resolution`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Pinhole",
-    ///    component_name: "rerun.components.Resolution",
-    ///    archetype_field_name: "resolution",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Resolution`.
     #[inline]
     pub fn descriptor_resolution() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -181,14 +167,7 @@ impl Pinhole {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::camera_xyz`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Pinhole",
-    ///    component_name: "rerun.components.ViewCoordinates",
-    ///    archetype_field_name: "camera_xyz",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ViewCoordinates`.
     #[inline]
     pub fn descriptor_camera_xyz() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -200,14 +179,7 @@ impl Pinhole {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::image_plane_distance`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Pinhole",
-    ///    component_name: "rerun.components.ImagePlaneDistance",
-    ///    archetype_field_name: "image_plane_distance",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImagePlaneDistance`.
     #[inline]
     pub fn descriptor_image_plane_distance() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -143,7 +143,7 @@ pub struct Pinhole {
 impl Pinhole {
     /// Returns the [`ComponentDescriptor`] for [`Self::image_from_camera`].
     ///
-    /// The `component_name` field will be set to `rerun.components.PinholeProjection`.
+    /// The corresponding component is [`crate::components::PinholeProjection`].
     #[inline]
     pub fn descriptor_image_from_camera() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -155,7 +155,7 @@ impl Pinhole {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::resolution`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Resolution`.
+    /// The corresponding component is [`crate::components::Resolution`].
     #[inline]
     pub fn descriptor_resolution() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,7 +167,7 @@ impl Pinhole {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::camera_xyz`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ViewCoordinates`.
+    /// The corresponding component is [`crate::components::ViewCoordinates`].
     #[inline]
     pub fn descriptor_camera_xyz() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -179,7 +179,7 @@ impl Pinhole {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::image_plane_distance`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImagePlaneDistance`.
+    /// The corresponding component is [`crate::components::ImagePlaneDistance`].
     #[inline]
     pub fn descriptor_image_plane_distance() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -140,14 +140,7 @@ pub struct Points2D {
 impl Points2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.Position2D",
-    ///    archetype_field_name: "positions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position2D`.
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -159,14 +152,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -178,14 +164,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -197,14 +176,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -216,14 +188,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -235,14 +200,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -254,14 +212,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -273,14 +224,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points2D",
-    ///    component_name: "rerun.components.KeypointId",
-    ///    archetype_field_name: "keypoint_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.KeypointId`.
     #[inline]
     pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -139,6 +139,15 @@ pub struct Points2D {
 
 impl Points2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.Position2D",
+    ///    archetype_field_name: "positions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -149,6 +158,15 @@ impl Points2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -159,6 +177,15 @@ impl Points2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -169,6 +196,15 @@ impl Points2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -179,6 +215,15 @@ impl Points2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -189,6 +234,15 @@ impl Points2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -199,6 +253,15 @@ impl Points2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -209,6 +272,15 @@ impl Points2D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points2D",
+    ///    component_name: "rerun.components.KeypointId",
+    ///    archetype_field_name: "keypoint_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -140,7 +140,7 @@ pub struct Points2D {
 impl Points2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position2D`.
+    /// The corresponding component is [`crate::components::Position2D`].
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,7 +152,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -164,7 +164,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,7 +176,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -188,7 +188,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -200,7 +200,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -212,7 +212,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -224,7 +224,7 @@ impl Points2D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.KeypointId`.
+    /// The corresponding component is [`crate::components::KeypointId`].
     #[inline]
     pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -223,6 +223,15 @@ pub struct Points3D {
 
 impl Points3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points3D",
+    ///    component_name: "rerun.components.Position3D",
+    ///    archetype_field_name: "positions",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -233,6 +242,15 @@ impl Points3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points3D",
+    ///    component_name: "rerun.components.Radius",
+    ///    archetype_field_name: "radii",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -243,6 +261,15 @@ impl Points3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -253,6 +280,15 @@ impl Points3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points3D",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -263,6 +299,15 @@ impl Points3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points3D",
+    ///    component_name: "rerun.components.ShowLabels",
+    ///    archetype_field_name: "show_labels",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -273,6 +318,15 @@ impl Points3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points3D",
+    ///    component_name: "rerun.components.ClassId",
+    ///    archetype_field_name: "class_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -283,6 +337,15 @@ impl Points3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Points3D",
+    ///    component_name: "rerun.components.KeypointId",
+    ///    archetype_field_name: "keypoint_ids",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -224,14 +224,7 @@ pub struct Points3D {
 impl Points3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points3D",
-    ///    component_name: "rerun.components.Position3D",
-    ///    archetype_field_name: "positions",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position3D`.
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -243,14 +236,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points3D",
-    ///    component_name: "rerun.components.Radius",
-    ///    archetype_field_name: "radii",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Radius`.
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -262,14 +248,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -281,14 +260,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points3D",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -300,14 +272,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points3D",
-    ///    component_name: "rerun.components.ShowLabels",
-    ///    archetype_field_name: "show_labels",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -319,14 +284,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points3D",
-    ///    component_name: "rerun.components.ClassId",
-    ///    archetype_field_name: "class_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClassId`.
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -338,14 +296,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Points3D",
-    ///    component_name: "rerun.components.KeypointId",
-    ///    archetype_field_name: "keypoint_ids",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.KeypointId`.
     #[inline]
     pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -224,7 +224,7 @@ pub struct Points3D {
 impl Points3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::positions`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position3D`.
+    /// The corresponding component is [`crate::components::Position3D`].
     #[inline]
     pub fn descriptor_positions() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -236,7 +236,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::radii`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Radius`.
+    /// The corresponding component is [`crate::components::Radius`].
     #[inline]
     pub fn descriptor_radii() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -248,7 +248,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -260,7 +260,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -272,7 +272,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::show_labels`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ShowLabels`.
+    /// The corresponding component is [`crate::components::ShowLabels`].
     #[inline]
     pub fn descriptor_show_labels() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -284,7 +284,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::class_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClassId`.
+    /// The corresponding component is [`crate::components::ClassId`].
     #[inline]
     pub fn descriptor_class_ids() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -296,7 +296,7 @@ impl Points3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::keypoint_ids`].
     ///
-    /// The `component_name` field will be set to `rerun.components.KeypointId`.
+    /// The corresponding component is [`crate::components::KeypointId`].
     #[inline]
     pub fn descriptor_keypoint_ids() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/recording_properties.rs
+++ b/crates/store/re_types/src/archetypes/recording_properties.rs
@@ -33,7 +33,7 @@ pub struct RecordingProperties {
 impl RecordingProperties {
     /// Returns the [`ComponentDescriptor`] for [`Self::start_time`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Timestamp`.
+    /// The corresponding component is [`crate::components::Timestamp`].
     #[inline]
     pub fn descriptor_start_time() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -45,7 +45,7 @@ impl RecordingProperties {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Name`.
+    /// The corresponding component is [`crate::components::Name`].
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/recording_properties.rs
+++ b/crates/store/re_types/src/archetypes/recording_properties.rs
@@ -33,14 +33,7 @@ pub struct RecordingProperties {
 impl RecordingProperties {
     /// Returns the [`ComponentDescriptor`] for [`Self::start_time`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.RecordingProperties",
-    ///    component_name: "rerun.components.Timestamp",
-    ///    archetype_field_name: "start_time",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Timestamp`.
     #[inline]
     pub fn descriptor_start_time() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,14 +45,7 @@ impl RecordingProperties {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.RecordingProperties",
-    ///    component_name: "rerun.components.Name",
-    ///    archetype_field_name: "name",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Name`.
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/recording_properties.rs
+++ b/crates/store/re_types/src/archetypes/recording_properties.rs
@@ -32,6 +32,15 @@ pub struct RecordingProperties {
 
 impl RecordingProperties {
     /// Returns the [`ComponentDescriptor`] for [`Self::start_time`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.RecordingProperties",
+    ///    component_name: "rerun.components.Timestamp",
+    ///    archetype_field_name: "start_time",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_start_time() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -42,6 +51,15 @@ impl RecordingProperties {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.RecordingProperties",
+    ///    component_name: "rerun.components.Name",
+    ///    archetype_field_name: "name",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -96,6 +96,15 @@ pub struct Scalar {
 
 impl Scalar {
     /// Returns the [`ComponentDescriptor`] for [`Self::scalar`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Scalar",
+    ///    component_name: "rerun.components.Scalar",
+    ///    archetype_field_name: "scalar",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_scalar() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -97,7 +97,7 @@ pub struct Scalar {
 impl Scalar {
     /// Returns the [`ComponentDescriptor`] for [`Self::scalar`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Scalar`.
+    /// The corresponding component is [`crate::components::Scalar`].
     #[inline]
     pub fn descriptor_scalar() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -97,14 +97,7 @@ pub struct Scalar {
 impl Scalar {
     /// Returns the [`ComponentDescriptor`] for [`Self::scalar`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Scalar",
-    ///    component_name: "rerun.components.Scalar",
-    ///    archetype_field_name: "scalar",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Scalar`.
     #[inline]
     pub fn descriptor_scalar() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalars.rs
+++ b/crates/store/re_types/src/archetypes/scalars.rs
@@ -94,14 +94,7 @@ pub struct Scalars {
 impl Scalars {
     /// Returns the [`ComponentDescriptor`] for [`Self::scalars`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Scalars",
-    ///    component_name: "rerun.components.Scalar",
-    ///    archetype_field_name: "scalars",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Scalar`.
     #[inline]
     pub fn descriptor_scalars() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalars.rs
+++ b/crates/store/re_types/src/archetypes/scalars.rs
@@ -93,6 +93,15 @@ pub struct Scalars {
 
 impl Scalars {
     /// Returns the [`ComponentDescriptor`] for [`Self::scalars`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Scalars",
+    ///    component_name: "rerun.components.Scalar",
+    ///    archetype_field_name: "scalars",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_scalars() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalars.rs
+++ b/crates/store/re_types/src/archetypes/scalars.rs
@@ -94,7 +94,7 @@ pub struct Scalars {
 impl Scalars {
     /// Returns the [`ComponentDescriptor`] for [`Self::scalars`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Scalar`.
+    /// The corresponding component is [`crate::components::Scalar`].
     #[inline]
     pub fn descriptor_scalars() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -85,6 +85,15 @@ pub struct SegmentationImage {
 
 impl SegmentationImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SegmentationImage",
+    ///    component_name: "rerun.components.ImageBuffer",
+    ///    archetype_field_name: "buffer",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -95,6 +104,15 @@ impl SegmentationImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SegmentationImage",
+    ///    component_name: "rerun.components.ImageFormat",
+    ///    archetype_field_name: "format",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -105,6 +123,15 @@ impl SegmentationImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SegmentationImage",
+    ///    component_name: "rerun.components.Opacity",
+    ///    archetype_field_name: "opacity",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -115,6 +142,15 @@ impl SegmentationImage {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SegmentationImage",
+    ///    component_name: "rerun.components.DrawOrder",
+    ///    archetype_field_name: "draw_order",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -86,7 +86,7 @@ pub struct SegmentationImage {
 impl SegmentationImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
+    /// The corresponding component is [`crate::components::ImageBuffer`].
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -98,7 +98,7 @@ impl SegmentationImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
+    /// The corresponding component is [`crate::components::ImageFormat`].
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -110,7 +110,7 @@ impl SegmentationImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Opacity`.
+    /// The corresponding component is [`crate::components::Opacity`].
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,7 +122,7 @@ impl SegmentationImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
+    /// The corresponding component is [`crate::components::DrawOrder`].
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -86,14 +86,7 @@ pub struct SegmentationImage {
 impl SegmentationImage {
     /// Returns the [`ComponentDescriptor`] for [`Self::buffer`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SegmentationImage",
-    ///    component_name: "rerun.components.ImageBuffer",
-    ///    archetype_field_name: "buffer",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageBuffer`.
     #[inline]
     pub fn descriptor_buffer() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -105,14 +98,7 @@ impl SegmentationImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::format`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SegmentationImage",
-    ///    component_name: "rerun.components.ImageFormat",
-    ///    archetype_field_name: "format",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ImageFormat`.
     #[inline]
     pub fn descriptor_format() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -124,14 +110,7 @@ impl SegmentationImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::opacity`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SegmentationImage",
-    ///    component_name: "rerun.components.Opacity",
-    ///    archetype_field_name: "opacity",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Opacity`.
     #[inline]
     pub fn descriptor_opacity() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -143,14 +122,7 @@ impl SegmentationImage {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::draw_order`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SegmentationImage",
-    ///    component_name: "rerun.components.DrawOrder",
-    ///    archetype_field_name: "draw_order",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.DrawOrder`.
     #[inline]
     pub fn descriptor_draw_order() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -109,6 +109,15 @@ pub struct SeriesLine {
 
 impl SeriesLine {
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLine",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "color",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -119,6 +128,15 @@ impl SeriesLine {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::width`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLine",
+    ///    component_name: "rerun.components.StrokeWidth",
+    ///    archetype_field_name: "width",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -129,6 +147,15 @@ impl SeriesLine {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLine",
+    ///    component_name: "rerun.components.Name",
+    ///    archetype_field_name: "name",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -139,6 +166,15 @@ impl SeriesLine {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLine",
+    ///    component_name: "rerun.components.SeriesVisible",
+    ///    archetype_field_name: "visible_series",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -149,6 +185,15 @@ impl SeriesLine {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::aggregation_policy`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLine",
+    ///    component_name: "rerun.components.AggregationPolicy",
+    ///    archetype_field_name: "aggregation_policy",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_aggregation_policy() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -110,7 +110,7 @@ pub struct SeriesLine {
 impl SeriesLine {
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,7 +122,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::width`].
     ///
-    /// The `component_name` field will be set to `rerun.components.StrokeWidth`.
+    /// The corresponding component is [`crate::components::StrokeWidth`].
     #[inline]
     pub fn descriptor_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -134,7 +134,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Name`.
+    /// The corresponding component is [`crate::components::Name`].
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -146,7 +146,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
+    /// The corresponding component is [`crate::components::SeriesVisible`].
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -158,7 +158,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::aggregation_policy`].
     ///
-    /// The `component_name` field will be set to `rerun.components.AggregationPolicy`.
+    /// The corresponding component is [`crate::components::AggregationPolicy`].
     #[inline]
     pub fn descriptor_aggregation_policy() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -110,14 +110,7 @@ pub struct SeriesLine {
 impl SeriesLine {
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLine",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "color",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -129,14 +122,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::width`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLine",
-    ///    component_name: "rerun.components.StrokeWidth",
-    ///    archetype_field_name: "width",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.StrokeWidth`.
     #[inline]
     pub fn descriptor_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -148,14 +134,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLine",
-    ///    component_name: "rerun.components.Name",
-    ///    archetype_field_name: "name",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Name`.
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,14 +146,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLine",
-    ///    component_name: "rerun.components.SeriesVisible",
-    ///    archetype_field_name: "visible_series",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -186,14 +158,7 @@ impl SeriesLine {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::aggregation_policy`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLine",
-    ///    component_name: "rerun.components.AggregationPolicy",
-    ///    archetype_field_name: "aggregation_policy",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.AggregationPolicy`.
     #[inline]
     pub fn descriptor_aggregation_policy() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_lines.rs
+++ b/crates/store/re_types/src/archetypes/series_lines.rs
@@ -116,6 +116,15 @@ pub struct SeriesLines {
 
 impl SeriesLines {
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLines",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -126,6 +135,15 @@ impl SeriesLines {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::widths`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLines",
+    ///    component_name: "rerun.components.StrokeWidth",
+    ///    archetype_field_name: "widths",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_widths() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,6 +154,15 @@ impl SeriesLines {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::names`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLines",
+    ///    component_name: "rerun.components.Name",
+    ///    archetype_field_name: "names",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_names() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -146,6 +173,15 @@ impl SeriesLines {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLines",
+    ///    component_name: "rerun.components.SeriesVisible",
+    ///    archetype_field_name: "visible_series",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -156,6 +192,15 @@ impl SeriesLines {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::aggregation_policy`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesLines",
+    ///    component_name: "rerun.components.AggregationPolicy",
+    ///    archetype_field_name: "aggregation_policy",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_aggregation_policy() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_lines.rs
+++ b/crates/store/re_types/src/archetypes/series_lines.rs
@@ -117,14 +117,7 @@ pub struct SeriesLines {
 impl SeriesLines {
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLines",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,14 +129,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::widths`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLines",
-    ///    component_name: "rerun.components.StrokeWidth",
-    ///    archetype_field_name: "widths",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.StrokeWidth`.
     #[inline]
     pub fn descriptor_widths() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -155,14 +141,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::names`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLines",
-    ///    component_name: "rerun.components.Name",
-    ///    archetype_field_name: "names",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Name`.
     #[inline]
     pub fn descriptor_names() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -174,14 +153,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLines",
-    ///    component_name: "rerun.components.SeriesVisible",
-    ///    archetype_field_name: "visible_series",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -193,14 +165,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::aggregation_policy`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesLines",
-    ///    component_name: "rerun.components.AggregationPolicy",
-    ///    archetype_field_name: "aggregation_policy",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.AggregationPolicy`.
     #[inline]
     pub fn descriptor_aggregation_policy() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_lines.rs
+++ b/crates/store/re_types/src/archetypes/series_lines.rs
@@ -117,7 +117,7 @@ pub struct SeriesLines {
 impl SeriesLines {
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -129,7 +129,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::widths`].
     ///
-    /// The `component_name` field will be set to `rerun.components.StrokeWidth`.
+    /// The corresponding component is [`crate::components::StrokeWidth`].
     #[inline]
     pub fn descriptor_widths() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -141,7 +141,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::names`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Name`.
+    /// The corresponding component is [`crate::components::Name`].
     #[inline]
     pub fn descriptor_names() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -153,7 +153,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
+    /// The corresponding component is [`crate::components::SeriesVisible`].
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -165,7 +165,7 @@ impl SeriesLines {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::aggregation_policy`].
     ///
-    /// The `component_name` field will be set to `rerun.components.AggregationPolicy`.
+    /// The corresponding component is [`crate::components::AggregationPolicy`].
     #[inline]
     pub fn descriptor_aggregation_policy() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -102,7 +102,7 @@ pub struct SeriesPoint {
 impl SeriesPoint {
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -114,7 +114,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MarkerShape`.
+    /// The corresponding component is [`crate::components::MarkerShape`].
     #[inline]
     pub fn descriptor_marker() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -126,7 +126,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Name`.
+    /// The corresponding component is [`crate::components::Name`].
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -138,7 +138,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
+    /// The corresponding component is [`crate::components::SeriesVisible`].
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -150,7 +150,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker_size`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MarkerSize`.
+    /// The corresponding component is [`crate::components::MarkerSize`].
     #[inline]
     pub fn descriptor_marker_size() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -101,6 +101,15 @@ pub struct SeriesPoint {
 
 impl SeriesPoint {
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoint",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "color",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -111,6 +120,15 @@ impl SeriesPoint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoint",
+    ///    component_name: "rerun.components.MarkerShape",
+    ///    archetype_field_name: "marker",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_marker() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -121,6 +139,15 @@ impl SeriesPoint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoint",
+    ///    component_name: "rerun.components.Name",
+    ///    archetype_field_name: "name",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -131,6 +158,15 @@ impl SeriesPoint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoint",
+    ///    component_name: "rerun.components.SeriesVisible",
+    ///    archetype_field_name: "visible_series",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -141,6 +177,15 @@ impl SeriesPoint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker_size`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoint",
+    ///    component_name: "rerun.components.MarkerSize",
+    ///    archetype_field_name: "marker_size",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_marker_size() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -102,14 +102,7 @@ pub struct SeriesPoint {
 impl SeriesPoint {
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoint",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "color",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -121,14 +114,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoint",
-    ///    component_name: "rerun.components.MarkerShape",
-    ///    archetype_field_name: "marker",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MarkerShape`.
     #[inline]
     pub fn descriptor_marker() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -140,14 +126,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::name`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoint",
-    ///    component_name: "rerun.components.Name",
-    ///    archetype_field_name: "name",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Name`.
     #[inline]
     pub fn descriptor_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -159,14 +138,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoint",
-    ///    component_name: "rerun.components.SeriesVisible",
-    ///    archetype_field_name: "visible_series",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -178,14 +150,7 @@ impl SeriesPoint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker_size`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoint",
-    ///    component_name: "rerun.components.MarkerSize",
-    ///    archetype_field_name: "marker_size",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MarkerSize`.
     #[inline]
     pub fn descriptor_marker_size() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_points.rs
+++ b/crates/store/re_types/src/archetypes/series_points.rs
@@ -109,7 +109,7 @@ pub struct SeriesPoints {
 impl SeriesPoints {
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -121,7 +121,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::markers`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MarkerShape`.
+    /// The corresponding component is [`crate::components::MarkerShape`].
     #[inline]
     pub fn descriptor_markers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -133,7 +133,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::names`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Name`.
+    /// The corresponding component is [`crate::components::Name`].
     #[inline]
     pub fn descriptor_names() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -145,7 +145,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
+    /// The corresponding component is [`crate::components::SeriesVisible`].
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,7 +157,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker_sizes`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MarkerSize`.
+    /// The corresponding component is [`crate::components::MarkerSize`].
     #[inline]
     pub fn descriptor_marker_sizes() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_points.rs
+++ b/crates/store/re_types/src/archetypes/series_points.rs
@@ -108,6 +108,15 @@ pub struct SeriesPoints {
 
 impl SeriesPoints {
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoints",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "colors",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -118,6 +127,15 @@ impl SeriesPoints {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::markers`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoints",
+    ///    component_name: "rerun.components.MarkerShape",
+    ///    archetype_field_name: "markers",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_markers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -128,6 +146,15 @@ impl SeriesPoints {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::names`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoints",
+    ///    component_name: "rerun.components.Name",
+    ///    archetype_field_name: "names",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_names() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -138,6 +165,15 @@ impl SeriesPoints {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoints",
+    ///    component_name: "rerun.components.SeriesVisible",
+    ///    archetype_field_name: "visible_series",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -148,6 +184,15 @@ impl SeriesPoints {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker_sizes`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.SeriesPoints",
+    ///    component_name: "rerun.components.MarkerSize",
+    ///    archetype_field_name: "marker_sizes",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_marker_sizes() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_points.rs
+++ b/crates/store/re_types/src/archetypes/series_points.rs
@@ -109,14 +109,7 @@ pub struct SeriesPoints {
 impl SeriesPoints {
     /// Returns the [`ComponentDescriptor`] for [`Self::colors`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoints",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "colors",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_colors() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -128,14 +121,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::markers`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoints",
-    ///    component_name: "rerun.components.MarkerShape",
-    ///    archetype_field_name: "markers",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MarkerShape`.
     #[inline]
     pub fn descriptor_markers() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -147,14 +133,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::names`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoints",
-    ///    component_name: "rerun.components.Name",
-    ///    archetype_field_name: "names",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Name`.
     #[inline]
     pub fn descriptor_names() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -166,14 +145,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible_series`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoints",
-    ///    component_name: "rerun.components.SeriesVisible",
-    ///    archetype_field_name: "visible_series",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.SeriesVisible`.
     #[inline]
     pub fn descriptor_visible_series() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -185,14 +157,7 @@ impl SeriesPoints {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::marker_sizes`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.SeriesPoints",
-    ///    component_name: "rerun.components.MarkerSize",
-    ///    archetype_field_name: "marker_sizes",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MarkerSize`.
     #[inline]
     pub fn descriptor_marker_sizes() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -72,14 +72,7 @@ pub struct Tensor {
 impl Tensor {
     /// Returns the [`ComponentDescriptor`] for [`Self::data`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Tensor",
-    ///    component_name: "rerun.components.TensorData",
-    ///    archetype_field_name: "data",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TensorData`.
     #[inline]
     pub fn descriptor_data() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -91,14 +84,7 @@ impl Tensor {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::value_range`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Tensor",
-    ///    component_name: "rerun.components.ValueRange",
-    ///    archetype_field_name: "value_range",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ValueRange`.
     #[inline]
     pub fn descriptor_value_range() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -72,7 +72,7 @@ pub struct Tensor {
 impl Tensor {
     /// Returns the [`ComponentDescriptor`] for [`Self::data`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TensorData`.
+    /// The corresponding component is [`crate::components::TensorData`].
     #[inline]
     pub fn descriptor_data() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -84,7 +84,7 @@ impl Tensor {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::value_range`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ValueRange`.
+    /// The corresponding component is [`crate::components::ValueRange`].
     #[inline]
     pub fn descriptor_value_range() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -71,6 +71,15 @@ pub struct Tensor {
 
 impl Tensor {
     /// Returns the [`ComponentDescriptor`] for [`Self::data`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Tensor",
+    ///    component_name: "rerun.components.TensorData",
+    ///    archetype_field_name: "data",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_data() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -81,6 +90,15 @@ impl Tensor {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::value_range`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Tensor",
+    ///    component_name: "rerun.components.ValueRange",
+    ///    archetype_field_name: "value_range",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_value_range() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -104,6 +104,15 @@ pub struct TextDocument {
 
 impl TextDocument {
     /// Returns the [`ComponentDescriptor`] for [`Self::text`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.TextDocument",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "text",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_text() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -114,6 +123,15 @@ impl TextDocument {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.TextDocument",
+    ///    component_name: "rerun.components.MediaType",
+    ///    archetype_field_name: "media_type",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -105,14 +105,7 @@ pub struct TextDocument {
 impl TextDocument {
     /// Returns the [`ComponentDescriptor`] for [`Self::text`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.TextDocument",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "text",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_text() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -124,14 +117,7 @@ impl TextDocument {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.TextDocument",
-    ///    component_name: "rerun.components.MediaType",
-    ///    archetype_field_name: "media_type",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MediaType`.
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -105,7 +105,7 @@ pub struct TextDocument {
 impl TextDocument {
     /// Returns the [`ComponentDescriptor`] for [`Self::text`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_text() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -117,7 +117,7 @@ impl TextDocument {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::media_type`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MediaType`.
+    /// The corresponding component is [`crate::components::MediaType`].
     #[inline]
     pub fn descriptor_media_type() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -75,7 +75,7 @@ pub struct TextLog {
 impl TextLog {
     /// Returns the [`ComponentDescriptor`] for [`Self::text`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Text`.
+    /// The corresponding component is [`crate::components::Text`].
     #[inline]
     pub fn descriptor_text() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -87,7 +87,7 @@ impl TextLog {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::level`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TextLogLevel`.
+    /// The corresponding component is [`crate::components::TextLogLevel`].
     #[inline]
     pub fn descriptor_level() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -99,7 +99,7 @@ impl TextLog {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -75,14 +75,7 @@ pub struct TextLog {
 impl TextLog {
     /// Returns the [`ComponentDescriptor`] for [`Self::text`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.TextLog",
-    ///    component_name: "rerun.components.Text",
-    ///    archetype_field_name: "text",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Text`.
     #[inline]
     pub fn descriptor_text() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -94,14 +87,7 @@ impl TextLog {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::level`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.TextLog",
-    ///    component_name: "rerun.components.TextLogLevel",
-    ///    archetype_field_name: "level",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TextLogLevel`.
     #[inline]
     pub fn descriptor_level() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -113,14 +99,7 @@ impl TextLog {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.TextLog",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "color",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -74,6 +74,15 @@ pub struct TextLog {
 
 impl TextLog {
     /// Returns the [`ComponentDescriptor`] for [`Self::text`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.TextLog",
+    ///    component_name: "rerun.components.Text",
+    ///    archetype_field_name: "text",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_text() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -84,6 +93,15 @@ impl TextLog {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::level`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.TextLog",
+    ///    component_name: "rerun.components.TextLogLevel",
+    ///    archetype_field_name: "level",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_level() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -94,6 +112,15 @@ impl TextLog {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.TextLog",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "color",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -361,14 +361,7 @@ pub struct Transform3D {
 impl Transform3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::translation`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Transform3D",
-    ///    component_name: "rerun.components.Translation3D",
-    ///    archetype_field_name: "translation",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Translation3D`.
     #[inline]
     pub fn descriptor_translation() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -380,14 +373,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angle`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Transform3D",
-    ///    component_name: "rerun.components.RotationAxisAngle",
-    ///    archetype_field_name: "rotation_axis_angle",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.RotationAxisAngle`.
     #[inline]
     pub fn descriptor_rotation_axis_angle() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -399,14 +385,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternion`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Transform3D",
-    ///    component_name: "rerun.components.RotationQuat",
-    ///    archetype_field_name: "quaternion",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.RotationQuat`.
     #[inline]
     pub fn descriptor_quaternion() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -418,14 +397,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::scale`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Transform3D",
-    ///    component_name: "rerun.components.Scale3D",
-    ///    archetype_field_name: "scale",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Scale3D`.
     #[inline]
     pub fn descriptor_scale() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -437,14 +409,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Transform3D",
-    ///    component_name: "rerun.components.TransformMat3x3",
-    ///    archetype_field_name: "mat3x3",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TransformMat3x3`.
     #[inline]
     pub fn descriptor_mat3x3() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -456,14 +421,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::relation`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Transform3D",
-    ///    component_name: "rerun.components.TransformRelation",
-    ///    archetype_field_name: "relation",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TransformRelation`.
     #[inline]
     pub fn descriptor_relation() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -475,14 +433,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::axis_length`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Transform3D",
-    ///    component_name: "rerun.components.AxisLength",
-    ///    archetype_field_name: "axis_length",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.AxisLength`.
     #[inline]
     pub fn descriptor_axis_length() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -361,7 +361,7 @@ pub struct Transform3D {
 impl Transform3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::translation`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Translation3D`.
+    /// The corresponding component is [`crate::components::Translation3D`].
     #[inline]
     pub fn descriptor_translation() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -373,7 +373,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angle`].
     ///
-    /// The `component_name` field will be set to `rerun.components.RotationAxisAngle`.
+    /// The corresponding component is [`crate::components::RotationAxisAngle`].
     #[inline]
     pub fn descriptor_rotation_axis_angle() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -385,7 +385,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternion`].
     ///
-    /// The `component_name` field will be set to `rerun.components.RotationQuat`.
+    /// The corresponding component is [`crate::components::RotationQuat`].
     #[inline]
     pub fn descriptor_quaternion() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -397,7 +397,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::scale`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Scale3D`.
+    /// The corresponding component is [`crate::components::Scale3D`].
     #[inline]
     pub fn descriptor_scale() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -409,7 +409,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TransformMat3x3`.
+    /// The corresponding component is [`crate::components::TransformMat3x3`].
     #[inline]
     pub fn descriptor_mat3x3() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -421,7 +421,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::relation`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TransformRelation`.
+    /// The corresponding component is [`crate::components::TransformRelation`].
     #[inline]
     pub fn descriptor_relation() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -433,7 +433,7 @@ impl Transform3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::axis_length`].
     ///
-    /// The `component_name` field will be set to `rerun.components.AxisLength`.
+    /// The corresponding component is [`crate::components::AxisLength`].
     #[inline]
     pub fn descriptor_axis_length() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -360,6 +360,15 @@ pub struct Transform3D {
 
 impl Transform3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::translation`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Transform3D",
+    ///    component_name: "rerun.components.Translation3D",
+    ///    archetype_field_name: "translation",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_translation() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -370,6 +379,15 @@ impl Transform3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::rotation_axis_angle`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Transform3D",
+    ///    component_name: "rerun.components.RotationAxisAngle",
+    ///    archetype_field_name: "rotation_axis_angle",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_rotation_axis_angle() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -380,6 +398,15 @@ impl Transform3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::quaternion`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Transform3D",
+    ///    component_name: "rerun.components.RotationQuat",
+    ///    archetype_field_name: "quaternion",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_quaternion() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -390,6 +417,15 @@ impl Transform3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::scale`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Transform3D",
+    ///    component_name: "rerun.components.Scale3D",
+    ///    archetype_field_name: "scale",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_scale() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -400,6 +436,15 @@ impl Transform3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::mat3x3`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Transform3D",
+    ///    component_name: "rerun.components.TransformMat3x3",
+    ///    archetype_field_name: "mat3x3",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_mat3x3() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -410,6 +455,15 @@ impl Transform3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::relation`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Transform3D",
+    ///    component_name: "rerun.components.TransformRelation",
+    ///    archetype_field_name: "relation",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_relation() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -420,6 +474,15 @@ impl Transform3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::axis_length`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Transform3D",
+    ///    component_name: "rerun.components.AxisLength",
+    ///    archetype_field_name: "axis_length",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_axis_length() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -148,14 +148,7 @@ pub struct VideoFrameReference {
 impl VideoFrameReference {
     /// Returns the [`ComponentDescriptor`] for [`Self::timestamp`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.VideoFrameReference",
-    ///    component_name: "rerun.components.VideoTimestamp",
-    ///    archetype_field_name: "timestamp",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.VideoTimestamp`.
     #[inline]
     pub fn descriptor_timestamp() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,14 +160,7 @@ impl VideoFrameReference {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::video_reference`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.VideoFrameReference",
-    ///    component_name: "rerun.components.EntityPath",
-    ///    archetype_field_name: "video_reference",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.EntityPath`.
     #[inline]
     pub fn descriptor_video_reference() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -148,7 +148,7 @@ pub struct VideoFrameReference {
 impl VideoFrameReference {
     /// Returns the [`ComponentDescriptor`] for [`Self::timestamp`].
     ///
-    /// The `component_name` field will be set to `rerun.components.VideoTimestamp`.
+    /// The corresponding component is [`crate::components::VideoTimestamp`].
     #[inline]
     pub fn descriptor_timestamp() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -160,7 +160,7 @@ impl VideoFrameReference {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::video_reference`].
     ///
-    /// The `component_name` field will be set to `rerun.components.EntityPath`.
+    /// The corresponding component is [`crate::components::EntityPath`].
     #[inline]
     pub fn descriptor_video_reference() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -147,6 +147,15 @@ pub struct VideoFrameReference {
 
 impl VideoFrameReference {
     /// Returns the [`ComponentDescriptor`] for [`Self::timestamp`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.VideoFrameReference",
+    ///    component_name: "rerun.components.VideoTimestamp",
+    ///    archetype_field_name: "timestamp",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_timestamp() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,6 +166,15 @@ impl VideoFrameReference {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::video_reference`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.VideoFrameReference",
+    ///    component_name: "rerun.components.EntityPath",
+    ///    archetype_field_name: "video_reference",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_video_reference() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -71,14 +71,7 @@ pub struct ViewCoordinates {
 impl ViewCoordinates {
     /// Returns the [`ComponentDescriptor`] for [`Self::xyz`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.ViewCoordinates",
-    ///    component_name: "rerun.components.ViewCoordinates",
-    ///    archetype_field_name: "xyz",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ViewCoordinates`.
     #[inline]
     pub fn descriptor_xyz() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -71,7 +71,7 @@ pub struct ViewCoordinates {
 impl ViewCoordinates {
     /// Returns the [`ComponentDescriptor`] for [`Self::xyz`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ViewCoordinates`.
+    /// The corresponding component is [`crate::components::ViewCoordinates`].
     #[inline]
     pub fn descriptor_xyz() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -70,6 +70,15 @@ pub struct ViewCoordinates {
 
 impl ViewCoordinates {
     /// Returns the [`ComponentDescriptor`] for [`Self::xyz`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.ViewCoordinates",
+    ///    component_name: "rerun.components.ViewCoordinates",
+    ///    archetype_field_name: "xyz",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_xyz() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -33,14 +33,7 @@ pub struct Background {
 impl Background {
     /// Returns the [`ComponentDescriptor`] for [`Self::kind`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.Background",
-    ///    component_name: "rerun.blueprint.components.BackgroundKind",
-    ///    archetype_field_name: "kind",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.BackgroundKind`.
     #[inline]
     pub fn descriptor_kind() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,14 +45,7 @@ impl Background {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.Background",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "color",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -32,6 +32,15 @@ pub struct Background {
 
 impl Background {
     /// Returns the [`ComponentDescriptor`] for [`Self::kind`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.Background",
+    ///    component_name: "rerun.blueprint.components.BackgroundKind",
+    ///    archetype_field_name: "kind",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_kind() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -42,6 +51,15 @@ impl Background {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.Background",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "color",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -33,7 +33,7 @@ pub struct Background {
 impl Background {
     /// Returns the [`ComponentDescriptor`] for [`Self::kind`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.BackgroundKind`.
+    /// The corresponding component is [`crate::blueprint::components::BackgroundKind`].
     #[inline]
     pub fn descriptor_kind() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -45,7 +45,7 @@ impl Background {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
@@ -67,14 +67,7 @@ pub struct ContainerBlueprint {
 impl ContainerBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::container_kind`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.blueprint.components.ContainerKind",
-    ///    archetype_field_name: "container_kind",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ContainerKind`.
     #[inline]
     pub fn descriptor_container_kind() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -86,14 +79,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.components.Name",
-    ///    archetype_field_name: "display_name",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Name`.
     #[inline]
     pub fn descriptor_display_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -105,14 +91,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::contents`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.blueprint.components.IncludedContent",
-    ///    archetype_field_name: "contents",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.IncludedContent`.
     #[inline]
     pub fn descriptor_contents() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -124,14 +103,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::col_shares`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.blueprint.components.ColumnShare",
-    ///    archetype_field_name: "col_shares",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ColumnShare`.
     #[inline]
     pub fn descriptor_col_shares() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -143,14 +115,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::row_shares`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.blueprint.components.RowShare",
-    ///    archetype_field_name: "row_shares",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.RowShare`.
     #[inline]
     pub fn descriptor_row_shares() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -162,14 +127,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::active_tab`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.blueprint.components.ActiveTab",
-    ///    archetype_field_name: "active_tab",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ActiveTab`.
     #[inline]
     pub fn descriptor_active_tab() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -181,14 +139,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.components.Visible",
-    ///    archetype_field_name: "visible",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Visible`.
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -200,14 +151,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::grid_columns`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
-    ///    component_name: "rerun.blueprint.components.GridColumns",
-    ///    archetype_field_name: "grid_columns",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.GridColumns`.
     #[inline]
     pub fn descriptor_grid_columns() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
@@ -66,6 +66,15 @@ pub struct ContainerBlueprint {
 
 impl ContainerBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::container_kind`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.blueprint.components.ContainerKind",
+    ///    archetype_field_name: "container_kind",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_container_kind() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -76,6 +85,15 @@ impl ContainerBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.components.Name",
+    ///    archetype_field_name: "display_name",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_display_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -86,6 +104,15 @@ impl ContainerBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::contents`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.blueprint.components.IncludedContent",
+    ///    archetype_field_name: "contents",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_contents() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -96,6 +123,15 @@ impl ContainerBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::col_shares`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.blueprint.components.ColumnShare",
+    ///    archetype_field_name: "col_shares",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_col_shares() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -106,6 +142,15 @@ impl ContainerBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::row_shares`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.blueprint.components.RowShare",
+    ///    archetype_field_name: "row_shares",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_row_shares() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -116,6 +161,15 @@ impl ContainerBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::active_tab`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.blueprint.components.ActiveTab",
+    ///    archetype_field_name: "active_tab",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_active_tab() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -126,6 +180,15 @@ impl ContainerBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.components.Visible",
+    ///    archetype_field_name: "visible",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,6 +199,15 @@ impl ContainerBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::grid_columns`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ContainerBlueprint",
+    ///    component_name: "rerun.blueprint.components.GridColumns",
+    ///    archetype_field_name: "grid_columns",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_grid_columns() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
@@ -67,7 +67,7 @@ pub struct ContainerBlueprint {
 impl ContainerBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::container_kind`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ContainerKind`.
+    /// The corresponding component is [`crate::blueprint::components::ContainerKind`].
     #[inline]
     pub fn descriptor_container_kind() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -79,7 +79,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Name`.
+    /// The corresponding component is [`crate::components::Name`].
     #[inline]
     pub fn descriptor_display_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -91,7 +91,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::contents`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.IncludedContent`.
+    /// The corresponding component is [`crate::blueprint::components::IncludedContent`].
     #[inline]
     pub fn descriptor_contents() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -103,7 +103,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::col_shares`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ColumnShare`.
+    /// The corresponding component is [`crate::blueprint::components::ColumnShare`].
     #[inline]
     pub fn descriptor_col_shares() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -115,7 +115,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::row_shares`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.RowShare`.
+    /// The corresponding component is [`crate::blueprint::components::RowShare`].
     #[inline]
     pub fn descriptor_row_shares() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -127,7 +127,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::active_tab`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ActiveTab`.
+    /// The corresponding component is [`crate::blueprint::components::ActiveTab`].
     #[inline]
     pub fn descriptor_active_tab() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -139,7 +139,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Visible`.
+    /// The corresponding component is [`crate::components::Visible`].
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -151,7 +151,7 @@ impl ContainerBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::grid_columns`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.GridColumns`.
+    /// The corresponding component is [`crate::blueprint::components::GridColumns`].
     #[inline]
     pub fn descriptor_grid_columns() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -46,7 +46,7 @@ pub struct DataframeQuery {
 impl DataframeQuery {
     /// Returns the [`ComponentDescriptor`] for [`Self::timeline`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.TimelineName`.
+    /// The corresponding component is [`crate::blueprint::components::TimelineName`].
     #[inline]
     pub fn descriptor_timeline() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -58,7 +58,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::filter_by_range`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.FilterByRange`.
+    /// The corresponding component is [`crate::blueprint::components::FilterByRange`].
     #[inline]
     pub fn descriptor_filter_by_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -70,7 +70,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::filter_is_not_null`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.FilterIsNotNull`.
+    /// The corresponding component is [`crate::blueprint::components::FilterIsNotNull`].
     #[inline]
     pub fn descriptor_filter_is_not_null() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -82,7 +82,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::apply_latest_at`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ApplyLatestAt`.
+    /// The corresponding component is [`crate::blueprint::components::ApplyLatestAt`].
     #[inline]
     pub fn descriptor_apply_latest_at() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -94,7 +94,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::select`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.SelectedColumns`.
+    /// The corresponding component is [`crate::blueprint::components::SelectedColumns`].
     #[inline]
     pub fn descriptor_select() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -45,6 +45,15 @@ pub struct DataframeQuery {
 
 impl DataframeQuery {
     /// Returns the [`ComponentDescriptor`] for [`Self::timeline`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
+    ///    component_name: "rerun.blueprint.components.TimelineName",
+    ///    archetype_field_name: "timeline",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_timeline() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -55,6 +64,15 @@ impl DataframeQuery {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::filter_by_range`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
+    ///    component_name: "rerun.blueprint.components.FilterByRange",
+    ///    archetype_field_name: "filter_by_range",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_filter_by_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -65,6 +83,15 @@ impl DataframeQuery {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::filter_is_not_null`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
+    ///    component_name: "rerun.blueprint.components.FilterIsNotNull",
+    ///    archetype_field_name: "filter_is_not_null",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_filter_is_not_null() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -75,6 +102,15 @@ impl DataframeQuery {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::apply_latest_at`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
+    ///    component_name: "rerun.blueprint.components.ApplyLatestAt",
+    ///    archetype_field_name: "apply_latest_at",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_apply_latest_at() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -85,6 +121,15 @@ impl DataframeQuery {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::select`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
+    ///    component_name: "rerun.blueprint.components.SelectedColumns",
+    ///    archetype_field_name: "select",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_select() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -46,14 +46,7 @@ pub struct DataframeQuery {
 impl DataframeQuery {
     /// Returns the [`ComponentDescriptor`] for [`Self::timeline`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
-    ///    component_name: "rerun.blueprint.components.TimelineName",
-    ///    archetype_field_name: "timeline",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.TimelineName`.
     #[inline]
     pub fn descriptor_timeline() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -65,14 +58,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::filter_by_range`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
-    ///    component_name: "rerun.blueprint.components.FilterByRange",
-    ///    archetype_field_name: "filter_by_range",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.FilterByRange`.
     #[inline]
     pub fn descriptor_filter_by_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -84,14 +70,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::filter_is_not_null`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
-    ///    component_name: "rerun.blueprint.components.FilterIsNotNull",
-    ///    archetype_field_name: "filter_is_not_null",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.FilterIsNotNull`.
     #[inline]
     pub fn descriptor_filter_is_not_null() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -103,14 +82,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::apply_latest_at`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
-    ///    component_name: "rerun.blueprint.components.ApplyLatestAt",
-    ///    archetype_field_name: "apply_latest_at",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ApplyLatestAt`.
     #[inline]
     pub fn descriptor_apply_latest_at() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,14 +94,7 @@ impl DataframeQuery {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::select`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.DataframeQuery",
-    ///    component_name: "rerun.blueprint.components.SelectedColumns",
-    ///    archetype_field_name: "select",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.SelectedColumns`.
     #[inline]
     pub fn descriptor_select() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
@@ -43,14 +43,7 @@ pub struct EntityBehavior {
 impl EntityBehavior {
     /// Returns the [`ComponentDescriptor`] for [`Self::interactive`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.EntityBehavior",
-    ///    component_name: "rerun.components.Interactive",
-    ///    archetype_field_name: "interactive",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Interactive`.
     #[inline]
     pub fn descriptor_interactive() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -62,14 +55,7 @@ impl EntityBehavior {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.EntityBehavior",
-    ///    component_name: "rerun.components.Visible",
-    ///    archetype_field_name: "visible",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Visible`.
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
@@ -42,6 +42,15 @@ pub struct EntityBehavior {
 
 impl EntityBehavior {
     /// Returns the [`ComponentDescriptor`] for [`Self::interactive`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.EntityBehavior",
+    ///    component_name: "rerun.components.Interactive",
+    ///    archetype_field_name: "interactive",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_interactive() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,6 +61,15 @@ impl EntityBehavior {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.EntityBehavior",
+    ///    component_name: "rerun.components.Visible",
+    ///    archetype_field_name: "visible",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
@@ -43,7 +43,7 @@ pub struct EntityBehavior {
 impl EntityBehavior {
     /// Returns the [`ComponentDescriptor`] for [`Self::interactive`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Interactive`.
+    /// The corresponding component is [`crate::components::Interactive`].
     #[inline]
     pub fn descriptor_interactive() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -55,7 +55,7 @@ impl EntityBehavior {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Visible`.
+    /// The corresponding component is [`crate::components::Visible`].
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_center.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_center.rs
@@ -35,7 +35,7 @@ pub struct ForceCenter {
 impl ForceCenter {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
+    /// The corresponding component is [`crate::blueprint::components::Enabled`].
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -47,7 +47,7 @@ impl ForceCenter {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
+    /// The corresponding component is [`crate::blueprint::components::ForceStrength`].
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_center.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_center.rs
@@ -35,14 +35,7 @@ pub struct ForceCenter {
 impl ForceCenter {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceCenter",
-    ///    component_name: "rerun.blueprint.components.Enabled",
-    ///    archetype_field_name: "enabled",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -54,14 +47,7 @@ impl ForceCenter {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceCenter",
-    ///    component_name: "rerun.blueprint.components.ForceStrength",
-    ///    archetype_field_name: "strength",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_center.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_center.rs
@@ -34,6 +34,15 @@ pub struct ForceCenter {
 
 impl ForceCenter {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceCenter",
+    ///    component_name: "rerun.blueprint.components.Enabled",
+    ///    archetype_field_name: "enabled",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -44,6 +53,15 @@ impl ForceCenter {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceCenter",
+    ///    component_name: "rerun.blueprint.components.ForceStrength",
+    ///    archetype_field_name: "strength",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
@@ -39,6 +39,15 @@ pub struct ForceCollisionRadius {
 
 impl ForceCollisionRadius {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceCollisionRadius",
+    ///    component_name: "rerun.blueprint.components.Enabled",
+    ///    archetype_field_name: "enabled",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -49,6 +58,15 @@ impl ForceCollisionRadius {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceCollisionRadius",
+    ///    component_name: "rerun.blueprint.components.ForceStrength",
+    ///    archetype_field_name: "strength",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -59,6 +77,15 @@ impl ForceCollisionRadius {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceCollisionRadius",
+    ///    component_name: "rerun.blueprint.components.ForceIterations",
+    ///    archetype_field_name: "iterations",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_iterations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
@@ -40,14 +40,7 @@ pub struct ForceCollisionRadius {
 impl ForceCollisionRadius {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceCollisionRadius",
-    ///    component_name: "rerun.blueprint.components.Enabled",
-    ///    archetype_field_name: "enabled",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -59,14 +52,7 @@ impl ForceCollisionRadius {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceCollisionRadius",
-    ///    component_name: "rerun.blueprint.components.ForceStrength",
-    ///    archetype_field_name: "strength",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -78,14 +64,7 @@ impl ForceCollisionRadius {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceCollisionRadius",
-    ///    component_name: "rerun.blueprint.components.ForceIterations",
-    ///    archetype_field_name: "iterations",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ForceIterations`.
     #[inline]
     pub fn descriptor_iterations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
@@ -40,7 +40,7 @@ pub struct ForceCollisionRadius {
 impl ForceCollisionRadius {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
+    /// The corresponding component is [`crate::blueprint::components::Enabled`].
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,7 +52,7 @@ impl ForceCollisionRadius {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
+    /// The corresponding component is [`crate::blueprint::components::ForceStrength`].
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -64,7 +64,7 @@ impl ForceCollisionRadius {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ForceIterations`.
+    /// The corresponding component is [`crate::blueprint::components::ForceIterations`].
     #[inline]
     pub fn descriptor_iterations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_link.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_link.rs
@@ -39,6 +39,15 @@ pub struct ForceLink {
 
 impl ForceLink {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceLink",
+    ///    component_name: "rerun.blueprint.components.Enabled",
+    ///    archetype_field_name: "enabled",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -49,6 +58,15 @@ impl ForceLink {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::distance`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceLink",
+    ///    component_name: "rerun.blueprint.components.ForceDistance",
+    ///    archetype_field_name: "distance",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_distance() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -59,6 +77,15 @@ impl ForceLink {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceLink",
+    ///    component_name: "rerun.blueprint.components.ForceIterations",
+    ///    archetype_field_name: "iterations",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_iterations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_link.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_link.rs
@@ -40,14 +40,7 @@ pub struct ForceLink {
 impl ForceLink {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceLink",
-    ///    component_name: "rerun.blueprint.components.Enabled",
-    ///    archetype_field_name: "enabled",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -59,14 +52,7 @@ impl ForceLink {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::distance`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceLink",
-    ///    component_name: "rerun.blueprint.components.ForceDistance",
-    ///    archetype_field_name: "distance",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ForceDistance`.
     #[inline]
     pub fn descriptor_distance() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -78,14 +64,7 @@ impl ForceLink {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceLink",
-    ///    component_name: "rerun.blueprint.components.ForceIterations",
-    ///    archetype_field_name: "iterations",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ForceIterations`.
     #[inline]
     pub fn descriptor_iterations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_link.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_link.rs
@@ -40,7 +40,7 @@ pub struct ForceLink {
 impl ForceLink {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
+    /// The corresponding component is [`crate::blueprint::components::Enabled`].
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,7 +52,7 @@ impl ForceLink {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::distance`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ForceDistance`.
+    /// The corresponding component is [`crate::blueprint::components::ForceDistance`].
     #[inline]
     pub fn descriptor_distance() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -64,7 +64,7 @@ impl ForceLink {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::iterations`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ForceIterations`.
+    /// The corresponding component is [`crate::blueprint::components::ForceIterations`].
     #[inline]
     pub fn descriptor_iterations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
@@ -40,7 +40,7 @@ pub struct ForceManyBody {
 impl ForceManyBody {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
+    /// The corresponding component is [`crate::blueprint::components::Enabled`].
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,7 +52,7 @@ impl ForceManyBody {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
+    /// The corresponding component is [`crate::blueprint::components::ForceStrength`].
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
@@ -40,14 +40,7 @@ pub struct ForceManyBody {
 impl ForceManyBody {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceManyBody",
-    ///    component_name: "rerun.blueprint.components.Enabled",
-    ///    archetype_field_name: "enabled",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -59,14 +52,7 @@ impl ForceManyBody {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForceManyBody",
-    ///    component_name: "rerun.blueprint.components.ForceStrength",
-    ///    archetype_field_name: "strength",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
@@ -39,6 +39,15 @@ pub struct ForceManyBody {
 
 impl ForceManyBody {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceManyBody",
+    ///    component_name: "rerun.blueprint.components.Enabled",
+    ///    archetype_field_name: "enabled",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -49,6 +58,15 @@ impl ForceManyBody {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForceManyBody",
+    ///    component_name: "rerun.blueprint.components.ForceStrength",
+    ///    archetype_field_name: "strength",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_position.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_position.rs
@@ -38,14 +38,7 @@ pub struct ForcePosition {
 impl ForcePosition {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForcePosition",
-    ///    component_name: "rerun.blueprint.components.Enabled",
-    ///    archetype_field_name: "enabled",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -57,14 +50,7 @@ impl ForcePosition {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForcePosition",
-    ///    component_name: "rerun.blueprint.components.ForceStrength",
-    ///    archetype_field_name: "strength",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -76,14 +62,7 @@ impl ForcePosition {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::position`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ForcePosition",
-    ///    component_name: "rerun.components.Position2D",
-    ///    archetype_field_name: "position",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Position2D`.
     #[inline]
     pub fn descriptor_position() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_position.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_position.rs
@@ -38,7 +38,7 @@ pub struct ForcePosition {
 impl ForcePosition {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.Enabled`.
+    /// The corresponding component is [`crate::blueprint::components::Enabled`].
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -50,7 +50,7 @@ impl ForcePosition {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ForceStrength`.
+    /// The corresponding component is [`crate::blueprint::components::ForceStrength`].
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -62,7 +62,7 @@ impl ForcePosition {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::position`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Position2D`.
+    /// The corresponding component is [`crate::components::Position2D`].
     #[inline]
     pub fn descriptor_position() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/force_position.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_position.rs
@@ -37,6 +37,15 @@ pub struct ForcePosition {
 
 impl ForcePosition {
     /// Returns the [`ComponentDescriptor`] for [`Self::enabled`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForcePosition",
+    ///    component_name: "rerun.blueprint.components.Enabled",
+    ///    archetype_field_name: "enabled",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_enabled() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -47,6 +56,15 @@ impl ForcePosition {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::strength`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForcePosition",
+    ///    component_name: "rerun.blueprint.components.ForceStrength",
+    ///    archetype_field_name: "strength",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_strength() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -57,6 +75,15 @@ impl ForcePosition {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::position`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ForcePosition",
+    ///    component_name: "rerun.components.Position2D",
+    ///    archetype_field_name: "position",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_position() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -53,6 +53,15 @@ pub struct LineGrid3D {
 
 impl LineGrid3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
+    ///    component_name: "rerun.components.Visible",
+    ///    archetype_field_name: "visible",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -63,6 +72,15 @@ impl LineGrid3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::spacing`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
+    ///    component_name: "rerun.blueprint.components.GridSpacing",
+    ///    archetype_field_name: "spacing",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_spacing() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -73,6 +91,15 @@ impl LineGrid3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::plane`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
+    ///    component_name: "rerun.components.Plane3D",
+    ///    archetype_field_name: "plane",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_plane() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -83,6 +110,15 @@ impl LineGrid3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::stroke_width`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
+    ///    component_name: "rerun.components.StrokeWidth",
+    ///    archetype_field_name: "stroke_width",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_stroke_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -93,6 +129,15 @@ impl LineGrid3D {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
+    ///    component_name: "rerun.components.Color",
+    ///    archetype_field_name: "color",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -54,7 +54,7 @@ pub struct LineGrid3D {
 impl LineGrid3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Visible`.
+    /// The corresponding component is [`crate::components::Visible`].
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -66,7 +66,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::spacing`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.GridSpacing`.
+    /// The corresponding component is [`crate::blueprint::components::GridSpacing`].
     #[inline]
     pub fn descriptor_spacing() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -78,7 +78,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::plane`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Plane3D`.
+    /// The corresponding component is [`crate::components::Plane3D`].
     #[inline]
     pub fn descriptor_plane() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -90,7 +90,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::stroke_width`].
     ///
-    /// The `component_name` field will be set to `rerun.components.StrokeWidth`.
+    /// The corresponding component is [`crate::components::StrokeWidth`].
     #[inline]
     pub fn descriptor_stroke_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,7 +102,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Color`.
+    /// The corresponding component is [`crate::components::Color`].
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -54,14 +54,7 @@ pub struct LineGrid3D {
 impl LineGrid3D {
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
-    ///    component_name: "rerun.components.Visible",
-    ///    archetype_field_name: "visible",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Visible`.
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -73,14 +66,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::spacing`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
-    ///    component_name: "rerun.blueprint.components.GridSpacing",
-    ///    archetype_field_name: "spacing",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.GridSpacing`.
     #[inline]
     pub fn descriptor_spacing() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,14 +78,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::plane`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
-    ///    component_name: "rerun.components.Plane3D",
-    ///    archetype_field_name: "plane",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Plane3D`.
     #[inline]
     pub fn descriptor_plane() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -111,14 +90,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::stroke_width`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
-    ///    component_name: "rerun.components.StrokeWidth",
-    ///    archetype_field_name: "stroke_width",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.StrokeWidth`.
     #[inline]
     pub fn descriptor_stroke_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -130,14 +102,7 @@ impl LineGrid3D {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::color`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.LineGrid3D",
-    ///    component_name: "rerun.components.Color",
-    ///    archetype_field_name: "color",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Color`.
     #[inline]
     pub fn descriptor_color() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -32,14 +32,7 @@ pub struct MapBackground {
 impl MapBackground {
     /// Returns the [`ComponentDescriptor`] for [`Self::provider`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.MapBackground",
-    ///    component_name: "rerun.blueprint.components.MapProvider",
-    ///    archetype_field_name: "provider",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.MapProvider`.
     #[inline]
     pub fn descriptor_provider() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -32,7 +32,7 @@ pub struct MapBackground {
 impl MapBackground {
     /// Returns the [`ComponentDescriptor`] for [`Self::provider`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.MapProvider`.
+    /// The corresponding component is [`crate::blueprint::components::MapProvider`].
     #[inline]
     pub fn descriptor_provider() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -31,6 +31,15 @@ pub struct MapBackground {
 
 impl MapBackground {
     /// Returns the [`ComponentDescriptor`] for [`Self::provider`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.MapBackground",
+    ///    component_name: "rerun.blueprint.components.MapProvider",
+    ///    archetype_field_name: "provider",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_provider() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -31,6 +31,15 @@ pub struct MapZoom {
 
 impl MapZoom {
     /// Returns the [`ComponentDescriptor`] for [`Self::zoom`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.MapZoom",
+    ///    component_name: "rerun.blueprint.components.ZoomLevel",
+    ///    archetype_field_name: "zoom",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_zoom() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -32,14 +32,7 @@ pub struct MapZoom {
 impl MapZoom {
     /// Returns the [`ComponentDescriptor`] for [`Self::zoom`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.MapZoom",
-    ///    component_name: "rerun.blueprint.components.ZoomLevel",
-    ///    archetype_field_name: "zoom",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ZoomLevel`.
     #[inline]
     pub fn descriptor_zoom() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -32,7 +32,7 @@ pub struct MapZoom {
 impl MapZoom {
     /// Returns the [`ComponentDescriptor`] for [`Self::zoom`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ZoomLevel`.
+    /// The corresponding component is [`crate::blueprint::components::ZoomLevel`].
     #[inline]
     pub fn descriptor_zoom() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
@@ -32,14 +32,7 @@ pub struct NearClipPlane {
 impl NearClipPlane {
     /// Returns the [`ComponentDescriptor`] for [`Self::near_clip_plane`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.NearClipPlane",
-    ///    component_name: "rerun.blueprint.components.NearClipPlane",
-    ///    archetype_field_name: "near_clip_plane",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.NearClipPlane`.
     #[inline]
     pub fn descriptor_near_clip_plane() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
@@ -31,6 +31,15 @@ pub struct NearClipPlane {
 
 impl NearClipPlane {
     /// Returns the [`ComponentDescriptor`] for [`Self::near_clip_plane`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.NearClipPlane",
+    ///    component_name: "rerun.blueprint.components.NearClipPlane",
+    ///    archetype_field_name: "near_clip_plane",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_near_clip_plane() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
@@ -32,7 +32,7 @@ pub struct NearClipPlane {
 impl NearClipPlane {
     /// Returns the [`ComponentDescriptor`] for [`Self::near_clip_plane`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.NearClipPlane`.
+    /// The corresponding component is [`crate::blueprint::components::NearClipPlane`].
     #[inline]
     pub fn descriptor_near_clip_plane() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
@@ -29,6 +29,15 @@ pub struct PanelBlueprint {
 
 impl PanelBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::state`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.PanelBlueprint",
+    ///    component_name: "rerun.blueprint.components.PanelState",
+    ///    archetype_field_name: "state",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_state() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
@@ -30,7 +30,7 @@ pub struct PanelBlueprint {
 impl PanelBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::state`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.PanelState`.
+    /// The corresponding component is [`crate::blueprint::components::PanelState`].
     #[inline]
     pub fn descriptor_state() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
@@ -30,14 +30,7 @@ pub struct PanelBlueprint {
 impl PanelBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::state`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.PanelBlueprint",
-    ///    component_name: "rerun.blueprint.components.PanelState",
-    ///    archetype_field_name: "state",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.PanelState`.
     #[inline]
     pub fn descriptor_state() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -36,6 +36,15 @@ pub struct PlotLegend {
 
 impl PlotLegend {
     /// Returns the [`ComponentDescriptor`] for [`Self::corner`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.PlotLegend",
+    ///    component_name: "rerun.blueprint.components.Corner2D",
+    ///    archetype_field_name: "corner",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_corner() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -46,6 +55,15 @@ impl PlotLegend {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.PlotLegend",
+    ///    component_name: "rerun.components.Visible",
+    ///    archetype_field_name: "visible",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -37,7 +37,7 @@ pub struct PlotLegend {
 impl PlotLegend {
     /// Returns the [`ComponentDescriptor`] for [`Self::corner`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.Corner2D`.
+    /// The corresponding component is [`crate::blueprint::components::Corner2D`].
     #[inline]
     pub fn descriptor_corner() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -49,7 +49,7 @@ impl PlotLegend {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Visible`.
+    /// The corresponding component is [`crate::components::Visible`].
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -37,14 +37,7 @@ pub struct PlotLegend {
 impl PlotLegend {
     /// Returns the [`ComponentDescriptor`] for [`Self::corner`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.PlotLegend",
-    ///    component_name: "rerun.blueprint.components.Corner2D",
-    ///    archetype_field_name: "corner",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.Corner2D`.
     #[inline]
     pub fn descriptor_corner() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -56,14 +49,7 @@ impl PlotLegend {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.PlotLegend",
-    ///    component_name: "rerun.components.Visible",
-    ///    archetype_field_name: "visible",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Visible`.
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -35,7 +35,7 @@ pub struct ScalarAxis {
 impl ScalarAxis {
     /// Returns the [`ComponentDescriptor`] for [`Self::range`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Range1D`.
+    /// The corresponding component is [`crate::components::Range1D`].
     #[inline]
     pub fn descriptor_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -47,7 +47,7 @@ impl ScalarAxis {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::zoom_lock`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.LockRangeDuringZoom`.
+    /// The corresponding component is [`crate::blueprint::components::LockRangeDuringZoom`].
     #[inline]
     pub fn descriptor_zoom_lock() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -35,14 +35,7 @@ pub struct ScalarAxis {
 impl ScalarAxis {
     /// Returns the [`ComponentDescriptor`] for [`Self::range`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ScalarAxis",
-    ///    component_name: "rerun.components.Range1D",
-    ///    archetype_field_name: "range",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Range1D`.
     #[inline]
     pub fn descriptor_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -54,14 +47,7 @@ impl ScalarAxis {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::zoom_lock`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ScalarAxis",
-    ///    component_name: "rerun.blueprint.components.LockRangeDuringZoom",
-    ///    archetype_field_name: "zoom_lock",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.LockRangeDuringZoom`.
     #[inline]
     pub fn descriptor_zoom_lock() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -34,6 +34,15 @@ pub struct ScalarAxis {
 
 impl ScalarAxis {
     /// Returns the [`ComponentDescriptor`] for [`Self::range`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ScalarAxis",
+    ///    component_name: "rerun.components.Range1D",
+    ///    archetype_field_name: "range",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_range() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -44,6 +53,15 @@ impl ScalarAxis {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::zoom_lock`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ScalarAxis",
+    ///    component_name: "rerun.blueprint.components.LockRangeDuringZoom",
+    ///    archetype_field_name: "zoom_lock",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_zoom_lock() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -44,14 +44,7 @@ pub struct TensorScalarMapping {
 impl TensorScalarMapping {
     /// Returns the [`ComponentDescriptor`] for [`Self::mag_filter`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorScalarMapping",
-    ///    component_name: "rerun.components.MagnificationFilter",
-    ///    archetype_field_name: "mag_filter",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.MagnificationFilter`.
     #[inline]
     pub fn descriptor_mag_filter() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -63,14 +56,7 @@ impl TensorScalarMapping {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorScalarMapping",
-    ///    component_name: "rerun.components.Colormap",
-    ///    archetype_field_name: "colormap",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Colormap`.
     #[inline]
     pub fn descriptor_colormap() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -82,14 +68,7 @@ impl TensorScalarMapping {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::gamma`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorScalarMapping",
-    ///    component_name: "rerun.components.GammaCorrection",
-    ///    archetype_field_name: "gamma",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.GammaCorrection`.
     #[inline]
     pub fn descriptor_gamma() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -44,7 +44,7 @@ pub struct TensorScalarMapping {
 impl TensorScalarMapping {
     /// Returns the [`ComponentDescriptor`] for [`Self::mag_filter`].
     ///
-    /// The `component_name` field will be set to `rerun.components.MagnificationFilter`.
+    /// The corresponding component is [`crate::components::MagnificationFilter`].
     #[inline]
     pub fn descriptor_mag_filter() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -56,7 +56,7 @@ impl TensorScalarMapping {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Colormap`.
+    /// The corresponding component is [`crate::components::Colormap`].
     #[inline]
     pub fn descriptor_colormap() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -68,7 +68,7 @@ impl TensorScalarMapping {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::gamma`].
     ///
-    /// The `component_name` field will be set to `rerun.components.GammaCorrection`.
+    /// The corresponding component is [`crate::components::GammaCorrection`].
     #[inline]
     pub fn descriptor_gamma() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -43,6 +43,15 @@ pub struct TensorScalarMapping {
 
 impl TensorScalarMapping {
     /// Returns the [`ComponentDescriptor`] for [`Self::mag_filter`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorScalarMapping",
+    ///    component_name: "rerun.components.MagnificationFilter",
+    ///    archetype_field_name: "mag_filter",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_mag_filter() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -53,6 +62,15 @@ impl TensorScalarMapping {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::colormap`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorScalarMapping",
+    ///    component_name: "rerun.components.Colormap",
+    ///    archetype_field_name: "colormap",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_colormap() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -63,6 +81,15 @@ impl TensorScalarMapping {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::gamma`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorScalarMapping",
+    ///    component_name: "rerun.components.GammaCorrection",
+    ///    archetype_field_name: "gamma",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_gamma() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -48,6 +48,15 @@ pub struct TensorSliceSelection {
 
 impl TensorSliceSelection {
     /// Returns the [`ComponentDescriptor`] for [`Self::width`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
+    ///    component_name: "rerun.components.TensorWidthDimension",
+    ///    archetype_field_name: "width",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -58,6 +67,15 @@ impl TensorSliceSelection {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::height`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
+    ///    component_name: "rerun.components.TensorHeightDimension",
+    ///    archetype_field_name: "height",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_height() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -68,6 +86,15 @@ impl TensorSliceSelection {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::indices`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
+    ///    component_name: "rerun.components.TensorDimensionIndexSelection",
+    ///    archetype_field_name: "indices",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_indices() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -78,6 +105,15 @@ impl TensorSliceSelection {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::slider`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
+    ///    component_name: "rerun.blueprint.components.TensorDimensionIndexSlider",
+    ///    archetype_field_name: "slider",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_slider() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -49,14 +49,7 @@ pub struct TensorSliceSelection {
 impl TensorSliceSelection {
     /// Returns the [`ComponentDescriptor`] for [`Self::width`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
-    ///    component_name: "rerun.components.TensorWidthDimension",
-    ///    archetype_field_name: "width",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TensorWidthDimension`.
     #[inline]
     pub fn descriptor_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -68,14 +61,7 @@ impl TensorSliceSelection {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::height`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
-    ///    component_name: "rerun.components.TensorHeightDimension",
-    ///    archetype_field_name: "height",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TensorHeightDimension`.
     #[inline]
     pub fn descriptor_height() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -87,14 +73,7 @@ impl TensorSliceSelection {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::indices`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
-    ///    component_name: "rerun.components.TensorDimensionIndexSelection",
-    ///    archetype_field_name: "indices",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.TensorDimensionIndexSelection`.
     #[inline]
     pub fn descriptor_indices() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -106,14 +85,7 @@ impl TensorSliceSelection {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::slider`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorSliceSelection",
-    ///    component_name: "rerun.blueprint.components.TensorDimensionIndexSlider",
-    ///    archetype_field_name: "slider",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.TensorDimensionIndexSlider`.
     #[inline]
     pub fn descriptor_slider() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -49,7 +49,7 @@ pub struct TensorSliceSelection {
 impl TensorSliceSelection {
     /// Returns the [`ComponentDescriptor`] for [`Self::width`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TensorWidthDimension`.
+    /// The corresponding component is [`crate::components::TensorWidthDimension`].
     #[inline]
     pub fn descriptor_width() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -61,7 +61,7 @@ impl TensorSliceSelection {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::height`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TensorHeightDimension`.
+    /// The corresponding component is [`crate::components::TensorHeightDimension`].
     #[inline]
     pub fn descriptor_height() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -73,7 +73,7 @@ impl TensorSliceSelection {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::indices`].
     ///
-    /// The `component_name` field will be set to `rerun.components.TensorDimensionIndexSelection`.
+    /// The corresponding component is [`crate::components::TensorDimensionIndexSelection`].
     #[inline]
     pub fn descriptor_indices() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -85,7 +85,7 @@ impl TensorSliceSelection {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::slider`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.TensorDimensionIndexSlider`.
+    /// The corresponding component is [`crate::blueprint::components::TensorDimensionIndexSlider`].
     #[inline]
     pub fn descriptor_slider() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -29,6 +29,15 @@ pub struct TensorViewFit {
 
 impl TensorViewFit {
     /// Returns the [`ComponentDescriptor`] for [`Self::scaling`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.TensorViewFit",
+    ///    component_name: "rerun.blueprint.components.ViewFit",
+    ///    archetype_field_name: "scaling",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_scaling() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -30,14 +30,7 @@ pub struct TensorViewFit {
 impl TensorViewFit {
     /// Returns the [`ComponentDescriptor`] for [`Self::scaling`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.TensorViewFit",
-    ///    component_name: "rerun.blueprint.components.ViewFit",
-    ///    archetype_field_name: "scaling",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ViewFit`.
     #[inline]
     pub fn descriptor_scaling() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -30,7 +30,7 @@ pub struct TensorViewFit {
 impl TensorViewFit {
     /// Returns the [`ComponentDescriptor`] for [`Self::scaling`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ViewFit`.
+    /// The corresponding component is [`crate::blueprint::components::ViewFit`].
     #[inline]
     pub fn descriptor_scaling() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
@@ -46,6 +46,15 @@ pub struct ViewBlueprint {
 
 impl ViewBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::class_identifier`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
+    ///    component_name: "rerun.blueprint.components.ViewClass",
+    ///    archetype_field_name: "class_identifier",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_class_identifier() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -56,6 +65,15 @@ impl ViewBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
+    ///    component_name: "rerun.components.Name",
+    ///    archetype_field_name: "display_name",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_display_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -66,6 +84,15 @@ impl ViewBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::space_origin`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
+    ///    component_name: "rerun.blueprint.components.ViewOrigin",
+    ///    archetype_field_name: "space_origin",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_space_origin() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -76,6 +103,15 @@ impl ViewBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
+    ///    component_name: "rerun.components.Visible",
+    ///    archetype_field_name: "visible",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
@@ -47,7 +47,7 @@ pub struct ViewBlueprint {
 impl ViewBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::class_identifier`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ViewClass`.
+    /// The corresponding component is [`crate::blueprint::components::ViewClass`].
     #[inline]
     pub fn descriptor_class_identifier() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -59,7 +59,7 @@ impl ViewBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Name`.
+    /// The corresponding component is [`crate::components::Name`].
     #[inline]
     pub fn descriptor_display_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -71,7 +71,7 @@ impl ViewBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::space_origin`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ViewOrigin`.
+    /// The corresponding component is [`crate::blueprint::components::ViewOrigin`].
     #[inline]
     pub fn descriptor_space_origin() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -83,7 +83,7 @@ impl ViewBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `component_name` field will be set to `rerun.components.Visible`.
+    /// The corresponding component is [`crate::components::Visible`].
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
@@ -47,14 +47,7 @@ pub struct ViewBlueprint {
 impl ViewBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::class_identifier`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
-    ///    component_name: "rerun.blueprint.components.ViewClass",
-    ///    archetype_field_name: "class_identifier",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ViewClass`.
     #[inline]
     pub fn descriptor_class_identifier() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -66,14 +59,7 @@ impl ViewBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::display_name`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
-    ///    component_name: "rerun.components.Name",
-    ///    archetype_field_name: "display_name",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Name`.
     #[inline]
     pub fn descriptor_display_name() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -85,14 +71,7 @@ impl ViewBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::space_origin`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
-    ///    component_name: "rerun.blueprint.components.ViewOrigin",
-    ///    archetype_field_name: "space_origin",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ViewOrigin`.
     #[inline]
     pub fn descriptor_space_origin() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -104,14 +83,7 @@ impl ViewBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::visible`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewBlueprint",
-    ///    component_name: "rerun.components.Visible",
-    ///    archetype_field_name: "visible",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.Visible`.
     #[inline]
     pub fn descriptor_visible() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
@@ -69,14 +69,7 @@ pub struct ViewContents {
 impl ViewContents {
     /// Returns the [`ComponentDescriptor`] for [`Self::query`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewContents",
-    ///    component_name: "rerun.blueprint.components.QueryExpression",
-    ///    archetype_field_name: "query",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.QueryExpression`.
     #[inline]
     pub fn descriptor_query() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
@@ -69,7 +69,7 @@ pub struct ViewContents {
 impl ViewContents {
     /// Returns the [`ComponentDescriptor`] for [`Self::query`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.QueryExpression`.
+    /// The corresponding component is [`crate::blueprint::components::QueryExpression`].
     #[inline]
     pub fn descriptor_query() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
@@ -68,6 +68,15 @@ pub struct ViewContents {
 
 impl ViewContents {
     /// Returns the [`ComponentDescriptor`] for [`Self::query`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewContents",
+    ///    component_name: "rerun.blueprint.components.QueryExpression",
+    ///    archetype_field_name: "query",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_query() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
@@ -53,6 +53,15 @@ pub struct ViewportBlueprint {
 
 impl ViewportBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::root_container`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
+    ///    component_name: "rerun.blueprint.components.RootContainer",
+    ///    archetype_field_name: "root_container",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_root_container() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -63,6 +72,15 @@ impl ViewportBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::maximized`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
+    ///    component_name: "rerun.blueprint.components.ViewMaximized",
+    ///    archetype_field_name: "maximized",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_maximized() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -73,6 +91,15 @@ impl ViewportBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::auto_layout`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
+    ///    component_name: "rerun.blueprint.components.AutoLayout",
+    ///    archetype_field_name: "auto_layout",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_auto_layout() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -83,6 +110,15 @@ impl ViewportBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::auto_views`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
+    ///    component_name: "rerun.blueprint.components.AutoViews",
+    ///    archetype_field_name: "auto_views",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_auto_views() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -93,6 +129,15 @@ impl ViewportBlueprint {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::past_viewer_recommendations`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
+    ///    component_name: "rerun.blueprint.components.ViewerRecommendationHash",
+    ///    archetype_field_name: "past_viewer_recommendations",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_past_viewer_recommendations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
@@ -54,14 +54,7 @@ pub struct ViewportBlueprint {
 impl ViewportBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::root_container`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
-    ///    component_name: "rerun.blueprint.components.RootContainer",
-    ///    archetype_field_name: "root_container",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.RootContainer`.
     #[inline]
     pub fn descriptor_root_container() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -73,14 +66,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::maximized`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
-    ///    component_name: "rerun.blueprint.components.ViewMaximized",
-    ///    archetype_field_name: "maximized",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ViewMaximized`.
     #[inline]
     pub fn descriptor_maximized() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,14 +78,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::auto_layout`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
-    ///    component_name: "rerun.blueprint.components.AutoLayout",
-    ///    archetype_field_name: "auto_layout",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.AutoLayout`.
     #[inline]
     pub fn descriptor_auto_layout() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -111,14 +90,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::auto_views`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
-    ///    component_name: "rerun.blueprint.components.AutoViews",
-    ///    archetype_field_name: "auto_views",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.AutoViews`.
     #[inline]
     pub fn descriptor_auto_views() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -130,14 +102,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::past_viewer_recommendations`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.ViewportBlueprint",
-    ///    component_name: "rerun.blueprint.components.ViewerRecommendationHash",
-    ///    archetype_field_name: "past_viewer_recommendations",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.ViewerRecommendationHash`.
     #[inline]
     pub fn descriptor_past_viewer_recommendations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
@@ -54,7 +54,7 @@ pub struct ViewportBlueprint {
 impl ViewportBlueprint {
     /// Returns the [`ComponentDescriptor`] for [`Self::root_container`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.RootContainer`.
+    /// The corresponding component is [`crate::blueprint::components::RootContainer`].
     #[inline]
     pub fn descriptor_root_container() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -66,7 +66,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::maximized`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ViewMaximized`.
+    /// The corresponding component is [`crate::blueprint::components::ViewMaximized`].
     #[inline]
     pub fn descriptor_maximized() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -78,7 +78,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::auto_layout`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.AutoLayout`.
+    /// The corresponding component is [`crate::blueprint::components::AutoLayout`].
     #[inline]
     pub fn descriptor_auto_layout() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -90,7 +90,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::auto_views`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.AutoViews`.
+    /// The corresponding component is [`crate::blueprint::components::AutoViews`].
     #[inline]
     pub fn descriptor_auto_views() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,7 +102,7 @@ impl ViewportBlueprint {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::past_viewer_recommendations`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.ViewerRecommendationHash`.
+    /// The corresponding component is [`crate::blueprint::components::ViewerRecommendationHash`].
     #[inline]
     pub fn descriptor_past_viewer_recommendations() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -40,14 +40,7 @@ pub struct VisibleTimeRanges {
 impl VisibleTimeRanges {
     /// Returns the [`ComponentDescriptor`] for [`Self::ranges`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.VisibleTimeRanges",
-    ///    component_name: "rerun.blueprint.components.VisibleTimeRange",
-    ///    archetype_field_name: "ranges",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.VisibleTimeRange`.
     #[inline]
     pub fn descriptor_ranges() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -39,6 +39,15 @@ pub struct VisibleTimeRanges {
 
 impl VisibleTimeRanges {
     /// Returns the [`ComponentDescriptor`] for [`Self::ranges`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.VisibleTimeRanges",
+    ///    component_name: "rerun.blueprint.components.VisibleTimeRange",
+    ///    archetype_field_name: "ranges",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_ranges() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -40,7 +40,7 @@ pub struct VisibleTimeRanges {
 impl VisibleTimeRanges {
     /// Returns the [`ComponentDescriptor`] for [`Self::ranges`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.VisibleTimeRange`.
+    /// The corresponding component is [`crate::blueprint::components::VisibleTimeRange`].
     #[inline]
     pub fn descriptor_ranges() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -37,6 +37,15 @@ pub struct VisualBounds2D {
 
 impl VisualBounds2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::range`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.VisualBounds2D",
+    ///    component_name: "rerun.blueprint.components.VisualBounds2D",
+    ///    archetype_field_name: "range",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_range() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -38,14 +38,7 @@ pub struct VisualBounds2D {
 impl VisualBounds2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::range`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.VisualBounds2D",
-    ///    component_name: "rerun.blueprint.components.VisualBounds2D",
-    ///    archetype_field_name: "range",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.VisualBounds2D`.
     #[inline]
     pub fn descriptor_range() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -38,7 +38,7 @@ pub struct VisualBounds2D {
 impl VisualBounds2D {
     /// Returns the [`ComponentDescriptor`] for [`Self::range`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.VisualBounds2D`.
+    /// The corresponding component is [`crate::blueprint::components::VisualBounds2D`].
     #[inline]
     pub fn descriptor_range() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
@@ -39,7 +39,7 @@ pub struct VisualizerOverrides {
 impl VisualizerOverrides {
     /// Returns the [`ComponentDescriptor`] for [`Self::ranges`].
     ///
-    /// The `component_name` field will be set to `rerun.blueprint.components.VisualizerOverride`.
+    /// The corresponding component is [`crate::blueprint::components::VisualizerOverride`].
     #[inline]
     pub fn descriptor_ranges() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
@@ -39,14 +39,7 @@ pub struct VisualizerOverrides {
 impl VisualizerOverrides {
     /// Returns the [`ComponentDescriptor`] for [`Self::ranges`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.blueprint.archetypes.VisualizerOverrides",
-    ///    component_name: "rerun.blueprint.components.VisualizerOverride",
-    ///    archetype_field_name: "ranges",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.blueprint.components.VisualizerOverride`.
     #[inline]
     pub fn descriptor_ranges() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
@@ -38,6 +38,15 @@ pub struct VisualizerOverrides {
 
 impl VisualizerOverrides {
     /// Returns the [`ComponentDescriptor`] for [`Self::ranges`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.blueprint.archetypes.VisualizerOverrides",
+    ///    component_name: "rerun.blueprint.components.VisualizerOverride",
+    ///    archetype_field_name: "ranges",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_ranges() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -46,6 +46,15 @@ pub struct AffixFuzzer1 {
 
 impl AffixFuzzer1 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1001`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer1",
+    ///    archetype_field_name: "fuzz1001",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1001() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -56,6 +65,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1002`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer2",
+    ///    archetype_field_name: "fuzz1002",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1002() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -66,6 +84,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1003`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer3",
+    ///    archetype_field_name: "fuzz1003",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1003() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -76,6 +103,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1004`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer4",
+    ///    archetype_field_name: "fuzz1004",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1004() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -86,6 +122,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1005`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer5",
+    ///    archetype_field_name: "fuzz1005",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1005() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -96,6 +141,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1006`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer6",
+    ///    archetype_field_name: "fuzz1006",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1006() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -106,6 +160,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1007`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer7",
+    ///    archetype_field_name: "fuzz1007",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1007() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -116,6 +179,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1008`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer8",
+    ///    archetype_field_name: "fuzz1008",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1008() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -126,6 +198,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1009`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer9",
+    ///    archetype_field_name: "fuzz1009",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1009() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -136,6 +217,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1010`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer10",
+    ///    archetype_field_name: "fuzz1010",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1010() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -146,6 +236,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1011`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer11",
+    ///    archetype_field_name: "fuzz1011",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1011() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -156,6 +255,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1012`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer12",
+    ///    archetype_field_name: "fuzz1012",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1012() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -166,6 +274,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1013`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer13",
+    ///    archetype_field_name: "fuzz1013",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1013() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,6 +293,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1014`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer14",
+    ///    archetype_field_name: "fuzz1014",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1014() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -186,6 +312,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1015`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer15",
+    ///    archetype_field_name: "fuzz1015",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1015() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -196,6 +331,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1016`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer16",
+    ///    archetype_field_name: "fuzz1016",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1016() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -206,6 +350,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1017`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer17",
+    ///    archetype_field_name: "fuzz1017",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1017() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -216,6 +369,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1018`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer18",
+    ///    archetype_field_name: "fuzz1018",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1018() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -226,6 +388,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1019`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer19",
+    ///    archetype_field_name: "fuzz1019",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1019() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -236,6 +407,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1020`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer20",
+    ///    archetype_field_name: "fuzz1020",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1020() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -246,6 +426,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1021`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer21",
+    ///    archetype_field_name: "fuzz1021",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1021() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -256,6 +445,15 @@ impl AffixFuzzer1 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1022`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
+    ///    component_name: "rerun.testing.components.AffixFuzzer22",
+    ///    archetype_field_name: "fuzz1022",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1022() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -47,7 +47,7 @@ pub struct AffixFuzzer1 {
 impl AffixFuzzer1 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1001`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer1`].
     #[inline]
     pub fn descriptor_fuzz1001() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -59,7 +59,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1002`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer2`].
     #[inline]
     pub fn descriptor_fuzz1002() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -71,7 +71,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1003`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer3`].
     #[inline]
     pub fn descriptor_fuzz1003() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -83,7 +83,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1004`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer4`].
     #[inline]
     pub fn descriptor_fuzz1004() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -95,7 +95,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1005`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer5`].
     #[inline]
     pub fn descriptor_fuzz1005() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -107,7 +107,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1006`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer6`].
     #[inline]
     pub fn descriptor_fuzz1006() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -119,7 +119,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1007`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer7`].
     #[inline]
     pub fn descriptor_fuzz1007() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -131,7 +131,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1008`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer8`].
     #[inline]
     pub fn descriptor_fuzz1008() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -143,7 +143,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1009`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer9`].
     #[inline]
     pub fn descriptor_fuzz1009() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -155,7 +155,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1010`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer10`].
     #[inline]
     pub fn descriptor_fuzz1010() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -167,7 +167,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1011`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer11`].
     #[inline]
     pub fn descriptor_fuzz1011() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -179,7 +179,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1012`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer12`].
     #[inline]
     pub fn descriptor_fuzz1012() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -191,7 +191,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1013`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer13`].
     #[inline]
     pub fn descriptor_fuzz1013() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -203,7 +203,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1014`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer14`].
     #[inline]
     pub fn descriptor_fuzz1014() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -215,7 +215,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1015`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer15`].
     #[inline]
     pub fn descriptor_fuzz1015() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -227,7 +227,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1016`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer16`].
     #[inline]
     pub fn descriptor_fuzz1016() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -239,7 +239,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1017`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer17`].
     #[inline]
     pub fn descriptor_fuzz1017() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -251,7 +251,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1018`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer18`].
     #[inline]
     pub fn descriptor_fuzz1018() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -263,7 +263,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1019`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer19`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer19`].
     #[inline]
     pub fn descriptor_fuzz1019() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -275,7 +275,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1020`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer20`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer20`].
     #[inline]
     pub fn descriptor_fuzz1020() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -287,7 +287,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1021`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer21`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer21`].
     #[inline]
     pub fn descriptor_fuzz1021() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -299,7 +299,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1022`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer22`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer22`].
     #[inline]
     pub fn descriptor_fuzz1022() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -47,14 +47,7 @@ pub struct AffixFuzzer1 {
 impl AffixFuzzer1 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1001`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer1",
-    ///    archetype_field_name: "fuzz1001",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
     #[inline]
     pub fn descriptor_fuzz1001() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -66,14 +59,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1002`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer2",
-    ///    archetype_field_name: "fuzz1002",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
     #[inline]
     pub fn descriptor_fuzz1002() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -85,14 +71,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1003`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer3",
-    ///    archetype_field_name: "fuzz1003",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
     #[inline]
     pub fn descriptor_fuzz1003() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -104,14 +83,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1004`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer4",
-    ///    archetype_field_name: "fuzz1004",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
     #[inline]
     pub fn descriptor_fuzz1004() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -123,14 +95,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1005`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer5",
-    ///    archetype_field_name: "fuzz1005",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
     #[inline]
     pub fn descriptor_fuzz1005() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -142,14 +107,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1006`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer6",
-    ///    archetype_field_name: "fuzz1006",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
     #[inline]
     pub fn descriptor_fuzz1006() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -161,14 +119,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1007`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer7",
-    ///    archetype_field_name: "fuzz1007",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
     #[inline]
     pub fn descriptor_fuzz1007() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -180,14 +131,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1008`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer8",
-    ///    archetype_field_name: "fuzz1008",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
     #[inline]
     pub fn descriptor_fuzz1008() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -199,14 +143,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1009`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer9",
-    ///    archetype_field_name: "fuzz1009",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
     #[inline]
     pub fn descriptor_fuzz1009() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -218,14 +155,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1010`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer10",
-    ///    archetype_field_name: "fuzz1010",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
     #[inline]
     pub fn descriptor_fuzz1010() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -237,14 +167,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1011`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer11",
-    ///    archetype_field_name: "fuzz1011",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
     #[inline]
     pub fn descriptor_fuzz1011() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -256,14 +179,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1012`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer12",
-    ///    archetype_field_name: "fuzz1012",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
     #[inline]
     pub fn descriptor_fuzz1012() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -275,14 +191,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1013`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer13",
-    ///    archetype_field_name: "fuzz1013",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
     #[inline]
     pub fn descriptor_fuzz1013() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -294,14 +203,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1014`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer14",
-    ///    archetype_field_name: "fuzz1014",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
     #[inline]
     pub fn descriptor_fuzz1014() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -313,14 +215,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1015`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer15",
-    ///    archetype_field_name: "fuzz1015",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
     #[inline]
     pub fn descriptor_fuzz1015() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -332,14 +227,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1016`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer16",
-    ///    archetype_field_name: "fuzz1016",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
     #[inline]
     pub fn descriptor_fuzz1016() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -351,14 +239,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1017`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer17",
-    ///    archetype_field_name: "fuzz1017",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
     #[inline]
     pub fn descriptor_fuzz1017() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -370,14 +251,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1018`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer18",
-    ///    archetype_field_name: "fuzz1018",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
     #[inline]
     pub fn descriptor_fuzz1018() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -389,14 +263,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1019`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer19",
-    ///    archetype_field_name: "fuzz1019",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer19`.
     #[inline]
     pub fn descriptor_fuzz1019() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -408,14 +275,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1020`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer20",
-    ///    archetype_field_name: "fuzz1020",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer20`.
     #[inline]
     pub fn descriptor_fuzz1020() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -427,14 +287,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1021`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer21",
-    ///    archetype_field_name: "fuzz1021",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer21`.
     #[inline]
     pub fn descriptor_fuzz1021() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -446,14 +299,7 @@ impl AffixFuzzer1 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1022`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer1",
-    ///    component_name: "rerun.testing.components.AffixFuzzer22",
-    ///    archetype_field_name: "fuzz1022",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer22`.
     #[inline]
     pub fn descriptor_fuzz1022() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -43,6 +43,15 @@ pub struct AffixFuzzer2 {
 
 impl AffixFuzzer2 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1101`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer1",
+    ///    archetype_field_name: "fuzz1101",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1101() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -53,6 +62,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1102`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer2",
+    ///    archetype_field_name: "fuzz1102",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1102() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -63,6 +81,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1103`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer3",
+    ///    archetype_field_name: "fuzz1103",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1103() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -73,6 +100,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1104`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer4",
+    ///    archetype_field_name: "fuzz1104",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1104() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -83,6 +119,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1105`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer5",
+    ///    archetype_field_name: "fuzz1105",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1105() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -93,6 +138,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1106`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer6",
+    ///    archetype_field_name: "fuzz1106",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1106() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -103,6 +157,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1107`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer7",
+    ///    archetype_field_name: "fuzz1107",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1107() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -113,6 +176,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1108`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer8",
+    ///    archetype_field_name: "fuzz1108",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1108() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -123,6 +195,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1109`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer9",
+    ///    archetype_field_name: "fuzz1109",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1109() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -133,6 +214,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1110`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer10",
+    ///    archetype_field_name: "fuzz1110",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1110() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -143,6 +233,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1111`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer11",
+    ///    archetype_field_name: "fuzz1111",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1111() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -153,6 +252,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1112`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer12",
+    ///    archetype_field_name: "fuzz1112",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1112() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -163,6 +271,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1113`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer13",
+    ///    archetype_field_name: "fuzz1113",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1113() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -173,6 +290,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1114`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer14",
+    ///    archetype_field_name: "fuzz1114",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1114() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -183,6 +309,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1115`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer15",
+    ///    archetype_field_name: "fuzz1115",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1115() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -193,6 +328,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1116`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer16",
+    ///    archetype_field_name: "fuzz1116",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1116() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -203,6 +347,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1117`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer17",
+    ///    archetype_field_name: "fuzz1117",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1117() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -213,6 +366,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1118`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer18",
+    ///    archetype_field_name: "fuzz1118",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1118() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -223,6 +385,15 @@ impl AffixFuzzer2 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1122`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
+    ///    component_name: "rerun.testing.components.AffixFuzzer22",
+    ///    archetype_field_name: "fuzz1122",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz1122() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -44,14 +44,7 @@ pub struct AffixFuzzer2 {
 impl AffixFuzzer2 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1101`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer1",
-    ///    archetype_field_name: "fuzz1101",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
     #[inline]
     pub fn descriptor_fuzz1101() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -63,14 +56,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1102`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer2",
-    ///    archetype_field_name: "fuzz1102",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
     #[inline]
     pub fn descriptor_fuzz1102() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -82,14 +68,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1103`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer3",
-    ///    archetype_field_name: "fuzz1103",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
     #[inline]
     pub fn descriptor_fuzz1103() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -101,14 +80,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1104`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer4",
-    ///    archetype_field_name: "fuzz1104",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
     #[inline]
     pub fn descriptor_fuzz1104() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -120,14 +92,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1105`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer5",
-    ///    archetype_field_name: "fuzz1105",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
     #[inline]
     pub fn descriptor_fuzz1105() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -139,14 +104,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1106`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer6",
-    ///    archetype_field_name: "fuzz1106",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
     #[inline]
     pub fn descriptor_fuzz1106() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -158,14 +116,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1107`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer7",
-    ///    archetype_field_name: "fuzz1107",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
     #[inline]
     pub fn descriptor_fuzz1107() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -177,14 +128,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1108`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer8",
-    ///    archetype_field_name: "fuzz1108",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
     #[inline]
     pub fn descriptor_fuzz1108() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -196,14 +140,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1109`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer9",
-    ///    archetype_field_name: "fuzz1109",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
     #[inline]
     pub fn descriptor_fuzz1109() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -215,14 +152,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1110`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer10",
-    ///    archetype_field_name: "fuzz1110",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
     #[inline]
     pub fn descriptor_fuzz1110() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -234,14 +164,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1111`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer11",
-    ///    archetype_field_name: "fuzz1111",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
     #[inline]
     pub fn descriptor_fuzz1111() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -253,14 +176,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1112`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer12",
-    ///    archetype_field_name: "fuzz1112",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
     #[inline]
     pub fn descriptor_fuzz1112() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -272,14 +188,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1113`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer13",
-    ///    archetype_field_name: "fuzz1113",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
     #[inline]
     pub fn descriptor_fuzz1113() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -291,14 +200,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1114`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer14",
-    ///    archetype_field_name: "fuzz1114",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
     #[inline]
     pub fn descriptor_fuzz1114() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -310,14 +212,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1115`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer15",
-    ///    archetype_field_name: "fuzz1115",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
     #[inline]
     pub fn descriptor_fuzz1115() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -329,14 +224,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1116`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer16",
-    ///    archetype_field_name: "fuzz1116",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
     #[inline]
     pub fn descriptor_fuzz1116() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -348,14 +236,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1117`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer17",
-    ///    archetype_field_name: "fuzz1117",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
     #[inline]
     pub fn descriptor_fuzz1117() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -367,14 +248,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1118`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer18",
-    ///    archetype_field_name: "fuzz1118",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
     #[inline]
     pub fn descriptor_fuzz1118() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -386,14 +260,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1122`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer2",
-    ///    component_name: "rerun.testing.components.AffixFuzzer22",
-    ///    archetype_field_name: "fuzz1122",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer22`.
     #[inline]
     pub fn descriptor_fuzz1122() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -44,7 +44,7 @@ pub struct AffixFuzzer2 {
 impl AffixFuzzer2 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1101`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer1`].
     #[inline]
     pub fn descriptor_fuzz1101() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -56,7 +56,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1102`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer2`].
     #[inline]
     pub fn descriptor_fuzz1102() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -68,7 +68,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1103`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer3`].
     #[inline]
     pub fn descriptor_fuzz1103() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -80,7 +80,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1104`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer4`].
     #[inline]
     pub fn descriptor_fuzz1104() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,7 +92,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1105`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer5`].
     #[inline]
     pub fn descriptor_fuzz1105() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -104,7 +104,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1106`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer6`].
     #[inline]
     pub fn descriptor_fuzz1106() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -116,7 +116,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1107`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer7`].
     #[inline]
     pub fn descriptor_fuzz1107() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -128,7 +128,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1108`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer8`].
     #[inline]
     pub fn descriptor_fuzz1108() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -140,7 +140,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1109`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer9`].
     #[inline]
     pub fn descriptor_fuzz1109() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,7 +152,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1110`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer10`].
     #[inline]
     pub fn descriptor_fuzz1110() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -164,7 +164,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1111`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer11`].
     #[inline]
     pub fn descriptor_fuzz1111() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,7 +176,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1112`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer12`].
     #[inline]
     pub fn descriptor_fuzz1112() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -188,7 +188,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1113`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer13`].
     #[inline]
     pub fn descriptor_fuzz1113() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -200,7 +200,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1114`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer14`].
     #[inline]
     pub fn descriptor_fuzz1114() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -212,7 +212,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1115`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer15`].
     #[inline]
     pub fn descriptor_fuzz1115() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -224,7 +224,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1116`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer16`].
     #[inline]
     pub fn descriptor_fuzz1116() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -236,7 +236,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1117`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer17`].
     #[inline]
     pub fn descriptor_fuzz1117() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -248,7 +248,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1118`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer18`].
     #[inline]
     pub fn descriptor_fuzz1118() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -260,7 +260,7 @@ impl AffixFuzzer2 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz1122`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer22`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer22`].
     #[inline]
     pub fn descriptor_fuzz1122() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -43,14 +43,7 @@ pub struct AffixFuzzer3 {
 impl AffixFuzzer3 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2001`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer1",
-    ///    archetype_field_name: "fuzz2001",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
     #[inline]
     pub fn descriptor_fuzz2001() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -62,14 +55,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2002`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer2",
-    ///    archetype_field_name: "fuzz2002",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
     #[inline]
     pub fn descriptor_fuzz2002() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -81,14 +67,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2003`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer3",
-    ///    archetype_field_name: "fuzz2003",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
     #[inline]
     pub fn descriptor_fuzz2003() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -100,14 +79,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2004`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer4",
-    ///    archetype_field_name: "fuzz2004",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
     #[inline]
     pub fn descriptor_fuzz2004() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -119,14 +91,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2005`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer5",
-    ///    archetype_field_name: "fuzz2005",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
     #[inline]
     pub fn descriptor_fuzz2005() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -138,14 +103,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2006`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer6",
-    ///    archetype_field_name: "fuzz2006",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
     #[inline]
     pub fn descriptor_fuzz2006() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,14 +115,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2007`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer7",
-    ///    archetype_field_name: "fuzz2007",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
     #[inline]
     pub fn descriptor_fuzz2007() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,14 +127,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2008`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer8",
-    ///    archetype_field_name: "fuzz2008",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
     #[inline]
     pub fn descriptor_fuzz2008() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -195,14 +139,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2009`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer9",
-    ///    archetype_field_name: "fuzz2009",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
     #[inline]
     pub fn descriptor_fuzz2009() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -214,14 +151,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2010`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer10",
-    ///    archetype_field_name: "fuzz2010",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
     #[inline]
     pub fn descriptor_fuzz2010() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -233,14 +163,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2011`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer11",
-    ///    archetype_field_name: "fuzz2011",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
     #[inline]
     pub fn descriptor_fuzz2011() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -252,14 +175,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2012`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer12",
-    ///    archetype_field_name: "fuzz2012",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
     #[inline]
     pub fn descriptor_fuzz2012() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -271,14 +187,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2013`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer13",
-    ///    archetype_field_name: "fuzz2013",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
     #[inline]
     pub fn descriptor_fuzz2013() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -290,14 +199,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2014`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer14",
-    ///    archetype_field_name: "fuzz2014",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
     #[inline]
     pub fn descriptor_fuzz2014() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -309,14 +211,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2015`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer15",
-    ///    archetype_field_name: "fuzz2015",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
     #[inline]
     pub fn descriptor_fuzz2015() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -328,14 +223,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2016`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer16",
-    ///    archetype_field_name: "fuzz2016",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
     #[inline]
     pub fn descriptor_fuzz2016() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -347,14 +235,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2017`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer17",
-    ///    archetype_field_name: "fuzz2017",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
     #[inline]
     pub fn descriptor_fuzz2017() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -366,14 +247,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2018`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
-    ///    component_name: "rerun.testing.components.AffixFuzzer18",
-    ///    archetype_field_name: "fuzz2018",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
     #[inline]
     pub fn descriptor_fuzz2018() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -42,6 +42,15 @@ pub struct AffixFuzzer3 {
 
 impl AffixFuzzer3 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2001`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer1",
+    ///    archetype_field_name: "fuzz2001",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2001() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,6 +61,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2002`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer2",
+    ///    archetype_field_name: "fuzz2002",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2002() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -62,6 +80,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2003`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer3",
+    ///    archetype_field_name: "fuzz2003",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2003() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -72,6 +99,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2004`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer4",
+    ///    archetype_field_name: "fuzz2004",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2004() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -82,6 +118,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2005`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer5",
+    ///    archetype_field_name: "fuzz2005",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2005() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,6 +137,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2006`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer6",
+    ///    archetype_field_name: "fuzz2006",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2006() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,6 +156,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2007`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer7",
+    ///    archetype_field_name: "fuzz2007",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2007() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -112,6 +175,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2008`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer8",
+    ///    archetype_field_name: "fuzz2008",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2008() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,6 +194,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2009`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer9",
+    ///    archetype_field_name: "fuzz2009",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2009() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -132,6 +213,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2010`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer10",
+    ///    archetype_field_name: "fuzz2010",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2010() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -142,6 +232,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2011`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer11",
+    ///    archetype_field_name: "fuzz2011",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2011() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,6 +251,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2012`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer12",
+    ///    archetype_field_name: "fuzz2012",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2012() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -162,6 +270,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2013`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer13",
+    ///    archetype_field_name: "fuzz2013",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2013() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -172,6 +289,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2014`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer14",
+    ///    archetype_field_name: "fuzz2014",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2014() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -182,6 +308,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2015`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer15",
+    ///    archetype_field_name: "fuzz2015",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2015() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -192,6 +327,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2016`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer16",
+    ///    archetype_field_name: "fuzz2016",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2016() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -202,6 +346,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2017`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer17",
+    ///    archetype_field_name: "fuzz2017",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2017() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -212,6 +365,15 @@ impl AffixFuzzer3 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2018`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer3",
+    ///    component_name: "rerun.testing.components.AffixFuzzer18",
+    ///    archetype_field_name: "fuzz2018",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2018() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -43,7 +43,7 @@ pub struct AffixFuzzer3 {
 impl AffixFuzzer3 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2001`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer1`].
     #[inline]
     pub fn descriptor_fuzz2001() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -55,7 +55,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2002`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer2`].
     #[inline]
     pub fn descriptor_fuzz2002() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -67,7 +67,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2003`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer3`].
     #[inline]
     pub fn descriptor_fuzz2003() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -79,7 +79,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2004`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer4`].
     #[inline]
     pub fn descriptor_fuzz2004() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -91,7 +91,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2005`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer5`].
     #[inline]
     pub fn descriptor_fuzz2005() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -103,7 +103,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2006`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer6`].
     #[inline]
     pub fn descriptor_fuzz2006() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -115,7 +115,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2007`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer7`].
     #[inline]
     pub fn descriptor_fuzz2007() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -127,7 +127,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2008`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer8`].
     #[inline]
     pub fn descriptor_fuzz2008() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -139,7 +139,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2009`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer9`].
     #[inline]
     pub fn descriptor_fuzz2009() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -151,7 +151,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2010`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer10`].
     #[inline]
     pub fn descriptor_fuzz2010() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -163,7 +163,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2011`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer11`].
     #[inline]
     pub fn descriptor_fuzz2011() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -175,7 +175,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2012`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer12`].
     #[inline]
     pub fn descriptor_fuzz2012() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -187,7 +187,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2013`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer13`].
     #[inline]
     pub fn descriptor_fuzz2013() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -199,7 +199,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2014`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer14`].
     #[inline]
     pub fn descriptor_fuzz2014() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -211,7 +211,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2015`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer15`].
     #[inline]
     pub fn descriptor_fuzz2015() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -223,7 +223,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2016`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer16`].
     #[inline]
     pub fn descriptor_fuzz2016() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -235,7 +235,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2017`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer17`].
     #[inline]
     pub fn descriptor_fuzz2017() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -247,7 +247,7 @@ impl AffixFuzzer3 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2018`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer18`].
     #[inline]
     pub fn descriptor_fuzz2018() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -43,14 +43,7 @@ pub struct AffixFuzzer4 {
 impl AffixFuzzer4 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2101`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer1",
-    ///    archetype_field_name: "fuzz2101",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
     #[inline]
     pub fn descriptor_fuzz2101() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -62,14 +55,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2102`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer2",
-    ///    archetype_field_name: "fuzz2102",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
     #[inline]
     pub fn descriptor_fuzz2102() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -81,14 +67,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2103`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer3",
-    ///    archetype_field_name: "fuzz2103",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
     #[inline]
     pub fn descriptor_fuzz2103() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -100,14 +79,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2104`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer4",
-    ///    archetype_field_name: "fuzz2104",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
     #[inline]
     pub fn descriptor_fuzz2104() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -119,14 +91,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2105`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer5",
-    ///    archetype_field_name: "fuzz2105",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
     #[inline]
     pub fn descriptor_fuzz2105() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -138,14 +103,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2106`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer6",
-    ///    archetype_field_name: "fuzz2106",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
     #[inline]
     pub fn descriptor_fuzz2106() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -157,14 +115,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2107`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer7",
-    ///    archetype_field_name: "fuzz2107",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
     #[inline]
     pub fn descriptor_fuzz2107() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -176,14 +127,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2108`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer8",
-    ///    archetype_field_name: "fuzz2108",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
     #[inline]
     pub fn descriptor_fuzz2108() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -195,14 +139,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2109`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer9",
-    ///    archetype_field_name: "fuzz2109",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
     #[inline]
     pub fn descriptor_fuzz2109() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -214,14 +151,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2110`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer10",
-    ///    archetype_field_name: "fuzz2110",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
     #[inline]
     pub fn descriptor_fuzz2110() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -233,14 +163,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2111`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer11",
-    ///    archetype_field_name: "fuzz2111",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
     #[inline]
     pub fn descriptor_fuzz2111() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -252,14 +175,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2112`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer12",
-    ///    archetype_field_name: "fuzz2112",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
     #[inline]
     pub fn descriptor_fuzz2112() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -271,14 +187,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2113`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer13",
-    ///    archetype_field_name: "fuzz2113",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
     #[inline]
     pub fn descriptor_fuzz2113() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -290,14 +199,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2114`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer14",
-    ///    archetype_field_name: "fuzz2114",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
     #[inline]
     pub fn descriptor_fuzz2114() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -309,14 +211,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2115`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer15",
-    ///    archetype_field_name: "fuzz2115",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
     #[inline]
     pub fn descriptor_fuzz2115() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -328,14 +223,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2116`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer16",
-    ///    archetype_field_name: "fuzz2116",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
     #[inline]
     pub fn descriptor_fuzz2116() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -347,14 +235,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2117`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer17",
-    ///    archetype_field_name: "fuzz2117",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
     #[inline]
     pub fn descriptor_fuzz2117() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -366,14 +247,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2118`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
-    ///    component_name: "rerun.testing.components.AffixFuzzer18",
-    ///    archetype_field_name: "fuzz2118",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
     #[inline]
     pub fn descriptor_fuzz2118() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -43,7 +43,7 @@ pub struct AffixFuzzer4 {
 impl AffixFuzzer4 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2101`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer1`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer1`].
     #[inline]
     pub fn descriptor_fuzz2101() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -55,7 +55,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2102`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer2`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer2`].
     #[inline]
     pub fn descriptor_fuzz2102() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -67,7 +67,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2103`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer3`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer3`].
     #[inline]
     pub fn descriptor_fuzz2103() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -79,7 +79,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2104`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer4`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer4`].
     #[inline]
     pub fn descriptor_fuzz2104() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -91,7 +91,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2105`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer5`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer5`].
     #[inline]
     pub fn descriptor_fuzz2105() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -103,7 +103,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2106`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer6`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer6`].
     #[inline]
     pub fn descriptor_fuzz2106() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -115,7 +115,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2107`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer7`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer7`].
     #[inline]
     pub fn descriptor_fuzz2107() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -127,7 +127,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2108`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer8`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer8`].
     #[inline]
     pub fn descriptor_fuzz2108() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -139,7 +139,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2109`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer9`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer9`].
     #[inline]
     pub fn descriptor_fuzz2109() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -151,7 +151,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2110`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer10`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer10`].
     #[inline]
     pub fn descriptor_fuzz2110() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -163,7 +163,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2111`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer11`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer11`].
     #[inline]
     pub fn descriptor_fuzz2111() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -175,7 +175,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2112`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer12`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer12`].
     #[inline]
     pub fn descriptor_fuzz2112() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -187,7 +187,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2113`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer13`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer13`].
     #[inline]
     pub fn descriptor_fuzz2113() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -199,7 +199,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2114`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer14`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer14`].
     #[inline]
     pub fn descriptor_fuzz2114() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -211,7 +211,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2115`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer15`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer15`].
     #[inline]
     pub fn descriptor_fuzz2115() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -223,7 +223,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2116`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer16`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer16`].
     #[inline]
     pub fn descriptor_fuzz2116() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -235,7 +235,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2117`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer17`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer17`].
     #[inline]
     pub fn descriptor_fuzz2117() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -247,7 +247,7 @@ impl AffixFuzzer4 {
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2118`].
     ///
-    /// The `component_name` field will be set to `rerun.testing.components.AffixFuzzer18`.
+    /// The corresponding component is [`crate::testing::components::AffixFuzzer18`].
     #[inline]
     pub fn descriptor_fuzz2118() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -42,6 +42,15 @@ pub struct AffixFuzzer4 {
 
 impl AffixFuzzer4 {
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2101`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer1",
+    ///    archetype_field_name: "fuzz2101",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2101() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -52,6 +61,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2102`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer2",
+    ///    archetype_field_name: "fuzz2102",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2102() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -62,6 +80,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2103`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer3",
+    ///    archetype_field_name: "fuzz2103",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2103() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -72,6 +99,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2104`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer4",
+    ///    archetype_field_name: "fuzz2104",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2104() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -82,6 +118,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2105`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer5",
+    ///    archetype_field_name: "fuzz2105",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2105() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -92,6 +137,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2106`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer6",
+    ///    archetype_field_name: "fuzz2106",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2106() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -102,6 +156,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2107`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer7",
+    ///    archetype_field_name: "fuzz2107",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2107() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -112,6 +175,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2108`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer8",
+    ///    archetype_field_name: "fuzz2108",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2108() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -122,6 +194,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2109`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer9",
+    ///    archetype_field_name: "fuzz2109",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2109() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -132,6 +213,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2110`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer10",
+    ///    archetype_field_name: "fuzz2110",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2110() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -142,6 +232,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2111`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer11",
+    ///    archetype_field_name: "fuzz2111",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2111() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -152,6 +251,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2112`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer12",
+    ///    archetype_field_name: "fuzz2112",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2112() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -162,6 +270,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2113`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer13",
+    ///    archetype_field_name: "fuzz2113",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2113() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -172,6 +289,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2114`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer14",
+    ///    archetype_field_name: "fuzz2114",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2114() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -182,6 +308,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2115`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer15",
+    ///    archetype_field_name: "fuzz2115",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2115() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -192,6 +327,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2116`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer16",
+    ///    archetype_field_name: "fuzz2116",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2116() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -202,6 +346,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2117`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer17",
+    ///    archetype_field_name: "fuzz2117",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2117() -> ComponentDescriptor {
         ComponentDescriptor {
@@ -212,6 +365,15 @@ impl AffixFuzzer4 {
     }
 
     /// Returns the [`ComponentDescriptor`] for [`Self::fuzz2118`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.testing.archetypes.AffixFuzzer4",
+    ///    component_name: "rerun.testing.components.AffixFuzzer18",
+    ///    archetype_field_name: "fuzz2118",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_fuzz2118() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -81,7 +81,7 @@ pub struct Clear {
 impl Clear {
     /// Returns the [`ComponentDescriptor`] for [`Self::is_recursive`].
     ///
-    /// The `component_name` field will be set to `rerun.components.ClearIsRecursive`.
+    /// The corresponding component is [`crate::components::ClearIsRecursive`].
     #[inline]
     pub fn descriptor_is_recursive() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -81,14 +81,7 @@ pub struct Clear {
 impl Clear {
     /// Returns the [`ComponentDescriptor`] for [`Self::is_recursive`].
     ///
-    /// The `descriptor` will have the following fields:
-    /// ```
-    /// let descriptor = ComponentDescriptor {
-    ///    archetype_name: "rerun.archetypes.Clear",
-    ///    component_name: "rerun.components.ClearIsRecursive",
-    ///    archetype_field_name: "is_recursive",
-    /// };
-    /// ```
+    /// The `component_name` field will be set to `rerun.components.ClearIsRecursive`.
     #[inline]
     pub fn descriptor_is_recursive() -> ComponentDescriptor {
         ComponentDescriptor {

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -80,6 +80,15 @@ pub struct Clear {
 
 impl Clear {
     /// Returns the [`ComponentDescriptor`] for [`Self::is_recursive`].
+    ///
+    /// The `descriptor` will have the following fields:
+    /// ```
+    /// let descriptor = ComponentDescriptor {
+    ///    archetype_name: "rerun.archetypes.Clear",
+    ///    component_name: "rerun.components.ClearIsRecursive",
+    ///    archetype_field_name: "is_recursive",
+    /// };
+    /// ```
     #[inline]
     pub fn descriptor_is_recursive() -> ComponentDescriptor {
         ComponentDescriptor {


### PR DESCRIPTION
### Related

* Part of #6889.

### What

This is to prevent me from going insane and to limit the amount of bugs we introduce.

#### Rendered

<img width="1026" alt="image" src="https://github.com/user-attachments/assets/5ed77319-f841-4d02-9095-281dad6a879e" />


