### PR TITLE
Fix test execution seeping into lint-only job that didn't have software rasterizer setup

### DIFF
--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -80,13 +80,13 @@ jobs:
         if: ${{ inputs.CHANNEL == 'pr' }}
         run: pixi run rs-check --only base_checks sdk_variations cargo_deny wasm docs
 
-      - name: Rust most checks & tests
+      - name: Rust most checks (`main` branch subset)
         if: ${{ inputs.CHANNEL == 'main' }}
-        run: pixi run rs-check --skip individual_crates docs_slow
+        run: pixi run rs-check --skip individual_crates docs_slow tests tests_without_all_features # Tests run in a separate job
 
-      - name: Rust all checks & tests
+      - name: Rust all checks (nightly)
         if: ${{ inputs.CHANNEL == 'nightly' }}
-        run: pixi run rs-check
+        run: pixi run rs-check --skip tests tests_without_all_features # Tests run in a separate job
 
       - name: .rrd backwards compatibility
         # We don't yet guarantee backwards compatibility, but we at least check it
@@ -95,7 +95,7 @@ jobs:
         run: pixi run check-backwards-compatibility
 
   rs-tests:
-    name: Rust lints (tests)
+    name: Rust tests
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
     runs-on: ubuntu-22.04-large
     env:
@@ -132,9 +132,12 @@ jobs:
       - name: Setup software rasterizer
         run: pixi run python ./scripts/ci/setup_software_rasterizer.py
 
-      - name: Rust checks (PR subset)
-        if: ${{ inputs.CHANNEL == 'pr' }}
+      - name: Rust tests
         run: pixi run rs-check --only tests
+
+      - name: Rust tests without --all-features
+        if: ${{ inputs.CHANNEL != 'pr' }}
+        run: pixi run rs-check --only tests_without_all_features
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -386,11 +386,7 @@ pub fn testing_instance_descriptor() -> wgpu::InstanceDescriptor {
     let backends = wgpu::Backends::VULKAN | wgpu::Backends::METAL;
 
     let flags = (
-        wgpu::InstanceFlags::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER
-        // Validation would be great, but it looks like we don't always get validation layers, causing this error:
-        // `InstanceFlags::VALIDATION requested, but unable to find layer: VK_LAYER_KHRONOS_validation`
-        //| wgpu::InstanceFlags::VALIDATION
-
+        wgpu::InstanceFlags::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER | wgpu::InstanceFlags::VALIDATION
         // TODO(andreas): GPU based validation layer sounds like a great idea,
         // but as of writing this makes tests crash on my Windows machine!
         // It looks like the crash is in the Vulkan/Nvidia driver, but further investigation is needed.


### PR DESCRIPTION
### Related

* rolls back https://github.com/rerun-io/rerun/pull/10023
* fixes ci issues introduced in https://github.com/rerun-io/rerun/pull/9787

### What

(see title)

* [ ] pass `main` ci