### PR TITLE
Fix typo in `descr_custom_archetype.py` snippet

### DIFF
--- a/docs/snippets/all/descriptors/descr_custom_archetype.py
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.py
@@ -18,7 +18,7 @@ class CustomPoints3D(rr.AsComponents):
             ),
         )
         self.colors = rr.components.ColorBatch(colors).described(
-            rr.ComponentDescriptor("rerun.components.Colors").with_overrides(
+            rr.ComponentDescriptor("rerun.components.Color").with_overrides(
                 archetype_name="user.CustomPoints3D",
                 archetype_field_name="colors",
             )


### PR DESCRIPTION
### Related

* This was introduced by #10147.

### What

Title.
