### PR TITLE
moving partition type and storage url to partition manifest

### DIFF
--- a/crates/store/re_protos/src/lib.rs
+++ b/crates/store/re_protos/src/lib.rs
@@ -83,12 +83,13 @@ pub mod manifest_registry {
         /// `DatasetManifest` mandatory field names. All mandatory metadata fields are prefixed
         /// with "rerun_" to avoid conflicts with user-defined fields.
         pub const DATASET_MANIFEST_ID_FIELD_NAME: &str = "rerun_partition_id";
+        pub const DATASET_MANIFEST_CREATED_AT_FIELD_NAME: &str = "rerun_created_at";
         pub const DATASET_MANIFEST_PARTITION_MANIFEST_UPDATED_AT_FIELD_NAME: &str = "rerun_partition_manifest_updated_at";
         pub const DATASET_MANIFEST_PARTITION_MANIFEST_URL_FIELD_NAME: &str = "rerun_partition_manifest_url";
-        pub const DATASET_MANIFEST_RECORDING_TYPE_FIELD_NAME: &str = "rerun_partition_type";
-        pub const DATASET_MANIFEST_REGISTRATION_TIME_FIELD_NAME: &str = "rerun_registration_time";
-        pub const DATASET_MANIFEST_START_TIME_FIELD_NAME: &str = "rerun_start_time";
-        pub const DATASET_MANIFEST_STORAGE_URL_FIELD_NAME: &str = "rerun_storage_url";
+
+        /// Partition manifest mandatory field names.
+        pub const PARTITION_MANIFEST_PARTITION_TYPE_FIELD_NAME: &str = "rerun_partition_type";
+        pub const PARTITION_MANIFEST_STORAGE_URL_FIELD_NAME: &str = "rerun_storage_url";
     }
 }
 

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -5,7 +5,7 @@ use egui::{Frame, Margin, RichText};
 
 use re_log_types::{EntityPathPart, EntryId};
 use re_protos::manifest_registry::v1alpha1::{
-    DATASET_MANIFEST_ID_FIELD_NAME, DATASET_MANIFEST_REGISTRATION_TIME_FIELD_NAME,
+    DATASET_MANIFEST_ID_FIELD_NAME, DATASET_MANIFEST_CREATED_AT_FIELD_NAME,
 };
 use re_ui::list_item::ItemActionButton;
 use re_ui::{UiExt as _, icons, list_item};
@@ -147,7 +147,7 @@ impl Server {
                     desc.display_name().as_str(),
                     RECORDING_LINK_FIELD_NAME
                         | DATASET_MANIFEST_ID_FIELD_NAME
-                        | DATASET_MANIFEST_REGISTRATION_TIME_FIELD_NAME
+                        | DATASET_MANIFEST_CREATED_AT_FIELD_NAME
                 )
             }
         })


### PR DESCRIPTION
As part of append workflow changes, we're moving type and storage url to partition manifest. This is the necessary rerun side update. 