### PR TITLE
Remove untagged `Component::descriptor()`

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1016,8 +1016,8 @@ fn quote_trait_impls_for_datatype_or_component(
         quote! {
             impl ::re_types_core::Component for #name {
                 #[inline]
-                fn descriptor() -> ComponentDescriptor {
-                    ComponentDescriptor::new(#fqname)
+                fn name() -> ComponentName {
+                    #fqname.into()
                 }
             }
         }

--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -1030,7 +1030,7 @@ mod tests {
     use crossbeam::channel::TryRecvError;
 
     use re_log_types::example_components::{MyIndex, MyLabel, MyPoint, MyPoint64, MyPoints};
-    use re_types_core::{Component as _, Loggable as _};
+    use re_types_core::Loggable as _;
 
     use super::*;
 
@@ -1231,7 +1231,7 @@ mod tests {
             MyPoints::descriptor_points(),
             MyPoints::descriptor_colors(),
             MyPoints::descriptor_labels(),
-            MyPoint64::descriptor(),
+            MyPoint64::untagged_descriptor(),
             MyIndex::untagged_descriptor(),
         ];
 

--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -1060,17 +1060,17 @@ mod tests {
         let components1 = [
             (MyPoints::descriptor_points(), points1.clone()),
             (MyPoints::descriptor_labels(), labels1.clone()),
-            (MyIndex::untagged_descriptor(), indices1.clone()),
+            (MyIndex::partial_descriptor(), indices1.clone()),
         ];
         let components2 = [
             (MyPoints::descriptor_points(), points2.clone()),
             (MyPoints::descriptor_labels(), labels2.clone()),
-            (MyIndex::untagged_descriptor(), indices2.clone()),
+            (MyIndex::partial_descriptor(), indices2.clone()),
         ];
         let components3 = [
             (MyPoints::descriptor_points(), points3.clone()),
             (MyPoints::descriptor_labels(), labels3.clone()),
-            (MyIndex::untagged_descriptor(), indices3.clone()),
+            (MyIndex::partial_descriptor(), indices3.clone()),
         ];
 
         let row1 = PendingRow::new(timepoint1.clone(), components1.into_iter().collect());
@@ -1121,7 +1121,7 @@ mod tests {
                     arrays_to_list_array_opt(&[&*labels1, &*labels2, &*labels3].map(Some)).unwrap(),
                 ), //
                 (
-                    MyIndex::untagged_descriptor(),
+                    MyIndex::partial_descriptor(),
                     arrays_to_list_array_opt(&[&*indices1, &*indices2, &*indices3].map(Some))
                         .unwrap(),
                 ), //
@@ -1167,18 +1167,18 @@ mod tests {
         let indices3 = MyIndex::to_arrow([MyIndex(4), MyIndex(5)])?;
 
         let components1 = [
-            (MyIndex::untagged_descriptor(), indices1.clone()),
+            (MyIndex::partial_descriptor(), indices1.clone()),
             (MyPoints::descriptor_points(), points1.clone()),
             (MyPoints::descriptor_labels(), labels1.clone()),
         ];
         let components2 = [
             (MyPoints::descriptor_points(), points2.clone()),
             (MyPoints::descriptor_labels(), labels2.clone()),
-            (MyIndex::untagged_descriptor(), indices2.clone()),
+            (MyIndex::partial_descriptor(), indices2.clone()),
         ];
         let components3 = [
             (MyPoints::descriptor_labels(), labels3.clone()),
-            (MyIndex::untagged_descriptor(), indices3.clone()),
+            (MyIndex::partial_descriptor(), indices3.clone()),
             (MyPoints::descriptor_points(), points3.clone()),
         ];
 
@@ -1231,8 +1231,8 @@ mod tests {
             MyPoints::descriptor_points(),
             MyPoints::descriptor_colors(),
             MyPoints::descriptor_labels(),
-            MyPoint64::untagged_descriptor(),
-            MyIndex::untagged_descriptor(),
+            MyPoint64::partial_descriptor(),
+            MyIndex::partial_descriptor(),
         ];
 
         let expected: IntMap<ComponentDescriptor, ()> =

--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -1060,17 +1060,17 @@ mod tests {
         let components1 = [
             (MyPoints::descriptor_points(), points1.clone()),
             (MyPoints::descriptor_labels(), labels1.clone()),
-            (MyIndex::descriptor(), indices1.clone()),
+            (MyIndex::untagged_descriptor(), indices1.clone()),
         ];
         let components2 = [
             (MyPoints::descriptor_points(), points2.clone()),
             (MyPoints::descriptor_labels(), labels2.clone()),
-            (MyIndex::descriptor(), indices2.clone()),
+            (MyIndex::untagged_descriptor(), indices2.clone()),
         ];
         let components3 = [
             (MyPoints::descriptor_points(), points3.clone()),
             (MyPoints::descriptor_labels(), labels3.clone()),
-            (MyIndex::descriptor(), indices3.clone()),
+            (MyIndex::untagged_descriptor(), indices3.clone()),
         ];
 
         let row1 = PendingRow::new(timepoint1.clone(), components1.into_iter().collect());
@@ -1121,7 +1121,7 @@ mod tests {
                     arrays_to_list_array_opt(&[&*labels1, &*labels2, &*labels3].map(Some)).unwrap(),
                 ), //
                 (
-                    MyIndex::descriptor(),
+                    MyIndex::untagged_descriptor(),
                     arrays_to_list_array_opt(&[&*indices1, &*indices2, &*indices3].map(Some))
                         .unwrap(),
                 ), //
@@ -1167,18 +1167,18 @@ mod tests {
         let indices3 = MyIndex::to_arrow([MyIndex(4), MyIndex(5)])?;
 
         let components1 = [
-            (MyIndex::descriptor(), indices1.clone()),
+            (MyIndex::untagged_descriptor(), indices1.clone()),
             (MyPoints::descriptor_points(), points1.clone()),
             (MyPoints::descriptor_labels(), labels1.clone()),
         ];
         let components2 = [
             (MyPoints::descriptor_points(), points2.clone()),
             (MyPoints::descriptor_labels(), labels2.clone()),
-            (MyIndex::descriptor(), indices2.clone()),
+            (MyIndex::untagged_descriptor(), indices2.clone()),
         ];
         let components3 = [
             (MyPoints::descriptor_labels(), labels3.clone()),
-            (MyIndex::descriptor(), indices3.clone()),
+            (MyIndex::untagged_descriptor(), indices3.clone()),
             (MyPoints::descriptor_points(), points3.clone()),
         ];
 
@@ -1232,7 +1232,7 @@ mod tests {
             MyPoints::descriptor_colors(),
             MyPoints::descriptor_labels(),
             MyPoint64::descriptor(),
-            MyIndex::descriptor(),
+            MyIndex::untagged_descriptor(),
         ];
 
         let expected: IntMap<ComponentDescriptor, ()> =

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -308,7 +308,7 @@ mod tests {
             .with_component_batch(
                 row_id1,
                 timepoint1.clone(),
-                (MyIndex::descriptor(), &MyIndex::from_iter(0..10)),
+                (MyIndex::untagged_descriptor(), &MyIndex::from_iter(0..10)),
             )
             .build()?;
 
@@ -407,7 +407,7 @@ mod tests {
                     timepoint3.clone(),
                     [
                         (
-                            MyIndex::descriptor(),
+                            MyIndex::untagged_descriptor(),
                             &MyIndex::from_iter(0..num_instances as _) as _,
                         ),
                         (MyPoints::descriptor_colors(), &colors as _),

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -308,7 +308,7 @@ mod tests {
             .with_component_batch(
                 row_id1,
                 timepoint1.clone(),
-                (MyIndex::untagged_descriptor(), &MyIndex::from_iter(0..10)),
+                (MyIndex::partial_descriptor(), &MyIndex::from_iter(0..10)),
             )
             .build()?;
 
@@ -407,7 +407,7 @@ mod tests {
                     timepoint3.clone(),
                     [
                         (
-                            MyIndex::untagged_descriptor(),
+                            MyIndex::partial_descriptor(),
                             &MyIndex::from_iter(0..num_instances as _) as _,
                         ),
                         (MyPoints::descriptor_colors(), &colors as _),

--- a/crates/store/re_chunk_store/src/subscribers.rs
+++ b/crates/store/re_chunk_store/src/subscribers.rs
@@ -387,7 +387,7 @@ mod tests {
                     (timeline_other, 666),     //
                     (timeline_yet_another, 1), //
                 ]),
-                (MyIndex::untagged_descriptor(), &MyIndex::from_iter(0..10)),
+                (MyIndex::partial_descriptor(), &MyIndex::from_iter(0..10)),
             )
             .build()?;
 
@@ -425,7 +425,7 @@ mod tests {
                     TimePoint::default(),
                     [
                         (
-                            MyIndex::untagged_descriptor(),
+                            MyIndex::partial_descriptor(),
                             &MyIndex::from_iter(0..num_instances as _) as _,
                         ),
                         (MyPoints::descriptor_colors(), &colors as _),

--- a/crates/store/re_chunk_store/src/subscribers.rs
+++ b/crates/store/re_chunk_store/src/subscribers.rs
@@ -314,7 +314,6 @@ mod tests {
         StoreId, TimePoint, Timeline,
         example_components::{MyColor, MyIndex, MyPoint, MyPoints},
     };
-    use re_types::Component as _;
 
     use crate::{ChunkStore, ChunkStoreSubscriber, GarbageCollectionOptions};
 
@@ -388,7 +387,7 @@ mod tests {
                     (timeline_other, 666),     //
                     (timeline_yet_another, 1), //
                 ]),
-                (MyIndex::descriptor(), &MyIndex::from_iter(0..10)),
+                (MyIndex::untagged_descriptor(), &MyIndex::from_iter(0..10)),
             )
             .build()?;
 
@@ -426,7 +425,7 @@ mod tests {
                     TimePoint::default(),
                     [
                         (
-                            MyIndex::descriptor(),
+                            MyIndex::untagged_descriptor(),
                             &MyIndex::from_iter(0..num_instances as _) as _,
                         ),
                         (MyPoints::descriptor_colors(), &colors as _),

--- a/crates/store/re_chunk_store/tests/correctness.rs
+++ b/crates/store/re_chunk_store/tests/correctness.rs
@@ -318,7 +318,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
             RowId::new(),
             [build_log_time(now), build_frame_nr(frame40)],
             (
-                MyIndex::untagged_descriptor(),
+                MyIndex::partial_descriptor(),
                 &MyIndex::from_iter(0..num_instances),
             ),
         )
@@ -334,7 +334,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_frame_nr, frame39),
             &entity_path,
-            &MyIndex::untagged_descriptor(),
+            &MyIndex::partial_descriptor(),
         );
         assert!(chunks.is_empty());
     }
@@ -344,7 +344,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_log_time, now_minus_1s_nanos),
             &entity_path,
-            &MyIndex::untagged_descriptor(),
+            &MyIndex::partial_descriptor(),
         );
         assert!(chunks.is_empty());
     }
@@ -354,7 +354,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_frame_nr, frame40),
             &EntityPath::from("does/not/exist"),
-            &MyIndex::untagged_descriptor(),
+            &MyIndex::partial_descriptor(),
         );
         assert!(chunks.is_empty());
     }
@@ -364,7 +364,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_wrong_name, frame40),
             &EntityPath::from("does/not/exist"),
-            &MyIndex::untagged_descriptor(),
+            &MyIndex::partial_descriptor(),
         );
         assert!(chunks.is_empty());
     }

--- a/crates/store/re_chunk_store/tests/correctness.rs
+++ b/crates/store/re_chunk_store/tests/correctness.rs
@@ -11,7 +11,6 @@ use re_log_types::{
     build_log_time,
 };
 use re_types::ComponentDescriptor;
-use re_types_core::Component as _;
 
 // ---
 
@@ -318,7 +317,10 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         .with_component_batch(
             RowId::new(),
             [build_log_time(now), build_frame_nr(frame40)],
-            (MyIndex::descriptor(), &MyIndex::from_iter(0..num_instances)),
+            (
+                MyIndex::untagged_descriptor(),
+                &MyIndex::from_iter(0..num_instances),
+            ),
         )
         .build()?;
     store.insert_chunk(&Arc::new(chunk))?;
@@ -332,7 +334,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_frame_nr, frame39),
             &entity_path,
-            &MyIndex::descriptor(),
+            &MyIndex::untagged_descriptor(),
         );
         assert!(chunks.is_empty());
     }
@@ -342,7 +344,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_log_time, now_minus_1s_nanos),
             &entity_path,
-            &MyIndex::descriptor(),
+            &MyIndex::untagged_descriptor(),
         );
         assert!(chunks.is_empty());
     }
@@ -352,7 +354,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_frame_nr, frame40),
             &EntityPath::from("does/not/exist"),
-            &MyIndex::descriptor(),
+            &MyIndex::untagged_descriptor(),
         );
         assert!(chunks.is_empty());
     }
@@ -362,7 +364,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
         let chunks = store.latest_at_relevant_chunks(
             &LatestAtQuery::new(timeline_wrong_name, frame40),
             &EntityPath::from("does/not/exist"),
-            &MyIndex::descriptor(),
+            &MyIndex::untagged_descriptor(),
         );
         assert!(chunks.is_empty());
     }

--- a/crates/store/re_chunk_store/tests/gc.rs
+++ b/crates/store/re_chunk_store/tests/gc.rs
@@ -129,7 +129,7 @@ fn simple_static() -> anyhow::Result<()> {
                 row_id1,
                 [build_frame_nr(frame1)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices1 as _),
+                    (MyIndex::partial_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_colors(), &colors1 as _),
                 ],
             )
@@ -144,7 +144,7 @@ fn simple_static() -> anyhow::Result<()> {
                 row_id2,
                 [build_frame_nr(frame2)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices1 as _),
+                    (MyIndex::partial_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_points(), &points2 as _),
                 ],
             )
@@ -212,7 +212,7 @@ fn simple_static() -> anyhow::Result<()> {
     assert_latest_components(
         TimeInt::MAX,
         &[
-            (MyIndex::untagged_descriptor(), row_id2_static),
+            (MyIndex::partial_descriptor(), row_id2_static),
             (MyPoints::descriptor_colors(), row_id1_static),
             (MyPoints::descriptor_points(), row_id2_static),
         ],
@@ -244,7 +244,7 @@ fn protected() -> anyhow::Result<()> {
             row_id1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::untagged_descriptor(), &indices1 as _),
+                (MyIndex::partial_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_colors(), &colors1 as _),
             ],
         )
@@ -257,7 +257,7 @@ fn protected() -> anyhow::Result<()> {
             row_id2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::untagged_descriptor(), &indices1 as _),
+                (MyIndex::partial_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_points(), &points2 as _),
             ],
         )
@@ -315,7 +315,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame1,
         &[
-            (MyIndex::untagged_descriptor(), None),
+            (MyIndex::partial_descriptor(), None),
             (MyPoints::descriptor_colors(), None),
             (MyPoints::descriptor_points(), None),
         ],
@@ -324,7 +324,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame2,
         &[
-            (MyIndex::untagged_descriptor(), Some(row_id2)),
+            (MyIndex::partial_descriptor(), Some(row_id2)),
             (MyPoints::descriptor_colors(), None),
             (MyPoints::descriptor_points(), Some(row_id2)),
         ],
@@ -333,7 +333,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame3,
         &[
-            (MyIndex::untagged_descriptor(), Some(row_id2)),
+            (MyIndex::partial_descriptor(), Some(row_id2)),
             (MyPoints::descriptor_colors(), None),
             (MyPoints::descriptor_points(), Some(row_id3)),
         ],
@@ -342,7 +342,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame4,
         &[
-            (MyIndex::untagged_descriptor(), Some(row_id2)),
+            (MyIndex::partial_descriptor(), Some(row_id2)),
             (MyPoints::descriptor_colors(), Some(row_id4)),
             (MyPoints::descriptor_points(), Some(row_id3)),
         ],
@@ -374,7 +374,7 @@ fn protected_time_ranges() -> anyhow::Result<()> {
             row_id1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::untagged_descriptor(), &indices1 as _),
+                (MyIndex::partial_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_colors(), &colors1 as _),
             ],
         )
@@ -387,7 +387,7 @@ fn protected_time_ranges() -> anyhow::Result<()> {
             row_id2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::untagged_descriptor(), &indices1 as _),
+                (MyIndex::partial_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_points(), &points2 as _),
             ],
         )
@@ -468,7 +468,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id1,
                 [build_frame_nr(10)],
-                [(MyIndex::untagged_descriptor(), &indices1 as _)],
+                [(MyIndex::partial_descriptor(), &indices1 as _)],
             )
             .build()?,
     );
@@ -480,7 +480,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id2,
                 [build_log_time(Timestamp::now())],
-                [(MyIndex::untagged_descriptor(), &indices2 as _)],
+                [(MyIndex::partial_descriptor(), &indices2 as _)],
             )
             .build()?,
     );
@@ -492,7 +492,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id3,
                 TimePoint::default(),
-                [(MyIndex::untagged_descriptor(), &indices3 as _)],
+                [(MyIndex::partial_descriptor(), &indices3 as _)],
             )
             .build()?,
     );
@@ -504,7 +504,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id4,
                 [build_frame_nr(42), build_log_time(Timestamp::now())],
-                [(MyIndex::untagged_descriptor(), &indices4 as _)],
+                [(MyIndex::partial_descriptor(), &indices4 as _)],
             )
             .build()?,
     );
@@ -518,7 +518,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
                                entity_path: &EntityPath,
                                query: &LatestAtQuery,
                                expected_row_id: Option<RowId>| {
-        let row_id = query_latest_array(store, entity_path, &MyIndex::untagged_descriptor(), query)
+        let row_id = query_latest_array(store, entity_path, &MyIndex::partial_descriptor(), query)
             .map(|(_data_time, row_id, _array)| row_id);
 
         assert_eq!(expected_row_id, row_id);

--- a/crates/store/re_chunk_store/tests/gc.rs
+++ b/crates/store/re_chunk_store/tests/gc.rs
@@ -130,7 +130,7 @@ fn simple_static() -> anyhow::Result<()> {
                 row_id1,
                 [build_frame_nr(frame1)],
                 [
-                    (MyIndex::descriptor(), &indices1 as _),
+                    (MyIndex::untagged_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_colors(), &colors1 as _),
                 ],
             )
@@ -145,7 +145,7 @@ fn simple_static() -> anyhow::Result<()> {
                 row_id2,
                 [build_frame_nr(frame2)],
                 [
-                    (MyIndex::descriptor(), &indices1 as _),
+                    (MyIndex::untagged_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_points(), &points2 as _),
                 ],
             )
@@ -213,7 +213,7 @@ fn simple_static() -> anyhow::Result<()> {
     assert_latest_components(
         TimeInt::MAX,
         &[
-            (MyIndex::descriptor(), row_id2_static),
+            (MyIndex::untagged_descriptor(), row_id2_static),
             (MyPoints::descriptor_colors(), row_id1_static),
             (MyPoints::descriptor_points(), row_id2_static),
         ],
@@ -245,7 +245,7 @@ fn protected() -> anyhow::Result<()> {
             row_id1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::descriptor(), &indices1 as _),
+                (MyIndex::untagged_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_colors(), &colors1 as _),
             ],
         )
@@ -258,7 +258,7 @@ fn protected() -> anyhow::Result<()> {
             row_id2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::descriptor(), &indices1 as _),
+                (MyIndex::untagged_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_points(), &points2 as _),
             ],
         )
@@ -316,7 +316,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame1,
         &[
-            (MyIndex::descriptor(), None),
+            (MyIndex::untagged_descriptor(), None),
             (MyPoints::descriptor_colors(), None),
             (MyPoints::descriptor_points(), None),
         ],
@@ -325,7 +325,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame2,
         &[
-            (MyIndex::descriptor(), Some(row_id2)),
+            (MyIndex::untagged_descriptor(), Some(row_id2)),
             (MyPoints::descriptor_colors(), None),
             (MyPoints::descriptor_points(), Some(row_id2)),
         ],
@@ -334,7 +334,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame3,
         &[
-            (MyIndex::descriptor(), Some(row_id2)),
+            (MyIndex::untagged_descriptor(), Some(row_id2)),
             (MyPoints::descriptor_colors(), None),
             (MyPoints::descriptor_points(), Some(row_id3)),
         ],
@@ -343,7 +343,7 @@ fn protected() -> anyhow::Result<()> {
     assert_latest_components(
         frame4,
         &[
-            (MyIndex::descriptor(), Some(row_id2)),
+            (MyIndex::untagged_descriptor(), Some(row_id2)),
             (MyPoints::descriptor_colors(), Some(row_id4)),
             (MyPoints::descriptor_points(), Some(row_id3)),
         ],
@@ -375,7 +375,7 @@ fn protected_time_ranges() -> anyhow::Result<()> {
             row_id1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::descriptor(), &indices1 as _),
+                (MyIndex::untagged_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_colors(), &colors1 as _),
             ],
         )
@@ -388,7 +388,7 @@ fn protected_time_ranges() -> anyhow::Result<()> {
             row_id2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::descriptor(), &indices1 as _),
+                (MyIndex::untagged_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_points(), &points2 as _),
             ],
         )
@@ -469,7 +469,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id1,
                 [build_frame_nr(10)],
-                [(MyIndex::descriptor(), &indices1 as _)],
+                [(MyIndex::untagged_descriptor(), &indices1 as _)],
             )
             .build()?,
     );
@@ -481,7 +481,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id2,
                 [build_log_time(Timestamp::now())],
-                [(MyIndex::descriptor(), &indices2 as _)],
+                [(MyIndex::untagged_descriptor(), &indices2 as _)],
             )
             .build()?,
     );
@@ -493,7 +493,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id3,
                 TimePoint::default(),
-                [(MyIndex::descriptor(), &indices3 as _)],
+                [(MyIndex::untagged_descriptor(), &indices3 as _)],
             )
             .build()?,
     );
@@ -505,7 +505,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id4,
                 [build_frame_nr(42), build_log_time(Timestamp::now())],
-                [(MyIndex::descriptor(), &indices4 as _)],
+                [(MyIndex::untagged_descriptor(), &indices4 as _)],
             )
             .build()?,
     );
@@ -519,7 +519,7 @@ fn manual_drop_entity_path() -> anyhow::Result<()> {
                                entity_path: &EntityPath,
                                query: &LatestAtQuery,
                                expected_row_id: Option<RowId>| {
-        let row_id = query_latest_array(store, entity_path, &MyIndex::descriptor(), query)
+        let row_id = query_latest_array(store, entity_path, &MyIndex::untagged_descriptor(), query)
             .map(|(_data_time, row_id, _array)| row_id);
 
         assert_eq!(expected_row_id, row_id);

--- a/crates/store/re_chunk_store/tests/gc.rs
+++ b/crates/store/re_chunk_store/tests/gc.rs
@@ -14,9 +14,8 @@ use re_log_types::{
 };
 use re_types::{
     ComponentDescriptor,
-    testing::{LargeStruct, build_some_large_structs},
+    testing::{build_some_large_structs, large_struct_descriptor},
 };
-use re_types_core::Component as _;
 
 // ---
 
@@ -70,7 +69,7 @@ fn simple() -> anyhow::Result<()> {
                         RowId::new(),
                         [build_frame_nr(frame_nr)],
                         (
-                            LargeStruct::descriptor(),
+                            large_struct_descriptor(),
                             &build_some_large_structs(num_instances),
                         ),
                     )

--- a/crates/store/re_chunk_store/tests/memory_test.rs
+++ b/crates/store/re_chunk_store/tests/memory_test.rs
@@ -73,7 +73,7 @@ use re_chunk::{
 };
 use re_chunk_store::{ChunkStore, ChunkStoreConfig};
 use re_log_types::{TimePoint, Timeline};
-use re_types::{Component as _, Loggable as _, components::Scalar};
+use re_types::{Loggable as _, archetypes, components::Scalar};
 
 /// The memory overhead of storing many scalars in the store.
 #[test]
@@ -105,7 +105,7 @@ fn scalar_memory_overhead() {
 
             let row = PendingRow::new(
                 timepoint,
-                std::iter::once((Scalar::descriptor(), scalars)).collect(),
+                std::iter::once((archetypes::Scalars::descriptor_scalars(), scalars)).collect(),
             );
 
             batcher.push_row(entity_path.clone(), row);

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -219,7 +219,7 @@ fn latest_at() -> anyhow::Result<()> {
             row_id1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::descriptor(), &indices1 as _),
+                (MyIndex::untagged_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_colors(), &colors1 as _),
             ],
         )
@@ -232,7 +232,7 @@ fn latest_at() -> anyhow::Result<()> {
             row_id2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::descriptor(), &indices1 as _),
+                (MyIndex::untagged_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_points(), &points2 as _),
             ],
         )
@@ -302,7 +302,7 @@ fn latest_at() -> anyhow::Result<()> {
         frame0,
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)), // static
-            (MyIndex::descriptor(), None),
+            (MyIndex::untagged_descriptor(), None),
             (MyPoints::descriptor_points(), None),
         ],
     );
@@ -310,7 +310,7 @@ fn latest_at() -> anyhow::Result<()> {
         frame1,
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)), // static
-            (MyIndex::descriptor(), Some(row_id1)),
+            (MyIndex::untagged_descriptor(), Some(row_id1)),
             (MyPoints::descriptor_points(), None),
         ],
     );
@@ -319,7 +319,7 @@ fn latest_at() -> anyhow::Result<()> {
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)),
             (MyPoints::descriptor_points(), Some(row_id2)),
-            (MyIndex::descriptor(), Some(row_id2)),
+            (MyIndex::untagged_descriptor(), Some(row_id2)),
         ],
     );
     assert_latest_components(
@@ -327,7 +327,7 @@ fn latest_at() -> anyhow::Result<()> {
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)),
             (MyPoints::descriptor_points(), Some(row_id3)),
-            (MyIndex::descriptor(), Some(row_id2)),
+            (MyIndex::untagged_descriptor(), Some(row_id2)),
         ],
     );
     assert_latest_components(
@@ -335,7 +335,7 @@ fn latest_at() -> anyhow::Result<()> {
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)),
             (MyPoints::descriptor_points(), Some(row_id3)),
-            (MyIndex::descriptor(), Some(row_id2)),
+            (MyIndex::untagged_descriptor(), Some(row_id2)),
         ],
     );
 
@@ -400,7 +400,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id1_1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::descriptor(), None),
+                (MyIndex::untagged_descriptor(), None),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(0..1) as _),
@@ -411,7 +411,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id1_2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::descriptor(), None),
+                (MyIndex::untagged_descriptor(), None),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(1..2) as _),
@@ -422,7 +422,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id1_3,
             [build_frame_nr(frame3)],
             [
-                (MyIndex::descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
+                (MyIndex::untagged_descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(2..3) as _),
@@ -444,7 +444,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id2_1,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
+                (MyIndex::untagged_descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(1..2) as _),
@@ -465,7 +465,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
     let row_id = query_latest_array(
         &store,
         &entity_path,
-        &MyIndex::descriptor(),
+        &MyIndex::untagged_descriptor(),
         &LatestAtQuery::new(TimelineName::new("frame_nr"), TimeInt::MAX),
     )
     .map(|(_data_time, row_id, _array)| row_id);
@@ -703,7 +703,7 @@ fn range() -> anyhow::Result<()> {
                 row_id1,
                 [build_frame_nr(frame1)],
                 [
-                    (MyIndex::descriptor(), &indices1 as _),
+                    (MyIndex::untagged_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_colors(), &colors1 as _),
                 ],
             )
@@ -718,7 +718,7 @@ fn range() -> anyhow::Result<()> {
                 row_id2,
                 [build_frame_nr(frame2)],
                 [
-                    (MyIndex::descriptor(), &indices1 as _),
+                    (MyIndex::untagged_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_points(), &points2 as _),
                 ],
             )
@@ -746,7 +746,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_1,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::descriptor(), &indices4_1 as _),
+                    (MyIndex::untagged_descriptor(), &indices4_1 as _),
                     (MyPoints::descriptor_colors(), &colors4_1 as _),
                 ],
             )
@@ -762,7 +762,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_2,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::descriptor(), &indices4_2 as _),
+                    (MyIndex::untagged_descriptor(), &indices4_2 as _),
                     (MyPoints::descriptor_colors(), &colors4_2 as _),
                 ],
             )
@@ -777,7 +777,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_25,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::descriptor(), &indices4_2 as _),
+                    (MyIndex::untagged_descriptor(), &indices4_2 as _),
                     (MyPoints::descriptor_points(), &points4_25 as _),
                 ],
             )
@@ -793,7 +793,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_3,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::descriptor(), &indices4_3 as _),
+                    (MyIndex::untagged_descriptor(), &indices4_3 as _),
                     (MyPoints::descriptor_colors(), &colors4_3 as _),
                 ],
             )
@@ -808,7 +808,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_4,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::descriptor(), &indices4_3 as _),
+                    (MyIndex::untagged_descriptor(), &indices4_3 as _),
                     (MyPoints::descriptor_points(), &points4_4 as _),
                 ],
             )

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -13,9 +13,8 @@ use re_log_types::{
 };
 use re_types::{
     ComponentDescriptor, ComponentDescriptorSet,
-    testing::{LargeStruct, build_some_large_structs},
+    testing::{build_some_large_structs, large_struct_descriptor},
 };
-use re_types_core::Component as _;
 
 // ---
 
@@ -77,13 +76,13 @@ fn all_components() -> anyhow::Result<()> {
 
     let components_a = &[
         MyPoints::descriptor_colors(), // added by test, static
-        LargeStruct::descriptor(),     // added by test
+        large_struct_descriptor(),     // added by test
     ];
 
     let components_b = &[
         MyPoints::descriptor_colors(), // added by test, static
         MyPoints::descriptor_points(), // added by test
-        LargeStruct::descriptor(),     // added by test
+        large_struct_descriptor(),     // added by test
     ];
 
     let chunk = Chunk::builder(entity_path.clone())
@@ -99,7 +98,7 @@ fn all_components() -> anyhow::Result<()> {
         .with_component_batch(
             RowId::new(),
             [build_frame_nr(frame1)],
-            (LargeStruct::descriptor(), &build_some_large_structs(2)),
+            (large_struct_descriptor(), &build_some_large_structs(2)),
         )
         .build()?;
     store.insert_chunk(&Arc::new(chunk))?;
@@ -111,7 +110,7 @@ fn all_components() -> anyhow::Result<()> {
             RowId::new(),
             [build_frame_nr(frame2)],
             [
-                (LargeStruct::descriptor(), &build_some_large_structs(2) as _),
+                (large_struct_descriptor(), &build_some_large_structs(2) as _),
                 (
                     MyPoints::descriptor_points(),
                     &MyPoint::from_iter(0..2) as _,
@@ -147,7 +146,7 @@ fn test_all_components_on_timeline() -> anyhow::Result<()> {
         .with_component_batch(
             RowId::new(),
             [(timeline1, time), (timeline2, time)],
-            (LargeStruct::descriptor(), &build_some_large_structs(2)),
+            (large_struct_descriptor(), &build_some_large_structs(2)),
         )
         .build()?;
     store.insert_chunk(&Arc::new(chunk))?;
@@ -156,7 +155,7 @@ fn test_all_components_on_timeline() -> anyhow::Result<()> {
         .with_component_batches(
             RowId::new(),
             [(timeline1, time)],
-            [(LargeStruct::descriptor(), &build_some_large_structs(2) as _)],
+            [(large_struct_descriptor(), &build_some_large_structs(2) as _)],
         )
         .build()?;
     store.insert_chunk(&Arc::new(chunk))?;
@@ -422,7 +421,10 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id1_3,
             [build_frame_nr(frame3)],
             [
-                (MyIndex::untagged_descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
+                (
+                    MyIndex::untagged_descriptor(),
+                    Some(&MyIndex::from_iter(2..3) as _),
+                ),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(2..3) as _),
@@ -444,7 +446,10 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id2_1,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::untagged_descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
+                (
+                    MyIndex::untagged_descriptor(),
+                    Some(&MyIndex::from_iter(2..3) as _),
+                ),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(1..2) as _),

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -218,7 +218,7 @@ fn latest_at() -> anyhow::Result<()> {
             row_id1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::untagged_descriptor(), &indices1 as _),
+                (MyIndex::partial_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_colors(), &colors1 as _),
             ],
         )
@@ -231,7 +231,7 @@ fn latest_at() -> anyhow::Result<()> {
             row_id2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::untagged_descriptor(), &indices1 as _),
+                (MyIndex::partial_descriptor(), &indices1 as _),
                 (MyPoints::descriptor_points(), &points2 as _),
             ],
         )
@@ -301,7 +301,7 @@ fn latest_at() -> anyhow::Result<()> {
         frame0,
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)), // static
-            (MyIndex::untagged_descriptor(), None),
+            (MyIndex::partial_descriptor(), None),
             (MyPoints::descriptor_points(), None),
         ],
     );
@@ -309,7 +309,7 @@ fn latest_at() -> anyhow::Result<()> {
         frame1,
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)), // static
-            (MyIndex::untagged_descriptor(), Some(row_id1)),
+            (MyIndex::partial_descriptor(), Some(row_id1)),
             (MyPoints::descriptor_points(), None),
         ],
     );
@@ -318,7 +318,7 @@ fn latest_at() -> anyhow::Result<()> {
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)),
             (MyPoints::descriptor_points(), Some(row_id2)),
-            (MyIndex::untagged_descriptor(), Some(row_id2)),
+            (MyIndex::partial_descriptor(), Some(row_id2)),
         ],
     );
     assert_latest_components(
@@ -326,7 +326,7 @@ fn latest_at() -> anyhow::Result<()> {
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)),
             (MyPoints::descriptor_points(), Some(row_id3)),
-            (MyIndex::untagged_descriptor(), Some(row_id2)),
+            (MyIndex::partial_descriptor(), Some(row_id2)),
         ],
     );
     assert_latest_components(
@@ -334,7 +334,7 @@ fn latest_at() -> anyhow::Result<()> {
         &[
             (MyPoints::descriptor_colors(), Some(row_id5)),
             (MyPoints::descriptor_points(), Some(row_id3)),
-            (MyIndex::untagged_descriptor(), Some(row_id2)),
+            (MyIndex::partial_descriptor(), Some(row_id2)),
         ],
     );
 
@@ -399,7 +399,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id1_1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::untagged_descriptor(), None),
+                (MyIndex::partial_descriptor(), None),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(0..1) as _),
@@ -410,7 +410,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id1_2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::untagged_descriptor(), None),
+                (MyIndex::partial_descriptor(), None),
                 (
                     MyPoints::descriptor_points(),
                     Some(&MyPoint::from_iter(1..2) as _),
@@ -422,7 +422,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             [build_frame_nr(frame3)],
             [
                 (
-                    MyIndex::untagged_descriptor(),
+                    MyIndex::partial_descriptor(),
                     Some(&MyIndex::from_iter(2..3) as _),
                 ),
                 (
@@ -447,7 +447,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             [build_frame_nr(frame2)],
             [
                 (
-                    MyIndex::untagged_descriptor(),
+                    MyIndex::partial_descriptor(),
                     Some(&MyIndex::from_iter(2..3) as _),
                 ),
                 (
@@ -470,7 +470,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
     let row_id = query_latest_array(
         &store,
         &entity_path,
-        &MyIndex::untagged_descriptor(),
+        &MyIndex::partial_descriptor(),
         &LatestAtQuery::new(TimelineName::new("frame_nr"), TimeInt::MAX),
     )
     .map(|(_data_time, row_id, _array)| row_id);
@@ -708,7 +708,7 @@ fn range() -> anyhow::Result<()> {
                 row_id1,
                 [build_frame_nr(frame1)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices1 as _),
+                    (MyIndex::partial_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_colors(), &colors1 as _),
                 ],
             )
@@ -723,7 +723,7 @@ fn range() -> anyhow::Result<()> {
                 row_id2,
                 [build_frame_nr(frame2)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices1 as _),
+                    (MyIndex::partial_descriptor(), &indices1 as _),
                     (MyPoints::descriptor_points(), &points2 as _),
                 ],
             )
@@ -751,7 +751,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_1,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices4_1 as _),
+                    (MyIndex::partial_descriptor(), &indices4_1 as _),
                     (MyPoints::descriptor_colors(), &colors4_1 as _),
                 ],
             )
@@ -767,7 +767,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_2,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices4_2 as _),
+                    (MyIndex::partial_descriptor(), &indices4_2 as _),
                     (MyPoints::descriptor_colors(), &colors4_2 as _),
                 ],
             )
@@ -782,7 +782,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_25,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices4_2 as _),
+                    (MyIndex::partial_descriptor(), &indices4_2 as _),
                     (MyPoints::descriptor_points(), &points4_25 as _),
                 ],
             )
@@ -798,7 +798,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_3,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices4_3 as _),
+                    (MyIndex::partial_descriptor(), &indices4_3 as _),
                     (MyPoints::descriptor_colors(), &colors4_3 as _),
                 ],
             )
@@ -813,7 +813,7 @@ fn range() -> anyhow::Result<()> {
                 row_id4_4,
                 [build_frame_nr(frame4)],
                 [
-                    (MyIndex::untagged_descriptor(), &indices4_3 as _),
+                    (MyIndex::partial_descriptor(), &indices4_3 as _),
                     (MyPoints::descriptor_points(), &points4_4 as _),
                 ],
             )

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -21,11 +21,11 @@ use re_chunk::{
 };
 use re_log_types::{ApplicationId, StoreId};
 use re_types::{
-    Archetype, Component, ComponentBatch,
+    Archetype, ComponentBatch,
     archetypes::{
-        AssetVideo, DepthImage, EncodedImage, Scalars, TextDocument, VideoFrameReference,
+        self, AssetVideo, DepthImage, EncodedImage, Scalars, TextDocument, VideoFrameReference,
     },
-    components::{Name, VideoTimestamp},
+    components::VideoTimestamp,
 };
 
 use crate::lerobot::{
@@ -583,7 +583,7 @@ fn make_scalar_batch_entity_chunks(
                     RowId::new(),
                     TimePoint::default(),
                     std::iter::once((
-                        <Name as Component>::descriptor().clone(),
+                        archetypes::SeriesLines::descriptor_names(),
                         Arc::new(StringArray::from_iter(names)) as Arc<dyn ArrowArray>,
                     )),
                 )

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -310,7 +310,10 @@ fn clears() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id,
                 timepoint,
-                [(<re_log_types::example_components::MyIndex as re_types_core::Component>::descriptor(), &[instance] as _)],
+                [(
+                    re_log_types::example_components::MyIndex::untagged_descriptor(),
+                    &[instance] as _,
+                )],
             )
             .build()?;
 

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -311,7 +311,7 @@ fn clears() -> anyhow::Result<()> {
                 row_id,
                 timepoint,
                 [(
-                    re_log_types::example_components::MyIndex::untagged_descriptor(),
+                    re_log_types::example_components::MyIndex::partial_descriptor(),
                     &[instance] as _,
                 )],
             )

--- a/crates/store/re_log_types/src/example_components.rs
+++ b/crates/store/re_log_types/src/example_components.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use re_arrow_util::ArrowArrayDowncastRef as _;
 use re_byte_size::SizeBytes;
 use re_types_core::{
-    Component, ComponentDescriptor, DeserializationError, Loggable, SerializedComponentBatch,
+    Component, ComponentDescriptor, ComponentName, DeserializationError, Loggable,
+    SerializedComponentBatch,
 };
 
 // ----------------------------------------------------------------------------
@@ -254,8 +255,8 @@ impl Loggable for MyPoint {
 }
 
 impl Component for MyPoint {
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("example.MyPoint")
+    fn name() -> ComponentName {
+        "example.MyPoint".into()
     }
 }
 
@@ -375,8 +376,8 @@ impl Loggable for MyPoint64 {
 }
 
 impl Component for MyPoint64 {
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("example.MyPoint64")
+    fn name() -> ComponentName {
+        "example.MyPoint64".into()
     }
 }
 
@@ -449,8 +450,8 @@ impl Loggable for MyColor {
 }
 
 impl Component for MyColor {
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("example.MyColor")
+    fn name() -> ComponentName {
+        "example.MyColor".into()
     }
 }
 
@@ -500,8 +501,8 @@ impl Loggable for MyLabel {
 }
 
 impl Component for MyLabel {
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("example.MyLabel")
+    fn name() -> ComponentName {
+        "example.MyLabel".into()
     }
 }
 
@@ -565,7 +566,7 @@ impl Loggable for MyIndex {
 }
 
 impl Component for MyIndex {
-    fn descriptor() -> re_types_core::ComponentDescriptor {
-        ComponentDescriptor::new("example.MyIndex")
+    fn name() -> re_types_core::ComponentName {
+        "example.MyIndex".into()
     }
 }

--- a/crates/store/re_log_types/src/example_components.rs
+++ b/crates/store/re_log_types/src/example_components.rs
@@ -513,6 +513,11 @@ impl MyIndex {
     pub fn from_iter(it: impl IntoIterator<Item = u64>) -> Vec<Self> {
         it.into_iter().map(Self).collect()
     }
+
+    #[inline]
+    pub fn untagged_descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new(Self::name())
+    }
 }
 
 re_types_core::macros::impl_into_cow!(MyIndex);

--- a/crates/store/re_log_types/src/example_components.rs
+++ b/crates/store/re_log_types/src/example_components.rs
@@ -276,6 +276,11 @@ impl MyPoint64 {
             .map(|i| Self::new(i as f64, i as f64))
             .collect()
     }
+
+    #[inline]
+    pub fn untagged_descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new(Self::name())
+    }
 }
 
 impl MyPoint64 {

--- a/crates/store/re_log_types/src/example_components.rs
+++ b/crates/store/re_log_types/src/example_components.rs
@@ -279,7 +279,7 @@ impl MyPoint64 {
     }
 
     #[inline]
-    pub fn untagged_descriptor() -> ComponentDescriptor {
+    pub fn partial_descriptor() -> ComponentDescriptor {
         ComponentDescriptor::new(Self::name())
     }
 }
@@ -521,7 +521,7 @@ impl MyIndex {
     }
 
     #[inline]
-    pub fn untagged_descriptor() -> ComponentDescriptor {
+    pub fn partial_descriptor() -> ComponentDescriptor {
         ComponentDescriptor::new(Self::name())
     }
 }

--- a/crates/store/re_sorbet/src/row_id_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/row_id_column_descriptor.rs
@@ -1,5 +1,5 @@
 use arrow::datatypes::{DataType as ArrowDatatype, Field as ArrowField};
-use re_types_core::{Component as _, Loggable as _, RowId};
+use re_types_core::{Loggable as _, RowId};
 
 use crate::MetadataExt as _;
 

--- a/crates/store/re_sorbet/src/row_id_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/row_id_column_descriptor.rs
@@ -26,7 +26,7 @@ impl RowIdColumnDescriptor {
     #[inline]
     #[expect(clippy::unused_self)]
     pub fn short_name(&self) -> String {
-        RowId::descriptor().display_name()
+        RowId::untagged_descriptor().display_name()
     }
 
     /// Human-readable name for this column.
@@ -61,7 +61,7 @@ impl RowIdColumnDescriptor {
 
         let nullable = false; // All rows has an id
         ArrowField::new(
-            RowId::descriptor().to_string(),
+            RowId::untagged_descriptor().to_string(),
             RowId::arrow_datatype(),
             nullable,
         )

--- a/crates/store/re_sorbet/src/row_id_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/row_id_column_descriptor.rs
@@ -26,7 +26,7 @@ impl RowIdColumnDescriptor {
     #[inline]
     #[expect(clippy::unused_self)]
     pub fn short_name(&self) -> String {
-        RowId::untagged_descriptor().display_name()
+        RowId::partial_descriptor().display_name()
     }
 
     /// Human-readable name for this column.
@@ -61,7 +61,7 @@ impl RowIdColumnDescriptor {
 
         let nullable = false; // All rows has an id
         ArrowField::new(
-            RowId::untagged_descriptor().to_string(),
+            RowId::partial_descriptor().to_string(),
             RowId::arrow_datatype(),
             nullable,
         )

--- a/crates/store/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/store/re_types/src/blueprint/components/active_tab.rs
@@ -32,8 +32,8 @@ pub struct ActiveTab(
 
 impl ::re_types_core::Component for ActiveTab {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ActiveTab")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ActiveTab".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
+++ b/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
@@ -28,8 +28,8 @@ pub struct ApplyLatestAt(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for ApplyLatestAt {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ApplyLatestAt")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ApplyLatestAt".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/auto_layout.rs
+++ b/crates/store/re_types/src/blueprint/components/auto_layout.rs
@@ -28,8 +28,8 @@ pub struct AutoLayout(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for AutoLayout {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.AutoLayout")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.AutoLayout".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/auto_views.rs
+++ b/crates/store/re_types/src/blueprint/components/auto_views.rs
@@ -28,8 +28,8 @@ pub struct AutoViews(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for AutoViews {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.AutoViews")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.AutoViews".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/background_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/background_kind.rs
@@ -41,8 +41,8 @@ pub enum BackgroundKind {
 
 impl ::re_types_core::Component for BackgroundKind {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.BackgroundKind")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.BackgroundKind".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/column_share.rs
+++ b/crates/store/re_types/src/blueprint/components/column_share.rs
@@ -30,8 +30,8 @@ pub struct ColumnShare(
 
 impl ::re_types_core::Component for ColumnShare {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ColumnShare")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ColumnShare".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/components/component_column_selector.rs
@@ -28,8 +28,8 @@ pub struct ComponentColumnSelector(pub crate::blueprint::datatypes::ComponentCol
 
 impl ::re_types_core::Component for ComponentColumnSelector {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ComponentColumnSelector")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ComponentColumnSelector".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/container_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/container_kind.rs
@@ -40,8 +40,8 @@ pub enum ContainerKind {
 
 impl ::re_types_core::Component for ContainerKind {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ContainerKind")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ContainerKind".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/corner2d.rs
+++ b/crates/store/re_types/src/blueprint/components/corner2d.rs
@@ -40,8 +40,8 @@ pub enum Corner2D {
 
 impl ::re_types_core::Component for Corner2D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.Corner2D")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.Corner2D".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/enabled.rs
+++ b/crates/store/re_types/src/blueprint/components/enabled.rs
@@ -28,8 +28,8 @@ pub struct Enabled(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for Enabled {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.Enabled")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.Enabled".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_by_range.rs
@@ -28,8 +28,8 @@ pub struct FilterByRange(pub crate::blueprint::datatypes::FilterByRange);
 
 impl ::re_types_core::Component for FilterByRange {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.FilterByRange")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.FilterByRange".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
@@ -28,8 +28,8 @@ pub struct FilterIsNotNull(pub crate::blueprint::datatypes::FilterIsNotNull);
 
 impl ::re_types_core::Component for FilterIsNotNull {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.FilterIsNotNull")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.FilterIsNotNull".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/force_distance.rs
+++ b/crates/store/re_types/src/blueprint/components/force_distance.rs
@@ -30,8 +30,8 @@ pub struct ForceDistance(pub crate::datatypes::Float64);
 
 impl ::re_types_core::Component for ForceDistance {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ForceDistance")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ForceDistance".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/force_iterations.rs
+++ b/crates/store/re_types/src/blueprint/components/force_iterations.rs
@@ -30,8 +30,8 @@ pub struct ForceIterations(pub crate::datatypes::UInt64);
 
 impl ::re_types_core::Component for ForceIterations {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ForceIterations")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ForceIterations".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/force_strength.rs
+++ b/crates/store/re_types/src/blueprint/components/force_strength.rs
@@ -30,8 +30,8 @@ pub struct ForceStrength(pub crate::datatypes::Float64);
 
 impl ::re_types_core::Component for ForceStrength {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ForceStrength")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ForceStrength".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/grid_columns.rs
+++ b/crates/store/re_types/src/blueprint/components/grid_columns.rs
@@ -30,8 +30,8 @@ pub struct GridColumns(
 
 impl ::re_types_core::Component for GridColumns {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.GridColumns")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.GridColumns".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/grid_spacing.rs
+++ b/crates/store/re_types/src/blueprint/components/grid_spacing.rs
@@ -30,8 +30,8 @@ pub struct GridSpacing(
 
 impl ::re_types_core::Component for GridSpacing {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.GridSpacing")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.GridSpacing".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/included_content.rs
+++ b/crates/store/re_types/src/blueprint/components/included_content.rs
@@ -33,8 +33,8 @@ pub struct IncludedContent(
 
 impl ::re_types_core::Component for IncludedContent {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.IncludedContent")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.IncludedContent".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -30,8 +30,8 @@ pub struct LockRangeDuringZoom(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for LockRangeDuringZoom {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.LockRangeDuringZoom")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.LockRangeDuringZoom".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/map_provider.rs
+++ b/crates/store/re_types/src/blueprint/components/map_provider.rs
@@ -40,8 +40,8 @@ pub enum MapProvider {
 
 impl ::re_types_core::Component for MapProvider {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.MapProvider")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.MapProvider".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/near_clip_plane.rs
+++ b/crates/store/re_types/src/blueprint/components/near_clip_plane.rs
@@ -31,8 +31,8 @@ pub struct NearClipPlane(
 
 impl ::re_types_core::Component for NearClipPlane {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.NearClipPlane")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.NearClipPlane".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/panel_state.rs
+++ b/crates/store/re_types/src/blueprint/components/panel_state.rs
@@ -37,8 +37,8 @@ pub enum PanelState {
 
 impl ::re_types_core::Component for PanelState {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.PanelState")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.PanelState".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/store/re_types/src/blueprint/components/query_expression.rs
@@ -37,8 +37,8 @@ pub struct QueryExpression(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for QueryExpression {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.QueryExpression")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.QueryExpression".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/root_container.rs
+++ b/crates/store/re_types/src/blueprint/components/root_container.rs
@@ -30,8 +30,8 @@ pub struct RootContainer(
 
 impl ::re_types_core::Component for RootContainer {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.RootContainer")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.RootContainer".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/row_share.rs
+++ b/crates/store/re_types/src/blueprint/components/row_share.rs
@@ -30,8 +30,8 @@ pub struct RowShare(
 
 impl ::re_types_core::Component for RowShare {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.RowShare")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.RowShare".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/components/selected_columns.rs
@@ -28,8 +28,8 @@ pub struct SelectedColumns(pub crate::blueprint::datatypes::SelectedColumns);
 
 impl ::re_types_core::Component for SelectedColumns {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.SelectedColumns")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.SelectedColumns".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -28,8 +28,8 @@ pub struct TensorDimensionIndexSlider(pub crate::blueprint::datatypes::TensorDim
 
 impl ::re_types_core::Component for TensorDimensionIndexSlider {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.TensorDimensionIndexSlider")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.TensorDimensionIndexSlider".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/timeline_name.rs
+++ b/crates/store/re_types/src/blueprint/components/timeline_name.rs
@@ -28,8 +28,8 @@ pub struct TimelineName(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for TimelineName {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.TimelineName")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.TimelineName".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/view_class.rs
+++ b/crates/store/re_types/src/blueprint/components/view_class.rs
@@ -28,8 +28,8 @@ pub struct ViewClass(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for ViewClass {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ViewClass")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ViewClass".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/view_fit.rs
+++ b/crates/store/re_types/src/blueprint/components/view_fit.rs
@@ -37,8 +37,8 @@ pub enum ViewFit {
 
 impl ::re_types_core::Component for ViewFit {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ViewFit")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ViewFit".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/view_maximized.rs
+++ b/crates/store/re_types/src/blueprint/components/view_maximized.rs
@@ -27,8 +27,8 @@ pub struct ViewMaximized(pub crate::datatypes::Uuid);
 
 impl ::re_types_core::Component for ViewMaximized {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ViewMaximized")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ViewMaximized".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/view_origin.rs
+++ b/crates/store/re_types/src/blueprint/components/view_origin.rs
@@ -28,8 +28,8 @@ pub struct ViewOrigin(pub crate::datatypes::EntityPath);
 
 impl ::re_types_core::Component for ViewOrigin {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ViewOrigin")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ViewOrigin".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -30,8 +30,8 @@ pub struct ViewerRecommendationHash(pub crate::datatypes::UInt64);
 
 impl ::re_types_core::Component for ViewerRecommendationHash {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ViewerRecommendationHash")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ViewerRecommendationHash".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/store/re_types/src/blueprint/components/visible_time_range.rs
@@ -30,8 +30,8 @@ pub struct VisibleTimeRange(pub crate::datatypes::VisibleTimeRange);
 
 impl ::re_types_core::Component for VisibleTimeRange {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.VisibleTimeRange")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.VisibleTimeRange".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -31,8 +31,8 @@ pub struct VisualBounds2D(
 
 impl ::re_types_core::Component for VisualBounds2D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.VisualBounds2D")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.VisualBounds2D".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/visualizer_override.rs
+++ b/crates/store/re_types/src/blueprint/components/visualizer_override.rs
@@ -33,8 +33,8 @@ pub struct VisualizerOverride(
 
 impl ::re_types_core::Component for VisualizerOverride {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.VisualizerOverride")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.VisualizerOverride".into()
     }
 }
 

--- a/crates/store/re_types/src/blueprint/components/zoom_level.rs
+++ b/crates/store/re_types/src/blueprint/components/zoom_level.rs
@@ -30,8 +30,8 @@ pub struct ZoomLevel(
 
 impl ::re_types_core::Component for ZoomLevel {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.blueprint.components.ZoomLevel")
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ZoomLevel".into()
     }
 }
 

--- a/crates/store/re_types/src/components/aggregation_policy.rs
+++ b/crates/store/re_types/src/components/aggregation_policy.rs
@@ -52,8 +52,8 @@ pub enum AggregationPolicy {
 
 impl ::re_types_core::Component for AggregationPolicy {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.AggregationPolicy")
+    fn name() -> ComponentName {
+        "rerun.components.AggregationPolicy".into()
     }
 }
 

--- a/crates/store/re_types/src/components/albedo_factor.rs
+++ b/crates/store/re_types/src/components/albedo_factor.rs
@@ -28,8 +28,8 @@ pub struct AlbedoFactor(pub crate::datatypes::Rgba32);
 
 impl ::re_types_core::Component for AlbedoFactor {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.AlbedoFactor")
+    fn name() -> ComponentName {
+        "rerun.components.AlbedoFactor".into()
     }
 }
 

--- a/crates/store/re_types/src/components/annotation_context.rs
+++ b/crates/store/re_types/src/components/annotation_context.rs
@@ -36,8 +36,8 @@ pub struct AnnotationContext(
 
 impl ::re_types_core::Component for AnnotationContext {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.AnnotationContext")
+    fn name() -> ComponentName {
+        "rerun.components.AnnotationContext".into()
     }
 }
 

--- a/crates/store/re_types/src/components/axis_length.rs
+++ b/crates/store/re_types/src/components/axis_length.rs
@@ -26,8 +26,8 @@ pub struct AxisLength(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for AxisLength {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.AxisLength")
+    fn name() -> ComponentName {
+        "rerun.components.AxisLength".into()
     }
 }
 

--- a/crates/store/re_types/src/components/blob.rs
+++ b/crates/store/re_types/src/components/blob.rs
@@ -28,8 +28,8 @@ pub struct Blob(pub crate::datatypes::Blob);
 
 impl ::re_types_core::Component for Blob {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Blob")
+    fn name() -> ComponentName {
+        "rerun.components.Blob".into()
     }
 }
 

--- a/crates/store/re_types/src/components/class_id.rs
+++ b/crates/store/re_types/src/components/class_id.rs
@@ -31,8 +31,8 @@ pub struct ClassId(pub crate::datatypes::ClassId);
 
 impl ::re_types_core::Component for ClassId {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ClassId")
+    fn name() -> ComponentName {
+        "rerun.components.ClassId".into()
     }
 }
 

--- a/crates/store/re_types/src/components/color.rs
+++ b/crates/store/re_types/src/components/color.rs
@@ -29,8 +29,8 @@ pub struct Color(pub crate::datatypes::Rgba32);
 
 impl ::re_types_core::Component for Color {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Color")
+    fn name() -> ComponentName {
+        "rerun.components.Color".into()
     }
 }
 

--- a/crates/store/re_types/src/components/colormap.rs
+++ b/crates/store/re_types/src/components/colormap.rs
@@ -76,8 +76,8 @@ pub enum Colormap {
 
 impl ::re_types_core::Component for Colormap {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Colormap")
+    fn name() -> ComponentName {
+        "rerun.components.Colormap".into()
     }
 }
 

--- a/crates/store/re_types/src/components/depth_meter.rs
+++ b/crates/store/re_types/src/components/depth_meter.rs
@@ -35,8 +35,8 @@ pub struct DepthMeter(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for DepthMeter {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.DepthMeter")
+    fn name() -> ComponentName {
+        "rerun.components.DepthMeter".into()
     }
 }
 

--- a/crates/store/re_types/src/components/draw_order.rs
+++ b/crates/store/re_types/src/components/draw_order.rs
@@ -31,8 +31,8 @@ pub struct DrawOrder(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for DrawOrder {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.DrawOrder")
+    fn name() -> ComponentName {
+        "rerun.components.DrawOrder".into()
     }
 }
 

--- a/crates/store/re_types/src/components/entity_path.rs
+++ b/crates/store/re_types/src/components/entity_path.rs
@@ -26,8 +26,8 @@ pub struct EntityPath(pub crate::datatypes::EntityPath);
 
 impl ::re_types_core::Component for EntityPath {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.EntityPath")
+    fn name() -> ComponentName {
+        "rerun.components.EntityPath".into()
     }
 }
 

--- a/crates/store/re_types/src/components/fill_mode.rs
+++ b/crates/store/re_types/src/components/fill_mode.rs
@@ -49,8 +49,8 @@ pub enum FillMode {
 
 impl ::re_types_core::Component for FillMode {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.FillMode")
+    fn name() -> ComponentName {
+        "rerun.components.FillMode".into()
     }
 }
 

--- a/crates/store/re_types/src/components/fill_ratio.rs
+++ b/crates/store/re_types/src/components/fill_ratio.rs
@@ -31,8 +31,8 @@ pub struct FillRatio(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for FillRatio {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.FillRatio")
+    fn name() -> ComponentName {
+        "rerun.components.FillRatio".into()
     }
 }
 

--- a/crates/store/re_types/src/components/gamma_correction.rs
+++ b/crates/store/re_types/src/components/gamma_correction.rs
@@ -32,8 +32,8 @@ pub struct GammaCorrection(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for GammaCorrection {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.GammaCorrection")
+    fn name() -> ComponentName {
+        "rerun.components.GammaCorrection".into()
     }
 }
 

--- a/crates/store/re_types/src/components/geo_line_string.rs
+++ b/crates/store/re_types/src/components/geo_line_string.rs
@@ -26,8 +26,8 @@ pub struct GeoLineString(pub Vec<crate::datatypes::DVec2D>);
 
 impl ::re_types_core::Component for GeoLineString {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.GeoLineString")
+    fn name() -> ComponentName {
+        "rerun.components.GeoLineString".into()
     }
 }
 

--- a/crates/store/re_types/src/components/graph_edge.rs
+++ b/crates/store/re_types/src/components/graph_edge.rs
@@ -26,8 +26,8 @@ pub struct GraphEdge(pub crate::datatypes::Utf8Pair);
 
 impl ::re_types_core::Component for GraphEdge {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.GraphEdge")
+    fn name() -> ComponentName {
+        "rerun.components.GraphEdge".into()
     }
 }
 

--- a/crates/store/re_types/src/components/graph_node.rs
+++ b/crates/store/re_types/src/components/graph_node.rs
@@ -26,8 +26,8 @@ pub struct GraphNode(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for GraphNode {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.GraphNode")
+    fn name() -> ComponentName {
+        "rerun.components.GraphNode".into()
     }
 }
 

--- a/crates/store/re_types/src/components/graph_type.rs
+++ b/crates/store/re_types/src/components/graph_type.rs
@@ -34,8 +34,8 @@ pub enum GraphType {
 
 impl ::re_types_core::Component for GraphType {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.GraphType")
+    fn name() -> ComponentName {
+        "rerun.components.GraphType".into()
     }
 }
 

--- a/crates/store/re_types/src/components/half_size2d.rs
+++ b/crates/store/re_types/src/components/half_size2d.rs
@@ -31,8 +31,8 @@ pub struct HalfSize2D(pub crate::datatypes::Vec2D);
 
 impl ::re_types_core::Component for HalfSize2D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.HalfSize2D")
+    fn name() -> ComponentName {
+        "rerun.components.HalfSize2D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/half_size3d.rs
+++ b/crates/store/re_types/src/components/half_size3d.rs
@@ -31,8 +31,8 @@ pub struct HalfSize3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::Component for HalfSize3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.HalfSize3D")
+    fn name() -> ComponentName {
+        "rerun.components.HalfSize3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/image_buffer.rs
+++ b/crates/store/re_types/src/components/image_buffer.rs
@@ -28,8 +28,8 @@ pub struct ImageBuffer(pub crate::datatypes::Blob);
 
 impl ::re_types_core::Component for ImageBuffer {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ImageBuffer")
+    fn name() -> ComponentName {
+        "rerun.components.ImageBuffer".into()
     }
 }
 

--- a/crates/store/re_types/src/components/image_format.rs
+++ b/crates/store/re_types/src/components/image_format.rs
@@ -26,8 +26,8 @@ pub struct ImageFormat(pub crate::datatypes::ImageFormat);
 
 impl ::re_types_core::Component for ImageFormat {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ImageFormat")
+    fn name() -> ComponentName {
+        "rerun.components.ImageFormat".into()
     }
 }
 

--- a/crates/store/re_types/src/components/image_plane_distance.rs
+++ b/crates/store/re_types/src/components/image_plane_distance.rs
@@ -27,8 +27,8 @@ pub struct ImagePlaneDistance(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for ImagePlaneDistance {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ImagePlaneDistance")
+    fn name() -> ComponentName {
+        "rerun.components.ImagePlaneDistance".into()
     }
 }
 

--- a/crates/store/re_types/src/components/interactive.rs
+++ b/crates/store/re_types/src/components/interactive.rs
@@ -28,8 +28,8 @@ pub struct Interactive(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for Interactive {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Interactive")
+    fn name() -> ComponentName {
+        "rerun.components.Interactive".into()
     }
 }
 

--- a/crates/store/re_types/src/components/keypoint_id.rs
+++ b/crates/store/re_types/src/components/keypoint_id.rs
@@ -43,8 +43,8 @@ pub struct KeypointId(pub crate::datatypes::KeypointId);
 
 impl ::re_types_core::Component for KeypointId {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.KeypointId")
+    fn name() -> ComponentName {
+        "rerun.components.KeypointId".into()
     }
 }
 

--- a/crates/store/re_types/src/components/lat_lon.rs
+++ b/crates/store/re_types/src/components/lat_lon.rs
@@ -26,8 +26,8 @@ pub struct LatLon(pub crate::datatypes::DVec2D);
 
 impl ::re_types_core::Component for LatLon {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.LatLon")
+    fn name() -> ComponentName {
+        "rerun.components.LatLon".into()
     }
 }
 

--- a/crates/store/re_types/src/components/length.rs
+++ b/crates/store/re_types/src/components/length.rs
@@ -29,8 +29,8 @@ pub struct Length(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for Length {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Length")
+    fn name() -> ComponentName {
+        "rerun.components.Length".into()
     }
 }
 

--- a/crates/store/re_types/src/components/line_strip2d.rs
+++ b/crates/store/re_types/src/components/line_strip2d.rs
@@ -36,8 +36,8 @@ pub struct LineStrip2D(pub Vec<crate::datatypes::Vec2D>);
 
 impl ::re_types_core::Component for LineStrip2D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.LineStrip2D")
+    fn name() -> ComponentName {
+        "rerun.components.LineStrip2D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/line_strip3d.rs
+++ b/crates/store/re_types/src/components/line_strip3d.rs
@@ -36,8 +36,8 @@ pub struct LineStrip3D(pub Vec<crate::datatypes::Vec3D>);
 
 impl ::re_types_core::Component for LineStrip3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.LineStrip3D")
+    fn name() -> ComponentName {
+        "rerun.components.LineStrip3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/magnification_filter.rs
+++ b/crates/store/re_types/src/components/magnification_filter.rs
@@ -39,8 +39,8 @@ pub enum MagnificationFilter {
 
 impl ::re_types_core::Component for MagnificationFilter {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.MagnificationFilter")
+    fn name() -> ComponentName {
+        "rerun.components.MagnificationFilter".into()
     }
 }
 

--- a/crates/store/re_types/src/components/marker_shape.rs
+++ b/crates/store/re_types/src/components/marker_shape.rs
@@ -58,8 +58,8 @@ pub enum MarkerShape {
 
 impl ::re_types_core::Component for MarkerShape {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.MarkerShape")
+    fn name() -> ComponentName {
+        "rerun.components.MarkerShape".into()
     }
 }
 

--- a/crates/store/re_types/src/components/marker_size.rs
+++ b/crates/store/re_types/src/components/marker_size.rs
@@ -26,8 +26,8 @@ pub struct MarkerSize(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for MarkerSize {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.MarkerSize")
+    fn name() -> ComponentName {
+        "rerun.components.MarkerSize".into()
     }
 }
 

--- a/crates/store/re_types/src/components/media_type.rs
+++ b/crates/store/re_types/src/components/media_type.rs
@@ -29,8 +29,8 @@ pub struct MediaType(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for MediaType {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.MediaType")
+    fn name() -> ComponentName {
+        "rerun.components.MediaType".into()
     }
 }
 

--- a/crates/store/re_types/src/components/name.rs
+++ b/crates/store/re_types/src/components/name.rs
@@ -26,8 +26,8 @@ pub struct Name(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for Name {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Name")
+    fn name() -> ComponentName {
+        "rerun.components.Name".into()
     }
 }
 

--- a/crates/store/re_types/src/components/opacity.rs
+++ b/crates/store/re_types/src/components/opacity.rs
@@ -29,8 +29,8 @@ pub struct Opacity(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for Opacity {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Opacity")
+    fn name() -> ComponentName {
+        "rerun.components.Opacity".into()
     }
 }
 

--- a/crates/store/re_types/src/components/pinhole_projection.rs
+++ b/crates/store/re_types/src/components/pinhole_projection.rs
@@ -35,8 +35,8 @@ pub struct PinholeProjection(pub crate::datatypes::Mat3x3);
 
 impl ::re_types_core::Component for PinholeProjection {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.PinholeProjection")
+    fn name() -> ComponentName {
+        "rerun.components.PinholeProjection".into()
     }
 }
 

--- a/crates/store/re_types/src/components/plane3d.rs
+++ b/crates/store/re_types/src/components/plane3d.rs
@@ -34,8 +34,8 @@ pub struct Plane3D(pub crate::datatypes::Plane3D);
 
 impl ::re_types_core::Component for Plane3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Plane3D")
+    fn name() -> ComponentName {
+        "rerun.components.Plane3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
@@ -29,8 +29,8 @@ pub struct PoseRotationAxisAngle(pub crate::datatypes::RotationAxisAngle);
 
 impl ::re_types_core::Component for PoseRotationAxisAngle {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.PoseRotationAxisAngle")
+    fn name() -> ComponentName {
+        "rerun.components.PoseRotationAxisAngle".into()
     }
 }
 

--- a/crates/store/re_types/src/components/pose_rotation_quat.rs
+++ b/crates/store/re_types/src/components/pose_rotation_quat.rs
@@ -30,8 +30,8 @@ pub struct PoseRotationQuat(pub crate::datatypes::Quaternion);
 
 impl ::re_types_core::Component for PoseRotationQuat {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.PoseRotationQuat")
+    fn name() -> ComponentName {
+        "rerun.components.PoseRotationQuat".into()
     }
 }
 

--- a/crates/store/re_types/src/components/pose_scale3d.rs
+++ b/crates/store/re_types/src/components/pose_scale3d.rs
@@ -30,8 +30,8 @@ pub struct PoseScale3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::Component for PoseScale3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.PoseScale3D")
+    fn name() -> ComponentName {
+        "rerun.components.PoseScale3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/pose_transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/pose_transform_mat3x3.rs
@@ -38,8 +38,8 @@ pub struct PoseTransformMat3x3(pub crate::datatypes::Mat3x3);
 
 impl ::re_types_core::Component for PoseTransformMat3x3 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.PoseTransformMat3x3")
+    fn name() -> ComponentName {
+        "rerun.components.PoseTransformMat3x3".into()
     }
 }
 

--- a/crates/store/re_types/src/components/pose_translation3d.rs
+++ b/crates/store/re_types/src/components/pose_translation3d.rs
@@ -26,8 +26,8 @@ pub struct PoseTranslation3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::Component for PoseTranslation3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.PoseTranslation3D")
+    fn name() -> ComponentName {
+        "rerun.components.PoseTranslation3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/position2d.rs
+++ b/crates/store/re_types/src/components/position2d.rs
@@ -26,8 +26,8 @@ pub struct Position2D(pub crate::datatypes::Vec2D);
 
 impl ::re_types_core::Component for Position2D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Position2D")
+    fn name() -> ComponentName {
+        "rerun.components.Position2D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/position3d.rs
+++ b/crates/store/re_types/src/components/position3d.rs
@@ -26,8 +26,8 @@ pub struct Position3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::Component for Position3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Position3D")
+    fn name() -> ComponentName {
+        "rerun.components.Position3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/radius.rs
+++ b/crates/store/re_types/src/components/radius.rs
@@ -33,8 +33,8 @@ pub struct Radius(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for Radius {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Radius")
+    fn name() -> ComponentName {
+        "rerun.components.Radius".into()
     }
 }
 

--- a/crates/store/re_types/src/components/range1d.rs
+++ b/crates/store/re_types/src/components/range1d.rs
@@ -26,8 +26,8 @@ pub struct Range1D(pub crate::datatypes::Range1D);
 
 impl ::re_types_core::Component for Range1D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Range1D")
+    fn name() -> ComponentName {
+        "rerun.components.Range1D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/resolution.rs
+++ b/crates/store/re_types/src/components/resolution.rs
@@ -27,8 +27,8 @@ pub struct Resolution(pub crate::datatypes::Vec2D);
 
 impl ::re_types_core::Component for Resolution {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Resolution")
+    fn name() -> ComponentName {
+        "rerun.components.Resolution".into()
     }
 }
 

--- a/crates/store/re_types/src/components/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/rotation_axis_angle.rs
@@ -29,8 +29,8 @@ pub struct RotationAxisAngle(pub crate::datatypes::RotationAxisAngle);
 
 impl ::re_types_core::Component for RotationAxisAngle {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.RotationAxisAngle")
+    fn name() -> ComponentName {
+        "rerun.components.RotationAxisAngle".into()
     }
 }
 

--- a/crates/store/re_types/src/components/rotation_quat.rs
+++ b/crates/store/re_types/src/components/rotation_quat.rs
@@ -30,8 +30,8 @@ pub struct RotationQuat(pub crate::datatypes::Quaternion);
 
 impl ::re_types_core::Component for RotationQuat {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.RotationQuat")
+    fn name() -> ComponentName {
+        "rerun.components.RotationQuat".into()
     }
 }
 

--- a/crates/store/re_types/src/components/scalar.rs
+++ b/crates/store/re_types/src/components/scalar.rs
@@ -28,8 +28,8 @@ pub struct Scalar(pub crate::datatypes::Float64);
 
 impl ::re_types_core::Component for Scalar {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Scalar")
+    fn name() -> ComponentName {
+        "rerun.components.Scalar".into()
     }
 }
 

--- a/crates/store/re_types/src/components/scale3d.rs
+++ b/crates/store/re_types/src/components/scale3d.rs
@@ -30,8 +30,8 @@ pub struct Scale3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::Component for Scale3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Scale3D")
+    fn name() -> ComponentName {
+        "rerun.components.Scale3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/series_visible.rs
+++ b/crates/store/re_types/src/components/series_visible.rs
@@ -28,8 +28,8 @@ pub struct SeriesVisible(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for SeriesVisible {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.SeriesVisible")
+    fn name() -> ComponentName {
+        "rerun.components.SeriesVisible".into()
     }
 }
 

--- a/crates/store/re_types/src/components/show_labels.rs
+++ b/crates/store/re_types/src/components/show_labels.rs
@@ -32,8 +32,8 @@ pub struct ShowLabels(
 
 impl ::re_types_core::Component for ShowLabels {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ShowLabels")
+    fn name() -> ComponentName {
+        "rerun.components.ShowLabels".into()
     }
 }
 

--- a/crates/store/re_types/src/components/stroke_width.rs
+++ b/crates/store/re_types/src/components/stroke_width.rs
@@ -26,8 +26,8 @@ pub struct StrokeWidth(pub crate::datatypes::Float32);
 
 impl ::re_types_core::Component for StrokeWidth {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.StrokeWidth")
+    fn name() -> ComponentName {
+        "rerun.components.StrokeWidth".into()
     }
 }
 

--- a/crates/store/re_types/src/components/tensor_data.rs
+++ b/crates/store/re_types/src/components/tensor_data.rs
@@ -33,8 +33,8 @@ pub struct TensorData(pub crate::datatypes::TensorData);
 
 impl ::re_types_core::Component for TensorData {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TensorData")
+    fn name() -> ComponentName {
+        "rerun.components.TensorData".into()
     }
 }
 

--- a/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
@@ -26,8 +26,8 @@ pub struct TensorDimensionIndexSelection(pub crate::datatypes::TensorDimensionIn
 
 impl ::re_types_core::Component for TensorDimensionIndexSelection {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TensorDimensionIndexSelection")
+    fn name() -> ComponentName {
+        "rerun.components.TensorDimensionIndexSelection".into()
     }
 }
 

--- a/crates/store/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_height_dimension.rs
@@ -26,8 +26,8 @@ pub struct TensorHeightDimension(pub crate::datatypes::TensorDimensionSelection)
 
 impl ::re_types_core::Component for TensorHeightDimension {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TensorHeightDimension")
+    fn name() -> ComponentName {
+        "rerun.components.TensorHeightDimension".into()
     }
 }
 

--- a/crates/store/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_width_dimension.rs
@@ -26,8 +26,8 @@ pub struct TensorWidthDimension(pub crate::datatypes::TensorDimensionSelection);
 
 impl ::re_types_core::Component for TensorWidthDimension {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TensorWidthDimension")
+    fn name() -> ComponentName {
+        "rerun.components.TensorWidthDimension".into()
     }
 }
 

--- a/crates/store/re_types/src/components/texcoord2d.rs
+++ b/crates/store/re_types/src/components/texcoord2d.rs
@@ -41,8 +41,8 @@ pub struct Texcoord2D(pub crate::datatypes::Vec2D);
 
 impl ::re_types_core::Component for Texcoord2D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Texcoord2D")
+    fn name() -> ComponentName {
+        "rerun.components.Texcoord2D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/text.rs
+++ b/crates/store/re_types/src/components/text.rs
@@ -26,8 +26,8 @@ pub struct Text(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for Text {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Text")
+    fn name() -> ComponentName {
+        "rerun.components.Text".into()
     }
 }
 

--- a/crates/store/re_types/src/components/text_log_level.rs
+++ b/crates/store/re_types/src/components/text_log_level.rs
@@ -34,8 +34,8 @@ pub struct TextLogLevel(pub crate::datatypes::Utf8);
 
 impl ::re_types_core::Component for TextLogLevel {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TextLogLevel")
+    fn name() -> ComponentName {
+        "rerun.components.TextLogLevel".into()
     }
 }
 

--- a/crates/store/re_types/src/components/timestamp.rs
+++ b/crates/store/re_types/src/components/timestamp.rs
@@ -28,8 +28,8 @@ pub struct Timestamp(pub crate::datatypes::TimeInt);
 
 impl ::re_types_core::Component for Timestamp {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Timestamp")
+    fn name() -> ComponentName {
+        "rerun.components.Timestamp".into()
     }
 }
 

--- a/crates/store/re_types/src/components/transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/transform_mat3x3.rs
@@ -38,8 +38,8 @@ pub struct TransformMat3x3(pub crate::datatypes::Mat3x3);
 
 impl ::re_types_core::Component for TransformMat3x3 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TransformMat3x3")
+    fn name() -> ComponentName {
+        "rerun.components.TransformMat3x3".into()
     }
 }
 

--- a/crates/store/re_types/src/components/transform_relation.rs
+++ b/crates/store/re_types/src/components/transform_relation.rs
@@ -42,8 +42,8 @@ pub enum TransformRelation {
 
 impl ::re_types_core::Component for TransformRelation {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TransformRelation")
+    fn name() -> ComponentName {
+        "rerun.components.TransformRelation".into()
     }
 }
 

--- a/crates/store/re_types/src/components/translation3d.rs
+++ b/crates/store/re_types/src/components/translation3d.rs
@@ -26,8 +26,8 @@ pub struct Translation3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::Component for Translation3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Translation3D")
+    fn name() -> ComponentName {
+        "rerun.components.Translation3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/triangle_indices.rs
+++ b/crates/store/re_types/src/components/triangle_indices.rs
@@ -26,8 +26,8 @@ pub struct TriangleIndices(pub crate::datatypes::UVec3D);
 
 impl ::re_types_core::Component for TriangleIndices {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.TriangleIndices")
+    fn name() -> ComponentName {
+        "rerun.components.TriangleIndices".into()
     }
 }
 

--- a/crates/store/re_types/src/components/value_range.rs
+++ b/crates/store/re_types/src/components/value_range.rs
@@ -28,8 +28,8 @@ pub struct ValueRange(pub crate::datatypes::Range1D);
 
 impl ::re_types_core::Component for ValueRange {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ValueRange")
+    fn name() -> ComponentName {
+        "rerun.components.ValueRange".into()
     }
 }
 

--- a/crates/store/re_types/src/components/vector2d.rs
+++ b/crates/store/re_types/src/components/vector2d.rs
@@ -26,8 +26,8 @@ pub struct Vector2D(pub crate::datatypes::Vec2D);
 
 impl ::re_types_core::Component for Vector2D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Vector2D")
+    fn name() -> ComponentName {
+        "rerun.components.Vector2D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/vector3d.rs
+++ b/crates/store/re_types/src/components/vector3d.rs
@@ -26,8 +26,8 @@ pub struct Vector3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::Component for Vector3D {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Vector3D")
+    fn name() -> ComponentName {
+        "rerun.components.Vector3D".into()
     }
 }
 

--- a/crates/store/re_types/src/components/video_timestamp.rs
+++ b/crates/store/re_types/src/components/video_timestamp.rs
@@ -26,8 +26,8 @@ pub struct VideoTimestamp(pub crate::datatypes::VideoTimestamp);
 
 impl ::re_types_core::Component for VideoTimestamp {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.VideoTimestamp")
+    fn name() -> ComponentName {
+        "rerun.components.VideoTimestamp".into()
     }
 }
 

--- a/crates/store/re_types/src/components/view_coordinates.rs
+++ b/crates/store/re_types/src/components/view_coordinates.rs
@@ -48,8 +48,8 @@ pub struct ViewCoordinates(
 
 impl ::re_types_core::Component for ViewCoordinates {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ViewCoordinates")
+    fn name() -> ComponentName {
+        "rerun.components.ViewCoordinates".into()
     }
 }
 

--- a/crates/store/re_types/src/components/visible.rs
+++ b/crates/store/re_types/src/components/visible.rs
@@ -26,8 +26,8 @@ pub struct Visible(pub crate::datatypes::Bool);
 
 impl ::re_types_core::Component for Visible {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.Visible")
+    fn name() -> ComponentName {
+        "rerun.components.Visible".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer1(pub crate::testing::datatypes::AffixFuzzer1);
 
 impl ::re_types_core::Component for AffixFuzzer1 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer1")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer1".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer10(pub Option<::re_types_core::ArrowString>);
 
 impl ::re_types_core::Component for AffixFuzzer10 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer10")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer10".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer11(pub Option<::arrow::buffer::ScalarBuffer<f32>>);
 
 impl ::re_types_core::Component for AffixFuzzer11 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer11")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer11".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer12(pub Vec<::re_types_core::ArrowString>);
 
 impl ::re_types_core::Component for AffixFuzzer12 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer12")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer12".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer13(pub Option<Vec<::re_types_core::ArrowString>>);
 
 impl ::re_types_core::Component for AffixFuzzer13 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer13")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer13".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer14(pub crate::testing::datatypes::AffixFuzzer3);
 
 impl ::re_types_core::Component for AffixFuzzer14 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer14")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer14".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer15(pub Option<crate::testing::datatypes::AffixFuzzer3>);
 
 impl ::re_types_core::Component for AffixFuzzer15 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer15")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer15".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer16(pub Vec<crate::testing::datatypes::AffixFuzzer3>);
 
 impl ::re_types_core::Component for AffixFuzzer16 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer16")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer16".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer17(pub Option<Vec<crate::testing::datatypes::AffixFuzzer3>
 
 impl ::re_types_core::Component for AffixFuzzer17 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer17")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer17".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer18(pub Option<Vec<crate::testing::datatypes::AffixFuzzer4>
 
 impl ::re_types_core::Component for AffixFuzzer18 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer18")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer18".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer19(pub crate::testing::datatypes::AffixFuzzer5);
 
 impl ::re_types_core::Component for AffixFuzzer19 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer19")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer19".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer2(pub crate::testing::datatypes::AffixFuzzer1);
 
 impl ::re_types_core::Component for AffixFuzzer2 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer2")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer2".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer20(pub crate::testing::datatypes::AffixFuzzer20);
 
 impl ::re_types_core::Component for AffixFuzzer20 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer20")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer20".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer21(pub crate::testing::datatypes::AffixFuzzer21);
 
 impl ::re_types_core::Component for AffixFuzzer21 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer21")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer21".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer22(pub Option<crate::testing::datatypes::AffixFuzzer22>);
 
 impl ::re_types_core::Component for AffixFuzzer22 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer22")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer22".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer23(pub Option<crate::testing::datatypes::MultiEnum>);
 
 impl ::re_types_core::Component for AffixFuzzer23 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer23")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer23".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer3(pub crate::testing::datatypes::AffixFuzzer1);
 
 impl ::re_types_core::Component for AffixFuzzer3 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer3")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer3".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer4(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
 impl ::re_types_core::Component for AffixFuzzer4 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer4")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer4".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer5(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
 impl ::re_types_core::Component for AffixFuzzer5 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer5")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer5".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer6(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
 impl ::re_types_core::Component for AffixFuzzer6 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer6")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer6".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer7(pub Option<Vec<crate::testing::datatypes::AffixFuzzer1>>
 
 impl ::re_types_core::Component for AffixFuzzer7 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer7")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer7".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer8(pub Option<f32>);
 
 impl ::re_types_core::Component for AffixFuzzer8 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer8")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer8".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
@@ -24,8 +24,8 @@ pub struct AffixFuzzer9(pub ::re_types_core::ArrowString);
 
 impl ::re_types_core::Component for AffixFuzzer9 {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer9")
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer9".into()
     }
 }
 

--- a/crates/store/re_types/src/testing/mod.rs
+++ b/crates/store/re_types/src/testing/mod.rs
@@ -1,8 +1,14 @@
 #![allow(missing_docs)] // It's only for testing
 
+use re_types_core::{Component, ComponentDescriptor};
+
 pub mod archetypes;
 pub mod components;
 pub mod datatypes;
+
+pub fn large_struct_descriptor() -> ComponentDescriptor {
+    ComponentDescriptor::new(<LargeStruct as Component>::name())
+}
 
 /// Large struct used for benchmarking.
 pub type LargeStruct = components::AffixFuzzer1;

--- a/crates/store/re_types_core/src/as_components.rs
+++ b/crates/store/re_types_core/src/as_components.rs
@@ -251,8 +251,8 @@ mod tests {
     }
 
     impl crate::Component for MyColor {
-        fn descriptor() -> crate::ComponentDescriptor {
-            crate::ComponentDescriptor::new("example.MyColor")
+        fn name() -> crate::ComponentName {
+            "example.MyColor".into()
         }
     }
 

--- a/crates/store/re_types_core/src/components/clear_is_recursive.rs
+++ b/crates/store/re_types_core/src/components/clear_is_recursive.rs
@@ -28,8 +28,8 @@ pub struct ClearIsRecursive(
 
 impl crate::Component for ClearIsRecursive {
     #[inline]
-    fn descriptor() -> ComponentDescriptor {
-        ComponentDescriptor::new("rerun.components.ClearIsRecursive")
+    fn name() -> ComponentName {
+        "rerun.components.ClearIsRecursive".into()
     }
 }
 

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -89,34 +89,8 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
 /// Implementing the [`Component`] trait automatically derives the [`ComponentBatch`] implementation,
 /// which makes it possible to work with lists' worth of data in a generic fashion.
 pub trait Component: Loggable {
-    /// Returns the complete [`ComponentDescriptor`] for this [`Component`].
-    ///
-    /// Every component is uniquely identified by its [`ComponentDescriptor`].
-    //
-    // NOTE: Builtin Rerun components don't (yet) have anything but a `ComponentName` attached to
-    // them (other tags are injected at the Archetype level), therefore having a full
-    // `ComponentDescriptor` might seem overkill.
-    // It's not:
-    // * Users might still want to register Components with specific tags.
-    // * In the future, `ComponentDescriptor`s will very likely cover more than Archetype-related tags
-    //   (e.g. generics, metric units, etc).
-    // TODO(#6889): This method should be removed, or made dynamic.
-    fn descriptor() -> ComponentDescriptor;
-
     /// The fully-qualified name of this component, e.g. `rerun.components.Position2D`.
-    ///
-    /// This is a trivial but useful helper for `Self::descriptor().component_name`.
-    ///
-    /// The default implementation already does the right thing: do not override unless you know
-    /// what you're doing.
-    /// `Self::name()` must exactly match the value returned by `Self::descriptor().component_name`,
-    /// or undefined behavior ensues.
-    //
-    // TODO(#6889): This method should be removed.
-    #[inline]
-    fn name() -> ComponentName {
-        Self::descriptor().component_name
-    }
+    fn name() -> ComponentName;
 }
 
 // ---

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -347,7 +347,8 @@ impl<L: Clone + Loggable> LoggableBatch for L {
 impl<C: Component> ComponentBatch for C {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }
 
@@ -363,7 +364,8 @@ impl<L: Clone + Loggable> LoggableBatch for Option<L> {
 impl<C: Component> ComponentBatch for Option<C> {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }
 
@@ -379,7 +381,8 @@ impl<L: Clone + Loggable> LoggableBatch for Vec<L> {
 impl<C: Component> ComponentBatch for Vec<C> {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }
 
@@ -398,7 +401,8 @@ impl<L: Loggable> LoggableBatch for Vec<Option<L>> {
 impl<C: Component> ComponentBatch for Vec<Option<C>> {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }
 
@@ -414,7 +418,8 @@ impl<L: Loggable, const N: usize> LoggableBatch for [L; N] {
 impl<C: Component, const N: usize> ComponentBatch for [C; N] {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }
 
@@ -433,7 +438,8 @@ impl<L: Loggable, const N: usize> LoggableBatch for [Option<L>; N] {
 impl<C: Component, const N: usize> ComponentBatch for [Option<C>; N] {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }
 
@@ -449,7 +455,8 @@ impl<L: Loggable> LoggableBatch for [L] {
 impl<C: Component> ComponentBatch for [C] {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }
 
@@ -468,6 +475,7 @@ impl<L: Loggable> LoggableBatch for [Option<L>] {
 impl<C: Component> ComponentBatch for [Option<C>] {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
+        // TODO(#6889): This is still untagged.
+        ComponentDescriptor::new(C::name()).into()
     }
 }

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -89,7 +89,7 @@ macro_rules! delegate_arrow_tuid {
 
         impl $typ {
             #[inline]
-            pub fn untagged_descriptor() -> $crate::ComponentDescriptor {
+            pub fn partial_descriptor() -> $crate::ComponentDescriptor {
                 $crate::ComponentDescriptor::new($fqname)
             }
         }

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -144,11 +144,6 @@ macro_rules! delegate_arrow_tuid {
             fn name() -> $crate::ComponentName {
                 $fqname.into()
             }
-
-            #[inline]
-            fn descriptor() -> $crate::ComponentDescriptor {
-                $crate::ComponentDescriptor::new($fqname)
-            }
         }
     };
 }

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -87,6 +87,13 @@ macro_rules! delegate_arrow_tuid {
     ($typ:ident as $fqname:expr) => {
         $crate::macros::impl_into_cow!($typ);
 
+        impl $typ {
+            #[inline]
+            pub fn untagged_descriptor() -> $crate::ComponentDescriptor {
+                $crate::ComponentDescriptor::new($fqname)
+            }
+        }
+
         impl $crate::Loggable for $typ {
             #[inline]
             fn arrow_datatype() -> ::arrow::datatypes::DataType {

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -15,7 +15,7 @@ impl CustomPoints3D {
     }
 
     fn overridden_color_descriptor() -> ComponentDescriptor {
-        <rerun::components::Color as rerun::Component>::descriptor()
+        ComponentDescriptor::new(<rerun::components::Color as rerun::Component>::name())
             .or_with_archetype_name(|| "user.CustomPoints3D".into())
             .or_with_archetype_field_name(|| "colors".into())
     }

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -3,7 +3,7 @@
 use rerun::{
     demo_util::grid,
     external::{arrow, glam, re_types},
-    ComponentBatch as _, ComponentName, SerializedComponentBatch,
+    ComponentBatch as _, SerializedComponentBatch,
 };
 
 // ---

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -3,7 +3,7 @@
 use rerun::{
     demo_util::grid,
     external::{arrow, glam, re_types},
-    ComponentBatch as _, SerializedComponentBatch,
+    ComponentBatch as _, ComponentName, SerializedComponentBatch,
 };
 
 // ---
@@ -77,8 +77,8 @@ impl rerun::Loggable for Confidence {
 
 impl rerun::Component for Confidence {
     #[inline]
-    fn descriptor() -> rerun::ComponentDescriptor {
-        rerun::ComponentDescriptor::new("user.Confidence")
+    fn name() -> rerun::ComponentName {
+        "user.Confidence".into()
     }
 }
 


### PR DESCRIPTION
### Related

* Part of #6889.

### What

Another big step towards having full tagging support in the viewer. By removing `Component::descriptor()` we make it harder to accidentally use untagged descriptors and therefore reduce bugs in our code, and in our users code.

This refactor goes right up to the point where we have to change our SDKs, so there is more design work to be made (via new `AnyValues`).

To achieve this we still rely on untagged components when implementing `ComponentBatch::descriptor` (left todos there).

Next steps are:
* Remove remaining untagged methods (track usage of `Component::name()`)
* Designing new `AnyValues` #9906 for all SDKs.
* Making `ComponentDescriptor::new` more explicit when using untagged components or prevent untagged components all together by removing the optionals.
* Optionally getting rid of `ComponentBatch` (Maybe we wait for the removal of indicator components).

## Dependency

* Requires: https://github.com/rerun-io/dataplatform/pull/815