### PR TITLE
Fix incorrect 'structfields' doc links

### DIFF
--- a/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -53,7 +53,7 @@ pub struct CpuWriteGpuReadBuffer<T: bytemuck::Pod + Send + Sync> {
     /// Write view into the relevant buffer portion.
     ///
     /// UNSAFE: The lifetime is transmuted to be `'static`.
-    /// In actuality it is tied to the lifetime of [`chunk_buffer`](#structfield.chunk_buffer)!
+    /// In actuality it is tied to the lifetime of [`chunk_buffer`](Self::chunk_buffer)!
     write_view: wgpu::BufferViewMut<'static>,
 
     /// Range in T elements in `write_view` that haven't been written yet.

--- a/crates/viewer/re_renderer/src/wgpu_resources/buffer_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/buffer_pool.rs
@@ -30,7 +30,7 @@ pub struct BufferDesc {
     /// [`wgpu::BufferUsages::MAP_WRITE`], all buffers are allowed to be mapped at creation.
     ///
     /// *WARNING*: If this is `true`, the pool won't be able to reclaim the buffer later!
-    /// Furthermore, [`size`](#structfield.size) must be a multiple of [`wgpu::COPY_BUFFER_ALIGNMENT`].
+    /// Furthermore, [`size`](Self::size) must be a multiple of [`wgpu::COPY_BUFFER_ALIGNMENT`].
     pub mapped_at_creation: bool,
 }
 


### PR DESCRIPTION
rust analyzer wasn't interpreting those. to be noted those types are not part of public API (thus not appearing in rustdoc).