### PR TITLE
Prepare for supporting SVG icons

### DIFF
--- a/crates/viewer/re_ui/src/icon_text.rs
+++ b/crates/viewer/re_ui/src/icon_text.rs
@@ -15,7 +15,7 @@ pub enum IconTextItem {
 impl Debug for IconTextItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Icon(icon) => write!(f, "Icon({})", icon.id),
+            Self::Icon(icon) => write!(f, "Icon({})", icon.uri()),
             Self::Text(text) => write!(f, "Text({})", text.text()),
         }
     }

--- a/crates/viewer/re_ui/src/icons.rs
+++ b/crates/viewer/re_ui/src/icons.rs
@@ -4,24 +4,40 @@ use crate::DesignTokens;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Icon {
-    /// Human readable unique id
-    pub id: &'static str,
+    /// Human readable unique id.
+    ///
+    /// This usually ends with `.png` or `.svg`.
+    uri: &'static str,
 
-    pub png_bytes: &'static [u8],
+    /// The raw contents of e.g. a PNG or SVG file.
+    image_bytes: &'static [u8],
 }
 
 impl Icon {
     #[inline]
-    pub const fn new(id: &'static str, png_bytes: &'static [u8]) -> Self {
-        Self { id, png_bytes }
+    pub const fn new(uri: &'static str, image_bytes: &'static [u8]) -> Self {
+        Self { uri, image_bytes }
+    }
+
+    pub fn uri(&self) -> &'static str {
+        self.uri
     }
 
     #[inline]
     pub fn as_image_source(&self) -> ImageSource<'static> {
         ImageSource::Bytes {
-            uri: self.id.into(),
-            bytes: self.png_bytes.into(),
+            uri: self.uri.into(),
+            bytes: self.image_bytes.into(),
         }
+    }
+
+    pub fn load_image(
+        &self,
+        egui_ctx: &egui::Context,
+        size_hint: egui::SizeHint,
+    ) -> egui::load::ImageLoadResult {
+        egui_ctx.include_bytes(self.uri(), self.image_bytes);
+        egui_ctx.try_load_image(self.uri(), size_hint)
     }
 
     #[inline]

--- a/crates/viewer/re_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/videos.rs
@@ -291,23 +291,34 @@ impl VideoFrameReferenceVisualizer {
         entity_path: &EntityPath,
     ) {
         let render_ctx = ctx.viewer_ctx.render_ctx();
+
+        let video_error_image = match re_ui::icons::VIDEO_ERROR
+            .load_image(ctx.viewer_ctx.egui_ctx(), egui::SizeHint::default())
+        {
+            Err(err) => {
+                re_log::error_once!("Failed to load video error icon: {err}");
+                return;
+            }
+            Ok(egui::load::ImagePoll::Ready { image }) => image,
+            Ok(egui::load::ImagePoll::Pending { .. }) => {
+                return; // wait for it to load
+            }
+        };
+
         let video_error_texture_result = render_ctx
             .texture_manager_2d
             .get_or_try_create_with::<image::ImageError>(
                 Hash64::hash("video_error").hash64(),
                 render_ctx,
                 || {
-                    let mut reader = image::ImageReader::new(std::io::Cursor::new(
-                        re_ui::icons::VIDEO_ERROR.png_bytes,
-                    ));
-                    reader.set_format(image::ImageFormat::Png);
-                    let dynamic_image = reader.decode()?;
-
                     Ok(ImageDataDesc {
                         label: "video_error".into(),
-                        data: std::borrow::Cow::Owned(dynamic_image.to_rgba8().to_vec()),
+                        data: std::borrow::Cow::Owned(video_error_image.as_raw().to_vec()),
                         format: re_renderer::external::wgpu::TextureFormat::Rgba8UnormSrgb.into(),
-                        width_height: [dynamic_image.width(), dynamic_image.height()],
+                        width_height: [
+                            video_error_image.width() as _,
+                            video_error_image.height() as _,
+                        ],
                     })
                 },
             );

--- a/crates/viewer/re_viewer_context/src/tables.rs
+++ b/crates/viewer/re_viewer_context/src/tables.rs
@@ -118,7 +118,7 @@ impl TableStore {
 
         {
             let blob = re_types::components::Blob(re_types::datatypes::Blob::from(
-                re_ui::icons::RERUN_MENU.png_bytes,
+                include_bytes!("../../re_ui/data/icons/rerun_io.png").to_vec(),
             ));
 
             let array = Arc::new(


### PR DESCRIPTION
### What
Hides the privates of `Icon` so we can turn more and more icons into SVG:s

I've tested that the video error icon still works as expected.