### PR TITLE
Expose more `re_renderer` symbols and allow shader reload for shaders outside of the regular shader directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7377,7 +7377,6 @@ dependencies = [
  "anyhow",
  "bitflags 2.9.1",
  "bytemuck",
- "cfg-if",
  "cfg_aliases",
  "clean-path",
  "crossbeam",

--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -61,7 +61,6 @@ ahash.workspace = true
 anyhow.workspace = true
 bitflags.workspace = true
 bytemuck.workspace = true
-cfg-if.workspace = true
 clean-path.workspace = true
 document-features.workspace = true
 ecolor = { workspace = true, features = ["bytemuck"] }

--- a/crates/viewer/re_renderer/src/file_resolver.rs
+++ b/crates/viewer/re_renderer/src/file_resolver.rs
@@ -467,7 +467,9 @@ pub type RecommendedFileResolver = FileResolver<&'static crate::MemFileSystem>;
 
 /// Returns the recommended `FileResolver` for the current platform/target.
 pub fn new_recommended() -> RecommendedFileResolver {
-    FileResolver::with_search_path(crate::get_filesystem(), SearchPath::from_env())
+    let mut search_path = SearchPath::from_env();
+    search_path.push("crates/viewer/re_renderer/shader");
+    FileResolver::with_search_path(crate::get_filesystem(), search_path)
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/viewer/re_renderer/src/global_bindings.rs
+++ b/crates/viewer/re_renderer/src/global_bindings.rs
@@ -43,8 +43,9 @@ pub struct FrameUniformBuffer {
     pub device_tier: wgpu_buffer_types::U32RowPadded,
 }
 
-pub(crate) struct GlobalBindings {
-    pub(crate) layout: GpuBindGroupLayoutHandle,
+/// Global bindings which are always available on bind group 0 for all [`crate::renderer::Renderer`].
+pub struct GlobalBindings {
+    pub layout: GpuBindGroupLayoutHandle,
     nearest_neighbor_sampler_repeat: GpuSamplerHandle,
     nearest_neighbor_sampler_clamped: GpuSamplerHandle,
     trilinear_sampler_repeat: GpuSamplerHandle,

--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -10,6 +10,7 @@
 // TODO(#6330): remove unwrap()
 #![allow(clippy::unwrap_used)]
 
+mod allocator;
 pub mod device_caps;
 pub mod importer;
 pub mod mesh;
@@ -18,8 +19,8 @@ pub mod resource_managers;
 pub mod texture_info;
 pub mod video;
 pub mod view_builder;
+pub mod wgpu_buffer_types;
 
-mod allocator;
 mod color;
 mod colormap;
 mod context;
@@ -37,7 +38,6 @@ mod queueable_draw_data;
 mod rect;
 mod size;
 mod transform;
-mod wgpu_buffer_types;
 mod wgpu_resources;
 
 #[cfg(test)]
@@ -52,7 +52,10 @@ mod workspace_shaders;
 
 use allocator::GpuReadbackBuffer;
 
-pub use allocator::{CpuWriteGpuReadError, GpuReadbackIdentifier};
+pub use allocator::{
+    CpuWriteGpuReadError, GpuReadbackIdentifier, create_and_fill_uniform_buffer,
+    create_and_fill_uniform_buffer_batch,
+};
 pub use color::Rgba32Unmul;
 pub use colormap::{
     Colormap, colormap_cyan_to_yellow_srgb, colormap_inferno_srgb, colormap_magma_srgb,
@@ -64,6 +67,11 @@ pub use context::{
 };
 pub use debug_label::DebugLabel;
 pub use depth_offset::DepthOffset;
+pub use draw_phases::{
+    DrawPhase, OutlineConfig, OutlineMaskPreference, OutlineMaskProcessor, PickingLayerId,
+    PickingLayerInstanceId, PickingLayerObjectId, PickingLayerProcessor, ScreenshotProcessor,
+};
+pub use global_bindings::GlobalBindings;
 pub use importer::{CpuMeshInstance, CpuModel, CpuModelMeshKey};
 pub use line_drawable_builder::{LineBatchBuilder, LineDrawableBuilder, LineStripBuilder};
 pub use point_cloud_builder::{PointCloudBatchBuilder, PointCloudBuilder};
@@ -73,11 +81,11 @@ pub use size::Size;
 pub use texture_info::Texture2DBufferInfo;
 pub use transform::RectTransform;
 pub use view_builder::ViewBuilder;
-pub use wgpu_resources::WgpuResourcePoolStatistics;
-
-pub use draw_phases::{
-    DrawPhase, OutlineConfig, OutlineMaskPreference, PickingLayerId, PickingLayerInstanceId,
-    PickingLayerObjectId, PickingLayerProcessor, ScreenshotProcessor,
+pub use wgpu_resources::{
+    BindGroupDesc, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
+    GpuPipelineLayoutPool, GpuRenderPipelineHandle, GpuRenderPipelinePool,
+    GpuRenderPipelinePoolAccessor, GpuShaderModuleHandle, GpuShaderModulePool, PipelineLayoutDesc,
+    RenderPipelineDesc, ShaderModuleDesc, VertexBufferLayout, WgpuResourcePoolStatistics,
 };
 
 pub use self::file_system::{FileSystem, get_filesystem};
@@ -94,7 +102,10 @@ pub use self::file_server::FileServer;
 pub use ecolor::{Color32, Hsva, Rgba};
 
 pub mod external {
+    pub use anyhow;
+    pub use bytemuck;
     pub use re_video;
+    pub use smallvec;
     pub use wgpu;
 }
 

--- a/crates/viewer/re_renderer/src/wgpu_resources/shader_module_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/shader_module_pool.rs
@@ -19,7 +19,7 @@ const RERUN_WGSL_SHADER_DUMP_PATH: &str = "RERUN_WGSL_SHADER_DUMP_PATH";
 #[macro_export]
 macro_rules! include_shader_module {
     ($path:expr $(,)?) => {{
-        $crate::wgpu_resources::ShaderModuleDesc {
+        $crate::ShaderModuleDesc {
             label: $crate::DebugLabel::from(stringify!($path).strip_prefix("../../shader/")),
             source: $crate::include_file!($path),
             extra_workaround_replacements: Vec::new(),


### PR DESCRIPTION
### Related

* Split out of https://github.com/rerun-io/rerun/pull/9820

### What

See title.
The shader reload changes feel a little bit dubious to me, needs more testing in the future. But doesn't break existing debug-only shader reloading in the viewer (tested that) so I think this is fine.