### PR TITLE
Py builds with`pixi run py-build-release` now spawn release viewer

### DIFF
--- a/rerun_py/rerun/__init__.py
+++ b/rerun_py/rerun/__init__.py
@@ -27,7 +27,10 @@ real_path = pathlib.Path(__file__).parent.parent.joinpath("rerun_sdk").resolve()
 print(f"DEV ENVIRONMENT DETECTED! Re-importing rerun from: {real_path}", file=sys.stderr)
 
 if "RERUN_CLI_PATH" not in os.environ:
-    target_path = pathlib.Path(__file__).parent.parent.parent.joinpath("target/debug/rerun").resolve()
+    import rerun_bindings as bindings
+
+    flavor = "debug" if bindings.is_dev_build() else "release"
+    target_path = pathlib.Path(__file__).parent.parent.parent.joinpath(f"target/{flavor}/rerun").resolve()
     os.environ["RERUN_CLI_PATH"] = str(target_path)
 
 sys.path.insert(0, str(real_path))

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -940,6 +940,9 @@ def send_recording(rrd: Recording, recording: Optional[PyRecordingStream] = None
 def version() -> str:
     """Return a verbose version string."""
 
+def is_dev_build() -> bool:
+    """Return True if the Rerun SDK is a dev/debug build."""
+
 def get_app_url() -> str:
     """
     Get an url to an instance of the web-viewer.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -180,6 +180,7 @@ fn rerun_bindings(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // misc
     m.add_function(wrap_pyfunction!(version, m)?)?;
+    m.add_function(wrap_pyfunction!(is_dev_build, m)?)?;
     m.add_function(wrap_pyfunction!(get_app_url, m)?)?;
     m.add_function(wrap_pyfunction!(start_web_viewer_server, m)?)?;
     m.add_function(wrap_pyfunction!(escape_entity_path_part, m)?)?;
@@ -1448,6 +1449,12 @@ fn send_recording(rrd: &PyRecording, recording: Option<&PyRecordingStream>) {
 #[pyfunction]
 fn version() -> String {
     re_build_info::build_info!().to_string()
+}
+
+/// Return True if the Rerun SDK is a dev/debug build.
+#[pyfunction]
+fn is_dev_build() -> bool {
+    cfg!(debug_assertions)
 }
 
 /// Get an url to an instance of the web-viewer.


### PR DESCRIPTION
Previously it would always open the debug viewer which was quite annoying