### PR TITLE
Bump `ron` to 0.10.1 and enable the `integer128` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,7 +2818,7 @@ dependencies = [
  "pollster 0.4.0",
  "profiling",
  "raw-window-handle",
- "ron 0.10.1",
+ "ron",
  "serde",
  "static_assertions",
  "wasm-bindgen",
@@ -2845,7 +2845,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "profiling",
- "ron 0.10.1",
+ "ron",
  "serde",
  "unicode-segmentation",
 ]
@@ -8080,7 +8080,7 @@ dependencies = [
  "re_viewport",
  "re_viewport_blueprint",
  "rfd",
- "ron 0.8.1",
+ "ron",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -8586,18 +8586,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64 0.21.7",
- "bitflags 2.8.0",
- "serde",
- "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ rfd = { version = "0.15", default-features = false, features = [
   "async-std",
   "xdg-portal",
 ] }
-ron = "0.8.0"
+ron = { version = "0.10.1", features = ["integer128"] }
 roxmltree = "0.19.0"
 rust-format = "0.3"
 rustdoc-json = "0.9.4"


### PR DESCRIPTION
Title.

Bump is in sync with egui. Enabling the feature fix the issue where the viewer wasn't able to restore state.