### PR TITLE
Fix nightly build. maybe

### DIFF
--- a/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
+++ b/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
@@ -29,9 +29,7 @@ permissions:
 jobs:
   bundle-and-upload-rerun_cpp:
     name: Bundle and upload rerun_cpp_sdk.zip
-    runs-on: ubuntu-latest
-    container:
-      image: rerunio/ci_docker:0.16.0 # Need container for arrow dependency.
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
upload rerun cpp build runs an old python which . I think that's because it's using our docker container..?