### PR TITLE
Use weaker version of `ComponentDescriptor` for indicators

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1144,7 +1144,7 @@ fn quote_trait_impls_for_archetype(reporter: &Reporter, obj: &Object) -> TokenSt
                 #[inline]
                 pub fn descriptor_indicator() -> ComponentDescriptor {
                     ComponentDescriptor {
-                        archetype_name: Some(#archetype_name.into()),
+                        archetype_name: None,
                         component_name: #indicator_component_name.into(),
                         archetype_field_name: None,
                     }

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -95,7 +95,7 @@ impl AnnotationContext {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
+            archetype_name: None,
             component_name: "rerun.components.AnnotationContextIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -189,7 +189,7 @@ impl Arrows2D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Arrows2DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -185,7 +185,7 @@ impl Arrows3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Arrows3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -120,7 +120,7 @@ impl Asset3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Asset3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Asset3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -168,7 +168,7 @@ impl AssetVideo {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+            archetype_name: None,
             component_name: "rerun.components.AssetVideoIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -85,7 +85,7 @@ impl BarChart {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.BarChart".into()),
+            archetype_name: None,
             component_name: "rerun.components.BarChartIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -181,7 +181,7 @@ impl Boxes2D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Boxes2DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -236,7 +236,7 @@ impl Boxes3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Boxes3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -229,7 +229,7 @@ impl Capsules3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Capsules3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -205,7 +205,7 @@ impl DepthImage {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            archetype_name: None,
             component_name: "rerun.components.DepthImageIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -251,7 +251,7 @@ impl Ellipsoids3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Ellipsoids3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -120,7 +120,7 @@ impl EncodedImage {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+            archetype_name: None,
             component_name: "rerun.components.EncodedImageIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -111,7 +111,7 @@ impl GeoLineStrings {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
+            archetype_name: None,
             component_name: "rerun.components.GeoLineStringsIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -119,7 +119,7 @@ impl GeoPoints {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            archetype_name: None,
             component_name: "rerun.components.GeoPointsIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -92,7 +92,7 @@ impl GraphEdges {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+            archetype_name: None,
             component_name: "rerun.components.GraphEdgesIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -148,7 +148,7 @@ impl GraphNodes {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            archetype_name: None,
             component_name: "rerun.components.GraphNodesIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -204,7 +204,7 @@ impl Image {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Image".into()),
+            archetype_name: None,
             component_name: "rerun.components.ImageIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -174,7 +174,7 @@ impl InstancePoses3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.InstancePoses3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -207,7 +207,7 @@ impl LineStrips2D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            archetype_name: None,
             component_name: "rerun.components.LineStrips2DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -202,7 +202,7 @@ impl LineStrips3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.LineStrips3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -259,7 +259,7 @@ impl Mesh3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Mesh3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -194,7 +194,7 @@ impl Pinhole {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Pinhole".into()),
+            archetype_name: None,
             component_name: "rerun.components.PinholeIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -242,7 +242,7 @@ impl Points2D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Points2DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -311,7 +311,7 @@ impl Points3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Points3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/recording_properties.rs
+++ b/crates/store/re_types/src/archetypes/recording_properties.rs
@@ -60,7 +60,7 @@ impl RecordingProperties {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.RecordingProperties".into()),
+            archetype_name: None,
             component_name: "rerun.components.RecordingPropertiesIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/scalars.rs
+++ b/crates/store/re_types/src/archetypes/scalars.rs
@@ -109,7 +109,7 @@ impl Scalars {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Scalars".into()),
+            archetype_name: None,
             component_name: "rerun.components.ScalarsIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -138,7 +138,7 @@ impl SegmentationImage {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+            archetype_name: None,
             component_name: "rerun.components.SegmentationImageIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/series_lines.rs
+++ b/crates/store/re_types/src/archetypes/series_lines.rs
@@ -180,7 +180,7 @@ impl SeriesLines {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.SeriesLines".into()),
+            archetype_name: None,
             component_name: "rerun.components.SeriesLinesIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/series_points.rs
+++ b/crates/store/re_types/src/archetypes/series_points.rs
@@ -172,7 +172,7 @@ impl SeriesPoints {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.SeriesPoints".into()),
+            archetype_name: None,
             component_name: "rerun.components.SeriesPointsIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -99,7 +99,7 @@ impl Tensor {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Tensor".into()),
+            archetype_name: None,
             component_name: "rerun.components.TensorIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -132,7 +132,7 @@ impl TextDocument {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.TextDocument".into()),
+            archetype_name: None,
             component_name: "rerun.components.TextDocumentIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -114,7 +114,7 @@ impl TextLog {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.TextLog".into()),
+            archetype_name: None,
             component_name: "rerun.components.TextLogIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -448,7 +448,7 @@ impl Transform3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            archetype_name: None,
             component_name: "rerun.components.Transform3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -193,7 +193,7 @@ impl VideoFrameReference {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
+            archetype_name: None,
             component_name: "rerun.components.VideoFrameReferenceIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -86,7 +86,7 @@ impl ViewCoordinates {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
+            archetype_name: None,
             component_name: "rerun.components.ViewCoordinatesIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -60,7 +60,7 @@ impl Background {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.BackgroundIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/container_blueprint.rs
@@ -166,7 +166,7 @@ impl ContainerBlueprint {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ContainerBlueprintIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -109,7 +109,7 @@ impl DataframeQuery {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.DataframeQueryIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/entity_behavior.rs
@@ -70,7 +70,7 @@ impl EntityBehavior {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.EntityBehavior".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.EntityBehaviorIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/force_center.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_center.rs
@@ -62,7 +62,7 @@ impl ForceCenter {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceCenter".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ForceCenterIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_collision_radius.rs
@@ -79,7 +79,7 @@ impl ForceCollisionRadius {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceCollisionRadius".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ForceCollisionRadiusIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/force_link.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_link.rs
@@ -79,7 +79,7 @@ impl ForceLink {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceLink".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ForceLinkIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_many_body.rs
@@ -67,7 +67,7 @@ impl ForceManyBody {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForceManyBody".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ForceManyBodyIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/force_position.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/force_position.rs
@@ -77,7 +77,7 @@ impl ForcePosition {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ForcePosition".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ForcePositionIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -117,7 +117,7 @@ impl LineGrid3D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.LineGrid3DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -47,7 +47,7 @@ impl MapBackground {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.MapBackgroundIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -47,7 +47,7 @@ impl MapZoom {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.MapZoomIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/near_clip_plane.rs
@@ -47,7 +47,7 @@ impl NearClipPlane {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.NearClipPlane".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.NearClipPlaneIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/panel_blueprint.rs
@@ -45,7 +45,7 @@ impl PanelBlueprint {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.PanelBlueprintIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -64,7 +64,7 @@ impl PlotLegend {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.PlotLegendIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -62,7 +62,7 @@ impl ScalarAxis {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ScalarAxisIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -83,7 +83,7 @@ impl TensorScalarMapping {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.TensorScalarMappingIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -100,7 +100,7 @@ impl TensorSliceSelection {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.TensorSliceSelectionIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -45,7 +45,7 @@ impl TensorViewFit {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.TensorViewFitIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_blueprint.rs
@@ -98,7 +98,7 @@ impl ViewBlueprint {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ViewBlueprint".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ViewBlueprintIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/view_contents.rs
@@ -84,7 +84,7 @@ impl ViewContents {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ViewContents".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ViewContentsIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/viewport_blueprint.rs
@@ -117,7 +117,7 @@ impl ViewportBlueprint {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -55,7 +55,7 @@ impl VisibleTimeRanges {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.VisibleTimeRangesIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -53,7 +53,7 @@ impl VisualBounds2D {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.VisualBounds2DIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visualizer_overrides.rs
@@ -54,7 +54,7 @@ impl VisualizerOverrides {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.blueprint.archetypes.VisualizerOverrides".into()),
+            archetype_name: None,
             component_name: "rerun.blueprint.components.VisualizerOverridesIndicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -314,7 +314,7 @@ impl AffixFuzzer1 {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            archetype_name: None,
             component_name: "rerun.testing.components.AffixFuzzer1Indicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -275,7 +275,7 @@ impl AffixFuzzer2 {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            archetype_name: None,
             component_name: "rerun.testing.components.AffixFuzzer2Indicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -262,7 +262,7 @@ impl AffixFuzzer3 {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            archetype_name: None,
             component_name: "rerun.testing.components.AffixFuzzer3Indicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -262,7 +262,7 @@ impl AffixFuzzer4 {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            archetype_name: None,
             component_name: "rerun.testing.components.AffixFuzzer4Indicator".into(),
             archetype_field_name: None,
         }

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -96,7 +96,7 @@ impl Clear {
     #[inline]
     pub fn descriptor_indicator() -> ComponentDescriptor {
         ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.Clear".into()),
+            archetype_name: None,
             component_name: "rerun.components.ClearIndicator".into(),
             archetype_field_name: None,
         }


### PR DESCRIPTION
### Related

* Parto of #6889.
* From https://github.com/rerun-io/rerun/pull/9938#issuecomment-2888808593:

> was curious and poked a lil bit into the ci failure: took me a while to notice but the primary issue presented by the failing images is that it draws lines instead of points.
> 
> Which implies an issue with indicators (wtf why is that the only test failing then.. but sure usually there's no choice; have only a vague hunch about that :/). Looking at `impl<A: Archetype> crate::ComponentBatch for GenericIndicatorComponentArray<A>` indicators are never logged with their full descriptor, but are advertised as such.
> 
> So I quickly hacked the generated `SeriesPoints::descriptor_indicator` to be name only and sure enough that fixed the test. What to do about this knowledge? Uhm.. yeah... that is definitely a Monday problem 😄

### What

Because indicators are about to go away soon (™️) anyways, making them weaker (qualification-wise) is probably the easiest choice.

Doing this in a separate PR to help with potential `git bisect` in the future. 
