### PR TITLE
Mention URL scheme in `connect_grpc` docs

### DIFF
--- a/crates/top/rerun/src/clap.rs
+++ b/crates/top/rerun/src/clap.rs
@@ -55,7 +55,12 @@ pub struct RerunArgs {
 
     /// Connects and sends the logged data to a remote Rerun viewer.
     ///
-    /// Optionally takes an HTTP(S) URL.
+    /// Optionally takes a URL to connect to.
+    ///
+    /// The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`,
+    /// and the pathname must be `/proxy`.
+    ///
+    /// The default is `rerun+http://127.0.0.1:9876/proxy`.
     #[clap(long)]
     #[allow(clippy::option_option)]
     connect: Option<Option<String>>,

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -175,7 +175,12 @@ When persisted, the state will be stored at the following locations:
 
     /// Do not attempt to start a new server, instead try to connect to an existing one.
     ///
-    /// Optionally accepts an HTTP(S) URL to a gRPC server.
+    /// Optionally accepts a URL to a gRPC server.
+    ///
+    /// The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`,
+    /// and the pathname must be `/proxy`.
+    ///
+    /// The default is `rerun+http://127.0.0.1:9876/proxy`.
     #[clap(long)]
     #[allow(clippy::option_option)] // Tri-state: none, --connect, --connect <url>.
     connect: Option<Option<String>>,

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -421,9 +421,15 @@ extern void rr_recording_stream_set_thread_local(
 /// Check whether the recording stream is enabled.
 extern bool rr_recording_stream_is_enabled(rr_recording_stream stream, rr_error* error);
 
-/// Connect to a remote Rerun Viewer on the given HTTP(S) URL.
+/// Connect to a remote Rerun Viewer on the given URL.
 ///
 /// Requires that you first start a Rerun Viewer by typing 'rerun' in a terminal.
+///
+/// url:
+/// The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`,
+/// and the pathname must be `/proxy`.
+///
+/// The default is `rerun+http://127.0.0.1:9876/proxy`.
 ///
 /// flush_timeout_sec:
 /// The minimum time the SDK will wait during a flush before potentially

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -139,9 +139,15 @@ namespace rerun {
         /// \details Either of these needs to be called, otherwise the stream will buffer up indefinitely.
         /// @{
 
-        /// Connect to a remote Rerun Viewer on the given HTTP(S) URL.
+        /// Connect to a remote Rerun Viewer on the given URL.
         ///
         /// Requires that you first start a Rerun Viewer by typing 'rerun' in a terminal.
+        ///
+        /// url:
+        /// The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`,
+        /// and the pathname must be `/proxy`.
+        ///
+        /// The default is `rerun+http://127.0.0.1:9876/proxy`.
         ///
         /// flush_timeout_sec:
         /// The minimum time the SDK will wait during a flush before potentially
@@ -150,7 +156,7 @@ namespace rerun {
         ///
         /// This function returns immediately.
         Error connect_grpc(
-            std::string_view url = "rerun+http://127.0.0.1:9876", float flush_timeout_sec = 2.0
+            std::string_view url = "rerun+http://127.0.0.1:9876/proxy", float flush_timeout_sec = 2.0
         ) const;
 
         /// Swaps the underlying sink for a gRPC server sink pre-configured to listen on `rerun+http://{bind_ip}:{port}/proxy`.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -739,7 +739,7 @@ def connect_grpc(
     default_blueprint: Optional[PyMemorySinkStorage] = None,
     recording: Optional[PyRecordingStream] = None,
 ) -> None:
-    """Connect the recording stream to a remote Rerun Viewer on the given HTTP(S) URL."""
+    """Connect the recording stream to a remote Rerun Viewer on the given URL."""
 
 def connect_grpc_blueprint(
     url: Optional[str],

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -592,7 +592,7 @@ class Blueprint:
         make_default: bool = True,
     ) -> None:
         """
-        Connect to a remote Rerun Viewer on the given HTTP(S) URL and send this blueprint.
+        Connect to a remote Rerun Viewer on the given URL and send this blueprint.
 
         Parameters
         ----------
@@ -600,7 +600,12 @@ class Blueprint:
             The application ID to use for this blueprint. This must match the application ID used
             when initiating rerun for any data logging you wish to associate with this blueprint.
         url:
-            The HTTP(S) URL to connect to
+            The URL to connect to
+
+            The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`,
+            and the pathname must be `/proxy`.
+
+            The default is `rerun+http://127.0.0.1:9876/proxy`.
         make_active:
             Immediately make this the active blueprint for the associated `app_id`.
             Note that setting this to `false` does not mean the blueprint may not still end

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -493,14 +493,19 @@ class RecordingStream:
         default_blueprint: BlueprintLike | None = None,
     ) -> None:
         """
-        Connect to a remote Rerun Viewer on the given HTTP(S) URL.
+        Connect to a remote Rerun Viewer on the given URL.
 
         This function returns immediately.
 
         Parameters
         ----------
         url:
-            The HTTP(S) URL to connect to
+            The URL to connect to
+
+            The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`,
+            and the pathname must be `/proxy`.
+
+            The default is `rerun+http://127.0.0.1:9876/proxy`.
         flush_timeout_sec:
             The minimum time the SDK will wait during a flush before potentially
             dropping data if progress is not being made. Passing `None` indicates no timeout,

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -51,7 +51,7 @@ def script_add_args(parser: ArgumentParser) -> None:
         action="store_true",
         help="Serve a web viewer (WARNING: experimental feature)",
     )
-    parser.add_argument("--url", type=str, default=None, help="Connect to this HTTP(S) URL")
+    parser.add_argument("--url", type=str, default=None, help="Connect to this Rerun URL")
     parser.add_argument("--save", type=str, default=None, help="Save data to a .rrd file at this path")
     parser.add_argument(
         "-o",

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -33,14 +33,19 @@ def connect_grpc(
     recording: RecordingStream | None = None,
 ) -> None:
     """
-    Connect to a remote Rerun Viewer on the given HTTP(S) URL.
+    Connect to a remote Rerun Viewer on the given URL.
 
     This function returns immediately.
 
     Parameters
     ----------
     url:
-        The HTTP(S) URL to connect to
+        The URL to connect to.
+
+        The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`,
+        and the pathname must be `/proxy`.
+
+        The default is `rerun+http://127.0.0.1:9876/proxy`.
     flush_timeout_sec:
         The minimum time the SDK will wait during a flush before potentially
         dropping data if progress is not being made. Passing `None` indicates no timeout,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -606,7 +606,7 @@ fn spawn(
     re_sdk::spawn(&spawn_opts).map_err(|err| PyRuntimeError::new_err(err.to_string()))
 }
 
-/// Connect the recording stream to a remote Rerun Viewer on the given HTTP(S) URL.
+/// Connect the recording stream to a remote Rerun Viewer on the given URL.
 #[pyfunction]
 #[pyo3(signature = (url, flush_timeout_sec=re_sdk::default_flush_timeout().expect("always Some()").as_secs_f32(), default_blueprint = None, recording = None))]
 fn connect_grpc(


### PR DESCRIPTION
We had a few places that mention connecting to a URL, but do not specify what that URL should look like.