### PR TITLE
Replace `tinystl` with `stl_io` to support more stl files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9462,8 +9462,9 @@ dependencies = [
 
 [[package]]
 name = "stl_io"
-version = "0.9.0"
-source = "git+https://github.com/oxkitsune/stl_io?branch=gijs%2Fmesh-name#b4325a398f16ed7b3ce9c35f21d49d7269687e6e"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff2e145168af9fef3b518ac0c6f9849c407b3df8a28582ced9f1fda510aa34c"
 dependencies = [
  "byteorder",
  "float-cmp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9462,9 +9462,8 @@ dependencies = [
 
 [[package]]
 name = "stl_io"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff2e145168af9fef3b518ac0c6f9849c407b3df8a28582ced9f1fda510aa34c"
+version = "0.9.0"
+source = "git+https://github.com/oxkitsune/stl_io?branch=gijs%2Fmesh-name#b4325a398f16ed7b3ce9c35f21d49d7269687e6e"
 dependencies = [
  "byteorder",
  "float-cmp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,7 +2741,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.5",
 ]
 
 [[package]]
@@ -3338,6 +3338,9 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -7390,8 +7393,8 @@ dependencies = [
  "slotmap",
  "smallvec",
  "static_assertions",
+ "stl_io",
  "thiserror 1.0.65",
- "tinystl",
  "tobj",
  "type-map",
  "unindent",
@@ -9458,6 +9461,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stl_io"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff2e145168af9fef3b518ac0c6f9849c407b3df8a28582ced9f1fda510aa34c"
+dependencies = [
+ "byteorder",
+ "float-cmp",
+]
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9827,15 +9840,6 @@ dependencies = [
  "chunked_transfer",
  "httpdate",
  "log",
-]
-
-[[package]]
-name = "tinystl"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbcdda2f86a57b89b5d9ac17cd4c9f3917ec8edcde403badf3d992d2947af2a"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,6 +296,7 @@ similar-asserts = "1.4.2"
 slotmap = { version = "1.0.6", features = ["serde"] }
 smallvec = { version = "1.0", features = ["const_generics", "union"] }
 static_assertions = "1.1"
+stl_io = "0.8.5"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 sublime_fuzzy = "0.7"
@@ -310,7 +311,6 @@ time = { version = "0.3.36", default-features = false, features = [
   "wasm-bindgen",
 ] }
 tiny_http = { version = "0.12", default-features = false }
-tinystl = { version = "0.0.3", default-features = false }
 tobj = "4.0"
 tokio = { version = "1.44.2", default-features = false }
 tokio-stream = "0.1.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ similar-asserts = "1.4.2"
 slotmap = { version = "1.0.6", features = ["serde"] }
 smallvec = { version = "1.0", features = ["const_generics", "union"] }
 static_assertions = "1.1"
-stl_io = "0.8.5"
+stl_io = { git = "https://github.com/oxkitsune/stl_io", branch = "gijs/mesh-name" }
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 sublime_fuzzy = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -296,7 +296,7 @@ similar-asserts = "1.4.2"
 slotmap = { version = "1.0.6", features = ["serde"] }
 smallvec = { version = "1.0", features = ["const_generics", "union"] }
 static_assertions = "1.1"
-stl_io = { git = "https://github.com/oxkitsune/stl_io", branch = "gijs/mesh-name" }
+stl_io = "0.8.5"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 sublime_fuzzy = "0.7"

--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -45,7 +45,7 @@ import-obj = ["dep:tobj"]
 import-gltf = ["dep:gltf"]
 
 ## Support importing binary & ascii .stl files
-import-stl = ["dep:tinystl"]
+import-stl = ["dep:stl_io"]
 
 ## Enable (de)serialization using serde.
 serde = ["dep:serde"]
@@ -85,7 +85,7 @@ wgpu.workspace = true
 
 # optional
 gltf = { workspace = true, optional = true }
-tinystl = { workspace = true, features = ["bytemuck"], optional = true }
+stl_io = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 tobj = { workspace = true, optional = true }
 

--- a/crates/viewer/re_renderer/src/importer/stl.rs
+++ b/crates/viewer/re_renderer/src/importer/stl.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools as _;
 use smallvec::smallvec;
-use stl_io::IndexedMesh;
 
 use crate::{CpuModel, RenderContext, mesh};
 

--- a/crates/viewer/re_renderer/src/importer/stl.rs
+++ b/crates/viewer/re_renderer/src/importer/stl.rs
@@ -1,13 +1,13 @@
 use itertools::Itertools as _;
 use smallvec::smallvec;
-use tinystl::StlData;
+use stl_io::IndexedMesh;
 
 use crate::{CpuModel, RenderContext, mesh};
 
 #[derive(thiserror::Error, Debug)]
 pub enum StlImportError {
     #[error("Error loading STL mesh: {0}")]
-    TinyStl(tinystl::Error),
+    StlIoError(std::io::Error),
 
     #[error(transparent)]
     MeshError(#[from] mesh::MeshError),
@@ -20,37 +20,46 @@ pub fn load_stl_from_buffer(
 ) -> Result<CpuModel, StlImportError> {
     re_tracing::profile_function!();
 
-    let cursor = std::io::Cursor::new(buffer);
-    let StlData {
-        name,
-        triangles,
-        normals,
-        ..
-    } = StlData::read_buffer(std::io::BufReader::new(cursor)).map_err(StlImportError::TinyStl)?;
+    let mut cursor = std::io::Cursor::new(buffer);
+    let IndexedMesh { vertices, faces } =
+        stl_io::read_stl(&mut cursor).map_err(StlImportError::StlIoError)?;
+    let num_vertices = faces.len() * 3;
 
-    let num_vertices = triangles.len() * 3;
+    // TODO(gijsd): parse name from ASCII?
+    let name = "";
 
     let material = mesh::Material {
-        label: name.clone().into(),
+        label: name.into(),
         index_range: 0..num_vertices as u32,
         albedo: ctx.texture_manager_2d.white_texture_unorm_handle().clone(),
         albedo_factor: crate::Rgba::WHITE,
     };
 
+    // TODO(gijsd): Does this not support sparse meshes/vertex positions?
     let mesh = mesh::CpuMesh {
         label: name.into(),
         triangle_indices: (0..num_vertices as u32)
             .tuples::<(_, _, _)>()
             .map(glam::UVec3::from)
             .collect::<Vec<_>>(),
-        vertex_positions: bytemuck::cast_slice(&triangles).to_vec(),
+
+        vertex_positions: faces
+            .iter()
+            .flat_map(|f| {
+                [
+                    glam::Vec3::from_array(vertices[f.vertices[0]].0),
+                    glam::Vec3::from_array(vertices[f.vertices[1]].0),
+                    glam::Vec3::from_array(vertices[f.vertices[2]].0),
+                ]
+            })
+            .collect(),
 
         // Normals on STL are per triangle, not per vertex.
         // Yes, this makes STL always look faceted.
-        vertex_normals: normals
-            .into_iter()
-            .flat_map(|n| {
-                let n = glam::Vec3::from_array(n);
+        vertex_normals: faces
+            .iter()
+            .flat_map(|f| {
+                let n = glam::Vec3::from_array(f.normal.0);
                 [n, n, n]
             })
             .collect(),

--- a/crates/viewer/re_renderer/src/importer/stl.rs
+++ b/crates/viewer/re_renderer/src/importer/stl.rs
@@ -26,6 +26,7 @@ pub fn load_stl_from_buffer(
     let num_vertices = faces.len() * 3;
 
     // TODO(gijsd): parse name from ASCII?
+    // https://github.com/hmeyer/stl_io/pull/26
     let name = "";
 
     let material = mesh::Material {
@@ -35,7 +36,6 @@ pub fn load_stl_from_buffer(
         albedo_factor: crate::Rgba::WHITE,
     };
 
-    // TODO(gijsd): Does this not support sparse meshes/vertex positions?
     let mesh = mesh::CpuMesh {
         label: name.into(),
         triangle_indices: (0..num_vertices as u32)

--- a/crates/viewer/re_renderer/src/importer/stl.rs
+++ b/crates/viewer/re_renderer/src/importer/stl.rs
@@ -25,7 +25,7 @@ pub fn load_stl_from_buffer(
     // https://github.com/hmeyer/stl_io/pull/26
     let name = reader.name().cloned().unwrap_or_default();
 
-    let (normals, vertices): (Vec<_>, Vec<_>) = reader
+    let (normals, triangles): (Vec<_>, Vec<_>) = reader
         .into_iter()
         .map(|triangle| triangle.unwrap())
         .map(|triangle| {
@@ -40,7 +40,7 @@ pub fn load_stl_from_buffer(
         })
         .unzip();
 
-    let num_vertices = vertices.len() * 3;
+    let num_vertices = triangles.len() * 3;
 
     let material = mesh::Material {
         label: name.clone().into(),
@@ -56,7 +56,7 @@ pub fn load_stl_from_buffer(
             .map(glam::UVec3::from)
             .collect::<Vec<_>>(),
 
-        vertex_positions: bytemuck::cast_vec(vertices),
+        vertex_positions: bytemuck::cast_vec(triangles),
 
         // Normals on STL are per triangle, not per vertex.
         // Yes, this makes STL always look faceted.


### PR DESCRIPTION
### What

This replaces `tinystl` with `stl_io` in our stl parser, because some binary stl files (e.g. g1 [right_wrist_yaw_link.STL](https://github.com/unitreerobotics/unitree_ros/blob/master/robots/g1_description/meshes/right_wrist_yaw_link.STL)) could not be parsed, resulting in a warning:

```
 Failed to load mesh "../unitree_ros/robots/g1_description/meshes/right_wrist_yaw_link.STL": Error loading STL mesh: Error { kind: InvalidData, message: "stream did not contain valid UTF-8" }
```

Using `stl_io` this mesh is parsed correctly.

TODO:
- [x] Currently this uses an empty string for the mesh name as debug label, as `stl_io` does not expose this field. This is in line with the behavior of `tinystl` for meshes without a name. I opened a PR that exposes the mesh name: https://github.com/hmeyer/stl_io/pull/26
