### PR TITLE
Add draw order to video (-frame-reference), fix 2d objects sometimes being behind videos

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/boxes2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/boxes2d.fbs
@@ -47,8 +47,7 @@ table Boxes2D (
   /// An optional floating point value that specifies the 2D drawing order.
   ///
   /// Objects with higher values are drawn on top of those with lower values.
-  ///
-  /// The default for 2D boxes is 10.0.
+  /// Defaults to `10.0`.
   draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3100);
 
   /// Optional [components.ClassId]s for the boxes.

--- a/crates/store/re_types/definitions/rerun/archetypes/depth_image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/depth_image.fbs
@@ -67,5 +67,6 @@ table DepthImage (
   /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
   ///
   /// Objects with higher values are drawn on top of those with lower values.
+  /// Defaults to `-20.0`.
   draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3500);
 }

--- a/crates/store/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/image.fbs
@@ -50,5 +50,6 @@ table Image (
   /// An optional floating point value that specifies the 2D drawing order.
   ///
   /// Objects with higher values are drawn on top of those with lower values.
+  /// Defaults to `-10.0`.
   draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3100);
 }

--- a/crates/store/re_types/definitions/rerun/archetypes/line_strips2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/line_strips2d.fbs
@@ -41,6 +41,7 @@ table LineStrips2D (
   /// An optional floating point value that specifies the 2D drawing order of each line strip.
   ///
   /// Objects with higher values are drawn on top of those with lower values.
+  /// Defaults to `20.0`.
   draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3100);
 
   /// Optional [components.ClassId]s for the lines.

--- a/crates/store/re_types/definitions/rerun/archetypes/points2d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/points2d.fbs
@@ -45,6 +45,7 @@ table Points2D (
   /// An optional floating point value that specifies the 2D drawing order.
   ///
   /// Objects with higher values are drawn on top of those with lower values.
+  /// Defaults to `30.0`.
   draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3100);
 
   /// Optional class Ids for the points.

--- a/crates/store/re_types/definitions/rerun/archetypes/segmentation_image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/segmentation_image.fbs
@@ -39,5 +39,6 @@ table SegmentationImage (
   /// An optional floating point value that specifies the 2D drawing order.
   ///
   /// Objects with higher values are drawn on top of those with lower values.
+  /// Defaults to `0.0`.
   draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3100);
 }

--- a/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
@@ -38,4 +38,9 @@ table VideoFrameReference (
     /// at the beginning of the series and then rely on latest-at query semantics to
     /// keep the video reference active.
     video_reference: rerun.components.EntityPath ("attr.rerun.component_optional", nullable, order: 2000);
+
+    /// An optional floating point value that specifies the 2D drawing order.
+    ///
+    /// Objects with higher values are drawn on top of those with lower values.
+    draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 2100);
 }

--- a/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
@@ -42,5 +42,6 @@ table VideoFrameReference (
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `-15.0`.
     draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 2100);
 }

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -71,8 +71,7 @@ pub struct Boxes2D {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
-    ///
-    /// The default for 2D boxes is 10.0.
+    /// Defaults to `10.0`.
     pub draw_order: Option<SerializedComponentBatch>,
 
     /// Optional [`components::ClassId`][crate::components::ClassId]s for the boxes.
@@ -573,8 +572,7 @@ impl Boxes2D {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
-    ///
-    /// The default for 2D boxes is 10.0.
+    /// Defaults to `10.0`.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -112,6 +112,7 @@ pub struct DepthImage {
     /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `-20.0`.
     pub draw_order: Option<SerializedComponentBatch>,
 }
 
@@ -653,6 +654,7 @@ impl DepthImage {
     /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `-20.0`.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -147,6 +147,7 @@ pub struct Image {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `-10.0`.
     pub draw_order: Option<SerializedComponentBatch>,
 }
 
@@ -497,6 +498,7 @@ impl Image {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `-10.0`.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -109,6 +109,7 @@ pub struct LineStrips2D {
     /// An optional floating point value that specifies the 2D drawing order of each line strip.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `20.0`.
     pub draw_order: Option<SerializedComponentBatch>,
 
     /// Optional [`components::ClassId`][crate::components::ClassId]s for the lines.
@@ -568,6 +569,7 @@ impl LineStrips2D {
     /// An optional floating point value that specifies the 2D drawing order of each line strip.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `20.0`.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -122,6 +122,7 @@ pub struct Points2D {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `30.0`.
     pub draw_order: Option<SerializedComponentBatch>,
 
     /// Optional class Ids for the points.
@@ -624,6 +625,7 @@ impl Points2D {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `30.0`.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -81,6 +81,7 @@ pub struct SegmentationImage {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `0.0`.
     pub draw_order: Option<SerializedComponentBatch>,
 }
 
@@ -441,6 +442,7 @@ impl SegmentationImage {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `0.0`.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -148,6 +148,7 @@ pub struct VideoFrameReference {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `-15.0`.
     pub draw_order: Option<SerializedComponentBatch>,
 }
 
@@ -478,6 +479,7 @@ impl VideoFrameReference {
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
+    /// Defaults to `-15.0`.
     #[inline]
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = try_serialize_field(Self::descriptor_draw_order(), [draw_order]);

--- a/crates/store/re_types/src/components/draw_order_ext.rs
+++ b/crates/store/re_types/src/components/draw_order_ext.rs
@@ -9,6 +9,9 @@ impl DrawOrder {
     pub const DEFAULT_DEPTH_IMAGE: Self = Self(Float32(-20.0));
 
     /// Draw order used for images if no draw order was specified.
+    pub const DEFAULT_VIDEO_FRAME_REFERENCE: Self = Self(Float32(-15.0));
+
+    /// Draw order used for images if no draw order was specified.
     pub const DEFAULT_IMAGE: Self = Self(Float32(-10.0));
 
     /// Draw order used for segmentation images if no draw order was specified.

--- a/crates/store/re_types/src/reflection/mod.rs
+++ b/crates/store/re_types/src/reflection/mod.rs
@@ -2294,6 +2294,10 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     "video_reference".into(), display_name : "Video reference",
                     component_name : "rerun.components.EntityPath".into(), docstring_md :
                     "Optional reference to an entity with a [`archetypes.AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video).\n\nIf none is specified, the video is assumed to be at the same entity.\nNote that blueprint overrides on the referenced video will be ignored regardless,\nas this is always interpreted as a reference to the data store.\n\nFor a series of video frame references, it is recommended to specify this path only once\nat the beginning of the series and then rely on latest-at query semantics to\nkeep the video reference active.",
+                    is_required : false, }, ArchetypeFieldReflection { name :
+                    "draw_order".into(), display_name : "Draw order", component_name :
+                    "rerun.components.DrawOrder".into(), docstring_md :
+                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.",
                     is_required : false, },
                 ],
             },

--- a/crates/store/re_types/src/reflection/mod.rs
+++ b/crates/store/re_types/src/reflection/mod.rs
@@ -1345,7 +1345,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
-                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.\n\nThe default for 2D boxes is 10.0.",
+                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `10.0`.",
                     is_required : false, }, ArchetypeFieldReflection { name : "class_ids"
                     .into(), display_name : "Class ids", component_name :
                     "rerun.components.ClassId".into(), docstring_md :
@@ -1503,7 +1503,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
-                    "An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.\n\nObjects with higher values are drawn on top of those with lower values.",
+                    "An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `-20.0`.",
                     is_required : false, },
                 ],
             },
@@ -1710,7 +1710,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
-                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.",
+                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `-10.0`.",
                     is_required : false, },
                 ],
             },
@@ -1774,7 +1774,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
-                    "An optional floating point value that specifies the 2D drawing order of each line strip.\n\nObjects with higher values are drawn on top of those with lower values.",
+                    "An optional floating point value that specifies the 2D drawing order of each line strip.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `20.0`.",
                     is_required : false, }, ArchetypeFieldReflection { name : "class_ids"
                     .into(), display_name : "Class ids", component_name :
                     "rerun.components.ClassId".into(), docstring_md :
@@ -1928,7 +1928,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
-                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.",
+                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `30.0`.",
                     is_required : false, }, ArchetypeFieldReflection { name : "class_ids"
                     .into(), display_name : "Class ids", component_name :
                     "rerun.components.ClassId".into(), docstring_md :
@@ -2049,7 +2049,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
-                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.",
+                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `0.0`.",
                     is_required : false, },
                 ],
             },
@@ -2297,7 +2297,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
-                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.",
+                    "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `-15.0`.",
                     is_required : false, },
                 ],
             },

--- a/crates/viewer/re_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/mod.rs
@@ -154,6 +154,10 @@ pub fn visualizers_processing_draw_order()
             segmentation_images::SegmentationImageVisualizer::identifier(),
             archetypes::SegmentationImage::descriptor_draw_order(),
         ),
+        (
+            videos::VideoFrameReferenceVisualizer::identifier(),
+            archetypes::VideoFrameReference::descriptor_draw_order(),
+        ),
     ]
     .into_iter()
 }

--- a/crates/viewer/re_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/videos.rs
@@ -12,7 +12,7 @@ use re_renderer::{
 use re_types::{
     Archetype as _,
     archetypes::{AssetVideo, VideoFrameReference},
-    components::{Blob, MediaType, VideoTimestamp},
+    components::{self, Blob, MediaType, VideoTimestamp},
 };
 use re_viewer_context::{
     IdentifiedViewSystem, MaybeVisualizableEntities, TypedComponentFallbackProvider, VideoCache,
@@ -155,7 +155,11 @@ impl VideoFrameReferenceVisualizer {
         // Follow the reference to the video asset.
         let video_reference: EntityPath = video_references
             .and_then(|v| v.first().map(|e| e.as_str().into()))
-            .unwrap_or_else(|| self.fallback_for(ctx).as_str().into());
+            .unwrap_or_else(|| {
+                TypedComponentFallbackProvider::<components::EntityPath>::fallback_for(self, ctx)
+                    .as_str()
+                    .into()
+            });
         let query_result = latest_at_query_video_from_datastore(ctx.viewer_ctx, &video_reference);
 
         let world_from_entity = spatial_ctx
@@ -229,6 +233,7 @@ impl VideoFrameReferenceVisualizer {
                                     texture_filter_magnification: TextureFilterMag::Nearest,
                                     texture_filter_minification: TextureFilterMin::Linear,
                                     outline_mask: spatial_ctx.highlight.overall,
+                                    depth_offset: spatial_ctx.depth_offset,
                                     ..Default::default()
                                 },
                             };
@@ -411,15 +416,16 @@ fn latest_at_query_video_from_datastore(
     Some((video, blob))
 }
 
-impl TypedComponentFallbackProvider<re_types::components::EntityPath>
-    for VideoFrameReferenceVisualizer
-{
-    fn fallback_for(
-        &self,
-        ctx: &re_viewer_context::QueryContext<'_>,
-    ) -> re_types::components::EntityPath {
+impl TypedComponentFallbackProvider<components::EntityPath> for VideoFrameReferenceVisualizer {
+    fn fallback_for(&self, ctx: &re_viewer_context::QueryContext<'_>) -> components::EntityPath {
         ctx.target_entity_path.to_string().into()
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(VideoFrameReferenceVisualizer => [re_types::components::EntityPath]);
+impl TypedComponentFallbackProvider<components::DrawOrder> for VideoFrameReferenceVisualizer {
+    fn fallback_for(&self, _ctx: &re_viewer_context::QueryContext<'_>) -> components::DrawOrder {
+        components::DrawOrder::DEFAULT_VIDEO_FRAME_REFERENCE
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(VideoFrameReferenceVisualizer => [components::EntityPath, components::DrawOrder]);

--- a/docs/content/reference/types/archetypes/video_frame_reference.md
+++ b/docs/content/reference/types/archetypes/video_frame_reference.md
@@ -16,6 +16,7 @@ See <https://rerun.io/docs/reference/video> for details of what is and isn't sup
 
 ### Optional
 * `video_reference`: [`EntityPath`](../components/entity_path.md)
+* `draw_order`: [`DrawOrder`](../components/draw_order.md)
 
 
 ## Can be shown in

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -35,3 +35,4 @@ float32
 * [`LineStrips2D`](../archetypes/line_strips2d.md)
 * [`Points2D`](../archetypes/points2d.md)
 * [`SegmentationImage`](../archetypes/segmentation_image.md)
+* [`VideoFrameReference`](../archetypes/video_frame_reference.md)

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -65,8 +65,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
-        ///
-        /// The default for 2D boxes is 10.0.
+        /// Defaults to `10.0`.
         std::optional<ComponentBatch> draw_order;
 
         /// Optional `components::ClassId`s for the boxes.
@@ -234,8 +233,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
-        ///
-        /// The default for 2D boxes is 10.0.
+        /// Defaults to `10.0`.
         Boxes2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -120,6 +120,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `-20.0`.
         std::optional<ComponentBatch> draw_order;
 
       public:
@@ -372,6 +373,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `-20.0`.
         DepthImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -156,6 +156,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `-10.0`.
         std::optional<ComponentBatch> draw_order;
 
       public:
@@ -383,6 +384,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `-10.0`.
         Image with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -108,6 +108,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order of each line strip.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `20.0`.
         std::optional<ComponentBatch> draw_order;
 
         /// Optional `components::ClassId`s for the lines.
@@ -225,6 +226,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order of each line strip.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `20.0`.
         LineStrips2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -126,6 +126,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `30.0`.
         std::optional<ComponentBatch> draw_order;
 
         /// Optional class Ids for the points.
@@ -257,6 +258,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `30.0`.
         Points2D with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -86,6 +86,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `0.0`.
         std::optional<ComponentBatch> draw_order;
 
       public:
@@ -250,6 +251,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `0.0`.
         SegmentationImage with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.cpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.cpp
@@ -14,17 +14,23 @@ namespace rerun::archetypes {
         archetype.video_reference =
             ComponentBatch::empty<rerun::components::EntityPath>(Descriptor_video_reference)
                 .value_or_throw();
+        archetype.draw_order =
+            ComponentBatch::empty<rerun::components::DrawOrder>(Descriptor_draw_order)
+                .value_or_throw();
         return archetype;
     }
 
     Collection<ComponentColumn> VideoFrameReference::columns(const Collection<uint32_t>& lengths_) {
         std::vector<ComponentColumn> columns;
-        columns.reserve(3);
+        columns.reserve(4);
         if (timestamp.has_value()) {
             columns.push_back(timestamp.value().partitioned(lengths_).value_or_throw());
         }
         if (video_reference.has_value()) {
             columns.push_back(video_reference.value().partitioned(lengths_).value_or_throw());
+        }
+        if (draw_order.has_value()) {
+            columns.push_back(draw_order.value().partitioned(lengths_).value_or_throw());
         }
         columns.push_back(ComponentColumn::from_indicators<VideoFrameReference>(
                               static_cast<uint32_t>(lengths_.size())
@@ -40,6 +46,9 @@ namespace rerun::archetypes {
         if (video_reference.has_value()) {
             return columns(std::vector<uint32_t>(video_reference.value().length(), 1));
         }
+        if (draw_order.has_value()) {
+            return columns(std::vector<uint32_t>(draw_order.value().length(), 1));
+        }
         return Collection<ComponentColumn>();
     }
 } // namespace rerun::archetypes
@@ -51,13 +60,16 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<ComponentBatch> cells;
-        cells.reserve(3);
+        cells.reserve(4);
 
         if (archetype.timestamp.has_value()) {
             cells.push_back(archetype.timestamp.value());
         }
         if (archetype.video_reference.has_value()) {
             cells.push_back(archetype.video_reference.value());
+        }
+        if (archetype.draw_order.has_value()) {
+            cells.push_back(archetype.draw_order.value());
         }
         {
             auto result = ComponentBatch::from_indicator<VideoFrameReference>();

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -134,6 +134,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `-15.0`.
         std::optional<ComponentBatch> draw_order;
 
       public:
@@ -240,6 +241,7 @@ namespace rerun::archetypes {
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
+        /// Defaults to `-15.0`.
         VideoFrameReference with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
             draw_order =
                 ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -6,6 +6,7 @@
 #include "../collection.hpp"
 #include "../component_batch.hpp"
 #include "../component_column.hpp"
+#include "../components/draw_order.hpp"
 #include "../components/entity_path.hpp"
 #include "../components/video_timestamp.hpp"
 #include "../indicator_component.hpp"
@@ -130,6 +131,11 @@ namespace rerun::archetypes {
         /// keep the video reference active.
         std::optional<ComponentBatch> video_reference;
 
+        /// An optional floating point value that specifies the 2D drawing order.
+        ///
+        /// Objects with higher values are drawn on top of those with lower values.
+        std::optional<ComponentBatch> draw_order;
+
       public:
         static constexpr const char IndicatorComponentName[] =
             "rerun.components.VideoFrameReferenceIndicator";
@@ -148,6 +154,11 @@ namespace rerun::archetypes {
         static constexpr auto Descriptor_video_reference = ComponentDescriptor(
             ArchetypeName, "video_reference",
             Loggable<rerun::components::EntityPath>::Descriptor.component_name
+        );
+        /// `ComponentDescriptor` for the `draw_order` field.
+        static constexpr auto Descriptor_draw_order = ComponentDescriptor(
+            ArchetypeName, "draw_order",
+            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
         );
 
       public:
@@ -223,6 +234,27 @@ namespace rerun::archetypes {
             video_reference =
                 ComponentBatch::from_loggable(_video_reference, Descriptor_video_reference)
                     .value_or_throw();
+            return std::move(*this);
+        }
+
+        /// An optional floating point value that specifies the 2D drawing order.
+        ///
+        /// Objects with higher values are drawn on top of those with lower values.
+        VideoFrameReference with_draw_order(const rerun::components::DrawOrder& _draw_order) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `draw_order` in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_draw_order` should
+        /// be used when logging a single row's worth of data.
+        VideoFrameReference with_many_draw_order(
+            const Collection<rerun::components::DrawOrder>& _draw_order
+        ) && {
+            draw_order =
+                ComponentBatch::from_loggable(_draw_order, Descriptor_draw_order).value_or_throw();
             return std::move(*this);
         }
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -109,8 +109,7 @@ class Boxes2D(Boxes2DExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
-
-            The default for 2D boxes is 10.0.
+            Defaults to `10.0`.
         class_ids:
             Optional [`components.ClassId`][rerun.components.ClassId]s for the boxes.
 
@@ -187,8 +186,7 @@ class Boxes2D(Boxes2DExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
-
-            The default for 2D boxes is 10.0.
+            Defaults to `10.0`.
         class_ids:
             Optional [`components.ClassId`][rerun.components.ClassId]s for the boxes.
 
@@ -318,8 +316,7 @@ class Boxes2D(Boxes2DExt, Archetype):
     # An optional floating point value that specifies the 2D drawing order.
     #
     # Objects with higher values are drawn on top of those with lower values.
-    #
-    # The default for 2D boxes is 10.0.
+    # Defaults to `10.0`.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -146,6 +146,7 @@ class DepthImage(DepthImageExt, Archetype):
             An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `-20.0`.
 
         """
 
@@ -237,6 +238,7 @@ class DepthImage(DepthImageExt, Archetype):
             An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `-20.0`.
 
         """
 
@@ -381,6 +383,7 @@ class DepthImage(DepthImageExt, Archetype):
     # An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
     #
     # Objects with higher values are drawn on top of those with lower values.
+    # Defaults to `-20.0`.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -142,6 +142,7 @@ class Image(ImageExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `-10.0`.
 
         """
 
@@ -199,6 +200,7 @@ class Image(ImageExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `-10.0`.
 
         """
 
@@ -283,6 +285,7 @@ class Image(ImageExt, Archetype):
     # An optional floating point value that specifies the 2D drawing order.
     #
     # Objects with higher values are drawn on top of those with lower values.
+    # Defaults to `-10.0`.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -133,6 +133,7 @@ class LineStrips2D(Archetype):
             An optional floating point value that specifies the 2D drawing order of each line strip.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `20.0`.
         class_ids:
             Optional [`components.ClassId`][rerun.components.ClassId]s for the lines.
 
@@ -210,6 +211,7 @@ class LineStrips2D(Archetype):
             An optional floating point value that specifies the 2D drawing order of each line strip.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `20.0`.
         class_ids:
             Optional [`components.ClassId`][rerun.components.ClassId]s for the lines.
 
@@ -282,6 +284,7 @@ class LineStrips2D(Archetype):
             An optional floating point value that specifies the 2D drawing order of each line strip.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `20.0`.
         class_ids:
             Optional [`components.ClassId`][rerun.components.ClassId]s for the lines.
 
@@ -400,6 +403,7 @@ class LineStrips2D(Archetype):
     # An optional floating point value that specifies the 2D drawing order of each line strip.
     #
     # Objects with higher values are drawn on top of those with lower values.
+    # Defaults to `20.0`.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -164,6 +164,7 @@ class Points2D(Points2DExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `30.0`.
         class_ids:
             Optional class Ids for the points.
 
@@ -250,6 +251,7 @@ class Points2D(Points2DExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `30.0`.
         class_ids:
             Optional class Ids for the points.
 
@@ -382,6 +384,7 @@ class Points2D(Points2DExt, Archetype):
     # An optional floating point value that specifies the 2D drawing order.
     #
     # Objects with higher values are drawn on top of those with lower values.
+    # Defaults to `30.0`.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -110,6 +110,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `0.0`.
 
         """
 
@@ -167,6 +168,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `0.0`.
 
         """
 
@@ -251,6 +253,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
     # An optional floating point value that specifies the 2D drawing order.
     #
     # Objects with higher values are drawn on top of those with lower values.
+    # Defaults to `0.0`.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -166,6 +166,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `-15.0`.
 
         """
 
@@ -232,6 +233,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
             An optional floating point value that specifies the 2D drawing order.
 
             Objects with higher values are drawn on top of those with lower values.
+            Defaults to `-15.0`.
 
         """
 
@@ -319,6 +321,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
     # An optional floating point value that specifies the 2D drawing order.
     #
     # Objects with higher values are drawn on top of those with lower values.
+    # Defaults to `-15.0`.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -117,6 +117,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
         self.__attrs_init__(
             timestamp=None,
             video_reference=None,
+            draw_order=None,
         )
 
     @classmethod
@@ -133,6 +134,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
         clear_unset: bool = False,
         timestamp: datatypes.VideoTimestampLike | None = None,
         video_reference: datatypes.EntityPathLike | None = None,
+        draw_order: datatypes.Float32Like | None = None,
     ) -> VideoFrameReference:
         """
         Update only some specific fields of a `VideoFrameReference`.
@@ -160,6 +162,10 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
             For a series of video frame references, it is recommended to specify this path only once
             at the beginning of the series and then rely on latest-at query semantics to
             keep the video reference active.
+        draw_order:
+            An optional floating point value that specifies the 2D drawing order.
+
+            Objects with higher values are drawn on top of those with lower values.
 
         """
 
@@ -168,6 +174,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
             kwargs = {
                 "timestamp": timestamp,
                 "video_reference": video_reference,
+                "draw_order": draw_order,
             }
 
             if clear_unset:
@@ -190,6 +197,7 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
         *,
         timestamp: datatypes.VideoTimestampArrayLike | None = None,
         video_reference: datatypes.EntityPathArrayLike | None = None,
+        draw_order: datatypes.Float32ArrayLike | None = None,
     ) -> ComponentColumnList:
         """
         Construct a new column-oriented component bundle.
@@ -220,6 +228,10 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
             For a series of video frame references, it is recommended to specify this path only once
             at the beginning of the series and then rely on latest-at query semantics to
             keep the video reference active.
+        draw_order:
+            An optional floating point value that specifies the 2D drawing order.
+
+            Objects with higher values are drawn on top of those with lower values.
 
         """
 
@@ -228,13 +240,14 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
             inst.__attrs_init__(
                 timestamp=timestamp,
                 video_reference=video_reference,
+                draw_order=draw_order,
             )
 
         batches = inst.as_component_batches(include_indicators=False)
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        kwargs = {"timestamp": timestamp, "video_reference": video_reference}
+        kwargs = {"timestamp": timestamp, "video_reference": video_reference, "draw_order": draw_order}
         columns = []
 
         for batch in batches:
@@ -295,6 +308,17 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
     # For a series of video frame references, it is recommended to specify this path only once
     # at the beginning of the series and then rely on latest-at query semantics to
     # keep the video reference active.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    draw_order: components.DrawOrderBatch | None = field(
+        metadata={"component": True},
+        default=None,
+        converter=components.DrawOrderBatch._converter,  # type: ignore[misc]
+    )
+    # An optional floating point value that specifies the 2D drawing order.
+    #
+    # Objects with higher values are drawn on top of those with lower values.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/9138

### What

Adds a draw order to video assets which also fixes issues with bounding boxes sometimes not showing correctly on top of videos.

(Commit-by-commit friendly PR; but most of it is gen'ed, it's a simple one :))