### PR TITLE
Fix time series points querying extra points at start and end of time range (causing stuttering on playback in some scenes)

### DIFF
--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -191,10 +191,7 @@ impl SeriesPointsSystem {
             re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
 
             let entity_path = &data_result.entity_path;
-            let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range)
-                // We must fetch data with extended bounds, otherwise the query clamping would
-                // cut-off the data early at the edge of the view.
-                .include_extended_bounds(true);
+            let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range);
 
             let results = range_with_blueprint_resolved_data(
                 ctx,


### PR DESCRIPTION
### Related

* Fixes half of #9270

### What

Ever since we actually cut off the range queries correctly (in https://github.com/rerun-io/rerun/pull/7133) we queried an extra scalars at the start and end of the range. For points that obviously wrong, for lines we have to cut the lines to the range - this caused the stuttering described & demonstrated in #9270

I fixed this for points only here since it's trivial.
