### PR TITLE
Check TextEdit state before copying selection description

### DIFF
--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -1,5 +1,5 @@
 use ahash::HashMap;
-use egui::{NumExt as _, Ui, text_selection::LabelSelectionState};
+use egui::{NumExt as _, Ui, text_edit::TextEditState, text_selection::LabelSelectionState};
 
 use re_chunk::TimelineName;
 use re_chunk_store::LatestAtQuery;
@@ -683,8 +683,12 @@ impl AppState {
             self.selection_state.clear_selection();
         }
 
-        // If there's no label selected, and the user triggers a copy command, copy a description of the current selection.
-        if !LabelSelectionState::load(ui.ctx()).has_selection()
+        // If there's no text edit or label selected, and the user triggers a copy command, copy a description of the current selection.
+        if ui
+            .memory(|mem| mem.focused())
+            .and_then(|id| TextEditState::load(ui.ctx(), id))
+            .is_none()
+            && !LabelSelectionState::load(ui.ctx()).has_selection()
             && ui.input(|input| input.events.iter().any(|e| e == &egui::Event::Copy))
         {
             self.selection_state


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/9926

If a `TextEdit` is focused, we shouldn't trigger our own selection copy.