### PR TITLE
Always enable `svg` feature on `egui_extras`, fixing svgs for viewer embedding examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,12 @@ egui = { version = "0.31.1", features = [
 ] }
 egui_commonmark = { version = "0.20.0", default-features = false }
 egui_dnd = { version = "0.12.0" }
-egui_extras = { version = "0.31.1", features = ["http", "image", "serde"] }
+egui_extras = { version = "0.31.1", features = [
+  "http",
+  "image",
+  "serde",
+  "svg",
+] }
 egui_kittest = { version = "0.31.1", features = ["wgpu", "snapshot", "eframe"] }
 egui_plot = "0.32.1" # https://github.com/emilk/egui_plot
 egui_table = "0.3.0" # https://github.com/rerun-io/egui_table


### PR DESCRIPTION
Looks like this was dragged in via some dependency, not sure what but also doesn't matter since we should enable it directly regardless