### PR TITLE
Forward `REDAP_TOKEN` to the web viewer in notebook environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8056,6 +8056,7 @@ dependencies = [
  "percent-encoding",
  "poll-promise",
  "re_analytics",
+ "re_auth",
  "re_blueprint_tree",
  "re_build_info",
  "re_build_tools",

--- a/crates/store/re_grpc_client/src/connection_registry.rs
+++ b/crates/store/re_grpc_client/src/connection_registry.rs
@@ -37,6 +37,7 @@ impl ConnectionRegistry {
         ConnectionRegistryHandle {
             inner: Arc::new(RwLock::new(Self {
                 saved_tokens: HashMap::new(),
+                fallback_token: None,
                 clients: HashMap::new(),
             })),
         }

--- a/crates/store/re_grpc_client/src/connection_registry.rs
+++ b/crates/store/re_grpc_client/src/connection_registry.rs
@@ -18,6 +18,11 @@ pub struct ConnectionRegistry {
     /// envvar if set. See [`ConnectionRegistryHandle::client`].
     saved_tokens: HashMap<re_uri::Origin, Jwt>,
 
+    /// Fallback token.
+    ///
+    /// If set, the fallback token is used when no specific token is registered for a given origin.
+    fallback_token: Option<Jwt>,
+
     /// The cached clients.
     ///
     /// Clients are much cheaper to clone than create (since the latter involves establishing an
@@ -53,10 +58,19 @@ impl ConnectionRegistryHandle {
         inner.clients.remove(origin);
     }
 
+    pub fn set_fallback_token(&self, token: Jwt) {
+        let mut inner = self.inner.blocking_write();
+        inner.fallback_token = Some(token);
+    }
+
     /// Get a client for the given origin, creating one if it doesn't exist yet.
     ///
-    /// If a token has already been registered for this origin, it will be used. Otherwise, if the
-    /// `REDAP_TOKEN` environment variable is set, it will be used as the token.
+    /// If a token has already been registered for this origin, it will be used. It will attempt to
+    /// use the following token, in this order:
+    /// - The fallback token, if set via [`Self::set_fallback_token`].
+    /// - The `REDAP_TOKEN` environment variable is set.
+    ///
+    /// Failing that, no token will be used.
     ///
     /// Note that a token set via `REDAP_TOKEN` will not be persisted unless [`Self::set_token`] is
     /// explicitly called. The rationale is to avoid sneakily saving in clear text potentially
@@ -75,6 +89,7 @@ impl ConnectionRegistryHandle {
             .saved_tokens
             .get(&origin)
             .cloned()
+            .or_else(|| inner.fallback_token.clone())
             .or_else(get_token_from_env);
 
         let client = crate::redap::client(origin.clone(), token).await;

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -45,6 +45,7 @@ map_view = ["dep:re_view_map"]
 
 [dependencies]
 # Internal:
+re_auth.workspace = true
 re_blueprint_tree.workspace = true
 re_build_info.workspace = true
 re_capabilities.workspace = true

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -53,7 +53,7 @@ impl WebHandle {
 
         let app_options: Option<AppOptions> = serde_wasm_bindgen::from_value(app_options)?;
 
-        let connection_registry = re_grpc_client::ConnectionRegistry::new()();
+        let connection_registry = re_grpc_client::ConnectionRegistry::new();
 
         Ok(Self {
             runner: eframe::WebRunner::new(),

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -88,6 +88,13 @@ export interface WebViewerOptions {
 
   /** The CSS height of the canvas. */
   height?: string;
+
+  /** The fallback token to use, if any.
+   *
+   * The fallback token behaves similarly to the `REDAP_TOKEN` env variable. If set in the
+   * enclosing notebook environment, it should be used to set the fallback token.
+   */
+  fallback_token?: string;
 }
 
 // `AppOptions` and `WebViewerOptions` must be compatible

--- a/rerun_notebook/build.mjs
+++ b/rerun_notebook/build.mjs
@@ -48,7 +48,7 @@ async function build() {
     });
     log(`Built widget in ${Date.now() - start}ms`);
   } catch (e) {
-    error(`Failed to rebuild widget:\n${e.toString()}`);
+    throw new Error(`Failed to rebuild widget:\n${e.toString()}`);
   }
 }
 

--- a/rerun_notebook/src/js/widget.ts
+++ b/rerun_notebook/src/js/widget.ts
@@ -3,6 +3,7 @@ import {
   type Panel,
   type PanelState,
   WebViewer,
+  type WebViewerOptions,
 } from "@rerun-io/web-viewer/inlined.js";
 
 import type { AnyModel, Render } from "@anywidget/types";
@@ -21,6 +22,8 @@ interface WidgetModel {
   _panel_states?: PanelStates;
   _time_ctrl: [timeline: string | null, time: number | null, play: boolean];
   _recording_id?: string;
+
+  _fallback_token?: string;
 }
 
 type Opt<T> = T | null | undefined;
@@ -29,7 +32,7 @@ class ViewerWidget {
   viewer: WebViewer = new WebViewer();
   url: Opt<string> = null;
   panel_states: Opt<PanelStates> = null;
-  options = { hide_welcome_screen: true };
+  options: WebViewerOptions = { hide_welcome_screen: true };
 
   channel: LogChannel | null = null;
 
@@ -49,6 +52,8 @@ class ViewerWidget {
       this.on_time_ctrl(null, timeline, time, play),
     );
     model.on("change:_recording_id", this.on_set_recording_id);
+
+    this.options.fallback_token = model.get("_fallback_token");
 
     (this.viewer as any)._on_raw_event((event: string) => model.send(event));
 

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -83,6 +83,8 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
     ).tag(sync=True)
     _recording_id = traitlets.Unicode(allow_none=True).tag(sync=True)
 
+    _fallback_token = traitlets.Unicode(allow_none=True).tag(sync=True)
+
     _raw_event_callbacks: list[Callable[[str], None]] = []
 
     def __init__(
@@ -92,6 +94,7 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
         height: int | None = None,
         url: str | None = None,
         panel_states: Mapping[Panel, PanelState] | None = None,
+        fallback_token: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -108,6 +111,9 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
 
         if panel_states:
             self.update_panel_states(panel_states)
+
+        if fallback_token:
+            self._fallback_token = fallback_token
 
         def handle_msg(widget: Any, content: Any, buffers: list[bytes]) -> None:
             if isinstance(content, str):

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Callable, Literal
 
@@ -111,6 +112,7 @@ class Viewer:
             width=width if width is not None else _default_width,
             height=height if height is not None else _default_height,
             url=url,
+            fallback_token=os.environ.get("REDAP_TOKEN", None),
         )
 
         # Viewer event handling


### PR DESCRIPTION
### Related

- closes https://github.com/rerun-io/dataplatform/issues/726
- closes https://github.com/rerun-io/dataplatform/issues/721
- part of https://github.com/rerun-io/dataplatform/issues/750
- part of https://github.com/rerun-io/dataplatform/issues/763
- follow-up to https://github.com/rerun-io/rerun/pull/10078
- DNM: chained

### What

This PR introduce the concept of "fallback token", which is essentially the same as the `REDAP_TOKEN` env var for the purpose of the web viewer. It is now automatically set from the enclosing notebook environment, if that environment has `REDAP_TOKEN` set.

Thanks @jprochazk for the help 🙏🏻 