### PR TITLE
Expose LineBatchBuilder

### DIFF
--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -65,7 +65,7 @@ pub use context::{
 pub use debug_label::DebugLabel;
 pub use depth_offset::DepthOffset;
 pub use importer::{CpuMeshInstance, CpuModel, CpuModelMeshKey};
-pub use line_drawable_builder::{LineDrawableBuilder, LineStripBuilder};
+pub use line_drawable_builder::{LineBatchBuilder, LineDrawableBuilder, LineStripBuilder};
 pub use point_cloud_builder::{PointCloudBatchBuilder, PointCloudBuilder};
 pub use queueable_draw_data::QueueableDrawData;
 pub use rect::{RectF32, RectInt};


### PR DESCRIPTION
`LineBatchBuilder` was not public, resulting in missing documentation and inability to use it in user code explicitly.