### PR TITLE
Fix column names and hide indicator components in the partition table

### DIFF
--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -144,7 +144,7 @@ impl Server {
                 entity_path.starts_with(&std::iter::once(EntityPathPart::properties()).collect())
             }) {
                 // Property column, just hide indicator components
-                //TODO(ab): remove this when we no longer have indicator components
+                //TODO(#8129): remove this when we no longer have indicator components
                 !desc
                     .column_name(BatchType::Dataframe)
                     .ends_with("Indicator")

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -133,12 +133,12 @@ impl Server {
         .column_blueprint(|desc| {
             let mut name = default_display_name_for_column(desc);
 
-            if name.starts_with("rerun_") {
-                name = name
-                    .strip_prefix("rerun_")
-                    .unwrap_or(name.as_ref())
-                    .replace('_', " ");
-            }
+            // strip prefix and remove underscores, _only_ for the base columns (aka not the
+            // properties)
+            name = name
+                .strip_prefix("rerun_")
+                .map(|name| name.replace('_', " "))
+                .unwrap_or(name);
 
             let default_visible = if desc.entity_path().is_some_and(|entity_path| {
                 entity_path.starts_with(&std::iter::once(EntityPathPart::properties()).collect())

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -7,6 +7,7 @@ use re_log_types::{EntityPathPart, EntryId};
 use re_protos::manifest_registry::v1alpha1::{
     DATASET_MANIFEST_ID_FIELD_NAME, DATASET_MANIFEST_REGISTRATION_TIME_FIELD_NAME,
 };
+use re_sorbet::BatchType;
 use re_ui::list_item::ItemActionButton;
 use re_ui::{UiExt as _, icons, list_item};
 use re_viewer_context::{
@@ -130,16 +131,23 @@ impl Server {
                 .ok();
         }))
         .column_blueprint(|desc| {
-            let name = default_display_name_for_column(desc);
-            let name = name
-                .strip_prefix("rerun_")
-                .unwrap_or(name.as_ref())
-                .replace('_', " ");
+            let mut name = default_display_name_for_column(desc);
+
+            if name.starts_with("rerun_") {
+                name = name
+                    .strip_prefix("rerun_")
+                    .unwrap_or(name.as_ref())
+                    .replace('_', " ");
+            }
 
             let default_visible = if desc.entity_path().is_some_and(|entity_path| {
                 entity_path.starts_with(&std::iter::once(EntityPathPart::properties()).collect())
             }) {
-                true
+                // Property column, just hide indicator components
+                //TODO(ab): remove this when we no longer have indicator components
+                !desc
+                    .column_name(BatchType::Dataframe)
+                    .ends_with("Indicator")
             } else {
                 matches!(
                     desc.display_name().as_str(),


### PR DESCRIPTION
Title.

Part of:
- https://github.com/rerun-io/dataplatform/issues/750

Default view now looks like this:

<img width="1561" alt="image" src="https://github.com/user-attachments/assets/dee3bb71-53e6-4ca0-8b1b-1ebd02661ee5" />
