### PR TITLE
Do not attempt to download blueprint dataset partition tables in redap server

### DIFF
--- a/crates/viewer/re_redap_browser/src/tables_session_context.rs
+++ b/crates/viewer/re_redap_browser/src/tables_session_context.rs
@@ -103,8 +103,14 @@ async fn register_all_table_entries(
     let mut registered_tables = vec![];
 
     for entry in entries {
+        #[expect(clippy::match_same_arms)]
         let table_provider = match entry.kind {
-            EntryKind::Dataset | EntryKind::BlueprintDataset => Some(
+            // TODO(rerun-io/dataplatform#857): these are often empty datasets, and thus fail. For
+            // some reason, this failure is silent but blocks other tables from being registered.
+            // Since we don't need these tables yet, we just skip them for now.
+            EntryKind::BlueprintDataset => None,
+
+            EntryKind::Dataset => Some(
                 PartitionTableProvider::new(client.clone(), entry.id)
                     .into_provider()
                     .await?,


### PR DESCRIPTION
### Related

* introduced by https://github.com/rerun-io/rerun/pull/10128
* root caused by https://github.com/rerun-io/dataplatform/issues/857

### What

Hot fix to partition table not loading. Stop attempting to load partition tables for blueprint dataset because they are often empty and thus fail (because of above issue). For reasons yet unknown to me  this failure also lead to regular dataset to fail partition table. So let's not even attempt.