### PR TITLE
Improve UX of opening recordings in catalog browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,7 +2762,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "ecolor"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -2779,7 +2779,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2819,7 +2819,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2857,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "ahash",
  "egui",
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2955,7 +2955,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "dify",
  "eframe",
@@ -3027,7 +3027,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3144,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#b8334f365be7325ce2974bd1cefc8abd5326299d"
+source = "git+https://github.com/emilk/egui.git?branch=main#da67465a6cd00e6c1732ecb96e0febc917d63c31"
 
 [[package]]
 name = "equivalent"
@@ -4469,7 +4469,7 @@ dependencies = [
  "portable-atomic-util",
  "serde",
  "wasm-bindgen",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4714,7 +4714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6412,7 +6412,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9450,7 +9450,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11030,7 +11030,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -233,8 +233,8 @@ impl DataSource {
                 ..
             } => {
                 let (tx, rx) = re_smart_channel::smart_channel(
-                    re_smart_channel::SmartMessageSource::RedapGrpcStream(uri.clone()),
-                    re_smart_channel::SmartChannelSource::RedapGrpcStream(uri.clone()),
+                    re_smart_channel::SmartMessageSource::RedapGrpcStream { uri: uri.clone() },
+                    re_smart_channel::SmartChannelSource::RedapGrpcStream { uri: uri.clone() },
                 );
 
                 let on_cmd = Box::new(move |cmd: re_grpc_client::redap::Command| match cmd {

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -32,8 +32,14 @@ pub fn stream_dataset_from_redap(
     re_log::debug!("Loading {uri}…");
 
     let (tx, rx) = re_smart_channel::smart_channel(
-        re_smart_channel::SmartMessageSource::RedapGrpcStream { uri: uri.clone() },
-        re_smart_channel::SmartChannelSource::RedapGrpcStream { uri: uri.clone() },
+        re_smart_channel::SmartMessageSource::RedapGrpcStream {
+            uri: uri.clone(),
+            select_when_loaded: true,
+        },
+        re_smart_channel::SmartChannelSource::RedapGrpcStream {
+            uri: uri.clone(),
+            select_when_loaded: true,
+        },
     );
 
     spawn_future(async move {

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -32,8 +32,8 @@ pub fn stream_dataset_from_redap(
     re_log::debug!("Loading {uri}…");
 
     let (tx, rx) = re_smart_channel::smart_channel(
-        re_smart_channel::SmartMessageSource::RedapGrpcStream(uri.clone()),
-        re_smart_channel::SmartChannelSource::RedapGrpcStream(uri.clone()),
+        re_smart_channel::SmartMessageSource::RedapGrpcStream { uri: uri.clone() },
+        re_smart_channel::SmartChannelSource::RedapGrpcStream { uri: uri.clone() },
     );
 
     spawn_future(async move {

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -736,8 +736,9 @@ fn run_impl(
 
         #[cfg(feature = "web_viewer")]
         if data_sources.len() == 1 && args.web_viewer {
-            if let DataSource::RerunGrpcStream(re_uri::RedapUri::Proxy(uri)) =
-                data_sources[0].clone()
+            if let DataSource::RerunGrpcStream {
+                uri: re_uri::RedapUri::Proxy(uri),
+            } = data_sources[0].clone()
             {
                 // Special case! We are connecting a web-viewer to a gRPC address.
                 // Instead of piping, just host a web-viewer that connects to the gRPC server directly:

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -738,6 +738,7 @@ fn run_impl(
         if data_sources.len() == 1 && args.web_viewer {
             if let DataSource::RerunGrpcStream {
                 uri: re_uri::RedapUri::Proxy(uri),
+                ..
             } = data_sources[0].clone()
             {
                 // Special case! We are connecting a web-viewer to a gRPC address.

--- a/crates/utils/re_smart_channel/src/lib.rs
+++ b/crates/utils/re_smart_channel/src/lib.rs
@@ -51,7 +51,12 @@ pub enum SmartChannelSource {
     Stdin,
 
     /// The data is streaming in directly from a Rerun Data Platform server, over gRPC.
-    RedapGrpcStream { uri: re_uri::DatasetDataUri },
+    RedapGrpcStream {
+        uri: re_uri::DatasetDataUri,
+
+        /// Switch to this recording once it has been loaded?
+        select_when_loaded: bool,
+    },
 
     /// The data is streaming in via a message proxy.
     MessageProxy(re_uri::ProxyUri),
@@ -63,7 +68,7 @@ impl std::fmt::Display for SmartChannelSource {
             Self::File(path) => path.display().fmt(f),
             Self::RrdHttpStream { url, follow: _ } => url.fmt(f),
             Self::MessageProxy(uri) => uri.fmt(f),
-            Self::RedapGrpcStream { uri } => uri.fmt(f),
+            Self::RedapGrpcStream { uri, .. } => uri.fmt(f),
             Self::RrdWebEventListener => "Web event listener".fmt(f),
             Self::JsChannel { channel_name } => write!(f, "Javascript channel: {channel_name}"),
             Self::Sdk => "SDK".fmt(f),
@@ -80,6 +85,22 @@ impl SmartChannelSource {
             | Self::JsChannel { .. }
             | Self::RedapGrpcStream { .. }
             | Self::MessageProxy { .. } => true,
+        }
+    }
+
+    pub fn select_when_loaded(&self) -> bool {
+        match self {
+            Self::File(_)
+            | Self::Sdk
+            | Self::RrdWebEventListener
+            | Self::Stdin
+            | Self::RrdHttpStream { .. }
+            | Self::JsChannel { .. }
+            | Self::MessageProxy { .. } => true,
+
+            Self::RedapGrpcStream {
+                select_when_loaded, ..
+            } => *select_when_loaded,
         }
     }
 }
@@ -123,7 +144,12 @@ pub enum SmartMessageSource {
     Stdin,
 
     /// A file on a Rerun Data Platform server, over `rerun://` gRPC interface.
-    RedapGrpcStream { uri: re_uri::DatasetDataUri },
+    RedapGrpcStream {
+        uri: re_uri::DatasetDataUri,
+
+        /// Switch to this recording once it has been loaded?
+        select_when_loaded: bool,
+    },
 
     /// A stream of messages over message proxy gRPC interface.
     MessageProxy(re_uri::ProxyUri),
@@ -136,7 +162,7 @@ impl std::fmt::Display for SmartMessageSource {
             Self::File(path) => format!("file://{}", path.to_string_lossy()),
             Self::RrdHttpStream { url } => url.clone(),
             Self::MessageProxy(uri) => uri.to_string(),
-            Self::RedapGrpcStream { uri } => uri.to_string(),
+            Self::RedapGrpcStream { uri, .. } => uri.to_string(),
             Self::RrdWebEventCallback => "web_callback".into(),
             Self::JsChannelPush => "javascript".into(),
             Self::Sdk => "sdk".into(),

--- a/crates/utils/re_smart_channel/src/lib.rs
+++ b/crates/utils/re_smart_channel/src/lib.rs
@@ -51,7 +51,7 @@ pub enum SmartChannelSource {
     Stdin,
 
     /// The data is streaming in directly from a Rerun Data Platform server, over gRPC.
-    RedapGrpcStream(re_uri::DatasetDataUri),
+    RedapGrpcStream { uri: re_uri::DatasetDataUri },
 
     /// The data is streaming in via a message proxy.
     MessageProxy(re_uri::ProxyUri),
@@ -63,7 +63,7 @@ impl std::fmt::Display for SmartChannelSource {
             Self::File(path) => path.display().fmt(f),
             Self::RrdHttpStream { url, follow: _ } => url.fmt(f),
             Self::MessageProxy(uri) => uri.fmt(f),
-            Self::RedapGrpcStream(uri) => uri.fmt(f),
+            Self::RedapGrpcStream { uri } => uri.fmt(f),
             Self::RrdWebEventListener => "Web event listener".fmt(f),
             Self::JsChannel { channel_name } => write!(f, "Javascript channel: {channel_name}"),
             Self::Sdk => "SDK".fmt(f),
@@ -123,7 +123,7 @@ pub enum SmartMessageSource {
     Stdin,
 
     /// A file on a Rerun Data Platform server, over `rerun://` gRPC interface.
-    RedapGrpcStream(re_uri::DatasetDataUri),
+    RedapGrpcStream { uri: re_uri::DatasetDataUri },
 
     /// A stream of messages over message proxy gRPC interface.
     MessageProxy(re_uri::ProxyUri),
@@ -136,7 +136,7 @@ impl std::fmt::Display for SmartMessageSource {
             Self::File(path) => format!("file://{}", path.to_string_lossy()),
             Self::RrdHttpStream { url } => url.clone(),
             Self::MessageProxy(uri) => uri.to_string(),
-            Self::RedapGrpcStream(uri) => uri.to_string(),
+            Self::RedapGrpcStream { uri } => uri.to_string(),
             Self::RrdWebEventCallback => "web_callback".into(),
             Self::JsChannelPush => "javascript".into(),
             Self::Sdk => "sdk".into(),

--- a/crates/utils/re_smart_channel/src/lib.rs
+++ b/crates/utils/re_smart_channel/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::sync::{Arc, atomic::AtomicU64};
 
+use re_uri::RedapUri;
 use web_time::Instant;
 
 pub use crossbeam::channel::{RecvError, RecvTimeoutError, SendError, TryRecvError};
@@ -101,6 +102,20 @@ impl SmartChannelSource {
             Self::RedapGrpcStream {
                 select_when_loaded, ..
             } => *select_when_loaded,
+        }
+    }
+
+    pub fn redap_uri(&self) -> Option<RedapUri> {
+        match self {
+            Self::RedapGrpcStream { uri, .. } => Some(RedapUri::DatasetData(uri.clone())),
+            Self::MessageProxy(uri) => Some(RedapUri::Proxy(uri.clone())),
+
+            Self::File(_)
+            | Self::Sdk
+            | Self::RrdWebEventListener
+            | Self::Stdin
+            | Self::RrdHttpStream { .. }
+            | Self::JsChannel { .. } => None,
         }
     }
 }

--- a/crates/utils/re_smart_channel/src/receive_set.rs
+++ b/crates/utils/re_smart_channel/src/receive_set.rs
@@ -46,15 +46,14 @@ impl<T: Send> ReceiveSet<T> {
     }
 
     /// Disconnect from any channel with a source pointing at this `uri`.
-    #[cfg(target_arch = "wasm32")]
-    pub fn remove_by_uri(&self, uri: &str) {
+    pub fn remove_by_uri(&self, needle: &str) {
         self.receivers.lock().retain(|r| match r.source() {
             // retain only sources which:
             // - aren't network sources
-            // - don't point at the given `uri`
-            SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
-            SmartChannelSource::MessageProxy(url) => url.to_string() != uri,
-            SmartChannelSource::RedapGrpcStream(url) => url.to_string() != uri,
+            // - don't point at the given `needle`
+            SmartChannelSource::RrdHttpStream { url, .. } => url != needle,
+            SmartChannelSource::MessageProxy(url) => url.to_string() != needle,
+            SmartChannelSource::RedapGrpcStream { uri, .. } => uri.to_string() != needle,
 
             SmartChannelSource::File(_)
             | SmartChannelSource::Stdin

--- a/crates/utils/re_uri/src/redap_uri.rs
+++ b/crates/utils/re_uri/src/redap_uri.rs
@@ -23,6 +23,15 @@ pub enum RedapUri {
 }
 
 impl RedapUri {
+    pub fn origin(&self) -> &Origin {
+        match self {
+            Self::Catalog(uri) => &uri.origin,
+            Self::Entry(uri) => &uri.origin,
+            Self::DatasetData(uri) => &uri.origin,
+            Self::Proxy(uri) => &uri.origin,
+        }
+    }
+
     /// Return the parsed `#fragment` of the URI, if any.
     pub fn fragment(&self) -> Option<&Fragment> {
         match self {

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -52,10 +52,6 @@ pub fn redap_uri_button(
         if response.clicked() {
             // Show it:
             ctx.command_sender()
-                .send_system(SystemCommand::ChangeDisplayMode(
-                    re_viewer_context::DisplayMode::RedapServer(uri.origin().clone()),
-                ));
-            ctx.command_sender()
                 .send_system(SystemCommand::SetSelection(
                     re_viewer_context::Item::StoreId(loaded_recording_id),
                 ));

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -33,14 +33,13 @@ pub fn redap_uri_button(
     let uri = RedapUri::from_str(url_str)?;
 
     //TODO(#10036): we should provide feedback if the URI is already loaded, e.g. have "go to" instead of "open"
-    if ui
-        .button("Open")
-        .on_hover_ui(|ui| {
-            ui.label(uri.to_string());
-        })
-        .clicked()
-    {
-        let url = if ui.input(|i| i.modifiers.command) {
+    let response = ui.button("Open").on_hover_ui(|ui| {
+        ui.label(uri.to_string());
+    });
+    if response.middle_clicked() {
+        ui.ctx().open_url(egui::OpenUrl::new_tab(uri));
+    } else if response.clicked() {
+        let url = if ui.input(|i| i.modifiers.any()) {
             egui::OpenUrl::new_tab(uri)
         } else {
             egui::OpenUrl::same_tab(uri)

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -61,16 +61,10 @@ pub fn redap_uri_button(
             ui.label(uri.to_string());
         });
 
-        if response.middle_clicked() {
+        if response.clicked_with_open_in_background() {
             ui.ctx().open_url(egui::OpenUrl::new_tab(uri));
         } else if response.clicked() {
-            let url = if ui.input(|i| i.modifiers.any()) {
-                egui::OpenUrl::new_tab(uri)
-            } else {
-                egui::OpenUrl::same_tab(uri)
-            };
-
-            ui.ctx().open_url(url);
+            ui.ctx().open_url(egui::OpenUrl::same_tab(uri));
         }
     }
 

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -3,7 +3,7 @@ use std::str::FromStr as _;
 
 use re_types_core::{ComponentDescriptor, RowId};
 use re_uri::RedapUri;
-use re_viewer_context::{SystemCommand, SystemCommandSender, ViewerContext};
+use re_viewer_context::{SystemCommand, SystemCommandSender as _, ViewerContext};
 
 /// Display an URL as an `Open` button (instead of spelling the full URL).
 ///

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -182,7 +182,7 @@ pub fn sort_datasets<'a>(viewer_ctx: &ViewerContext<'a>) -> SortDatasetsResults<
         let Some(app_id) = entity_db.app_id().cloned() else {
             continue; // this only happens if we haven't even started loading it, or if something is really wrong with it.
         };
-        if let Some(SmartChannelSource::RedapGrpcStream(uri)) = &entity_db.data_source {
+        if let Some(SmartChannelSource::RedapGrpcStream{uri}) = &entity_db.data_source {
             let origin_recordings = remote_recordings.entry(uri.origin.clone()).or_default();
 
             let dataset_recordings = origin_recordings

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -182,7 +182,7 @@ pub fn sort_datasets<'a>(viewer_ctx: &ViewerContext<'a>) -> SortDatasetsResults<
         let Some(app_id) = entity_db.app_id().cloned() else {
             continue; // this only happens if we haven't even started loading it, or if something is really wrong with it.
         };
-        if let Some(SmartChannelSource::RedapGrpcStream{uri}) = &entity_db.data_source {
+        if let Some(SmartChannelSource::RedapGrpcStream { uri, .. }) = &entity_db.data_source {
             let origin_recordings = remote_recordings.entry(uri.origin.clone()).or_default();
 
             let dataset_recordings = origin_recordings

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -996,14 +996,13 @@ pub trait UiExt {
                 .add(crate::icons::EXTERNAL_LINK.as_button_with_label(ui.design_tokens(), text))
                 .on_hover_cursor(egui::CursorIcon::PointingHand);
 
-            // Inspired from `egui::Ui::Hyperlink::ui()`
-            if response.clicked() {
+            if response.clicked_with_open_in_background() {
+                ui.ctx().open_url(egui::OpenUrl::new_tab(url.to_string()));
+            } else if response.clicked() {
                 ui.ctx().open_url(egui::OpenUrl {
                     url: url.to_string(),
                     new_tab: always_new_tab || ui.input(|i| i.modifiers.any()),
                 });
-            } else if response.middle_clicked() {
-                ui.ctx().open_url(egui::OpenUrl::new_tab(url));
             }
 
             response

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1618,31 +1618,33 @@ impl App {
 
             match &msg {
                 LogMsg::SetStoreInfo(_) => {
-                    // Set the recording-id after potentially creating the store in the hub.
-                    // This ordering is important because the `StoreHub` internally
-                    // updates the app-id when changing the recording.
-                    match store_id.kind {
-                        StoreKind::Recording => {
-                            re_log::trace!("Opening a new recording: '{store_id}'");
-                            store_hub.set_active_recording_id(store_id.clone());
+                    if channel_source.select_when_loaded() {
+                        // Set the recording-id after potentially creating the store in the hub.
+                        // This ordering is important because the `StoreHub` internally
+                        // updates the app-id when changing the recording.
+                        match store_id.kind {
+                            StoreKind::Recording => {
+                                re_log::trace!("Opening a new recording: '{store_id}'");
+                                store_hub.set_active_recording_id(store_id.clone());
 
-                            // Also select the new recording:
-                            self.command_sender.send_system(SystemCommand::SetSelection(
-                                re_viewer_context::Item::StoreId(store_id.clone()),
-                            ));
+                                // Also select the new recording:
+                                self.command_sender.send_system(SystemCommand::SetSelection(
+                                    re_viewer_context::Item::StoreId(store_id.clone()),
+                                ));
 
-                            // If the viewer is in the background, tell the user that it has received something new.
-                            egui_ctx.send_viewport_cmd(
-                                egui::ViewportCommand::RequestUserAttention(
-                                    egui::UserAttentionType::Informational,
-                                ),
-                            );
-                        }
-                        StoreKind::Blueprint => {
-                            // We wait with activating blueprints until they are fully loaded,
-                            // so that we don't run heuristics on half-loaded blueprints.
-                            // Otherwise on a mixed connection (SDK sending both blueprint and recording)
-                            // the blueprint won't be activated until the whole _recording_ has finished loading.
+                                // If the viewer is in the background, tell the user that it has received something new.
+                                egui_ctx.send_viewport_cmd(
+                                    egui::ViewportCommand::RequestUserAttention(
+                                        egui::UserAttentionType::Informational,
+                                    ),
+                                );
+                            }
+                            StoreKind::Blueprint => {
+                                // We wait with activating blueprints until they are fully loaded,
+                                // so that we don't run heuristics on half-loaded blueprints.
+                                // Otherwise on a mixed connection (SDK sending both blueprint and recording)
+                                // the blueprint won't be activated until the whole _recording_ has finished loading.
+                            }
                         }
                     }
                 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -360,7 +360,7 @@ impl App {
         //
         // Otherwise we end up in a situation where we have a data from an unknown server,
         // which is unnecessary and can get us into a strange ui state.
-        if let SmartChannelSource::RedapGrpcStream(uri) = rx.source() {
+        if let SmartChannelSource::RedapGrpcStream { uri } = rx.source() {
             self.add_redap_server(uri.origin.clone());
 
             self.go_to_uri_fragment(uri.recording_id(), uri.fragment.clone());
@@ -1297,7 +1297,7 @@ impl App {
             return;
         };
 
-        let Some(SmartChannelSource::RedapGrpcStream(mut uri)) = entity_db.data_source.clone()
+        let Some(SmartChannelSource::RedapGrpcStream { mut uri }) = entity_db.data_source.clone()
         else {
             re_log::warn!("Could not copy time range link: Data source is not a gRPC stream");
             return;
@@ -1610,7 +1610,7 @@ impl App {
             if was_empty && !entity_db.is_empty() {
                 // Hack: we cannot go to a specific timeline or entity until we know about it.
                 // Now we _hopefully_ do.
-                if let SmartChannelSource::RedapGrpcStream(uri) = channel_source.as_ref() {
+                if let SmartChannelSource::RedapGrpcStream { uri } = channel_source.as_ref() {
                     self.go_to_uri_fragment(uri.recording_id(), uri.fragment.clone());
                 }
             }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -642,9 +642,13 @@ impl App {
                             .replace(DisplayMode::LocalTable(table_id.clone()));
                     }
 
+                    Item::StoreId(store_id) => {
+                        self.state.navigation.replace(DisplayMode::LocalRecordings);
+                        store_hub.set_active_recording_id(store_id.clone());
+                    }
+
                     Item::AppId(_)
                     | Item::DataSource(_)
-                    | Item::StoreId(_)
                     | Item::InstancePath(_)
                     | Item::ComponentPath(_)
                     | Item::Container(_)

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -360,7 +360,7 @@ impl App {
         //
         // Otherwise we end up in a situation where we have a data from an unknown server,
         // which is unnecessary and can get us into a strange ui state.
-        if let SmartChannelSource::RedapGrpcStream { uri } = rx.source() {
+        if let SmartChannelSource::RedapGrpcStream { uri, .. } = rx.source() {
             self.add_redap_server(uri.origin.clone());
 
             self.go_to_uri_fragment(uri.recording_id(), uri.fragment.clone());
@@ -1297,7 +1297,8 @@ impl App {
             return;
         };
 
-        let Some(SmartChannelSource::RedapGrpcStream { mut uri }) = entity_db.data_source.clone()
+        let Some(SmartChannelSource::RedapGrpcStream { mut uri, .. }) =
+            entity_db.data_source.clone()
         else {
             re_log::warn!("Could not copy time range link: Data source is not a gRPC stream");
             return;
@@ -1610,7 +1611,7 @@ impl App {
             if was_empty && !entity_db.is_empty() {
                 // Hack: we cannot go to a specific timeline or entity until we know about it.
                 // Now we _hopefully_ do.
-                if let SmartChannelSource::RedapGrpcStream { uri } = channel_source.as_ref() {
+                if let SmartChannelSource::RedapGrpcStream { uri, .. } = channel_source.as_ref() {
                     self.go_to_uri_fragment(uri.recording_id(), uri.fragment.clone());
                 }
             }

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -893,7 +893,10 @@ fn check_for_clicked_hyperlinks(
                     let is_dataset_uri = matches!(uri, re_uri::RedapUri::DatasetData { .. });
 
                     command_sender.send_system(SystemCommand::LoadDataSource(
-                        re_data_source::DataSource::RerunGrpcStream { uri },
+                        re_data_source::DataSource::RerunGrpcStream {
+                            uri,
+                            select_when_loaded: !open_url.new_tab,
+                        },
                     ));
 
                     if is_dataset_uri && !open_url.new_tab {

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -893,7 +893,7 @@ fn check_for_clicked_hyperlinks(
                     let is_dataset_uri = matches!(uri, re_uri::RedapUri::DatasetData { .. });
 
                     command_sender.send_system(SystemCommand::LoadDataSource(
-                        re_data_source::DataSource::RerunGrpcStream(uri),
+                        re_data_source::DataSource::RerunGrpcStream { uri },
                     ));
 
                     if is_dataset_uri && !open_url.new_tab {

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -890,8 +890,6 @@ fn check_for_clicked_hyperlinks(
         o.commands.retain_mut(|command| {
             if let egui::OutputCommand::OpenUrl(open_url) = command {
                 if let Ok(uri) = open_url.url.parse::<re_uri::RedapUri>() {
-                    let is_dataset_uri = matches!(uri, re_uri::RedapUri::DatasetData { .. });
-
                     command_sender.send_system(SystemCommand::LoadDataSource(
                         re_data_source::DataSource::RerunGrpcStream {
                             uri,
@@ -899,11 +897,9 @@ fn check_for_clicked_hyperlinks(
                         },
                     ));
 
-                    if is_dataset_uri && !open_url.new_tab {
-                        command_sender.send_system(SystemCommand::ChangeDisplayMode(
-                            DisplayMode::LocalRecordings,
-                        ));
-                    }
+                    // NOTE: we do NOT change the display mode here.
+                    // Instead we rely on `select_when_loaded` to trigger the selection… once the data is loaded.
+
                     return false;
                 } else if let Some(path_str) = open_url.url.strip_prefix(recording_scheme) {
                     recording_path = Some(path_str.to_owned());

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -27,10 +27,14 @@ impl Navigation {
         self.history.push(display_mode);
     }
 
-    pub fn replace(&mut self, display_mode: DisplayMode) -> Option<DisplayMode> {
+    pub fn replace(&mut self, new_mode: DisplayMode) -> Option<DisplayMode> {
         let previous = self.history.pop();
-        re_log::trace!("Navigated from {previous:?} to {display_mode:?}");
-        self.history.push(display_mode);
+
+        if previous.as_ref().is_none_or(|prev| prev != &new_mode) {
+            re_log::trace!("Navigated from {previous:?} to {new_mode:?}");
+        }
+
+        self.history.push(new_mode);
         previous
     }
 

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -62,7 +62,7 @@ fn loading_receivers_ui(ctx: &ViewerContext<'_>, rx: &ReceiveSet<LogMsg>, ui: &m
             // We only show things we know are very-soon-to-be recordings:
             SmartChannelSource::File(path) => format!("Loading {}…", path.display()),
             SmartChannelSource::RrdHttpStream { url, .. } => format!("Loading {url}…"),
-            SmartChannelSource::RedapGrpcStream { uri } => format!("Loading {uri}…"),
+            SmartChannelSource::RedapGrpcStream { uri, .. } => format!("Loading {uri}…"),
 
             SmartChannelSource::RrdWebEventListener
             | SmartChannelSource::JsChannel { .. }

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -62,7 +62,7 @@ fn loading_receivers_ui(ctx: &ViewerContext<'_>, rx: &ReceiveSet<LogMsg>, ui: &m
             // We only show things we know are very-soon-to-be recordings:
             SmartChannelSource::File(path) => format!("Loading {}…", path.display()),
             SmartChannelSource::RrdHttpStream { url, .. } => format!("Loading {url}…"),
-            SmartChannelSource::RedapGrpcStream(uri) => format!("Loading {uri}…"),
+            SmartChannelSource::RedapGrpcStream { uri } => format!("Loading {uri}…"),
 
             SmartChannelSource::RrdWebEventListener
             | SmartChannelSource::JsChannel { .. }

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -227,7 +227,7 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
             re_smart_channel::SmartChannelSource::MessageProxy(uri) => {
                 format!("Waiting for data on {uri}…")
             }
-            re_smart_channel::SmartChannelSource::RedapGrpcStream { uri } => {
+            re_smart_channel::SmartChannelSource::RedapGrpcStream { uri, .. } => {
                 format!(
                     "Waiting for data on {}…",
                     uri.clone().without_query_and_fragment()

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -227,7 +227,7 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
             re_smart_channel::SmartChannelSource::MessageProxy(uri) => {
                 format!("Waiting for data on {uri}…")
             }
-            re_smart_channel::SmartChannelSource::RedapGrpcStream(uri) => {
+            re_smart_channel::SmartChannelSource::RedapGrpcStream { uri } => {
                 format!(
                     "Waiting for data on {}…",
                     uri.clone().without_query_and_fragment()

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -96,7 +96,7 @@ enum EndpointCategory {
 impl EndpointCategory {
     fn categorize_uri(uri: String) -> Self {
         if let Ok(uri) = uri.parse() {
-            return Self::RerunGrpcStream(uri);
+            return Self::RerunGrpcStream { uri };
         }
 
         if uri.starts_with("web_event:") {

--- a/crates/viewer/re_viewer/src/web_tools.rs
+++ b/crates/viewer/re_viewer/src/web_tools.rs
@@ -96,7 +96,7 @@ enum EndpointCategory {
 impl EndpointCategory {
     fn categorize_uri(uri: String) -> Self {
         if let Ok(uri) = uri.parse() {
-            return Self::RerunGrpcStream { uri };
+            return Self::RerunGrpcStream(uri);
         }
 
         if uri.starts_with("web_event:") {

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -270,7 +270,7 @@ impl ItemCollection {
                     re_smart_channel::SmartChannelSource::JsChannel { .. } => None,
                     re_smart_channel::SmartChannelSource::Sdk => None,
                     re_smart_channel::SmartChannelSource::Stdin => None,
-                    re_smart_channel::SmartChannelSource::RedapGrpcStream(uri) => {
+                    re_smart_channel::SmartChannelSource::RedapGrpcStream{uri} => {
                         Some((ClipboardTextDesc::Url, uri.to_string()))
                     }
                     re_smart_channel::SmartChannelSource::MessageProxy(uri) => {

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -270,7 +270,7 @@ impl ItemCollection {
                     re_smart_channel::SmartChannelSource::JsChannel { .. } => None,
                     re_smart_channel::SmartChannelSource::Sdk => None,
                     re_smart_channel::SmartChannelSource::Stdin => None,
-                    re_smart_channel::SmartChannelSource::RedapGrpcStream{uri} => {
+                    re_smart_channel::SmartChannelSource::RedapGrpcStream { uri, .. } => {
                         Some((ClipboardTextDesc::Url, uri.to_string()))
                     }
                     re_smart_channel::SmartChannelSource::MessageProxy(uri) => {

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -753,9 +753,9 @@ impl StoreHub {
             match data_source {
                 re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
 
-                re_smart_channel::SmartChannelSource::RedapGrpcStream { uri: redap_uri } => {
-                    redap_uri.to_string() != uri
-                }
+                re_smart_channel::SmartChannelSource::RedapGrpcStream {
+                    uri: redap_uri, ..
+                } => redap_uri.to_string() != uri,
                 _ => true,
             }
         });

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -752,7 +752,8 @@ impl StoreHub {
             // - don't point at the given `uri`
             match data_source {
                 re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. } => url != uri,
-                re_smart_channel::SmartChannelSource::RedapGrpcStream(redap_uri) => {
+
+                re_smart_channel::SmartChannelSource::RedapGrpcStream { uri: redap_uri } => {
                     redap_uri.to_string() != uri
                 }
                 _ => true,


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/10067
* Closes https://github.com/rerun-io/rerun/issues/10066

### What
#### Fix "open in background" when clicking redap recording links
This adds a `bool` flag to the `re_smart_channel` data srouce to indicate wether or not the user intended to switch to this recording once it has loaded.

Putting it in the smart channel was not the easiest decision, but I think it was the least bad.

For one, the smart channel source already keeps track of things like the URI fragment which already contains instructions on what to do next, once the URI is loaded (e.g. go to a specific timeline).

But also, I found no better place for this data.

#### Show "Switch to" button if recording is already open
cmd-clicking a few links:
![open-in-background](https://github.com/user-attachments/assets/a01143d2-0901-4ef7-828f-37e9d0ed60b5)
