### PR TITLE
change copy to reflect timeline nav

### DIFF
--- a/crates/viewer/re_time_panel/src/time_control_ui.rs
+++ b/crates/viewer/re_time_panel/src/time_control_ui.rs
@@ -163,7 +163,7 @@ You can also define your own timelines, e.g. for sensor time or camera frame num
     ) {
         if ui
             .large_button(&re_ui::icons::ARROW_LEFT)
-            .on_hover_text("Step back to previous time with any new data (Ctrl+Left arrow)")
+            .on_hover_text("Step back to previous time with any new data (Ctrl/Cmd+Left arrow)")
             .clicked()
         {
             time_control.step_time_back(times_per_timeline);
@@ -171,7 +171,7 @@ You can also define your own timelines, e.g. for sensor time or camera frame num
 
         if ui
             .large_button(&re_ui::icons::ARROW_RIGHT)
-            .on_hover_text("Step forwards to next time with any new data (Ctrl+Right arrow)")
+            .on_hover_text("Step forwards to next time with any new data (Ctrl/Cmd+Right arrow)")
             .clicked()
         {
             time_control.step_time_fwd(times_per_timeline);

--- a/crates/viewer/re_time_panel/src/time_control_ui.rs
+++ b/crates/viewer/re_time_panel/src/time_control_ui.rs
@@ -163,7 +163,7 @@ You can also define your own timelines, e.g. for sensor time or camera frame num
     ) {
         if ui
             .large_button(&re_ui::icons::ARROW_LEFT)
-            .on_hover_text("Step back to previous time with any new data (left arrow)")
+            .on_hover_text("Step back to previous time with any new data (Ctrl+Left arrow)")
             .clicked()
         {
             time_control.step_time_back(times_per_timeline);
@@ -171,7 +171,7 @@ You can also define your own timelines, e.g. for sensor time or camera frame num
 
         if ui
             .large_button(&re_ui::icons::ARROW_RIGHT)
-            .on_hover_text("Step forwards to next time with any new data (right arrow)")
+            .on_hover_text("Step forwards to next time with any new data (Ctrl+Right arrow)")
             .clicked()
         {
             time_control.step_time_fwd(times_per_timeline);

--- a/docs/content/getting-started/navigating-the-viewer.md
+++ b/docs/content/getting-started/navigating-the-viewer.md
@@ -169,7 +169,7 @@ There are several ways to navigate through the timeline:
 
 Try out the following:
 
--   Use Ctrl+Left/Right arrow keys to step forward and backwards by a single frame
+-   Use Ctrl/Cmd+Left/Right arrow keys to step forward and backwards by a single frame
 -   Click play to watch the data update on its own
 -   Hit space bar to stop and start the playback
 -   Hold shift and drag in the timeline to select a region

--- a/docs/content/getting-started/navigating-the-viewer.md
+++ b/docs/content/getting-started/navigating-the-viewer.md
@@ -169,7 +169,7 @@ There are several ways to navigate through the timeline:
 
 Try out the following:
 
--   Use the arrow buttons (or Arrow keys on your keyboard) to step forward and backwards by a single frame
+-   Use Ctrl+Left/Right arrow keys to step forward and backwards by a single frame
 -   Click play to watch the data update on its own
 -   Hit space bar to stop and start the playback
 -   Hold shift and drag in the timeline to select a region


### PR DESCRIPTION
used to be like this : 
![image](https://github.com/user-attachments/assets/63deed30-6d75-4c52-9627-d1758a58e44d)
but now it's with Ctrl+right/left

see [changes](https://github.com/rerun-io/rerun/blob/main/docs/content/reference/migration/migration-0-24.md)