### PR TITLE
Perfecting light mode design

### DIFF
--- a/crates/viewer/re_ui/data/color_table.ron
+++ b/crates/viewer/re_ui/data/color_table.ron
@@ -2,168 +2,177 @@
   "Global": {
     "Color": {
       "Gray": {
+
+        "white":{
+          "value": "#FFFFFF",
+          "type": "color"
+        },
         "0": {
-          "value": "#000000",
+          "value": "#030305",
           "type": "color"
         },
         "25": {
-          "value": "#020303",
+          "value": "#090B0F",
           "type": "color"
         },
         "50": {
-          "value": "#050607",
+          "value": "#090B0F",
           "type": "color"
         },
         "75": {
-          "value": "#090b0c",
+          "value": "#14161A",
           "type": "color"
         },
         "100": {
-          "value": "#0d1011",
+          "value": "#14161A",
           "type": "color"
         },
         "125": {
-          "value": "#111415",
+          "value": "#202226",
           "type": "color"
         },
         "150": {
-          "value": "#141819",
+          "value": "#202226",
           "type": "color"
         },
         "175": {
-          "value": "#181c1e",
+          "value": "#2C2E33",
           "type": "color"
         },
         "200": {
-          "value": "#1c2123",
+          "value": "#2C2E33",
           "type": "color"
         },
         "225": {
-          "value": "#212628",
+          "value": "#383A3F",
           "type": "color"
         },
         "250": {
-          "value": "#262b2e",
+          "value": "#383A3F",
           "type": "color"
         },
         "275": {
-          "value": "#2b3134",
+          "value": "#45484D",
           "type": "color"
         },
         "300": {
-          "value": "#31383b",
+          "value": "#45484D",
           "type": "color"
         },
         "325": {
-          "value": "#373f42",
+          "value": "#53555A",
           "type": "color"
         },
         "350": {
-          "value": "#3e464a",
+          "value": "#53555A",
           "type": "color"
         },
         "375": {
-          "value": "#454e52",
+          "value": "#616369",
           "type": "color"
         },
         "400": {
-          "value": "#4c565a",
+          "value": "#616369",
           "type": "color"
         },
         "425": {
           "value": "#545e63",
-          "type": "color"
+          "type": "6F7177"
         },
         "450": {
-          "value": "#5c676c",
+          "value": "#6F7177",
           "type": "color"
         },
         "475": {
-          "value": "#647075",
+          "value": "#7E8086",
           "type": "color"
         },
         "500": {
-          "value": "#6c797f",
+          "value": "#7E8086",
           "type": "color"
         },
         "525": {
-          "value": "#748288",
+          "value": "#8D8F94",
           "type": "color"
         },
         "550": {
-          "value": "#7d8c92",
+          "value": "#8D8F94",
           "type": "color"
         },
         "575": {
-          "value": "#85959c",
+          "value": "#9C9EA3",
           "type": "color"
         },
         "600": {
-          "value": "#8e9ea5",
+          "value": "#9C9EA3",
           "type": "color"
         },
         "625": {
-          "value": "#96a7af",
+          "value": "#ACAEB2",
           "type": "color"
         },
         "650": {
-          "value": "#9eb0b8",
+          "value": "#ACAEB2",
           "type": "color"
         },
         "675": {
-          "value": "#a6b9c1",
+          "value": "#BCBEC1",
           "type": "color"
         },
         "700": {
-          "value": "#aec2ca",
+          "value": "#BCBEC1",
           "type": "color"
         },
         "725": {
-          "value": "#b6cad2",
+          "value": "#CCCED0",
           "type": "color"
         },
         "750": {
-          "value": "#c0d1d8",
+          "value": "#CCCED0",
           "type": "color"
         },
         "775": {
-          "value": "#cad8de",
+          "value": "#DDDEE0",
           "type": "color"
         },
         "800": {
-          "value": "#d3dee3",
+          "value": "#DDDEE0",
           "type": "color"
         },
         "825": {
-          "value": "#dbe4e8",
+          "value": "#E5E6E7",
           "type": "color"
         },
         "850": {
-          "value": "#e3eaed",
+          "value": "#E5E6E7",
           "type": "color"
         },
         "875": {
-          "value": "#e9eff1",
+          "value": "#EEEFF0",
           "type": "color"
         },
         "900": {
-          "value": "#eff3f5",
+          "value": "#EEEFF0",
           "type": "color"
         },
         "925": {
-          "value": "#f4f7f8",
+          "value": "#F4F5F6",
           "type": "color"
         },
         "950": {
-          "value": "#f9fafb",
+          "value": "#F4F5F6",
           "type": "color"
         },
         "975": {
-          "value": "#fcfdfd",
+          "value": "#F9FAFB",
           "type": "color"
         },
         "1000": {
-          "value": "#ffffff",
+          "value": "#FBFCFD",
+          "type": "color"
+        },
+        "black":{
+          "value": "#000000",
           "type": "color"
         }
       },

--- a/crates/viewer/re_ui/data/dark_theme.ron
+++ b/crates/viewer/re_ui/data/dark_theme.ron
@@ -13,7 +13,7 @@
       "color": "{Gray.100}"
     },
     "tab_bar_color": {
-      "color": "{Gray.200}"
+      "color": "{Gray.100}"
     },
     "bottom_bar_color": {
       "color": "{Gray.150}"

--- a/crates/viewer/re_ui/data/light_theme.ron
+++ b/crates/viewer/re_ui/data/light_theme.ron
@@ -5,7 +5,95 @@
   "small_icon_size": 14,
 
   "Alias": {
-    "native_frame_stroke": { //couldn't find
+
+/* surfaces and backgrounds */
+
+    "surface_panel":{ //new! background of side panels: left, bottom, right
+      "color": "{Gray.1000}"
+    },
+
+    "surface_panel-header":{ //new! headers like blueprint, selection, streams, recordings, also within selection
+      "color": "{Gray.900}"
+    },
+
+    "surface_viewport":{ //new! background of any empty space behind content in the views, ex: when viewport is bigger than a picture/video
+      "color": "{Gray.900}"
+    },
+
+    "surface_viewport-header":{ //new! background of not-selected header in viewport
+      "color": "{Gray.800}"
+    },
+
+    "surface_interactive_primary":{ //new! background of the most important interactive elements, can't be too much. now: play/pause btns, selected view,
+      "color": "{Blue.400}"
+    },
+
+    "surface_interactive_secondary":{ //new! background of interactive elements, that are important, but less than primary. now: selected list item, final breadcrumb
+      "color": "{Blue.400}",
+      "alpha": 50
+    },
+
+    "surface_interactive_on-secondary_hover":{ //new! background of interactive elements, appearing on top of secondary surface, think blue background for an icon to highlight it's clickable
+      "color": "{Blue.400}",
+      "alpha": 25
+    },
+
+    "surface_interactive_neutral":{ //new! majority of interactive backgrounds, like default list item (maybe this one is not even needed?@katya to check with real ex)
+      "color": "{Gray.1000}"
+    },
+
+    "surface_interactive_on-neutral":{ //new! when interactive element in on top of neutral background, ex. timeline btns, input fields, dropdowns
+      "color": "{Gray.850}"
+    },
+
+    "surface_interactive_hover":{ //new! when in doubt about hover: use this one, almost universal for icon background hovers
+      "color": "{Gray.0}",
+      "alpha": 20
+    },
+
+/* icon content */
+
+    "icon_content":{ //new! default color of icon content (almost all)
+      "color": "{Gray.300}"
+    },
+
+    "icon_content_on-primary":{ //new! color of an icon if placed on top of primary surface, ex: play/pause, view icon
+      "color": "{Gray.1000}"
+    },
+
+    "icon_content_on-secondary":{ //new! color of an icon if placed on top of secondary surface, ex: icon in the selected list view
+      "color": "{Blue.400}"
+    },
+
+    "icon_content_disabled":{ //new! when icon is disabled, ex: visualizers
+      "color": "{Gray.650}"
+    },
+
+/* text, font */
+
+    "text_header":{ //new! headers of panel headers
+      "color": "{Gray.300}"
+    },
+
+    "text_body":{ //new! when in doubt - use this one, main content info, maybe also try Gray.300
+      "color": "{Gray.200}"
+    },
+
+    "text_subtle":{ //new! secondary kind of info, ex: parameter, hotkey, input units
+      "color": "{Gray.500}"
+    },
+
+    "text_interactive_disabled":{ //new! input that is not changable
+      "color": "{Gray.500}"
+    },
+
+    "name":{ //new!
+      "color": "{Blue.400}"
+    },
+
+
+
+    "native_frame_stroke": { //related to Windows and Linux https://github.com/rerun-io/rerun/issues/1063
       "color": "{Green.500}",
       "width": 10
     },
@@ -273,7 +361,7 @@
     "Typography": {
       "Default": {
         "value": {
-          "fontSize": "12px",
+          "fontSize": "11.5px",
           "fontWeight": "Medium",
           "fontFamily": "Inter",
           "lineHeight": "16px",

--- a/crates/viewer/re_ui/data/light_theme.ron
+++ b/crates/viewer/re_ui/data/light_theme.ron
@@ -5,18 +5,18 @@
   "small_icon_size": 14,
 
   "Alias": {
-    "native_frame_stroke": {
-      "color": "{Gray.750}",
-      "width": 1
+    "native_frame_stroke": { //couldn't find
+      "color": "{Green.500}",
+      "width": 10
     },
-    "top_bar_color": {
+    "top_bar_color": { // top menu bar
+      "color": "{Gray.1000}"
+    },
+    "tab_bar_color": { //headers for views AND(???) stroke (TO CHANGE)
       "color": "{Gray.800}"
     },
-    "tab_bar_color": {
-      "color": "{Gray.900}"
-    },
-    "bottom_bar_color": {
-      "color": "{Gray.950}"
+    "bottom_bar_color": { //WHOLE bottom panel background
+      "color": "{Gray.1000}"
     },
     "bottom_bar_stroke": {
       "color": "{Gray.800}",
@@ -24,49 +24,47 @@
     },
     "shadow_gradient_dark_start": {
       "color": "{Gray.0}",
-      "alpha": 10
+      "alpha": 5
     },
-    "strong_fg_color": {
-      "color": "{Gray.0}"
-    },
-    "info_log_text_color": {
-      "color": "{Green.500}"
-    },
-    "debug_log_text_color": {
-      "color": "{Blue.500}"
-    },
-    "trace_log_text_color": {
+    "strong_fg_color": { // color of rerun icons in menu (eeeh..), shall be one with all other icons
       "color": "{Gray.300}"
     },
-
+    "info_log_text_color": { //text log view: info font => should go into text.success
+      "color": "{Green.500}"
+    },
+    "debug_log_text_color": { //text log view: debug font => shall go into text.info
+      "color": "{Blue.500}"
+    },
+    "trace_log_text_color": { //?text log view => shall be moved
+      "color": "{Red.300}"
+    },
     "success_text_color": {
       "color": "{Green.300}"
     },
     "info_text_color": {
       "color": "{Blue.300}"
     },
-
-    "label_button_icon_color": {
-      "color": "{Gray.550}"
+    "label_button_icon_color": { //icons next to menu list items AND also on-surface (which needs to be separated)
+      "color": "{Gray.300}"
     },
-    "section_collapsing_header_color": {
+    "section_collapsing_header_color": { //section background of selection panel
       "color": "{Gray.900}"
     },
-    "loop_selection_color": {
-      "color": "#6386C9B2"
+    "loop_selection_color": { //on the timeline
+      "color": "#A1BCFF50"
     },
     "loop_everything_color": {
-      "color": "#06A35C"
+      "color": "#A1BCFF"
     },
-    "thumbnail_background_color": {
+    "thumbnail_background_color": { //when adding a new view/container
       "color": "{Gray.800}"
     },
 
     "example_card_background_color": {
-      "color": "{Gray.850}"
+      "color": "{Gray.900}"
     },
     "example_tag_bg_fill": {
-      "color": "{Gray.700}",
+      "color": "{Gray.800}",
     },
     "example_tag_stroke": {
       "color": "{Gray.800}",
@@ -74,46 +72,47 @@
     },
 
     "breadcrumb_text_color": {
-      "color": "{Blue.300}"
+      "color": "{Blue.900}"
     },
     "breadcrumb_separator_color": {
-      "color": "{Blue.400}"
-    },
-
-    "panel_bg_color": {
-      "color": "{Gray.1000}"
-    },
-
-    "blueprint_time_panel_bg_fill": {
       "color": "{Blue.900}"
     },
 
-    "notification_panel_background_color": {
-      "color": "{Gray.850}"
-    },
-    "notification_background_color": {
-      "color": "{Gray.800}"
+    "panel_bg_color": { //all background panels: side AND centered, need to split the centered
+      "color": "{Gray.1000}"
     },
 
-    "table_header_bg_fill": {
-      "color": "{Gray.850}"
+    "blueprint_time_panel_bg_fill": { //blueprint streams panel
+      "color": "{Gray.900}"
+    },
+
+    "notification_panel_background_color": {
+      "color": "{Gray.1000}"
+    },
+    "notification_background_color": {
+      "color": "{Gray.950}"
+    },
+
+    "table_header_bg_fill": { //redap table
+      "color": "{Gray.900}"
     },
     "table_header_stroke_color": {
-      "color": "{Gray.700}"
+      "color": "{Gray.800}"
     },
     "table_interaction_hovered_bg_stroke": {
       "color": "{Gray.700}"
     },
     "table_interaction_active_bg_stroke": {
-      "color": "{Gray.650}"
+      "color": "{Gray.700}"
     },
     "table_interaction_noninteractive_bg_stroke": {
-      "color": "{Gray.800}"
+      "color": "{Gray.850}"
     },
     "table_sort_icon_color": {
       "color": "{Blue.250}"
     },
 
+/* drag and drop  styles*/
     "drag_pill_droppable_fill": {
       "color": "{Blue.725}"
     },
@@ -131,86 +130,89 @@
       "width": 2
     },
     "tile_drag_preview_stroke" : {
-      "color": "{Gray.0}",
+      "color": "{Blue.500}",
       "alpha": 127,
-      "width": 1
+      "width": 1.5
     },
     "tile_drag_preview_color": {
       "color": "{Gray.0}",
       "alpha": 26
     },
 
-    "floating_color": {
+/*----*/
+    "floating_color": { //pop up backgrounds
       "color": "{Gray.1000}"
     },
-    "faint_bg_color": {
+    "faint_bg_color": { //table zebra
+      "color": "{Gray.950}"
+    },
+    "extreme_bg_color": { //all the inputs AND default image (2D) background
       "color": "{Gray.900}"
     },
-    "extreme_bg_color": {
-      "color": "{Gray.1000}"
+    "extreme_fg_color": { //can't find
+      "color": "{Green.500}"
     },
-    "extreme_fg_color": {
-      "color": "{Gray.0}"
+    "widget_noninteractive_weak_bg_fill": { //in old version it was font of hot keys in menu, now can't find
+      "color": "{Green.550}"
     },
-    "widget_noninteractive_weak_bg_fill": {
-      "color": "{Gray.550}"
+    "widget_noninteractive_bg_fill": { //in old version it was background behind the event timeline (on the left/right of it)
+      "color": "{Green.500}"
     },
-    "widget_noninteractive_bg_fill": {
+    "widget_inactive_bg_fill": { //surface of timeline buttons, checkbox, radios AND (??) also label in 3D scene?
       "color": "{Gray.800}"
     },
-    "widget_inactive_bg_fill": {
+    "widget_hovered_weak_bg_fill": { //in old version it was i.e. background of entities in entity filter, now can't find it
+      "color": "{Green.500}"
+    },
+    "widget_hovered_bg_fill": { //used to be selected view subtitle, now can't find
+      "color": "{Green.500}"
+    },
+    "widget_active_weak_bg_fill": { //no idea
+      "color": "{Green.500}"
+    },
+    "widget_active_bg_fill": { //no idea
+      "color": "{Green.500}"
+    },
+    "widget_open_weak_bg_fill": { //no idea
+      "color": "{Green.500}"
+    },
+    "selection_bg_fill": { // all the selected backgrounds: play btn, selected view, selection panel
+      "color": "{Blue.500}"
+    },
+    "selection_stroke_color": { //icon content of play/stop
+      "color": "{Blue.900}"
+    },
+    "widget_noninteractive_bg_stroke": { //almost ALL the strokes
       "color": "{Gray.800}"
     },
-    "widget_hovered_weak_bg_fill": {
-      "color": "{Gray.800}"
-    },
-    "widget_hovered_bg_fill": {
-      "color": "{Gray.700}"
-    },
-    "widget_active_weak_bg_fill": {
-      "color": "{Gray.750}"
-    },
-    "widget_active_bg_fill": {
-      "color": "{Gray.650}"
-    },
-    "widget_open_weak_bg_fill": {
-      "color": "{Gray.650}"
-    },
-    "selection_bg_fill": {
-      "color": "{Blue.550}"
-    },
-    "selection_stroke_color": {
-      "color": "{Blue.800}"
-    },
-    "widget_noninteractive_bg_stroke": {
-      "color": "{Gray.800}"
-    },
-    "text_subdued": {
+    "text_subdued": { // generic tertiary font, but mixed for few styles
       "color": "{Gray.500}"
     },
-    "text_default": {
-      "color": "{Gray.250}"
+    "text_default": { //generic default font, which is applied not only to text, but to icons as well, needs changes, especially when on_active!
+      "color": "{Gray.300}"
     },
-    "text_strong": {
-      "color": "{Gray.0}"
+    "text_strong": { //generic headers font, (!) also ON_ACTIVE, (!) also hover window, (!) also video loader
+      "color": "{Gray.300}"
     },
     "error_fg_color": {
-      "color": "#AB0116"
+      "color": "{Red.500}"
     },
-    "warn_fg_color": {
+    "warn_fg_color": { //need to add warning palette
       "color": "#FF7A0C"
     },
-    "widget_hovered_color": {
-      "color": "{Gray.700}"
+    "widget_hovered_color": { //generic hover to all, including active states and play menu
+      "color": "{Gray.0}",
+      "alpha": 30
     },
     "popup_shadow_color": {
-      "color": "#00000020"
+      "color": "{Gray.0}",
+      "alpha": 30
     },
 
-    "density_graph_selected": {
+    "density_graph_selected": { //can't find
       "color": "{Blue.200}"
     },
-    "density_graph_unselected": {
+    "density_graph_unselected": { //can't find
       "color": "{Gray.300}"
     },
 
@@ -224,38 +226,38 @@
       "color": "{Blue.550}"
     },
     "frustum_color": {
-      "color": "{Gray.300}"
+      "color": "{Gray.300}",
     },
 
     "list_item_selected_text": {
-      "color": "{Blue.100}"
+      "color": "{Blue.900}"
     },
     "list_item_active_text": {
       "color": "{Gray.0}"
     },
-    "list_item_noninteractive_text": {
-      "color": "{Gray.550}"
+    "list_item_noninteractive_text": { //projections
+      "color": "{Gray.500}"
     },
     "list_item_hovered_text": {
-      "color": "{Gray.250}"
+      "color": "{Gray.300}"
     },
     "list_item_default_text": {
-      "color": "{Gray.350}"
+      "color": "{Gray.300}"
     },
     "list_item_strong_text": {
       "color": "{Gray.300}"
     },
     "list_item_selected_icon": {
-      "color": "{Blue.250}"
+      "color": "{Blue.700}"
     },
     "list_item_active_icon": {
       "color": "{Gray.300}"
     },
     "list_item_hovered_icon": {
-      "color": "{Gray.400}"
+      "color": "{Gray.300}"
     },
     "list_item_default_icon": {
-      "color": "{Gray.550}"
+      "color": "{Gray.400}"
     },
     "list_item_hovered_bg": {
       "color": "{Gray.900}"
@@ -264,7 +266,7 @@
       "color": "{Gray.800}"
     },
     "list_item_collapse_default": {
-      "color": "{Gray.250}"
+      "color": "{Gray.300}"
     },
   },
   "Global": {
@@ -275,7 +277,6 @@
           "fontWeight": "Medium",
           "fontFamily": "Inter",
           "lineHeight": "16px",
-          "letterSpacing": "-0.15px"
         },
         "description": "",
         "type": "typography"

--- a/crates/viewer/re_ui/src/notifications.rs
+++ b/crates/viewer/re_ui/src/notifications.rs
@@ -385,7 +385,10 @@ fn show_notification(
                     ui.horizontal_top(|ui| {
                         ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
                         ui.set_width(270.0);
-                        ui.label(egui::RichText::new(notification.text.clone()));
+                        ui.label(
+                            egui::RichText::new(notification.text.clone())
+                                .color(ui.tokens().text_subdued),
+                        );
                     });
 
                     ui.add_space(4.0);

--- a/crates/viewer/re_view_bar_chart/src/view_class.rs
+++ b/crates/viewer/re_view_bar_chart/src/view_class.rs
@@ -203,7 +203,7 @@ impl ViewClass for BarChartView {
                     color: &re_types::components::Color,
                 ) -> BarChart {
                     let color: egui::Color32 = color.0.into();
-                    let fill = color.gamma_multiply(0.75).additive(); // make sure overlapping bars are obvious
+                    let fill = color.gamma_multiply(0.75); // make sure overlapping bars are obvious
                     let stroke_color = fill.linear_multiply(0.5);
                     BarChart::new(
                         "bar_chart",


### PR DESCRIPTION
WIP

notes: 

- [x] notifications 
- [x] bar in barchart

- ? shall be an icon and not a font

- backgrounds of all views (except 3D) shall be 1 alias

Fancy triangles icons: needs resizing. tried, but it was magic math beyond my patience.
<img width="768" alt="image" src="https://github.com/user-attachments/assets/9bb58ff5-773a-42ea-bd79-c529e3529d5c" />
 
separate font style from default and on-surface
now both `Gyroscope` and `3d view` defined by the same alias
<img width="812" alt="image" src="https://github.com/user-attachments/assets/7fb837e5-c481-46ca-8d11-27453d747ef6" />

... many more to copy here from notes