### PR TITLE
Add pixi command to build wheel with the viewer

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -38,6 +38,20 @@ libc = "2.28"
 
 
 ################################################################################
+# GLOBAL ACTIVATION
+################################################################################
+
+[activation]
+
+[target.unix.activation.env]
+# The executable extension for binaries on the current platform.
+EXECUTABLE_EXTENSION = ""
+
+[target.win-64.activation.env]
+# The executable extension for binaries on the current platform.
+EXECUTABLE_EXTENSION = ".exe"
+
+################################################################################
 # ENVIRONMENTS
 ################################################################################
 
@@ -363,9 +377,9 @@ py-build-notebook = { cmd = "pip install -e rerun_notebook", depends-on = [
   "js-build-base",
 ] }
 
-# Build an installable wheel. This needs `RERUN_ALLOW_MISSING_BIN=1` because the `rerun` binary is not part of the
-# python package, and maturin will otherwise fail to build the wheel.
-py-build-wheel = { cmd = "cp target/release/rerun rerun_py/rerun_sdk/rerun_cli/rerun && maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
+# Build an installable wheel.
+# The wheel will contain the rerun executable including the web viewer.
+py-build-wheel = { cmd = "cp target/release/rerun$EXECUTABLE_EXTENSION rerun_py/rerun_sdk/rerun_cli/rerun$EXECUTABLE_EXTENSION && maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
   "rerun-build-native-and-web-release",
 ] }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -363,10 +363,13 @@ py-build-notebook = { cmd = "pip install -e rerun_notebook", depends-on = [
   "js-build-base",
 ] }
 
-# Build an installable SDK-only wheel. IMPORTANT: unlike the officially published wheels, the wheel produced by this command does NOT include the viewer.
-# TODO(ab): add a command that produce a complete wheel, including the viewer.
-py-build-wheels-sdk-only = { cmd = "RERUN_ALLOW_MISSING_BIN=1 python scripts/ci/build_and_upload_wheels.py --mode pr --dir ''" }
+# Build an installable wheel.
+py-build-wheels = { cmd = "RERUN_ALLOW_MISSING_BIN=1 maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
+  "rerun-build-release",
+] }
 
+# Build an installable SDK-only wheel. IMPORTANT: unlike the officially published wheels, the wheel produced by this command does NOT include the viewer.
+py-build-wheels-sdk-only = { cmd = "RERUN_ALLOW_MISSING_BIN=1 python scripts/ci/build_and_upload_wheels.py --mode pr --dir ''" }
 
 [feature.python-tasks.tasks]
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -363,9 +363,10 @@ py-build-notebook = { cmd = "pip install -e rerun_notebook", depends-on = [
   "js-build-base",
 ] }
 
-# Build an installable wheel.
-py-build-wheels = { cmd = "RERUN_ALLOW_MISSING_BIN=1 maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
-  "rerun-build-release",
+# Build an installable wheel. This needs `RERUN_ALLOW_MISSING_BIN=1` because the `rerun` binary is not part of the
+# python package, and maturin will otherwise fail to build the wheel.
+py-build-wheel = { cmd = "cp target/release/rerun rerun_py/rerun_sdk/rerun_cli/rerun && maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
+  "rerun-build-native-and-web-release",
 ] }
 
 # Build an installable SDK-only wheel. IMPORTANT: unlike the officially published wheels, the wheel produced by this command does NOT include the viewer.

--- a/pixi.toml
+++ b/pixi.toml
@@ -379,7 +379,7 @@ py-build-notebook = { cmd = "pip install -e rerun_notebook", depends-on = [
 
 # Build an installable wheel.
 # The wheel will contain the rerun executable including the web viewer.
-py-build-wheel = { cmd = "cp target/release/rerun$EXECUTABLE_EXTENSION rerun_py/rerun_sdk/rerun_cli/rerun$EXECUTABLE_EXTENSION && maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
+py-build-wheel = { cmd = "cp target/release/rerun$EXECUTABLE_EXTENSION rerun_py/rerun_sdk/rerun_cli/ && maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
   "rerun-build-native-and-web-release",
 ] }
 

--- a/rerun_py/README.md
+++ b/rerun_py/README.md
@@ -72,7 +72,7 @@ You can then run examples from the repository, either by making the Pixi shell a
 
 Respectively, to build a wheel instead for manual install use:
 ```sh
-pixi run py-wheel --release
+pixi run py-build-wheel
 ```
 
 Refer to [BUILD.md](../BUILD.md) for details on the various different build options of the Rerun Viewer and SDKs for all target languages.


### PR DESCRIPTION
### What

Adds `pixi run py-build-wheels`, which builds a python wheel which _includes_ the viewer.
