### PR TITLE
Remove `_COMPONENT_DESCRIPTOR` from components in Python

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -1942,7 +1942,7 @@ fn quote_arrow_support_from_obj(
             r#"
             class {extension_batch}{batch_superclass_decl}:
                 _ARROW_DATATYPE = {datatype}
-                _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("{fqname}")
+                _COMPONENT_NAME: str = "{fqname}"
 
                 @staticmethod
                 def _native_to_pa_array(data: {many_aliases}, data_type: pa.DataType) -> pa.Array:
@@ -1955,7 +1955,7 @@ fn quote_arrow_support_from_obj(
         unindent(&format!(
             r#"
             class {extension_batch}{batch_superclass_decl}:
-                _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("{fqname}")
+                _COMPONENT_NAME: str = "{fqname}"
             "#
         ))
     }

--- a/docs/snippets/all/descriptors/descr_builtin_component.py
+++ b/docs/snippets/all/descriptors/descr_builtin_component.py
@@ -10,9 +10,8 @@ rr.spawn()
 rr.log(
     "data",
     [
-        rr.components.Position3DBatch([1, 2, 3]).with_descriptor(
+        rr.components.Position3DBatch([1, 2, 3]).described(
             rr.ComponentDescriptor(
-                # TODO(#6889): Temporary fix, should improve API
                 "rerun.components.Position3D",
                 archetype_name="user.CustomPoints3D",
                 archetype_field_name="points",

--- a/docs/snippets/all/descriptors/descr_custom_archetype.py
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.py
@@ -10,16 +10,18 @@ import rerun as rr  # pip install rerun-sdk
 
 class CustomPoints3D(rr.AsComponents):
     def __init__(self: Any, positions: npt.ArrayLike, colors: npt.ArrayLike) -> None:
-        self.positions = rr.components.Position3DBatch(positions).with_descriptor(
+        self.positions = rr.components.Position3DBatch(positions).described(
             rr.ComponentDescriptor(
                 "user.CustomPosition3D",
                 archetype_name="user.CustomPoints3D",
                 archetype_field_name="custom_positions",
             ),
         )
-        self.colors = rr.components.ColorBatch(colors).or_with_descriptor_overrides(
-            archetype_name="user.CustomPoints3D",
-            archetype_field_name="colors",
+        self.colors = rr.components.ColorBatch(colors).described(
+            rr.ComponentDescriptor("rerun.components.Colors").with_overrides(
+                archetype_name="user.CustomPoints3D",
+                archetype_field_name="colors",
+            )
         )
 
     def as_component_batches(self) -> list[rr.DescribedComponentBatch]:

--- a/docs/snippets/all/descriptors/descr_custom_component.py
+++ b/docs/snippets/all/descriptors/descr_custom_component.py
@@ -7,7 +7,7 @@ import rerun as rr  # pip install rerun-sdk
 rr.init("rerun_example_descriptors_custom_component")
 rr.spawn()
 
-positions = rr.components.Position3DBatch([1, 2, 3]).with_descriptor(
+positions = rr.components.Position3DBatch([1, 2, 3]).described(
     rr.ComponentDescriptor(
         "user.CustomPosition3D",
         archetype_name="user.CustomArchetype",

--- a/docs/snippets/all/tutorials/custom_data.py
+++ b/docs/snippets/all/tutorials/custom_data.py
@@ -17,10 +17,6 @@ class ConfidenceBatch(rr.ComponentBatchMixin):
     def __init__(self: Any, confidence: npt.ArrayLike) -> None:
         self.confidence = confidence
 
-    def component_descriptor(self) -> rr.ComponentDescriptor:
-        """The descriptor of the custom component."""
-        return rr.ComponentDescriptor("user.Confidence")
-
     def as_arrow_array(self) -> pa.Array:
         """The arrow batch representing the custom component."""
         return pa.array(self.confidence, type=pa.float32())
@@ -31,9 +27,12 @@ class CustomPoints3D(rr.AsComponents):
 
     def __init__(self: Any, positions: npt.ArrayLike, confidences: npt.ArrayLike) -> None:
         self.points3d = rr.Points3D(positions)
-        self.confidences = ConfidenceBatch(confidences).or_with_descriptor_overrides(
-            archetype_name="user.CustomPoints3D",
-            archetype_field_name="confidences",
+        self.confidences = ConfidenceBatch(confidences).described(
+            rr.ComponentDescriptor(
+                "user.Confidence",
+                archetype_name="user.CustomPoints3D",
+                archetype_field_name="confidences",
+            )
         )
 
     def as_component_batches(self) -> list[rr.DescribedComponentBatch]:

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -183,7 +183,7 @@ class AnyBatchValue(ComponentBatchLike):
 
         """
         inst = cls(descriptor, value, drop_untyped_nones)
-        return ComponentColumn(inst)
+        return ComponentColumn(descriptor, inst)
 
 
 class AnyValues(AsComponents):
@@ -316,4 +316,6 @@ class AnyValues(AsComponents):
 
         """
         inst = cls(drop_untyped_nones, **kwargs)
-        return ComponentColumnList([ComponentColumn(batch) for batch in inst.component_batches])
+        return ComponentColumnList([
+            ComponentColumn(batch.component_descriptor(), batch) for batch in inst.component_batches
+        ])

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ActiveTab(datatypes.EntityPath, ComponentMixin):
 
 
 class ActiveTabBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ActiveTab")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ActiveTab"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/apply_latest_at.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/apply_latest_at.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ApplyLatestAt(datatypes.Bool, ComponentMixin):
 
 
 class ApplyLatestAtBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ApplyLatestAt")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ApplyLatestAt"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class AutoLayout(datatypes.Bool, ComponentMixin):
 
 
 class AutoLayoutBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.AutoLayout")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.AutoLayout"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_views.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class AutoViews(datatypes.Bool, ComponentMixin):
 
 
 class AutoViewsBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.AutoViews")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.AutoViews"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["BackgroundKind", "BackgroundKindArrayLike", "BackgroundKindBatch", "BackgroundKindLike"]
@@ -73,7 +72,7 @@ BackgroundKindArrayLike = Union[BackgroundKindLike, Sequence[BackgroundKindLike]
 
 class BackgroundKindBatch(BaseBatch[BackgroundKindArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.BackgroundKind")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.BackgroundKind"
 
     @staticmethod
     def _native_to_pa_array(data: BackgroundKindArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ColumnShare(datatypes.Float32, ComponentMixin):
 
 
 class ColumnShareBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ColumnShare")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ColumnShare"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/component_column_selector.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/component_column_selector.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -29,9 +28,7 @@ class ComponentColumnSelector(blueprint_datatypes.ComponentColumnSelector, Compo
 
 
 class ComponentColumnSelectorBatch(blueprint_datatypes.ComponentColumnSelectorBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor(
-        "rerun.blueprint.components.ComponentColumnSelector"
-    )
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ComponentColumnSelector"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["ContainerKind", "ContainerKindArrayLike", "ContainerKindBatch", "ContainerKindLike"]
@@ -66,7 +65,7 @@ ContainerKindArrayLike = Union[ContainerKindLike, Sequence[ContainerKindLike]]
 
 class ContainerKindBatch(BaseBatch[ContainerKindArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ContainerKind")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ContainerKind"
 
     @staticmethod
     def _native_to_pa_array(data: ContainerKindArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["Corner2D", "Corner2DArrayLike", "Corner2DBatch", "Corner2DLike"]
@@ -68,7 +67,7 @@ Corner2DArrayLike = Union[Corner2DLike, Sequence[Corner2DLike]]
 
 class Corner2DBatch(BaseBatch[Corner2DArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.Corner2D")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.Corner2D"
 
     @staticmethod
     def _native_to_pa_array(data: Corner2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/enabled.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/enabled.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class Enabled(datatypes.Bool, ComponentMixin):
 
 
 class EnabledBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.Enabled")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.Enabled"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/filter_by_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/filter_by_range.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -29,7 +28,7 @@ class FilterByRange(blueprint_datatypes.FilterByRange, ComponentMixin):
 
 
 class FilterByRangeBatch(blueprint_datatypes.FilterByRangeBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.FilterByRange")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.FilterByRange"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/filter_is_not_null.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/filter_is_not_null.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -29,7 +28,7 @@ class FilterIsNotNull(blueprint_datatypes.FilterIsNotNull, ComponentMixin):
 
 
 class FilterIsNotNullBatch(blueprint_datatypes.FilterIsNotNullBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.FilterIsNotNull")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.FilterIsNotNull"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/force_distance.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/force_distance.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class ForceDistance(datatypes.Float64, ComponentMixin):
 
 
 class ForceDistanceBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ForceDistance")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ForceDistance"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/force_iterations.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/force_iterations.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class ForceIterations(datatypes.UInt64, ComponentMixin):
 
 
 class ForceIterationsBatch(datatypes.UInt64Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ForceIterations")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ForceIterations"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/force_strength.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/force_strength.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class ForceStrength(datatypes.Float64, ComponentMixin):
 
 
 class ForceStrengthBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ForceStrength")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ForceStrength"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class GridColumns(datatypes.UInt32, ComponentMixin):
 
 
 class GridColumnsBatch(datatypes.UInt32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.GridColumns")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.GridColumns"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/grid_spacing.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/grid_spacing.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class GridSpacing(datatypes.Float32, ComponentMixin):
 
 
 class GridSpacingBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.GridSpacing")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.GridSpacing"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class IncludedContent(datatypes.EntityPath, ComponentMixin):
 
 
 class IncludedContentBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.IncludedContent")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.IncludedContent"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class LockRangeDuringZoom(datatypes.Bool, ComponentMixin):
 
 
 class LockRangeDuringZoomBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.LockRangeDuringZoom")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.LockRangeDuringZoom"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["MapProvider", "MapProviderArrayLike", "MapProviderBatch", "MapProviderLike"]
@@ -77,7 +76,7 @@ MapProviderArrayLike = Union[MapProviderLike, Sequence[MapProviderLike]]
 
 class MapProviderBatch(BaseBatch[MapProviderArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.MapProvider")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.MapProvider"
 
     @staticmethod
     def _native_to_pa_array(data: MapProviderArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/near_clip_plane.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/near_clip_plane.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class NearClipPlane(datatypes.Float32, ComponentMixin):
 
 
 class NearClipPlaneBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.NearClipPlane")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.NearClipPlane"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["PanelState", "PanelStateArrayLike", "PanelStateBatch", "PanelStateLike"]
@@ -61,7 +60,7 @@ PanelStateArrayLike = Union[PanelStateLike, Sequence[PanelStateLike]]
 
 class PanelStateBatch(BaseBatch[PanelStateArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.PanelState")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.PanelState"
 
     @staticmethod
     def _native_to_pa_array(data: PanelStateArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -38,7 +37,7 @@ class QueryExpression(datatypes.Utf8, ComponentMixin):
 
 
 class QueryExpressionBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.QueryExpression")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.QueryExpression"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class RootContainer(datatypes.Uuid, ComponentMixin):
 
 
 class RootContainerBatch(datatypes.UuidBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.RootContainer")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.RootContainer"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class RowShare(datatypes.Float32, ComponentMixin):
 
 
 class RowShareBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.RowShare")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.RowShare"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/selected_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/selected_columns.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -29,7 +28,7 @@ class SelectedColumns(blueprint_datatypes.SelectedColumns, ComponentMixin):
 
 
 class SelectedColumnsBatch(blueprint_datatypes.SelectedColumnsBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.SelectedColumns")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.SelectedColumns"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/tensor_dimension_index_slider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/tensor_dimension_index_slider.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -29,9 +28,7 @@ class TensorDimensionIndexSlider(blueprint_datatypes.TensorDimensionIndexSlider,
 
 
 class TensorDimensionIndexSliderBatch(blueprint_datatypes.TensorDimensionIndexSliderBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor(
-        "rerun.blueprint.components.TensorDimensionIndexSlider"
-    )
+    _COMPONENT_NAME: str = "rerun.blueprint.components.TensorDimensionIndexSlider"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/timeline_name.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/timeline_name.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class TimelineName(datatypes.Utf8, ComponentMixin):
 
 
 class TimelineNameBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.TimelineName")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.TimelineName"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_class.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_class.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ViewClass(datatypes.Utf8, ComponentMixin):
 
 
 class ViewClassBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ViewClass")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewClass"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["ViewFit", "ViewFitArrayLike", "ViewFitBatch", "ViewFitLike"]
@@ -63,7 +62,7 @@ ViewFitArrayLike = Union[ViewFitLike, Sequence[ViewFitLike]]
 
 class ViewFitBatch(BaseBatch[ViewFitArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ViewFit")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewFit"
 
     @staticmethod
     def _native_to_pa_array(data: ViewFitArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_maximized.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_maximized.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ViewMaximized(datatypes.Uuid, ComponentMixin):
 
 
 class ViewMaximizedBatch(datatypes.UuidBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ViewMaximized")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewMaximized"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_origin.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_origin.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ViewOrigin(datatypes.EntityPath, ComponentMixin):
 
 
 class ViewOriginBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ViewOrigin")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewOrigin"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,9 +30,7 @@ class ViewerRecommendationHash(datatypes.UInt64, ComponentMixin):
 
 
 class ViewerRecommendationHashBatch(datatypes.UInt64Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor(
-        "rerun.blueprint.components.ViewerRecommendationHash"
-    )
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewerRecommendationHash"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class VisibleTimeRange(datatypes.VisibleTimeRange, ComponentMixin):
 
 
 class VisibleTimeRangeBatch(datatypes.VisibleTimeRangeBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.VisibleTimeRange")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.VisibleTimeRange"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .visual_bounds2d_ext import VisualBounds2DExt
@@ -30,7 +29,7 @@ class VisualBounds2D(VisualBounds2DExt, datatypes.Range2D, ComponentMixin):
 
 
 class VisualBounds2DBatch(datatypes.Range2DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.VisualBounds2D")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.VisualBounds2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visualizer_override.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visualizer_override.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class VisualizerOverride(datatypes.Utf8, ComponentMixin):
 
 
 class VisualizerOverrideBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.VisualizerOverride")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.VisualizerOverride"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ZoomLevel(datatypes.Float64, ComponentMixin):
 
 
 class ZoomLevelBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ZoomLevel")
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ZoomLevel"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
+++ b/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["AggregationPolicy", "AggregationPolicyArrayLike", "AggregationPolicyBatch", "AggregationPolicyLike"]
@@ -97,7 +96,7 @@ AggregationPolicyArrayLike = Union[AggregationPolicyLike, Sequence[AggregationPo
 
 class AggregationPolicyBatch(BaseBatch[AggregationPolicyArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AggregationPolicy")
+    _COMPONENT_NAME: str = "rerun.components.AggregationPolicy"
 
     @staticmethod
     def _native_to_pa_array(data: AggregationPolicyArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/albedo_factor.py
+++ b/rerun_py/rerun_sdk/rerun/components/albedo_factor.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class AlbedoFactor(datatypes.Rgba32, ComponentMixin):
 
 
 class AlbedoFactorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AlbedoFactor")
+    _COMPONENT_NAME: str = "rerun.components.AlbedoFactor"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -15,7 +15,6 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .annotation_context_ext import AnnotationContextExt
@@ -135,7 +134,7 @@ class AnnotationContextBatch(BaseBatch[AnnotationContextArrayLike], ComponentBat
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AnnotationContext")
+    _COMPONENT_NAME: str = "rerun.components.AnnotationContext"
 
     @staticmethod
     def _native_to_pa_array(data: AnnotationContextArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/axis_length.py
+++ b/rerun_py/rerun_sdk/rerun/components/axis_length.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class AxisLength(datatypes.Float32, ComponentMixin):
 
 
 class AxisLengthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AxisLength")
+    _COMPONENT_NAME: str = "rerun.components.AxisLength"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/blob.py
+++ b/rerun_py/rerun_sdk/rerun/components/blob.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Blob(datatypes.Blob, ComponentMixin):
 
 
 class BlobBatch(datatypes.BlobBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Blob")
+    _COMPONENT_NAME: str = "rerun.components.Blob"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/class_id.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class ClassId(datatypes.ClassId, ComponentMixin):
 
 
 class ClassIdBatch(datatypes.ClassIdBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ClassId")
+    _COMPONENT_NAME: str = "rerun.components.ClassId"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .clear_is_recursive_ext import ClearIsRecursiveExt
@@ -26,7 +25,7 @@ class ClearIsRecursive(ClearIsRecursiveExt, datatypes.Bool, ComponentMixin):
 
 
 class ClearIsRecursiveBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ClearIsRecursive")
+    _COMPONENT_NAME: str = "rerun.components.ClearIsRecursive"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .color_ext import ColorExt
@@ -35,7 +34,7 @@ class Color(ColorExt, datatypes.Rgba32, ComponentMixin):
 
 
 class ColorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Color")
+    _COMPONENT_NAME: str = "rerun.components.Color"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/colormap.py
+++ b/rerun_py/rerun_sdk/rerun/components/colormap.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["Colormap", "ColormapArrayLike", "ColormapBatch", "ColormapLike"]
@@ -135,7 +134,7 @@ ColormapArrayLike = Union[ColormapLike, Sequence[ColormapLike]]
 
 class ColormapBatch(BaseBatch[ColormapArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Colormap")
+    _COMPONENT_NAME: str = "rerun.components.Colormap"
 
     @staticmethod
     def _native_to_pa_array(data: ColormapArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -36,7 +35,7 @@ class DepthMeter(datatypes.Float32, ComponentMixin):
 
 
 class DepthMeterBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.DepthMeter")
+    _COMPONENT_NAME: str = "rerun.components.DepthMeter"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +31,7 @@ class DrawOrder(datatypes.Float32, ComponentMixin):
 
 
 class DrawOrderBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.DrawOrder")
+    _COMPONENT_NAME: str = "rerun.components.DrawOrder"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/entity_path.py
+++ b/rerun_py/rerun_sdk/rerun/components/entity_path.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class EntityPath(datatypes.EntityPath, ComponentMixin):
 
 
 class EntityPathBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.EntityPath")
+    _COMPONENT_NAME: str = "rerun.components.EntityPath"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/fill_mode.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_mode.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["FillMode", "FillModeArrayLike", "FillModeBatch", "FillModeLike"]
@@ -79,7 +78,7 @@ FillModeArrayLike = Union[FillModeLike, Sequence[FillModeLike]]
 
 class FillModeBatch(BaseBatch[FillModeArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.FillMode")
+    _COMPONENT_NAME: str = "rerun.components.FillMode"
 
     @staticmethod
     def _native_to_pa_array(data: FillModeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +31,7 @@ class FillRatio(datatypes.Float32, ComponentMixin):
 
 
 class FillRatioBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.FillRatio")
+    _COMPONENT_NAME: str = "rerun.components.FillRatio"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/gamma_correction.py
+++ b/rerun_py/rerun_sdk/rerun/components/gamma_correction.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -33,7 +32,7 @@ class GammaCorrection(datatypes.Float32, ComponentMixin):
 
 
 class GammaCorrectionBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GammaCorrection")
+    _COMPONENT_NAME: str = "rerun.components.GammaCorrection"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
+++ b/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
@@ -17,7 +17,6 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .geo_line_string_ext import GeoLineStringExt
@@ -52,7 +51,7 @@ class GeoLineStringBatch(BaseBatch[GeoLineStringArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GeoLineString")
+    _COMPONENT_NAME: str = "rerun.components.GeoLineString"
 
     @staticmethod
     def _native_to_pa_array(data: GeoLineStringArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/graph_edge.py
+++ b/rerun_py/rerun_sdk/rerun/components/graph_edge.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class GraphEdge(datatypes.Utf8Pair, ComponentMixin):
 
 
 class GraphEdgeBatch(datatypes.Utf8PairBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GraphEdge")
+    _COMPONENT_NAME: str = "rerun.components.GraphEdge"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/graph_node.py
+++ b/rerun_py/rerun_sdk/rerun/components/graph_node.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class GraphNode(datatypes.Utf8, ComponentMixin):
 
 
 class GraphNodeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GraphNode")
+    _COMPONENT_NAME: str = "rerun.components.GraphNode"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/graph_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/graph_type.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["GraphType", "GraphTypeArrayLike", "GraphTypeBatch", "GraphTypeLike"]
@@ -58,7 +57,7 @@ GraphTypeArrayLike = Union[GraphTypeLike, Sequence[GraphTypeLike]]
 
 class GraphTypeBatch(BaseBatch[GraphTypeArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GraphType")
+    _COMPONENT_NAME: str = "rerun.components.GraphType"
 
     @staticmethod
     def _native_to_pa_array(data: GraphTypeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/half_size2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_size2d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +31,7 @@ class HalfSize2D(datatypes.Vec2D, ComponentMixin):
 
 
 class HalfSize2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.HalfSize2D")
+    _COMPONENT_NAME: str = "rerun.components.HalfSize2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/half_size3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_size3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +31,7 @@ class HalfSize3D(datatypes.Vec3D, ComponentMixin):
 
 
 class HalfSize3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.HalfSize3D")
+    _COMPONENT_NAME: str = "rerun.components.HalfSize3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_buffer.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ImageBuffer(datatypes.Blob, ComponentMixin):
 
 
 class ImageBufferBatch(datatypes.BlobBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ImageBuffer")
+    _COMPONENT_NAME: str = "rerun.components.ImageBuffer"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_format.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_format.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class ImageFormat(datatypes.ImageFormat, ComponentMixin):
 
 
 class ImageFormatBatch(datatypes.ImageFormatBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ImageFormat")
+    _COMPONENT_NAME: str = "rerun.components.ImageFormat"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ImagePlaneDistance(datatypes.Float32, ComponentMixin):
 
 
 class ImagePlaneDistanceBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ImagePlaneDistance")
+    _COMPONENT_NAME: str = "rerun.components.ImagePlaneDistance"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/interactive.py
+++ b/rerun_py/rerun_sdk/rerun/components/interactive.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class Interactive(datatypes.Bool, ComponentMixin):
 
 
 class InteractiveBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Interactive")
+    _COMPONENT_NAME: str = "rerun.components.Interactive"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +31,7 @@ class KeypointId(datatypes.KeypointId, ComponentMixin):
 
 
 class KeypointIdBatch(datatypes.KeypointIdBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.KeypointId")
+    _COMPONENT_NAME: str = "rerun.components.KeypointId"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/lat_lon.py
+++ b/rerun_py/rerun_sdk/rerun/components/lat_lon.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class LatLon(datatypes.DVec2D, ComponentMixin):
 
 
 class LatLonBatch(datatypes.DVec2DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.LatLon")
+    _COMPONENT_NAME: str = "rerun.components.LatLon"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/length.py
+++ b/rerun_py/rerun_sdk/rerun/components/length.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +29,7 @@ class Length(datatypes.Float32, ComponentMixin):
 
 
 class LengthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Length")
+    _COMPONENT_NAME: str = "rerun.components.Length"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -17,7 +17,6 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .line_strip2d_ext import LineStrip2DExt
@@ -70,7 +69,7 @@ class LineStrip2DBatch(BaseBatch[LineStrip2DArrayLike], ComponentBatchMixin):
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.LineStrip2D")
+    _COMPONENT_NAME: str = "rerun.components.LineStrip2D"
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -17,7 +17,6 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .line_strip3d_ext import LineStrip3DExt
@@ -70,7 +69,7 @@ class LineStrip3DBatch(BaseBatch[LineStrip3DArrayLike], ComponentBatchMixin):
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.LineStrip3D")
+    _COMPONENT_NAME: str = "rerun.components.LineStrip3D"
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip3DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
+++ b/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["MagnificationFilter", "MagnificationFilterArrayLike", "MagnificationFilterBatch", "MagnificationFilterLike"]
@@ -67,7 +66,7 @@ MagnificationFilterArrayLike = Union[MagnificationFilterLike, Sequence[Magnifica
 
 class MagnificationFilterBatch(BaseBatch[MagnificationFilterArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MagnificationFilter")
+    _COMPONENT_NAME: str = "rerun.components.MagnificationFilter"
 
     @staticmethod
     def _native_to_pa_array(data: MagnificationFilterArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/marker_shape.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_shape.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["MarkerShape", "MarkerShapeArrayLike", "MarkerShapeBatch", "MarkerShapeLike"]
@@ -107,7 +106,7 @@ MarkerShapeArrayLike = Union[MarkerShapeLike, Sequence[MarkerShapeLike]]
 
 class MarkerShapeBatch(BaseBatch[MarkerShapeArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MarkerShape")
+    _COMPONENT_NAME: str = "rerun.components.MarkerShape"
 
     @staticmethod
     def _native_to_pa_array(data: MarkerShapeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/marker_size.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_size.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class MarkerSize(datatypes.Float32, ComponentMixin):
 
 
 class MarkerSizeBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MarkerSize")
+    _COMPONENT_NAME: str = "rerun.components.MarkerSize"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/media_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/media_type.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .media_type_ext import MediaTypeExt
@@ -31,7 +30,7 @@ class MediaType(MediaTypeExt, datatypes.Utf8, ComponentMixin):
 
 
 class MediaTypeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MediaType")
+    _COMPONENT_NAME: str = "rerun.components.MediaType"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/name.py
+++ b/rerun_py/rerun_sdk/rerun/components/name.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Name(datatypes.Utf8, ComponentMixin):
 
 
 class NameBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Name")
+    _COMPONENT_NAME: str = "rerun.components.Name"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/opacity.py
+++ b/rerun_py/rerun_sdk/rerun/components/opacity.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +29,7 @@ class Opacity(datatypes.Float32, ComponentMixin):
 
 
 class OpacityBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Opacity")
+    _COMPONENT_NAME: str = "rerun.components.Opacity"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
+++ b/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -38,7 +37,7 @@ class PinholeProjection(datatypes.Mat3x3, ComponentMixin):
 
 
 class PinholeProjectionBatch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PinholeProjection")
+    _COMPONENT_NAME: str = "rerun.components.PinholeProjection"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/plane3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/plane3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -35,7 +34,7 @@ class Plane3D(datatypes.Plane3D, ComponentMixin):
 
 
 class Plane3DBatch(datatypes.Plane3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Plane3D")
+    _COMPONENT_NAME: str = "rerun.components.Plane3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +29,7 @@ class PoseRotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
 
 
 class PoseRotationAxisAngleBatch(datatypes.RotationAxisAngleBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseRotationAxisAngle")
+    _COMPONENT_NAME: str = "rerun.components.PoseRotationAxisAngle"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_rotation_quat.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_rotation_quat.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class PoseRotationQuat(datatypes.Quaternion, ComponentMixin):
 
 
 class PoseRotationQuatBatch(datatypes.QuaternionBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseRotationQuat")
+    _COMPONENT_NAME: str = "rerun.components.PoseRotationQuat"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_scale3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .pose_scale3d_ext import PoseScale3DExt
@@ -32,7 +31,7 @@ class PoseScale3D(PoseScale3DExt, datatypes.Vec3D, ComponentMixin):
 
 
 class PoseScale3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseScale3D")
+    _COMPONENT_NAME: str = "rerun.components.PoseScale3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_transform_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_transform_mat3x3.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -61,7 +60,7 @@ class PoseTransformMat3x3(datatypes.Mat3x3, ComponentMixin):
 
 
 class PoseTransformMat3x3Batch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseTransformMat3x3")
+    _COMPONENT_NAME: str = "rerun.components.PoseTransformMat3x3"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_translation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_translation3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class PoseTranslation3D(datatypes.Vec3D, ComponentMixin):
 
 
 class PoseTranslation3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseTranslation3D")
+    _COMPONENT_NAME: str = "rerun.components.PoseTranslation3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/position2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position2d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Position2D(datatypes.Vec2D, ComponentMixin):
 
 
 class Position2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Position2D")
+    _COMPONENT_NAME: str = "rerun.components.Position2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/position3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Position3D(datatypes.Vec3D, ComponentMixin):
 
 
 class Position3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Position3D")
+    _COMPONENT_NAME: str = "rerun.components.Position3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .radius_ext import RadiusExt
@@ -35,7 +34,7 @@ class Radius(RadiusExt, datatypes.Float32, ComponentMixin):
 
 
 class RadiusBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Radius")
+    _COMPONENT_NAME: str = "rerun.components.Radius"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/components/range1d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Range1D(datatypes.Range1D, ComponentMixin):
 
 
 class Range1DBatch(datatypes.Range1DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Range1D")
+    _COMPONENT_NAME: str = "rerun.components.Range1D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/resolution.py
+++ b/rerun_py/rerun_sdk/rerun/components/resolution.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class Resolution(datatypes.Vec2D, ComponentMixin):
 
 
 class ResolutionBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Resolution")
+    _COMPONENT_NAME: str = "rerun.components.Resolution"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +29,7 @@ class RotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
 
 
 class RotationAxisAngleBatch(datatypes.RotationAxisAngleBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.RotationAxisAngle")
+    _COMPONENT_NAME: str = "rerun.components.RotationAxisAngle"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/rotation_quat.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation_quat.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class RotationQuat(datatypes.Quaternion, ComponentMixin):
 
 
 class RotationQuatBatch(datatypes.QuaternionBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.RotationQuat")
+    _COMPONENT_NAME: str = "rerun.components.RotationQuat"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class Scalar(datatypes.Float64, ComponentMixin):
 
 
 class ScalarBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Scalar")
+    _COMPONENT_NAME: str = "rerun.components.Scalar"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/scale3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .scale3d_ext import Scale3DExt
@@ -32,7 +31,7 @@ class Scale3D(Scale3DExt, datatypes.Vec3D, ComponentMixin):
 
 
 class Scale3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Scale3D")
+    _COMPONENT_NAME: str = "rerun.components.Scale3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/series_visible.py
+++ b/rerun_py/rerun_sdk/rerun/components/series_visible.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class SeriesVisible(datatypes.Bool, ComponentMixin):
 
 
 class SeriesVisibleBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.SeriesVisible")
+    _COMPONENT_NAME: str = "rerun.components.SeriesVisible"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/show_labels.py
+++ b/rerun_py/rerun_sdk/rerun/components/show_labels.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +30,7 @@ class ShowLabels(datatypes.Bool, ComponentMixin):
 
 
 class ShowLabelsBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ShowLabels")
+    _COMPONENT_NAME: str = "rerun.components.ShowLabels"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/stroke_width.py
+++ b/rerun_py/rerun_sdk/rerun/components/stroke_width.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class StrokeWidth(datatypes.Float32, ComponentMixin):
 
 
 class StrokeWidthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.StrokeWidth")
+    _COMPONENT_NAME: str = "rerun.components.StrokeWidth"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_data.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -34,7 +33,7 @@ class TensorData(datatypes.TensorData, ComponentMixin):
 
 
 class TensorDataBatch(datatypes.TensorDataBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorData")
+    _COMPONENT_NAME: str = "rerun.components.TensorData"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_dimension_index_selection.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_dimension_index_selection.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class TensorDimensionIndexSelection(datatypes.TensorDimensionIndexSelection, Com
 
 
 class TensorDimensionIndexSelectionBatch(datatypes.TensorDimensionIndexSelectionBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorDimensionIndexSelection")
+    _COMPONENT_NAME: str = "rerun.components.TensorDimensionIndexSelection"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_height_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_height_dimension.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class TensorHeightDimension(datatypes.TensorDimensionSelection, ComponentMixin):
 
 
 class TensorHeightDimensionBatch(datatypes.TensorDimensionSelectionBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorHeightDimension")
+    _COMPONENT_NAME: str = "rerun.components.TensorHeightDimension"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_width_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_width_dimension.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class TensorWidthDimension(datatypes.TensorDimensionSelection, ComponentMixin):
 
 
 class TensorWidthDimensionBatch(datatypes.TensorDimensionSelectionBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorWidthDimension")
+    _COMPONENT_NAME: str = "rerun.components.TensorWidthDimension"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -42,7 +41,7 @@ class Texcoord2D(datatypes.Vec2D, ComponentMixin):
 
 
 class Texcoord2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Texcoord2D")
+    _COMPONENT_NAME: str = "rerun.components.Texcoord2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/text.py
+++ b/rerun_py/rerun_sdk/rerun/components/text.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Text(datatypes.Utf8, ComponentMixin):
 
 
 class TextBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Text")
+    _COMPONENT_NAME: str = "rerun.components.Text"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/text_log_level.py
+++ b/rerun_py/rerun_sdk/rerun/components/text_log_level.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .text_log_level_ext import TextLogLevelExt
@@ -36,7 +35,7 @@ class TextLogLevel(TextLogLevelExt, datatypes.Utf8, ComponentMixin):
 
 
 class TextLogLevelBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TextLogLevel")
+    _COMPONENT_NAME: str = "rerun.components.TextLogLevel"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/timestamp.py
+++ b/rerun_py/rerun_sdk/rerun/components/timestamp.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class Timestamp(datatypes.TimeInt, ComponentMixin):
 
 
 class TimestampBatch(datatypes.TimeIntBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Timestamp")
+    _COMPONENT_NAME: str = "rerun.components.Timestamp"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/transform_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform_mat3x3.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -61,7 +60,7 @@ class TransformMat3x3(datatypes.Mat3x3, ComponentMixin):
 
 
 class TransformMat3x3Batch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TransformMat3x3")
+    _COMPONENT_NAME: str = "rerun.components.TransformMat3x3"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/transform_relation.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform_relation.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
 )
 
 __all__ = ["TransformRelation", "TransformRelationArrayLike", "TransformRelationBatch", "TransformRelationLike"]
@@ -72,7 +71,7 @@ TransformRelationArrayLike = Union[TransformRelationLike, Sequence[TransformRela
 
 class TransformRelationBatch(BaseBatch[TransformRelationArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TransformRelation")
+    _COMPONENT_NAME: str = "rerun.components.TransformRelation"
 
     @staticmethod
     def _native_to_pa_array(data: TransformRelationArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/translation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/translation3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Translation3D(datatypes.Vec3D, ComponentMixin):
 
 
 class Translation3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Translation3D")
+    _COMPONENT_NAME: str = "rerun.components.Translation3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
+++ b/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class TriangleIndices(datatypes.UVec3D, ComponentMixin):
 
 
 class TriangleIndicesBatch(datatypes.UVec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TriangleIndices")
+    _COMPONENT_NAME: str = "rerun.components.TriangleIndices"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/value_range.py
+++ b/rerun_py/rerun_sdk/rerun/components/value_range.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +28,7 @@ class ValueRange(datatypes.Range1D, ComponentMixin):
 
 
 class ValueRangeBatch(datatypes.Range1DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ValueRange")
+    _COMPONENT_NAME: str = "rerun.components.ValueRange"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/vector2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector2d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Vector2D(datatypes.Vec2D, ComponentMixin):
 
 
 class Vector2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Vector2D")
+    _COMPONENT_NAME: str = "rerun.components.Vector2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/vector3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector3d.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Vector3D(datatypes.Vec3D, ComponentMixin):
 
 
 class Vector3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Vector3D")
+    _COMPONENT_NAME: str = "rerun.components.Vector3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/video_timestamp.py
+++ b/rerun_py/rerun_sdk/rerun/components/video_timestamp.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .video_timestamp_ext import VideoTimestampExt
@@ -26,7 +25,7 @@ class VideoTimestamp(VideoTimestampExt, datatypes.VideoTimestamp, ComponentMixin
 
 
 class VideoTimestampBatch(datatypes.VideoTimestampBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.VideoTimestamp")
+    _COMPONENT_NAME: str = "rerun.components.VideoTimestamp"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from .view_coordinates_ext import ViewCoordinatesExt
@@ -47,7 +46,7 @@ class ViewCoordinates(ViewCoordinatesExt, datatypes.ViewCoordinates, ComponentMi
 
 
 class ViewCoordinatesBatch(datatypes.ViewCoordinatesBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ViewCoordinates")
+    _COMPONENT_NAME: str = "rerun.components.ViewCoordinates"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/visible.py
+++ b/rerun_py/rerun_sdk/rerun/components/visible.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +24,7 @@ class Visible(datatypes.Bool, ComponentMixin):
 
 
 class VisibleBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Visible")
+    _COMPONENT_NAME: str = "rerun.components.Visible"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -450,8 +450,8 @@ impl FromPyObject<'_> for ComponentLike {
             Ok(Self(component_str))
         } else if let Ok(component_str) = component
             .getattr("_BATCH_TYPE")
-            .and_then(|batch_type| batch_type.getattr("_COMPONENT_DESCRIPTOR"))
-            .and_then(|descr| descr.getattr("component_name")?.extract::<String>())
+            .and_then(|batch_type| batch_type.getattr("_COMPONENT_NAME"))?
+            .extract::<String>()
         {
             Ok(Self(component_str))
         } else {

--- a/rerun_py/tests/test_types/components/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer1.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer1(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer1Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer1")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer1"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer10.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer10.py
@@ -15,7 +15,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from rerun._converters import (
@@ -47,7 +46,7 @@ AffixFuzzer10ArrayLike = Union[
 
 class AffixFuzzer10Batch(BaseBatch[AffixFuzzer10ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.utf8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer10")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer10"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer10ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -15,7 +15,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from rerun._converters import (
@@ -51,7 +50,7 @@ AffixFuzzer11ArrayLike = Union[
 
 class AffixFuzzer11Batch(BaseBatch[AffixFuzzer11ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}))
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer11")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer11"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer11ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -42,7 +41,7 @@ AffixFuzzer12ArrayLike = Union[
 
 class AffixFuzzer12Batch(BaseBatch[AffixFuzzer12ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={}))
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer12")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer12"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer12ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -42,7 +41,7 @@ AffixFuzzer13ArrayLike = Union[
 
 class AffixFuzzer13Batch(BaseBatch[AffixFuzzer13ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={}))
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer13")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer13"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer13ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer14.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer14.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer14(datatypes.AffixFuzzer3, ComponentMixin):
 
 
 class AffixFuzzer14Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer14")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer14"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer15.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer15.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer15(datatypes.AffixFuzzer3, ComponentMixin):
 
 
 class AffixFuzzer15Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer15")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer15"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -104,7 +103,7 @@ class AffixFuzzer16Batch(BaseBatch[AffixFuzzer16ArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer16")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer16"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer16ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -104,7 +103,7 @@ class AffixFuzzer17Batch(BaseBatch[AffixFuzzer17ArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer17")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer17"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer17ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -188,7 +187,7 @@ class AffixFuzzer18Batch(BaseBatch[AffixFuzzer18ArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer18")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer18"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer18ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer19.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer19.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer19(datatypes.AffixFuzzer5, ComponentMixin):
 
 
 class AffixFuzzer19Batch(datatypes.AffixFuzzer5Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer19")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer19"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer2.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer2(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer2Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer2")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer2"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer20.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer20(datatypes.AffixFuzzer20, ComponentMixin):
 
 
 class AffixFuzzer20Batch(datatypes.AffixFuzzer20Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer20")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer20"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer21.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer21(datatypes.AffixFuzzer21, ComponentMixin):
 
 
 class AffixFuzzer21Batch(datatypes.AffixFuzzer21Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer21")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer21"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer22.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer22.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer22(datatypes.AffixFuzzer22, ComponentMixin):
 
 
 class AffixFuzzer22Batch(datatypes.AffixFuzzer22Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer22")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer22"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer23.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer23.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer23(datatypes.MultiEnum, ComponentMixin):
 
 
 class AffixFuzzer23Batch(datatypes.MultiEnumBatch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer23")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer23"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer3.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer3(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer3Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer3")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer3"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer4.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer4(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer4Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer4")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer4"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer5.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer5(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer5Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer5")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer5"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer6.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer6.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +23,7 @@ class AffixFuzzer6(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer6Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer6")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer6"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -81,7 +80,7 @@ class AffixFuzzer7Batch(BaseBatch[AffixFuzzer7ArrayLike], ComponentBatchMixin):
             metadata={},
         )
     )
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer7")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer7"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer7ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer8.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer8.py
@@ -15,7 +15,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 from rerun._converters import (
@@ -51,7 +50,7 @@ AffixFuzzer8ArrayLike = Union[
 
 class AffixFuzzer8Batch(BaseBatch[AffixFuzzer8ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.float32()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer8")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer8"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer8ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -15,7 +15,6 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
-    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -50,7 +49,7 @@ AffixFuzzer9ArrayLike = Union[
 
 class AffixFuzzer9Batch(BaseBatch[AffixFuzzer9ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.utf8()
-    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer9")
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer9"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer9ArrayLike, data_type: pa.DataType) -> pa.Array:


### PR DESCRIPTION
### Related

* Closes #10058.
* Precursor to #10082.

### What

Analogous to the Rust API, we guarantee that all batches have a full descriptor.
