### PR TITLE
Expose `DrawPhase`

### DIFF
--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -75,9 +75,8 @@ pub use transform::RectTransform;
 pub use view_builder::ViewBuilder;
 pub use wgpu_resources::WgpuResourcePoolStatistics;
 
-use draw_phases::DrawPhase;
 pub use draw_phases::{
-    OutlineConfig, OutlineMaskPreference, PickingLayerId, PickingLayerInstanceId,
+    DrawPhase, OutlineConfig, OutlineMaskPreference, PickingLayerId, PickingLayerInstanceId,
     PickingLayerObjectId, PickingLayerProcessor, ScreenshotProcessor,
 };
 


### PR DESCRIPTION
If one wants to make a custom renderer, `DrawPhase` not being exposed is getting in the way, as it's a public interface of the `Renderer` trait, especially for [`participated_phases()`](https://docs.rs/re_renderer/latest/re_renderer/renderer/trait.Renderer.html#tymethod.participated_phases)