### PR TITLE
Add `/env/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _deps
 # Python virtual environment:
 **/venv*
 **/.venv*
+/env/
 .python-version
 
 # Python build artifacts:


### PR DESCRIPTION
Some of our tooling (for example `pixi run lint-rerun`) relies on `.gitignore`. By adding `/env/` here we prevent runing unneeded lints on these files.
