### PR TITLE
Use BuildJet runners with more CPUs and RAM

### DIFF
--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           case "${{ inputs.PLATFORM }}" in
             linux-arm64)
-              runner="buildjet-8vcpu-ubuntu-2204-arm"
+              runner="buildjet-16vcpu-ubuntu-2204-arm"
               target="aarch64-unknown-linux-gnu"
               container="'rerunio/ci_docker:0.15.0'"
               lib_name="librerun_c.a"

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           case "${{ inputs.PLATFORM }}" in
             linux-arm64)
-              runner="buildjet-8vcpu-ubuntu-2204-arm"
+              runner="buildjet-16vcpu-ubuntu-2204-arm"
               target="aarch64-unknown-linux-gnu"
               container="'rerunio/ci_docker:0.15.0'"
               bin_name="rerun"

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           case "${{ inputs.PLATFORM }}" in
             linux-arm64)
-                runner="buildjet-8vcpu-ubuntu-2204-arm"
+                runner="buildjet-16vcpu-ubuntu-2204-arm"
                 target="aarch64-unknown-linux-gnu"
                 container="'rerunio/ci_docker:0.15.0'" # Required to be manylinux compatible
                 compat="manylinux_2_31"

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           case "${{ inputs.PLATFORM }}" in
             linux-arm64)
-              runner="buildjet-8vcpu-ubuntu-2204-arm"
+              runner="buildjet-16vcpu-ubuntu-2204-arm"
               target="aarch64-unknown-linux-gnu"
               container="'rerunio/ci_docker:0.15.0'"
               ;;


### PR DESCRIPTION
### Related

* attempt at fixing these err 137 ci failure: https://github.com/rerun-io/rerun/actions/runs/15128223538/job/42525117004

### What

This PR bumps our BuildJet runners to 16vcpu/24GB, up from 8vcpu/12GB.

In the worst case, this should double our monthly costs, which has recently averaged at around ~35USD/month. Hopefully, faster workflow should mean less cost increase.