### PR TITLE
Allow editing existing recording properties, like name

### DIFF
--- a/crates/store/re_log_types/src/index/time_point.rs
+++ b/crates/store/re_log_types/src/index/time_point.rs
@@ -20,6 +20,9 @@ impl From<BTreeMap<TimelineName, TimeCell>> for TimePoint {
 }
 
 impl TimePoint {
+    /// A static time point, equivalent to [`TimePoint::default`].
+    pub const STATIC: Self = Self(BTreeMap::new());
+
     #[inline]
     pub fn get(&self, timeline_name: &TimelineName) -> Option<NonMinI64> {
         self.0.get(timeline_name).map(|cell| cell.value)

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -2,7 +2,7 @@ use egui::NumExt as _;
 
 use re_chunk_store::UnitChunkShared;
 use re_entity_db::InstancePath;
-use re_log_types::{ComponentPath, Instance, TimeInt};
+use re_log_types::{ComponentPath, EntityPath, Instance, TimeInt, TimePoint};
 use re_ui::{ContextExt as _, SyntaxHighlighting as _, UiExt as _};
 use re_viewer_context::{UiLayout, ViewerContext};
 
@@ -126,6 +126,24 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
         };
 
         if num_instances <= 1 {
+            // Allow editing recording properties:
+            if entity_path.starts_with(&EntityPath::properties()) {
+                if let Some(array) = self.unit.component_batch_raw(component_descriptor) {
+                    if ctx.component_ui_registry().try_show_edit_ui(
+                        ctx,
+                        ui,
+                        ctx.recording_id(),
+                        TimePoint::STATIC,
+                        array.as_ref(),
+                        entity_path,
+                        component_descriptor.clone(),
+                        !ui_layout.is_single_line(),
+                    ) {
+                        return;
+                    }
+                }
+            }
+
             ctx.component_ui_registry().ui(
                 ctx,
                 ui,

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -132,10 +132,12 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
                     if ctx.component_ui_registry().try_show_edit_ui(
                         ctx,
                         ui,
-                        ctx.recording_id(),
-                        TimePoint::STATIC,
+                        re_viewer_context::EditTarget {
+                            store_id: ctx.recording_id(),
+                            timepoint: TimePoint::STATIC,
+                            entity_path: entity_path.clone(),
+                        },
                         array.as_ref(),
-                        entity_path,
                         component_descriptor.clone(),
                         !ui_layout.is_single_line(),
                     ) {

--- a/crates/viewer/re_data_ui/src/component_name.rs
+++ b/crates/viewer/re_data_ui/src/component_name.rs
@@ -21,7 +21,9 @@ impl DataUi for ComponentName {
 
                 if ui_layout.is_selection_panel() {
                     ui.label(format!("Full name: {}", self.full_name()));
-                };
+                } else {
+                    ui.label(self.full_name());
+                }
 
                 // Only show the first line of the docs:
                 if let Some(markdown) = ctx

--- a/crates/viewer/re_selection_panel/Cargo.toml
+++ b/crates/viewer/re_selection_panel/Cargo.toml
@@ -28,11 +28,11 @@ re_entity_db.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
-re_view.workspace = true
 re_tracing.workspace = true
 re_types_core.workspace = true
 re_types.workspace = true
 re_ui.workspace = true
+re_view.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -368,7 +368,7 @@ fn add_new_default(
         Ok(chunk) => {
             ctx.viewer_ctx
                 .command_sender()
-                .send_system(SystemCommand::UpdateBlueprint(
+                .send_system(SystemCommand::AppendToStore(
                     ctx.blueprint_db().store_id().clone(),
                     vec![chunk],
                 ));

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -134,7 +134,7 @@ fn active_default_ui(
                     &query_context,
                     ui,
                     db,
-                    &view.defaults_path,
+                    view.defaults_path.clone(),
                     component_descr,
                     None, // No cache key.
                     default_value,
@@ -154,7 +154,10 @@ fn active_default_ui(
                 )
                 .min_desired_width(150.0)
                 .action_button(&re_ui::icons::CLOSE, || {
-                    ctx.clear_blueprint_component(&view.defaults_path, component_descr.clone());
+                    ctx.clear_blueprint_component(
+                        view.defaults_path.clone(),
+                        component_descr.clone(),
+                    );
                 })
                 .value_fn(|ui, _| value_fn(ui)),
             )

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -96,7 +96,7 @@ fn visible_time_range_ui(
             &timeline_name,
             has_individual_range,
             resolved_query_range,
-            time_range_override_path,
+            time_range_override_path.clone(),
             visible_time_ranges,
         );
     }
@@ -107,7 +107,7 @@ fn save_visible_time_ranges(
     timeline_name: &TimelineName,
     has_individual_range: bool,
     query_range: QueryRange,
-    property_path: &EntityPath,
+    property_path: EntityPath,
     mut visible_time_range_list: Vec<VisibleTimeRange>,
 ) {
     if has_individual_range {

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -231,6 +231,8 @@ fn visualizer_components(
                 || !ctx.viewer_ctx.component_ui_registry().try_show_edit_ui(
                     ctx.viewer_ctx,
                     ui,
+                    ctx.viewer_ctx.store_context.blueprint.store_id().clone(),
+                    ctx.viewer_ctx.store_context.blueprint_timepoint_for_writes(),
                     raw_current_value.as_ref(),
                     override_path,
                     component_descr.clone(),

--- a/crates/viewer/re_ui/src/list_item/item_button.rs
+++ b/crates/viewer/re_ui/src/list_item/item_button.rs
@@ -1,7 +1,7 @@
 //! Abstraction for buttons to be used in list items.
 
 use crate::{Icon, UiExt as _};
-use egui::containers::menu::MenuButton;
+use egui::containers::menu::{MenuButton, MenuConfig};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -12,6 +12,7 @@ pub struct ItemMenuButton<'a> {
     enabled: bool,
     hover_text: Option<String>,
     disabled_hover_text: Option<String>,
+    config: Option<MenuConfig>,
 }
 
 impl<'a> ItemMenuButton<'a> {
@@ -22,6 +23,7 @@ impl<'a> ItemMenuButton<'a> {
             enabled: true,
             hover_text: None,
             disabled_hover_text: None,
+            config: Default::default(),
         }
     }
 
@@ -45,19 +47,38 @@ impl<'a> ItemMenuButton<'a> {
         self.disabled_hover_text = Some(hover_text.into());
         self
     }
+
+    #[inline]
+    pub fn config(mut self, config: MenuConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
 }
 
 impl super::ItemButton for ItemMenuButton<'_> {
     fn ui(self: Box<Self>, ui: &mut egui::Ui) -> egui::Response {
-        ui.add_enabled_ui(self.enabled, |ui| {
+        let Self {
+            icon,
+            add_contents,
+            enabled,
+            hover_text,
+            disabled_hover_text,
+            config,
+        } = *self;
+
+        ui.add_enabled_ui(enabled, |ui| {
             ui.spacing_mut().item_spacing = egui::Vec2::ZERO;
 
-            let (mut response, _) = MenuButton::from_button(ui.small_icon_button_widget(self.icon))
-                .ui(ui, self.add_contents);
-            if let Some(hover_text) = self.hover_text {
+            let mut button = MenuButton::from_button(ui.small_icon_button_widget(icon));
+            if let Some(config) = config {
+                button = button.config(config);
+            }
+
+            let (mut response, _) = button.ui(ui, add_contents);
+            if let Some(hover_text) = hover_text {
                 response = response.on_hover_text(hover_text);
             }
-            if let Some(disabled_hover_text) = self.disabled_hover_text {
+            if let Some(disabled_hover_text) = disabled_hover_text {
                 response = response.on_disabled_hover_text(disabled_hover_text);
             }
 

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -103,7 +103,7 @@ pub fn view_property_component_ui(
             ctx,
             ui,
             ctx.viewer_ctx.blueprint_db(),
-            ctx.target_entity_path,
+            ctx.target_entity_path.clone(),
             &component_descr,
             row_id,
             component_array.as_deref(),
@@ -116,7 +116,7 @@ pub fn view_property_component_ui(
             ctx,
             ui,
             ctx.viewer_ctx.blueprint_db(),
-            ctx.target_entity_path,
+            ctx.target_entity_path.clone(),
             &component_descr,
             row_id,
             component_array.as_deref(),
@@ -214,7 +214,10 @@ If no default blueprint was set or it didn't set any value for this field, this 
             "The property is already set to the same value it has in the default blueprint",
         );
     if response.clicked() {
-        ctx.reset_blueprint_component(&property.blueprint_store_path, component_descr.clone());
+        ctx.reset_blueprint_component(
+            property.blueprint_store_path.clone(),
+            component_descr.clone(),
+        );
         ui.close();
     }
 
@@ -229,7 +232,10 @@ This has the same effect as not setting the value in the blueprint at all."
         )
         .on_disabled_hover_text("The property is already unset.");
     if response.clicked() {
-        ctx.clear_blueprint_component(&property.blueprint_store_path, component_descr.clone());
+        ctx.clear_blueprint_component(
+            property.blueprint_store_path.clone(),
+            component_descr.clone(),
+        );
         ui.close();
     }
 

--- a/crates/viewer/re_view_graph/src/ui/selection.rs
+++ b/crates/viewer/re_view_graph/src/ui/selection.rs
@@ -70,7 +70,7 @@ pub fn view_property_force_ui<A: Archetype + ArchetypeReflectionMarker>(
                 &query_ctx,
                 ui,
                 ctx.blueprint_db(),
-                query_ctx.target_entity_path,
+                query_ctx.target_entity_path.clone(),
                 &component_descr,
                 row_id,
                 component_array.as_deref(),

--- a/crates/viewer/re_view_spatial/tests/visible_time_range.rs
+++ b/crates/viewer/re_view_spatial/tests/visible_time_range.rs
@@ -338,7 +338,7 @@ fn setup_blueprint(
             re_types::blueprint::archetypes::VisualBounds2D::name(),
         );
         ctx.save_blueprint_archetype(
-            &property_path,
+            property_path.clone(),
             &re_types::blueprint::archetypes::VisualBounds2D::new(re_types::datatypes::Range2D {
                 x_range: [0.0, 100.0].into(),
                 y_range: [0.0, 100.0].into(),
@@ -354,14 +354,14 @@ fn setup_blueprint(
                 re_types::blueprint::archetypes::VisibleTimeRanges::name(),
             );
 
-            ctx.save_blueprint_archetype(&property_path, &visible_time_range_list);
+            ctx.save_blueprint_archetype(property_path, &visible_time_range_list);
         }
 
         if let Some(green_time_range) = green_time_range {
             let visible_time_range_list =
                 re_types::blueprint::archetypes::VisibleTimeRanges::new([green_time_range]);
             ctx.save_blueprint_archetype(
-                &re_viewport_blueprint::ViewContents::override_path_for_entity(
+                re_viewport_blueprint::ViewContents::override_path_for_entity(
                     view_id,
                     &"green".into(),
                 ),

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -731,7 +731,10 @@ fn update_series_visibility_overrides_from_plot(
                 .serialized()
                 .map(|serialized| serialized.with_descriptor_override(descriptor))
         }) {
-            ctx.save_serialized_blueprint_component(override_path, serialized_component_batch);
+            ctx.save_serialized_blueprint_component(
+                override_path.clone(),
+                serialized_component_batch,
+            );
         }
     }
 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -568,7 +568,8 @@ impl App {
 
             SystemCommand::AppendToStore(store_id, chunks) => {
                 re_log::trace!(
-                    "Update entities: {}",
+                    "Update {} entities: {}",
+                    store_id.kind,
                     chunks.iter().map(|c| c.entity_path()).join(", ")
                 );
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -565,29 +565,36 @@ impl App {
                 store_hub.clear_active_blueprint();
                 egui_ctx.request_repaint(); // Many changes take a frame delay to show up.
             }
-            SystemCommand::UpdateBlueprint(blueprint_id, chunks) => {
+
+            SystemCommand::AppendToStore(store_id, chunks) => {
                 re_log::trace!(
-                    "Update blueprint entities: {}",
+                    "Update entities: {}",
                     chunks.iter().map(|c| c.entity_path()).join(", ")
                 );
 
-                let blueprint_db = store_hub.entity_db_mut(&blueprint_id);
+                let db = store_hub.entity_db_mut(&store_id);
 
-                self.state
-                    .blueprint_undo_state
-                    .entry(blueprint_id)
-                    .or_default()
-                    .clear_redo_buffer(blueprint_db);
+                if store_id.kind == StoreKind::Blueprint {
+                    self.state
+                        .blueprint_undo_state
+                        .entry(store_id)
+                        .or_default()
+                        .clear_redo_buffer(db);
+                } else {
+                    // It would be nice to be able to undo edits to a recording, but
+                    // we haven't implemented that yet.
+                }
 
                 for chunk in chunks {
-                    match blueprint_db.add_chunk(&Arc::new(chunk)) {
+                    match db.add_chunk(&Arc::new(chunk)) {
                         Ok(_store_events) => {}
                         Err(err) => {
-                            re_log::warn_once!("Failed to store blueprint delta: {err}");
+                            re_log::warn_once!("Failed to append chunk: {err}");
                         }
                     }
                 }
             }
+
             SystemCommand::UndoBlueprint { blueprint_id } => {
                 let blueprint_db = store_hub.entity_db_mut(&blueprint_id);
                 self.state

--- a/crates/viewer/re_viewer/src/app_blueprint.rs
+++ b/crates/viewer/re_viewer/src/app_blueprint.rs
@@ -241,7 +241,7 @@ impl AppBlueprint<'_> {
                 // All builtin types, no reason for this to ever fail.
                 .expect("Failed to build chunk.");
 
-            command_sender.send_system(SystemCommand::UpdateBlueprint(
+            command_sender.send_system(SystemCommand::AppendToStore(
                 blueprint_db.store_id().clone(),
                 vec![chunk],
             ));

--- a/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
@@ -33,14 +33,10 @@ impl StoreContext<'_> {
 }
 
 impl ViewerContext<'_> {
-    pub fn save_blueprint_archetype(
-        &self,
-        entity_path: &EntityPath,
-        components: &dyn AsComponents,
-    ) {
+    pub fn save_blueprint_archetype(&self, entity_path: EntityPath, components: &dyn AsComponents) {
         let timepoint = self.store_context.blueprint_timepoint_for_writes();
 
-        let chunk = match Chunk::builder(entity_path.clone())
+        let chunk = match Chunk::builder(entity_path)
             .with_archetype(RowId::new(), timepoint.clone(), components)
             .build()
         {
@@ -60,7 +56,7 @@ impl ViewerContext<'_> {
 
     pub fn save_blueprint_component(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: &ComponentDescriptor,
         component_batch: &dyn ComponentBatch,
     ) {
@@ -77,12 +73,12 @@ impl ViewerContext<'_> {
 
     pub fn save_serialized_blueprint_component(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_batch: SerializedComponentBatch,
     ) {
         let timepoint = self.store_context.blueprint_timepoint_for_writes();
 
-        let chunk = match Chunk::builder(entity_path.clone())
+        let chunk = match Chunk::builder(entity_path)
             .with_serialized_batch(RowId::new(), timepoint.clone(), component_batch)
             .build()
         {
@@ -102,7 +98,7 @@ impl ViewerContext<'_> {
 
     pub fn save_blueprint_array(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: ComponentDescriptor,
         array: ArrayRef,
     ) {
@@ -120,11 +116,11 @@ impl ViewerContext<'_> {
         &self,
         store_id: StoreId,
         timepoint: TimePoint,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: ComponentDescriptor,
         array: ArrayRef,
     ) {
-        let chunk = match Chunk::builder(entity_path.clone())
+        let chunk = match Chunk::builder(entity_path)
             .with_row(RowId::new(), timepoint, [(component_descr, array)])
             .build()
         {
@@ -158,11 +154,11 @@ impl ViewerContext<'_> {
     /// Resets a blueprint component to the value it had in the default blueprint.
     pub fn reset_blueprint_component(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: ComponentDescriptor,
     ) {
         if let Some(default_value) =
-            self.raw_latest_at_in_default_blueprint(entity_path, &component_descr)
+            self.raw_latest_at_in_default_blueprint(&entity_path, &component_descr)
         {
             self.save_blueprint_array(entity_path, component_descr, default_value);
         } else {
@@ -173,13 +169,13 @@ impl ViewerContext<'_> {
     /// Clears a component in the blueprint store by logging an empty array if it exists.
     pub fn clear_blueprint_component(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: ComponentDescriptor,
     ) {
         let blueprint = &self.store_context.blueprint;
 
         let Some(datatype) = blueprint
-            .latest_at(self.blueprint_query, entity_path, [&component_descr])
+            .latest_at(self.blueprint_query, &entity_path, [&component_descr])
             .get(&component_descr)
             .and_then(|unit| {
                 unit.component_batch_raw(&component_descr)
@@ -191,7 +187,7 @@ impl ViewerContext<'_> {
         };
 
         let timepoint = self.store_context.blueprint_timepoint_for_writes();
-        let chunk = Chunk::builder(entity_path.clone())
+        let chunk = Chunk::builder(entity_path)
             .with_row(
                 RowId::new(),
                 timepoint,

--- a/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/command_sender.rs
@@ -62,15 +62,15 @@ pub enum SystemCommand {
     /// Close all stores and show the welcome screen again.
     CloseAllEntries,
 
-    /// Update the blueprint with additional data
+    /// Add more data to a store (blueprint or recording).
     ///
-    /// The [`StoreId`] should generally be the currently selected blueprint
-    /// but is tracked manually to ensure self-consistency if the blueprint
-    /// is both modified and changed in the same frame.
+    /// Edit recordings with case: we generally regard recordings as immutable.
+    ///
+    /// For blueprints,the [`StoreId`] should generally be the currently selected blueprint.
     ///
     /// Instead of using this directly, consider using
     /// [`crate::ViewerContext::save_blueprint_archetype`] or similar.
-    UpdateBlueprint(StoreId, Vec<Chunk>),
+    AppendToStore(StoreId, Vec<Chunk>),
 
     UndoBlueprint {
         blueprint_id: StoreId,

--- a/crates/viewer/re_viewer_context/src/global_context/mod.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/mod.rs
@@ -14,7 +14,7 @@ pub use self::{
     command_sender::{
         CommandReceiver, CommandSender, SystemCommand, SystemCommandSender, command_channel,
     },
-    component_ui_registry::{ComponentUiRegistry, ComponentUiTypes},
+    component_ui_registry::{ComponentUiRegistry, ComponentUiTypes, EditTarget},
     item::Item,
 };
 

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -53,7 +53,8 @@ pub use self::{
     file_dialog::santitize_file_name,
     global_context::{
         AppOptions, CommandReceiver, CommandSender, ComponentUiRegistry, ComponentUiTypes,
-        DisplayMode, GlobalContext, Item, SystemCommand, SystemCommandSender, command_channel,
+        DisplayMode, EditTarget, GlobalContext, Item, SystemCommand, SystemCommandSender,
+        command_channel,
     },
     image_info::{ColormapWithRange, ImageInfo, StoredBlobCacheKey},
     maybe_mut_ref::MaybeMutRef,

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -474,13 +474,21 @@ impl TestContext {
             let mut handled = true;
             let command_name = format!("{command:?}");
             match command {
-                SystemCommand::UpdateBlueprint(store_id, chunks) => {
-                    assert_eq!(store_id, self.blueprint_store.store_id());
-
-                    for chunk in chunks {
-                        self.blueprint_store
-                            .add_chunk(&Arc::new(chunk))
-                            .expect("Updating the blueprint chunk store failed");
+                SystemCommand::AppendToStore(store_id, chunks) => {
+                    if store_id == self.recording_store.store_id() {
+                        for chunk in chunks {
+                            self.recording_store
+                                .add_chunk(&Arc::new(chunk))
+                                .expect("Updating the recording chunk store failed");
+                        }
+                    } else if store_id == self.blueprint_store.store_id() {
+                        for chunk in chunks {
+                            self.blueprint_store
+                                .add_chunk(&Arc::new(chunk))
+                                .expect("Updating the blueprint chunk store failed");
+                        }
+                    } else {
+                        panic!("Unknown store id: {store_id:?}");
                     }
                 }
 

--- a/crates/viewer/re_viewer_context/src/view/view_context.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_context.rs
@@ -94,7 +94,7 @@ impl<'a> ViewContext<'a> {
     #[inline]
     pub fn save_blueprint_array(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: ComponentDescriptor,
         array: arrow::array::ArrayRef,
     ) {
@@ -103,11 +103,7 @@ impl<'a> ViewContext<'a> {
     }
 
     #[inline]
-    pub fn save_blueprint_archetype(
-        &self,
-        entity_path: &EntityPath,
-        components: &dyn AsComponents,
-    ) {
+    pub fn save_blueprint_archetype(&self, entity_path: EntityPath, components: &dyn AsComponents) {
         self.viewer_ctx
             .save_blueprint_archetype(entity_path, components);
     }
@@ -115,7 +111,7 @@ impl<'a> ViewContext<'a> {
     #[inline]
     pub fn save_blueprint_component(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_desc: &ComponentDescriptor,
         component_batch: &dyn ComponentBatch,
     ) {
@@ -126,7 +122,7 @@ impl<'a> ViewContext<'a> {
     #[inline]
     pub fn reset_blueprint_component(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: ComponentDescriptor,
     ) {
         self.viewer_ctx
@@ -137,7 +133,7 @@ impl<'a> ViewContext<'a> {
     #[inline]
     pub fn clear_blueprint_component(
         &self,
-        entity_path: &EntityPath,
+        entity_path: EntityPath,
         component_descr: ComponentDescriptor,
     ) {
         self.viewer_ctx

--- a/crates/viewer/re_viewer_context/src/view/view_query.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_query.rs
@@ -119,7 +119,7 @@ impl DataResult {
 
             if parent_visibility == new_value {
                 ctx.clear_blueprint_component(
-                    &self.property_overrides.override_path,
+                    self.property_overrides.override_path.clone(),
                     EntityBehavior::descriptor_visible(),
                 );
                 return;
@@ -127,7 +127,7 @@ impl DataResult {
         }
 
         ctx.save_blueprint_archetype(
-            &self.property_overrides.override_path,
+            self.property_overrides.override_path.clone(),
             &blueprint_archetypes::EntityBehavior::update_fields().with_visible(new_value),
         );
     }
@@ -154,7 +154,7 @@ impl DataResult {
 
             if parent_interactivity == new_value {
                 ctx.clear_blueprint_component(
-                    &self.property_overrides.override_path,
+                    self.property_overrides.override_path.clone(),
                     EntityBehavior::descriptor_interactive(),
                 );
                 return;
@@ -162,7 +162,7 @@ impl DataResult {
         }
 
         ctx.save_blueprint_archetype(
-            &self.property_overrides.override_path,
+            self.property_overrides.override_path.clone(),
             &blueprint_archetypes::EntityBehavior::update_fields().with_interactive(new_value),
         );
     }

--- a/crates/viewer/re_viewport_blueprint/src/container.rs
+++ b/crates/viewer/re_viewport_blueprint/src/container.rs
@@ -201,7 +201,7 @@ impl ContainerBlueprint {
             ));
         }
 
-        ctx.save_blueprint_archetype(&id.as_entity_path(), &arch);
+        ctx.save_blueprint_archetype(id.as_entity_path(), &arch);
     }
 
     /// Creates a new [`ContainerBlueprint`] from the given [`egui_tiles::Container`].
@@ -321,14 +321,14 @@ impl ContainerBlueprint {
                 Some(name) => {
                     let component = Name(name.into());
                     ctx.save_blueprint_component(
-                        &self.entity_path(),
+                        self.entity_path(),
                         &blueprint_archetypes::ContainerBlueprint::descriptor_display_name(),
                         &component,
                     );
                 }
                 None => {
                     ctx.clear_blueprint_component(
-                        &self.entity_path(),
+                        self.entity_path(),
                         blueprint_archetypes::ContainerBlueprint::descriptor_display_name(),
                     );
                 }
@@ -341,7 +341,7 @@ impl ContainerBlueprint {
         if visible != self.visible {
             let component = Visible::from(visible);
             ctx.save_blueprint_component(
-                &self.entity_path(),
+                self.entity_path(),
                 &blueprint_archetypes::ContainerBlueprint::descriptor_visible(),
                 &component,
             );
@@ -354,13 +354,13 @@ impl ContainerBlueprint {
             if let Some(grid_columns) = grid_columns {
                 let component = GridColumns(grid_columns.into());
                 ctx.save_blueprint_component(
-                    &self.entity_path(),
+                    self.entity_path(),
                     &blueprint_archetypes::ContainerBlueprint::descriptor_grid_columns(),
                     &component,
                 );
             } else {
                 ctx.clear_blueprint_component(
-                    &self.entity_path(),
+                    self.entity_path(),
                     blueprint_archetypes::ContainerBlueprint::descriptor_grid_columns(),
                 );
             }
@@ -372,7 +372,7 @@ impl ContainerBlueprint {
         // We can't delete the entity, because we need to support undo.
         // TODO(#8249): configure blueprint GC to remove this entity if all that remains is the recursive clear.
         ctx.save_blueprint_archetype(
-            &self.entity_path(),
+            self.entity_path(),
             &re_types::archetypes::Clear::recursive(),
         );
     }

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -306,7 +306,7 @@ impl ViewBlueprint {
         // We can't delete the entity, because we need to support undo.
         // TODO(#8249): configure blueprint GC to remove this entity if all that remains is the recursive clear.
         ctx.save_blueprint_archetype(
-            &self.entity_path(),
+            self.entity_path(),
             &re_types::archetypes::Clear::recursive(),
         );
     }
@@ -318,14 +318,14 @@ impl ViewBlueprint {
                 Some(name) => {
                     let component = Name(name.into());
                     ctx.save_blueprint_component(
-                        &self.entity_path(),
+                        self.entity_path(),
                         &blueprint_archetypes::ViewBlueprint::descriptor_display_name(),
                         &component,
                     );
                 }
                 None => {
                     ctx.clear_blueprint_component(
-                        &self.entity_path(),
+                        self.entity_path(),
                         blueprint_archetypes::ViewBlueprint::descriptor_display_name(),
                     );
                 }
@@ -338,7 +338,7 @@ impl ViewBlueprint {
         if origin != &self.space_origin {
             let component = ViewOrigin(origin.into());
             ctx.save_blueprint_component(
-                &self.entity_path(),
+                self.entity_path(),
                 &blueprint_archetypes::ViewBlueprint::descriptor_space_origin(),
                 &component,
             );
@@ -350,7 +350,7 @@ impl ViewBlueprint {
         if visible != self.visible {
             let component = Visible::from(visible);
             ctx.save_blueprint_component(
-                &self.entity_path(),
+                self.entity_path(),
                 &blueprint_archetypes::ViewBlueprint::descriptor_visible(),
                 &component,
             );

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -221,7 +221,7 @@ impl ViewBlueprint {
         contents.save_to_blueprint_store(ctx);
 
         ctx.command_sender()
-            .send_system(SystemCommand::UpdateBlueprint(
+            .send_system(SystemCommand::AppendToStore(
                 ctx.store_context.blueprint.store_id().clone(),
                 deltas,
             ));

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -204,7 +204,11 @@ impl ViewProperty {
                 );
             }
         }
-        ctx.save_blueprint_component(&self.blueprint_store_path, component_descr, component_batch);
+        ctx.save_blueprint_component(
+            self.blueprint_store_path.clone(),
+            component_descr,
+            component_batch,
+        );
     }
 
     /// Clears a blueprint component.
@@ -213,7 +217,7 @@ impl ViewProperty {
         ctx: &ViewerContext<'_>,
         component_descr: ComponentDescriptor,
     ) {
-        ctx.clear_blueprint_component(&self.blueprint_store_path, component_descr);
+        ctx.clear_blueprint_component(self.blueprint_store_path.clone(), component_descr);
     }
 
     /// Resets a blueprint component to the value it had in the default blueprint.
@@ -222,21 +226,21 @@ impl ViewProperty {
         ctx: &ViewerContext<'_>,
         component_descr: ComponentDescriptor,
     ) {
-        ctx.reset_blueprint_component(&self.blueprint_store_path, component_descr);
+        ctx.reset_blueprint_component(self.blueprint_store_path.clone(), component_descr);
     }
 
     /// Resets all components to the values they had in the default blueprint.
     pub fn reset_all_components(&self, ctx: &ViewerContext<'_>) {
         // Don't use `self.query_results.components.keys()` since it may already have some components missing since they didn't show up in the query.
         for component_descr in self.component_descrs.iter().cloned() {
-            ctx.reset_blueprint_component(&self.blueprint_store_path, component_descr);
+            ctx.reset_blueprint_component(self.blueprint_store_path.clone(), component_descr);
         }
     }
 
     /// Resets all components to empty values, i.e. the fallback.
     pub fn reset_all_components_to_empty(&self, ctx: &ViewerContext<'_>) {
         for component_descr in self.query_results.components.keys().cloned() {
-            ctx.clear_blueprint_component(&self.blueprint_store_path, component_descr);
+            ctx.clear_blueprint_component(self.blueprint_store_path.clone(), component_descr);
         }
     }
 

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -349,7 +349,7 @@ impl ViewportBlueprint {
                     .collect();
 
                 ctx.save_blueprint_component(
-                    &VIEWPORT_PATH.into(),
+                    VIEWPORT_PATH.into(),
                     &blueprint_archetypes::ViewportBlueprint::descriptor_past_viewer_recommendations(),
                     &new_viewer_recommendation_hashes,
                 );
@@ -765,7 +765,7 @@ impl ViewportBlueprint {
         if old_value != value {
             let auto_layout = AutoLayout::from(value);
             ctx.save_blueprint_component(
-                &VIEWPORT_PATH.into(),
+                VIEWPORT_PATH.into(),
                 &blueprint_archetypes::ViewportBlueprint::descriptor_auto_layout(),
                 &auto_layout,
             );
@@ -786,7 +786,7 @@ impl ViewportBlueprint {
         if old_value != value {
             let auto_views = AutoViews::from(value);
             ctx.save_blueprint_component(
-                &VIEWPORT_PATH.into(),
+                VIEWPORT_PATH.into(),
                 &blueprint_archetypes::ViewportBlueprint::descriptor_auto_views(),
                 &auto_views,
             );
@@ -798,7 +798,7 @@ impl ViewportBlueprint {
         if self.maximized != view_id {
             let view_maximized = view_id.map(|id| ViewMaximized(id.into()));
             ctx.save_blueprint_component(
-                &VIEWPORT_PATH.into(),
+                VIEWPORT_PATH.into(),
                 &blueprint_archetypes::ViewportBlueprint::descriptor_maximized(),
                 &view_maximized,
             );
@@ -901,14 +901,14 @@ impl ViewportBlueprint {
         {
             re_log::trace!("Saving with a root container");
             ctx.save_blueprint_component(
-                &VIEWPORT_PATH.into(),
+                VIEWPORT_PATH.into(),
                 &blueprint_archetypes::ViewportBlueprint::descriptor_root_container(),
                 &root_container,
             );
         } else {
             re_log::trace!("Saving empty viewport");
             ctx.clear_blueprint_component(
-                &VIEWPORT_PATH.into(),
+                VIEWPORT_PATH.into(),
                 blueprint_archetypes::ViewportBlueprint::descriptor_root_container(),
             );
         }


### PR DESCRIPTION
### Related
* Pulled out from https://github.com/rerun-io/rerun/pull/9970

### What
If a recording has a name, you can now edit it in the selection panel.

If a recording has no name, there is no way to add one. That would require design, and thus a lot more work, and is out-of-scope for this cycle.