### PR TITLE
Fix building with arrow 20.0.0

### DIFF
--- a/rerun_cpp/src/rerun/time_column.cpp
+++ b/rerun_cpp/src/rerun/time_column.cpp
@@ -4,6 +4,7 @@
 #include "c/rerun.h"
 
 #include <arrow/array/array_base.h>
+#include <arrow/array/util.h>
 #include <arrow/buffer.h>
 #include <arrow/c/bridge.h>
 
@@ -20,7 +21,9 @@ namespace rerun {
         // which may or may not be another copy (if the collection already owns the data this is just a move).
         auto length = static_cast<int64_t>(times.size());
         auto buffer = arrow_buffer_from_vector(std::move(times).to_vector());
-        array = std::make_shared<arrow::PrimitiveArray>(datatype, length, buffer);
+        auto buffers = std::vector<std::shared_ptr<arrow::Buffer>>{nullptr, buffer};
+        auto array_data = std::make_shared<arrow::ArrayData>(datatype, length, std::move(buffers));
+        array = arrow::MakeArray(array_data);
     }
 
     TimeColumn TimeColumn::from_seconds(


### PR DESCRIPTION
### Related

Fixes #9864

### What

Fixes compatibility with Arrow 20, which made the constructor of `arrow::PrimitiveArray` protected due to its use from user code resulting in invalid arrays.

I've tested building the `rerun-sdk` port in vcpkg at version 0.22.1 with this patch applied and Arrow upgraded to 20.0.0.