### PR TITLE
Fix non-determinstic mesh rendering order

### DIFF
--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -3,9 +3,8 @@
 //! Uses instancing to render instances of the same mesh in a single draw call.
 //! Instance data is kept in an instance-stepped vertex data.
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
-use ahash::{HashMap, HashMapExt as _};
 use smallvec::smallvec;
 
 use crate::{
@@ -177,7 +176,9 @@ impl MeshDrawData {
             },
         );
 
-        let mut instances_by_mesh: HashMap<_, Vec<_>> = HashMap::new();
+        // NOTE: can't use HashMap here or we get undeterrministic rendering order.
+        // See <https://github.com/rerun-io/rerun/issues/10116> for more.
+        let mut instances_by_mesh: BTreeMap<_, Vec<_>> = BTreeMap::new();
         for instance in instances {
             instances_by_mesh
                 // Use pointer equality, this is enough to determine if two instances use the same mesh.

--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -178,6 +178,9 @@ impl MeshDrawData {
 
         // NOTE: can't use HashMap here or we get undeterrministic rendering order.
         // See <https://github.com/rerun-io/rerun/issues/10116> for more.
+        // Using a `BTreeMap` at least gives the same order every frame,
+        // but since it uses the pointer address as the key,
+        // it will still change if we run the app multiple times.
         let mut instances_by_mesh: BTreeMap<_, Vec<_>> = BTreeMap::new();
         for instance in instances {
             instances_by_mesh


### PR DESCRIPTION
### What
* Closes #10116

#### Details
This is not a perfect fix, since you still get a different order each time you restart Rerun, but at least the flickering is gone.