### PR TITLE
[TEST] redap_client: parallel get_chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8493,6 +8493,7 @@ dependencies = [
  "datafusion",
  "datafusion-ffi",
  "document-features",
+ "futures",
  "infer",
  "itertools 0.14.0",
  "mimalloc",

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -73,6 +73,7 @@ crossbeam.workspace = true
 datafusion.workspace = true
 datafusion-ffi.workspace = true
 document-features.workspace = true
+futures.workspace = true
 itertools.workspace = true
 infer.workspace = true
 mimalloc = { workspace = true, features = ["local_dynamic_tls"] }


### PR DESCRIPTION
This is an attempt to make reading from the server stream faster, to see if there is a client bottleneck.
What this does is:
- One tokio task (the main task), pulls items from the stream, no processing
- We spawn one task per item and do the chunk conversion work, which I assumed could be expensive, and puts the results in a channel
- Another task pulls the data from the channel, and adds the data to the stores map.


## Related
* https://github.com/rerun-io/dataplatform/issues/832
