### PR TITLE
`LatestAtResults::component_mono_quiet` now requires `ComponentDescriptor`

### DIFF
--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -243,7 +243,7 @@ impl EntityDb {
                 .cache()
                 .latest_at(query, entity_path, [component_descr]);
         results
-            .component_mono_quiet()
+            .component_mono_quiet(component_descr)
             .map(|value| (results.index(), value))
     }
 

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -554,9 +554,10 @@ impl LatestAtResults {
     ///
     /// Returns none if the data cannot be deserialized, or if the underlying batch is not of unit length.
     #[inline]
-    pub fn component_mono_quiet<C: Component>(&self) -> Option<C> {
-        let component_descr = self.find_component_descriptor(C::name())?;
-
+    pub fn component_mono_quiet<C: Component>(
+        &self,
+        component_descr: &ComponentDescriptor,
+    ) -> Option<C> {
         self.components
             .get(component_descr)
             .and_then(|unit| unit.component_mono(component_descr)?.ok())

--- a/crates/viewer/re_view_spatial/src/pinhole.rs
+++ b/crates/viewer/re_view_spatial/src/pinhole.rs
@@ -99,7 +99,12 @@ pub fn query_pinhole_and_view_coordinates_from_store_without_blueprint(
         [
             &archetypes::Pinhole::descriptor_image_from_camera(),
             &archetypes::Pinhole::descriptor_resolution(),
+            // Note that `components::ViewCoordinates` is somewhat special, in that for convenience it can
+            // be specified in multiple places (i.e. `archetypes`). This used to be fine, but got quite a
+            // bit more cumbersome with fully-qualified component descriptors. Because of this, we now have
+            // to query using descriptors from a "secondary" archetype.
             &archetypes::Pinhole::descriptor_camera_xyz(),
+            &archetypes::ViewCoordinates::descriptor_xyz(),
         ],
     );
 
@@ -116,6 +121,7 @@ pub fn query_pinhole_and_view_coordinates_from_store_without_blueprint(
         });
     let camera_xyz: components::ViewCoordinates = query_results
         .component_mono_quiet(&archetypes::Pinhole::descriptor_camera_xyz())
+        // This is the "secondary" descriptor (mentioned above) that we are interested in.
         .or_else(|| {
             query_results.component_mono_quiet(&archetypes::ViewCoordinates::descriptor_xyz())
         })

--- a/crates/viewer/re_view_spatial/src/pinhole.rs
+++ b/crates/viewer/re_view_spatial/src/pinhole.rs
@@ -103,16 +103,22 @@ pub fn query_pinhole_and_view_coordinates_from_store_without_blueprint(
         ],
     );
 
-    let pinhole_projection =
-        query_results.component_mono_quiet::<components::PinholeProjection>()?;
+    let pinhole_projection = query_results.component_mono_quiet::<components::PinholeProjection>(
+        &archetypes::Pinhole::descriptor_image_from_camera(),
+    )?;
 
     let resolution = query_results
-        .component_mono_quiet::<components::Resolution>()
+        .component_mono_quiet::<components::Resolution>(
+            &archetypes::Pinhole::descriptor_resolution(),
+        )
         .unwrap_or_else(|| {
             resolution_of_image_at(ctx, query, entity_path).unwrap_or([100.0, 100.0].into())
         });
-    let camera_xyz = query_results
-        .component_mono_quiet::<components::ViewCoordinates>()
+    let camera_xyz: components::ViewCoordinates = query_results
+        .component_mono_quiet(&archetypes::Pinhole::descriptor_camera_xyz())
+        .or_else(|| {
+            query_results.component_mono_quiet(&archetypes::ViewCoordinates::descriptor_xyz())
+        })
         .unwrap_or(archetypes::Pinhole::DEFAULT_CAMERA_XYZ);
 
     Some((


### PR DESCRIPTION
### Related

* Part of #6889.
* Closes #9917.

### What

Title. @Wumpf please double check if this is the logic that you had in mind for #9917. 🙏 
