### PR TITLE
Follow system theme in debug builds

### DIFF
--- a/crates/utils/re_log/src/lib.rs
+++ b/crates/utils/re_log/src/lib.rs
@@ -76,6 +76,7 @@ const CRATES_AT_INFO_LEVEL: &[&str] = &[
     "h2",
     "hyper",
     "prost_build",
+    "sqlparser",
     "tower",
     "ureq",
     // only let rustls log in debug mode: https://github.com/rerun-io/rerun/issues/3104

--- a/crates/viewer/re_ui/src/lib.rs
+++ b/crates/viewer/re_ui/src/lib.rs
@@ -124,7 +124,11 @@ pub fn apply_style_and_install_loaders(egui_ctx: &egui::Context) {
     );
 
     egui_ctx.options_mut(|o| {
-        o.theme_preference = egui::ThemePreference::Dark; // TODO(#3058): switch this to system
+        if cfg!(debug_assertions) {
+            // Keep whatever the developer has previously set
+        } else {
+            o.theme_preference = egui::ThemePreference::Dark; // TODO(#3058): switch this to system (by removing it)
+        }
         o.fallback_theme = egui::Theme::Dark;
     });
 

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -64,14 +64,17 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
 
     ui.strong("General");
 
-    ui.horizontal(|ui| {
-        ui.label("Theme:");
-        egui::global_theme_preference_buttons(ui);
-        let theme_preference = ui.ctx().options(|opt| opt.theme_preference);
-        if theme_preference != egui::ThemePreference::Dark {
-            ui.warning_label("Light mode support is experimental!");
-        }
-    });
+    if cfg!(debug_assertions) {
+        // TODO(#3058): finish light node
+        ui.horizontal(|ui| {
+            ui.label("Theme:");
+            egui::global_theme_preference_buttons(ui);
+            let theme_preference = ui.ctx().options(|opt| opt.theme_preference);
+            if theme_preference != egui::ThemePreference::Dark {
+                ui.warning_label("Light mode support is experimental!");
+            }
+        });
+    }
 
     ui.re_checkbox(
         &mut app_options.include_welcome_screen_button_in_recordings_panel,


### PR DESCRIPTION
### Related
* Part of #9953 

### What
In debug builds, follow the system theme preference.
In release builds, dark mode is still default and the only thing you can select.