### PR TITLE
Enforce full `ComponentDescriptors` in C++ SDK

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           pixi-version: v0.41.4
           # Only has the deps for round-trips. Not all examples.
-          environments: wheel-test-min
+          environments: wheel-test-min, cpp
 
       - name: Download Wheel
         uses: actions/download-artifact@v4
@@ -201,7 +201,7 @@ jobs:
         if: ${{ !inputs.FAST }}
         # Separated out of roundtrips.py run so we control the pixi environment.
         # This used to cause issues on Windows during the setup of the pixi environment when running from inside `roundtrips.py`.
-        run: pixi run -e wheel-test-min cpp-build-roundtrips
+        run: pixi run -e cpp cpp-build-roundtrips
 
       - name: Run tests/roundtrips.py
         if: ${{ !inputs.FAST }}
@@ -213,7 +213,7 @@ jobs:
         if: ${{ !inputs.FAST }}
         # Separated out of compare_snippet_output.py run so we control the pixi environment.
         # This used to cause issues on Windows during the setup of the pixi environment when running from inside `compare_snippet_output.py`.
-        run: pixi run -e wheel-test-min cpp-build-snippets
+        run: pixi run -e cpp cpp-build-snippets
 
       - name: Run docs/snippets/compare_snippet_output.py
         if: ${{ !inputs.FAST }}

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           pixi-version: v0.41.4
           # Only has the deps for round-trips. Not all examples.
-          environments: wheel-test-min, cpp
+          environments: wheel-test-min
 
       - name: Download Wheel
         uses: actions/download-artifact@v4

--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -536,7 +536,7 @@ impl QuotedObject {
                     #NEWLINE_TOKEN
                     #comment
                     static constexpr auto #constant_name = ComponentDescriptor(
-                        ArchetypeName, #field_name, Loggable<#field_type>::Descriptor.component_name
+                        ArchetypeName, #field_name, Loggable<#field_type>::ComponentName
                     );
                 }
             })
@@ -2787,8 +2787,6 @@ fn quote_loggable_hpp_and_cpp(
     let methods_cpp = methods.iter().map(|m| m.to_cpp_tokens(&loggable_type_name));
     let hide_from_docs_comment = quote_hide_from_docs();
 
-    hpp_includes.insert_rerun("component_descriptor.hpp");
-
     let (deprecation_ignore_start, deprecation_ignore_end) =
         quote_deprecation_ignore_start_and_end(hpp_includes, obj.is_deprecated());
 
@@ -2801,7 +2799,7 @@ fn quote_loggable_hpp_and_cpp(
             #hide_from_docs_comment
             template<>
             struct #loggable_type_name {
-                static constexpr ComponentDescriptor Descriptor = #fqname;
+                static constexpr std::string_view ComponentName = #fqname;
                 #NEWLINE_TOKEN
                 #NEWLINE_TOKEN
                 #(#methods_hpp)*

--- a/crates/store/re_sorbet/src/migration.rs
+++ b/crates/store/re_sorbet/src/migration.rs
@@ -255,6 +255,13 @@ pub fn rewire_indicator_components(batch: &ArrowRecordBatch) -> ArrowRecordBatch
                             "Stripped archetype name from indicator: {archetype_name}"
                         );
                     }
+                } else if !metadata.contains_key("rerun.archetype")
+                    && !metadata.contains_key("rerun.archetype_field")
+                {
+                    // If we don't find the above keys, we likely encountered data that was logged via `AnyValues`.
+                    // We do our best effort to convert that.
+                    re_log::debug!("Moving stray component name to archetype field: {value}");
+                    metadata.insert("rerun.archetype_field".to_owned(), value);
                 } else {
                     metadata.insert("rerun.component".to_owned(), value);
                 }

--- a/docs/snippets/all/descriptors/descr_builtin_component.cpp
+++ b/docs/snippets/all/descriptors/descr_builtin_component.cpp
@@ -9,10 +9,9 @@ int main() {
         rerun::ComponentBatch::from_loggable(
             rerun::Position3D(1.0f, 2.0f, 3.0f),
             rerun::ComponentDescriptor(
-                "user.CustomPoints3D", // archetype name
-                "points",              // archetype field name
-                // TODO(#6889): Clean up in follow up PR
-                rerun::Loggable<rerun::Position3D>::Descriptor.component_name
+                "user.CustomPoints3D",                            // archetype name
+                "points",                                         // archetype field name
+                rerun::Loggable<rerun::Position3D>::ComponentName // component name
             )
         )
     );

--- a/docs/snippets/all/descriptors/descr_custom_archetype.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.cpp
@@ -35,17 +35,19 @@ struct rerun::AsComponents<CustomPoints3D> {
     static Result<rerun::Collection<ComponentBatch>> as_batches(const CustomPoints3D& archetype) {
         std::vector<rerun::ComponentBatch> batches;
 
-        auto positions_descr =
-            rerun::Points3D::Descriptor_positions.or_with_archetype_name("user.CustomPoints3D")
-                .or_with_archetype_field_name("custom_positions");
+        auto positions_descr = rerun::ComponentDescriptor(
+            "user.CustomPoints3D",
+            "custom_positions",
+            "user.CustomPosition3D"
+        );
         batches.push_back(
             ComponentBatch::from_loggable(archetype.positions, positions_descr).value_or_throw()
         );
 
         if (archetype.colors) {
-            auto colors_descr =
-                rerun::Points3D::Descriptor_colors.or_with_archetype_name("user.CustomPoints3D")
-                    .or_with_archetype_field_name("colors");
+            auto colors_descr = rerun::ComponentDescriptor("colors")
+                                    .with_archetype_name("user.CustomPoints3D")
+                                    .with_component_name("rerun.components.Colors");
             batches.push_back(
                 ComponentBatch::from_loggable(archetype.colors, colors_descr).value_or_throw()
             );

--- a/docs/snippets/all/descriptors/descr_custom_archetype.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.cpp
@@ -45,9 +45,10 @@ struct rerun::AsComponents<CustomPoints3D> {
         );
 
         if (archetype.colors) {
-            auto colors_descr = rerun::ComponentDescriptor("colors")
-                                    .with_archetype_name("user.CustomPoints3D")
-                                    .with_component_name("rerun.components.Colors");
+            auto colors_descr =
+                rerun::ComponentDescriptor("colors")
+                    .with_archetype_name("user.CustomPoints3D")
+                    .with_component_name(rerun::Loggable<rerun::components::Color>::ComponentName);
             batches.push_back(
                 ComponentBatch::from_loggable(archetype.colors, colors_descr).value_or_throw()
             );

--- a/docs/snippets/all/descriptors/descr_custom_archetype.cpp
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.cpp
@@ -35,17 +35,17 @@ struct rerun::AsComponents<CustomPoints3D> {
     static Result<rerun::Collection<ComponentBatch>> as_batches(const CustomPoints3D& archetype) {
         std::vector<rerun::ComponentBatch> batches;
 
-        auto positions_descr = rerun::Loggable<CustomPosition3D>::Descriptor
-                                   .or_with_archetype_name("user.CustomPoints3D")
-                                   .or_with_archetype_field_name("custom_positions");
+        auto positions_descr =
+            rerun::Points3D::Descriptor_positions.or_with_archetype_name("user.CustomPoints3D")
+                .or_with_archetype_field_name("custom_positions");
         batches.push_back(
             ComponentBatch::from_loggable(archetype.positions, positions_descr).value_or_throw()
         );
 
         if (archetype.colors) {
-            auto colors_descr = rerun::Loggable<rerun::Color>::Descriptor
-                                    .or_with_archetype_name("user.CustomPoints3D")
-                                    .or_with_archetype_field_name("colors");
+            auto colors_descr =
+                rerun::Points3D::Descriptor_colors.or_with_archetype_name("user.CustomPoints3D")
+                    .or_with_archetype_field_name("colors");
             batches.push_back(
                 ComponentBatch::from_loggable(archetype.colors, colors_descr).value_or_throw()
             );

--- a/docs/snippets/all/descriptors/descr_custom_archetype.py
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.py
@@ -20,7 +20,7 @@ class CustomPoints3D(rr.AsComponents):
         self.colors = rr.components.ColorBatch(colors).described(
             rr.ComponentDescriptor("colors").with_overrides(
                 archetype_name="user.CustomPoints3D",
-                component_name="rerun.components.Colors",
+                component_name=rr.components.ColorBatch._COMPONENT_NAME,
             )
         )
 

--- a/docs/snippets/all/tutorials/custom_data.cpp
+++ b/docs/snippets/all/tutorials/custom_data.cpp
@@ -10,7 +10,7 @@ struct Confidence {
 
 template <>
 struct rerun::Loggable<Confidence> {
-    static constexpr ComponentDescriptor Descriptor = "user.Confidence";
+    static constexpr std::string_view ComponentName = "user.Confidence";
 
     static const std::shared_ptr<arrow::DataType>& arrow_datatype() {
         return rerun::Loggable<rerun::Float32>::arrow_datatype();
@@ -44,9 +44,10 @@ struct rerun::AsComponents<CustomPoints3D> {
 
         // Add custom confidence components if present.
         if (archetype.confidences) {
-            auto descriptor = rerun::Loggable<Confidence>::Descriptor
-                                  .or_with_archetype_name("user.CustomPoints3D")
-                                  .or_with_archetype_field_name("confidences");
+            auto descriptor =
+                rerun::ComponentDescriptor("confidences")
+                    .or_with_archetype_name("user.CustomPoints3D")
+                    .or_with_component_name(rerun::Loggable<Confidence>::ComponentName);
             batches.push_back(
                 ComponentBatch::from_loggable(*archetype.confidences, descriptor).value_or_throw()
             );

--- a/pixi.lock
+++ b/pixi.lock
@@ -30,10 +30,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.8.0-h736e048_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.12.0-ha633028_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/buf-1.50.0-ha8f183a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-16-16.0.6-default_hb5137d0_13.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-16.0.6-default_h9e3a008_13.conda
@@ -42,16 +45,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-16.0.6-default_hb5137d0_13.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.9.7-h661eb56_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fd-find-10.2.0-h8fae777_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flatbuffers-24.3.25-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.4.0-h236703b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.4.0-hb2e57f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.4.0-h6b7512a_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.4.0-h236703b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.4.0-h613a52c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.4.0-h8489865_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
@@ -99,9 +109,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-18.0.0-h6bd9018_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.27.5-h5b01275_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hbbce691_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.4.0-h46f95d5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.2.0-hc0a3c3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.4.0-ha4f9413_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
@@ -250,9 +262,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.13.0-h185ecfd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-common-cpp-12.8.0-h1b94036_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/azure-storage-files-datalake-cpp-12.12.0-h37d6d07_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.43-h4c662bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h68df207_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.2-ha64f414_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.6.0-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.8.30-hcefe29a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-16-16.0.6-default_he324ac1_13.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-16.0.6-default_h7e7f49e_13.conda
@@ -261,16 +276,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-tools-16.0.6-default_he324ac1_13.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.27.6-hef020d8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.6.0-h2a328a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/doxygen-1.9.7-h7b6a552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fd-find-10.2.0-ha3529ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/flatbuffers-24.3.25-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.4.1-py311ha879c10_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.4.0-h7e62973_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.4.0-hfb8d6db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.4.0-heb3b579_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitignore-parser-0.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.43-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-h468a4a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.4.0-h7e62973_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.4.0-h3c1ec91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.4.0-h3f57e68_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-75.1-hf9b3779_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
@@ -318,9 +340,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-18.0.0-h23a96eb_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-5.27.5-h029595c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2024.07.02-h18dbdb1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.4.0-h469570c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.46.1-hc4a20ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-14.2.0-h3f4de04_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.4.0-h7b3af7c_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-14.2.0-hf1166c9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libthrift-0.21.0-h154c74f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libutf8proc-2.8.0-h4e544f5_0.tar.bz2
@@ -468,14 +492,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.12.0-h86941f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h282daa2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h40f6528_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-heaa7f0c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16-16.0.6-default_h0c94c6a_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-16.0.6-default_h179603d_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16-16.0.6-default_h0c94c6a_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-16.0.6-default_h0c94c6a_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-tools-16.0.6-default_h0c94c6a_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h179603d_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h7728843_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.9.7-hd7636e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fd-find-10.2.0-h9bb4cbb_0.conda
@@ -491,6 +526,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-ha02d983_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h3516399_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240722.0-cxx17_hac325c4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-18.0.0-h4f78622_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-18.0.0-h240833e_0_cpu.conda
@@ -506,6 +543,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.10.1-h58e7537_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.2-hf95d169_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-16.0.6-h8f8a49f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
@@ -533,6 +571,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.2-hf78d878_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.1-py311ha971863_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/multidict-6.1.0-py311h1cc1194_1.conda
@@ -562,8 +601,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.5-ha44c9a9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.9.6-py311h8115247_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.9.1-h236d3af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
@@ -669,14 +710,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/buf-1.50.0-h75b854d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.2-h7ab814d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-h6aa9301_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-h4faf515_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4f2c9d0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16-16.0.6-default_h5c12605_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-16.0.6-default_h675cc0c_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16-16.0.6-default_h5c12605_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-16.0.6-default_h5c12605_13.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-tools-16.0.6-default_h5c12605_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h675cc0c_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h2ffa867_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.9.7-h0e2417a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fd-find-10.2.0-h3bba108_0.conda
@@ -692,6 +744,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h634c8be_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-h0605c9f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-18.0.0-h6fea68a_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-18.0.0-h286801f_0_cpu.conda
@@ -707,6 +761,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.10.1-h13a7ad3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.2-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-16.0.6-h86353a2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
@@ -734,6 +789,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.7-h01dff8b_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.2-hb52a8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.1-py311h0ecf0c1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/meilisearch-1.5.1-h5ef7bb8_0.conda
@@ -764,8 +820,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.5-h7ab814d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.9.6-py311hdb0c05a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/semver-2.13.0-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.1-hd02b534_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.9.1-h16c8c8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.2-pyhd8ed1ab_0.conda
@@ -7200,7 +7258,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/13/d9839089b900fa7b479cce495d62110cddc4bd5630a04d8469916c0e79c5/frozendict-2.4.6-py311-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
@@ -7680,7 +7737,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/13/d9839089b900fa7b479cce495d62110cddc4bd5630a04d8469916c0e79c5/frozendict-2.4.6-py311-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
@@ -8077,8 +8133,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
@@ -8130,7 +8184,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/13/d9839089b900fa7b479cce495d62110cddc4bd5630a04d8469916c0e79c5/frozendict-2.4.6-py311-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
@@ -8631,7 +8684,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
@@ -8693,7 +8745,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ee/87/f1bb6a595f14a327e8285b9eb54d41fef76c585a0edef0a45f6fc95de125/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/69/0325cf8122337f8e817cd79c69c51aa578c6fa51fe15fb692b327e06d11f/rerun_notebook-0.23.4a2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/44/8df19f37fa4e176ccc7ea5708ee67e1bbbfd1ee318a18e02816f4564d598/rerun_sdk-0.23.4a2-cp39-abi3-manylinux_2_28_x86_64.whl
@@ -8966,7 +9017,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
@@ -9015,7 +9065,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/bb/fddf10acd09637327a97ef89d2a9d621328850a72f1fdc8c08bdf72e385f/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/69/0325cf8122337f8e817cd79c69c51aa578c6fa51fe15fb692b327e06d11f/rerun_notebook-0.23.4a2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/aa/14/61e9883ad1c36fbdcb9c33db5e3315c7676e43a510ab6699b8686bd1a2c4/rerun_sdk-0.23.4a2-cp39-abi3-manylinux_2_28_aarch64.whl
@@ -9260,7 +9309,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
@@ -9308,7 +9356,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/75/0b8ede18506041c0bf23ac4d8e2971b4161cd6ce630b177d0a08eb0d8857/PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/69/0325cf8122337f8e817cd79c69c51aa578c6fa51fe15fb692b327e06d11f/rerun_notebook-0.23.4a2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ea/04a57c969736ce8823cf79771d7bc1e473c266378336a020787d186df5ea/rerun_sdk-0.23.4a2-cp39-abi3-macosx_11_0_arm64.whl
@@ -9518,8 +9565,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-ha32ba9b_22.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-hcc2c482_22.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_22.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.7-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
@@ -9544,7 +9589,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/a0/6aaea0c2fbea2f89bfd5db25fb1e3481896a423002ebe4e55288907a97a3/fsspec-2024.9.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/ef/79fa8388c95edbd8fe36c763259dade36e5cb562dcf3e85c0e32070dc9b0/google_api_core-2.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/1f/3a72917afcb0d5cd842cbccb81bf7a8a7b45b4c66d8dc4556ccb3b016bfc/google_auth-2.35.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
@@ -9592,7 +9636,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/69/0325cf8122337f8e817cd79c69c51aa578c6fa51fe15fb692b327e06d11f/rerun_notebook-0.23.4a2-py2.py3-none-any.whl
@@ -9861,31 +9904,6 @@ packages:
   purls: []
   size: 555868
   timestamp: 1718118368236
-- pypi: https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl
-  name: anyio
-  version: 4.6.2.post1
-  sha256: 6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d
-  requires_dist:
-  - idna>=2.8
-  - sniffio>=1.1
-  - exceptiongroup>=1.0.2 ; python_full_version < '3.11'
-  - typing-extensions>=4.1 ; python_full_version < '3.11'
-  - packaging ; extra == 'doc'
-  - sphinx~=7.4 ; extra == 'doc'
-  - sphinx-rtd-theme ; extra == 'doc'
-  - sphinx-autodoc-typehints>=1.2.0 ; extra == 'doc'
-  - anyio[trio] ; extra == 'test'
-  - coverage[toml]>=7 ; extra == 'test'
-  - exceptiongroup>=1.2.0 ; extra == 'test'
-  - hypothesis>=4.0 ; extra == 'test'
-  - psutil>=5.9 ; extra == 'test'
-  - pytest>=7.0 ; extra == 'test'
-  - pytest-mock>=3.6.1 ; extra == 'test'
-  - trustme ; extra == 'test'
-  - uvloop>=0.21.0b1 ; platform_python_implementation == 'CPython' and platform_system != 'Windows' and extra == 'test'
-  - truststore>=0.9.1 ; python_full_version >= '3.10' and extra == 'test'
-  - trio>=0.26.1 ; extra == 'trio'
-  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl
   name: anyio
   version: 4.6.2.post1
@@ -11487,6 +11505,26 @@ packages:
   purls: []
   size: 40046563
   timestamp: 1709093094826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.43-h4852527_4.conda
+  sha256: 99a94eead18e7704225ac43682cce3f316fd33bc483749c093eaadef1d31de75
+  md5: 29782348a527eda3ecfc673109d28e93
+  depends:
+  - binutils_impl_linux-64 >=2.43,<2.44.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 34646
+  timestamp: 1740155498138
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.43-hf1166c9_4.conda
+  sha256: a76c9a2b0458d369b5cfc7a0e1c04a7d7e978605002af8bf740576529371c0c1
+  md5: 98c98a2b9c60ef737195045f39054a63
+  depends:
+  - binutils_impl_linux-aarch64 >=2.43,<2.44.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 34775
+  timestamp: 1740155693291
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_1.conda
   sha256: 6f945b3b150112c7c6e4783e6c3132410a7b226f2a8965adfd23895318151d46
   md5: 5f354010f194e85dc681dec92405ef9e
@@ -11531,6 +11569,26 @@ packages:
   purls: []
   size: 6251460
   timestamp: 1740155660413
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.43-h4852527_1.conda
+  sha256: 16739398bff4d77e151e037f4c2932ad2a3ed57bb92396d50c33d3c395ad8e22
+  md5: 8d70caec6e4c8754066ea278f0a282dd
+  depends:
+  - binutils_impl_linux-64 2.43 h4bf12b8_1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 34906
+  timestamp: 1727304732860
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.43-hf1166c9_1.conda
+  sha256: 89b224e61b341cd182b90a83379e3e6dd98bf1ef7c9eed52dbeb04ad35cc3a87
+  md5: 7b77397fb65e894dc248733020e0d0a5
+  depends:
+  - binutils_impl_linux-aarch64 2.43 h4c662bb_1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 35030
+  timestamp: 1727304736343
 - pypi: https://files.pythonhosted.org/packages/2b/e3/69a738fb5ba18b5422f50b4f143544c664d7da40f09c13969b2fd52900e0/black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl
   name: black
   version: 24.10.0
@@ -11743,6 +11801,52 @@ packages:
   purls: []
   size: 192859
   timestamp: 1729006899124
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
+  sha256: d741ff93d5f71a83a9be0f592682f31ca2d468c37177f18a8d1a2469bb821c05
+  md5: ea6c792f792bdd7ae6e7e2dee32f0a48
+  depends:
+  - binutils
+  - gcc
+  - gcc_linux-64 12.*
+  license: BSD
+  purls: []
+  size: 6184
+  timestamp: 1689097480051
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.6.0-h31becfc_0.conda
+  sha256: 36bc9d1673939980e7692ccce27e677dd4477d4c727ea173ec4210605b73927d
+  md5: b98866e63b17433ea5921a826c93cb97
+  depends:
+  - binutils
+  - gcc
+  - gcc_linux-aarch64 12.*
+  license: BSD
+  purls: []
+  size: 6213
+  timestamp: 1689097449087
+- conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h282daa2_0.conda
+  sha256: c52dcdd9b5fc9fd9a7eb028b7d4bb9f11f4ba3a7361e904d2b28bc12053bac23
+  md5: 2b801fd417843897458f4f8e132e05bb
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-64 16.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD
+  purls: []
+  size: 6375
+  timestamp: 1701504699534
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-h6aa9301_0.conda
+  sha256: c7d7c09724e7c324ecd3ad2dee4f016149b93f9bd8ee67661cafb20993f5b8a9
+  md5: 0b204833d66694f214a5b3d7d2b87700
+  depends:
+  - cctools >=949.0.1
+  - clang_osx-arm64 16.*
+  - ld64 >=530
+  - llvm-openmp
+  license: BSD
+  purls: []
+  size: 6380
+  timestamp: 1701504712958
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
   sha256: afee721baa6d988e27fef1832f68d6f32ac8cc99cdf6015732224c2841a09cea
   md5: c27d1c142233b5bc9ca570c6e2e0c244
@@ -11873,6 +11977,70 @@ packages:
   purls: []
   size: 1516680
   timestamp: 1721139332360
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-1010.6-h40f6528_1.conda
+  sha256: 3e6ab1eb84f55df432af6b1893067c0dfa86e312c04d91824b199c125cf729e1
+  md5: 7e7eb6bef28acef1112673443a8d692b
+  depends:
+  - cctools_osx-64 1010.6 heaa7f0c_1
+  - ld64 951.9 ha02d983_1
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 21588
+  timestamp: 1726771695380
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-1010.6-h4faf515_1.conda
+  sha256: e0a69226e1f70b79f41c471c86fd0c450cc4fd5ec3343cd7689eb1c016babc70
+  md5: d200afcb0b601ad89c79212b9a124347
+  depends:
+  - cctools_osx-arm64 1010.6 h4f2c9d0_1
+  - ld64 951.9 h634c8be_1
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 21621
+  timestamp: 1726771337947
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1010.6-heaa7f0c_1.conda
+  sha256: 2769f7bde9888d100a9997da14aabef345a8ee0850fe2c90e2ca2306e7fe79bd
+  md5: eaedf7d6a7b93b35381f7a0b4663922a
+  depends:
+  - __osx >=10.13
+  - ld64_osx-64 >=951.9,<951.10.0a0
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 16.0.*
+  - sigtool
+  constrains:
+  - ld64 951.9.*
+  - cctools 1010.6.*
+  - clang 16.0.*
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 1099432
+  timestamp: 1726771664399
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1010.6-h4f2c9d0_1.conda
+  sha256: 3585a1d44fae9fd6839734e25ddde9dfb1dbb99c6974deb7bdbc6470b54af76d
+  md5: 3cf0dad98fcf3cec8cf6372ba2954724
+  depends:
+  - __osx >=11.0
+  - ld64_osx-arm64 >=951.9,<951.10.0a0
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 16.0.*
+  - sigtool
+  constrains:
+  - ld64 951.9.*
+  - cctools 1010.6.*
+  - clang 16.0.*
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 1091944
+  timestamp: 1726771303834
 - pypi: https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl
   name: certifi
   version: 2024.8.30
@@ -12494,14 +12662,128 @@ packages:
   purls: []
   size: 226631847
   timestamp: 1725066670598
-- pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
-  name: click
-  version: 8.1.7
-  sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
-  requires_dist:
-  - colorama ; platform_system == 'Windows'
-  - importlib-metadata ; python_full_version < '3.8'
-  requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-16.0.6-h8787910_19.conda
+  sha256: 7c8146bb69ddf42af2e30d83ad357985732052eccfbaf279d433349e0c1324de
+  md5: 64155ef139280e8c181dad866dea2980
+  depends:
+  - cctools_osx-64
+  - clang 16.0.6.*
+  - compiler-rt 16.0.6.*
+  - ld64_osx-64
+  - llvm-tools 16.0.6.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 17589
+  timestamp: 1723069343993
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-16.0.6-hc421ffc_19.conda
+  sha256: e131b316c772b9ecd57f47e221b0b460d817650ee29de3a6d017ba17f834e3a3
+  md5: 44d46e1690d60e9dfdf9ab9fc8a344f6
+  depends:
+  - cctools_osx-arm64
+  - clang 16.0.6.*
+  - compiler-rt 16.0.6.*
+  - ld64_osx-arm64
+  - llvm-tools 16.0.6.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 17659
+  timestamp: 1723069383236
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-16.0.6-hb91bd55_19.conda
+  sha256: d38be1dc9476fdc60dfbd428df0fb3e284ee9101e7eeaa1764b54b11bab54105
+  md5: 760ecbc6f4b6cecbe440b0080626286f
+  depends:
+  - clang_impl_osx-64 16.0.6 h8787910_19
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 20580
+  timestamp: 1723069348997
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-16.0.6-h54d7cd3_19.conda
+  sha256: 1be2d2b837267e9cc61c1cb5e0ce780047ceb87063005144c1332a82a5996fb3
+  md5: 1a9ab8ce6143c14e425059e61a4fb737
+  depends:
+  - clang_impl_osx-arm64 16.0.6 hc421ffc_19
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 20589
+  timestamp: 1723069388608
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-16.0.6-default_h179603d_13.conda
+  sha256: 1618831d070df1233cdbd3003d4ddb0fdc221515837a21cee93d3bc30447d51b
+  md5: 8934fd8e83d051adcaba71fcbed9ecf0
+  depends:
+  - clang 16.0.6 default_h179603d_13
+  - libcxx-devel 16.0.6.*
+  constrains:
+  - libcxx-devel 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 85265
+  timestamp: 1725062403776
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-16.0.6-default_h675cc0c_13.conda
+  sha256: 5d884561858c9144fe20aab74f72d946b656c6c82a3bef81bb57d4dbf7e2a98e
+  md5: 8757588c5e8097c0e9a8986225bddc0a
+  depends:
+  - clang 16.0.6 default_h675cc0c_13
+  - libcxx-devel 16.0.6.*
+  constrains:
+  - libcxx-devel 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 85293
+  timestamp: 1725061917963
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-16.0.6-h6d92fbe_19.conda
+  sha256: c99c773d76a93066f1e78d368f934cd904b4f39a3939bf1d5a5cf26e3b812dbc
+  md5: 9ffa16e2bd7eb5b8b1a0d19185710cd3
+  depends:
+  - clang_osx-64 16.0.6 hb91bd55_19
+  - clangxx 16.0.6.*
+  - libcxx >=16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 17642
+  timestamp: 1723069387016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-16.0.6-hcd7bac0_19.conda
+  sha256: 6847b38f815e43a01e7cfe78fc9d2d7ab90c749bce1301322707ccbad4f2d7a2
+  md5: 263f7e2b3196bea030602830381cc84e
+  depends:
+  - clang_osx-arm64 16.0.6 h54d7cd3_19
+  - clangxx 16.0.6.*
+  - libcxx >=16
+  - libllvm16 >=16.0.6,<16.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 17740
+  timestamp: 1723069417515
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-16.0.6-hb91bd55_19.conda
+  sha256: 8c2cf371561f8de565aa721520d34e14ff9cf9b7e3a868879ec2f99760c433cc
+  md5: 81d40fad4c14cc7a893f2e274647c7a4
+  depends:
+  - clang_osx-64 16.0.6 hb91bd55_19
+  - clangxx_impl_osx-64 16.0.6 h6d92fbe_19
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 19289
+  timestamp: 1723069392162
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-16.0.6-h54d7cd3_19.conda
+  sha256: 6e4344d0bc29fc76e6c6c8aa463536ea0615ffe60512c883b8ae26d73ac4804d
+  md5: 26ffc845adddf183c15dd4285e97fc66
+  depends:
+  - clang_osx-arm64 16.0.6 h54d7cd3_19
+  - clangxx_impl_osx-arm64 16.0.6 hcd7bac0_19
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 19366
+  timestamp: 1723069423746
 - pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
   name: click
   version: 8.1.7
@@ -12644,6 +12926,56 @@ packages:
   - traitlets>=4
   - pytest ; extra == 'test'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-16.0.6-ha38d28d_2.conda
+  sha256: de0e2c94d9a04f60ec9aedde863d6c1fad3f261bdb63ec8adc70e2d9ecdb07bb
+  md5: 3b9e8c5c63b8e86234f499490acd85c2
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  - compiler-rt_osx-64 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 94198
+  timestamp: 1701467261175
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-16.0.6-h3808999_2.conda
+  sha256: 67f6883f37ea720f97d016c3384962d86ec8853e5f4b0065aa77e335ca80193e
+  md5: 517f18b3260bb7a508d1f54a96e6285b
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  - compiler-rt_osx-arm64 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 93724
+  timestamp: 1701467327657
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-16.0.6-ha38d28d_2.conda
+  sha256: 75270bd8e306967f6e1a8c17d14f2dfe76602a5c162088f3ea98034fe3d71e0c
+  md5: 7a46507edc35c6c8818db0adaf8d787f
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  constrains:
+  - compiler-rt 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 9895261
+  timestamp: 1701467223753
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-16.0.6-h3808999_2.conda
+  sha256: 61f1a10e6e8ec147f17c5e36cf1c2fe77ac6d1907b05443fa319fd59be20fa33
+  md5: 8c7d77d888e1a218cccd9e82b1458ec6
+  depends:
+  - clang 16.0.6.*
+  - clangxx 16.0.6.*
+  constrains:
+  - compiler-rt 16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 9829914
+  timestamp: 1701467293179
 - pypi: https://files.pythonhosted.org/packages/03/33/003065374f38894cdf1040cef474ad0546368eea7e3a51d48b8a423961f8/contourpy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: contourpy
   version: 1.3.0
@@ -12866,6 +13198,48 @@ packages:
   - pytz ; extra == 'test'
   - hypothesis>=1.11.4,!=3.79.2 ; extra == 'test'
   requires_python: '>=3.6'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
+  sha256: 472b6b7f967df1db634c67d71c6b31cd186d18b5d0548196c2e426833ff17d99
+  md5: 364c6ae36c4e36fcbd4d273cf4db78af
+  depends:
+  - c-compiler 1.6.0 hd590300_0
+  - gxx
+  - gxx_linux-64 12.*
+  license: BSD
+  purls: []
+  size: 6179
+  timestamp: 1689097484095
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.6.0-h2a328a1_0.conda
+  sha256: aebe297f355fb3a5101eb11a5233d94c3445d2f1bbf4c0d7e3ff88b98d399694
+  md5: 3847c922cacfe5a3d7ee663ffde014a4
+  depends:
+  - c-compiler 1.6.0 h31becfc_0
+  - gxx
+  - gxx_linux-aarch64 12.*
+  license: BSD
+  purls: []
+  size: 6220
+  timestamp: 1689097451413
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h7728843_0.conda
+  sha256: 3d609b7cf397b1d9f8627dedd0abd95a9daffa919d9593b56096a4e6e4a8597e
+  md5: 52efcad0d146779100e46c973cc1cb56
+  depends:
+  - c-compiler 1.6.0 h282daa2_0
+  - clangxx_osx-64 16.*
+  license: BSD
+  purls: []
+  size: 6415
+  timestamp: 1701504710176
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h2ffa867_0.conda
+  sha256: c3a4ee7382e548f1e98ca1a348c941094b8d5f38c84d3258c00f9e493c591344
+  md5: b3bf27600fda1f6770fd28c45805d689
+  depends:
+  - c-compiler 1.6.0 h6aa9301_0
+  - clangxx_osx-arm64 16.*
+  license: BSD
+  purls: []
+  size: 6399
+  timestamp: 1701504753445
 - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
   name: cycler
   version: 0.12.1
@@ -14200,6 +14574,82 @@ packages:
   - zstandard ; extra == 'test-full'
   - tqdm ; extra == 'tqdm'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.4.0-h236703b_2.conda
+  sha256: ebe2dabb0a6f0ef05039d3a26b9c6b0aa050d7e791c6ab77ee91653b2098cdc3
+  md5: ec54d965fd9d276c256ae3cf1d3aface
+  depends:
+  - gcc_impl_linux-64 12.4.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 55424
+  timestamp: 1740240489245
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.4.0-h7e62973_2.conda
+  sha256: 62b7d45f5e8042890d7d6cacfdabaa0f2e5c9b8fe0f9b12d4f81fc078b66b347
+  md5: e605824a02a81b3e3256636524c229d5
+  depends:
+  - gcc_impl_linux-aarch64 12.4.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 55373
+  timestamp: 1740240463826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.4.0-hb2e57f8_1.conda
+  sha256: 778cd1bfd417a9d4ddeb0fc4b5a0eb9eb9edf69112e1be0b2f2df125225f27af
+  md5: 3085fe2c70960ea96f1b4171584b500b
+  depends:
+  - binutils_impl_linux-64 >=2.40
+  - libgcc >=12.4.0
+  - libgcc-devel_linux-64 12.4.0 ha4f9413_101
+  - libgomp >=12.4.0
+  - libsanitizer 12.4.0 h46f95d5_1
+  - libstdcxx >=12.4.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 62030150
+  timestamp: 1724801895487
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.4.0-hfb8d6db_1.conda
+  sha256: f70203b042e44b2b8e27980b3f202c7da6c04bab6ae42a5a3a4a601986e5900c
+  md5: 451c421aa42ab02ae34cdfb44388f912
+  depends:
+  - binutils_impl_linux-aarch64 >=2.40
+  - libgcc >=12.4.0
+  - libgcc-devel_linux-aarch64 12.4.0 h7b3af7c_101
+  - libgomp >=12.4.0
+  - libsanitizer 12.4.0 h469570c_1
+  - libstdcxx >=12.4.0
+  - sysroot_linux-aarch64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 57707204
+  timestamp: 1724801206430
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.4.0-h6b7512a_10.conda
+  sha256: 004d2ed6a3fc79452dec4c6cac556d0b26cf2457d33c4ace95beed4e6e832b55
+  md5: 18432a261dca2bb05b45e60adee37d77
+  depends:
+  - binutils_linux-64
+  - gcc_impl_linux-64 12.4.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 32617
+  timestamp: 1745040673228
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.4.0-heb3b579_10.conda
+  sha256: 1ff4bb3d09d84c42fb1f338c2f76f2ab4ea989e8469583c47ce4b1843a522523
+  md5: aa8fc7586ec58fcc44e4b9f4895181fe
+  depends:
+  - binutils_linux-aarch64
+  - gcc_impl_linux-aarch64 12.4.0.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 32648
+  timestamp: 1745040658439
 - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
   name: geopandas
   version: 1.0.1
@@ -14601,6 +15051,80 @@ packages:
   - multidict
   - protobuf>=3.20.0 ; extra == 'protobuf'
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.4.0-h236703b_2.conda
+  sha256: 6c3ea9877dc6babf064bafacd9e67280072b676864c26e90cbfec52eaa32a60e
+  md5: 5735863174438abb776bd1fefccec00a
+  depends:
+  - gcc 12.4.0.*
+  - gxx_impl_linux-64 12.4.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 54818
+  timestamp: 1740240626426
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.4.0-h7e62973_2.conda
+  sha256: f54f7ec55907e31bde2681256d7135215c4ee3f7dcf4d6aebbaebf17ef66efcb
+  md5: 37d28c3a8d6a9408b8c9b043e74500fa
+  depends:
+  - gcc 12.4.0.*
+  - gxx_impl_linux-aarch64 12.4.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 54875
+  timestamp: 1740240579366
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.4.0-h613a52c_1.conda
+  sha256: b08ddbe2bdb1c0c0804e86a99eac9f5041227ba44c652b1dc9083843a4e25374
+  md5: ef8a8e632fd38345288c3419c868904f
+  depends:
+  - gcc_impl_linux-64 12.4.0 hb2e57f8_1
+  - libstdcxx-devel_linux-64 12.4.0 ha4f9413_101
+  - sysroot_linux-64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 12711904
+  timestamp: 1724802140227
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.4.0-h3c1ec91_1.conda
+  sha256: ac82bbb080d546b8314f9ce87df799cdf9bfca5a2ea3006f2b6bf76d8a278fb6
+  md5: 610f731f5550536ad5d39044b6ff138a
+  depends:
+  - gcc_impl_linux-aarch64 12.4.0 hfb8d6db_1
+  - libstdcxx-devel_linux-aarch64 12.4.0 h7b3af7c_101
+  - sysroot_linux-aarch64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 11571845
+  timestamp: 1724801391775
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.4.0-h8489865_10.conda
+  sha256: 6ea7b3957ace8960347069f032851a66755b785a5e34cd845c1b6b1e649b686e
+  md5: f01962bad75d6d68802a1eb56bb70478
+  depends:
+  - binutils_linux-64
+  - gcc_linux-64 12.4.0 h6b7512a_10
+  - gxx_impl_linux-64 12.4.0.*
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 30953
+  timestamp: 1745040691868
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.4.0-h3f57e68_10.conda
+  sha256: 19edef472580cef8c145ccb307dd71ed2b7c18ac86e43aafce356047ce0f8352
+  md5: ba65e3da87da43ba05bed772c89d084d
+  depends:
+  - binutils_linux-aarch64
+  - gcc_linux-aarch64 12.4.0 heb3b579_10
+  - gxx_impl_linux-aarch64 12.4.0.*
+  - sysroot_linux-aarch64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 30955
+  timestamp: 1745040677759
 - pypi: https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl
   name: h11
   version: 0.14.0
@@ -15171,46 +15695,6 @@ packages:
   purls: []
   size: 1852356
   timestamp: 1723739573141
-- pypi: https://files.pythonhosted.org/packages/94/5c/368ae6c01c7628438358e6d337c19b05425727fbb221d2a3c4303c372f42/ipykernel-6.29.5-py3-none-any.whl
-  name: ipykernel
-  version: 6.29.5
-  sha256: afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5
-  requires_dist:
-  - appnope ; platform_system == 'Darwin'
-  - comm>=0.1.1
-  - debugpy>=1.6.5
-  - ipython>=7.23.1
-  - jupyter-client>=6.1.12
-  - jupyter-core>=4.12,!=5.0.*
-  - matplotlib-inline>=0.1
-  - nest-asyncio
-  - packaging
-  - psutil
-  - pyzmq>=24
-  - tornado>=6.1
-  - traitlets>=5.4.0
-  - coverage[toml] ; extra == 'cov'
-  - curio ; extra == 'cov'
-  - matplotlib ; extra == 'cov'
-  - pytest-cov ; extra == 'cov'
-  - trio ; extra == 'cov'
-  - myst-parser ; extra == 'docs'
-  - pydata-sphinx-theme ; extra == 'docs'
-  - sphinx ; extra == 'docs'
-  - sphinx-autodoc-typehints ; extra == 'docs'
-  - sphinxcontrib-github-alt ; extra == 'docs'
-  - sphinxcontrib-spelling ; extra == 'docs'
-  - trio ; extra == 'docs'
-  - pyqt5 ; extra == 'pyqt5'
-  - pyside6 ; extra == 'pyside6'
-  - flaky ; extra == 'test'
-  - ipyparallel ; extra == 'test'
-  - pre-commit ; extra == 'test'
-  - pytest-asyncio>=0.23.5 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-timeout ; extra == 'test'
-  - pytest>=7.0 ; extra == 'test'
-  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/94/5c/368ae6c01c7628438358e6d337c19b05425727fbb221d2a3c4303c372f42/ipykernel-6.29.5-py3-none-any.whl
   name: ipykernel
   version: 6.29.5
@@ -16244,6 +16728,72 @@ packages:
   - pyproj ; extra == 'pyproj'
   - requests ; extra == 'requests'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-951.9-ha02d983_1.conda
+  sha256: 4a27102c8451ce30b3c2d90722826e8bd02e9bb3b92cd5afaa08c65bbe6447f5
+  md5: 8991ffc3c5c410692d8740de4cb92849
+  depends:
+  - ld64_osx-64 951.9 h3516399_1
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - cctools 1010.6.*
+  - cctools_osx-64 1010.6.*
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 18850
+  timestamp: 1726771680769
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-951.9-h634c8be_1.conda
+  sha256: d347ecd273ea7552ae703a37650ea211ff640ed8fd921fe6f1ede49dcdc1358c
+  md5: 294a282b67deea1f0ea1c7d8be2bb5c5
+  depends:
+  - ld64_osx-arm64 951.9 h0605c9f_1
+  - libllvm16 >=16.0.6,<16.1.0a0
+  constrains:
+  - cctools_osx-arm64 1010.6.*
+  - cctools 1010.6.*
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 18928
+  timestamp: 1726771322773
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-951.9-h3516399_1.conda
+  sha256: 03417d5a379bf8e7b2ac99000d9af836cae53b843e02de7cea066c4ddd88767c
+  md5: 4656f00ccd13a49804387450302c4f45
+  depends:
+  - __osx >=10.13
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - sigtool
+  - tapi >=1300.6.5,<1301.0a0
+  constrains:
+  - clang >=16.0.6,<17.0a0
+  - cctools 1010.6.*
+  - cctools_osx-64 1010.6.*
+  - ld 951.9.*
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 1088101
+  timestamp: 1726771578888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-951.9-h0605c9f_1.conda
+  sha256: 2183f5fc32084bbaa83a84817cfc68091e9e739a048a185dcfa55be908b9fe54
+  md5: 77076839b5a8ac684c7971641d69b97a
+  depends:
+  - __osx >=11.0
+  - libcxx
+  - libllvm16 >=16.0.6,<16.1.0a0
+  - sigtool
+  - tapi >=1300.6.5,<1301.0a0
+  constrains:
+  - clang >=16.0.6,<17.0a0
+  - cctools_osx-arm64 1010.6.*
+  - ld 951.9.*
+  - cctools 1010.6.*
+  license: APSL-2.0
+  license_family: Other
+  purls: []
+  size: 1006497
+  timestamp: 1726771248963
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_1.conda
   sha256: 0c21387f9a411e3d1f7f2969026bacfece133c8f1e72faea9cde29c0c19e1f3a
   md5: 83e1364586ceb8d0739fbc85b5c95837
@@ -17592,6 +18142,26 @@ packages:
   purls: []
   size: 521199
   timestamp: 1729038190391
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-devel-16.0.6-h8f8a49f_2.conda
+  sha256: 1c1c6f6f4eca07be3f03929c59c2dd077da3c676fbf5e92c0df3bad2a4f069ab
+  md5: 677580dee2d1412311d9dd9bf6bfa6b7
+  depends:
+  - libcxx >=16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 716532
+  timestamp: 1725067685814
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-devel-16.0.6-h86353a2_2.conda
+  sha256: fb51aaeb9911d9999afaf0a3dc8f4eee97c524aac4ec152217372e8645ef8856
+  md5: f81c638415433ea5bb5024b49cda17ea
+  depends:
+  - libcxx >=16.0.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 717680
+  timestamp: 1725067968232
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
   sha256: 780f0530a3adfc1497ba49d626931c6afc978c540e1abfde6ccd57128ded6ad6
   md5: b422943d5d772b7cc858b36ad2a92db5
@@ -18070,8 +18640,6 @@ packages:
   md5: 044a210bc1d5b8367857755665157413
   depends:
   - libgfortran5 14.2.0 h6c33f7e_103
-  arch: arm64
-  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -18140,8 +18708,6 @@ packages:
   - llvm-openmp >=8.0.0
   constrains:
   - libgfortran 5.0.0 14_2_0_*_103
-  arch: arm64
-  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
@@ -20289,6 +20855,28 @@ packages:
   purls: []
   size: 260860
   timestamp: 1728779502416
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.4.0-h46f95d5_1.conda
+  sha256: 09bfebe6b68ca51018df751e231bf187f96aa49f4d0804556c3920b50d7a244b
+  md5: 6cf3b8a6dd5b1525d7b2653f1ce8c2c5
+  depends:
+  - libgcc >=12.4.0
+  - libstdcxx >=12.4.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3947704
+  timestamp: 1724801833649
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.4.0-h469570c_1.conda
+  sha256: 2dfb9ec14fd6f2c89eac3af64a6bdc4362fe6f70835e7eb6171c5ae4f5a93009
+  md5: 0e5754cdbc01923d95406be98dc5126c
+  depends:
+  - libgcc >=12.4.0
+  - libstdcxx >=12.4.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3879458
+  timestamp: 1724801157229
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
   sha256: 9851c049abafed3ee329d6c7c2033407e2fc269d33a75c071110ab52300002b0
   md5: 36f79405ab16bf271edb55b213836dac
@@ -20421,6 +21009,26 @@ packages:
   purls: []
   size: 3816794
   timestamp: 1729089463404
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-12.4.0-ha4f9413_101.conda
+  sha256: 13a2c9b166b4338ef6b0a91c6597198dbb227c038ebaa55df4b6a3f6bfccd5f3
+  md5: 5e22204cb6cedf08c64933360ccebe7e
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 11890684
+  timestamp: 1724801712899
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.4.0-h7b3af7c_101.conda
+  sha256: 6f47666e2c1d06d670cdd85493b01cc11b3424e031b31124057385ed50fff978
+  md5: 29a9692d3789a0ea5ebc810c16215ca6
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 10168094
+  timestamp: 1724801076172
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.2.0-h4852527_1.conda
   sha256: 25bb30b827d4f6d6f0522cc0579e431695503822f144043b93c50237017fffd8
   md5: 8371ac6457591af2cf6159439c1fd051
@@ -21102,6 +21710,42 @@ packages:
   purls: []
   size: 280830
   timestamp: 1736986295869
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-16.0.6-hbedff68_3.conda
+  sha256: dff3ca83c6945f020ee6d3c62ddb3ed175ae8a357be3689a8836bcfe25ad9882
+  md5: e9356b0807462e8f84c1384a8da539a5
+  depends:
+  - libllvm16 16.0.6 hbedff68_3
+  - libxml2 >=2.12.1,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - llvmdev   16.0.6
+  - clang 16.0.6.*
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 22221159
+  timestamp: 1701379965425
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-16.0.6-haab561b_3.conda
+  sha256: 64cc3547a2b0a3700a9fa0bd1fd3258156900b48ae73fc1a4b391002ca1462bf
+  md5: ca8e3771122c520fbe72af7c83d6d4cd
+  depends:
+  - libllvm16 16.0.6 haab561b_3
+  - libxml2 >=2.12.1,<2.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - llvmdev   16.0.6
+  - clang 16.0.6.*
+  - clang-tools 16.0.6.*
+  - llvm 16.0.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 20685770
+  timestamp: 1701375136405
 - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py311h9c9ff8c_0.conda
   sha256: 4f0f29c81da661a39506b3ea9349ad8e661c96fb8e6b2858221f5523be3aa6ee
   md5: 2982bb97e921bbc90b762ba301cc4a74
@@ -26733,6 +27377,26 @@ packages:
   version: 1.5.4
   sha256: 7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+  sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
+  md5: fbfb84b9de9a6939cb165c02c69b1865
+  depends:
+  - openssl >=3.0.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 213817
+  timestamp: 1643442169866
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+  sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
+  md5: 4a2cac04f86a4540b8c9b8d8f597848f
+  depends:
+  - openssl >=3.0.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 210264
+  timestamp: 1643442231687
 - pypi: https://files.pythonhosted.org/packages/65/be/d8ab9717f471be3c114f16abd8be21d9a6a0a09b9b49177d93d64d3717d9/simplejson-3.19.3-cp311-cp311-win_amd64.whl
   name: simplejson
   version: 3.19.3
@@ -27036,6 +27700,30 @@ packages:
   purls: []
   size: 15739604
   timestamp: 1735290496248
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1300.6.5-h390ca13_0.conda
+  sha256: f97372a1c75b749298cb990405a690527e8004ff97e452ed2c59e4bc6a35d132
+  md5: c6ee25eb54accb3f1c8fc39203acfaf1
+  depends:
+  - __osx >=10.13
+  - libcxx >=17.0.0.a0
+  - ncurses >=6.5,<7.0a0
+  license: NCSA
+  license_family: MIT
+  purls: []
+  size: 221236
+  timestamp: 1725491044729
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
+  sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
+  md5: b703bc3e6cba5943acf0e5f987b5d0e2
+  depends:
+  - __osx >=11.0
+  - libcxx >=17.0.0.a0
+  - ncurses >=6.5,<7.0a0
+  license: NCSA
+  license_family: MIT
+  purls: []
+  size: 207679
+  timestamp: 1725491499758
 - conda: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.9.1-h1ff36dd_0.conda
   sha256: 82b3528f63ae71e0158fdbf8b66e66f619cb70584c471f3d89a2ee6fd44ef20b
   md5: 29207c9b716932300221e5acd0b310f7

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,8 +38,10 @@ libc = "2.28"
 
 
 ################################################################################
-# GLOBAL ACTIVATION
+# ACTIVATION
 ################################################################################
+
+# Global
 
 [activation]
 
@@ -50,6 +52,14 @@ EXECUTABLE_EXTENSION = ""
 [target.win-64.activation.env]
 # The executable extension for binaries on the current platform.
 EXECUTABLE_EXTENSION = ".exe"
+
+# python-dev
+
+[feature.python-dev.activation.env]
+# RERUN_ALLOW_MISSING_BIN is needed to allow maturin to run without the `rerun` binary being part of the rerun-sdk.
+RERUN_ALLOW_MISSING_BIN = "1"
+RERUN_DEV_ENVIRONMENT = "true"
+
 
 ################################################################################
 # ENVIRONMENTS
@@ -77,6 +87,10 @@ py = ["base", "wheel-build", "python-dev", "python-tasks", "py-test-deps"]
 py-docs = ["base", "python-docs"]
 
 # The cpp environment is for building any code that depends on the C++ `rerun-sdk`.
+#
+# ⚠️ This environment sets the C/C++ compiler to the system compiler (see c-compiler/cxx-compiler dependencies).
+# As of writing this breaks building the web viewer on MacOS, so do not enable it in any environment
+# in which you want to do viewer builds.
 cpp = ["base", "cpp"]
 
 # The wheel-test environment is for testing the python package when built from a wheel.
@@ -95,7 +109,6 @@ cpp = ["base", "cpp"]
 #  Just the deps for running roundtrips
 wheel-test-min = [
   "base",
-  "cpp",
   "wheel-test",
   "wheel-build",
   "py-test-deps",
@@ -105,7 +118,6 @@ wheel-test-min = [
 # The full deps for running all examples
 wheel-test = [
   "base",
-  "cpp",
   "wheel-test",
   "wheel-build",
   "py-test-deps",
@@ -582,6 +594,16 @@ sysroot_linux-aarch64 = ">=2.17,<3" # rustc 1.64+ requires glibc 2.17+, see http
 
 [feature.cpp.target.unix.dependencies]
 ninja = "1.11.1.*"
+# Use system compilers for C/C++.
+#
+# This is important in particular on MacOS, where it's really hard to get a custom clang to work,
+# due to various pecularities of the linker setup.
+# (i.e. I have figured out to pick up the right compiler by setting CC/CXX env vars, but couldn't get it to link!)
+#
+# Note however, that as of writing, our web viewer build needs to use a newer compiler than what MacOS ships with,
+# so we have to make sure that anything building the web viewer does **not** use these packages.
+c-compiler = "1.6.0.*"
+cxx-compiler = "1.6.0.*"
 
 [feature.cpp.target.win-64.dependencies]
 vs2022_win-64 = "19.37.32822.*"
@@ -593,9 +615,6 @@ ghp-import = "==2.1.0" # for CI documentation handling
 [feature.python-dev]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64", "osx-64", "win-64"]
 
-[feature.python-dev.activation.env]
-RERUN_DEV_ENVIRONMENT = "true"
-
 [feature.python-dev.dependencies]
 # We need opencv for `compare_snippet_output.py` (needed by both C++ and Python)
 # and other common examples/snippets.
@@ -606,15 +625,6 @@ RERUN_DEV_ENVIRONMENT = "true"
 # This is also redundantly defined in `python-pypi`
 opencv = ">4.6"
 numpy = ">=2"   # Rerun still needs numpy <2. Enforce this outside of the pypi dep tree so we pick up the conda version.
-
-
-[feature.python-dev.activation]
-# Set up environment variables so maturin will do the right thing when
-# installing the python package.
-scripts = ["pixi/maturin_config.sh"]
-
-[feature.python-dev.target.win-64.activation]
-scripts = ["pixi/maturin_config.bat"]
 
 [feature.python-dev.pypi-dependencies]
 # Install the `rerun_py` as a package in editable mode.

--- a/pixi.toml
+++ b/pixi.toml
@@ -580,7 +580,7 @@ buf = "1.*"             # not available for linux-aarch64
 
 [target.osx-arm64.dependencies]
 buf = "1.*"             # not available for linux-aarch64
-libgfortran5 = ">=14" # Fixes issues with OpenCV
+libgfortran5 = ">=14"   # Fixes issues with OpenCV
 meilisearch = "1.5.1.*" # not available for linux-aarch64
 
 [target.win-64.dependencies]
@@ -597,7 +597,7 @@ ninja = "1.11.1.*"
 # Use system compilers for C/C++.
 #
 # This is important in particular on MacOS, where it's really hard to get a custom clang to work,
-# due to various pecularities of the linker setup.
+# due to various peculiarities of the linker setup.
 # (i.e. I have figured out to pick up the right compiler by setting CC/CXX env vars, but couldn't get it to link!)
 #
 # Note however, that as of writing, our web viewer build needs to use a newer compiler than what MacOS ships with,

--- a/pixi/maturin_config.bat
+++ b/pixi/maturin_config.bat
@@ -1,2 +1,0 @@
-:: RERUN_ALLOW_MISSING_BIN is needed to allow maturin to run without the `rerun` binary being part of the rerun-sdk.
-set RERUN_ALLOW_MISSING_BIN=1

--- a/pixi/maturin_config.sh
+++ b/pixi/maturin_config.sh
@@ -1,2 +1,0 @@
-# RERUN_ALLOW_MISSING_BIN is needed to allow maturin to run without the `rerun` binary being part of the rerun-sdk.
-export RERUN_ALLOW_MISSING_BIN=1

--- a/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/archetypes/annotation_context.hpp
@@ -82,8 +82,7 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `context` field.
         static constexpr auto Descriptor_context = ComponentDescriptor(
-            ArchetypeName, "context",
-            Loggable<rerun::components::AnnotationContext>::Descriptor.component_name
+            ArchetypeName, "context", Loggable<rerun::components::AnnotationContext>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
@@ -97,40 +97,35 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `vectors` field.
         static constexpr auto Descriptor_vectors = ComponentDescriptor(
-            ArchetypeName, "vectors",
-            Loggable<rerun::components::Vector2D>::Descriptor.component_name
+            ArchetypeName, "vectors", Loggable<rerun::components::Vector2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `origins` field.
         static constexpr auto Descriptor_origins = ComponentDescriptor(
-            ArchetypeName, "origins",
-            Loggable<rerun::components::Position2D>::Descriptor.component_name
+            ArchetypeName, "origins", Loggable<rerun::components::Position2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from arrows2d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows3d.hpp
@@ -107,35 +107,31 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `vectors` field.
         static constexpr auto Descriptor_vectors = ComponentDescriptor(
-            ArchetypeName, "vectors",
-            Loggable<rerun::components::Vector3D>::Descriptor.component_name
+            ArchetypeName, "vectors", Loggable<rerun::components::Vector3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `origins` field.
         static constexpr auto Descriptor_origins = ComponentDescriptor(
-            ArchetypeName, "origins",
-            Loggable<rerun::components::Position3D>::Descriptor.component_name
+            ArchetypeName, "origins", Loggable<rerun::components::Position3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from arrows3d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/asset3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset3d.hpp
@@ -83,17 +83,15 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `blob` field.
         static constexpr auto Descriptor_blob = ComponentDescriptor(
-            ArchetypeName, "blob", Loggable<rerun::components::Blob>::Descriptor.component_name
+            ArchetypeName, "blob", Loggable<rerun::components::Blob>::ComponentName
         );
         /// `ComponentDescriptor` for the `media_type` field.
         static constexpr auto Descriptor_media_type = ComponentDescriptor(
-            ArchetypeName, "media_type",
-            Loggable<rerun::components::MediaType>::Descriptor.component_name
+            ArchetypeName, "media_type", Loggable<rerun::components::MediaType>::ComponentName
         );
         /// `ComponentDescriptor` for the `albedo_factor` field.
         static constexpr auto Descriptor_albedo_factor = ComponentDescriptor(
-            ArchetypeName, "albedo_factor",
-            Loggable<rerun::components::AlbedoFactor>::Descriptor.component_name
+            ArchetypeName, "albedo_factor", Loggable<rerun::components::AlbedoFactor>::ComponentName
         );
 
       public: // START of extensions from asset3d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -136,12 +136,11 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `blob` field.
         static constexpr auto Descriptor_blob = ComponentDescriptor(
-            ArchetypeName, "blob", Loggable<rerun::components::Blob>::Descriptor.component_name
+            ArchetypeName, "blob", Loggable<rerun::components::Blob>::ComponentName
         );
         /// `ComponentDescriptor` for the `media_type` field.
         static constexpr auto Descriptor_media_type = ComponentDescriptor(
-            ArchetypeName, "media_type",
-            Loggable<rerun::components::MediaType>::Descriptor.component_name
+            ArchetypeName, "media_type", Loggable<rerun::components::MediaType>::ComponentName
         );
 
       public: // START of extensions from asset_video_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -53,12 +53,11 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `values` field.
         static constexpr auto Descriptor_values = ComponentDescriptor(
-            ArchetypeName, "values",
-            Loggable<rerun::components::TensorData>::Descriptor.component_name
+            ArchetypeName, "values", Loggable<rerun::components::TensorData>::ComponentName
         );
         /// `ComponentDescriptor` for the `color` field.
         static constexpr auto Descriptor_color = ComponentDescriptor(
-            ArchetypeName, "color", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "color", Loggable<rerun::components::Color>::ComponentName
         );
 
       public: // START of extensions from bar_chart_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes2d.hpp
@@ -86,40 +86,35 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `half_sizes` field.
         static constexpr auto Descriptor_half_sizes = ComponentDescriptor(
-            ArchetypeName, "half_sizes",
-            Loggable<rerun::components::HalfSize2D>::Descriptor.component_name
+            ArchetypeName, "half_sizes", Loggable<rerun::components::HalfSize2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `centers` field.
         static constexpr auto Descriptor_centers = ComponentDescriptor(
-            ArchetypeName, "centers",
-            Loggable<rerun::components::Position2D>::Descriptor.component_name
+            ArchetypeName, "centers", Loggable<rerun::components::Position2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from boxes2d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -119,50 +119,45 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `half_sizes` field.
         static constexpr auto Descriptor_half_sizes = ComponentDescriptor(
-            ArchetypeName, "half_sizes",
-            Loggable<rerun::components::HalfSize3D>::Descriptor.component_name
+            ArchetypeName, "half_sizes", Loggable<rerun::components::HalfSize3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `centers` field.
         static constexpr auto Descriptor_centers = ComponentDescriptor(
-            ArchetypeName, "centers",
-            Loggable<rerun::components::PoseTranslation3D>::Descriptor.component_name
+            ArchetypeName, "centers", Loggable<rerun::components::PoseTranslation3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `rotation_axis_angles` field.
         static constexpr auto Descriptor_rotation_axis_angles = ComponentDescriptor(
             ArchetypeName, "rotation_axis_angles",
-            Loggable<rerun::components::PoseRotationAxisAngle>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationAxisAngle>::ComponentName
         );
         /// `ComponentDescriptor` for the `quaternions` field.
         static constexpr auto Descriptor_quaternions = ComponentDescriptor(
             ArchetypeName, "quaternions",
-            Loggable<rerun::components::PoseRotationQuat>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationQuat>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `fill_mode` field.
         static constexpr auto Descriptor_fill_mode = ComponentDescriptor(
-            ArchetypeName, "fill_mode",
-            Loggable<rerun::components::FillMode>::Descriptor.component_name
+            ArchetypeName, "fill_mode", Loggable<rerun::components::FillMode>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from boxes3d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
@@ -126,44 +126,42 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `lengths` field.
         static constexpr auto Descriptor_lengths = ComponentDescriptor(
-            ArchetypeName, "lengths", Loggable<rerun::components::Length>::Descriptor.component_name
+            ArchetypeName, "lengths", Loggable<rerun::components::Length>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `translations` field.
         static constexpr auto Descriptor_translations = ComponentDescriptor(
             ArchetypeName, "translations",
-            Loggable<rerun::components::PoseTranslation3D>::Descriptor.component_name
+            Loggable<rerun::components::PoseTranslation3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `rotation_axis_angles` field.
         static constexpr auto Descriptor_rotation_axis_angles = ComponentDescriptor(
             ArchetypeName, "rotation_axis_angles",
-            Loggable<rerun::components::PoseRotationAxisAngle>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationAxisAngle>::ComponentName
         );
         /// `ComponentDescriptor` for the `quaternions` field.
         static constexpr auto Descriptor_quaternions = ComponentDescriptor(
             ArchetypeName, "quaternions",
-            Loggable<rerun::components::PoseRotationQuat>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationQuat>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from capsules3d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/clear.hpp
+++ b/rerun_cpp/src/rerun/archetypes/clear.hpp
@@ -97,7 +97,7 @@ namespace rerun::archetypes {
         /// `ComponentDescriptor` for the `is_recursive` field.
         static constexpr auto Descriptor_is_recursive = ComponentDescriptor(
             ArchetypeName, "is_recursive",
-            Loggable<rerun::components::ClearIsRecursive>::Descriptor.component_name
+            Loggable<rerun::components::ClearIsRecursive>::ComponentName
         );
 
       public: // START of extensions from clear_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/cylinders3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/cylinders3d.hpp
@@ -130,54 +130,49 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `lengths` field.
         static constexpr auto Descriptor_lengths = ComponentDescriptor(
-            ArchetypeName, "lengths", Loggable<rerun::components::Length>::Descriptor.component_name
+            ArchetypeName, "lengths", Loggable<rerun::components::Length>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `centers` field.
         static constexpr auto Descriptor_centers = ComponentDescriptor(
-            ArchetypeName, "centers",
-            Loggable<rerun::components::PoseTranslation3D>::Descriptor.component_name
+            ArchetypeName, "centers", Loggable<rerun::components::PoseTranslation3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `rotation_axis_angles` field.
         static constexpr auto Descriptor_rotation_axis_angles = ComponentDescriptor(
             ArchetypeName, "rotation_axis_angles",
-            Loggable<rerun::components::PoseRotationAxisAngle>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationAxisAngle>::ComponentName
         );
         /// `ComponentDescriptor` for the `quaternions` field.
         static constexpr auto Descriptor_quaternions = ComponentDescriptor(
             ArchetypeName, "quaternions",
-            Loggable<rerun::components::PoseRotationQuat>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationQuat>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `line_radii` field.
         static constexpr auto Descriptor_line_radii = ComponentDescriptor(
-            ArchetypeName, "line_radii",
-            Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "line_radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `fill_mode` field.
         static constexpr auto Descriptor_fill_mode = ComponentDescriptor(
-            ArchetypeName, "fill_mode",
-            Loggable<rerun::components::FillMode>::Descriptor.component_name
+            ArchetypeName, "fill_mode", Loggable<rerun::components::FillMode>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from cylinders3d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -134,38 +134,31 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `buffer` field.
         static constexpr auto Descriptor_buffer = ComponentDescriptor(
-            ArchetypeName, "buffer",
-            Loggable<rerun::components::ImageBuffer>::Descriptor.component_name
+            ArchetypeName, "buffer", Loggable<rerun::components::ImageBuffer>::ComponentName
         );
         /// `ComponentDescriptor` for the `format` field.
         static constexpr auto Descriptor_format = ComponentDescriptor(
-            ArchetypeName, "format",
-            Loggable<rerun::components::ImageFormat>::Descriptor.component_name
+            ArchetypeName, "format", Loggable<rerun::components::ImageFormat>::ComponentName
         );
         /// `ComponentDescriptor` for the `meter` field.
         static constexpr auto Descriptor_meter = ComponentDescriptor(
-            ArchetypeName, "meter",
-            Loggable<rerun::components::DepthMeter>::Descriptor.component_name
+            ArchetypeName, "meter", Loggable<rerun::components::DepthMeter>::ComponentName
         );
         /// `ComponentDescriptor` for the `colormap` field.
         static constexpr auto Descriptor_colormap = ComponentDescriptor(
-            ArchetypeName, "colormap",
-            Loggable<rerun::components::Colormap>::Descriptor.component_name
+            ArchetypeName, "colormap", Loggable<rerun::components::Colormap>::ComponentName
         );
         /// `ComponentDescriptor` for the `depth_range` field.
         static constexpr auto Descriptor_depth_range = ComponentDescriptor(
-            ArchetypeName, "depth_range",
-            Loggable<rerun::components::ValueRange>::Descriptor.component_name
+            ArchetypeName, "depth_range", Loggable<rerun::components::ValueRange>::ComponentName
         );
         /// `ComponentDescriptor` for the `point_fill_ratio` field.
         static constexpr auto Descriptor_point_fill_ratio = ComponentDescriptor(
-            ArchetypeName, "point_fill_ratio",
-            Loggable<rerun::components::FillRatio>::Descriptor.component_name
+            ArchetypeName, "point_fill_ratio", Loggable<rerun::components::FillRatio>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
 
       public: // START of extensions from depth_image_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
@@ -143,51 +143,45 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `half_sizes` field.
         static constexpr auto Descriptor_half_sizes = ComponentDescriptor(
-            ArchetypeName, "half_sizes",
-            Loggable<rerun::components::HalfSize3D>::Descriptor.component_name
+            ArchetypeName, "half_sizes", Loggable<rerun::components::HalfSize3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `centers` field.
         static constexpr auto Descriptor_centers = ComponentDescriptor(
-            ArchetypeName, "centers",
-            Loggable<rerun::components::PoseTranslation3D>::Descriptor.component_name
+            ArchetypeName, "centers", Loggable<rerun::components::PoseTranslation3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `rotation_axis_angles` field.
         static constexpr auto Descriptor_rotation_axis_angles = ComponentDescriptor(
             ArchetypeName, "rotation_axis_angles",
-            Loggable<rerun::components::PoseRotationAxisAngle>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationAxisAngle>::ComponentName
         );
         /// `ComponentDescriptor` for the `quaternions` field.
         static constexpr auto Descriptor_quaternions = ComponentDescriptor(
             ArchetypeName, "quaternions",
-            Loggable<rerun::components::PoseRotationQuat>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationQuat>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `line_radii` field.
         static constexpr auto Descriptor_line_radii = ComponentDescriptor(
-            ArchetypeName, "line_radii",
-            Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "line_radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `fill_mode` field.
         static constexpr auto Descriptor_fill_mode = ComponentDescriptor(
-            ArchetypeName, "fill_mode",
-            Loggable<rerun::components::FillMode>::Descriptor.component_name
+            ArchetypeName, "fill_mode", Loggable<rerun::components::FillMode>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from ellipsoids3d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/encoded_image.hpp
@@ -82,22 +82,19 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `blob` field.
         static constexpr auto Descriptor_blob = ComponentDescriptor(
-            ArchetypeName, "blob", Loggable<rerun::components::Blob>::Descriptor.component_name
+            ArchetypeName, "blob", Loggable<rerun::components::Blob>::ComponentName
         );
         /// `ComponentDescriptor` for the `media_type` field.
         static constexpr auto Descriptor_media_type = ComponentDescriptor(
-            ArchetypeName, "media_type",
-            Loggable<rerun::components::MediaType>::Descriptor.component_name
+            ArchetypeName, "media_type", Loggable<rerun::components::MediaType>::ComponentName
         );
         /// `ComponentDescriptor` for the `opacity` field.
         static constexpr auto Descriptor_opacity = ComponentDescriptor(
-            ArchetypeName, "opacity",
-            Loggable<rerun::components::Opacity>::Descriptor.component_name
+            ArchetypeName, "opacity", Loggable<rerun::components::Opacity>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
 
       public: // START of extensions from encoded_image_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
@@ -74,16 +74,15 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `line_strings` field.
         static constexpr auto Descriptor_line_strings = ComponentDescriptor(
-            ArchetypeName, "line_strings",
-            Loggable<rerun::components::GeoLineString>::Descriptor.component_name
+            ArchetypeName, "line_strings", Loggable<rerun::components::GeoLineString>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/geo_points.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_points.hpp
@@ -69,21 +69,19 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `positions` field.
         static constexpr auto Descriptor_positions = ComponentDescriptor(
-            ArchetypeName, "positions",
-            Loggable<rerun::components::LatLon>::Descriptor.component_name
+            ArchetypeName, "positions", Loggable<rerun::components::LatLon>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public: // START of extensions from geo_points_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
@@ -64,13 +64,11 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `edges` field.
         static constexpr auto Descriptor_edges = ComponentDescriptor(
-            ArchetypeName, "edges",
-            Loggable<rerun::components::GraphEdge>::Descriptor.component_name
+            ArchetypeName, "edges", Loggable<rerun::components::GraphEdge>::ComponentName
         );
         /// `ComponentDescriptor` for the `graph_type` field.
         static constexpr auto Descriptor_graph_type = ComponentDescriptor(
-            ArchetypeName, "graph_type",
-            Loggable<rerun::components::GraphType>::Descriptor.component_name
+            ArchetypeName, "graph_type", Loggable<rerun::components::GraphType>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
@@ -79,30 +79,27 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `node_ids` field.
         static constexpr auto Descriptor_node_ids = ComponentDescriptor(
-            ArchetypeName, "node_ids",
-            Loggable<rerun::components::GraphNode>::Descriptor.component_name
+            ArchetypeName, "node_ids", Loggable<rerun::components::GraphNode>::ComponentName
         );
         /// `ComponentDescriptor` for the `positions` field.
         static constexpr auto Descriptor_positions = ComponentDescriptor(
-            ArchetypeName, "positions",
-            Loggable<rerun::components::Position2D>::Descriptor.component_name
+            ArchetypeName, "positions", Loggable<rerun::components::Position2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -169,23 +169,19 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `buffer` field.
         static constexpr auto Descriptor_buffer = ComponentDescriptor(
-            ArchetypeName, "buffer",
-            Loggable<rerun::components::ImageBuffer>::Descriptor.component_name
+            ArchetypeName, "buffer", Loggable<rerun::components::ImageBuffer>::ComponentName
         );
         /// `ComponentDescriptor` for the `format` field.
         static constexpr auto Descriptor_format = ComponentDescriptor(
-            ArchetypeName, "format",
-            Loggable<rerun::components::ImageFormat>::Descriptor.component_name
+            ArchetypeName, "format", Loggable<rerun::components::ImageFormat>::ComponentName
         );
         /// `ComponentDescriptor` for the `opacity` field.
         static constexpr auto Descriptor_opacity = ComponentDescriptor(
-            ArchetypeName, "opacity",
-            Loggable<rerun::components::Opacity>::Descriptor.component_name
+            ArchetypeName, "opacity", Loggable<rerun::components::Opacity>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
 
       public: // START of extensions from image_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
@@ -104,27 +104,25 @@ namespace rerun::archetypes {
         /// `ComponentDescriptor` for the `translations` field.
         static constexpr auto Descriptor_translations = ComponentDescriptor(
             ArchetypeName, "translations",
-            Loggable<rerun::components::PoseTranslation3D>::Descriptor.component_name
+            Loggable<rerun::components::PoseTranslation3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `rotation_axis_angles` field.
         static constexpr auto Descriptor_rotation_axis_angles = ComponentDescriptor(
             ArchetypeName, "rotation_axis_angles",
-            Loggable<rerun::components::PoseRotationAxisAngle>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationAxisAngle>::ComponentName
         );
         /// `ComponentDescriptor` for the `quaternions` field.
         static constexpr auto Descriptor_quaternions = ComponentDescriptor(
             ArchetypeName, "quaternions",
-            Loggable<rerun::components::PoseRotationQuat>::Descriptor.component_name
+            Loggable<rerun::components::PoseRotationQuat>::ComponentName
         );
         /// `ComponentDescriptor` for the `scales` field.
         static constexpr auto Descriptor_scales = ComponentDescriptor(
-            ArchetypeName, "scales",
-            Loggable<rerun::components::PoseScale3D>::Descriptor.component_name
+            ArchetypeName, "scales", Loggable<rerun::components::PoseScale3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `mat3x3` field.
         static constexpr auto Descriptor_mat3x3 = ComponentDescriptor(
-            ArchetypeName, "mat3x3",
-            Loggable<rerun::components::PoseTransformMat3x3>::Descriptor.component_name
+            ArchetypeName, "mat3x3", Loggable<rerun::components::PoseTransformMat3x3>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips2d.hpp
@@ -130,35 +130,31 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `strips` field.
         static constexpr auto Descriptor_strips = ComponentDescriptor(
-            ArchetypeName, "strips",
-            Loggable<rerun::components::LineStrip2D>::Descriptor.component_name
+            ArchetypeName, "strips", Loggable<rerun::components::LineStrip2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -138,30 +138,27 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `strips` field.
         static constexpr auto Descriptor_strips = ComponentDescriptor(
-            ArchetypeName, "strips",
-            Loggable<rerun::components::LineStrip3D>::Descriptor.component_name
+            ArchetypeName, "strips", Loggable<rerun::components::LineStrip3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -155,47 +155,43 @@ namespace rerun::archetypes {
         /// `ComponentDescriptor` for the `vertex_positions` field.
         static constexpr auto Descriptor_vertex_positions = ComponentDescriptor(
             ArchetypeName, "vertex_positions",
-            Loggable<rerun::components::Position3D>::Descriptor.component_name
+            Loggable<rerun::components::Position3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `triangle_indices` field.
         static constexpr auto Descriptor_triangle_indices = ComponentDescriptor(
             ArchetypeName, "triangle_indices",
-            Loggable<rerun::components::TriangleIndices>::Descriptor.component_name
+            Loggable<rerun::components::TriangleIndices>::ComponentName
         );
         /// `ComponentDescriptor` for the `vertex_normals` field.
         static constexpr auto Descriptor_vertex_normals = ComponentDescriptor(
-            ArchetypeName, "vertex_normals",
-            Loggable<rerun::components::Vector3D>::Descriptor.component_name
+            ArchetypeName, "vertex_normals", Loggable<rerun::components::Vector3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `vertex_colors` field.
         static constexpr auto Descriptor_vertex_colors = ComponentDescriptor(
-            ArchetypeName, "vertex_colors",
-            Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "vertex_colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `vertex_texcoords` field.
         static constexpr auto Descriptor_vertex_texcoords = ComponentDescriptor(
             ArchetypeName, "vertex_texcoords",
-            Loggable<rerun::components::Texcoord2D>::Descriptor.component_name
+            Loggable<rerun::components::Texcoord2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `albedo_factor` field.
         static constexpr auto Descriptor_albedo_factor = ComponentDescriptor(
-            ArchetypeName, "albedo_factor",
-            Loggable<rerun::components::AlbedoFactor>::Descriptor.component_name
+            ArchetypeName, "albedo_factor", Loggable<rerun::components::AlbedoFactor>::ComponentName
         );
         /// `ComponentDescriptor` for the `albedo_texture_buffer` field.
         static constexpr auto Descriptor_albedo_texture_buffer = ComponentDescriptor(
             ArchetypeName, "albedo_texture_buffer",
-            Loggable<rerun::components::ImageBuffer>::Descriptor.component_name
+            Loggable<rerun::components::ImageBuffer>::ComponentName
         );
         /// `ComponentDescriptor` for the `albedo_texture_format` field.
         static constexpr auto Descriptor_albedo_texture_format = ComponentDescriptor(
             ArchetypeName, "albedo_texture_format",
-            Loggable<rerun::components::ImageFormat>::Descriptor.component_name
+            Loggable<rerun::components::ImageFormat>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/pinhole.hpp
+++ b/rerun_cpp/src/rerun/archetypes/pinhole.hpp
@@ -138,22 +138,20 @@ namespace rerun::archetypes {
         /// `ComponentDescriptor` for the `image_from_camera` field.
         static constexpr auto Descriptor_image_from_camera = ComponentDescriptor(
             ArchetypeName, "image_from_camera",
-            Loggable<rerun::components::PinholeProjection>::Descriptor.component_name
+            Loggable<rerun::components::PinholeProjection>::ComponentName
         );
         /// `ComponentDescriptor` for the `resolution` field.
         static constexpr auto Descriptor_resolution = ComponentDescriptor(
-            ArchetypeName, "resolution",
-            Loggable<rerun::components::Resolution>::Descriptor.component_name
+            ArchetypeName, "resolution", Loggable<rerun::components::Resolution>::ComponentName
         );
         /// `ComponentDescriptor` for the `camera_xyz` field.
         static constexpr auto Descriptor_camera_xyz = ComponentDescriptor(
-            ArchetypeName, "camera_xyz",
-            Loggable<rerun::components::ViewCoordinates>::Descriptor.component_name
+            ArchetypeName, "camera_xyz", Loggable<rerun::components::ViewCoordinates>::ComponentName
         );
         /// `ComponentDescriptor` for the `image_plane_distance` field.
         static constexpr auto Descriptor_image_plane_distance = ComponentDescriptor(
             ArchetypeName, "image_plane_distance",
-            Loggable<rerun::components::ImagePlaneDistance>::Descriptor.component_name
+            Loggable<rerun::components::ImagePlaneDistance>::ComponentName
         );
 
       public: // START of extensions from pinhole_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/points2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points2d.hpp
@@ -157,40 +157,35 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `positions` field.
         static constexpr auto Descriptor_positions = ComponentDescriptor(
-            ArchetypeName, "positions",
-            Loggable<rerun::components::Position2D>::Descriptor.component_name
+            ArchetypeName, "positions", Loggable<rerun::components::Position2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
         /// `ComponentDescriptor` for the `keypoint_ids` field.
         static constexpr auto Descriptor_keypoint_ids = ComponentDescriptor(
-            ArchetypeName, "keypoint_ids",
-            Loggable<rerun::components::KeypointId>::Descriptor.component_name
+            ArchetypeName, "keypoint_ids", Loggable<rerun::components::KeypointId>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -219,35 +219,31 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `positions` field.
         static constexpr auto Descriptor_positions = ComponentDescriptor(
-            ArchetypeName, "positions",
-            Loggable<rerun::components::Position3D>::Descriptor.component_name
+            ArchetypeName, "positions", Loggable<rerun::components::Position3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `radii` field.
         static constexpr auto Descriptor_radii = ComponentDescriptor(
-            ArchetypeName, "radii", Loggable<rerun::components::Radius>::Descriptor.component_name
+            ArchetypeName, "radii", Loggable<rerun::components::Radius>::ComponentName
         );
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
-            ArchetypeName, "labels", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "labels", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `show_labels` field.
         static constexpr auto Descriptor_show_labels = ComponentDescriptor(
-            ArchetypeName, "show_labels",
-            Loggable<rerun::components::ShowLabels>::Descriptor.component_name
+            ArchetypeName, "show_labels", Loggable<rerun::components::ShowLabels>::ComponentName
         );
         /// `ComponentDescriptor` for the `class_ids` field.
         static constexpr auto Descriptor_class_ids = ComponentDescriptor(
-            ArchetypeName, "class_ids",
-            Loggable<rerun::components::ClassId>::Descriptor.component_name
+            ArchetypeName, "class_ids", Loggable<rerun::components::ClassId>::ComponentName
         );
         /// `ComponentDescriptor` for the `keypoint_ids` field.
         static constexpr auto Descriptor_keypoint_ids = ComponentDescriptor(
-            ArchetypeName, "keypoint_ids",
-            Loggable<rerun::components::KeypointId>::Descriptor.component_name
+            ArchetypeName, "keypoint_ids", Loggable<rerun::components::KeypointId>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/recording_properties.hpp
+++ b/rerun_cpp/src/rerun/archetypes/recording_properties.hpp
@@ -38,12 +38,11 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `start_time` field.
         static constexpr auto Descriptor_start_time = ComponentDescriptor(
-            ArchetypeName, "start_time",
-            Loggable<rerun::components::Timestamp>::Descriptor.component_name
+            ArchetypeName, "start_time", Loggable<rerun::components::Timestamp>::ComponentName
         );
         /// `ComponentDescriptor` for the `name` field.
         static constexpr auto Descriptor_name = ComponentDescriptor(
-            ArchetypeName, "name", Loggable<rerun::components::Name>::Descriptor.component_name
+            ArchetypeName, "name", Loggable<rerun::components::Name>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/scalars.hpp
+++ b/rerun_cpp/src/rerun/archetypes/scalars.hpp
@@ -92,7 +92,7 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `scalars` field.
         static constexpr auto Descriptor_scalars = ComponentDescriptor(
-            ArchetypeName, "scalars", Loggable<rerun::components::Scalar>::Descriptor.component_name
+            ArchetypeName, "scalars", Loggable<rerun::components::Scalar>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -100,23 +100,19 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `buffer` field.
         static constexpr auto Descriptor_buffer = ComponentDescriptor(
-            ArchetypeName, "buffer",
-            Loggable<rerun::components::ImageBuffer>::Descriptor.component_name
+            ArchetypeName, "buffer", Loggable<rerun::components::ImageBuffer>::ComponentName
         );
         /// `ComponentDescriptor` for the `format` field.
         static constexpr auto Descriptor_format = ComponentDescriptor(
-            ArchetypeName, "format",
-            Loggable<rerun::components::ImageFormat>::Descriptor.component_name
+            ArchetypeName, "format", Loggable<rerun::components::ImageFormat>::ComponentName
         );
         /// `ComponentDescriptor` for the `opacity` field.
         static constexpr auto Descriptor_opacity = ComponentDescriptor(
-            ArchetypeName, "opacity",
-            Loggable<rerun::components::Opacity>::Descriptor.component_name
+            ArchetypeName, "opacity", Loggable<rerun::components::Opacity>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
 
       public: // START of extensions from segmentation_image_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/series_lines.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_lines.hpp
@@ -117,26 +117,25 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `widths` field.
         static constexpr auto Descriptor_widths = ComponentDescriptor(
-            ArchetypeName, "widths",
-            Loggable<rerun::components::StrokeWidth>::Descriptor.component_name
+            ArchetypeName, "widths", Loggable<rerun::components::StrokeWidth>::ComponentName
         );
         /// `ComponentDescriptor` for the `names` field.
         static constexpr auto Descriptor_names = ComponentDescriptor(
-            ArchetypeName, "names", Loggable<rerun::components::Name>::Descriptor.component_name
+            ArchetypeName, "names", Loggable<rerun::components::Name>::ComponentName
         );
         /// `ComponentDescriptor` for the `visible_series` field.
         static constexpr auto Descriptor_visible_series = ComponentDescriptor(
             ArchetypeName, "visible_series",
-            Loggable<rerun::components::SeriesVisible>::Descriptor.component_name
+            Loggable<rerun::components::SeriesVisible>::ComponentName
         );
         /// `ComponentDescriptor` for the `aggregation_policy` field.
         static constexpr auto Descriptor_aggregation_policy = ComponentDescriptor(
             ArchetypeName, "aggregation_policy",
-            Loggable<rerun::components::AggregationPolicy>::Descriptor.component_name
+            Loggable<rerun::components::AggregationPolicy>::ComponentName
         );
 
       public: // START of extensions from series_lines_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/series_points.hpp
+++ b/rerun_cpp/src/rerun/archetypes/series_points.hpp
@@ -115,26 +115,24 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
-            ArchetypeName, "colors", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
         );
         /// `ComponentDescriptor` for the `markers` field.
         static constexpr auto Descriptor_markers = ComponentDescriptor(
-            ArchetypeName, "markers",
-            Loggable<rerun::components::MarkerShape>::Descriptor.component_name
+            ArchetypeName, "markers", Loggable<rerun::components::MarkerShape>::ComponentName
         );
         /// `ComponentDescriptor` for the `names` field.
         static constexpr auto Descriptor_names = ComponentDescriptor(
-            ArchetypeName, "names", Loggable<rerun::components::Name>::Descriptor.component_name
+            ArchetypeName, "names", Loggable<rerun::components::Name>::ComponentName
         );
         /// `ComponentDescriptor` for the `visible_series` field.
         static constexpr auto Descriptor_visible_series = ComponentDescriptor(
             ArchetypeName, "visible_series",
-            Loggable<rerun::components::SeriesVisible>::Descriptor.component_name
+            Loggable<rerun::components::SeriesVisible>::ComponentName
         );
         /// `ComponentDescriptor` for the `marker_sizes` field.
         static constexpr auto Descriptor_marker_sizes = ComponentDescriptor(
-            ArchetypeName, "marker_sizes",
-            Loggable<rerun::components::MarkerSize>::Descriptor.component_name
+            ArchetypeName, "marker_sizes", Loggable<rerun::components::MarkerSize>::ComponentName
         );
 
       public: // START of extensions from series_points_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/tensor.hpp
+++ b/rerun_cpp/src/rerun/archetypes/tensor.hpp
@@ -79,13 +79,11 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `data` field.
         static constexpr auto Descriptor_data = ComponentDescriptor(
-            ArchetypeName, "data",
-            Loggable<rerun::components::TensorData>::Descriptor.component_name
+            ArchetypeName, "data", Loggable<rerun::components::TensorData>::ComponentName
         );
         /// `ComponentDescriptor` for the `value_range` field.
         static constexpr auto Descriptor_value_range = ComponentDescriptor(
-            ArchetypeName, "value_range",
-            Loggable<rerun::components::ValueRange>::Descriptor.component_name
+            ArchetypeName, "value_range", Loggable<rerun::components::ValueRange>::ComponentName
         );
 
       public: // START of extensions from tensor_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/text_document.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_document.hpp
@@ -98,12 +98,11 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `text` field.
         static constexpr auto Descriptor_text = ComponentDescriptor(
-            ArchetypeName, "text", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "text", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `media_type` field.
         static constexpr auto Descriptor_media_type = ComponentDescriptor(
-            ArchetypeName, "media_type",
-            Loggable<rerun::components::MediaType>::Descriptor.component_name
+            ArchetypeName, "media_type", Loggable<rerun::components::MediaType>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/text_log.hpp
+++ b/rerun_cpp/src/rerun/archetypes/text_log.hpp
@@ -100,16 +100,15 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `text` field.
         static constexpr auto Descriptor_text = ComponentDescriptor(
-            ArchetypeName, "text", Loggable<rerun::components::Text>::Descriptor.component_name
+            ArchetypeName, "text", Loggable<rerun::components::Text>::ComponentName
         );
         /// `ComponentDescriptor` for the `level` field.
         static constexpr auto Descriptor_level = ComponentDescriptor(
-            ArchetypeName, "level",
-            Loggable<rerun::components::TextLogLevel>::Descriptor.component_name
+            ArchetypeName, "level", Loggable<rerun::components::TextLogLevel>::ComponentName
         );
         /// `ComponentDescriptor` for the `color` field.
         static constexpr auto Descriptor_color = ComponentDescriptor(
-            ArchetypeName, "color", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "color", Loggable<rerun::components::Color>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -336,37 +336,32 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `translation` field.
         static constexpr auto Descriptor_translation = ComponentDescriptor(
-            ArchetypeName, "translation",
-            Loggable<rerun::components::Translation3D>::Descriptor.component_name
+            ArchetypeName, "translation", Loggable<rerun::components::Translation3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `rotation_axis_angle` field.
         static constexpr auto Descriptor_rotation_axis_angle = ComponentDescriptor(
             ArchetypeName, "rotation_axis_angle",
-            Loggable<rerun::components::RotationAxisAngle>::Descriptor.component_name
+            Loggable<rerun::components::RotationAxisAngle>::ComponentName
         );
         /// `ComponentDescriptor` for the `quaternion` field.
         static constexpr auto Descriptor_quaternion = ComponentDescriptor(
-            ArchetypeName, "quaternion",
-            Loggable<rerun::components::RotationQuat>::Descriptor.component_name
+            ArchetypeName, "quaternion", Loggable<rerun::components::RotationQuat>::ComponentName
         );
         /// `ComponentDescriptor` for the `scale` field.
         static constexpr auto Descriptor_scale = ComponentDescriptor(
-            ArchetypeName, "scale", Loggable<rerun::components::Scale3D>::Descriptor.component_name
+            ArchetypeName, "scale", Loggable<rerun::components::Scale3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `mat3x3` field.
         static constexpr auto Descriptor_mat3x3 = ComponentDescriptor(
-            ArchetypeName, "mat3x3",
-            Loggable<rerun::components::TransformMat3x3>::Descriptor.component_name
+            ArchetypeName, "mat3x3", Loggable<rerun::components::TransformMat3x3>::ComponentName
         );
         /// `ComponentDescriptor` for the `relation` field.
         static constexpr auto Descriptor_relation = ComponentDescriptor(
-            ArchetypeName, "relation",
-            Loggable<rerun::components::TransformRelation>::Descriptor.component_name
+            ArchetypeName, "relation", Loggable<rerun::components::TransformRelation>::ComponentName
         );
         /// `ComponentDescriptor` for the `axis_length` field.
         static constexpr auto Descriptor_axis_length = ComponentDescriptor(
-            ArchetypeName, "axis_length",
-            Loggable<rerun::components::AxisLength>::Descriptor.component_name
+            ArchetypeName, "axis_length", Loggable<rerun::components::AxisLength>::ComponentName
         );
 
       public: // START of extensions from transform3d_ext.cpp:

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -148,18 +148,15 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `timestamp` field.
         static constexpr auto Descriptor_timestamp = ComponentDescriptor(
-            ArchetypeName, "timestamp",
-            Loggable<rerun::components::VideoTimestamp>::Descriptor.component_name
+            ArchetypeName, "timestamp", Loggable<rerun::components::VideoTimestamp>::ComponentName
         );
         /// `ComponentDescriptor` for the `video_reference` field.
         static constexpr auto Descriptor_video_reference = ComponentDescriptor(
-            ArchetypeName, "video_reference",
-            Loggable<rerun::components::EntityPath>::Descriptor.component_name
+            ArchetypeName, "video_reference", Loggable<rerun::components::EntityPath>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/video_stream.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_stream.hpp
@@ -71,18 +71,15 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `sample` field.
         static constexpr auto Descriptor_sample = ComponentDescriptor(
-            ArchetypeName, "sample",
-            Loggable<rerun::components::VideoSample>::Descriptor.component_name
+            ArchetypeName, "sample", Loggable<rerun::components::VideoSample>::ComponentName
         );
         /// `ComponentDescriptor` for the `codec` field.
         static constexpr auto Descriptor_codec = ComponentDescriptor(
-            ArchetypeName, "codec",
-            Loggable<rerun::components::VideoCodec>::Descriptor.component_name
+            ArchetypeName, "codec", Loggable<rerun::components::VideoCodec>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
-            ArchetypeName, "draw_order",
-            Loggable<rerun::components::DrawOrder>::Descriptor.component_name
+            ArchetypeName, "draw_order", Loggable<rerun::components::DrawOrder>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/archetypes/view_coordinates.hpp
@@ -68,8 +68,7 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `xyz` field.
         static constexpr auto Descriptor_xyz = ComponentDescriptor(
-            ArchetypeName, "xyz",
-            Loggable<rerun::components::ViewCoordinates>::Descriptor.component_name
+            ArchetypeName, "xyz", Loggable<rerun::components::ViewCoordinates>::ComponentName
         );
 
       public: // START of extensions from view_coordinates_ext.cpp:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/background.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/background.hpp
@@ -40,11 +40,11 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `kind` field.
         static constexpr auto Descriptor_kind = ComponentDescriptor(
             ArchetypeName, "kind",
-            Loggable<rerun::blueprint::components::BackgroundKind>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::BackgroundKind>::ComponentName
         );
         /// `ComponentDescriptor` for the `color` field.
         static constexpr auto Descriptor_color = ComponentDescriptor(
-            ArchetypeName, "color", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "color", Loggable<rerun::components::Color>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/container_blueprint.hpp
@@ -81,42 +81,40 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `container_kind` field.
         static constexpr auto Descriptor_container_kind = ComponentDescriptor(
             ArchetypeName, "container_kind",
-            Loggable<rerun::blueprint::components::ContainerKind>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ContainerKind>::ComponentName
         );
         /// `ComponentDescriptor` for the `display_name` field.
         static constexpr auto Descriptor_display_name = ComponentDescriptor(
-            ArchetypeName, "display_name",
-            Loggable<rerun::components::Name>::Descriptor.component_name
+            ArchetypeName, "display_name", Loggable<rerun::components::Name>::ComponentName
         );
         /// `ComponentDescriptor` for the `contents` field.
         static constexpr auto Descriptor_contents = ComponentDescriptor(
             ArchetypeName, "contents",
-            Loggable<rerun::blueprint::components::IncludedContent>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::IncludedContent>::ComponentName
         );
         /// `ComponentDescriptor` for the `col_shares` field.
         static constexpr auto Descriptor_col_shares = ComponentDescriptor(
             ArchetypeName, "col_shares",
-            Loggable<rerun::blueprint::components::ColumnShare>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ColumnShare>::ComponentName
         );
         /// `ComponentDescriptor` for the `row_shares` field.
         static constexpr auto Descriptor_row_shares = ComponentDescriptor(
             ArchetypeName, "row_shares",
-            Loggable<rerun::blueprint::components::RowShare>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::RowShare>::ComponentName
         );
         /// `ComponentDescriptor` for the `active_tab` field.
         static constexpr auto Descriptor_active_tab = ComponentDescriptor(
             ArchetypeName, "active_tab",
-            Loggable<rerun::blueprint::components::ActiveTab>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ActiveTab>::ComponentName
         );
         /// `ComponentDescriptor` for the `visible` field.
         static constexpr auto Descriptor_visible = ComponentDescriptor(
-            ArchetypeName, "visible",
-            Loggable<rerun::components::Visible>::Descriptor.component_name
+            ArchetypeName, "visible", Loggable<rerun::components::Visible>::ComponentName
         );
         /// `ComponentDescriptor` for the `grid_columns` field.
         static constexpr auto Descriptor_grid_columns = ComponentDescriptor(
             ArchetypeName, "grid_columns",
-            Loggable<rerun::blueprint::components::GridColumns>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::GridColumns>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/dataframe_query.hpp
@@ -56,27 +56,27 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `timeline` field.
         static constexpr auto Descriptor_timeline = ComponentDescriptor(
             ArchetypeName, "timeline",
-            Loggable<rerun::blueprint::components::TimelineName>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::TimelineName>::ComponentName
         );
         /// `ComponentDescriptor` for the `filter_by_range` field.
         static constexpr auto Descriptor_filter_by_range = ComponentDescriptor(
             ArchetypeName, "filter_by_range",
-            Loggable<rerun::blueprint::components::FilterByRange>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::FilterByRange>::ComponentName
         );
         /// `ComponentDescriptor` for the `filter_is_not_null` field.
         static constexpr auto Descriptor_filter_is_not_null = ComponentDescriptor(
             ArchetypeName, "filter_is_not_null",
-            Loggable<rerun::blueprint::components::FilterIsNotNull>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::FilterIsNotNull>::ComponentName
         );
         /// `ComponentDescriptor` for the `apply_latest_at` field.
         static constexpr auto Descriptor_apply_latest_at = ComponentDescriptor(
             ArchetypeName, "apply_latest_at",
-            Loggable<rerun::blueprint::components::ApplyLatestAt>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ApplyLatestAt>::ComponentName
         );
         /// `ComponentDescriptor` for the `select` field.
         static constexpr auto Descriptor_select = ComponentDescriptor(
             ArchetypeName, "select",
-            Loggable<rerun::blueprint::components::SelectedColumns>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::SelectedColumns>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/entity_behavior.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/entity_behavior.hpp
@@ -48,13 +48,11 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `interactive` field.
         static constexpr auto Descriptor_interactive = ComponentDescriptor(
-            ArchetypeName, "interactive",
-            Loggable<rerun::components::Interactive>::Descriptor.component_name
+            ArchetypeName, "interactive", Loggable<rerun::components::Interactive>::ComponentName
         );
         /// `ComponentDescriptor` for the `visible` field.
         static constexpr auto Descriptor_visible = ComponentDescriptor(
-            ArchetypeName, "visible",
-            Loggable<rerun::components::Visible>::Descriptor.component_name
+            ArchetypeName, "visible", Loggable<rerun::components::Visible>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_center.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_center.hpp
@@ -41,13 +41,12 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `enabled` field.
         static constexpr auto Descriptor_enabled = ComponentDescriptor(
-            ArchetypeName, "enabled",
-            Loggable<rerun::blueprint::components::Enabled>::Descriptor.component_name
+            ArchetypeName, "enabled", Loggable<rerun::blueprint::components::Enabled>::ComponentName
         );
         /// `ComponentDescriptor` for the `strength` field.
         static constexpr auto Descriptor_strength = ComponentDescriptor(
             ArchetypeName, "strength",
-            Loggable<rerun::blueprint::components::ForceStrength>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ForceStrength>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_collision_radius.hpp
@@ -48,18 +48,17 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `enabled` field.
         static constexpr auto Descriptor_enabled = ComponentDescriptor(
-            ArchetypeName, "enabled",
-            Loggable<rerun::blueprint::components::Enabled>::Descriptor.component_name
+            ArchetypeName, "enabled", Loggable<rerun::blueprint::components::Enabled>::ComponentName
         );
         /// `ComponentDescriptor` for the `strength` field.
         static constexpr auto Descriptor_strength = ComponentDescriptor(
             ArchetypeName, "strength",
-            Loggable<rerun::blueprint::components::ForceStrength>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ForceStrength>::ComponentName
         );
         /// `ComponentDescriptor` for the `iterations` field.
         static constexpr auto Descriptor_iterations = ComponentDescriptor(
             ArchetypeName, "iterations",
-            Loggable<rerun::blueprint::components::ForceIterations>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ForceIterations>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_link.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_link.hpp
@@ -47,18 +47,17 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `enabled` field.
         static constexpr auto Descriptor_enabled = ComponentDescriptor(
-            ArchetypeName, "enabled",
-            Loggable<rerun::blueprint::components::Enabled>::Descriptor.component_name
+            ArchetypeName, "enabled", Loggable<rerun::blueprint::components::Enabled>::ComponentName
         );
         /// `ComponentDescriptor` for the `distance` field.
         static constexpr auto Descriptor_distance = ComponentDescriptor(
             ArchetypeName, "distance",
-            Loggable<rerun::blueprint::components::ForceDistance>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ForceDistance>::ComponentName
         );
         /// `ComponentDescriptor` for the `iterations` field.
         static constexpr auto Descriptor_iterations = ComponentDescriptor(
             ArchetypeName, "iterations",
-            Loggable<rerun::blueprint::components::ForceIterations>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ForceIterations>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_many_body.hpp
@@ -46,13 +46,12 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `enabled` field.
         static constexpr auto Descriptor_enabled = ComponentDescriptor(
-            ArchetypeName, "enabled",
-            Loggable<rerun::blueprint::components::Enabled>::Descriptor.component_name
+            ArchetypeName, "enabled", Loggable<rerun::blueprint::components::Enabled>::ComponentName
         );
         /// `ComponentDescriptor` for the `strength` field.
         static constexpr auto Descriptor_strength = ComponentDescriptor(
             ArchetypeName, "strength",
-            Loggable<rerun::blueprint::components::ForceStrength>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ForceStrength>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/force_position.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/force_position.hpp
@@ -45,18 +45,16 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `enabled` field.
         static constexpr auto Descriptor_enabled = ComponentDescriptor(
-            ArchetypeName, "enabled",
-            Loggable<rerun::blueprint::components::Enabled>::Descriptor.component_name
+            ArchetypeName, "enabled", Loggable<rerun::blueprint::components::Enabled>::ComponentName
         );
         /// `ComponentDescriptor` for the `strength` field.
         static constexpr auto Descriptor_strength = ComponentDescriptor(
             ArchetypeName, "strength",
-            Loggable<rerun::blueprint::components::ForceStrength>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ForceStrength>::ComponentName
         );
         /// `ComponentDescriptor` for the `position` field.
         static constexpr auto Descriptor_position = ComponentDescriptor(
-            ArchetypeName, "position",
-            Loggable<rerun::components::Position2D>::Descriptor.component_name
+            ArchetypeName, "position", Loggable<rerun::components::Position2D>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/line_grid3d.hpp
@@ -63,26 +63,24 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `visible` field.
         static constexpr auto Descriptor_visible = ComponentDescriptor(
-            ArchetypeName, "visible",
-            Loggable<rerun::components::Visible>::Descriptor.component_name
+            ArchetypeName, "visible", Loggable<rerun::components::Visible>::ComponentName
         );
         /// `ComponentDescriptor` for the `spacing` field.
         static constexpr auto Descriptor_spacing = ComponentDescriptor(
             ArchetypeName, "spacing",
-            Loggable<rerun::blueprint::components::GridSpacing>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::GridSpacing>::ComponentName
         );
         /// `ComponentDescriptor` for the `plane` field.
         static constexpr auto Descriptor_plane = ComponentDescriptor(
-            ArchetypeName, "plane", Loggable<rerun::components::Plane3D>::Descriptor.component_name
+            ArchetypeName, "plane", Loggable<rerun::components::Plane3D>::ComponentName
         );
         /// `ComponentDescriptor` for the `stroke_width` field.
         static constexpr auto Descriptor_stroke_width = ComponentDescriptor(
-            ArchetypeName, "stroke_width",
-            Loggable<rerun::components::StrokeWidth>::Descriptor.component_name
+            ArchetypeName, "stroke_width", Loggable<rerun::components::StrokeWidth>::ComponentName
         );
         /// `ComponentDescriptor` for the `color` field.
         static constexpr auto Descriptor_color = ComponentDescriptor(
-            ArchetypeName, "color", Loggable<rerun::components::Color>::Descriptor.component_name
+            ArchetypeName, "color", Loggable<rerun::components::Color>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_background.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_background.hpp
@@ -38,7 +38,7 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `provider` field.
         static constexpr auto Descriptor_provider = ComponentDescriptor(
             ArchetypeName, "provider",
-            Loggable<rerun::blueprint::components::MapProvider>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::MapProvider>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/map_zoom.hpp
@@ -37,8 +37,7 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `zoom` field.
         static constexpr auto Descriptor_zoom = ComponentDescriptor(
-            ArchetypeName, "zoom",
-            Loggable<rerun::blueprint::components::ZoomLevel>::Descriptor.component_name
+            ArchetypeName, "zoom", Loggable<rerun::blueprint::components::ZoomLevel>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/near_clip_plane.hpp
@@ -38,7 +38,7 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `near_clip_plane` field.
         static constexpr auto Descriptor_near_clip_plane = ComponentDescriptor(
             ArchetypeName, "near_clip_plane",
-            Loggable<rerun::blueprint::components::NearClipPlane>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::NearClipPlane>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/panel_blueprint.hpp
@@ -36,7 +36,7 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `state` field.
         static constexpr auto Descriptor_state = ComponentDescriptor(
             ArchetypeName, "state",
-            Loggable<rerun::blueprint::components::PanelState>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::PanelState>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/plot_legend.hpp
@@ -43,13 +43,11 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `corner` field.
         static constexpr auto Descriptor_corner = ComponentDescriptor(
-            ArchetypeName, "corner",
-            Loggable<rerun::blueprint::components::Corner2D>::Descriptor.component_name
+            ArchetypeName, "corner", Loggable<rerun::blueprint::components::Corner2D>::ComponentName
         );
         /// `ComponentDescriptor` for the `visible` field.
         static constexpr auto Descriptor_visible = ComponentDescriptor(
-            ArchetypeName, "visible",
-            Loggable<rerun::components::Visible>::Descriptor.component_name
+            ArchetypeName, "visible", Loggable<rerun::components::Visible>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/scalar_axis.hpp
@@ -41,12 +41,12 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `range` field.
         static constexpr auto Descriptor_range = ComponentDescriptor(
-            ArchetypeName, "range", Loggable<rerun::components::Range1D>::Descriptor.component_name
+            ArchetypeName, "range", Loggable<rerun::components::Range1D>::ComponentName
         );
         /// `ComponentDescriptor` for the `zoom_lock` field.
         static constexpr auto Descriptor_zoom_lock = ComponentDescriptor(
             ArchetypeName, "zoom_lock",
-            Loggable<rerun::blueprint::components::LockRangeDuringZoom>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::LockRangeDuringZoom>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_scalar_mapping.hpp
@@ -53,17 +53,15 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `mag_filter` field.
         static constexpr auto Descriptor_mag_filter = ComponentDescriptor(
             ArchetypeName, "mag_filter",
-            Loggable<rerun::components::MagnificationFilter>::Descriptor.component_name
+            Loggable<rerun::components::MagnificationFilter>::ComponentName
         );
         /// `ComponentDescriptor` for the `colormap` field.
         static constexpr auto Descriptor_colormap = ComponentDescriptor(
-            ArchetypeName, "colormap",
-            Loggable<rerun::components::Colormap>::Descriptor.component_name
+            ArchetypeName, "colormap", Loggable<rerun::components::Colormap>::ComponentName
         );
         /// `ComponentDescriptor` for the `gamma` field.
         static constexpr auto Descriptor_gamma = ComponentDescriptor(
-            ArchetypeName, "gamma",
-            Loggable<rerun::components::GammaCorrection>::Descriptor.component_name
+            ArchetypeName, "gamma", Loggable<rerun::components::GammaCorrection>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_slice_selection.hpp
@@ -58,24 +58,22 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `width` field.
         static constexpr auto Descriptor_width = ComponentDescriptor(
-            ArchetypeName, "width",
-            Loggable<rerun::components::TensorWidthDimension>::Descriptor.component_name
+            ArchetypeName, "width", Loggable<rerun::components::TensorWidthDimension>::ComponentName
         );
         /// `ComponentDescriptor` for the `height` field.
         static constexpr auto Descriptor_height = ComponentDescriptor(
             ArchetypeName, "height",
-            Loggable<rerun::components::TensorHeightDimension>::Descriptor.component_name
+            Loggable<rerun::components::TensorHeightDimension>::ComponentName
         );
         /// `ComponentDescriptor` for the `indices` field.
         static constexpr auto Descriptor_indices = ComponentDescriptor(
             ArchetypeName, "indices",
-            Loggable<rerun::components::TensorDimensionIndexSelection>::Descriptor.component_name
+            Loggable<rerun::components::TensorDimensionIndexSelection>::ComponentName
         );
         /// `ComponentDescriptor` for the `slider` field.
         static constexpr auto Descriptor_slider = ComponentDescriptor(
             ArchetypeName, "slider",
-            Loggable<rerun::blueprint::components::TensorDimensionIndexSlider>::Descriptor
-                .component_name
+            Loggable<rerun::blueprint::components::TensorDimensionIndexSlider>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/tensor_view_fit.hpp
@@ -35,8 +35,7 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `scaling` field.
         static constexpr auto Descriptor_scaling = ComponentDescriptor(
-            ArchetypeName, "scaling",
-            Loggable<rerun::blueprint::components::ViewFit>::Descriptor.component_name
+            ArchetypeName, "scaling", Loggable<rerun::blueprint::components::ViewFit>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/time_axis.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/time_axis.hpp
@@ -35,8 +35,7 @@ namespace rerun::blueprint::archetypes {
 
         /// `ComponentDescriptor` for the `link` field.
         static constexpr auto Descriptor_link = ComponentDescriptor(
-            ArchetypeName, "link",
-            Loggable<rerun::blueprint::components::LinkAxis>::Descriptor.component_name
+            ArchetypeName, "link", Loggable<rerun::blueprint::components::LinkAxis>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_blueprint.hpp
@@ -56,22 +56,20 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `class_identifier` field.
         static constexpr auto Descriptor_class_identifier = ComponentDescriptor(
             ArchetypeName, "class_identifier",
-            Loggable<rerun::blueprint::components::ViewClass>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ViewClass>::ComponentName
         );
         /// `ComponentDescriptor` for the `display_name` field.
         static constexpr auto Descriptor_display_name = ComponentDescriptor(
-            ArchetypeName, "display_name",
-            Loggable<rerun::components::Name>::Descriptor.component_name
+            ArchetypeName, "display_name", Loggable<rerun::components::Name>::ComponentName
         );
         /// `ComponentDescriptor` for the `space_origin` field.
         static constexpr auto Descriptor_space_origin = ComponentDescriptor(
             ArchetypeName, "space_origin",
-            Loggable<rerun::blueprint::components::ViewOrigin>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ViewOrigin>::ComponentName
         );
         /// `ComponentDescriptor` for the `visible` field.
         static constexpr auto Descriptor_visible = ComponentDescriptor(
-            ArchetypeName, "visible",
-            Loggable<rerun::components::Visible>::Descriptor.component_name
+            ArchetypeName, "visible", Loggable<rerun::components::Visible>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/view_contents.hpp
@@ -75,7 +75,7 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `query` field.
         static constexpr auto Descriptor_query = ComponentDescriptor(
             ArchetypeName, "query",
-            Loggable<rerun::blueprint::components::QueryExpression>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::QueryExpression>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/viewport_blueprint.hpp
@@ -65,28 +65,27 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `root_container` field.
         static constexpr auto Descriptor_root_container = ComponentDescriptor(
             ArchetypeName, "root_container",
-            Loggable<rerun::blueprint::components::RootContainer>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::RootContainer>::ComponentName
         );
         /// `ComponentDescriptor` for the `maximized` field.
         static constexpr auto Descriptor_maximized = ComponentDescriptor(
             ArchetypeName, "maximized",
-            Loggable<rerun::blueprint::components::ViewMaximized>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::ViewMaximized>::ComponentName
         );
         /// `ComponentDescriptor` for the `auto_layout` field.
         static constexpr auto Descriptor_auto_layout = ComponentDescriptor(
             ArchetypeName, "auto_layout",
-            Loggable<rerun::blueprint::components::AutoLayout>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::AutoLayout>::ComponentName
         );
         /// `ComponentDescriptor` for the `auto_views` field.
         static constexpr auto Descriptor_auto_views = ComponentDescriptor(
             ArchetypeName, "auto_views",
-            Loggable<rerun::blueprint::components::AutoViews>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::AutoViews>::ComponentName
         );
         /// `ComponentDescriptor` for the `past_viewer_recommendations` field.
         static constexpr auto Descriptor_past_viewer_recommendations = ComponentDescriptor(
             ArchetypeName, "past_viewer_recommendations",
-            Loggable<rerun::blueprint::components::ViewerRecommendationHash>::Descriptor
-                .component_name
+            Loggable<rerun::blueprint::components::ViewerRecommendationHash>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
@@ -47,7 +47,7 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `ranges` field.
         static constexpr auto Descriptor_ranges = ComponentDescriptor(
             ArchetypeName, "ranges",
-            Loggable<rerun::blueprint::components::VisibleTimeRange>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::VisibleTimeRange>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visual_bounds2d.hpp
@@ -44,7 +44,7 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `range` field.
         static constexpr auto Descriptor_range = ComponentDescriptor(
             ArchetypeName, "range",
-            Loggable<rerun::blueprint::components::VisualBounds2D>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::VisualBounds2D>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visualizer_overrides.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visualizer_overrides.hpp
@@ -46,7 +46,7 @@ namespace rerun::blueprint::archetypes {
         /// `ComponentDescriptor` for the `ranges` field.
         static constexpr auto Descriptor_ranges = ComponentDescriptor(
             ArchetypeName, "ranges",
-            Loggable<rerun::blueprint::components::VisualizerOverride>::Descriptor.component_name
+            Loggable<rerun::blueprint::components::VisualizerOverride>::ComponentName
         );
 
       public:

--- a/rerun_cpp/src/rerun/blueprint/components/active_tab.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/active_tab.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/entity_path.hpp"
 #include "../../result.hpp"
 
@@ -53,7 +52,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ActiveTab> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.ActiveTab";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.ActiveTab";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/apply_latest_at.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/apply_latest_at.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/bool.hpp"
 #include "../../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ApplyLatestAt> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ApplyLatestAt";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/auto_layout.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/auto_layout.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/bool.hpp"
 #include "../../result.hpp"
 
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::AutoLayout> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.AutoLayout";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.AutoLayout";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/auto_views.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/auto_views.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/bool.hpp"
 #include "../../result.hpp"
 
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::AutoViews> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.AutoViews";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.AutoViews";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/background_kind.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/background_kind.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::BackgroundKind> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.BackgroundKind";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/column_share.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/column_share.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/float32.hpp"
 #include "../../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ColumnShare> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.ColumnShare";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.ColumnShare";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/component_column_selector.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/component_column_selector.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../blueprint/datatypes/component_column_selector.hpp"
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ComponentColumnSelector> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ComponentColumnSelector";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/container_kind.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/container_kind.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ContainerKind> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ContainerKind";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/corner2d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/corner2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::Corner2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.Corner2D";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.Corner2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/blueprint/components/enabled.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/enabled.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/bool.hpp"
 #include "../../result.hpp"
 
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::Enabled> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.Enabled";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.Enabled";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/filter_by_range.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/filter_by_range.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../blueprint/datatypes/filter_by_range.hpp"
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::FilterByRange> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.FilterByRange";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/filter_is_not_null.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/filter_is_not_null.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../blueprint/datatypes/filter_is_not_null.hpp"
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::FilterIsNotNull> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.FilterIsNotNull";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/force_distance.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/force_distance.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/float64.hpp"
 #include "../../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ForceDistance> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ForceDistance";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/force_iterations.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/force_iterations.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/uint64.hpp"
 #include "../../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ForceIterations> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ForceIterations";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/force_strength.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/force_strength.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/float64.hpp"
 #include "../../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ForceStrength> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ForceStrength";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/grid_columns.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/grid_columns.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/uint32.hpp"
 #include "../../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::GridColumns> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.GridColumns";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.GridColumns";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/grid_spacing.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/grid_spacing.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/float32.hpp"
 #include "../../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::GridSpacing> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.GridSpacing";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.GridSpacing";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/included_content.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/included_content.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/entity_path.hpp"
 #include "../../result.hpp"
 
@@ -56,7 +55,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::IncludedContent> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.IncludedContent";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/link_axis.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/link_axis.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::LinkAxis> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.LinkAxis";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.LinkAxis";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/blueprint/components/lock_range_during_zoom.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/lock_range_during_zoom.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/bool.hpp"
 #include "../../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::LockRangeDuringZoom> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.LockRangeDuringZoom";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/map_provider.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/map_provider.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::MapProvider> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.MapProvider";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.MapProvider";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/blueprint/components/near_clip_plane.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/near_clip_plane.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/float32.hpp"
 #include "../../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::NearClipPlane> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.NearClipPlane";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/panel_state.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/panel_state.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::PanelState> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.PanelState";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.PanelState";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/utf8.hpp"
 #include "../../result.hpp"
 
@@ -59,7 +58,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::QueryExpression> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.QueryExpression";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/root_container.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/root_container.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/uuid.hpp"
 #include "../../result.hpp"
 
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::RootContainer> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.RootContainer";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/row_share.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/row_share.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/float32.hpp"
 #include "../../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::RowShare> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.RowShare";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.RowShare";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/selected_columns.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/selected_columns.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../blueprint/datatypes/selected_columns.hpp"
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::SelectedColumns> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.SelectedColumns";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/tensor_dimension_index_slider.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/tensor_dimension_index_slider.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../blueprint/datatypes/tensor_dimension_index_slider.hpp"
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -56,7 +55,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::TensorDimensionIndexSlider> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.TensorDimensionIndexSlider";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/timeline_name.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/timeline_name.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/utf8.hpp"
 #include "../../result.hpp"
 
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::TimelineName> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.TimelineName";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.TimelineName";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/view_class.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/view_class.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/utf8.hpp"
 #include "../../result.hpp"
 
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ViewClass> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.ViewClass";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.ViewClass";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/view_fit.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/view_fit.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ViewFit> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.ViewFit";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.ViewFit";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/blueprint/components/view_maximized.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/view_maximized.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/uuid.hpp"
 #include "../../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ViewMaximized> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ViewMaximized";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/view_origin.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/view_origin.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/entity_path.hpp"
 #include "../../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ViewOrigin> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.ViewOrigin";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.ViewOrigin";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/components/viewer_recommendation_hash.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/viewer_recommendation_hash.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/uint64.hpp"
 #include "../../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ViewerRecommendationHash> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.ViewerRecommendationHash";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/visible_time_range.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visible_time_range.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/visible_time_range.hpp"
 #include "../../result.hpp"
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::VisibleTimeRange> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.VisibleTimeRange";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/visual_bounds2d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visual_bounds2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/range2d.hpp"
 #include "../../result.hpp"
 
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::VisualBounds2D> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.VisualBounds2D";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/visualizer_override.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visualizer_override.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/utf8.hpp"
 #include "../../result.hpp"
 
@@ -56,7 +55,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::VisualizerOverride> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.components.VisualizerOverride";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/components/zoom_level.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/zoom_level.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/float64.hpp"
 #include "../../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::components::ZoomLevel> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.components.ZoomLevel";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.components.ZoomLevel";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/blueprint/datatypes/component_column_selector.hpp
+++ b/rerun_cpp/src/rerun/blueprint/datatypes/component_column_selector.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/entity_path.hpp"
 #include "../../datatypes/utf8.hpp"
 #include "../../result.hpp"
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::datatypes::ComponentColumnSelector> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.datatypes.ComponentColumnSelector";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/datatypes/filter_by_range.hpp
+++ b/rerun_cpp/src/rerun/blueprint/datatypes/filter_by_range.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/time_int.hpp"
 #include "../../result.hpp"
 
@@ -40,7 +39,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::datatypes::FilterByRange> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.blueprint.datatypes.FilterByRange";
+        static constexpr std::string_view ComponentName = "rerun.blueprint.datatypes.FilterByRange";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/blueprint/datatypes/filter_is_not_null.hpp
+++ b/rerun_cpp/src/rerun/blueprint/datatypes/filter_is_not_null.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/bool.hpp"
 #include "../../result.hpp"
 #include "component_column_selector.hpp"
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::datatypes::FilterIsNotNull> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.datatypes.FilterIsNotNull";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/datatypes/selected_columns.hpp
+++ b/rerun_cpp/src/rerun/blueprint/datatypes/selected_columns.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../../collection.hpp"
-#include "../../component_descriptor.hpp"
 #include "../../datatypes/utf8.hpp"
 #include "../../result.hpp"
 #include "component_column_selector.hpp"
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::datatypes::SelectedColumns> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.datatypes.SelectedColumns";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/blueprint/datatypes/tensor_dimension_index_slider.hpp
+++ b/rerun_cpp/src/rerun/blueprint/datatypes/tensor_dimension_index_slider.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../../component_descriptor.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -43,7 +42,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<blueprint::datatypes::TensorDimensionIndexSlider> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.blueprint.datatypes.TensorDimensionIndexSlider";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/component_descriptor.hpp
+++ b/rerun_cpp/src/rerun/component_descriptor.hpp
@@ -50,9 +50,11 @@ namespace rerun {
               archetype_field_name(archetype_field_name_),
               component_name(component_name_) {}
 
+        // TODO(#6889): This is only needed by indicators. Remove after removing them.
         constexpr ComponentDescriptor(std::string_view component_name_)
             : component_name(component_name_) {}
 
+        // TODO(#6889): This is only needed by indicators. Remove after removing them.
         constexpr ComponentDescriptor(const char* component_name_)
             : component_name(component_name_) {}
 

--- a/rerun_cpp/src/rerun/component_descriptor.hpp
+++ b/rerun_cpp/src/rerun/component_descriptor.hpp
@@ -19,24 +19,24 @@ namespace rerun {
         /// Example: `rerun.archetypes.Points3D`.
         std::optional<std::string_view> archetype_name;
 
-        /// Optional name of the field within `Archetype` associated with this data.
-        ///
-        /// `None` if the data wasn't logged through an archetype.
+        /// Name of the field within `Archetype` associated with this data.
         ///
         /// Example: `positions`.
-        std::optional<std::string_view> archetype_field_name;
+        std::string_view archetype_field_name;
 
-        /// Semantic name associated with this data.
+        /// Optional semantic name associated with this data.
         ///
         /// This is fully implied by `archetype_name` and `archetype_field`, but
         /// included for semantic convenience.
+        //
+        /// `None` if the data wasn't logged through an archetype.
         ///
         /// Example: `rerun.components.Position3D`.
-        std::string_view component_name;
+        std::optional<std::string_view> component_name;
 
         constexpr ComponentDescriptor(
             std::optional<std::string_view> archetype_name_,
-            std::optional<std::string_view> archetype_field_name_, std::string_view component_name_
+            std::optional<std::string_view> component_name_, std::string_view archetype_field_name_
         )
             : archetype_name(archetype_name_),
               archetype_field_name(archetype_field_name_),
@@ -50,20 +50,19 @@ namespace rerun {
               archetype_field_name(archetype_field_name_),
               component_name(component_name_) {}
 
-        // TODO(#6889): This is only needed by indicators. Remove after removing them.
-        constexpr ComponentDescriptor(std::string_view component_name_)
-            : component_name(component_name_) {}
+        constexpr ComponentDescriptor(std::string_view archetype_field_name_)
+            : archetype_field_name(archetype_field_name_) {}
 
-        // TODO(#6889): This is only needed by indicators. Remove after removing them.
-        constexpr ComponentDescriptor(const char* component_name_)
-            : component_name(component_name_) {}
+        constexpr ComponentDescriptor(const char* archetype_field_name_)
+            : archetype_field_name(archetype_field_name_) {}
 
         ComponentDescriptorHash hashed() const {
             std::size_t archetype_name_h =
                 std::hash<std::optional<std::string_view>>{}(this->archetype_name);
-            std::size_t component_name_h = std::hash<std::string_view>{}(this->component_name);
+            std::size_t component_name_h =
+                std::hash<std::optional<std::string_view>>{}(this->component_name);
             std::size_t archetype_field_name_h =
-                std::hash<std::optional<std::string_view>>{}(this->archetype_field_name);
+                std::hash<std::string_view>{}(this->archetype_field_name);
             return archetype_name_h ^ component_name_h ^ archetype_field_name_h;
         }
 
@@ -82,26 +81,25 @@ namespace rerun {
             return descriptor;
         }
 
-        /// Unconditionally sets `archetype_field_name` to the given one.
-        ComponentDescriptor with_archetype_field_name(
-            std::optional<std::string_view> archetype_field_name_
+        /// Unconditionally sets `component_name` to the given one.
+        ComponentDescriptor with_component_name(std::optional<std::string_view> component_name_
         ) const {
             ComponentDescriptor descriptor = *this;
-            descriptor.archetype_field_name = archetype_field_name_;
+            descriptor.component_name = component_name_;
             return descriptor;
         }
 
-        /// Unconditionally sets `archetype_field_name` to the given one.
-        ComponentDescriptor with_archetype_field_name(const char* archetype_field_name_) const {
+        /// Unconditionally sets `component_name` to the given one.
+        ComponentDescriptor with_component_name(const char* component_name_) const {
             ComponentDescriptor descriptor = *this;
-            descriptor.archetype_field_name = archetype_field_name_;
+            descriptor.component_name = component_name_;
             return descriptor;
         }
 
         /// Sets `archetype_name` to the given one iff it's not already set.
         ComponentDescriptor or_with_archetype_name(std::optional<std::string_view> archetype_name_
         ) const {
-            if (this->archetype_field_name.has_value()) {
+            if (this->archetype_name.has_value()) {
                 return *this;
             }
             ComponentDescriptor descriptor = *this;
@@ -111,7 +109,7 @@ namespace rerun {
 
         /// Sets `archetype_name` to the given one iff it's not already set.
         ComponentDescriptor or_with_archetype_name(const char* archetype_name_) const {
-            if (this->archetype_field_name.has_value()) {
+            if (this->archetype_name.has_value()) {
                 return *this;
             }
             ComponentDescriptor descriptor = *this;
@@ -120,24 +118,23 @@ namespace rerun {
         }
 
         /// Sets `archetype_field_name` to the given one iff it's not already set.
-        ComponentDescriptor or_with_archetype_field_name(
-            std::optional<std::string_view> archetype_field_name_
+        ComponentDescriptor or_with_component_name(std::optional<std::string_view> component_name_
         ) const {
-            if (this->archetype_field_name.has_value()) {
+            if (this->component_name.has_value()) {
                 return *this;
             }
             ComponentDescriptor descriptor = *this;
-            descriptor.archetype_field_name = archetype_field_name_;
+            descriptor.component_name = component_name_;
             return descriptor;
         }
 
-        /// Sets `archetype_field_name` to the given one iff it's not already set.
-        ComponentDescriptor or_with_archetype_field_name(const char* archetype_field_name_) const {
-            if (this->archetype_field_name.has_value()) {
+        /// Sets `component_name` to the given one iff it's not already set.
+        ComponentDescriptor or_with_component_name(const char* component_name_) const {
+            if (this->component_name.has_value()) {
                 return *this;
             }
             ComponentDescriptor descriptor = *this;
-            descriptor.archetype_field_name = archetype_field_name_;
+            descriptor.component_name = component_name_;
             return descriptor;
         }
     };

--- a/rerun_cpp/src/rerun/component_descriptor.hpp
+++ b/rerun_cpp/src/rerun/component_descriptor.hpp
@@ -35,8 +35,8 @@ namespace rerun {
         std::optional<std::string_view> component_name;
 
         constexpr ComponentDescriptor(
-            std::optional<std::string_view> archetype_name_,
-            std::optional<std::string_view> component_name_, std::string_view archetype_field_name_
+            std::optional<std::string_view> archetype_name_, std::string_view archetype_field_name_,
+            std::optional<std::string_view> component_name_
         )
             : archetype_name(archetype_name_),
               archetype_field_name(archetype_field_name_),

--- a/rerun_cpp/src/rerun/components/aggregation_policy.hpp
+++ b/rerun_cpp/src/rerun/components/aggregation_policy.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AggregationPolicy> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.AggregationPolicy";
+        static constexpr std::string_view ComponentName = "rerun.components.AggregationPolicy";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/albedo_factor.hpp
+++ b/rerun_cpp/src/rerun/components/albedo_factor.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/rgba32.hpp"
 #include "../result.hpp"
 
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AlbedoFactor> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.AlbedoFactor";
+        static constexpr std::string_view ComponentName = "rerun.components.AlbedoFactor";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/annotation_context.hpp
+++ b/rerun_cpp/src/rerun/components/annotation_context.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../datatypes/class_description_map_elem.hpp"
 #include "../result.hpp"
 
@@ -83,7 +82,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AnnotationContext> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.AnnotationContext";
+        static constexpr std::string_view ComponentName = "rerun.components.AnnotationContext";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/axis_length.hpp
+++ b/rerun_cpp/src/rerun/components/axis_length.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AxisLength> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.AxisLength";
+        static constexpr std::string_view ComponentName = "rerun.components.AxisLength";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/blob.hpp
+++ b/rerun_cpp/src/rerun/components/blob.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../datatypes/blob.hpp"
 #include "../result.hpp"
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Blob> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Blob";
+        static constexpr std::string_view ComponentName = "rerun.components.Blob";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/class_id.hpp"
 #include "../result.hpp"
 
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ClassId> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ClassId";
+        static constexpr std::string_view ComponentName = "rerun.components.ClassId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/bool.hpp"
 #include "../result.hpp"
 
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ClearIsRecursive> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ClearIsRecursive";
+        static constexpr std::string_view ComponentName = "rerun.components.ClearIsRecursive";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/rgba32.hpp"
 #include "../result.hpp"
 
@@ -70,7 +69,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Color> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Color";
+        static constexpr std::string_view ComponentName = "rerun.components.Color";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/colormap.hpp
+++ b/rerun_cpp/src/rerun/components/colormap.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -81,7 +80,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Colormap> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Colormap";
+        static constexpr std::string_view ComponentName = "rerun.components.Colormap";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/depth_meter.hpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -55,7 +54,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::DepthMeter> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.DepthMeter";
+        static constexpr std::string_view ComponentName = "rerun.components.DepthMeter";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::DrawOrder> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.DrawOrder";
+        static constexpr std::string_view ComponentName = "rerun.components.DrawOrder";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/entity_path.hpp
+++ b/rerun_cpp/src/rerun/components/entity_path.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/entity_path.hpp"
 #include "../result.hpp"
 
@@ -54,7 +53,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::EntityPath> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.EntityPath";
+        static constexpr std::string_view ComponentName = "rerun.components.EntityPath";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/fill_mode.hpp
+++ b/rerun_cpp/src/rerun/components/fill_mode.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -54,7 +53,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::FillMode> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.FillMode";
+        static constexpr std::string_view ComponentName = "rerun.components.FillMode";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/fill_ratio.hpp
+++ b/rerun_cpp/src/rerun/components/fill_ratio.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::FillRatio> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.FillRatio";
+        static constexpr std::string_view ComponentName = "rerun.components.FillRatio";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/gamma_correction.hpp
+++ b/rerun_cpp/src/rerun/components/gamma_correction.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -51,7 +50,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::GammaCorrection> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.GammaCorrection";
+        static constexpr std::string_view ComponentName = "rerun.components.GammaCorrection";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/geo_line_string.hpp
+++ b/rerun_cpp/src/rerun/components/geo_line_string.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../datatypes/dvec2d.hpp"
 #include "../result.hpp"
 
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::GeoLineString> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.GeoLineString";
+        static constexpr std::string_view ComponentName = "rerun.components.GeoLineString";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/graph_edge.hpp
+++ b/rerun_cpp/src/rerun/components/graph_edge.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/utf8pair.hpp"
 #include "../result.hpp"
 
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::GraphEdge> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.GraphEdge";
+        static constexpr std::string_view ComponentName = "rerun.components.GraphEdge";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/graph_node.hpp
+++ b/rerun_cpp/src/rerun/components/graph_node.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/utf8.hpp"
 #include "../result.hpp"
 
@@ -53,7 +52,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::GraphNode> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.GraphNode";
+        static constexpr std::string_view ComponentName = "rerun.components.GraphNode";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/graph_type.hpp
+++ b/rerun_cpp/src/rerun/components/graph_type.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::GraphType> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.GraphType";
+        static constexpr std::string_view ComponentName = "rerun.components.GraphType";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/half_size2d.hpp
+++ b/rerun_cpp/src/rerun/components/half_size2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
@@ -65,7 +64,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::HalfSize2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.HalfSize2D";
+        static constexpr std::string_view ComponentName = "rerun.components.HalfSize2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/half_size3d.hpp
+++ b/rerun_cpp/src/rerun/components/half_size3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -69,7 +68,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::HalfSize3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.HalfSize3D";
+        static constexpr std::string_view ComponentName = "rerun.components.HalfSize3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/image_buffer.hpp
+++ b/rerun_cpp/src/rerun/components/image_buffer.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../datatypes/blob.hpp"
 #include "../result.hpp"
 
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ImageBuffer> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ImageBuffer";
+        static constexpr std::string_view ComponentName = "rerun.components.ImageBuffer";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/image_format.hpp
+++ b/rerun_cpp/src/rerun/components/image_format.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/image_format.hpp"
 #include "../result.hpp"
 
@@ -55,7 +54,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ImageFormat> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ImageFormat";
+        static constexpr std::string_view ComponentName = "rerun.components.ImageFormat";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/image_plane_distance.hpp
+++ b/rerun_cpp/src/rerun/components/image_plane_distance.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ImagePlaneDistance> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ImagePlaneDistance";
+        static constexpr std::string_view ComponentName = "rerun.components.ImagePlaneDistance";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/interactive.hpp
+++ b/rerun_cpp/src/rerun/components/interactive.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/bool.hpp"
 #include "../result.hpp"
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Interactive> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Interactive";
+        static constexpr std::string_view ComponentName = "rerun.components.Interactive";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/keypoint_id.hpp"
 #include "../result.hpp"
 
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::KeypointId> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.KeypointId";
+        static constexpr std::string_view ComponentName = "rerun.components.KeypointId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/lat_lon.hpp
+++ b/rerun_cpp/src/rerun/components/lat_lon.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/dvec2d.hpp"
 #include "../result.hpp"
 
@@ -60,7 +59,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::LatLon> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.LatLon";
+        static constexpr std::string_view ComponentName = "rerun.components.LatLon";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/length.hpp
+++ b/rerun_cpp/src/rerun/components/length.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Length> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Length";
+        static constexpr std::string_view ComponentName = "rerun.components.Length";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/line_strip2d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip2d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
@@ -54,7 +53,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::LineStrip2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.LineStrip2D";
+        static constexpr std::string_view ComponentName = "rerun.components.LineStrip2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/line_strip3d.hpp
+++ b/rerun_cpp/src/rerun/components/line_strip3d.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -54,7 +53,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::LineStrip3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.LineStrip3D";
+        static constexpr std::string_view ComponentName = "rerun.components.LineStrip3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/magnification_filter.hpp
+++ b/rerun_cpp/src/rerun/components/magnification_filter.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::MagnificationFilter> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.MagnificationFilter";
+        static constexpr std::string_view ComponentName = "rerun.components.MagnificationFilter";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/marker_shape.hpp
+++ b/rerun_cpp/src/rerun/components/marker_shape.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -63,7 +62,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::MarkerShape> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.MarkerShape";
+        static constexpr std::string_view ComponentName = "rerun.components.MarkerShape";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/marker_size.hpp
+++ b/rerun_cpp/src/rerun/components/marker_size.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::MarkerSize> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.MarkerSize";
+        static constexpr std::string_view ComponentName = "rerun.components.MarkerSize";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/media_type.hpp
+++ b/rerun_cpp/src/rerun/components/media_type.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/utf8.hpp"
 #include "../result.hpp"
 
@@ -131,7 +130,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::MediaType> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.MediaType";
+        static constexpr std::string_view ComponentName = "rerun.components.MediaType";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/name.hpp
+++ b/rerun_cpp/src/rerun/components/name.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/utf8.hpp"
 #include "../result.hpp"
 
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Name> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Name";
+        static constexpr std::string_view ComponentName = "rerun.components.Name";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/opacity.hpp
+++ b/rerun_cpp/src/rerun/components/opacity.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Opacity> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Opacity";
+        static constexpr std::string_view ComponentName = "rerun.components.Opacity";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/pinhole_projection.hpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/mat3x3.hpp"
 #include "../result.hpp"
 
@@ -65,7 +64,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::PinholeProjection> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.PinholeProjection";
+        static constexpr std::string_view ComponentName = "rerun.components.PinholeProjection";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/plane3d.hpp
+++ b/rerun_cpp/src/rerun/components/plane3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/plane3d.hpp"
 #include "../result.hpp"
 
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Plane3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Plane3D";
+        static constexpr std::string_view ComponentName = "rerun.components.Plane3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/pose_rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/components/pose_rotation_axis_angle.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/rotation_axis_angle.hpp"
 #include "../result.hpp"
 
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::PoseRotationAxisAngle> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.PoseRotationAxisAngle";
+        static constexpr std::string_view ComponentName = "rerun.components.PoseRotationAxisAngle";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/pose_rotation_quat.hpp
+++ b/rerun_cpp/src/rerun/components/pose_rotation_quat.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/quaternion.hpp"
 #include "../result.hpp"
 
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::PoseRotationQuat> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.PoseRotationQuat";
+        static constexpr std::string_view ComponentName = "rerun.components.PoseRotationQuat";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/pose_scale3d.hpp
+++ b/rerun_cpp/src/rerun/components/pose_scale3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -73,7 +72,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::PoseScale3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.PoseScale3D";
+        static constexpr std::string_view ComponentName = "rerun.components.PoseScale3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/pose_transform_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/components/pose_transform_mat3x3.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/mat3x3.hpp"
 #include "../result.hpp"
 
@@ -58,7 +57,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::PoseTransformMat3x3> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.PoseTransformMat3x3";
+        static constexpr std::string_view ComponentName = "rerun.components.PoseTransformMat3x3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/pose_translation3d.hpp
+++ b/rerun_cpp/src/rerun/components/pose_translation3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -67,7 +66,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::PoseTranslation3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.PoseTranslation3D";
+        static constexpr std::string_view ComponentName = "rerun.components.PoseTranslation3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/position2d.hpp
+++ b/rerun_cpp/src/rerun/components/position2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
@@ -60,7 +59,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Position2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Position2D";
+        static constexpr std::string_view ComponentName = "rerun.components.Position2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/position3d.hpp
+++ b/rerun_cpp/src/rerun/components/position3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -64,7 +63,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Position3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Position3D";
+        static constexpr std::string_view ComponentName = "rerun.components.Position3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -69,7 +68,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Radius> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Radius";
+        static constexpr std::string_view ComponentName = "rerun.components.Radius";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/range1d.hpp
+++ b/rerun_cpp/src/rerun/components/range1d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/range1d.hpp"
 #include "../result.hpp"
 
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Range1D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Range1D";
+        static constexpr std::string_view ComponentName = "rerun.components.Range1D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/resolution.hpp
+++ b/rerun_cpp/src/rerun/components/resolution.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec2d.hpp"
 #include "../rerun_sdk_export.hpp"
 #include "../result.hpp"
@@ -59,7 +58,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Resolution> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Resolution";
+        static constexpr std::string_view ComponentName = "rerun.components.Resolution";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/components/rotation_axis_angle.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/rotation_axis_angle.hpp"
 #include "../result.hpp"
 
@@ -43,7 +42,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::RotationAxisAngle> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.RotationAxisAngle";
+        static constexpr std::string_view ComponentName = "rerun.components.RotationAxisAngle";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/rotation_quat.hpp
+++ b/rerun_cpp/src/rerun/components/rotation_quat.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/quaternion.hpp"
 #include "../result.hpp"
 
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::RotationQuat> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.RotationQuat";
+        static constexpr std::string_view ComponentName = "rerun.components.RotationQuat";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/scalar.hpp
+++ b/rerun_cpp/src/rerun/components/scalar.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float64.hpp"
 #include "../result.hpp"
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Scalar> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Scalar";
+        static constexpr std::string_view ComponentName = "rerun.components.Scalar";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/scale3d.hpp
+++ b/rerun_cpp/src/rerun/components/scale3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -73,7 +72,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Scale3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Scale3D";
+        static constexpr std::string_view ComponentName = "rerun.components.Scale3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/series_visible.hpp
+++ b/rerun_cpp/src/rerun/components/series_visible.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/bool.hpp"
 #include "../result.hpp"
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::SeriesVisible> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.SeriesVisible";
+        static constexpr std::string_view ComponentName = "rerun.components.SeriesVisible";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/show_labels.hpp
+++ b/rerun_cpp/src/rerun/components/show_labels.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/bool.hpp"
 #include "../result.hpp"
 
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ShowLabels> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ShowLabels";
+        static constexpr std::string_view ComponentName = "rerun.components.ShowLabels";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/stroke_width.hpp
+++ b/rerun_cpp/src/rerun/components/stroke_width.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/float32.hpp"
 #include "../result.hpp"
 
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::StrokeWidth> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.StrokeWidth";
+        static constexpr std::string_view ComponentName = "rerun.components.StrokeWidth";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/tensor_data.hpp"
 #include "../result.hpp"
 
@@ -65,7 +64,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TensorData> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.TensorData";
+        static constexpr std::string_view ComponentName = "rerun.components.TensorData";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/tensor_dimension_index_selection.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_dimension_index_selection.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/tensor_dimension_index_selection.hpp"
 #include "../result.hpp"
 
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TensorDimensionIndexSelection> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.components.TensorDimensionIndexSelection";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/components/tensor_height_dimension.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_height_dimension.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/tensor_dimension_selection.hpp"
 #include "../result.hpp"
 
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TensorHeightDimension> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.TensorHeightDimension";
+        static constexpr std::string_view ComponentName = "rerun.components.TensorHeightDimension";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/tensor_width_dimension.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_width_dimension.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/tensor_dimension_selection.hpp"
 #include "../result.hpp"
 
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TensorWidthDimension> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.TensorWidthDimension";
+        static constexpr std::string_view ComponentName = "rerun.components.TensorWidthDimension";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/texcoord2d.hpp
+++ b/rerun_cpp/src/rerun/components/texcoord2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
@@ -75,7 +74,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Texcoord2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Texcoord2D";
+        static constexpr std::string_view ComponentName = "rerun.components.Texcoord2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/text.hpp
+++ b/rerun_cpp/src/rerun/components/text.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/utf8.hpp"
 #include "../result.hpp"
 
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Text> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Text";
+        static constexpr std::string_view ComponentName = "rerun.components.Text";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/text_log_level.hpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/utf8.hpp"
 #include "../rerun_sdk_export.hpp"
 #include "../result.hpp"
@@ -84,7 +83,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TextLogLevel> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.TextLogLevel";
+        static constexpr std::string_view ComponentName = "rerun.components.TextLogLevel";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/timestamp.hpp
+++ b/rerun_cpp/src/rerun/components/timestamp.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/time_int.hpp"
 #include "../result.hpp"
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Timestamp> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Timestamp";
+        static constexpr std::string_view ComponentName = "rerun.components.Timestamp";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/transform_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/components/transform_mat3x3.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/mat3x3.hpp"
 #include "../result.hpp"
 
@@ -63,7 +62,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TransformMat3x3> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.TransformMat3x3";
+        static constexpr std::string_view ComponentName = "rerun.components.TransformMat3x3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/transform_relation.hpp
+++ b/rerun_cpp/src/rerun/components/transform_relation.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TransformRelation> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.TransformRelation";
+        static constexpr std::string_view ComponentName = "rerun.components.TransformRelation";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/translation3d.hpp
+++ b/rerun_cpp/src/rerun/components/translation3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -67,7 +66,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Translation3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Translation3D";
+        static constexpr std::string_view ComponentName = "rerun.components.Translation3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/triangle_indices.hpp
+++ b/rerun_cpp/src/rerun/components/triangle_indices.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/uvec3d.hpp"
 #include "../result.hpp"
 
@@ -56,7 +55,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::TriangleIndices> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.TriangleIndices";
+        static constexpr std::string_view ComponentName = "rerun.components.TriangleIndices";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/value_range.hpp
+++ b/rerun_cpp/src/rerun/components/value_range.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/range1d.hpp"
 #include "../result.hpp"
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ValueRange> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ValueRange";
+        static constexpr std::string_view ComponentName = "rerun.components.ValueRange";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/vector2d.hpp
+++ b/rerun_cpp/src/rerun/components/vector2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec2d.hpp"
 #include "../result.hpp"
 
@@ -63,7 +62,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Vector2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Vector2D";
+        static constexpr std::string_view ComponentName = "rerun.components.Vector2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/vec3d.hpp"
 #include "../result.hpp"
 
@@ -67,7 +66,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Vector3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Vector3D";
+        static constexpr std::string_view ComponentName = "rerun.components.Vector3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/video_codec.hpp
+++ b/rerun_cpp/src/rerun/components/video_codec.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::VideoCodec> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.VideoCodec";
+        static constexpr std::string_view ComponentName = "rerun.components.VideoCodec";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/components/video_sample.hpp
+++ b/rerun_cpp/src/rerun/components/video_sample.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../datatypes/blob.hpp"
 #include "../result.hpp"
 
@@ -52,7 +51,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::VideoSample> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.VideoSample";
+        static constexpr std::string_view ComponentName = "rerun.components.VideoSample";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/video_timestamp.hpp
+++ b/rerun_cpp/src/rerun/components/video_timestamp.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/video_timestamp.hpp"
 #include "../result.hpp"
 
@@ -91,7 +90,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::VideoTimestamp> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.VideoTimestamp";
+        static constexpr std::string_view ComponentName = "rerun.components.VideoTimestamp";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/view_coordinates.hpp"
 #include "../rerun_sdk_export.hpp"
 #include "../result.hpp"
@@ -317,7 +316,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::ViewCoordinates> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.ViewCoordinates";
+        static constexpr std::string_view ComponentName = "rerun.components.ViewCoordinates";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/components/visible.hpp
+++ b/rerun_cpp/src/rerun/components/visible.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../datatypes/bool.hpp"
 #include "../result.hpp"
 
@@ -45,7 +44,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::Visible> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.components.Visible";
+        static constexpr std::string_view ComponentName = "rerun.components.Visible";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/src/rerun/datatypes/angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/angle.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -58,7 +57,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Angle> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Angle";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Angle";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
+++ b/rerun_cpp/src/rerun/datatypes/annotation_info.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "rgba32.hpp"
 #include "utf8.hpp"
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AnnotationInfo> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.AnnotationInfo";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.AnnotationInfo";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/blob.hpp
+++ b/rerun_cpp/src/rerun/datatypes/blob.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Blob> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Blob";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Blob";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/bool.hpp
+++ b/rerun_cpp/src/rerun/datatypes/bool.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Bool> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Bool";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Bool";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/channel_datatype.hpp
+++ b/rerun_cpp/src/rerun/datatypes/channel_datatype.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -68,7 +67,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ChannelDatatype> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.ChannelDatatype";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.ChannelDatatype";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/class_description.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "annotation_info.hpp"
 #include "keypoint_pair.hpp"
@@ -73,7 +72,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ClassDescription> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.ClassDescription";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.ClassDescription";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_description_map_elem.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "class_description.hpp"
 #include "class_id.hpp"
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ClassDescriptionMapElem> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.ClassDescriptionMapElem";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.ClassDescriptionMapElem";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/class_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/class_id.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ClassId> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.ClassId";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.ClassId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/color_model.hpp
+++ b/rerun_cpp/src/rerun/datatypes/color_model.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ColorModel> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.ColorModel";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.ColorModel";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/dvec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/dvec2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::DVec2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.DVec2D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.DVec2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/entity_path.hpp
+++ b/rerun_cpp/src/rerun/datatypes/entity_path.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::EntityPath> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.EntityPath";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.EntityPath";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/float32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/float32.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Float32> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Float32";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Float32";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/float64.hpp
+++ b/rerun_cpp/src/rerun/datatypes/float64.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Float64> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Float64";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Float64";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/image_format.hpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../image_utils.hpp"
 #include "../result.hpp"
 #include "channel_datatype.hpp"
@@ -88,7 +87,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ImageFormat> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.ImageFormat";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.ImageFormat";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_id.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::KeypointId> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.KeypointId";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.KeypointId";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/keypoint_pair.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "keypoint_id.hpp"
 
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::KeypointPair> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.KeypointPair";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.KeypointPair";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat3x3.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../rerun_sdk_export.hpp"
 #include "../result.hpp"
 #include "vec3d.hpp"
@@ -86,7 +85,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Mat3x3> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Mat3x3";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Mat3x3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
+++ b/rerun_cpp/src/rerun/datatypes/mat4x4.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../rerun_sdk_export.hpp"
 #include "../result.hpp"
 #include "vec4d.hpp"
@@ -100,7 +99,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Mat4x4> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Mat4x4";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Mat4x4";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/pixel_format.hpp
+++ b/rerun_cpp/src/rerun/datatypes/pixel_format.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -123,7 +122,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::PixelFormat> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.PixelFormat";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.PixelFormat";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/plane3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/plane3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Plane3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Plane3D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Plane3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/quaternion.hpp
+++ b/rerun_cpp/src/rerun/datatypes/quaternion.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../rerun_sdk_export.hpp"
 #include "../result.hpp"
 
@@ -91,7 +90,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Quaternion> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Quaternion";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Quaternion";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/range1d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/range1d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -40,7 +39,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Range1D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Range1D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Range1D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/range2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/range2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "range1d.hpp"
 
@@ -37,7 +36,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Range2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Range2D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Range2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/rgba32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rgba32.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -76,7 +75,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Rgba32> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Rgba32";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Rgba32";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/datatypes/rotation_axis_angle.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "angle.hpp"
 #include "vec3d.hpp"
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::RotationAxisAngle> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.RotationAxisAngle";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.RotationAxisAngle";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../half.hpp"
 #include "../result.hpp"
 #include "../type_traits.hpp"
@@ -510,7 +509,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::TensorBuffer> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.TensorBuffer";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.TensorBuffer";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_data.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "../collection.hpp"
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "tensor_buffer.hpp"
 
@@ -81,7 +80,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::TensorData> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.TensorData";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.TensorData";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/tensor_dimension_index_selection.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_dimension_index_selection.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -38,7 +37,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::TensorDimensionIndexSelection> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.datatypes.TensorDimensionIndexSelection";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/tensor_dimension_selection.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_dimension_selection.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -36,7 +35,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::TensorDimensionSelection> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.datatypes.TensorDimensionSelection";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/src/rerun/datatypes/time_int.hpp
+++ b/rerun_cpp/src/rerun/datatypes/time_int.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::TimeInt> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.TimeInt";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.TimeInt";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/time_range.hpp
+++ b/rerun_cpp/src/rerun/datatypes/time_range.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "time_range_boundary.hpp"
 
@@ -37,7 +36,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::TimeRange> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.TimeRange";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.TimeRange";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/time_range_boundary.hpp
+++ b/rerun_cpp/src/rerun/datatypes/time_range_boundary.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "time_int.hpp"
 
@@ -156,7 +155,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::TimeRangeBoundary> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.TimeRangeBoundary";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.TimeRangeBoundary";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/uint16.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uint16.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::UInt16> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.UInt16";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.UInt16";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/uint32.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uint32.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::UInt32> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.UInt32";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.UInt32";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/uint64.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uint64.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::UInt64> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.UInt64";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.UInt64";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/utf8.hpp
+++ b/rerun_cpp/src/rerun/datatypes/utf8.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -58,7 +57,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Utf8> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Utf8";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Utf8";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/utf8pair.hpp
+++ b/rerun_cpp/src/rerun/datatypes/utf8pair.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "utf8.hpp"
 
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Utf8Pair> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Utf8Pair";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Utf8Pair";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/uuid.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uuid.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Uuid> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Uuid";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Uuid";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/uvec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::UVec2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.UVec2D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.UVec2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/uvec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -61,7 +60,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::UVec3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.UVec3D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.UVec3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/uvec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/uvec4d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -40,7 +39,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::UVec4D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.UVec4D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.UVec4D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/vec2d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec2d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Vec2D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Vec2D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Vec2D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/vec3d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec3d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -61,7 +60,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Vec3D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Vec3D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Vec3D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/vec4d.hpp
+++ b/rerun_cpp/src/rerun/datatypes/vec4d.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -65,7 +64,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::Vec4D> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.Vec4D";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.Vec4D";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/video_timestamp.hpp
+++ b/rerun_cpp/src/rerun/datatypes/video_timestamp.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <cstdint>
@@ -48,7 +47,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::VideoTimestamp> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.VideoTimestamp";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.VideoTimestamp";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/datatypes/view_coordinates.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 
 #include <array>
@@ -68,7 +67,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ViewCoordinates> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.ViewCoordinates";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.ViewCoordinates";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/src/rerun/datatypes/visible_time_range.hpp
+++ b/rerun_cpp/src/rerun/datatypes/visible_time_range.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "../component_descriptor.hpp"
 #include "../result.hpp"
 #include "time_range.hpp"
 #include "utf8.hpp"
@@ -38,7 +37,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::VisibleTimeRange> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.datatypes.VisibleTimeRange";
+        static constexpr std::string_view ComponentName = "rerun.datatypes.VisibleTimeRange";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/error_check.hpp
+++ b/rerun_cpp/tests/error_check.hpp
@@ -29,7 +29,7 @@ auto check_logged_error(
             if (expected_status_code != rerun::ErrorCode::Ok) {
                 CHECK(last_logged_status.description.length() > 0);
             } else {
-                CHECK(last_logged_status.description.length() == 0);
+                CHECK(last_logged_status.description == "");
             }
             rerun::Error::set_log_handler(nullptr);
         }

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer1.hpp
@@ -93,113 +93,91 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `fuzz1001` field.
         static constexpr auto Descriptor_fuzz1001 = ComponentDescriptor(
-            ArchetypeName, "fuzz1001",
-            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+            ArchetypeName, "fuzz1001", Loggable<rerun::components::AffixFuzzer1>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1002` field.
         static constexpr auto Descriptor_fuzz1002 = ComponentDescriptor(
-            ArchetypeName, "fuzz1002",
-            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+            ArchetypeName, "fuzz1002", Loggable<rerun::components::AffixFuzzer2>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1003` field.
         static constexpr auto Descriptor_fuzz1003 = ComponentDescriptor(
-            ArchetypeName, "fuzz1003",
-            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+            ArchetypeName, "fuzz1003", Loggable<rerun::components::AffixFuzzer3>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1004` field.
         static constexpr auto Descriptor_fuzz1004 = ComponentDescriptor(
-            ArchetypeName, "fuzz1004",
-            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+            ArchetypeName, "fuzz1004", Loggable<rerun::components::AffixFuzzer4>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1005` field.
         static constexpr auto Descriptor_fuzz1005 = ComponentDescriptor(
-            ArchetypeName, "fuzz1005",
-            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+            ArchetypeName, "fuzz1005", Loggable<rerun::components::AffixFuzzer5>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1006` field.
         static constexpr auto Descriptor_fuzz1006 = ComponentDescriptor(
-            ArchetypeName, "fuzz1006",
-            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+            ArchetypeName, "fuzz1006", Loggable<rerun::components::AffixFuzzer6>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1007` field.
         static constexpr auto Descriptor_fuzz1007 = ComponentDescriptor(
-            ArchetypeName, "fuzz1007",
-            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+            ArchetypeName, "fuzz1007", Loggable<rerun::components::AffixFuzzer7>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1008` field.
         static constexpr auto Descriptor_fuzz1008 = ComponentDescriptor(
-            ArchetypeName, "fuzz1008",
-            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+            ArchetypeName, "fuzz1008", Loggable<rerun::components::AffixFuzzer8>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1009` field.
         static constexpr auto Descriptor_fuzz1009 = ComponentDescriptor(
-            ArchetypeName, "fuzz1009",
-            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+            ArchetypeName, "fuzz1009", Loggable<rerun::components::AffixFuzzer9>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1010` field.
         static constexpr auto Descriptor_fuzz1010 = ComponentDescriptor(
-            ArchetypeName, "fuzz1010",
-            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+            ArchetypeName, "fuzz1010", Loggable<rerun::components::AffixFuzzer10>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1011` field.
         static constexpr auto Descriptor_fuzz1011 = ComponentDescriptor(
-            ArchetypeName, "fuzz1011",
-            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+            ArchetypeName, "fuzz1011", Loggable<rerun::components::AffixFuzzer11>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1012` field.
         static constexpr auto Descriptor_fuzz1012 = ComponentDescriptor(
-            ArchetypeName, "fuzz1012",
-            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+            ArchetypeName, "fuzz1012", Loggable<rerun::components::AffixFuzzer12>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1013` field.
         static constexpr auto Descriptor_fuzz1013 = ComponentDescriptor(
-            ArchetypeName, "fuzz1013",
-            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+            ArchetypeName, "fuzz1013", Loggable<rerun::components::AffixFuzzer13>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1014` field.
         static constexpr auto Descriptor_fuzz1014 = ComponentDescriptor(
-            ArchetypeName, "fuzz1014",
-            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+            ArchetypeName, "fuzz1014", Loggable<rerun::components::AffixFuzzer14>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1015` field.
         static constexpr auto Descriptor_fuzz1015 = ComponentDescriptor(
-            ArchetypeName, "fuzz1015",
-            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+            ArchetypeName, "fuzz1015", Loggable<rerun::components::AffixFuzzer15>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1016` field.
         static constexpr auto Descriptor_fuzz1016 = ComponentDescriptor(
-            ArchetypeName, "fuzz1016",
-            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+            ArchetypeName, "fuzz1016", Loggable<rerun::components::AffixFuzzer16>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1017` field.
         static constexpr auto Descriptor_fuzz1017 = ComponentDescriptor(
-            ArchetypeName, "fuzz1017",
-            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+            ArchetypeName, "fuzz1017", Loggable<rerun::components::AffixFuzzer17>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1018` field.
         static constexpr auto Descriptor_fuzz1018 = ComponentDescriptor(
-            ArchetypeName, "fuzz1018",
-            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+            ArchetypeName, "fuzz1018", Loggable<rerun::components::AffixFuzzer18>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1019` field.
         static constexpr auto Descriptor_fuzz1019 = ComponentDescriptor(
-            ArchetypeName, "fuzz1019",
-            Loggable<rerun::components::AffixFuzzer19>::Descriptor.component_name
+            ArchetypeName, "fuzz1019", Loggable<rerun::components::AffixFuzzer19>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1020` field.
         static constexpr auto Descriptor_fuzz1020 = ComponentDescriptor(
-            ArchetypeName, "fuzz1020",
-            Loggable<rerun::components::AffixFuzzer20>::Descriptor.component_name
+            ArchetypeName, "fuzz1020", Loggable<rerun::components::AffixFuzzer20>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1021` field.
         static constexpr auto Descriptor_fuzz1021 = ComponentDescriptor(
-            ArchetypeName, "fuzz1021",
-            Loggable<rerun::components::AffixFuzzer21>::Descriptor.component_name
+            ArchetypeName, "fuzz1021", Loggable<rerun::components::AffixFuzzer21>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1022` field.
         static constexpr auto Descriptor_fuzz1022 = ComponentDescriptor(
-            ArchetypeName, "fuzz1022",
-            Loggable<rerun::components::AffixFuzzer22>::Descriptor.component_name
+            ArchetypeName, "fuzz1022", Loggable<rerun::components::AffixFuzzer22>::ComponentName
         );
 
       public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer2.hpp
@@ -84,98 +84,79 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `fuzz1101` field.
         static constexpr auto Descriptor_fuzz1101 = ComponentDescriptor(
-            ArchetypeName, "fuzz1101",
-            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+            ArchetypeName, "fuzz1101", Loggable<rerun::components::AffixFuzzer1>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1102` field.
         static constexpr auto Descriptor_fuzz1102 = ComponentDescriptor(
-            ArchetypeName, "fuzz1102",
-            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+            ArchetypeName, "fuzz1102", Loggable<rerun::components::AffixFuzzer2>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1103` field.
         static constexpr auto Descriptor_fuzz1103 = ComponentDescriptor(
-            ArchetypeName, "fuzz1103",
-            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+            ArchetypeName, "fuzz1103", Loggable<rerun::components::AffixFuzzer3>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1104` field.
         static constexpr auto Descriptor_fuzz1104 = ComponentDescriptor(
-            ArchetypeName, "fuzz1104",
-            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+            ArchetypeName, "fuzz1104", Loggable<rerun::components::AffixFuzzer4>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1105` field.
         static constexpr auto Descriptor_fuzz1105 = ComponentDescriptor(
-            ArchetypeName, "fuzz1105",
-            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+            ArchetypeName, "fuzz1105", Loggable<rerun::components::AffixFuzzer5>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1106` field.
         static constexpr auto Descriptor_fuzz1106 = ComponentDescriptor(
-            ArchetypeName, "fuzz1106",
-            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+            ArchetypeName, "fuzz1106", Loggable<rerun::components::AffixFuzzer6>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1107` field.
         static constexpr auto Descriptor_fuzz1107 = ComponentDescriptor(
-            ArchetypeName, "fuzz1107",
-            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+            ArchetypeName, "fuzz1107", Loggable<rerun::components::AffixFuzzer7>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1108` field.
         static constexpr auto Descriptor_fuzz1108 = ComponentDescriptor(
-            ArchetypeName, "fuzz1108",
-            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+            ArchetypeName, "fuzz1108", Loggable<rerun::components::AffixFuzzer8>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1109` field.
         static constexpr auto Descriptor_fuzz1109 = ComponentDescriptor(
-            ArchetypeName, "fuzz1109",
-            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+            ArchetypeName, "fuzz1109", Loggable<rerun::components::AffixFuzzer9>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1110` field.
         static constexpr auto Descriptor_fuzz1110 = ComponentDescriptor(
-            ArchetypeName, "fuzz1110",
-            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+            ArchetypeName, "fuzz1110", Loggable<rerun::components::AffixFuzzer10>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1111` field.
         static constexpr auto Descriptor_fuzz1111 = ComponentDescriptor(
-            ArchetypeName, "fuzz1111",
-            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+            ArchetypeName, "fuzz1111", Loggable<rerun::components::AffixFuzzer11>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1112` field.
         static constexpr auto Descriptor_fuzz1112 = ComponentDescriptor(
-            ArchetypeName, "fuzz1112",
-            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+            ArchetypeName, "fuzz1112", Loggable<rerun::components::AffixFuzzer12>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1113` field.
         static constexpr auto Descriptor_fuzz1113 = ComponentDescriptor(
-            ArchetypeName, "fuzz1113",
-            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+            ArchetypeName, "fuzz1113", Loggable<rerun::components::AffixFuzzer13>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1114` field.
         static constexpr auto Descriptor_fuzz1114 = ComponentDescriptor(
-            ArchetypeName, "fuzz1114",
-            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+            ArchetypeName, "fuzz1114", Loggable<rerun::components::AffixFuzzer14>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1115` field.
         static constexpr auto Descriptor_fuzz1115 = ComponentDescriptor(
-            ArchetypeName, "fuzz1115",
-            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+            ArchetypeName, "fuzz1115", Loggable<rerun::components::AffixFuzzer15>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1116` field.
         static constexpr auto Descriptor_fuzz1116 = ComponentDescriptor(
-            ArchetypeName, "fuzz1116",
-            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+            ArchetypeName, "fuzz1116", Loggable<rerun::components::AffixFuzzer16>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1117` field.
         static constexpr auto Descriptor_fuzz1117 = ComponentDescriptor(
-            ArchetypeName, "fuzz1117",
-            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+            ArchetypeName, "fuzz1117", Loggable<rerun::components::AffixFuzzer17>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1118` field.
         static constexpr auto Descriptor_fuzz1118 = ComponentDescriptor(
-            ArchetypeName, "fuzz1118",
-            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+            ArchetypeName, "fuzz1118", Loggable<rerun::components::AffixFuzzer18>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz1122` field.
         static constexpr auto Descriptor_fuzz1122 = ComponentDescriptor(
-            ArchetypeName, "fuzz1122",
-            Loggable<rerun::components::AffixFuzzer22>::Descriptor.component_name
+            ArchetypeName, "fuzz1122", Loggable<rerun::components::AffixFuzzer22>::ComponentName
         );
 
       public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer3.hpp
@@ -81,93 +81,75 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `fuzz2001` field.
         static constexpr auto Descriptor_fuzz2001 = ComponentDescriptor(
-            ArchetypeName, "fuzz2001",
-            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+            ArchetypeName, "fuzz2001", Loggable<rerun::components::AffixFuzzer1>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2002` field.
         static constexpr auto Descriptor_fuzz2002 = ComponentDescriptor(
-            ArchetypeName, "fuzz2002",
-            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+            ArchetypeName, "fuzz2002", Loggable<rerun::components::AffixFuzzer2>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2003` field.
         static constexpr auto Descriptor_fuzz2003 = ComponentDescriptor(
-            ArchetypeName, "fuzz2003",
-            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+            ArchetypeName, "fuzz2003", Loggable<rerun::components::AffixFuzzer3>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2004` field.
         static constexpr auto Descriptor_fuzz2004 = ComponentDescriptor(
-            ArchetypeName, "fuzz2004",
-            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+            ArchetypeName, "fuzz2004", Loggable<rerun::components::AffixFuzzer4>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2005` field.
         static constexpr auto Descriptor_fuzz2005 = ComponentDescriptor(
-            ArchetypeName, "fuzz2005",
-            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+            ArchetypeName, "fuzz2005", Loggable<rerun::components::AffixFuzzer5>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2006` field.
         static constexpr auto Descriptor_fuzz2006 = ComponentDescriptor(
-            ArchetypeName, "fuzz2006",
-            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+            ArchetypeName, "fuzz2006", Loggable<rerun::components::AffixFuzzer6>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2007` field.
         static constexpr auto Descriptor_fuzz2007 = ComponentDescriptor(
-            ArchetypeName, "fuzz2007",
-            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+            ArchetypeName, "fuzz2007", Loggable<rerun::components::AffixFuzzer7>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2008` field.
         static constexpr auto Descriptor_fuzz2008 = ComponentDescriptor(
-            ArchetypeName, "fuzz2008",
-            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+            ArchetypeName, "fuzz2008", Loggable<rerun::components::AffixFuzzer8>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2009` field.
         static constexpr auto Descriptor_fuzz2009 = ComponentDescriptor(
-            ArchetypeName, "fuzz2009",
-            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+            ArchetypeName, "fuzz2009", Loggable<rerun::components::AffixFuzzer9>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2010` field.
         static constexpr auto Descriptor_fuzz2010 = ComponentDescriptor(
-            ArchetypeName, "fuzz2010",
-            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+            ArchetypeName, "fuzz2010", Loggable<rerun::components::AffixFuzzer10>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2011` field.
         static constexpr auto Descriptor_fuzz2011 = ComponentDescriptor(
-            ArchetypeName, "fuzz2011",
-            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+            ArchetypeName, "fuzz2011", Loggable<rerun::components::AffixFuzzer11>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2012` field.
         static constexpr auto Descriptor_fuzz2012 = ComponentDescriptor(
-            ArchetypeName, "fuzz2012",
-            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+            ArchetypeName, "fuzz2012", Loggable<rerun::components::AffixFuzzer12>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2013` field.
         static constexpr auto Descriptor_fuzz2013 = ComponentDescriptor(
-            ArchetypeName, "fuzz2013",
-            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+            ArchetypeName, "fuzz2013", Loggable<rerun::components::AffixFuzzer13>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2014` field.
         static constexpr auto Descriptor_fuzz2014 = ComponentDescriptor(
-            ArchetypeName, "fuzz2014",
-            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+            ArchetypeName, "fuzz2014", Loggable<rerun::components::AffixFuzzer14>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2015` field.
         static constexpr auto Descriptor_fuzz2015 = ComponentDescriptor(
-            ArchetypeName, "fuzz2015",
-            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+            ArchetypeName, "fuzz2015", Loggable<rerun::components::AffixFuzzer15>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2016` field.
         static constexpr auto Descriptor_fuzz2016 = ComponentDescriptor(
-            ArchetypeName, "fuzz2016",
-            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+            ArchetypeName, "fuzz2016", Loggable<rerun::components::AffixFuzzer16>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2017` field.
         static constexpr auto Descriptor_fuzz2017 = ComponentDescriptor(
-            ArchetypeName, "fuzz2017",
-            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+            ArchetypeName, "fuzz2017", Loggable<rerun::components::AffixFuzzer17>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2018` field.
         static constexpr auto Descriptor_fuzz2018 = ComponentDescriptor(
-            ArchetypeName, "fuzz2018",
-            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+            ArchetypeName, "fuzz2018", Loggable<rerun::components::AffixFuzzer18>::ComponentName
         );
 
       public:

--- a/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/archetypes/affix_fuzzer4.hpp
@@ -81,93 +81,75 @@ namespace rerun::archetypes {
 
         /// `ComponentDescriptor` for the `fuzz2101` field.
         static constexpr auto Descriptor_fuzz2101 = ComponentDescriptor(
-            ArchetypeName, "fuzz2101",
-            Loggable<rerun::components::AffixFuzzer1>::Descriptor.component_name
+            ArchetypeName, "fuzz2101", Loggable<rerun::components::AffixFuzzer1>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2102` field.
         static constexpr auto Descriptor_fuzz2102 = ComponentDescriptor(
-            ArchetypeName, "fuzz2102",
-            Loggable<rerun::components::AffixFuzzer2>::Descriptor.component_name
+            ArchetypeName, "fuzz2102", Loggable<rerun::components::AffixFuzzer2>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2103` field.
         static constexpr auto Descriptor_fuzz2103 = ComponentDescriptor(
-            ArchetypeName, "fuzz2103",
-            Loggable<rerun::components::AffixFuzzer3>::Descriptor.component_name
+            ArchetypeName, "fuzz2103", Loggable<rerun::components::AffixFuzzer3>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2104` field.
         static constexpr auto Descriptor_fuzz2104 = ComponentDescriptor(
-            ArchetypeName, "fuzz2104",
-            Loggable<rerun::components::AffixFuzzer4>::Descriptor.component_name
+            ArchetypeName, "fuzz2104", Loggable<rerun::components::AffixFuzzer4>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2105` field.
         static constexpr auto Descriptor_fuzz2105 = ComponentDescriptor(
-            ArchetypeName, "fuzz2105",
-            Loggable<rerun::components::AffixFuzzer5>::Descriptor.component_name
+            ArchetypeName, "fuzz2105", Loggable<rerun::components::AffixFuzzer5>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2106` field.
         static constexpr auto Descriptor_fuzz2106 = ComponentDescriptor(
-            ArchetypeName, "fuzz2106",
-            Loggable<rerun::components::AffixFuzzer6>::Descriptor.component_name
+            ArchetypeName, "fuzz2106", Loggable<rerun::components::AffixFuzzer6>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2107` field.
         static constexpr auto Descriptor_fuzz2107 = ComponentDescriptor(
-            ArchetypeName, "fuzz2107",
-            Loggable<rerun::components::AffixFuzzer7>::Descriptor.component_name
+            ArchetypeName, "fuzz2107", Loggable<rerun::components::AffixFuzzer7>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2108` field.
         static constexpr auto Descriptor_fuzz2108 = ComponentDescriptor(
-            ArchetypeName, "fuzz2108",
-            Loggable<rerun::components::AffixFuzzer8>::Descriptor.component_name
+            ArchetypeName, "fuzz2108", Loggable<rerun::components::AffixFuzzer8>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2109` field.
         static constexpr auto Descriptor_fuzz2109 = ComponentDescriptor(
-            ArchetypeName, "fuzz2109",
-            Loggable<rerun::components::AffixFuzzer9>::Descriptor.component_name
+            ArchetypeName, "fuzz2109", Loggable<rerun::components::AffixFuzzer9>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2110` field.
         static constexpr auto Descriptor_fuzz2110 = ComponentDescriptor(
-            ArchetypeName, "fuzz2110",
-            Loggable<rerun::components::AffixFuzzer10>::Descriptor.component_name
+            ArchetypeName, "fuzz2110", Loggable<rerun::components::AffixFuzzer10>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2111` field.
         static constexpr auto Descriptor_fuzz2111 = ComponentDescriptor(
-            ArchetypeName, "fuzz2111",
-            Loggable<rerun::components::AffixFuzzer11>::Descriptor.component_name
+            ArchetypeName, "fuzz2111", Loggable<rerun::components::AffixFuzzer11>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2112` field.
         static constexpr auto Descriptor_fuzz2112 = ComponentDescriptor(
-            ArchetypeName, "fuzz2112",
-            Loggable<rerun::components::AffixFuzzer12>::Descriptor.component_name
+            ArchetypeName, "fuzz2112", Loggable<rerun::components::AffixFuzzer12>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2113` field.
         static constexpr auto Descriptor_fuzz2113 = ComponentDescriptor(
-            ArchetypeName, "fuzz2113",
-            Loggable<rerun::components::AffixFuzzer13>::Descriptor.component_name
+            ArchetypeName, "fuzz2113", Loggable<rerun::components::AffixFuzzer13>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2114` field.
         static constexpr auto Descriptor_fuzz2114 = ComponentDescriptor(
-            ArchetypeName, "fuzz2114",
-            Loggable<rerun::components::AffixFuzzer14>::Descriptor.component_name
+            ArchetypeName, "fuzz2114", Loggable<rerun::components::AffixFuzzer14>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2115` field.
         static constexpr auto Descriptor_fuzz2115 = ComponentDescriptor(
-            ArchetypeName, "fuzz2115",
-            Loggable<rerun::components::AffixFuzzer15>::Descriptor.component_name
+            ArchetypeName, "fuzz2115", Loggable<rerun::components::AffixFuzzer15>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2116` field.
         static constexpr auto Descriptor_fuzz2116 = ComponentDescriptor(
-            ArchetypeName, "fuzz2116",
-            Loggable<rerun::components::AffixFuzzer16>::Descriptor.component_name
+            ArchetypeName, "fuzz2116", Loggable<rerun::components::AffixFuzzer16>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2117` field.
         static constexpr auto Descriptor_fuzz2117 = ComponentDescriptor(
-            ArchetypeName, "fuzz2117",
-            Loggable<rerun::components::AffixFuzzer17>::Descriptor.component_name
+            ArchetypeName, "fuzz2117", Loggable<rerun::components::AffixFuzzer17>::ComponentName
         );
         /// `ComponentDescriptor` for the `fuzz2118` field.
         static constexpr auto Descriptor_fuzz2118 = ComponentDescriptor(
-            ArchetypeName, "fuzz2118",
-            Loggable<rerun::components::AffixFuzzer18>::Descriptor.component_name
+            ArchetypeName, "fuzz2118", Loggable<rerun::components::AffixFuzzer18>::ComponentName
         );
 
       public:

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer1> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer1";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer1";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer10.hpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer10> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer10";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer10";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer11.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer11> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer11";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer11";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer12.hpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <memory>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
@@ -41,7 +40,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer12> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer12";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer12";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer13.hpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer13> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer13";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer13";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer14> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer14";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer14";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer15.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -49,7 +48,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer15> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer15";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer15";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer16.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer16> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer16";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer16";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer17.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer17> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer17";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer17";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer18.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer18> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer18";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer18";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -51,7 +50,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer19> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer19";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer19";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer2> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer2";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer2";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer20> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer20";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer20";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer21> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer21";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer21";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/tests/generated/components/affix_fuzzer22.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer22.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -57,7 +56,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer22> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer22";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer22";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer23.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer23.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer23> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer23";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer23";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer3> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer3";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {

--- a/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer4.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer4> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer4";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer4";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer5.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer5> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer5";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer5";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer6.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -47,7 +46,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer6> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer6";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer6";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer7.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -46,7 +45,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer7> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer7";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer7";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer8.hpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer8> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer8";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer8";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer9.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
@@ -40,7 +39,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<components::AffixFuzzer9> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.components.AffixFuzzer9";
+        static constexpr std::string_view ComponentName = "rerun.testing.components.AffixFuzzer9";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer1.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <string>
 
@@ -51,7 +50,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer1> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer1";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer1";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer2.hpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer2> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer2";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer2";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer20.hpp
@@ -8,7 +8,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -35,7 +34,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer20> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer20";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer20";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer21.hpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <memory>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/half.hpp>
 #include <rerun/result.hpp>
 
@@ -34,7 +33,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer21> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer21";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer21";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer22.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer22.hpp
@@ -6,7 +6,6 @@
 #include <array>
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer22> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer22";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer22";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -11,7 +11,6 @@
 #include <memory>
 #include <new>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -222,7 +221,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer3> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer3";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer3";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <new>
 #include <rerun/collection.hpp>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -181,7 +180,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer4> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer4";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer4";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer5.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <utility>
 
@@ -43,7 +42,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::AffixFuzzer5> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.AffixFuzzer5";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.AffixFuzzer5";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/enum_test.hpp
+++ b/rerun_cpp/tests/generated/datatypes/enum_test.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -50,7 +49,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::EnumTest> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.EnumTest";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.EnumTest";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
+++ b/rerun_cpp/tests/generated/datatypes/flattened_scalar.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -37,7 +36,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::FlattenedScalar> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.FlattenedScalar";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.FlattenedScalar";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/multi_enum.hpp
+++ b/rerun_cpp/tests/generated/datatypes/multi_enum.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -38,7 +37,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::MultiEnum> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.MultiEnum";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.MultiEnum";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/primitive_component.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -42,7 +41,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::PrimitiveComponent> {
-        static constexpr ComponentDescriptor Descriptor =
+        static constexpr std::string_view ComponentName =
             "rerun.testing.datatypes.PrimitiveComponent";
 
         /// Returns the arrow data type this type corresponds to.

--- a/rerun_cpp/tests/generated/datatypes/string_component.hpp
+++ b/rerun_cpp/tests/generated/datatypes/string_component.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 #include <string>
 #include <utility>
@@ -39,7 +38,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::StringComponent> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.StringComponent";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.StringComponent";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/generated/datatypes/valued_enum.hpp
+++ b/rerun_cpp/tests/generated/datatypes/valued_enum.hpp
@@ -5,7 +5,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <rerun/component_descriptor.hpp>
 #include <rerun/result.hpp>
 
 namespace arrow {
@@ -44,7 +43,7 @@ namespace rerun {
     /// \private
     template <>
     struct Loggable<datatypes::ValuedEnum> {
-        static constexpr ComponentDescriptor Descriptor = "rerun.testing.datatypes.ValuedEnum";
+        static constexpr std::string_view ComponentName = "rerun.testing.datatypes.ValuedEnum";
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype();

--- a/rerun_cpp/tests/log_empty.cpp
+++ b/rerun_cpp/tests/log_empty.cpp
@@ -20,7 +20,7 @@ SCENARIO("Log empty data", TEST_TAG) {
             stream.log(
                 "empty",
                 rerun::ComponentBatch::empty<rerun::Position3D>(
-                    rerun::Loggable<rerun::Position3D>::Descriptor
+                    rerun::Points3D::Descriptor_positions
                 )
             );
         });

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -191,8 +191,7 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     THEN("collection of component batch results can be logged") {
                         rerun::Collection<rerun::Result<rerun::ComponentBatch>> batches = {
                             batch0,
-                            batch1
-                        };
+                            batch1};
                         stream.log("log_archetype-splat", batches);
                         stream.log_static("log_archetype-splat", batches);
                     }
@@ -201,29 +200,29 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 THEN("an archetype can be logged") {
                     stream.log(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
-                            .with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
                     );
                     stream.log_static(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
-                            .with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
                     );
                 }
                 THEN("several archetypes can be logged") {
                     stream.log(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
-                            .with_colors(rerun::Color(0xFF0000FF)),
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
-                            .with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF)),
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
                     );
                     stream.log_static(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
-                            .with_colors(rerun::Color(0xFF0000FF)),
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
-                            .with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF)),
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
+                        ).with_colors(rerun::Color(0xFF0000FF))
                     );
                 }
 

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -149,12 +149,12 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 GIVEN("component batches") {
                     auto batch0 = rerun::ComponentBatch::from_loggable<rerun::Position2D>(
                                       {{1.0, 2.0}, {4.0, 5.0}},
-                                      rerun::Loggable<rerun::Position2D>::Descriptor
+                                      rerun::Points2D::Descriptor_positions
                     )
                                       .value_or_throw();
                     auto batch1 = rerun::ComponentBatch::from_loggable<rerun::Color>(
                                       {rerun::Color(0xFF0000FF)},
-                                      rerun::Loggable<rerun::Color>::Descriptor
+                                      rerun::Points2D::Descriptor_colors
                     )
                                       .value_or_throw();
                     THEN("single component batch can be logged") {
@@ -174,11 +174,11 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 GIVEN("component batches wrapped in `rerun::Result`") {
                     auto batch0 = rerun::ComponentBatch::from_loggable<rerun::Position2D>(
                         {{1.0, 2.0}, {4.0, 5.0}},
-                        rerun::Loggable<rerun::Position2D>::Descriptor
+                        rerun::Points2D::Descriptor_positions
                     );
                     auto batch1 = rerun::ComponentBatch::from_loggable<rerun::Color>(
                         {rerun::Color(0xFF0000FF)},
-                        rerun::Loggable<rerun::Color>::Descriptor
+                        rerun::Points2D::Descriptor_colors
                     );
                     THEN("single component batch can be logged") {
                         stream.log("log_archetype-splat", batch0);
@@ -191,7 +191,8 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                     THEN("collection of component batch results can be logged") {
                         rerun::Collection<rerun::Result<rerun::ComponentBatch>> batches = {
                             batch0,
-                            batch1};
+                            batch1
+                        };
                         stream.log("log_archetype-splat", batches);
                         stream.log_static("log_archetype-splat", batches);
                     }
@@ -200,29 +201,29 @@ SCENARIO("RecordingStream can be used for logging archetypes and components", TE
                 THEN("an archetype can be logged") {
                     stream.log(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
-                        ).with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
+                            .with_colors(rerun::Color(0xFF0000FF))
                     );
                     stream.log_static(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
-                        ).with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
+                            .with_colors(rerun::Color(0xFF0000FF))
                     );
                 }
                 THEN("several archetypes can be logged") {
                     stream.log(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
-                        ).with_colors(rerun::Color(0xFF0000FF)),
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
-                        ).with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
+                            .with_colors(rerun::Color(0xFF0000FF)),
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
+                            .with_colors(rerun::Color(0xFF0000FF))
                     );
                     stream.log_static(
                         "log_archetype-splat",
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
-                        ).with_colors(rerun::Color(0xFF0000FF)),
-                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}}
-                        ).with_colors(rerun::Color(0xFF0000FF))
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
+                            .with_colors(rerun::Color(0xFF0000FF)),
+                        rerun::Points2D({rerun::Vec2D{1.0, 2.0}, rerun::Vec2D{4.0, 5.0}})
+                            .with_colors(rerun::Color(0xFF0000FF))
                     );
                 }
 

--- a/scripts/roundtrip_utils.py
+++ b/scripts/roundtrip_utils.py
@@ -77,4 +77,4 @@ def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]
 
-    run(cmd, env=roundtrip_env(), timeout=30)
+    run(cmd, env=roundtrip_env(), timeout=60)


### PR DESCRIPTION
### Related

* Part of #6889.
* Closes #10057.
* Closes #10211.

### What

This changes `ComponentDescriptor(component_name)` constructors to `ComponentDescriptor(archetype_field_name)` and replaces the static `Descriptor` constant with `ComponentName` on all components.

* [x] main ci passes
