### PR TITLE
Supporting API changes for single PM Redap implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7233,6 +7233,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
+ "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/crates/store/re_log_encoding/Cargo.toml
+++ b/crates/store/re_log_encoding/Cargo.toml
@@ -60,6 +60,7 @@ re_tracing.workspace = true
 arrow = { workspace = true, features = ["ipc"] }
 parking_lot.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 # Optional external dependencies:
 bytes = { workspace = true, optional = true }

--- a/crates/store/re_log_encoding/src/codec/arrow.rs
+++ b/crates/store/re_log_encoding/src/codec/arrow.rs
@@ -39,6 +39,7 @@ pub(crate) struct Payload {
 }
 
 #[cfg(feature = "encoder")]
+#[tracing::instrument(level = "trace", skip_all)]
 pub(crate) fn encode_arrow(
     batch: &ArrowRecordBatch,
     compression: crate::Compression,
@@ -59,6 +60,7 @@ pub(crate) fn encode_arrow(
 }
 
 #[cfg(feature = "decoder")]
+#[tracing::instrument(level = "trace", skip_all)]
 pub(crate) fn decode_arrow(
     data: &[u8],
     uncompressed_size: usize,

--- a/crates/store/re_log_encoding/src/codec/file/decoder.rs
+++ b/crates/store/re_log_encoding/src/codec/file/decoder.rs
@@ -21,6 +21,7 @@ pub(crate) fn decode(data: &mut impl std::io::Read) -> Result<(u64, Option<LogMs
 /// Decode a message of kind `message_kind` from `buf`.
 ///
 /// `Ok(None)` returned from this function marks the end of the file stream.
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn decode_bytes(message_kind: MessageKind, buf: &[u8]) -> Result<Option<LogMsg>, DecodeError> {
     use re_protos::external::prost::Message as _;
     use re_protos::log_msg::v1alpha1::{

--- a/crates/store/re_log_encoding/src/decoder/streaming.rs
+++ b/crates/store/re_log_encoding/src/decoder/streaming.rs
@@ -110,6 +110,7 @@ impl<R: AsyncBufRead + Unpin> StreamingDecoder<R> {
 impl<R: AsyncBufRead + Unpin> Stream for StreamingDecoder<R> {
     type Item = Result<StreamingLogMsg, DecodeError>;
 
+    #[tracing::instrument(name = "streaming_decoder", level = "trace", skip_all)]
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,

--- a/crates/store/re_protos/proto/rerun/v1alpha1/common.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/common.proto
@@ -146,7 +146,7 @@ message ScanParameters {
   // ```text
   // scanner.order_by(…)
   // ```
-  ScanParametersOrderClause order_by = 6;
+  repeated ScanParametersOrderClause order_by = 6;
 
   // If set, the output of `scanner.explain_plan` will be dumped to the server's log.
   bool explain_plan = 7;

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -111,6 +111,9 @@ service ManifestRegistryService {
 
   // Fetch the internal state of a Partition Manifest.
   rpc FetchPartitionManifest(FetchPartitionManifestRequest) returns (stream FetchPartitionManifestResponse) {}
+
+  // Miscellaneous maintenance operations: scalar index creation, compaction, etc.
+  rpc DoMaintenance(DoMaintenanceRequest) returns (DoMaintenanceResponse) {}
 }
 
 // --- Write data ---
@@ -498,6 +501,16 @@ message FetchChunkManifestRequest {
 message FetchChunkManifestResponse {
   // Chunk manifest as arrow RecordBatches
   rerun.common.v1alpha1.DataframePart data = 1;
+}
+
+message DoMaintenanceRequest {
+  rerun.common.v1alpha1.DatasetHandle entry = 1;
+  bool build_scalar_indexes = 2;
+  bool compact_fragments = 3;
+}
+
+message DoMaintenanceResponse {
+  string report = 1;
 }
 
 // ----------------- Error handling -----------------

--- a/crates/store/re_protos/src/lib.rs
+++ b/crates/store/re_protos/src/lib.rs
@@ -84,7 +84,6 @@ pub mod manifest_registry {
         /// with "rerun_" to avoid conflicts with user-defined fields.
         pub const DATASET_MANIFEST_ID_FIELD_NAME: &str = "rerun_partition_id";
         pub const DATASET_MANIFEST_PARTITION_MANIFEST_UPDATED_AT_FIELD_NAME: &str = "rerun_partition_manifest_updated_at";
-        pub const DATASET_MANIFEST_PARTITION_MANIFEST_URL_FIELD_NAME: &str = "rerun_partition_manifest_url";
         pub const DATASET_MANIFEST_RECORDING_TYPE_FIELD_NAME: &str = "rerun_partition_type";
         pub const DATASET_MANIFEST_REGISTRATION_TIME_FIELD_NAME: &str = "rerun_registration_time";
         pub const DATASET_MANIFEST_START_TIME_FIELD_NAME: &str = "rerun_start_time";

--- a/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.rs
@@ -285,8 +285,8 @@ pub struct ScanParameters {
     /// ```text
     /// scanner.order_by(…)
     /// ```
-    #[prost(message, optional, tag = "6")]
-    pub order_by: ::core::option::Option<ScanParametersOrderClause>,
+    #[prost(message, repeated, tag = "6")]
+    pub order_by: ::prost::alloc::vec::Vec<ScanParametersOrderClause>,
     /// If set, the output of `scanner.explain_plan` will be dumped to the server's log.
     #[prost(bool, tag = "7")]
     pub explain_plan: bool,

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -287,7 +287,6 @@ pub struct QueryRange {
 impl CreatePartitionManifestsResponse {
     pub const FIELD_ID: &str = "id";
     pub const FIELD_UPDATED_AT: &str = "updated_at";
-    pub const FIELD_URL: &str = "url";
     pub const FIELD_ERROR: &str = "error";
 
     /// The Arrow schema of the dataframe in [`Self::data`].
@@ -299,7 +298,6 @@ impl CreatePartitionManifestsResponse {
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
                 true,
             ),
-            Field::new(Self::FIELD_URL, DataType::Utf8, true),
             Field::new(Self::FIELD_ERROR, DataType::Utf8, true),
         ])
     }
@@ -308,7 +306,6 @@ impl CreatePartitionManifestsResponse {
     pub fn create_dataframe(
         partition_ids: Vec<String>,
         updated_ats: Vec<Option<jiff::Timestamp>>,
-        partition_manifest_urls: Vec<Option<String>>,
         errors: Vec<Option<String>>,
     ) -> arrow::error::Result<RecordBatch> {
         let updated_ats = updated_ats
@@ -320,7 +317,6 @@ impl CreatePartitionManifestsResponse {
         let columns: Vec<ArrayRef> = vec![
             Arc::new(StringArray::from(partition_ids)),
             Arc::new(TimestampNanosecondArray::from(updated_ats)),
-            Arc::new(StringArray::from(partition_manifest_urls)),
             Arc::new(StringArray::from(errors)),
         ];
 

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -858,6 +858,40 @@ impl ::prost::Name for FetchChunkManifestResponse {
         "/rerun.manifest_registry.v1alpha1.FetchChunkManifestResponse".into()
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DoMaintenanceRequest {
+    #[prost(message, optional, tag = "1")]
+    pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
+    #[prost(bool, tag = "2")]
+    pub build_scalar_indexes: bool,
+    #[prost(bool, tag = "3")]
+    pub compact_fragments: bool,
+}
+impl ::prost::Name for DoMaintenanceRequest {
+    const NAME: &'static str = "DoMaintenanceRequest";
+    const PACKAGE: &'static str = "rerun.manifest_registry.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.manifest_registry.v1alpha1.DoMaintenanceRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.manifest_registry.v1alpha1.DoMaintenanceRequest".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DoMaintenanceResponse {
+    #[prost(string, tag = "1")]
+    pub report: ::prost::alloc::string::String,
+}
+impl ::prost::Name for DoMaintenanceResponse {
+    const NAME: &'static str = "DoMaintenanceResponse";
+    const PACKAGE: &'static str = "rerun.manifest_registry.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.manifest_registry.v1alpha1.DoMaintenanceResponse".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.manifest_registry.v1alpha1.DoMaintenanceResponse".into()
+    }
+}
 /// Application level error - used as `details` in the `google.rpc.Status` message
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Error {
@@ -1409,6 +1443,26 @@ pub mod manifest_registry_service_client {
             ));
             self.inner.server_streaming(req, path, codec).await
         }
+        /// Miscellaneous maintenance operations: scalar index creation, compaction, etc.
+        pub async fn do_maintenance(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DoMaintenanceRequest>,
+        ) -> std::result::Result<tonic::Response<super::DoMaintenanceResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.manifest_registry.v1alpha1.ManifestRegistryService/DoMaintenance",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
+                "DoMaintenance",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -1587,6 +1641,11 @@ pub mod manifest_registry_service_server {
             &self,
             request: tonic::Request<super::FetchPartitionManifestRequest>,
         ) -> std::result::Result<tonic::Response<Self::FetchPartitionManifestStream>, tonic::Status>;
+        /// Miscellaneous maintenance operations: scalar index creation, compaction, etc.
+        async fn do_maintenance(
+            &self,
+            request: tonic::Request<super::DoMaintenanceRequest>,
+        ) -> std::result::Result<tonic::Response<super::DoMaintenanceResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ManifestRegistryServiceServer<T> {
@@ -2283,6 +2342,49 @@ pub mod manifest_registry_service_server {
                                 max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.manifest_registry.v1alpha1.ManifestRegistryService/DoMaintenance" => {
+                    #[allow(non_camel_case_types)]
+                    struct DoMaintenanceSvc<T: ManifestRegistryService>(pub Arc<T>);
+                    impl<T: ManifestRegistryService>
+                        tonic::server::UnaryService<super::DoMaintenanceRequest>
+                        for DoMaintenanceSvc<T>
+                    {
+                        type Response = super::DoMaintenanceResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DoMaintenanceRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ManifestRegistryService>::do_maintenance(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = DoMaintenanceSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)


### PR DESCRIPTION
Miscellaneous changes required for the single PM Redap implementation:
* https://github.com/rerun-io/dataplatform/pull/897

Two main changes:
* `order_by` now has a list of ordering clauses instead of an option, so one can sort by multiple columns at once.
* introduction of the `DoMaintenance` private/dev APIs
