### PR TITLE
Arrow keys can be now used to navigation and un/collapse items in the blueprint and streams trees

### DIFF
--- a/crates/viewer/re_time_panel/src/streams_tree_data.rs
+++ b/crates/viewer/re_time_panel/src/streams_tree_data.rs
@@ -61,11 +61,11 @@ impl StreamsTreeData {
     /// Visit the entire tree.
     ///
     /// Note that we ALSO visit components, despite them not being part of the data structures. This
-    /// is because _currently_, we rarely need to visit, but when we do, we need to components, and
+    /// is because _currently_, we rarely need to visit, but when we do, we need components, and
     /// having them in the structure would be too expensive for the cases where it's unnecessary
     /// (e.g., when the tree is collapsed).
     ///
-    /// The provided closure is called once for each entity with `None` as component name argument.
+    /// The provided closure is called once for each entity with `None` as component argument.
     /// Then, consistent with the display order, its children entities are visited, and then its
     /// components are visited.
     pub fn visit<B>(

--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -1,3 +1,4 @@
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use egui::emath::Rangef;
@@ -134,6 +135,12 @@ pub struct TimePanel {
     #[serde(skip)]
     range_selection_anchor_item: Option<Item>,
 
+    /// Used when the selection is modified using key navigation.
+    ///
+    /// IMPORTANT: Always make sure that the item will be drawn this or next frame with setting this
+    /// to `Some`, so that this flag is immediately consumed.
+    scroll_to_me_item: Option<Item>,
+
     /// If the timestamp is being edited, the current value.
     ///
     /// It is applied only after removing focus.
@@ -155,6 +162,7 @@ impl Default for TimePanel {
             filter_state: Default::default(),
             filter_state_app_id: None,
             range_selection_anchor_item: None,
+            scroll_to_me_item: None,
             time_edit_string: None,
         }
     }
@@ -1003,7 +1011,136 @@ impl TimePanel {
         );
         ctx.handle_select_hover_drag_interactions(response, item.clone(), is_draggable);
 
-        self.handle_range_selection(ctx, streams_tree_data, entity_db, item, response);
+        self.handle_range_selection(ctx, streams_tree_data, entity_db, item.clone(), response);
+
+        self.handle_key_navigation(ctx, streams_tree_data, entity_db, item.clone());
+
+        if Some(item) == self.scroll_to_me_item {
+            response.scroll_to_me(None);
+            self.scroll_to_me_item = None;
+        }
+    }
+
+    fn handle_key_navigation(
+        &mut self,
+        ctx: &ViewerContext<'_>,
+        streams_tree_data: &StreamsTreeData,
+        entity_db: &re_entity_db::EntityDb,
+        item: Item,
+    ) {
+        if ctx.selection_state().selected_items().single_item() != Some(&item) {
+            return;
+        }
+
+        if ctx
+            .egui_ctx()
+            .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowRight))
+        {
+            if let Some(collapse_id) = self.collapse_scope().item(item.clone()) {
+                collapse_id.set_open(ctx.egui_ctx(), true);
+            }
+        }
+
+        if ctx
+            .egui_ctx()
+            .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowLeft))
+        {
+            if let Some(collapse_id) = self.collapse_scope().item(item.clone()) {
+                collapse_id.set_open(ctx.egui_ctx(), false);
+            }
+        }
+
+        if ctx
+            .egui_ctx()
+            .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown))
+        {
+            let mut found_current = false;
+
+            let result = streams_tree_data.visit(entity_db, |tree_item, component| {
+                let (tree_item, is_item_collapsed) = match component {
+                    None => (
+                        tree_item.item(),
+                        !tree_item
+                            .is_open(ctx.egui_ctx(), self.collapse_scope())
+                            .unwrap_or(tree_item.default_open),
+                    ),
+
+                    Some(desc) => (
+                        Item::ComponentPath(ComponentPath::new(
+                            tree_item.entity_path.clone(),
+                            desc,
+                        )),
+                        false,
+                    ),
+                };
+
+                if tree_item == item {
+                    found_current = true;
+
+                    return if is_item_collapsed {
+                        VisitorControlFlow::SkipBranch
+                    } else {
+                        VisitorControlFlow::Continue
+                    };
+                }
+
+                if found_current {
+                    VisitorControlFlow::Break(Some(tree_item))
+                } else if is_item_collapsed {
+                    VisitorControlFlow::SkipBranch
+                } else {
+                    VisitorControlFlow::Continue
+                }
+            });
+
+            if let ControlFlow::Break(Some(item)) = result {
+                ctx.selection_state().set_selection(item.clone());
+                self.scroll_to_me_item = Some(item);
+            }
+        }
+
+        if ctx
+            .egui_ctx()
+            .input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp))
+        {
+            let mut last_item = None;
+
+            let result = streams_tree_data.visit(entity_db, |tree_item, component| {
+                let (tree_item, is_item_collapsed) = match component {
+                    None => (
+                        tree_item.item(),
+                        !tree_item
+                            .is_open(ctx.egui_ctx(), self.collapse_scope())
+                            .unwrap_or(tree_item.default_open),
+                    ),
+
+                    Some(desc) => (
+                        Item::ComponentPath(ComponentPath::new(
+                            tree_item.entity_path.clone(),
+                            desc,
+                        )),
+                        false,
+                    ),
+                };
+
+                if tree_item == item {
+                    return VisitorControlFlow::Break(last_item.clone());
+                }
+
+                last_item = Some(tree_item);
+
+                if is_item_collapsed {
+                    VisitorControlFlow::SkipBranch
+                } else {
+                    VisitorControlFlow::Continue
+                }
+            });
+
+            if let ControlFlow::Break(Some(item)) = result {
+                ctx.selection_state().set_selection(item.clone());
+                self.scroll_to_me_item = Some(item);
+            }
+        }
     }
 
     /// Handle setting/extending the selection based on shift-clicking.

--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -321,6 +321,10 @@ impl UICommand {
             KeyboardShortcut::new(Modifiers::COMMAND, key)
         }
 
+        fn alt(key: Key) -> KeyboardShortcut {
+            KeyboardShortcut::new(Modifiers::ALT, key)
+        }
+
         fn cmd_shift(key: Key) -> KeyboardShortcut {
             KeyboardShortcut::new(Modifiers::COMMAND | Modifiers::SHIFT, key)
         }
@@ -397,10 +401,10 @@ impl UICommand {
             Self::ToggleCommandPalette => smallvec![cmd(Key::P)],
 
             Self::PlaybackTogglePlayPause => smallvec![key(Key::Space)],
-            Self::PlaybackFollow => smallvec![cmd(Key::ArrowRight)],
-            Self::PlaybackStepBack => smallvec![key(Key::ArrowLeft)],
-            Self::PlaybackStepForward => smallvec![key(Key::ArrowRight)],
-            Self::PlaybackRestart => smallvec![cmd(Key::ArrowLeft)],
+            Self::PlaybackFollow => smallvec![alt(Key::ArrowRight)],
+            Self::PlaybackStepBack => smallvec![cmd(Key::ArrowLeft)],
+            Self::PlaybackStepForward => smallvec![cmd(Key::ArrowRight)],
+            Self::PlaybackRestart => smallvec![alt(Key::ArrowLeft)],
 
             #[cfg(not(target_arch = "wasm32"))]
             Self::ScreenshotWholeApp => smallvec![],

--- a/docs/content/reference/migration/migration-0-24.md
+++ b/docs/content/reference/migration/migration-0-24.md
@@ -4,6 +4,13 @@ order: 986
 ---
 <!--   ^^^ this number must be _decremented_ when you copy/paste this file -->
 
+## Changed timeline navigation keyboard shortcut
+
+To accommodate the new tree keyboard navigation feature, the timeline navigation is changed as follows:
+
+- go to previous/next frame is ctrl-left/right (cmd on Mac) arrow (previously no modifier was needed)
+- go to beginning/end of timeline is alt-left/right (previously the ctrl/cmd modifier was used)
+
 ## Previously deprecated, now removed
 
 ### `Scalar`, `SeriesLine`, `SeriesPoint` archetypes


### PR DESCRIPTION
### Related

* Part of #3055

### What

Now in both the blueprint tree and streams tree:
- left/right collapses/uncollapses the selected item
- up/down selects the previous/next item

**Notes**:
- This only works with single selection.
- Previously, the left/right arrows were used to move the time cursor. This now requires cmd/alt-left/right. Also, the go to start/end of timeline is now alt-left/right.