### PR TITLE
Introduce variant UIs in `re_component_ui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8106,7 +8106,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pollster 0.4.0",
- "re_arrow_util",
  "re_capabilities",
  "re_chunk",
  "re_chunk_store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6731,6 +6731,7 @@ dependencies = [
  "egui_plot",
  "itertools 0.14.0",
  "nohash-hasher",
+ "re_arrow_util",
  "re_data_ui",
  "re_format",
  "re_log_types",
@@ -6738,6 +6739,7 @@ dependencies = [
  "re_types",
  "re_types_core",
  "re_ui",
+ "re_uri",
  "re_viewer_context",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8106,6 +8106,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pollster 0.4.0",
+ "re_arrow_util",
  "re_capabilities",
  "re_chunk",
  "re_chunk_store",

--- a/crates/viewer/re_component_ui/Cargo.toml
+++ b/crates/viewer/re_component_ui/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_arrow_util.workspace = true
 re_data_ui.workspace = true # Needed for `item_ui`.
 re_format.workspace = true
 re_log_types.workspace = true
@@ -27,7 +28,8 @@ re_types = { workspace = true, features = [
   "egui_plot", # Needed to draw marker shapes.
 ] }
 re_types_core.workspace = true
-re_ui = { workspace = true }
+re_ui.workspace = true
+re_uri.workspace = true
 re_viewer_context.workspace = true
 
 arrow.workspace = true

--- a/crates/viewer/re_component_ui/src/lib.rs
+++ b/crates/viewer/re_component_ui/src/lib.rs
@@ -19,6 +19,7 @@ mod resolution;
 mod response_utils;
 mod timeline;
 mod transforms;
+mod variant_uis;
 mod video_timestamp;
 mod view_coordinates;
 mod visual_bounds2d;
@@ -50,6 +51,10 @@ use re_viewer_context::gpu_bridge::colormap_edit_or_view_ui;
 
 /// Default number of ui points to show a number.
 const DEFAULT_NUMBER_WIDTH: f32 = 52.0;
+
+// ---
+
+pub const REDAP_URI_BUTTON_VARIANT: &str = "redap_uri";
 
 // ----
 
@@ -177,6 +182,12 @@ pub fn create_component_ui_registry() -> re_viewer_context::ComponentUiRegistry 
 
     registry.add_singleline_edit_or_view(plane3d::edit_or_view_plane3d);
     registry.add_multiline_edit_or_view(plane3d::multiline_edit_or_view_plane3d);
+
+    // --------------------------------------------------------------------------------
+    // All variant UIs:
+    // --------------------------------------------------------------------------------
+
+    registry.add_variant_ui(REDAP_URI_BUTTON_VARIANT, variant_uis::redap_uri_button);
 
     registry
 }

--- a/crates/viewer/re_component_ui/src/variant_uis/mod.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/mod.rs
@@ -1,0 +1,3 @@
+mod redap_uri_button;
+
+pub use redap_uri_button::redap_uri_button;

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -32,6 +32,7 @@ pub fn redap_uri_button(
 
     let uri = RedapUri::from_str(url_str)?;
 
+    //TODO(ab): we should provide feedback if the URI is already loaded, e.g. have "go to" instead of "open"
     if ui
         .button("Open")
         .on_hover_ui(|ui| {

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -1,0 +1,52 @@
+use std::error::Error;
+use std::str::FromStr as _;
+
+use re_types_core::{ComponentDescriptor, RowId};
+use re_uri::RedapUri;
+use re_viewer_context::ViewerContext;
+
+/// Display an URL as an `Open` button (instead of spelling the full URL).
+///
+/// Requires a String mono-component which is valid [`RedapUri`].
+pub fn redap_uri_button(
+    _ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    _component_descriptor: &ComponentDescriptor,
+    _row_id: Option<RowId>,
+    data: &dyn arrow::array::Array,
+) -> Result<(), Box<dyn Error>> {
+    if data.len() != 1 {
+        return Err("component batches are not supported".into());
+    }
+
+    let url_str = data
+        .as_any()
+        .downcast_ref::<arrow::array::StringArray>()
+        .ok_or_else(|| {
+            format!(
+                "unsupported arrow datatype: {}",
+                re_arrow_util::format_data_type(data.data_type())
+            )
+        })?
+        .value(0);
+
+    let uri = RedapUri::from_str(url_str)?;
+
+    if ui
+        .button("Open")
+        .on_hover_ui(|ui| {
+            ui.label(uri.to_string());
+        })
+        .clicked()
+    {
+        let url = if ui.input(|i| i.modifiers.command) {
+            egui::OpenUrl::new_tab(uri)
+        } else {
+            egui::OpenUrl::same_tab(uri)
+        };
+
+        ui.ctx().open_url(url);
+    }
+
+    Ok(())
+}

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -32,7 +32,7 @@ pub fn redap_uri_button(
 
     let uri = RedapUri::from_str(url_str)?;
 
-    //TODO(ab): we should provide feedback if the URI is already loaded, e.g. have "go to" instead of "open"
+    //TODO(#10036): we should provide feedback if the URI is already loaded, e.g. have "go to" instead of "open"
     if ui
         .button("Open")
         .on_hover_ui(|ui| {

--- a/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
+++ b/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
@@ -234,7 +234,7 @@ fn test_single_component_ui_as_list_item(
     let actual_ui = |ctx: &ViewerContext<'_>, ui: &mut egui::Ui| {
         ui.list_item_flat_noninteractive(
             list_item::PropertyContent::new("ComponentName").value_fn(|ui, _| {
-                ctx.component_ui_registry().ui_raw(
+                ctx.component_ui_registry().component_ui_raw(
                     ctx,
                     ui,
                     UiLayout::List,

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -146,7 +146,7 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
                 }
             }
 
-            ctx.component_ui_registry().ui(
+            ctx.component_ui_registry().component_ui(
                 ctx,
                 ui,
                 ui_layout,
@@ -194,7 +194,7 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
                             );
                         });
                         row.col(|ui| {
-                            ctx.component_ui_registry().ui(
+                            ctx.component_ui_registry().component_ui(
                                 ctx,
                                 ui,
                                 UiLayout::List,

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -223,7 +223,7 @@ fn component_list_ui(
                                         db,
                                     );
                                 } else {
-                                    ctx.component_ui_registry().ui(
+                                    ctx.component_ui_registry().component_ui(
                                         ctx,
                                         ui,
                                         UiLayout::List,

--- a/crates/viewer/re_dataframe_ui/src/display_record_batch.rs
+++ b/crates/viewer/re_dataframe_ui/src/display_record_batch.rs
@@ -230,7 +230,7 @@ impl DisplayComponentColumn {
                 }
             }
 
-            ctx.component_ui_registry().ui_raw(
+            ctx.component_ui_registry().component_ui_raw(
                 ctx,
                 ui,
                 UiLayout::List,

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -267,7 +267,7 @@ fn visualizer_components(
                     ValueSource::FallbackOrPlaceholder => {
                         // Fallback values are always single values, so we can directly go to the component ui.
                         // TODO(andreas): db & entity path don't make sense here.
-                        ctx.viewer_ctx.component_ui_registry().ui_raw(
+                        ctx.viewer_ctx.component_ui_registry().component_ui_raw(
                             ctx.viewer_ctx,
                             ui,
                             UiLayout::List,
@@ -360,7 +360,7 @@ fn visualizer_components(
                     ui.list_item_flat_noninteractive(
                         list_item::PropertyContent::new("Fallback").value_fn(|ui, _| {
                             // TODO(andreas): db & entity path don't make sense here.
-                            ctx.viewer_ctx.component_ui_registry().ui_raw(
+                            ctx.viewer_ctx.component_ui_registry().component_ui_raw(
                                 ctx.viewer_ctx,
                                 ui,
                                 UiLayout::List,

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -26,7 +26,6 @@ ignored = ["home"]
 testing = ["dep:pollster", "dep:egui_kittest"]
 
 [dependencies]
-re_arrow_util.workspace = true
 re_capabilities.workspace = true
 re_chunk_store.workspace = true
 re_chunk.workspace = true

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -26,6 +26,7 @@ ignored = ["home"]
 testing = ["dep:pollster", "dep:egui_kittest"]
 
 [dependencies]
+re_arrow_util.workspace = true
 re_capabilities.workspace = true
 re_chunk_store.workspace = true
 re_chunk.workspace = true

--- a/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
@@ -253,7 +253,7 @@ impl ComponentUiRegistry {
         .insert(C::name().into(), untyped_callback);
     }
 
-    /// Registers singleline UI to view Arrow data using a specific [`ComponentUiIdentifier::Variant`].
+    /// Registers singleline UI to view Arrow data using a specific [`VariantName`].
     pub fn add_variant_ui(
         &mut self,
         variant_name: impl Into<VariantName>,

--- a/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
@@ -225,6 +225,9 @@ impl ComponentUiRegistry {
     ) {
         let untyped_callback: UntypedComponentEditOrViewCallback = Box::new(
             move |ctx, ui, _component_descriptor, _row_id, value, edit_or_view| {
+                // if we end up being called with a mismatching component, its likely a bug.
+                debug_assert_eq!(_component_descriptor.component_name, C::name());
+
                 try_deserialize(value).and_then(|mut deserialized_value| match edit_or_view {
                     EditOrView::View => {
                         callback(ctx, ui, &mut MaybeMutRef::Ref(&deserialized_value));

--- a/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
@@ -258,7 +258,7 @@ impl ComponentUiRegistry {
             &ComponentDescriptor,
             Option<RowId>,
             &dyn arrow::array::Array,
-        ) -> Result<(), ()>
+        ) -> Result<(), Box<dyn std::error::Error>>
         + Send
         + Sync
         + 'static,
@@ -275,12 +275,12 @@ impl ComponentUiRegistry {
 
                 let res = callback(ctx, ui, component_descriptor, row_id, value);
 
-                if res.is_err() {
-                    fallback_ui(ui, UiLayout::List, value);
+                if let Err(err) = res {
                     re_log::error_once!(
-                        "UI for variant {variant_name} failed to display arrow data with type {}",
-                        re_arrow_util::format_data_type(value.data_type())
+                        "UI for variant {variant_name} failed to display the provided data {err}"
                     );
+
+                    fallback_ui(ui, UiLayout::List, value);
                 }
 
                 None

--- a/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/component_ui_registry.rs
@@ -476,6 +476,7 @@ impl ComponentUiRegistry {
             self.component_singleline_edit_or_view
                 .get(&variant_name.into())
         };
+
         if let Some(edit_or_view_ui) = edit_or_view_ui {
             // Use it in view mode (no mutation).
             (*edit_or_view_ui)(
@@ -487,6 +488,12 @@ impl ComponentUiRegistry {
                 EditOrView::View,
             );
             return;
+        } else {
+            re_log::debug_once!(
+                "Variant name {variant_name} was not found, using fallback ui instead"
+            );
+
+            //TODO(ab): should we instead revert to using the component based ui?
         }
 
         fallback_ui(ui, ui_layout, component_raw);

--- a/crates/viewer/re_viewer_context/src/global_context/mod.rs
+++ b/crates/viewer/re_viewer_context/src/global_context/mod.rs
@@ -14,7 +14,7 @@ pub use self::{
     command_sender::{
         CommandReceiver, CommandSender, SystemCommand, SystemCommandSender, command_channel,
     },
-    component_ui_registry::{ComponentUiRegistry, ComponentUiTypes, EditTarget},
+    component_ui_registry::{ComponentUiRegistry, ComponentUiTypes, EditTarget, VariantName},
     item::Item,
 };
 

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -54,7 +54,7 @@ pub use self::{
     global_context::{
         AppOptions, CommandReceiver, CommandSender, ComponentUiRegistry, ComponentUiTypes,
         DisplayMode, EditTarget, GlobalContext, Item, SystemCommand, SystemCommandSender,
-        command_channel,
+        VariantName, command_channel,
     },
     image_info::{ColormapWithRange, ImageInfo, StoredBlobCacheKey},
     maybe_mut_ref::MaybeMutRef,


### PR DESCRIPTION
### Related

* Part of https://github.com/rerun-io/rerun/issues/9741
* Part of https://github.com/rerun-io/rerun/issues/9795

### What

This PR add the capability to register and use arbitrary pieces of Arrow-based UI that are not necessarily linked to a specific component. They are called "variant UI", as opposed to "component UI".

To summarise, **component UIs**:
- are registered against a component name
- are (typically) implemented with closures that accept (and return, if editable) fully deserialised component
- (because of what precedes) are inflexible w.r.t the arrow datatype then can handle
- support view and edit, single line and multiline

In contrast, **variant UIs** (for now):
- are registered against a `VariantName` (conceptually a `&'static str` constant)
- are implemented with closures that accept raw arrow data
- are flexible w.r.t the arrow datatype they can handle
- (because of what precedes) should explicitly document what arrow datatype they expect/support
- only support edit, single line (for now)

Implementation notes:
- For now, the variant UI are registered with `add_variant_ui` and used with `variant_ui_raw`, which is mostly an independent, parallel path from the pre-existing stuff.
- Component descriptor and row id are now passed to `UntypedComponentEditOrViewCallback`, because these ~are~ will be convenient to have in variant ui impls.
- This PR includes a `redap_uri_button` variant ui, which handles data that happens to be rerun-conforming URIs.


