### PR TITLE
CMake improvement to download arrow inside the rerun build folder

### DIFF
--- a/rerun_cpp/download_and_build_arrow.cmake
+++ b/rerun_cpp/download_and_build_arrow.cmake
@@ -5,7 +5,7 @@
 function(download_and_build_arrow)
     include(ExternalProject)
 
-    set(ARROW_DOWNLOAD_PATH ${CMAKE_BINARY_DIR}/arrow)
+    set(ARROW_DOWNLOAD_PATH ${CMAKE_CURRENT_BINARY_DIR}/arrow)
 
     set(ARROW_LIB_PATH ${ARROW_DOWNLOAD_PATH}/lib)
     set(ARROW_BIN_PATH ${ARROW_DOWNLOAD_PATH}/bin)


### PR DESCRIPTION
Small improvement to make sure the arrow code is downloaded inside the rerun build folder. This avoids polluting custom project build folders when using CMake and FetchContent
