### PR TITLE
Animate the maximization of a view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8207,6 +8207,7 @@ dependencies = [
  "re_view",
  "re_viewer_context",
  "re_viewport_blueprint",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/viewer/re_viewport/Cargo.toml
+++ b/crates/viewer/re_viewport/Cargo.toml
@@ -40,3 +40,4 @@ egui_tiles.workspace = true
 egui.workspace = true
 nohash-hasher.workspace = true
 rayon.workspace = true
+web-time.workspace = true

--- a/crates/viewer/re_viewport/src/viewport_ui.rs
+++ b/crates/viewer/re_viewport/src/viewport_ui.rs
@@ -115,6 +115,7 @@ impl ViewportUi {
                 }
             }
         };
+        let animated_rect = animated_rect.intersect(ui.max_rect()); // Prevent glitches when the viewport has changed size since the animation started.
 
         let mut tree = if let Some(view_id) = blueprint.maximized.or(animating_view_id) {
             let mut tiles = egui_tiles::Tiles::default();


### PR DESCRIPTION
### Related
* Builds on https://github.com/rerun-io/rerun/pull/10162

### What
Animate the maximization/restoration of a view.
This helps the user stay oriented ("where did that view go…")


https://github.com/user-attachments/assets/ccd754e5-b9c6-4245-a438-fbe669116c5d

(The animation is much smoother in real life)