### PR TITLE
Provide `AnyValues` helpers in Rust SDK

### DIFF
--- a/crates/store/re_types/src/any_values.rs
+++ b/crates/store/re_types/src/any_values.rs
@@ -1,0 +1,108 @@
+//! Utilities to log arbitrary data to Rerun.
+
+use nohash_hasher::IntMap;
+
+use crate::{
+    ArchetypeFieldName, ArchetypeName, Component, ComponentDescriptor, SerializedComponentBatch,
+};
+use re_types_core::{try_serialize_field, AsComponents, ComponentName, Loggable};
+
+/// A helper for logging arbitrary data to Rerun.
+#[derive(Default)]
+pub struct AnyValues {
+    archetype_name: Option<ArchetypeName>,
+    batches: IntMap<ArchetypeFieldName, SerializedComponentBatch>,
+}
+
+impl AnyValues {
+    /// Assigns an (archetype) name to this set of any values.
+    #[inline]
+    pub fn new(archetype_name: impl Into<ArchetypeName>) -> Self {
+        Self {
+            archetype_name: Some(archetype_name.into()),
+            batches: Default::default(),
+        }
+    }
+
+    /// Adds a field of arbitrary data to this archetype.
+    ///
+    /// In many cases, it might be more convenient to use [`Self::with_component`] to log an existing Rerun component instead.
+    #[inline]
+    pub fn with_field(
+        mut self,
+        archetype_field_name: impl Into<ArchetypeFieldName>,
+        array: arrow::array::ArrayRef,
+    ) -> Self {
+        let archetype_field_name = archetype_field_name.into();
+        self.batches.insert(
+            archetype_field_name,
+            SerializedComponentBatch {
+                array,
+                descriptor: ComponentDescriptor {
+                    archetype_name: self.archetype_name,
+                    component_name: None,
+                    archetype_field_name,
+                },
+            },
+        );
+        self
+    }
+
+    /// Adds an existing Rerun [`Component`] to this archetype.
+    #[inline]
+    pub fn with_component<C: Component>(
+        self,
+        archetype_field_name: impl Into<ArchetypeFieldName>,
+        component: impl IntoIterator<Item = impl Into<C>>,
+    ) -> Self {
+        self.with_loggable(archetype_field_name, C::name(), component)
+    }
+
+    /// Adds an existing Rerun [`Component`] to this archetype.
+    ///
+    /// This method can be used to override the component name.
+    #[inline]
+    pub fn with_loggable<L: Loggable>(
+        mut self,
+        archetype_field_name: impl Into<ArchetypeFieldName>,
+        component_name: impl Into<ComponentName>,
+        loggable: impl IntoIterator<Item = impl Into<L>>,
+    ) -> Self {
+        let archetype_field_name = archetype_field_name.into();
+        try_serialize_field(
+            ComponentDescriptor {
+                archetype_name: self.archetype_name,
+                archetype_field_name,
+                component_name: Some(component_name.into()),
+            },
+            loggable,
+        )
+        .and_then(|serialized| self.batches.insert(archetype_field_name, serialized));
+        self
+    }
+}
+
+impl AsComponents for AnyValues {
+    fn as_serialized_batches(&self) -> Vec<SerializedComponentBatch> {
+        self.batches.values().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::components;
+
+    use super::*;
+
+    #[test]
+    fn simple() {
+        let _ = AnyValues::default()
+            .with_component::<components::Scalar>("confidence", [1.2f64, 3.4, 5.6])
+            .with_loggable::<components::Text>("homepage", "user.url", vec!["https://www.rerun.io"])
+            .with_field(
+                "description",
+                std::sync::Arc::new(arrow::array::StringArray::from(vec!["Bla bla bla…"])),
+            );
+    }
+}

--- a/crates/store/re_types/src/lib.rs
+++ b/crates/store/re_types/src/lib.rs
@@ -297,6 +297,9 @@ pub mod image;
 pub mod tensor_data;
 pub mod view_coordinates;
 
+pub mod any_values;
+pub use any_values::AnyValues;
+
 mod rotation3d;
 pub use rotation3d::Rotation3D;
 

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -147,11 +147,11 @@ macro_rules! static_assert_struct_has_fields {
 /// merely be logged, not returned (except in debug builds, where all errors panic).
 #[doc(hidden)] // public so we can access it from re_types too
 #[allow(clippy::unnecessary_wraps)] // clippy gets confused in debug builds
-pub fn try_serialize_field<C: crate::Component>(
+pub fn try_serialize_field<L: Loggable>(
     descriptor: ComponentDescriptor,
-    instances: impl IntoIterator<Item = impl Into<C>>,
+    instances: impl IntoIterator<Item = impl Into<L>>,
 ) -> Option<SerializedComponentBatch> {
-    let res = C::to_arrow(
+    let res = L::to_arrow(
         instances
             .into_iter()
             .map(|v| std::borrow::Cow::Owned(v.into())),

--- a/crates/top/rerun/src/sdk.rs
+++ b/crates/top/rerun/src/sdk.rs
@@ -19,7 +19,7 @@ mod prelude {
     pub use re_types::archetypes::*;
 
     // Special utility types.
-    pub use re_types::Rotation3D;
+    pub use re_types::{AnyValues, Rotation3D};
 
     // Also import any component or datatype that has a unique name:
     pub use re_chunk::TimeColumn;

--- a/docs/snippets/all/concepts/recording_properties.rs
+++ b/docs/snippets/all/concepts/recording_properties.rs
@@ -19,26 +19,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &rerun::archetypes::Points3D::new([[1.0, 0.1, 1.0]]),
     )?;
 
-    let confidences = rerun::SerializedComponentBatch::new(
-        Arc::new(arrow::array::Float64Array::from(vec![0.3, 0.4, 0.5, 0.6])),
-        rerun::ComponentDescriptor::partial("confidences"),
-    );
-
-    let traffic = rerun::SerializedComponentBatch::new(
-        Arc::new(arrow::array::StringArray::from(vec!["low"])),
-        rerun::ComponentDescriptor::partial("traffic"),
-    );
-
-    let weather = rerun::SerializedComponentBatch::new(
-        Arc::new(arrow::array::StringArray::from(vec!["sunny"])),
-        rerun::ComponentDescriptor::partial("weather"),
-    );
+    let other = rerun::AnyValues::default()
+        .with_field(
+            "confidences",
+            Arc::new(arrow::array::Float64Array::from(vec![0.3, 0.4, 0.5, 0.6])),
+        )
+        .with_field(
+            "traffic",
+            Arc::new(arrow::array::StringArray::from(vec!["low"])),
+        )
+        .with_field(
+            "weather",
+            Arc::new(arrow::array::StringArray::from(vec!["sunny"])),
+        );
 
     // Adds another property, this time with user-defined data.
-    rec.send_property(
-        "situation",
-        &[&confidences as &dyn rerun::AsComponents, &traffic, &weather],
-    )?;
+    rec.send_property("situation", &other)?;
 
     // Properties, including the name, can be overwritten at any time.
     rec.send_recording_name("My episode")?;

--- a/docs/snippets/all/howto/any_values_row_updates.rs
+++ b/docs/snippets/all/howto/any_values_row_updates.rs
@@ -12,22 +12,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_any_values_row_updates").spawn()?;
 
     for step in 0..64 {
-        let sin = rerun::SerializedComponentBatch::new(
-            Arc::new(arrow::array::Float64Array::from_iter(
-                [((step as f64) / 10.0).sin()], //
-            )),
-            rerun::ComponentDescriptor::partial("sin"),
-        );
-
-        let cos = rerun::SerializedComponentBatch::new(
-            Arc::new(arrow::array::Float64Array::from_iter(
-                [((step as f64) / 10.0).cos()], //
-            )),
-            rerun::ComponentDescriptor::partial("cos"),
-        );
+        let sin_cos = rerun::AnyValues::default()
+            .with_field(
+                "sin",
+                Arc::new(arrow::array::Float64Array::from_iter(
+                    [((step as f64) / 10.0).sin()], //
+                )),
+            )
+            .with_field(
+                "cos",
+                Arc::new(arrow::array::Float64Array::from_iter(
+                    [((step as f64) / 10.0).cos()], //
+                )),
+            );
 
         rec.set_time_sequence("step", step);
-        rec.log("/", &[sin, cos])?;
+        rec.log("/", &sin_cos)?;
     }
 
     Ok(())

--- a/docs/snippets/all/tutorials/any_values.rs
+++ b/docs/snippets/all/tutorials/any_values.rs
@@ -7,35 +7,25 @@ use rerun::external::arrow;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_any_values").spawn()?;
 
-    let confidences = rerun::SerializedComponentBatch::new(
-        Arc::new(arrow::array::Float64Array::from(vec![1.2, 3.4, 5.6])),
-        rerun::ComponentDescriptor::partial("confidence"),
-    );
+    let any_values = rerun::AnyValues::default()
+        // Using Rerun's builtin components.
+        .with_component::<rerun::components::Scalar>("confidence", [1.2, 3.4, 5.6])
+        .with_component::<rerun::components::Text>("description", vec!["Bla bla bla…"])
+        // Using arbitrary Arrow data.
+        .with_field(
+            "homepage",
+            Arc::new(arrow::array::StringArray::from(vec![
+                "https://www.rerun.io",
+            ])),
+        )
+        .with_field(
+            "repository",
+            Arc::new(arrow::array::StringArray::from(vec![
+                "https://github.com/rerun-io/rerun",
+            ])),
+        );
 
-    let description = rerun::SerializedComponentBatch::new(
-        Arc::new(arrow::array::StringArray::from(vec!["Bla bla bla…"])),
-        rerun::ComponentDescriptor::partial("description"),
-    );
-
-    // URIs will become clickable links
-    let homepage = rerun::SerializedComponentBatch::new(
-        Arc::new(arrow::array::StringArray::from(vec![
-            "https://www.rerun.io",
-        ])),
-        rerun::ComponentDescriptor::partial("homepage"),
-    );
-
-    let repository = rerun::SerializedComponentBatch::new(
-        Arc::new(arrow::array::StringArray::from(vec![
-            "https://github.com/rerun-io/rerun",
-        ])),
-        rerun::ComponentDescriptor::partial("repository"),
-    );
-
-    rec.log(
-        "any_values",
-        &[confidences, description, homepage, repository],
-    )?;
+    rec.log("any_values", &any_values)?;
 
     Ok(())
 }

--- a/docs/snippets/all/tutorials/extra_values.rs
+++ b/docs/snippets/all/tutorials/extra_values.rs
@@ -8,9 +8,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_extra_values").spawn()?;
 
     let points = rerun::Points2D::new([(-1.0, -1.0), (-1.0, 1.0), (1.0, -1.0), (1.0, 1.0)]);
-    let confidences = rerun::SerializedComponentBatch::new(
+    let confidences = rerun::AnyValues::default().with_field(
+        "confidence",
         Arc::new(arrow::array::Float64Array::from(vec![0.3, 0.4, 0.5, 0.6])),
-        rerun::ComponentDescriptor::partial("confidence"),
     );
 
     rec.log(


### PR DESCRIPTION
### Related

* Part of #6889.
* Closes #9906.
* Part of #9340.

### What

This PR does multiple things:

* Works towards providing a common `AnyValues` interface that is similar across Python 🐍 , C++ 🌊 , and Rust 🦀 SDKs (so far we only have `AnyValues` in Python).
* By using the new `AnyValues` we ensure that more of the logged data is actually tagged.