### PR TITLE
Use cargo binstall to install cargo shear

### DIFF
--- a/.github/workflows/cargo_shear.yml
+++ b/.github/workflows/cargo_shear.yml
@@ -14,10 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1.12.5
 
-      - name: Cargo binstall
-        uses: cargo-bins/cargo-binstall@main
+      - name: Install Cargo Shear
+        uses: taiki-e/install-action@v2.48.7
+        with:
+          tool: cargo-shear@1.1.11
 
-      - name: Cargo Shear
+      - name: Run Cargo Shear
         run: |
-          cargo +stable binstall cargo-shear@1.1.11 -y --locked
           cargo shear

--- a/.github/workflows/cargo_shear.yml
+++ b/.github/workflows/cargo_shear.yml
@@ -14,7 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Shear
+      - name: Cargo binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Cargo Shear
         run: |
-          cargo +stable install cargo-shear@1.1.11 --locked
+          cargo +stable binstall cargo-shear@1.1.11 --locked
           cargo shear

--- a/.github/workflows/cargo_shear.yml
+++ b/.github/workflows/cargo_shear.yml
@@ -19,5 +19,5 @@ jobs:
 
       - name: Cargo Shear
         run: |
-          cargo +stable binstall cargo-shear@1.1.11 --locked
+          cargo +stable binstall cargo-shear@1.1.11 -y --locked
           cargo shear

--- a/.github/workflows/cargo_shear.yml
+++ b/.github/workflows/cargo_shear.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v1.12.5
 
       - name: Cargo binstall
         uses: cargo-bins/cargo-binstall@main

--- a/.github/workflows/cargo_shear.yml
+++ b/.github/workflows/cargo_shear.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1.12.5
+        uses: actions/checkout@v4
 
       - name: Install Cargo Shear
         uses: taiki-e/install-action@v2.48.7


### PR DESCRIPTION
We used to `cargo install` cargo shear for every single push to a PR. Let's use binstall instead. No big deal (30s vs. 1m45s), but why not.