### PR TITLE
Fix rerun js package upload paths

### DIFF
--- a/.github/workflows/reusable_upload_js.yml
+++ b/.github/workflows/reusable_upload_js.yml
@@ -99,7 +99,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "rerun_js"
+          path: "rerun_js_package"
           destination: "rerun-builds/prerelease/rerun_js"
           parent: false
           process_gcloudignore: false
@@ -121,7 +121,7 @@ jobs:
         if: ${{ inputs.PR_NUMBER != '' }}
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "rerun_js"
+          path: "rerun_js_package"
           destination: "rerun-builds/pr/${{ inputs.PR_NUMBER }}/rerun_js"
           parent: false
           process_gcloudignore: false
@@ -132,7 +132,7 @@ jobs:
         if: ${{ inputs.NIGHTLY }}
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "rerun_js"
+          path: "rerun_js_package"
           destination: "rerun-builds/version/nightly/rerun_js"
           parent: false
           process_gcloudignore: false


### PR DESCRIPTION
It's uploading `rerun_js` instead of the artifact (`rerun_js_package`)