### PR TITLE
Rename `StoreHubEntry` to `RecordingOrTable`

### DIFF
--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -736,7 +736,9 @@ pub fn entity_db_button_ui(
                     });
             if resp.clicked() {
                 ctx.command_sender()
-                    .send_system(SystemCommand::CloseEntry(store_id.clone().into()));
+                    .send_system(SystemCommand::CloseRecordingOrTable(
+                        store_id.clone().into(),
+                    ));
             }
             resp
         });
@@ -779,7 +781,9 @@ pub fn entity_db_button_ui(
         // for the blueprint.
         if store_id.kind == re_log_types::StoreKind::Recording {
             ctx.command_sender()
-                .send_system(SystemCommand::ActivateEntry(store_id.clone().into()));
+                .send_system(SystemCommand::ActivateRecordingOrTable(
+                    store_id.clone().into(),
+                ));
         }
     }
 
@@ -804,7 +808,9 @@ pub fn table_id_button_ui(
                 .on_hover_text("Close this table (all data will be lost)");
             if resp.clicked() {
                 ctx.command_sender()
-                    .send_system(SystemCommand::CloseEntry(table_id.clone().into()));
+                    .send_system(SystemCommand::CloseRecordingOrTable(
+                        table_id.clone().into(),
+                    ));
             }
             resp
         });
@@ -833,7 +839,9 @@ pub fn table_id_button_ui(
 
     if response.clicked() {
         ctx.command_sender()
-            .send_system(SystemCommand::ActivateEntry(table_id.clone().into()));
+            .send_system(SystemCommand::ActivateRecordingOrTable(
+                table_id.clone().into(),
+            ));
     }
     ctx.handle_select_hover_drag_interactions(&response, item, false);
 }

--- a/crates/viewer/re_global_context/src/command_sender.rs
+++ b/crates/viewer/re_global_context/src/command_sender.rs
@@ -1,9 +1,11 @@
-use crate::StoreHubEntry;
 use re_chunk::{EntityPath, Timeline};
 use re_chunk_store::external::re_chunk::Chunk;
 use re_data_source::DataSource;
 use re_log_types::{ResolvedTimeRangeF, StoreId};
 use re_ui::{UICommand, UICommandSender};
+
+use crate::RecordingOrTable;
+
 // ----------------------------------------------------------------------------
 
 /// Commands used by internal system components
@@ -51,11 +53,11 @@ pub enum SystemCommand {
     /// does not affect the default blueprint if any was set.
     ClearActiveBlueprintAndEnableHeuristics,
 
-    /// Switch to this [`StoreHubEntry`].
-    ActivateEntry(StoreHubEntry),
+    /// Switch to this [`RecordingOrTable`].
+    ActivateRecordingOrTable(RecordingOrTable),
 
-    /// Close an [`StoreHubEntry`] and free its memory.
-    CloseEntry(StoreHubEntry),
+    /// Close an [`RecordingOrTable`] and free its memory.
+    CloseRecordingOrTable(RecordingOrTable),
 
     /// Close all stores and show the welcome screen again.
     CloseAllEntries,

--- a/crates/viewer/re_global_context/src/lib.rs
+++ b/crates/viewer/re_global_context/src/lib.rs
@@ -6,7 +6,7 @@ mod command_sender;
 mod contents;
 mod file_dialog;
 mod item;
-mod store_hub_entry;
+mod recording_or_table;
 
 pub use self::{
     app_options::AppOptions,
@@ -17,7 +17,7 @@ pub use self::{
     contents::{Contents, ContentsName, blueprint_id_to_tile_id},
     file_dialog::santitize_file_name,
     item::{Item, resolve_mono_instance_path, resolve_mono_instance_path_item},
-    store_hub_entry::StoreHubEntry,
+    recording_or_table::RecordingOrTable,
 };
 
 use re_log_types::TableId;

--- a/crates/viewer/re_global_context/src/recording_or_table.rs
+++ b/crates/viewer/re_global_context/src/recording_or_table.rs
@@ -1,7 +1,7 @@
 use re_log_types::{StoreId, TableId};
 
 #[derive(Clone, Debug)]
-pub enum StoreHubEntry {
+pub enum RecordingOrTable {
     Recording {
         store_id: StoreId,
         // TODO(grtlr): Add `applicationId` here.
@@ -11,19 +11,19 @@ pub enum StoreHubEntry {
     },
 }
 
-impl From<StoreId> for StoreHubEntry {
+impl From<StoreId> for RecordingOrTable {
     fn from(store_id: StoreId) -> Self {
         Self::Recording { store_id }
     }
 }
 
-impl From<TableId> for StoreHubEntry {
+impl From<TableId> for RecordingOrTable {
     fn from(table_id: TableId) -> Self {
         Self::Table { table_id }
     }
 }
 
-impl StoreHubEntry {
+impl RecordingOrTable {
     pub fn recording_ref(&self) -> Option<&StoreId> {
         match self {
             Self::Recording { store_id } => Some(store_id),

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -17,8 +17,8 @@ use re_types::archetypes::RecordingProperties;
 use re_types::components::{Name, Timestamp};
 use re_ui::{UiExt as _, UiLayout, icons, list_item};
 use re_viewer_context::{
-    AsyncRuntimeHandle, DisplayMode, Item, StoreHubEntry, SystemCommand, SystemCommandSender as _,
-    ViewerContext, external::re_entity_db::EntityDb,
+    AsyncRuntimeHandle, DisplayMode, Item, RecordingOrTable, SystemCommand,
+    SystemCommandSender as _, ViewerContext, external::re_entity_db::EntityDb,
 };
 
 use crate::context::Context;
@@ -214,11 +214,12 @@ impl EntryKind {
         match self {
             Self::Remote { .. } => {
                 for db in dbs {
-                    ctx.command_sender().send_system(SystemCommand::CloseEntry(
-                        StoreHubEntry::Recording {
-                            store_id: db.store_id(),
-                        },
-                    ));
+                    ctx.command_sender()
+                        .send_system(SystemCommand::CloseRecordingOrTable(
+                            RecordingOrTable::Recording {
+                                store_id: db.store_id(),
+                            },
+                        ));
                 }
             }
             Self::Local(app_id) => {

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -558,9 +558,9 @@ impl TestContext {
 
                 // not implemented
                 SystemCommand::ActivateApp(_)
-                | SystemCommand::ActivateEntry(_)
+                | SystemCommand::ActivateRecordingOrTable(_)
                 | SystemCommand::CloseApp(_)
-                | SystemCommand::CloseEntry(_)
+                | SystemCommand::CloseRecordingOrTable(_)
                 | SystemCommand::LoadDataSource(_)
                 | SystemCommand::ClearSourceAndItsStores(_)
                 | SystemCommand::AddReceiver { .. }


### PR DESCRIPTION
### Related

* Part of https://github.com/rerun-io/dataplatform/issues/777

### What

Pure refactor: let's not name entry things that are not (always) entries. It got me badly confused.

As an aside, the relationship between entries (aka Dataset/Table/etc.) and the recording panel/what-is-currently-displayed is cursed:
- A recording (leaf in recording panel) is no an entry, but _may_ be a partition of a (dataset) entry.
- Application ID are technically not entries, but are presented in a similar way to datasets (aka a "folder" that contains recording/partition), which are entries.
- Tables are entries, but are leaf item in the recording panel
