### PR TITLE
Fix video frame reference preview selection preview (again)

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -145,10 +145,15 @@ impl DataUi for InstancePath {
         }
 
         if instance.is_all() {
-            for components in components_by_archetype.values() {
-                preview_if_image_ui(ctx, ui, ui_layout, query, entity_path, components);
-                preview_if_blob_ui(ctx, ui, ui_layout, query, entity_path, components);
-            }
+            // There are some examples where we need to combine several archetypes for a single preview.
+            // For instance `VideoFrameReference` and `VideoAsset` are used together for a single preview.
+            let components = components_by_archetype
+                .values()
+                .flatten()
+                .cloned()
+                .collect::<Vec<_>>();
+            preview_if_image_ui(ctx, ui, ui_layout, query, entity_path, &components);
+            preview_if_blob_ui(ctx, ui, ui_layout, query, entity_path, &components);
         }
     }
 }
@@ -274,6 +279,8 @@ fn component_list_ui(
 }
 
 /// If this entity is an image, show it together with buttons to download and copy the image.
+///
+/// Expected to get a list of all components on the entity, not just the blob.
 fn preview_if_image_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
@@ -495,7 +502,7 @@ fn rgb8_histogram_ui(ui: &mut egui::Ui, rgb: &[u8]) -> egui::Response {
         .response
 }
 
-/// If this entity has a blob, preview it and show a download button
+/// If this entity has a blob, preview it and show a download button.
 fn preview_if_blob_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,


### PR DESCRIPTION
Fixed this recently, but unfortunately regressed again: when clicking on a video with video frame reference it would just play automatically.

These admittedly quite hacky special case data uis are a bit hard to unit test since providing data for it is not entirely straight forward. But we really should :/
I wish this was a clean extension mechanism to our component ui system to cover this in an extensible way.