### PR TITLE
Upload NPM package as tarball to GCS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,6 +83,22 @@ jobs:
       NIGHTLY: true
     secrets: inherit
 
+  build-js:
+    name: "Build JS"
+    uses: ./.github/workflows/reusable_build_js.yml
+    with:
+      CONCURRENCY: nightly
+    secrets: inherit
+
+  upload-js:
+    name: "Upload JS"
+    needs: [build-js]
+    uses: ./.github/workflows/reusable_upload_js.yml
+    with:
+      CONCURRENCY: nightly
+      NIGHTLY: true
+    secrets: inherit
+
   # -----------------------------------------------------------------------------------
   # Build rerun_c library binaries:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -449,6 +449,12 @@ jobs:
             FetchContent_MakeAvailable(rerun_sdk)
             ```
 
+            ## Web Viewer NPM package
+            Can be installed with:
+            ```
+            npm install https://build.rerun.io/commit/${{ env.SHORT_SHA }}/rerun_js
+            ```
+
           prerelease: true
           # Be explicit about the commit we're releasing/tagging.
           # Otherwise it can happen that there's a discrepancy between the tag and the commit for which we uploaded & linked artifacts.

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -207,6 +207,16 @@ jobs:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
+  
+  upload-js:
+    name: "Upload JS"
+    needs: [build-js]
+    if: github.event.pull_request.head.repo.owner.login == 'rerun-io'
+    uses: ./.github/workflows/reusable_upload_js.yml
+    with:
+      CONCURRENCY: pr-${{ github.event.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    secrets: inherit
 
   deploy-landing-preview:
     name: "Deploy Landing Preview"

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -207,7 +207,7 @@ jobs:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     secrets: inherit
-  
+
   upload-js:
     name: "Upload JS"
     needs: [build-js]

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -75,6 +75,21 @@ jobs:
       CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
     secrets: inherit
 
+  build-js:
+    name: "Build JS"
+    uses: ./.github/workflows/reusable_build_js.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
+    secrets: inherit
+
+  upload-js:
+    name: "Upload JS"
+    needs: [build-js]
+    uses: ./.github/workflows/reusable_upload_js.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
+    secrets: inherit
+
   build-examples:
     name: "Build Examples"
     needs: [build-wheel-linux-x64]

--- a/.github/workflows/reusable_build_js.yml
+++ b/.github/workflows/reusable_build_js.yml
@@ -72,3 +72,16 @@ jobs:
 
       - name: Build rerun_js package
         run: pixi run yarn --cwd rerun_js workspaces run build
+
+      - name: Package rerun_js
+        run: |
+          pixi run yarn --cwd rerun_js workspaces run pack
+          mkdir rerun_js_package
+          cp rerun_js/*/*.tar.gz rerun_js_package/
+
+      - name: Upload rerun_js
+        uses: actions/upload-artifact@v4
+        with:
+          name: rerun_js
+          path: rerun_js_package
+          compression-level: 0 # already compressed

--- a/.github/workflows/reusable_upload_js.yml
+++ b/.github/workflows/reusable_upload_js.yml
@@ -73,7 +73,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "rerun_js_package"
-          destination: "rerun-web-viewer/commit/${{ steps.get-sha.outputs.sha }}/rerun_js"
+          destination: "rerun-builds/commit/${{ steps.get-sha.outputs.sha }}/rerun_js"
           parent: false
           process_gcloudignore: false
 
@@ -82,7 +82,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "rerun_js_package"
-          destination: "rerun-web-viewer/version/${{inputs.RELEASE_VERSION}}/rerun_js"
+          destination: "rerun-builds/version/${{inputs.RELEASE_VERSION}}/rerun_js"
           parent: false
           process_gcloudignore: false
 
@@ -91,7 +91,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "rerun_js_package"
-          destination: "rerun-web-viewer/adhoc/${{inputs.ADHOC_NAME}}/rerun_js"
+          destination: "rerun-builds/adhoc/${{inputs.ADHOC_NAME}}/rerun_js"
           parent: false
           process_gcloudignore: false
 
@@ -100,7 +100,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "rerun_js"
-          destination: "rerun-web-viewer/prerelease/rerun_js"
+          destination: "rerun-builds/prerelease/rerun_js"
           parent: false
           process_gcloudignore: false
           headers: |-
@@ -111,7 +111,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "rerun_js_package"
-          destination: "rerun-web-viewer/version/main/rerun_js"
+          destination: "rerun-builds/version/main/rerun_js"
           parent: false
           process_gcloudignore: false
           headers: |-
@@ -122,7 +122,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "rerun_js"
-          destination: "rerun-web-viewer/pr/${{ inputs.PR_NUMBER }}/rerun_js"
+          destination: "rerun-builds/pr/${{ inputs.PR_NUMBER }}/rerun_js"
           parent: false
           process_gcloudignore: false
           headers: |-
@@ -133,7 +133,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "rerun_js"
-          destination: "rerun-web-viewer/version/nightly/rerun_js"
+          destination: "rerun-builds/version/nightly/rerun_js"
           parent: false
           process_gcloudignore: false
           headers: |-

--- a/.github/workflows/reusable_upload_js.yml
+++ b/.github/workflows/reusable_upload_js.yml
@@ -1,0 +1,141 @@
+name: Reusable Upload rerun_js
+
+on:
+  workflow_call:
+    inputs:
+      CONCURRENCY:
+        required: true
+        type: string
+      ADHOC_NAME:
+        type: string
+        required: false
+        default: ""
+      MARK_TAGGED_VERSION:
+        required: false
+        type: boolean
+        default: false
+      RELEASE_VERSION:
+        required: false
+        type: string
+        default: "prerelease"
+      PR_NUMBER:
+        required: false
+        type: string
+        default: ""
+      NIGHTLY:
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ inputs.CONCURRENCY }}-upload-js
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: "write"
+  id-token: "write"
+  pull-requests: "write"
+
+jobs:
+  upload-web:
+    name: Upload rerun_js to google cloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
+      - name: Download rerun_js package
+        uses: actions/download-artifact@v4
+        with:
+          name: rerun_js
+          path: rerun_js_package
+
+      # Upload the wasm, html etc to a Google cloud bucket:
+      - id: "auth"
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+
+      - name: Get sha
+        id: get-sha
+        run: |
+          full_commit="${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}"
+          echo "sha=$(echo $full_commit | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: "Upload rerun_js (commit)"
+        if: ${{ !inputs.NIGHTLY }}
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "rerun_js_package"
+          destination: "rerun-web-viewer/commit/${{ steps.get-sha.outputs.sha }}/rerun_js"
+          parent: false
+          process_gcloudignore: false
+
+      - name: "Upload rerun_js (tagged)"
+        if: inputs.MARK_TAGGED_VERSION
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "rerun_js_package"
+          destination: "rerun-web-viewer/version/${{inputs.RELEASE_VERSION}}/rerun_js"
+          parent: false
+          process_gcloudignore: false
+
+      - name: "Upload rerun_js (adhoc)"
+        if: ${{ inputs.ADHOC_NAME != '' }}
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "rerun_js_package"
+          destination: "rerun-web-viewer/adhoc/${{inputs.ADHOC_NAME}}/rerun_js"
+          parent: false
+          process_gcloudignore: false
+
+      - name: "Upload rerun_js (prerelease)"
+        if: github.ref == 'refs/heads/main'
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "rerun_js"
+          destination: "rerun-web-viewer/prerelease/rerun_js"
+          parent: false
+          process_gcloudignore: false
+          headers: |-
+            cache-control: no-cache, max-age=0
+
+      - name: "Upload rerun_js (main)"
+        if: github.ref == 'refs/heads/main'
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "rerun_js_package"
+          destination: "rerun-web-viewer/version/main/rerun_js"
+          parent: false
+          process_gcloudignore: false
+          headers: |-
+            cache-control: no-cache, max-age=0
+
+      - name: "Upload rerun_js (pr)"
+        if: ${{ inputs.PR_NUMBER != '' }}
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "rerun_js"
+          destination: "rerun-web-viewer/pr/${{ inputs.PR_NUMBER }}/rerun_js"
+          parent: false
+          process_gcloudignore: false
+          headers: |-
+            cache-control: no-cache, max-age=0
+
+      - name: "Upload rerun_js (nightly)"
+        if: ${{ inputs.NIGHTLY }}
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "rerun_js"
+          destination: "rerun-web-viewer/version/nightly/rerun_js"
+          parent: false
+          process_gcloudignore: false
+          headers: |-
+            cache-control: no-cache, max-age=0
+

--- a/.github/workflows/reusable_upload_js.yml
+++ b/.github/workflows/reusable_upload_js.yml
@@ -138,4 +138,3 @@ jobs:
           process_gcloudignore: false
           headers: |-
             cache-control: no-cache, max-age=0
-

--- a/rerun_js/web-viewer-react/package.json
+++ b/rerun_js/web-viewer-react/package.json
@@ -12,7 +12,8 @@
   ],
   "scripts": {
     "build:types": "tsc --noEmit && dts-buddy",
-    "build": "npm run build:types"
+    "build": "npm run build:types",
+    "pack": "yarn pack --filename web-viewer-react.tar.gz"
   },
   "repository": {
     "type": "git",

--- a/rerun_js/web-viewer/package.json
+++ b/rerun_js/web-viewer/package.json
@@ -15,7 +15,8 @@
     "build:js": "tsc && node bundle.mjs",
     "build": "npm run build:wasm && npm run build:js",
     "build:wasm:debug": "node build-wasm.mjs --mode debug",
-    "build:debug": "npm run build:wasm:debug && npm run build:js"
+    "build:debug": "npm run build:wasm:debug && npm run build:js",
+    "pack": "yarn pack --filename web-viewer.tar.gz"
   },
   "repository": {
     "type": "git",

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -191,7 +191,7 @@ def fetch_binary_assets(
             (
                 "rerun-js-web-viewer-react.tar.gz",
                 f"commit/{commit_short}/rerun_js/web-viewer-react.tar.gz",
-            )
+            ),
         ]
         for name, blob_url in rerun_js_blobs:
             blob = bucket.get_blob(blob_url)


### PR DESCRIPTION
We now use `yarn pack` to produce a tarball of each package, and upload them to GCS. They'll be available at `https://build.rerun.io/{spec}/rerun_js/{package-name}.tar.gz`, where `spec` is the version/commit, and `package-name` is what's listed in `package.json`.

For example, the `web-viewer` package built for commit c3a864f is hosted publicly at `https://build.rerun.io/commit/c3a864f/rerun_js/web-viewer.tar.gz`. It is possible to install this package via NPM directly:

```
npm install https://build.rerun.io/commit/c3a864f/rerun_js/web-viewer.tar.gz
```

We build these on PRs (using the same filter as web viewer build), on `main`, and for `nightly`.