### PR TITLE
Improve error message for `QueryError` and `DataLoaderError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6816,6 +6816,7 @@ dependencies = [
  "re_build_info",
  "re_chunk",
  "re_crash_handler",
+ "re_error",
  "re_log",
  "re_log_encoding",
  "re_log_types",

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -27,6 +27,7 @@ default = []
 re_arrow_util.workspace = true
 re_build_info.workspace = true
 re_chunk.workspace = true
+re_error.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder"] }
 re_log_types.workspace = true
 re_log.workspace = true

--- a/crates/store/re_data_loader/src/lib.rs
+++ b/crates/store/re_data_loader/src/lib.rs
@@ -328,7 +328,7 @@ pub enum DataLoaderError {
     #[error("No data-loader support for {0:?}")]
     Incompatible(std::path::PathBuf),
 
-    #[error(transparent)]
+    #[error("{}", re_error::format(.0))]
     Other(#[from] anyhow::Error),
 }
 

--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -67,7 +67,7 @@ pub enum QueryError {
     #[error("Not implemented")]
     NotImplemented,
 
-    #[error(transparent)]
+    #[error("{}", re_error::format(.0))]
     Other(#[from] anyhow::Error),
 }
 


### PR DESCRIPTION
### Related
* https://github.com/rerun-io/rerun/issues/1845
* https://github.com/rerun-io/rerun/issues/8681

### What
This problem keeps biting us in the ass: We get really bad error reports from users because the default `Display` for `anyhow::Error` only includes the latest context, and not the whole error 😠 