### PR TITLE
Replace some use of `backtrace` crate with `std::backtrace`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7144,7 +7144,6 @@ version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "arrow",
- "backtrace",
  "bytemuck",
  "clean-path",
  "criterion",
@@ -7653,7 +7652,6 @@ version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
- "backtrace",
  "bytemuck",
  "criterion",
  "document-features",

--- a/crates/store/re_chunk/Cargo.toml
+++ b/crates/store/re_chunk/Cargo.toml
@@ -51,7 +51,6 @@ half.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
-similar-asserts.workspace = true
 thiserror.workspace = true
 
 # Native dependencies:

--- a/crates/store/re_log_types/Cargo.toml
+++ b/crates/store/re_log_types/Cargo.toml
@@ -55,7 +55,6 @@ re_types_core.workspace = true
 # External
 ahash.workspace = true
 arrow = { workspace = true, features = ["ipc"] }
-backtrace.workspace = true
 bytemuck.workspace = true
 clean-path.workspace = true
 document-features.workspace = true
@@ -74,6 +73,11 @@ thiserror.workspace = true
 typenum.workspace = true
 uuid = { workspace = true, features = ["serde", "v4", "js"] }
 web-time.workspace = true
+
+
+# Native dependencies:
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+backtrace.workspace = true
 
 
 # Optional dependencies:

--- a/crates/store/re_log_types/Cargo.toml
+++ b/crates/store/re_log_types/Cargo.toml
@@ -75,11 +75,6 @@ uuid = { workspace = true, features = ["serde", "v4", "js"] }
 web-time.workspace = true
 
 
-# Native dependencies:
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-backtrace.workspace = true
-
-
 # Optional dependencies:
 serde = { workspace = true, optional = true, features = ["derive", "rc"] }
 

--- a/crates/store/re_log_types/src/instance.rs
+++ b/crates/store/re_log_types/src/instance.rs
@@ -11,7 +11,7 @@ impl From<u64> for Instance {
         if cfg!(debug_assertions) && instance == u64::MAX {
             re_log::warn!(
                 "u64::MAX is reserved to refer to all instances: {:#?}",
-                backtrace::Backtrace::new()
+                std::backtrace::Backtrace::capture()
             );
         }
         Self(instance)

--- a/crates/store/re_types_core/Cargo.toml
+++ b/crates/store/re_types_core/Cargo.toml
@@ -54,12 +54,15 @@ nohash-hasher.workspace = true
 once_cell.workspace = true
 thiserror.workspace = true
 
+
+# Optional dependencies
+serde = { workspace = true, optional = true }
+
+
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backtrace.workspace = true
 
-# Optional dependencies
-serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/store/re_types_core/Cargo.toml
+++ b/crates/store/re_types_core/Cargo.toml
@@ -46,7 +46,6 @@ re_tuid = { workspace = true, features = ["bytemuck"] }
 # External
 anyhow.workspace = true
 arrow.workspace = true
-backtrace.workspace = true
 bytemuck = { workspace = true, features = ["derive"] }
 document-features.workspace = true
 half.workspace = true
@@ -54,6 +53,10 @@ itertools.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true
 thiserror.workspace = true
+
+# Native dependencies:
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+backtrace.workspace = true
 
 # Optional dependencies
 serde = { workspace = true, optional = true }

--- a/crates/store/re_types_core/Cargo.toml
+++ b/crates/store/re_types_core/Cargo.toml
@@ -59,11 +59,6 @@ thiserror.workspace = true
 serde = { workspace = true, optional = true }
 
 
-# Native dependencies:
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-backtrace.workspace = true
-
-
 [dev-dependencies]
 criterion.workspace = true
 similar-asserts.workspace = true

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use crate::{
     ComponentBatch, ComponentDescriptor, ComponentName, DeserializationResult, SerializationResult,
-    SerializedComponentBatch, _Backtrace,
+    SerializedComponentBatch,
 };
 
 #[expect(unused_imports, clippy::unused_trait_names)] // used in docstrings
@@ -122,7 +122,7 @@ pub trait Archetype {
         _ = data; // NOTE: do this here to avoid breaking users' autocomplete snippets
         Err(crate::DeserializationError::NotImplemented {
             fqname: Self::name().to_string(),
-            backtrace: _Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         })
     }
 }

--- a/crates/store/re_types_core/src/result.rs
+++ b/crates/store/re_types_core/src/result.rs
@@ -4,9 +4,9 @@ use std::{any, fmt::Display, ops::Deref};
 
 // NOTE: We have to make an alias, otherwise we'll trigger `thiserror`'s magic codepath which will
 // attempt to use nightly features.
-pub type _Backtrace = backtrace::Backtrace;
+pub type _Backtrace = std::backtrace::Backtrace;
 
-#[derive(thiserror::Error, Clone)]
+#[derive(thiserror::Error)]
 pub enum SerializationError {
     #[error("Failed to serialize {location:?}")]
     Context {
@@ -34,16 +34,10 @@ pub enum SerializationError {
 
 impl std::fmt::Debug for SerializationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bt = self.backtrace().map(|mut bt| {
-            bt.resolve();
-            bt
-        });
-
-        let err = Box::new(self.clone()) as Box<dyn std::error::Error>;
-        if let Some(bt) = bt {
-            f.write_fmt(format_args!("{}:\n{:#?}", re_error::format(&err), bt))
+        if let Some(backtrace) = self.backtrace() {
+            f.write_fmt(format_args!("{self}:\n{backtrace:#?}"))
         } else {
-            f.write_fmt(format_args!("{}", re_error::format(&err)))
+            f.write_fmt(format_args!("{self}"))
         }
     }
 }
@@ -53,7 +47,7 @@ impl SerializationError {
     pub fn missing_extension_metadata(fqname: impl AsRef<str>) -> Self {
         Self::MissingExtensionMetadata {
             fqname: fqname.as_ref().into(),
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -62,17 +56,17 @@ impl SerializationError {
         Self::NotImplemented {
             fqname: fqname.as_ref().into(),
             reason: reason.as_ref().into(),
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
     /// Returns the _unresolved_ backtrace associated with this error, if it exists.
     ///
     /// Call `resolve()` on the returned [`_Backtrace`] to resolve it (costly!).
-    pub fn backtrace(&self) -> Option<_Backtrace> {
+    pub fn backtrace(&self) -> Option<&_Backtrace> {
         match self {
             Self::MissingExtensionMetadata { backtrace, .. }
-            | Self::NotImplemented { backtrace, .. } => Some(backtrace.clone()),
+            | Self::NotImplemented { backtrace, .. } => Some(backtrace),
             Self::ArrowError { .. } | Self::Context { .. } => None,
         }
     }
@@ -121,7 +115,7 @@ pub type SerializationResult<T> = ::std::result::Result<T, SerializationError>;
 
 // ---
 
-#[derive(thiserror::Error, Clone)]
+#[derive(thiserror::Error)]
 pub enum DeserializationError {
     #[error("Failed to deserialize {location:?}")]
     Context {
@@ -201,16 +195,10 @@ pub enum DeserializationError {
 
 impl std::fmt::Debug for DeserializationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bt = self.backtrace().map(|mut bt| {
-            bt.resolve();
-            bt
-        });
-
-        let err = Box::new(self.clone()) as Box<dyn std::error::Error>;
-        if let Some(bt) = bt {
-            f.write_fmt(format_args!("{}:\n{:#?}", re_error::format(&err), bt))
+        if let Some(backtrace) = self.backtrace() {
+            f.write_fmt(format_args!("{self}:\n{backtrace:#?}"))
         } else {
-            f.write_fmt(format_args!("{}", re_error::format(&err)))
+            f.write_fmt(format_args!("{self}"))
         }
     }
 }
@@ -219,7 +207,7 @@ impl DeserializationError {
     #[inline]
     pub fn missing_data() -> Self {
         Self::MissingData {
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -231,7 +219,7 @@ impl DeserializationError {
         Self::MissingStructField {
             datatype: datatype.into(),
             field_name: field_name.as_ref().into(),
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -247,7 +235,7 @@ impl DeserializationError {
             field1_length,
             field2_name: field2_name.as_ref().into(),
             field2_length,
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -261,7 +249,7 @@ impl DeserializationError {
             datatype: datatype.into(),
             arm_name: arm_name.as_ref().into(),
             arm_index,
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -273,7 +261,7 @@ impl DeserializationError {
         Self::DatatypeMismatch {
             expected: expected.into(),
             got: got.into(),
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -282,7 +270,7 @@ impl DeserializationError {
         Self::OffsetOutOfBounds {
             offset,
             len,
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -292,7 +280,7 @@ impl DeserializationError {
             from,
             to,
             len,
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -300,7 +288,7 @@ impl DeserializationError {
     pub fn downcast_error<ToType>() -> Self {
         Self::DowncastError {
             to: any::type_name::<ToType>().to_owned(),
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
+            backtrace: std::backtrace::Backtrace::capture(),
         }
     }
 
@@ -308,7 +296,7 @@ impl DeserializationError {
     ///
     /// Call `resolve()` on the returned [`_Backtrace`] to resolve it (costly!).
     #[inline]
-    pub fn backtrace(&self) -> Option<_Backtrace> {
+    pub fn backtrace(&self) -> Option<&_Backtrace> {
         match self {
             Self::Context {
                 location: _,
@@ -322,7 +310,7 @@ impl DeserializationError {
             | Self::DatatypeMismatch { backtrace, .. }
             | Self::OffsetOutOfBounds { backtrace, .. }
             | Self::OffsetSliceOutOfBounds { backtrace, .. }
-            | Self::DowncastError { backtrace, .. } => Some(backtrace.clone()),
+            | Self::DowncastError { backtrace, .. } => Some(backtrace),
             Self::DataCellError(_) | Self::ValidationError(_) => None,
         }
     }

--- a/examples/rust/external_data_loader/Cargo.toml
+++ b/examples/rust/external_data_loader/Cargo.toml
@@ -7,7 +7,9 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun" }
+rerun = { path = "../../../crates/top/rerun", default-features = false, features = [
+  "sdk",
+] }
 
 anyhow = "1.0"
 argh = "0.1"


### PR DESCRIPTION
Goal: get more of our crates working on wasm32