### PR TITLE
Toggle maximized view with ⌘+M or Ctrl+M

### DIFF
--- a/crates/viewer/re_view/src/controls.rs
+++ b/crates/viewer/re_view/src/controls.rs
@@ -1,52 +1,55 @@
-use egui::{Modifiers, os::OperatingSystem};
+use egui::{Key, KeyboardShortcut, Modifiers, PointerButton, os::OperatingSystem};
 
 /// Modifier to press for scroll to zoom.
-pub const ZOOM_SCROLL_MODIFIER: egui::Modifiers = egui::Modifiers::COMMAND;
+pub const ZOOM_SCROLL_MODIFIER: Modifiers = Modifiers::COMMAND;
 
 /// Modifier to press for scroll to change aspect ratio.
-pub const ASPECT_SCROLL_MODIFIER: egui::Modifiers =
-    egui::Modifiers::ALT.plus(egui::Modifiers::COMMAND);
+pub const ASPECT_SCROLL_MODIFIER: Modifiers = Modifiers::ALT.plus(Modifiers::COMMAND);
 
 /// Modifier to press for scroll to pan horizontally.
-pub const HORIZONTAL_SCROLL_MODIFIER: egui::Modifiers = egui::Modifiers::SHIFT;
+pub const HORIZONTAL_SCROLL_MODIFIER: Modifiers = Modifiers::SHIFT;
 
 /// Which mouse button to drag for panning a 2D view.
-pub const DRAG_PAN2D_BUTTON: egui::PointerButton = egui::PointerButton::Primary;
+pub const DRAG_PAN2D_BUTTON: PointerButton = PointerButton::Primary;
 
 /// Rectangles drawn with this mouse button zoom in 2D views.
-pub const SELECTION_RECT_ZOOM_BUTTON: egui::PointerButton = egui::PointerButton::Secondary;
+pub const SELECTION_RECT_ZOOM_BUTTON: PointerButton = PointerButton::Secondary;
 
 /// Clicking this button moves the timeline to where the cursor is.
-pub const MOVE_TIME_CURSOR_BUTTON: egui::PointerButton = egui::PointerButton::Secondary;
+pub const MOVE_TIME_CURSOR_BUTTON: PointerButton = PointerButton::Secondary;
 
 /// Which mouse button to drag for panning a 2D view.
-pub const DRAG_PAN3D_BUTTON: egui::PointerButton = egui::PointerButton::Secondary;
+pub const DRAG_PAN3D_BUTTON: PointerButton = PointerButton::Secondary;
 
 /// Which mouse button to drag for rotating a 3D view.
-pub const ROTATE3D_BUTTON: egui::PointerButton = egui::PointerButton::Primary;
+pub const ROTATE3D_BUTTON: PointerButton = PointerButton::Primary;
 
 /// Which mouse button rolls the camera.
-pub const ROLL_MOUSE: egui::PointerButton = egui::PointerButton::Middle;
+pub const ROLL_MOUSE: PointerButton = PointerButton::Middle;
 
 /// Which mouse button rolls the camera if the roll modifier is pressed.
-pub const ROLL_MOUSE_ALT: egui::PointerButton = egui::PointerButton::Primary;
+pub const ROLL_MOUSE_ALT: PointerButton = PointerButton::Primary;
 
 /// See [`ROLL_MOUSE_ALT`].
-pub const ROLL_MOUSE_MODIFIER: egui::Modifiers = egui::Modifiers::ALT;
+pub const ROLL_MOUSE_MODIFIER: Modifiers = Modifiers::ALT;
 
 /// Which modifier speeds up the 3D camera movement.
-pub const SPEED_UP_3D_MODIFIER: egui::Modifiers = egui::Modifiers::SHIFT;
+pub const SPEED_UP_3D_MODIFIER: Modifiers = Modifiers::SHIFT;
 
 /// Key to restore the camera.
-pub const TRACKED_OBJECT_RESTORE_KEY: egui::Key = egui::Key::Escape;
+pub const TRACKED_OBJECT_RESTORE_KEY: Key = Key::Escape;
+
+/// Toggle the currently selected view to be maximized or not.
+pub const TOGGLE_MAXIMIZE_VIEW: KeyboardShortcut =
+    KeyboardShortcut::new(Modifiers::COMMAND, Key::M);
 
 pub struct RuntimeModifiers {}
 
 impl RuntimeModifiers {
     pub fn slow_down(os: &OperatingSystem) -> Modifiers {
         match os {
-            egui::os::OperatingSystem::Mac => egui::Modifiers::CTRL,
-            _ => egui::Modifiers::ALT,
+            egui::os::OperatingSystem::Mac => Modifiers::CTRL,
+            _ => Modifiers::ALT,
         }
     }
 }

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
@@ -32,7 +32,7 @@ use super::get_or_create_texture;
 ///
 /// If the key changes, we upload a new texture.
 fn generate_texture_key(image: &ImageInfo) -> u64 {
-    // We need to inclde anything that, if changes, should result in a new texture being uploaded.
+    // We need to include anything that, if changes, should result in a new texture being uploaded.
     let ImageInfo {
         buffer_content_hash,
         buffer: _, // we hash `blob_row_id` instead; much faster!

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -4,7 +4,7 @@ use itertools::Itertools as _;
 use parking_lot::Mutex;
 
 use re_entity_db::EntityPath;
-use re_global_context::resolve_mono_instance_path_item;
+use re_global_context::{ViewId, resolve_mono_instance_path_item};
 use re_log_types::StoreKind;
 
 use crate::ViewerContext;
@@ -122,6 +122,24 @@ impl ItemCollection {
         items: impl IntoIterator<Item = (Item, Option<ItemContext>)>,
     ) -> Self {
         Self(items.into_iter().collect())
+    }
+
+    /// Is this view the selected one (and no other)?
+    pub fn is_view_the_only_selected(&self, needle: &ViewId) -> bool {
+        let mut is_selected = false;
+        for item in self.iter_items() {
+            let item_is_view = match item {
+                Item::View(id) | Item::DataResult(id, _) => id == needle,
+                _ => false,
+            };
+
+            if item_is_view {
+                is_selected = true;
+            } else {
+                return false; // More than one view selected
+            }
+        }
+        is_selected
     }
 }
 


### PR DESCRIPTION
### What
This adds a keyboard shortcut for toggling the currently _selected_ view as maximized or not.

### Questions
* Is cmd/ctrl M a good shortcut?
* Should we toggle the selected view, or the one currently hovered by the mouse?