### PR TITLE
Adapt `WriteChunks` definitions

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -38,8 +38,10 @@ service FrontendService {
   // Register new partitions with the Dataset
   rpc RegisterWithDataset(RegisterWithDatasetRequest) returns (rerun.manifest_registry.v1alpha1.RegisterWithDatasetResponse) {}
 
+  // TODO: Add upload endpoint
+
   // Unimplemented.
-  rpc WriteChunks(stream WriteChunksRequest) returns (stream rerun.manifest_registry.v1alpha1.WriteChunksResponse) {}
+  rpc WriteChunks(stream rerun.manifest_registry.v1alpha1.WriteChunksRequest) returns (rerun.manifest_registry.v1alpha1.WriteChunksResponse) {}
 
   /* Query schemas */
 
@@ -120,10 +122,6 @@ message RegisterWithDatasetRequest {
   rerun.common.v1alpha1.EntryId dataset_id = 1;
   repeated rerun.manifest_registry.v1alpha1.DataSource data_sources = 2;
   rerun.common.v1alpha1.IfDuplicateBehavior on_duplicate = 3;
-}
-
-message WriteChunksRequest {
-  rerun.common.v1alpha1.EntryId dataset_id = 1;
 }
 
 /* Query schemas */

--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -38,8 +38,6 @@ service FrontendService {
   // Register new partitions with the Dataset
   rpc RegisterWithDataset(RegisterWithDatasetRequest) returns (rerun.manifest_registry.v1alpha1.RegisterWithDatasetResponse) {}
 
-  // TODO: Add upload endpoint
-
   // Unimplemented.
   rpc WriteChunks(stream rerun.manifest_registry.v1alpha1.WriteChunksRequest) returns (rerun.manifest_registry.v1alpha1.WriteChunksResponse) {}
 

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -14,7 +14,7 @@ service ManifestRegistryService {
   rpc RegisterWithDatasetBlocking(RegisterWithDatasetBlockingRequest) returns (RegisterWithDatasetBlockingResponse) {}
 
   // Unimplemented.
-  rpc WriteChunks(stream WriteChunksRequest) returns (stream WriteChunksResponse) {}
+  rpc WriteChunks(stream WriteChunksRequest) returns (WriteChunksResponse) {}
 
   // --- Query schemas ---
 
@@ -148,7 +148,7 @@ message RegisterWithDatasetBlockingResponse {
 }
 
 message WriteChunksRequest {
-  rerun.common.v1alpha1.DatasetHandle entry = 1;
+  rerun.common.v1alpha1.RerunChunk chunk = 1;
 }
 
 message WriteChunksResponse {}

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -23,21 +23,6 @@ impl ::prost::Name for RegisterWithDatasetRequest {
     }
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct WriteChunksRequest {
-    #[prost(message, optional, tag = "1")]
-    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
-}
-impl ::prost::Name for WriteChunksRequest {
-    const NAME: &'static str = "WriteChunksRequest";
-    const PACKAGE: &'static str = "rerun.frontend.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        "rerun.frontend.v1alpha1.WriteChunksRequest".into()
-    }
-    fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.frontend.v1alpha1.WriteChunksRequest".into()
-    }
-}
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct GetPartitionTableSchemaRequest {
     #[prost(message, optional, tag = "1")]
     pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
@@ -497,13 +482,11 @@ pub mod frontend_service_client {
         /// Unimplemented.
         pub async fn write_chunks(
             &mut self,
-            request: impl tonic::IntoStreamingRequest<Message = super::WriteChunksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<
-                tonic::codec::Streaming<
-                    super::super::super::manifest_registry::v1alpha1::WriteChunksResponse,
-                >,
+            request: impl tonic::IntoStreamingRequest<
+                Message = super::super::super::manifest_registry::v1alpha1::WriteChunksRequest,
             >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::manifest_registry::v1alpha1::WriteChunksResponse>,
             tonic::Status,
         > {
             self.inner.ready().await.map_err(|e| {
@@ -518,7 +501,7 @@ pub mod frontend_service_client {
                 "rerun.frontend.v1alpha1.FrontendService",
                 "WriteChunks",
             ));
-            self.inner.streaming(req, path, codec).await
+            self.inner.client_streaming(req, path, codec).await
         }
         /// Returns the schema of the partition table (i.e. the dataset manifest) itself, *not* the underlying dataset.
         ///
@@ -921,19 +904,18 @@ pub mod frontend_service_server {
             >,
             tonic::Status,
         >;
-        /// Server streaming response type for the WriteChunks method.
-        type WriteChunksStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<
-                    super::super::super::manifest_registry::v1alpha1::WriteChunksResponse,
-                    tonic::Status,
-                >,
-            > + std::marker::Send
-            + 'static;
         /// Unimplemented.
         async fn write_chunks(
             &self,
-            request: tonic::Request<tonic::Streaming<super::WriteChunksRequest>>,
-        ) -> std::result::Result<tonic::Response<Self::WriteChunksStream>, tonic::Status>;
+            request: tonic::Request<
+                tonic::Streaming<
+                    super::super::super::manifest_registry::v1alpha1::WriteChunksRequest,
+                >,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::manifest_registry::v1alpha1::WriteChunksResponse>,
+            tonic::Status,
+        >;
         /// Returns the schema of the partition table (i.e. the dataset manifest) itself, *not* the underlying dataset.
         ///
         /// * To inspect the data of the partition table, use `ScanPartitionTable`.
@@ -1442,17 +1424,20 @@ pub mod frontend_service_server {
                     #[allow(non_camel_case_types)]
                     struct WriteChunksSvc<T: FrontendService>(pub Arc<T>);
                     impl<T: FrontendService>
-                        tonic::server::StreamingService<super::WriteChunksRequest>
-                        for WriteChunksSvc<T>
+                        tonic::server::ClientStreamingService<
+                            super::super::super::manifest_registry::v1alpha1::WriteChunksRequest,
+                        > for WriteChunksSvc<T>
                     {
                         type Response =
                             super::super::super::manifest_registry::v1alpha1::WriteChunksResponse;
-                        type ResponseStream = T::WriteChunksStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<tonic::Streaming<super::WriteChunksRequest>>,
+                            request: tonic::Request<
+                                tonic::Streaming<
+                                    super::super::super::manifest_registry::v1alpha1::WriteChunksRequest,
+                                >,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -1478,7 +1463,7 @@ pub mod frontend_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.streaming(method, req).await;
+                        let res = grpc.client_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -98,7 +98,7 @@ impl ::prost::Name for RegisterWithDatasetBlockingResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WriteChunksRequest {
     #[prost(message, optional, tag = "1")]
-    pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
+    pub chunk: ::core::option::Option<super::super::common::v1alpha1::RerunChunk>,
 }
 impl ::prost::Name for WriteChunksRequest {
     const NAME: &'static str = "WriteChunksRequest";
@@ -1104,10 +1104,8 @@ pub mod manifest_registry_service_client {
         pub async fn write_chunks(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::WriteChunksRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::WriteChunksResponse>>,
-            tonic::Status,
-        > {
+        ) -> std::result::Result<tonic::Response<super::WriteChunksResponse>, tonic::Status>
+        {
             self.inner.ready().await.map_err(|e| {
                 tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
             })?;
@@ -1120,7 +1118,7 @@ pub mod manifest_registry_service_client {
                 "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
                 "WriteChunks",
             ));
-            self.inner.streaming(req, path, codec).await
+            self.inner.client_streaming(req, path, codec).await
         }
         /// Returns the schema of the partition table (i.e. the dataset manifest) itself, *not* the underlying dataset.
         ///
@@ -1435,16 +1433,11 @@ pub mod manifest_registry_service_server {
             tonic::Response<super::RegisterWithDatasetBlockingResponse>,
             tonic::Status,
         >;
-        /// Server streaming response type for the WriteChunks method.
-        type WriteChunksStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::WriteChunksResponse, tonic::Status>,
-            > + std::marker::Send
-            + 'static;
         /// Unimplemented.
         async fn write_chunks(
             &self,
             request: tonic::Request<tonic::Streaming<super::WriteChunksRequest>>,
-        ) -> std::result::Result<tonic::Response<Self::WriteChunksStream>, tonic::Status>;
+        ) -> std::result::Result<tonic::Response<super::WriteChunksResponse>, tonic::Status>;
         /// Returns the schema of the partition table (i.e. the dataset manifest) itself, *not* the underlying dataset.
         ///
         /// * To inspect the data of the partition table, use `ScanPartitionTable`.
@@ -1755,13 +1748,11 @@ pub mod manifest_registry_service_server {
                     #[allow(non_camel_case_types)]
                     struct WriteChunksSvc<T: ManifestRegistryService>(pub Arc<T>);
                     impl<T: ManifestRegistryService>
-                        tonic::server::StreamingService<super::WriteChunksRequest>
+                        tonic::server::ClientStreamingService<super::WriteChunksRequest>
                         for WriteChunksSvc<T>
                     {
                         type Response = super::WriteChunksResponse;
-                        type ResponseStream = T::WriteChunksStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<tonic::Streaming<super::WriteChunksRequest>>,
@@ -1790,7 +1781,7 @@ pub mod manifest_registry_service_server {
                                 max_decoding_message_size,
                                 max_encoding_message_size,
                             );
-                        let res = grpc.streaming(method, req).await;
+                        let res = grpc.client_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)


### PR DESCRIPTION
### Related

* Part of #9981.
* Might be superseded by #9991 (leaving the order for @abey79 to decide).

### What

This changes the definitions of `WriteChunks` to what we have discussed / demoed during the meetup. Note that merging this PR will break the dataplatform build without a sibling PR.
