### PR TITLE
Enable `VideoStream` H264 on the web

### DIFF
--- a/crates/store/re_types/definitions/rerun/components/video_codec.fbs
+++ b/crates/store/re_types/definitions/rerun/components/video_codec.fbs
@@ -31,21 +31,20 @@ enum VideoCodec: ubyte ( // TODO(#7484): use fourcc values. Requires us to suppo
     /// Key frames (IRAP) require inclusion of a SPS (Sequence Parameter Set)
     // TODO(andreas): foxglove `CompressedVideo` mentions PPS (picture parameter set) and VPS (video parameter set) being required for IRAP as well.
     // need to confirm if we need those as well (they exist in h264 as well but we didn't need them so far?)
+    // TODO(#10185): Add support for H265.
     //H265,
 
     /// AOMedia Video 1 (AV1)
     ///
     /// See <https://en.wikipedia.org/wiki/AV1>
+    // TODO(#10184): Add support for AV1.
     //AV1,
 
-    /// VP8
-    ///
-    /// See <https://en.wikipedia.org/wiki/VP8>
-    //VP8,
 
     /// VP9
     ///
     /// See <https://en.wikipedia.org/wiki/VP9>
+    // TODO(#10186): Add support for VP8.
     //VP9,
 }
 

--- a/crates/store/re_types/src/image.rs
+++ b/crates/store/re_types/src/image.rs
@@ -304,9 +304,8 @@ fn test_find_non_empty_dim_indices() {
 // TODO(andreas): Expose this in the API?
 /// Yuv matrix coefficients that determine how a YUV image is meant to be converted to RGB.
 ///
-/// A rigorious definition of the yuv conversion matrix would still require to define
+/// A rigorious definition of the yuv conversion matrix would additionally require to define
 /// the transfer characteristics & color primaries of the resulting RGB space.
-/// See [`re_video::decode`]'s documentation.
 ///
 /// However, at this point we generally assume that no further processing is needed after the transform.
 /// This is acceptable for most non-HDR content because of the following properties of `Bt709`/`Bt601`/ sRGB:

--- a/crates/utils/re_video/examples/frames.rs
+++ b/crates/utils/re_video/examples/frames.rs
@@ -33,8 +33,14 @@ fn main() {
     println!(
         "{} {}x{}",
         video.gops.num_elements(),
-        video.coded_dimensions.as_ref().map_or(0, |c| c[0]),
-        video.coded_dimensions.as_ref().map_or(0, |c| c[1])
+        video
+            .encoding_details
+            .as_ref()
+            .map_or(0, |c| c.coded_dimensions[0]),
+        video
+            .encoding_details
+            .as_ref()
+            .map_or(0, |c| c.coded_dimensions[1])
     );
 
     let progress =
@@ -51,10 +57,10 @@ fn main() {
         }
     };
 
-    let mut decoder = re_video::decode::new_decoder(
+    let mut decoder = re_video::new_decoder(
         &video_path.to_string(),
         &video,
-        &re_video::decode::DecodeSettings::default(),
+        &re_video::DecodeSettings::default(),
         on_output,
     )
     .expect("Failed to create decoder");

--- a/crates/utils/re_video/src/decode/async_decoder_wrapper.rs
+++ b/crates/utils/re_video/src/decode/async_decoder_wrapper.rs
@@ -49,7 +49,7 @@ pub trait SyncDecoder {
     );
 
     /// Clear and reset everything
-    fn reset(&mut self, video_descr: &VideoDataDescription);
+    fn reset(&mut self, video_data_description: &crate::VideoDataDescription);
 }
 
 /// Runs a [`SyncDecoder`] in a background thread, for non-blocking video decoding.
@@ -109,7 +109,7 @@ impl AsyncDecoder for AsyncDecoderWrapper {
     ///
     /// This does not block, all chunks sent to `decode` before this point will be discarded.
     // NOTE: The interface is all `&mut self` to avoid certain types of races.
-    fn reset(&mut self, video_descr: &VideoDataDescription) -> Result<()> {
+    fn reset(&mut self, video_data_description: &VideoDataDescription) -> Result<()> {
         re_tracing::profile_function!();
 
         // Increment resets first…
@@ -119,7 +119,7 @@ impl AsyncDecoder for AsyncDecoderWrapper {
 
         // …so it is visible on the decoder thread when it gets the `Reset` command.
         self.command_tx
-            .send(Command::Reset(video_descr.clone()))
+            .send(Command::Reset(video_data_description.clone()))
             .ok();
 
         Ok(())
@@ -163,8 +163,8 @@ fn decoder_thread(
                     decoder.submit_chunk(&comms.should_stop, chunk, on_output);
                 }
             }
-            Command::Reset(video_descr) => {
-                decoder.reset(&video_descr);
+            Command::Reset(video_data_description) => {
+                decoder.reset(&video_data_description);
                 comms.num_outstanding_resets.fetch_sub(1, Ordering::Release);
             }
             Command::Stop => {

--- a/crates/utils/re_video/src/decode/av1.rs
+++ b/crates/utils/re_video/src/decode/av1.rs
@@ -6,7 +6,7 @@ use crate::Time;
 use dav1d::{PixelLayout, PlanarImageComponent};
 
 use super::{
-    Chunk, Error, Frame, FrameContent, FrameInfo, OutputCallback, PixelFormat, Result,
+    Chunk, DecodeError, Frame, FrameContent, FrameInfo, OutputCallback, PixelFormat, Result,
     YuvMatrixCoefficients, YuvPixelLayout, YuvRange, async_decoder_wrapper::SyncDecoder,
 };
 
@@ -53,7 +53,7 @@ impl SyncDav1dDecoder {
                 );
             } else {
                 // Better to return an error than to be perceived as being slow
-                return Err(Error::Dav1dWithoutNasm);
+                return Err(DecodeError::Dav1dWithoutNasm);
             }
         }
 
@@ -94,7 +94,7 @@ impl SyncDav1dDecoder {
                     err != dav1d::Error::Again,
                     "Bug in AV1 decoder: send_data returned `Error::Again`. This shouldn't happen, since we process all images in a chunk right away"
                 );
-                on_output(Err(Error::Dav1d(err)));
+                on_output(Err(DecodeError::Dav1d(err)));
             }
         };
     }
@@ -119,7 +119,7 @@ impl SyncDav1dDecoder {
                     break;
                 }
                 Err(err) => {
-                    on_output(Err(Error::Dav1d(err)));
+                    on_output(Err(DecodeError::Dav1d(err)));
                 }
             }
         }
@@ -146,7 +146,7 @@ fn create_frame(debug_name: &str, picture: &dav1d::Picture) -> Result<Frame> {
         // Note that `bit_depth` is either 8 or 16, which is semi-independent `bits_per_component` (which is None/8/10/12).
         2
     } else {
-        return Err(Error::BadBitsPerComponent(bits_per_component));
+        return Err(DecodeError::BadBitsPerComponent(bits_per_component));
     };
 
     let mut data = match picture.pixel_layout() {

--- a/crates/utils/re_video/src/decode/av1.rs
+++ b/crates/utils/re_video/src/decode/av1.rs
@@ -2,7 +2,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::Time;
+use crate::{Time, VideoDataDescription};
 use dav1d::{PixelLayout, PlanarImageComponent};
 
 use super::{
@@ -23,10 +23,12 @@ impl SyncDecoder for SyncDav1dDecoder {
     }
 
     /// Clear and reset everything
-    fn reset(&mut self) {
+    fn reset(&mut self, _video_data_description: &VideoDataDescription) {
         re_tracing::profile_function!();
 
         self.decoder.flush();
+
+        // TODO(#10184): Should take into account changed video
 
         debug_assert!(
             matches!(self.decoder.get_picture(), Err(dav1d::Error::Again)),

--- a/crates/utils/re_video/src/decode/av1.rs
+++ b/crates/utils/re_video/src/decode/av1.rs
@@ -28,8 +28,6 @@ impl SyncDecoder for SyncDav1dDecoder {
 
         self.decoder.flush();
 
-        // TODO(#10184): Should take into account changed video
-
         debug_assert!(
             matches!(self.decoder.get_picture(), Err(dav1d::Error::Again)),
             "There should be no pending pictures, since we output them directly after submitting a chunk."

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -21,7 +21,8 @@ use parking_lot::Mutex;
 use crate::{
     PixelFormat, Time,
     decode::{
-        AsyncDecoder, Chunk, Frame, FrameContent, FrameInfo, OutputCallback, YuvPixelLayout,
+        AsyncDecoder, Chunk, DecodeError, Frame, FrameContent, FrameInfo, OutputCallback,
+        YuvPixelLayout,
         ffmpeg_h264::{FFMPEG_MINIMUM_VERSION_MAJOR, FFMPEG_MINIMUM_VERSION_MINOR, FFmpegVersion},
     },
 };
@@ -87,7 +88,7 @@ pub enum Error {
     SpsParsing,
 }
 
-impl From<Error> for crate::decode::Error {
+impl From<Error> for DecodeError {
     fn from(err: Error) -> Self {
         Self::Ffmpeg(std::sync::Arc::new(err))
     }
@@ -908,7 +909,7 @@ impl AsyncDecoder for FFmpegCliH264Decoder {
         re_tracing::profile_function!();
 
         if let Err(err) = self.ffmpeg.submit_chunk(chunk) {
-            let err = crate::decode::Error::from(err);
+            let err = DecodeError::from(err);
 
             // Report the error on the decoding stream aswell.
             (self.on_output)(Err(err.clone()));

--- a/crates/utils/re_video/src/decode/gop_detection.rs
+++ b/crates/utils/re_video/src/decode/gop_detection.rs
@@ -6,7 +6,7 @@ use h264_reader::{
 
 use crate::{VideoCodec, VideoEncodingDetails, h264::encoding_details_from_h264_sps};
 
-/// Failure reason for [`is_sample_start_of_gop`].
+/// Failure reason for [`detect_gop_start`].
 #[derive(thiserror::Error, Debug)]
 pub enum DetectGopStartError {
     #[error("Detection not supported for codec: {0:?}")]

--- a/crates/utils/re_video/src/decode/gop_detection.rs
+++ b/crates/utils/re_video/src/decode/gop_detection.rs
@@ -187,13 +187,15 @@ fn detect_h264_annexb_gop(
                 Ok(GopStartDetection::StartOfGop(decoding_details))
             } else {
                 // In theory it could happen that we got an SPS but no IDR frame.
-                // Arguably we should preserve the information from the the SPS, but practically it's not useful:
+                // Arguably we should preserve the information from the SPS, but practically it's not useful:
                 // If we never hit an IDR frame, then we can't play the video and every IDR frame is supposed to have
                 // the *same* SPS.
                 Ok(GopStartDetection::NotStartOfGop)
             }
         }
-        Some(Err(error)) => Err(DetectGopStartError::FailedToExtractEncodingDetails(error)),
+        Some(Err(error_str)) => Err(DetectGopStartError::FailedToExtractEncodingDetails(
+            error_str,
+        )),
         None => Ok(GopStartDetection::NotStartOfGop),
     }
 }

--- a/crates/utils/re_video/src/decode/gop_detection.rs
+++ b/crates/utils/re_video/src/decode/gop_detection.rs
@@ -4,38 +4,78 @@ use h264_reader::{
     push::NalInterest,
 };
 
+use crate::{ChromaSubsamplingModes, VideoCodec, VideoEncodingDetails};
+
 /// Failure reason for [`is_sample_start_of_gop`].
 #[derive(thiserror::Error, Debug)]
-pub enum StartOfGopDetectionFailure {
+pub enum DetectGopStartError {
     #[error("Detection not supported for codec: {0:?}")]
-    UnsupportedCodec(crate::VideoCodec),
+    UnsupportedCodec(VideoCodec),
 
     #[error("NAL header error: {0:?}")]
     NalHeaderError(h264_reader::nal::NalHeaderError),
+
+    #[error("Detected group of picture but failed to extract encoding details: {0:?}")]
+    FailedToExtractEncodingDetails(String),
+}
+
+impl PartialEq<Self> for DetectGopStartError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::UnsupportedCodec(a), Self::UnsupportedCodec(b)) => a == b,
+            (Self::NalHeaderError(_), Self::NalHeaderError(_)) => true, // `NalHeaderError` isn't implementing PartialEq, but there's only one variant.
+            (Self::FailedToExtractEncodingDetails(a), Self::FailedToExtractEncodingDetails(b)) => {
+                a == b
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for DetectGopStartError {}
+
+/// Result of a successful GOP detection.
+///
+/// I.e. whether a sample is the start of a GOP and if so, encoding details we were able to extract from it.
+#[derive(Default, PartialEq, Eq, Debug)]
+pub enum GopStartDetection {
+    /// The sample is the start of a GOP and encoding details have been extracted.
+    StartOfGop(VideoEncodingDetails),
+
+    /// The sample is not the start of a GOP.
+    #[default]
+    NotStartOfGop,
+}
+
+impl GopStartDetection {
+    #[inline]
+    pub fn is_start_of_gop(&self) -> bool {
+        matches!(self, Self::StartOfGop(_))
+    }
 }
 
 /// Try to determine whether a frame chunk is the start of a GOP.
 ///
 /// This is a best effort attempt to determine this, but we won't always be able to.
 #[inline]
-pub fn is_sample_start_of_gop(
+pub fn detect_gop_start(
     sample_data: &[u8],
-    codec: crate::VideoCodec,
-) -> Result<bool, StartOfGopDetectionFailure> {
+    codec: VideoCodec,
+) -> Result<GopStartDetection, DetectGopStartError> {
     #[expect(clippy::match_same_arms)]
     match codec {
-        crate::VideoCodec::H264 => Ok(is_annexb_sample_start_of_gop(sample_data)),
-        crate::VideoCodec::H265 => Err(StartOfGopDetectionFailure::UnsupportedCodec(codec)),
-        crate::VideoCodec::AV1 => Err(StartOfGopDetectionFailure::UnsupportedCodec(codec)),
-        crate::VideoCodec::VP8 => Err(StartOfGopDetectionFailure::UnsupportedCodec(codec)),
-        crate::VideoCodec::VP9 => Err(StartOfGopDetectionFailure::UnsupportedCodec(codec)),
+        VideoCodec::H264 => detect_h264_annexb_gop(sample_data),
+        VideoCodec::H265 => Err(DetectGopStartError::UnsupportedCodec(codec)),
+        VideoCodec::AV1 => Err(DetectGopStartError::UnsupportedCodec(codec)),
+        VideoCodec::VP8 => Err(DetectGopStartError::UnsupportedCodec(codec)),
+        VideoCodec::VP9 => Err(DetectGopStartError::UnsupportedCodec(codec)),
     }
 }
 
 #[derive(Default)]
 struct H264GopDetectionState {
-    sps_found: bool,
-    idr_found: bool,
+    coding_details_from_sps: Option<Result<VideoEncodingDetails, String>>,
+    idr_frame_found: bool,
 }
 
 impl h264_reader::push::AccumulatedNalHandler for H264GopDetectionState {
@@ -46,26 +86,81 @@ impl h264_reader::push::AccumulatedNalHandler for H264GopDetectionState {
         let nal_unit_type = nal_header.nal_unit_type();
 
         if nal_unit_type == nal::UnitType::SeqParameterSet {
-            self.sps_found = true;
+            if !nal.is_complete() {
+                // Want full SPS, not just a partial one in order to extract the encoding details.
+                return NalInterest::Buffer;
+            }
+
+            // Note that if we find several SPS, we'll always use the latest one.
+            self.coding_details_from_sps = Some(
+                match nal::sps::SeqParameterSet::from_bits(nal.rbsp_bits())
+                    .and_then(|sps| encoding_details_from_h264_sps(&sps))
+                {
+                    Ok(coding_details) => {
+                        // A bit too much string concatenation something that frequent, better to enable this only for debug builds.
+                        if cfg!(debug_assertions) {
+                            re_log::trace!(
+                                "Parsed SPS to coding details for video stream: {coding_details:?}"
+                            );
+                        }
+                        Ok(coding_details)
+                    }
+                    Err(sps_error) => Err(format!("Failed reading SPS: {sps_error:?}")), // h264 errors don't implement display
+                },
+            );
         } else if nal_unit_type == nal::UnitType::SliceLayerWithoutPartitioningIdr {
-            self.idr_found = true;
+            self.idr_frame_found = true;
         }
 
         NalInterest::Ignore
     }
 }
 
-impl H264GopDetectionState {
-    fn detected_gop(&self) -> bool {
-        // We look for one SPS and one IDR frame in this chunk, otherwise we don't count it as a GOP.
-        self.sps_found && self.idr_found
-    }
+fn encoding_details_from_h264_sps(
+    sps: &nal::sps::SeqParameterSet,
+) -> Result<VideoEncodingDetails, nal::sps::SpsError> {
+    let bit_depth = sps.chroma_info.bit_depth_chroma_minus8 + 8;
+
+    // Codec string defined by WebCodec points to various spec documents.
+    // https://www.w3.org/TR/webcodecs-avc-codec-registration/#fully-qualified-codec-strings
+    // Not having read those, this is what we use in `re_mp4` and it works fine.
+    // Also as of writing, Claude 4 agrees and is able to nicely explain its meaning.
+    let profile = u8::from(sps.profile_idc);
+    let constraint = u8::from(sps.constraint_flags);
+    let level = sps.level_idc;
+    let codec_string = format!("avc1.{profile:02X}{constraint:02X}{level:02X}");
+
+    // Calculating the dimensions of the frame in pixels from the SPS is quite complicated
+    // as it has to take into account cropping and concepts like macro block sizes.
+    // Luckily h264-reader has a utility for this!
+    let coded_dimensions = sps.pixel_dimensions()?;
+    let chroma_subsampling = match sps.chroma_info.chroma_format {
+        nal::sps::ChromaFormat::Monochrome => Some(ChromaSubsamplingModes::Monochrome),
+        nal::sps::ChromaFormat::YUV420 => Some(ChromaSubsamplingModes::Yuv420),
+        nal::sps::ChromaFormat::YUV422 => Some(ChromaSubsamplingModes::Yuv422),
+        nal::sps::ChromaFormat::YUV444 => Some(ChromaSubsamplingModes::Yuv444),
+        nal::sps::ChromaFormat::Invalid(_) => {
+            re_log::error_once!(
+                "Invalid chroma format in H264 SPS: {:?}",
+                sps.chroma_info.chroma_format
+            );
+            None
+        }
+    };
+
+    Ok(VideoEncodingDetails {
+        codec_string,
+        coded_dimensions: [coded_dimensions.0 as _, coded_dimensions.1 as _],
+        bit_depth: Some(bit_depth),
+        chroma_subsampling,
+        stsd: None,
+    })
 }
 
-/// Try to determine whether a frame chunk is the start of a closed GOP.
-///
-/// Expects Annex B encoded frame.
-fn is_annexb_sample_start_of_gop(mut sample_data: &[u8]) -> bool {
+/// Try to determine whether a frame chunk is the start of a closed GOP in an h264 Annex B encoded stream.
+fn detect_h264_annexb_gop(
+    mut sample_data: &[u8],
+) -> Result<GopStartDetection, DetectGopStartError> {
     let mut reader = AnnexBReader::accumulate(H264GopDetectionState::default());
 
     while !sample_data.is_empty() {
@@ -75,22 +170,41 @@ fn is_annexb_sample_start_of_gop(mut sample_data: &[u8]) -> bool {
 
         reader.push(&sample_data[..chunk_size]);
 
-        if reader.nal_handler_ref().detected_gop() {
-            return true;
+        // In case of SPS parsing failure keep going.
+        // It's unlikely, but maybe there's another SPS in the chunk that succeeds parsing.
+        let handler = reader.nal_handler_ref();
+        if let (true, Some(Ok(_))) = (handler.idr_frame_found, &handler.coding_details_from_sps) {
+            break;
         }
 
         sample_data = &sample_data[chunk_size..];
     }
 
-    false
+    let handler = reader.into_nal_handler();
+    match handler.coding_details_from_sps {
+        Some(Ok(decoding_details)) => {
+            if handler.idr_frame_found {
+                Ok(GopStartDetection::StartOfGop(decoding_details))
+            } else {
+                // In theory it could happen that we got an SPS but no IDR frame.
+                // Arguably we should preserve the information from the the SPS, but practically it's not useful:
+                // If we never hit an IDR frame, then we can't play the video and every IDR frame is supposed to have
+                // the *same* SPS.
+                Ok(GopStartDetection::NotStartOfGop)
+            }
+        }
+        Some(Err(error)) => Err(DetectGopStartError::FailedToExtractEncodingDetails(error)),
+        None => Ok(GopStartDetection::NotStartOfGop),
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use super::is_annexb_sample_start_of_gop;
+    use super::{GopStartDetection, detect_h264_annexb_gop};
+    use crate::{ChromaSubsamplingModes, DetectGopStartError, VideoEncodingDetails};
 
     #[test]
-    fn test_is_annexb_sample_start_of_gop() {
+    fn test_detect_h264_annexb_gop() {
         // Example H.264 Annex B encoded data containing SPS and IDR frame. (ai generated)
         let sample_data = &[
             // SPS NAL unit
@@ -100,8 +214,34 @@ mod test {
             0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x84, 0x21, 0x43, 0x02, 0x4C, 0x82, 0x54, 0x2B,
             0x8F, 0x2C, 0x8C, 0x54, 0x4A, 0x92, 0x54, 0x2B, 0x8F, 0x2C, 0x8C, 0x54, 0x4A, 0x92,
         ];
-        let result = is_annexb_sample_start_of_gop(sample_data);
-        assert!(result);
+        let result = detect_h264_annexb_gop(sample_data);
+        assert_eq!(
+            result,
+            Ok(GopStartDetection::StartOfGop(VideoEncodingDetails {
+                codec_string: "avc1.64000A".to_owned(),
+                coded_dimensions: [64, 64],
+                bit_depth: Some(8),
+                chroma_subsampling: Some(ChromaSubsamplingModes::Yuv420),
+                stsd: None,
+            }))
+        );
+
+        // Example H.264 Annex B encoded data containing broken SPS and IDR frame. (above example but messed with the SPS)
+        let sample_data = &[
+            // SPS NAL unit
+            0x00, 0x00, 0x00, 0x01, 0x67, 0x00, 0x00, 0x0A, 0xAC, 0x72, 0x84, 0x44, 0x26, 0x84,
+            0x00, 0x00, 0x03, 0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0xCA, 0x3C, 0x48, 0x96, 0x11,
+            0x80, // IDR frame NAL unit
+            0x00, 0x00, 0x00, 0x01, 0x65, 0x88, 0x84, 0x21, 0x43, 0x02, 0x4C, 0x82, 0x54, 0x2B,
+            0x8F, 0x2C, 0x8C, 0x54, 0x4A, 0x92, 0x54, 0x2B, 0x8F, 0x2C, 0x8C, 0x54, 0x4A, 0x92,
+        ];
+        let result = detect_h264_annexb_gop(sample_data);
+        assert_eq!(
+            result,
+            Err(DetectGopStartError::FailedToExtractEncodingDetails(
+                "Failed reading SPS: RbspReaderError(RemainingData)".to_owned()
+            ))
+        );
 
         // Garbage data, still annex b shaped. (ai generated)
         let sample_data = &[
@@ -109,12 +249,12 @@ mod test {
             0x00, 0x00, 0x03, 0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0xCA, 0x3C, 0x48, 0x96, 0x11,
             0x80,
         ];
-        let result = is_annexb_sample_start_of_gop(sample_data);
-        assert!(!result);
+        let result = detect_h264_annexb_gop(sample_data);
+        assert_eq!(result, Ok(GopStartDetection::NotStartOfGop));
 
         // Garbage data, no detectable nalu units.
         let sample_data = &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A];
-        let result = is_annexb_sample_start_of_gop(sample_data);
-        assert!(!result);
+        let result = detect_h264_annexb_gop(sample_data);
+        assert_eq!(result, Ok(GopStartDetection::NotStartOfGop));
     }
 }

--- a/crates/utils/re_video/src/decode/gop_detection.rs
+++ b/crates/utils/re_video/src/decode/gop_detection.rs
@@ -4,7 +4,7 @@ use h264_reader::{
     push::NalInterest,
 };
 
-use crate::{ChromaSubsamplingModes, VideoCodec, VideoEncodingDetails};
+use crate::{VideoCodec, VideoEncodingDetails, h264::encoding_details_from_h264_sps};
 
 /// Failure reason for [`is_sample_start_of_gop`].
 #[derive(thiserror::Error, Debug)]
@@ -114,47 +114,6 @@ impl h264_reader::push::AccumulatedNalHandler for H264GopDetectionState {
 
         NalInterest::Ignore
     }
-}
-
-fn encoding_details_from_h264_sps(
-    sps: &nal::sps::SeqParameterSet,
-) -> Result<VideoEncodingDetails, nal::sps::SpsError> {
-    let bit_depth = sps.chroma_info.bit_depth_chroma_minus8 + 8;
-
-    // Codec string defined by WebCodec points to various spec documents.
-    // https://www.w3.org/TR/webcodecs-avc-codec-registration/#fully-qualified-codec-strings
-    // Not having read those, this is what we use in `re_mp4` and it works fine.
-    // Also as of writing, Claude 4 agrees and is able to nicely explain its meaning.
-    let profile = u8::from(sps.profile_idc);
-    let constraint = u8::from(sps.constraint_flags);
-    let level = sps.level_idc;
-    let codec_string = format!("avc1.{profile:02X}{constraint:02X}{level:02X}");
-
-    // Calculating the dimensions of the frame in pixels from the SPS is quite complicated
-    // as it has to take into account cropping and concepts like macro block sizes.
-    // Luckily h264-reader has a utility for this!
-    let coded_dimensions = sps.pixel_dimensions()?;
-    let chroma_subsampling = match sps.chroma_info.chroma_format {
-        nal::sps::ChromaFormat::Monochrome => Some(ChromaSubsamplingModes::Monochrome),
-        nal::sps::ChromaFormat::YUV420 => Some(ChromaSubsamplingModes::Yuv420),
-        nal::sps::ChromaFormat::YUV422 => Some(ChromaSubsamplingModes::Yuv422),
-        nal::sps::ChromaFormat::YUV444 => Some(ChromaSubsamplingModes::Yuv444),
-        nal::sps::ChromaFormat::Invalid(_) => {
-            re_log::error_once!(
-                "Invalid chroma format in H264 SPS: {:?}",
-                sps.chroma_info.chroma_format
-            );
-            None
-        }
-    };
-
-    Ok(VideoEncodingDetails {
-        codec_string,
-        coded_dimensions: [coded_dimensions.0 as _, coded_dimensions.1 as _],
-        bit_depth: Some(bit_depth),
-        chroma_subsampling,
-        stsd: None,
-    })
 }
 
 /// Try to determine whether a frame chunk is the start of a closed GOP in an h264 Annex B encoded stream.

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -95,7 +95,7 @@ mod webcodecs;
 
 mod gop_detection;
 
-pub use gop_detection::is_sample_start_of_gop;
+pub use gop_detection::{DetectGopStartError, GopStartDetection, detect_gop_start};
 
 use crate::Time;
 

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -95,12 +95,12 @@ mod webcodecs;
 
 mod gop_detection;
 
-pub use gop_detection::{StartOfGopDetectionFailure, is_sample_start_of_gop};
+pub use gop_detection::is_sample_start_of_gop;
 
 use crate::Time;
 
 #[derive(thiserror::Error, Debug, Clone)]
-pub enum Error {
+pub enum DecodeError {
     #[error("Unsupported codec: {0}")]
     UnsupportedCodec(String),
 
@@ -124,7 +124,7 @@ pub enum Error {
 
     #[cfg(target_arch = "wasm32")]
     #[error(transparent)]
-    WebDecoder(#[from] webcodecs::Error),
+    WebDecoder(#[from] webcodecs::WebError),
 
     #[cfg(with_ffmpeg)]
     #[error(transparent)]
@@ -134,7 +134,7 @@ pub enum Error {
     BadBitsPerComponent(usize),
 }
 
-pub type Result<T = (), E = Error> = std::result::Result<T, E>;
+pub type Result<T = (), E = DecodeError> = std::result::Result<T, E>;
 
 pub type OutputCallback = dyn Fn(Result<Frame>) + Send + Sync;
 
@@ -201,13 +201,13 @@ pub fn new_decoder(
         crate::VideoCodec::AV1 => {
             #[cfg(linux_arm64)]
             {
-                return Err(Error::NoDav1dOnLinuxArm64);
+                return Err(DecodeError::NoDav1dOnLinuxArm64);
             }
 
             #[cfg(with_dav1d)]
             {
                 if cfg!(debug_assertions) {
-                    return Err(Error::NoNativeAv1Debug); // because debug builds of rav1d is EXTREMELY slow
+                    return Err(DecodeError::NoNativeAv1Debug); // because debug builds of rav1d is EXTREMELY slow
                 }
 
                 re_log::trace!("Decoding AV1…");
@@ -224,16 +224,22 @@ pub fn new_decoder(
             re_log::trace!("Decoding H.264…");
             Ok(Box::new(ffmpeg_h264::FFmpegCliH264Decoder::new(
                 debug_name.to_owned(),
-                video.stsd.clone().and_then(|c| match c.contents {
-                    re_mp4::StsdBoxContent::Avc1(avc1) => Some(avc1),
-                    _ => None,
-                }),
+                video
+                    .encoding_details
+                    .as_ref()
+                    .and_then(|details| details.stsd.as_ref())
+                    .and_then(|stsd| match &stsd.contents {
+                        re_mp4::StsdBoxContent::Avc1(avc1) => Some(avc1.clone()),
+                        _ => None,
+                    }),
                 on_output,
                 decode_settings.ffmpeg_path.clone(),
             )?))
         }
 
-        _ => Err(Error::UnsupportedCodec(video.human_readable_codec_string())),
+        _ => Err(DecodeError::UnsupportedCodec(
+            video.human_readable_codec_string(),
+        )),
     }
 }
 

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -224,14 +224,7 @@ pub fn new_decoder(
             re_log::trace!("Decoding H.264…");
             Ok(Box::new(ffmpeg_h264::FFmpegCliH264Decoder::new(
                 debug_name.to_owned(),
-                video
-                    .encoding_details
-                    .as_ref()
-                    .and_then(|details| details.stsd.as_ref())
-                    .and_then(|stsd| match &stsd.contents {
-                        re_mp4::StsdBoxContent::Avc1(avc1) => Some(avc1.clone()),
-                        _ => None,
-                    }),
+                video.encoding_details.clone(),
                 on_output,
                 decode_settings.ffmpeg_path.clone(),
             )?))

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use js_sys::{Function, Uint8Array};
 use once_cell::sync::Lazy;
-use re_mp4::{StsdBox, StsdBoxContent};
+use re_mp4::StsdBoxContent;
 use wasm_bindgen::{JsCast as _, closure::Closure};
 use web_sys::{
     EncodedVideoChunk, EncodedVideoChunkInit, EncodedVideoChunkType, VideoDecoderConfig,
@@ -12,7 +12,7 @@ use web_sys::{
 use super::{
     AsyncDecoder, Chunk, DecodeHardwareAcceleration, Frame, FrameInfo, OutputCallback, Result,
 };
-use crate::{Time, Timescale, VideoCodec, VideoDataDescription};
+use crate::{Time, Timescale, VideoCodec, VideoDataDescription, VideoEncodingDetails};
 
 #[derive(Clone)]
 #[repr(transparent)]
@@ -35,8 +35,7 @@ impl std::ops::Deref for WebVideoFrame {
 
 pub struct WebVideoDecoder {
     codec: VideoCodec,
-    stsd: Option<StsdBox>,
-    coded_dimensions: Option<[u16; 2]>,
+    encoding_details: Option<VideoEncodingDetails>,
     timescale: Timescale,
     decoder: web_sys::VideoDecoder,
     hw_acceleration: DecodeHardwareAcceleration,
@@ -44,7 +43,7 @@ pub struct WebVideoDecoder {
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
-pub enum Error {
+pub enum WebError {
     #[error("Failed to create VideoDecoder: {0}")]
     DecoderSetupFailure(String),
 
@@ -62,6 +61,11 @@ pub enum Error {
     /// e.g. unsupported codec
     #[error("Failed to decode video: {0}")]
     Decoding(String),
+
+    #[error(
+        "Not enough codec information to configure the video decoder. For live streams this typically happens prior to the arrival of the first key frame."
+    )]
+    NotEnoughCodecInformation,
 }
 
 // SAFETY: There is no way to access the same JS object from different OS threads
@@ -109,7 +113,7 @@ impl WebVideoDecoder {
         video_descr: &VideoDataDescription,
         hw_acceleration: DecodeHardwareAcceleration,
         on_output: impl Fn(Result<Frame>) + Send + Sync + 'static,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, WebError> {
         let on_output = Arc::new(on_output);
 
         // Web APIs insist on microsecond timestamps throughout.
@@ -121,8 +125,7 @@ impl WebVideoDecoder {
 
         Ok(Self {
             codec: video_descr.codec,
-            stsd: video_descr.stsd.clone(),
-            coded_dimensions: video_descr.coded_dimensions,
+            encoding_details: video_descr.encoding_details.clone(),
             timescale,
             decoder,
             hw_acceleration,
@@ -154,10 +157,10 @@ impl AsyncDecoder for WebVideoDecoder {
         }
 
         let web_chunk = EncodedVideoChunk::new(&web_chunk)
-            .map_err(|err| Error::CreateChunk(js_error_to_string(&err)))?;
+            .map_err(|err| WebError::CreateChunk(js_error_to_string(&err)))?;
         self.decoder
             .decode(&web_chunk)
-            .map_err(|err| Error::DecodeChunk(js_error_to_string(&err)))?;
+            .map_err(|err| WebError::DecodeChunk(js_error_to_string(&err)))?;
 
         Ok(())
     }
@@ -173,16 +176,17 @@ impl AsyncDecoder for WebVideoDecoder {
             self.decoder = init_video_decoder(self.on_output.clone(), self.timescale)?;
         };
 
+        let encoding_details = self
+            .encoding_details
+            .as_ref()
+            .ok_or(WebError::NotEnoughCodecInformation)?;
+
         self.decoder
             .configure(&js_video_decoder_config(
-                &self.codec,
-                &self.stsd,
-                &self.coded_dimensions,
+                encoding_details,
                 self.hw_acceleration,
             ))
-            .map_err(|err| Error::ConfigureFailure(js_error_to_string(&err)))?;
-
-        Ok(())
+            .map_err(|err| WebError::ConfigureFailure(js_error_to_string(&err)).into())
     }
 
     /// Called after submitting the last chunk.
@@ -227,7 +231,7 @@ static IS_SAFARI: Lazy<bool> = Lazy::new(|| {
 fn init_video_decoder(
     on_output_callback: Arc<OutputCallback>,
     timescale: Timescale,
-) -> Result<web_sys::VideoDecoder, Error> {
+) -> Result<web_sys::VideoDecoder, WebError> {
     let on_output = {
         let on_output = on_output_callback.clone();
         Closure::wrap(Box::new(move |frame: web_sys::VideoFrame| {
@@ -252,7 +256,7 @@ fn init_video_decoder(
     };
 
     let on_error = Closure::wrap(Box::new(move |err: js_sys::Error| {
-        on_output_callback(Err(super::Error::WebDecoder(Error::Decoding(
+        on_output_callback(Err(super::DecodeError::WebDecoder(WebError::Decoding(
             js_error_to_string(&err),
         ))));
     }) as Box<dyn Fn(js_sys::Error)>);
@@ -265,32 +269,18 @@ fn init_video_decoder(
     };
 
     web_sys::VideoDecoder::new(&VideoDecoderInit::new(&on_error, &on_output))
-        .map_err(|err| Error::DecoderSetupFailure(js_error_to_string(&err)))
+        .map_err(|err| WebError::DecoderSetupFailure(js_error_to_string(&err)))
 }
 
 fn js_video_decoder_config(
-    codec: &VideoCodec,
-    stsd: &Option<StsdBox>,
-    coded_dimensions: &Option<[u16; 2]>,
+    encoding_details: &VideoEncodingDetails,
     hw_acceleration: DecodeHardwareAcceleration,
 ) -> VideoDecoderConfig {
-    let codec_string = stsd
-        .as_ref()
-        .and_then(|stsd| stsd.contents.codec_string())
-        .unwrap_or_else(|| {
-            // TODO(#7484): This is neat, but doesn't work. Need the full codec string as described by the spec.
-            // For h.264, we have to extract this from the first SPS we find.
-            codec.base_webcodec_string().to_owned()
-        });
+    let js = VideoDecoderConfig::new(&encoding_details.codec_string);
+    js.set_coded_width(encoding_details.coded_dimensions[0] as u32);
+    js.set_coded_height(encoding_details.coded_dimensions[1] as u32);
 
-    let js = VideoDecoderConfig::new(&codec_string);
-
-    if let Some(coded_dimensions) = coded_dimensions {
-        js.set_coded_width(coded_dimensions[0] as u32);
-        js.set_coded_height(coded_dimensions[1] as u32);
-    }
-
-    if let Some(stsd) = stsd {
+    if let Some(stsd) = &encoding_details.stsd {
         let description = match &stsd.contents {
             StsdBoxContent::Av01(content) => Some(content.av1c.raw.clone()),
             StsdBoxContent::Avc1(content) => Some(content.avcc.raw.clone()),
@@ -312,8 +302,15 @@ fn js_video_decoder_config(
             description.copy_from(&description_raw[..]);
             js.set_description(&description);
         }
+    } else {
+        // For H264 & H265, the bitstream is assumed to be in Annex B format if no AVCC box is present.
+        // * H264: https://www.w3.org/TR/webcodecs-avc-codec-registration/#videodecoderconfig-description
+        // * H265: https://www.w3.org/TR/webcodecs-hevc-codec-registration/#videodecoderconfig-description
     }
 
+    // "If true this is a hint that the selected decoder should be optimized to minimize the number
+    // of EncodedVideoChunk objects that have to be decoded before a VideoFrame is output."
+    // https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/configure#optimizeforlatency
     js.set_optimize_for_latency(true);
 
     match hw_acceleration {

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -35,7 +35,6 @@ impl std::ops::Deref for WebVideoFrame {
 
 pub struct WebVideoDecoder {
     codec: VideoCodec,
-    encoding_details: Option<VideoEncodingDetails>,
     timescale: Timescale,
     decoder: web_sys::VideoDecoder,
     hw_acceleration: DecodeHardwareAcceleration,
@@ -125,7 +124,6 @@ impl WebVideoDecoder {
 
         Ok(Self {
             codec: video_descr.codec,
-            encoding_details: video_descr.encoding_details.clone(),
             timescale,
             decoder,
             hw_acceleration,
@@ -166,7 +164,7 @@ impl AsyncDecoder for WebVideoDecoder {
     }
 
     /// Reset the video decoder and discard all frames.
-    fn reset(&mut self) -> Result<()> {
+    fn reset(&mut self, video_descr: &VideoDataDescription) -> Result<()> {
         re_log::trace!("Resetting video decoder.");
 
         if let Err(_err) = self.decoder.reset() {
@@ -176,7 +174,7 @@ impl AsyncDecoder for WebVideoDecoder {
             self.decoder = init_video_decoder(self.on_output.clone(), self.timescale)?;
         };
 
-        let encoding_details = self
+        let encoding_details = video_descr
             .encoding_details
             .as_ref()
             .ok_or(WebError::NotEnoughCodecInformation)?;

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -200,10 +200,12 @@ pub struct VideoEncodingDetails {
     /// Optional mp4 stsd box from which this data was derived.
     ///
     /// Used by some decoders directly for configuration.
-    /// For H264 & H265, its presence implies that the bitstream is in the AVCC format rather than Annex B.
-    // TODO(andreas): Really we're after the optional AVCC box here, right? Right now we occasionally also extract other things.
-    // But limiting this to an optional AVCC would make more sense as a codec information piece.
-    pub stsd: Option<re_mp4::StsdBox>, // TODO: only avcc
+    /// For H.264 & H.265, its presence implies that the bitstream is in the AVCC format rather than Annex B.
+    // TODO(andreas):
+    // It would be nice to instead have an enum of all the actually needed descriptors.
+    // We know for sure that H.264 & H.265 need an AVCC/HVCC box for data from mp4, since the stream
+    // is otherwise not readable. But what about the other codecs? On Web we *do* pass additional information right now.
+    pub stsd: Option<re_mp4::StsdBox>,
 }
 
 impl VideoEncodingDetails {

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -203,7 +203,7 @@ pub struct VideoEncodingDetails {
     /// For H264 & H265, its presence implies that the bitstream is in the AVCC format rather than Annex B.
     // TODO(andreas): Really we're after the optional AVCC box here, right? Right now we occasionally also extract other things.
     // But limiting this to an optional AVCC would make more sense as a codec information piece.
-    pub stsd: Option<re_mp4::StsdBox>,
+    pub stsd: Option<re_mp4::StsdBox>, // TODO: only avcc
 }
 
 impl VideoEncodingDetails {

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -16,9 +16,15 @@ use super::{Time, Timescale};
 
 use crate::{Chunk, StableIndexDeque, TrackId, TrackKind};
 
+/// Chroma subsampling mode.
+///
+/// Should ignore this for monochrome formats, as depending on the codec,
+/// this may be regarded as any of these.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ChromaSubsamplingModes {
     /// No subsampling.
+    ///
+    /// Note that this also often applies to RGB formats, not just YUV.
     Yuv444,
 
     /// Subsampling in X only.
@@ -109,8 +115,13 @@ pub struct VideoDataDescription {
     /// The codec used to encode the video.
     pub codec: VideoCodec,
 
-    /// Encoded width & height if known.
-    pub coded_dimensions: Option<[u16; 2]>,
+    /// Various information about how the video was encoded.
+    ///
+    /// Decoder may require this to be present before starting to decode.
+    ///
+    /// For video streams this is derived on the fly, therefore it may arrive only with the first key frame.
+    /// For mp4 this is read from the AVCC box.
+    pub encoding_details: Option<VideoEncodingDetails>,
 
     /// How many time units are there per second.
     ///
@@ -146,15 +157,56 @@ pub struct VideoDataDescription {
     /// Meta information about the samples.
     pub samples_statistics: SamplesStatistics,
 
-    /// Optional mp4 stsd box.
-    ///
-    /// Contains info about the codec, bit depth, etc.
-    pub stsd: Option<re_mp4::StsdBox>,
-
     /// All the tracks in the mp4; not just the video track.
     ///
     /// Can be nice to show in a UI.
     pub mp4_tracks: BTreeMap<TrackId, Option<TrackKind>>,
+}
+
+/// Various information about how the video was encoded.
+///
+/// For video streams this is derived on the fly.
+/// For mp4 this is read from the AVCC box.
+#[derive(Clone, Debug)]
+pub struct VideoEncodingDetails {
+    /// Detailed codec string as specified by the `WebCodecs` codec registry.
+    ///
+    /// See <https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry>
+    pub codec_string: String,
+
+    /// Encoded width & height.
+    pub coded_dimensions: [u16; 2],
+
+    /// Per color component bit depth.
+    ///
+    /// Usually 8, but 10 for HDR (for example).
+    ///
+    /// `None` if this couldn't be determined, either because of lack of implementation
+    /// or missing information at this point.
+    pub bit_depth: Option<u8>,
+
+    /// Whether the video is monochrome.
+    ///
+    /// `None` if this couldn't be determined, either because of lack of implementation
+    /// or missing information at this point.
+    pub is_monochrome: Option<bool>,
+
+    /// Chroma subsampling mode.
+    ///
+    /// RGB data without any chroma subsamling specifies [`YuvPixelLayout::Y_U_V444`] despite
+    /// not using a YUV format.
+    ///
+    /// `None` if this couldn't be determined, either because of lack of implementation
+    /// or missing information at this point.
+    pub chroma_subsampling: Option<ChromaSubsamplingModes>,
+
+    /// Optional mp4 stsd box from which this data was derived.
+    ///
+    /// Used by some decoders directly for configuration.
+    /// For H264 & H265, its presence implies that the bitstream is in the AVCC format rather than Annex B.
+    // TODO(andreas): Really we're after the optional AVCC box here, right? Right now we occasionally also extract other things.
+    // But limiting this to an optional AVCC would make more sense as a codec information piece.
+    pub stsd: Option<re_mp4::StsdBox>,
 }
 
 /// Meta informationa about the video samples.
@@ -250,34 +302,20 @@ impl VideoDataDescription {
     /// The codec used to encode the video.
     #[inline]
     pub fn human_readable_codec_string(&self) -> String {
-        if let Some(stsd) = self.stsd.as_ref() {
-            let human_readable = match &stsd.contents {
-                re_mp4::StsdBoxContent::Av01(_) => "AV1",
-                re_mp4::StsdBoxContent::Avc1(_) => "H.264",
-                re_mp4::StsdBoxContent::Hvc1(_) => "H.265 HVC1",
-                re_mp4::StsdBoxContent::Hev1(_) => "H.265 HEV1",
-                re_mp4::StsdBoxContent::Vp08(_) => "VP8",
-                re_mp4::StsdBoxContent::Vp09(_) => "VP9",
-                re_mp4::StsdBoxContent::Mp4a(_) => "AAC",
-                re_mp4::StsdBoxContent::Tx3g(_) => "TTXT",
-                re_mp4::StsdBoxContent::Unknown(_) => "Unknown",
-            };
+        let base_codec_string = match &self.codec {
+            VideoCodec::AV1 => "AV1",
+            // TODO(andreas): if we found an SPS in the stream, we could show more information.
+            VideoCodec::H264 => "H.265 HVC1",
+            VideoCodec::H265 => "H.265 HEV1",
+            VideoCodec::VP8 => "VP8",
+            VideoCodec::VP9 => "VP9",
+        }
+        .to_owned();
 
-            if let Some(codec) = stsd.contents.codec_string() {
-                format!("{human_readable} ({codec})")
-            } else {
-                human_readable.to_owned()
-            }
+        if let Some(encoding_details) = self.encoding_details.as_ref() {
+            format!("{base_codec_string} ({})", encoding_details.codec_string)
         } else {
-            match &self.codec {
-                VideoCodec::AV1 => "AV1",
-                // TODO(andreas): if we found an SPS in the stream, we could show more information.
-                VideoCodec::H264 => "H.265 HVC1",
-                VideoCodec::H265 => "H.265 HEV1",
-                VideoCodec::VP8 => "VP8",
-                VideoCodec::VP9 => "VP9",
-            }
-            .to_owned()
+            base_codec_string
         }
     }
 
@@ -285,93 +323,6 @@ impl VideoDataDescription {
     #[inline]
     pub fn num_samples(&self) -> usize {
         self.samples.num_elements()
-    }
-
-    /// Returns the subsampling mode of the video.
-    ///
-    /// Returns None if not detected or unknown.
-    pub fn subsampling_mode(&self) -> Option<ChromaSubsamplingModes> {
-        match &self.stsd.as_ref()?.contents {
-            re_mp4::StsdBoxContent::Av01(av01_box) => {
-                // These are boolean options, see https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-semantics
-                match (
-                    av01_box.av1c.chroma_subsampling_x != 0,
-                    av01_box.av1c.chroma_subsampling_y != 0,
-                ) {
-                    (true, true) => Some(ChromaSubsamplingModes::Yuv420),
-                    (true, false) => Some(ChromaSubsamplingModes::Yuv422),
-                    (false, true) => None, // Downsampling in Y but not in X is unheard of!
-                    // Either that or monochrome.
-                    // See https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=131
-                    (false, false) => Some(ChromaSubsamplingModes::Yuv444),
-                }
-            }
-            re_mp4::StsdBoxContent::Avc1(_)
-            | re_mp4::StsdBoxContent::Hvc1(_)
-            | re_mp4::StsdBoxContent::Hev1(_) => {
-                // Surely there's a way to get this!
-                None
-            }
-
-            re_mp4::StsdBoxContent::Vp08(vp08_box) => {
-                // Via https://www.ffmpeg.org/doxygen/4.3/vpcc_8c_source.html#l00116
-                // enum VPX_CHROMA_SUBSAMPLING
-                // {
-                //     VPX_SUBSAMPLING_420_VERTICAL = 0,
-                //     VPX_SUBSAMPLING_420_COLLOCATED_WITH_LUMA = 1,
-                //     VPX_SUBSAMPLING_422 = 2,
-                //     VPX_SUBSAMPLING_444 = 3,
-                // };
-                match vp08_box.vpcc.chroma_subsampling {
-                    0 | 1 => Some(ChromaSubsamplingModes::Yuv420),
-                    2 => Some(ChromaSubsamplingModes::Yuv422),
-                    3 => Some(ChromaSubsamplingModes::Yuv444),
-                    _ => None, // Unknown mode.
-                }
-            }
-            re_mp4::StsdBoxContent::Vp09(vp09_box) => {
-                // As above!
-                match vp09_box.vpcc.chroma_subsampling {
-                    0 | 1 => Some(ChromaSubsamplingModes::Yuv420),
-                    2 => Some(ChromaSubsamplingModes::Yuv422),
-                    3 => Some(ChromaSubsamplingModes::Yuv444),
-                    _ => None, // Unknown mode.
-                }
-            }
-
-            re_mp4::StsdBoxContent::Mp4a(_)
-            | re_mp4::StsdBoxContent::Tx3g(_)
-            | re_mp4::StsdBoxContent::Unknown(_) => None,
-        }
-    }
-
-    /// Per color component bit depth.
-    ///
-    /// Usually 8, but 10 for HDR (for example).
-    pub fn bit_depth(&self) -> Option<u8> {
-        self.stsd.as_ref()?.contents.bit_depth()
-    }
-
-    /// Returns None if the mp4 doesn't specify whether the video is monochrome or
-    /// we haven't yet implemented the logic to determine this.
-    pub fn is_monochrome(&self) -> Option<bool> {
-        match &self.stsd.as_ref()?.contents {
-            re_mp4::StsdBoxContent::Av01(av01_box) => Some(av01_box.av1c.monochrome),
-            re_mp4::StsdBoxContent::Avc1(_)
-            | re_mp4::StsdBoxContent::Hvc1(_)
-            | re_mp4::StsdBoxContent::Hev1(_) => {
-                // It should be possible to extract this from the picture parameter set.
-                None
-            }
-            re_mp4::StsdBoxContent::Vp08(_) | re_mp4::StsdBoxContent::Vp09(_) => {
-                // Similar to AVC/HEVC, this information is likely accessible.
-                None
-            }
-
-            re_mp4::StsdBoxContent::Mp4a(_)
-            | re_mp4::StsdBoxContent::Tx3g(_)
-            | re_mp4::StsdBoxContent::Unknown(_) => None,
-        }
     }
 
     /// Determines the video timestamps of all frames inside a video, returning raw time values.
@@ -636,14 +587,16 @@ pub enum VideoLoadError {
     // `FourCC`'s debug impl doesn't quote the result
     #[error("Video track uses unsupported codec \"{0}\"")] // NOLINT
     UnsupportedCodec(re_mp4::FourCC),
+
+    #[error("Unable to determine codec string from the video contents")]
+    UnableToDetermineCodecString,
 }
 
 impl std::fmt::Debug for VideoDataDescription {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Video")
             .field("codec", &self.codec)
-            .field("stsd", &self.stsd)
-            .field("coded_dimensions", &self.coded_dimensions)
+            .field("encoding_details", &self.encoding_details)
             .field("timescale", &self.timescale)
             .field("duration", &self.duration)
             .field("gops", &self.gops)

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -173,7 +173,7 @@ pub struct VideoDataDescription {
 ///
 /// For video streams this is derived on the fly.
 /// For mp4 this is read from the AVCC box.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VideoEncodingDetails {
     /// Detailed codec string as specified by the `WebCodecs` codec registry.
     ///

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -313,8 +313,7 @@ impl VideoDataDescription {
     pub fn human_readable_codec_string(&self) -> String {
         let base_codec_string = match &self.codec {
             VideoCodec::AV1 => "AV1",
-            // TODO(andreas): if we found an SPS in the stream, we could show more information.
-            VideoCodec::H264 => "H.265 HVC1",
+            VideoCodec::H264 => "H.264 AVC1",
             VideoCodec::H265 => "H.265 HEV1",
             VideoCodec::VP8 => "VP8",
             VideoCodec::VP9 => "VP9",

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -599,6 +599,9 @@ pub enum VideoLoadError {
 
     #[error("Unable to determine codec string from the video contents")]
     UnableToDetermineCodecString,
+
+    #[error("Failed to parse H.264 SPS from mp4: {0:?}")]
+    SpsParsingError(h264_reader::nal::sps::SpsError),
 }
 
 impl std::fmt::Debug for VideoDataDescription {

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -23,6 +23,9 @@ use crate::{Chunk, StableIndexDeque, TrackId, TrackKind};
 /// Instead, this is just a description whether any subsampling occurs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ChromaSubsamplingModes {
+    /// No subsampling at all, since the format is monochrome.
+    Monochrome,
+
     /// No subsampling.
     ///
     /// Note that this also applies to RGB formats, not just YUV.
@@ -34,18 +37,16 @@ pub enum ChromaSubsamplingModes {
 
     /// Subsampling in both X and Y.
     Yuv420,
-
-    /// No subsampling at all, since the format is monochrome.
-    Monochrome,
 }
 
 impl std::fmt::Display for ChromaSubsamplingModes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            // Could also call this 4:0:0, but that's a fairly uncommon way to describe it.
+            Self::Monochrome => write!(f, "monochrome"),
             Self::Yuv444 => write!(f, "4:4:4"),
             Self::Yuv422 => write!(f, "4:2:2"),
             Self::Yuv420 => write!(f, "4:2:0"),
-            Self::Monochrome => write!(f, "monochrome"),
         }
     }
 }

--- a/crates/utils/re_video/src/demux/mp4.rs
+++ b/crates/utils/re_video/src/demux/mp4.rs
@@ -1,4 +1,4 @@
-use h264_reader::nal::{self, Nal};
+use h264_reader::nal::{self, Nal as _};
 use itertools::Itertools as _;
 
 use super::{GroupOfPictures, SampleMetadata, VideoDataDescription, VideoLoadError};
@@ -169,7 +169,8 @@ fn codec_details_from_stds(
     // re_mp4 doesn't have a full SPS parser, so almost certainly we're getting more information out this way,
     // also this means that we have less divergence with the video streaming case.
     if let re_mp4::StsdBoxContent::Avc1(avcc_box) = &stsd.contents {
-        for sps_nal in &avcc_box.avcc.sequence_parameter_sets {
+        // TODO(andreas): How to handle multiple SPS?
+        if let Some(sps_nal) = avcc_box.avcc.sequence_parameter_sets.first() {
             let complete = true;
             let sps_nal = nal::RefNal::new(sps_nal.bytes.as_slice(), &[], complete);
 

--- a/crates/utils/re_video/src/demux/mp4.rs
+++ b/crates/utils/re_video/src/demux/mp4.rs
@@ -203,15 +203,14 @@ fn subsampling_mode(stsd: &re_mp4::StsdBox) -> Option<ChromaSubsamplingModes> {
                 Some(ChromaSubsamplingModes::Monochrome)
             } else {
                 // These are boolean options, see https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-semantics
+                // For spec of meaning see https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=131
                 match (
                     av01_box.av1c.chroma_subsampling_x != 0,
                     av01_box.av1c.chroma_subsampling_y != 0,
                 ) {
-                    (true, true) => Some(ChromaSubsamplingModes::Yuv420), // May also be monochrome.
+                    (true, true) => Some(ChromaSubsamplingModes::Yuv420), // May also be monochrome, but we already checked for that.
                     (true, false) => Some(ChromaSubsamplingModes::Yuv422),
                     (false, true) => None, // Downsampling in Y but not in X is unheard of!
-                    // Either that or monochrome.
-                    // See https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=131
                     (false, false) => Some(ChromaSubsamplingModes::Yuv444),
                 }
             }

--- a/crates/utils/re_video/src/demux/mp4.rs
+++ b/crates/utils/re_video/src/demux/mp4.rs
@@ -172,13 +172,16 @@ fn codec_details_from_stds(
             .ok_or(VideoLoadError::UnableToDetermineCodecString)?,
         coded_dimensions: [track.width, track.height],
         bit_depth: stsd.contents.bit_depth(),
-        is_monochrome: is_monochrome(&stsd),
         chroma_subsampling: subsampling_mode(&stsd),
         stsd: Some(stsd),
     })
 }
 
 fn subsampling_mode(stsd: &re_mp4::StsdBox) -> Option<ChromaSubsamplingModes> {
+    if is_monochrome(stsd).unwrap_or(false) {
+        return Some(ChromaSubsamplingModes::Monochrome);
+    }
+
     match &stsd.contents {
         re_mp4::StsdBoxContent::Av01(av01_box) => {
             // These are boolean options, see https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-semantics

--- a/crates/utils/re_video/src/h264.rs
+++ b/crates/utils/re_video/src/h264.rs
@@ -1,0 +1,47 @@
+//! General H.264 utilities.
+
+use h264_reader::nal;
+
+use crate::{ChromaSubsamplingModes, VideoEncodingDetails};
+
+/// Retrieve [`VideoEncodingDetails`] from a H.264 SPS.
+pub fn encoding_details_from_h264_sps(
+    sps: &nal::sps::SeqParameterSet,
+) -> Result<VideoEncodingDetails, nal::sps::SpsError> {
+    let bit_depth = sps.chroma_info.bit_depth_chroma_minus8 + 8;
+
+    // Codec string defined by WebCodec points to various spec documents.
+    // https://www.w3.org/TR/webcodecs-avc-codec-registration/#fully-qualified-codec-strings
+    // Not having read those, this is what we use in `re_mp4` and it works fine.
+    // Also as of writing, Claude 4 agrees and is able to nicely explain its meaning.
+    let profile = u8::from(sps.profile_idc);
+    let constraint = u8::from(sps.constraint_flags);
+    let level = sps.level_idc;
+    let codec_string = format!("avc1.{profile:02X}{constraint:02X}{level:02X}");
+
+    // Calculating the dimensions of the frame in pixels from the SPS is quite complicated
+    // as it has to take into account cropping and concepts like macro block sizes.
+    // Luckily h264-reader has a utility for this!
+    let coded_dimensions = sps.pixel_dimensions()?;
+    let chroma_subsampling = match sps.chroma_info.chroma_format {
+        nal::sps::ChromaFormat::Monochrome => Some(ChromaSubsamplingModes::Monochrome),
+        nal::sps::ChromaFormat::YUV420 => Some(ChromaSubsamplingModes::Yuv420),
+        nal::sps::ChromaFormat::YUV422 => Some(ChromaSubsamplingModes::Yuv422),
+        nal::sps::ChromaFormat::YUV444 => Some(ChromaSubsamplingModes::Yuv444),
+        nal::sps::ChromaFormat::Invalid(_) => {
+            re_log::error_once!(
+                "Invalid chroma format in H264 SPS: {:?}",
+                sps.chroma_info.chroma_format
+            );
+            None
+        }
+    };
+
+    Ok(VideoEncodingDetails {
+        codec_string,
+        coded_dimensions: [coded_dimensions.0 as _, coded_dimensions.1 as _],
+        bit_depth: Some(bit_depth),
+        chroma_subsampling,
+        stsd: None,
+    })
+}

--- a/crates/utils/re_video/src/lib.rs
+++ b/crates/utils/re_video/src/lib.rs
@@ -6,9 +6,10 @@ mod stable_index_deque;
 mod time;
 
 pub use decode::{
-    AsyncDecoder, Chunk, DecodeError, DecodeHardwareAcceleration, DecodeSettings, Frame,
-    FrameContent, FrameInfo, PixelFormat, Result as DecodeResult, YuvMatrixCoefficients,
-    YuvPixelLayout, YuvRange, is_sample_start_of_gop, new_decoder,
+    AsyncDecoder, Chunk, DecodeError, DecodeHardwareAcceleration, DecodeSettings,
+    DetectGopStartError, Frame, FrameContent, FrameInfo, GopStartDetection, PixelFormat,
+    Result as DecodeResult, YuvMatrixCoefficients, YuvPixelLayout, YuvRange, detect_gop_start,
+    new_decoder,
 };
 
 #[cfg(with_ffmpeg)]

--- a/crates/utils/re_video/src/lib.rs
+++ b/crates/utils/re_video/src/lib.rs
@@ -15,8 +15,8 @@ pub use decode::{
 pub use decode::{FFmpegError, FFmpegVersion, FFmpegVersionParseError, ffmpeg_download_url};
 
 pub use demux::{
-    GopIndex, GroupOfPictures, SampleIndex, SampleMetadata, SamplesStatistics, VideoCodec,
-    VideoDataDescription, VideoEncodingDetails, VideoLoadError,
+    ChromaSubsamplingModes, GopIndex, GroupOfPictures, SampleIndex, SampleMetadata,
+    SamplesStatistics, VideoCodec, VideoDataDescription, VideoEncodingDetails, VideoLoadError,
 };
 pub use stable_index_deque::StableIndexDeque;
 pub use time::{Time, Timescale};

--- a/crates/utils/re_video/src/lib.rs
+++ b/crates/utils/re_video/src/lib.rs
@@ -1,20 +1,25 @@
 //! Video decoding library.
 
+mod decode;
+mod demux;
+mod stable_index_deque;
 mod time;
 
-pub mod decode;
-pub mod demux;
-pub mod stable_index_deque;
-
-pub use self::stable_index_deque::StableIndexDeque;
-pub use self::{
-    decode::{Chunk, Frame, PixelFormat, is_sample_start_of_gop},
-    demux::{
-        GopIndex, SampleIndex, SampleMetadata, SamplesStatistics, VideoCodec, VideoDataDescription,
-        VideoLoadError,
-    },
-    time::{Time, Timescale},
+pub use decode::{
+    AsyncDecoder, Chunk, DecodeError, DecodeHardwareAcceleration, DecodeSettings, Frame,
+    FrameContent, FrameInfo, PixelFormat, Result as DecodeResult, YuvMatrixCoefficients,
+    YuvPixelLayout, YuvRange, is_sample_start_of_gop, new_decoder,
 };
+
+#[cfg(with_ffmpeg)]
+pub use decode::{FFmpegError, FFmpegVersion, FFmpegVersionParseError, ffmpeg_download_url};
+
+pub use demux::{
+    GopIndex, GroupOfPictures, SampleIndex, SampleMetadata, SamplesStatistics, VideoCodec,
+    VideoDataDescription, VideoEncodingDetails, VideoLoadError,
+};
+pub use stable_index_deque::StableIndexDeque;
+pub use time::{Time, Timescale};
 
 pub use re_mp4::{TrackId, TrackKind};
 

--- a/crates/utils/re_video/src/lib.rs
+++ b/crates/utils/re_video/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod decode;
 mod demux;
+mod h264;
 mod stable_index_deque;
 mod time;
 

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -69,17 +69,19 @@ fn video_data_ui(ui: &mut egui::Ui, ui_layout: UiLayout, video_descr: &VideoData
                             ui.hyperlink("https://github.com/rerun-io/rerun/issues/7594");
                         });
                     }
-                    if encoding_details.is_monochrome == Some(true) {
+                    if encoding_details.chroma_subsampling
+                        == Some(re_video::ChromaSubsamplingModes::Monochrome)
+                    {
                         ui.label("(monochrome)");
                     }
                 },
             ));
         }
-        if let Some(subsampling_mode) = encoding_details.chroma_subsampling {
-            // Don't show subsampling mode for monochrome, doesn't make sense usually.
-            if encoding_details.is_monochrome != Some(true) {
+        if let Some(chroma_subsampling) = encoding_details.chroma_subsampling {
+            // Don't show subsampling mode for monochrome. Usually we know the bit depth and already shown it there.
+            if chroma_subsampling != re_video::ChromaSubsamplingModes::Monochrome {
                 ui.list_item_flat_noninteractive(
-                    PropertyContent::new("Subsampling").value_text(subsampling_mode.to_string()),
+                    PropertyContent::new("Subsampling").value_text(chroma_subsampling.to_string()),
                 );
             }
         }

--- a/crates/viewer/re_global_context/src/app_options.rs
+++ b/crates/viewer/re_global_context/src/app_options.rs
@@ -1,5 +1,5 @@
 use re_log_types::TimestampFormat;
-use re_video::decode::{DecodeHardwareAcceleration, DecodeSettings};
+use re_video::{DecodeHardwareAcceleration, DecodeSettings};
 
 const MAPBOX_ACCESS_TOKEN_ENV_VAR: &str = "RERUN_MAPBOX_ACCESS_TOKEN";
 

--- a/crates/viewer/re_renderer/src/resource_managers/yuv_converter.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/yuv_converter.rs
@@ -188,9 +188,8 @@ impl std::fmt::Display for YuvPixelLayout {
 
 /// Yuv matrix coefficients that determine how a YUV image is meant to be converted to RGB.
 ///
-/// A rigorious definition of the yuv conversion matrix would still require to define
+/// A rigorious definition of the yuv conversion matrix would additionally require to define
 /// the transfer characteristics & color primaries of the resulting RGB space.
-/// See [`re_video::decode`]'s documentation.
 ///
 /// However, at this point we generally assume that no further processing is needed after the transform.
 /// This is acceptable for most non-HDR content because of the following properties of `Bt709`/`Bt601`/ sRGB:

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use re_video::{Chunk, Frame, Time, decode::FrameContent};
+use re_video::{Chunk, Frame, FrameContent, Time};
 
 use parking_lot::Mutex;
 
@@ -27,7 +27,7 @@ struct DecoderOutput {
 /// Internal implementation detail of the [`super::player::VideoPlayer`].
 // TODO(andreas): Meld this into `super::player::VideoPlayer`.
 pub struct VideoSampleDecoder {
-    decoder: Box<dyn re_video::decode::AsyncDecoder>,
+    decoder: Box<dyn re_video::AsyncDecoder>,
     decoder_output: Arc<Mutex<DecoderOutput>>,
 }
 
@@ -35,9 +35,8 @@ impl VideoSampleDecoder {
     pub fn new(
         debug_name: String,
         make_decoder: impl FnOnce(
-            Box<dyn Fn(re_video::decode::Result<Frame>) + Send + Sync>,
-        )
-            -> re_video::decode::Result<Box<dyn re_video::decode::AsyncDecoder>>,
+            Box<dyn Fn(re_video::DecodeResult<Frame>) + Send + Sync>,
+        ) -> re_video::DecodeResult<Box<dyn re_video::AsyncDecoder>>,
     ) -> Result<Self, VideoPlayerError> {
         re_tracing::profile_function!();
 
@@ -45,7 +44,7 @@ impl VideoSampleDecoder {
 
         let on_output = {
             let decoder_output = decoder_output.clone();
-            move |frame: re_video::decode::Result<Frame>| match frame {
+            move |frame: re_video::DecodeResult<Frame>| match frame {
                 Ok(frame) => {
                     re_log::trace!(
                         "Decoded frame at PTS {:?}",
@@ -306,21 +305,19 @@ fn copy_native_video_frame_to_texture(
             coefficients,
         } => SourceImageDataFormat::Yuv {
             layout: match layout {
-                re_video::decode::YuvPixelLayout::Y_U_V444 => YuvPixelLayout::Y_U_V444,
-                re_video::decode::YuvPixelLayout::Y_U_V422 => YuvPixelLayout::Y_U_V422,
-                re_video::decode::YuvPixelLayout::Y_U_V420 => YuvPixelLayout::Y_U_V420,
-                re_video::decode::YuvPixelLayout::Y400 => YuvPixelLayout::Y400,
+                re_video::YuvPixelLayout::Y_U_V444 => YuvPixelLayout::Y_U_V444,
+                re_video::YuvPixelLayout::Y_U_V422 => YuvPixelLayout::Y_U_V422,
+                re_video::YuvPixelLayout::Y_U_V420 => YuvPixelLayout::Y_U_V420,
+                re_video::YuvPixelLayout::Y400 => YuvPixelLayout::Y400,
             },
             coefficients: match coefficients {
-                re_video::decode::YuvMatrixCoefficients::Identity => {
-                    YuvMatrixCoefficients::Identity
-                }
-                re_video::decode::YuvMatrixCoefficients::Bt601 => YuvMatrixCoefficients::Bt601,
-                re_video::decode::YuvMatrixCoefficients::Bt709 => YuvMatrixCoefficients::Bt709,
+                re_video::YuvMatrixCoefficients::Identity => YuvMatrixCoefficients::Identity,
+                re_video::YuvMatrixCoefficients::Bt601 => YuvMatrixCoefficients::Bt601,
+                re_video::YuvMatrixCoefficients::Bt709 => YuvMatrixCoefficients::Bt709,
             },
             range: match range {
-                re_video::decode::YuvRange::Limited => YuvRange::Limited,
-                re_video::decode::YuvRange::Full => YuvRange::Full,
+                re_video::YuvRange::Limited => YuvRange::Limited,
+                re_video::YuvRange::Full => YuvRange::Full,
             },
         },
     };

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use re_video::{Chunk, Frame, FrameContent, Time};
+use re_video::{Chunk, Frame, FrameContent, Time, VideoDataDescription};
 
 use parking_lot::Mutex;
 
@@ -172,8 +172,8 @@ impl VideoSampleDecoder {
     }
 
     /// Reset the video decoder and discard all frames.
-    pub fn reset(&mut self) -> Result<(), VideoPlayerError> {
-        self.decoder.reset()?;
+    pub fn reset(&mut self, video_descr: &VideoDataDescription) -> Result<(), VideoPlayerError> {
+        self.decoder.reset(video_descr)?;
 
         let mut decoder_output = self.decoder_output.lock();
         decoder_output.error = None;

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -5,6 +5,7 @@ use std::collections::hash_map::Entry;
 
 use ahash::HashMap;
 use parking_lot::Mutex;
+use re_log::ResultExt;
 
 use crate::{
     RenderContext,
@@ -125,6 +126,19 @@ impl Video {
     #[inline]
     pub fn data_descr_mut(&mut self) -> &mut re_video::VideoDataDescription {
         &mut self.video_description
+    }
+
+    /// Resets all decoders and purges any cached frames.
+    ///
+    /// This is useful when the video description has changed since the decoders were created.
+    pub fn reset_all_decoders(&self) {
+        let mut players = self.players.lock();
+        for player in players.values_mut() {
+            player
+                .player
+                .reset(&self.video_description)
+                .ok_or_log_error_once();
+        }
     }
 
     /// Natural dimensions of the video if known.

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     RenderContext,
     resource_managers::{GpuTexture2D, SourceImageDataFormat},
 };
-use re_video::{StableIndexDeque, VideoDataDescription, decode::DecodeSettings};
+use re_video::{DecodeSettings, StableIndexDeque, VideoDataDescription};
 
 /// Error that can occur during playing videos.
 #[derive(thiserror::Error, Debug, Clone)]
@@ -31,7 +31,7 @@ pub enum VideoPlayerError {
 
     /// e.g. unsupported codec
     #[error("Failed to decode video: {0}")]
-    Decoding(#[from] re_video::decode::Error),
+    Decoding(#[from] re_video::DecodeError),
 
     #[error("The timestamp passed was negative.")]
     NegativeTimestamp,
@@ -63,7 +63,7 @@ pub struct VideoFrameTexture {
     pub source_pixel_format: SourceImageDataFormat,
 
     /// Meta information about the decoded frame.
-    pub frame_info: Option<re_video::decode::FrameInfo>,
+    pub frame_info: Option<re_video::FrameInfo>,
 }
 
 /// Identifier for an independent video decoding stream.
@@ -130,7 +130,10 @@ impl Video {
     /// Natural dimensions of the video if known.
     #[inline]
     pub fn dimensions(&self) -> Option<[u16; 2]> {
-        self.video_description.coded_dimensions
+        self.video_description
+            .encoding_details
+            .as_ref()
+            .map(|details| details.coded_dimensions)
     }
 
     /// Returns a texture with the latest frame at the given time since video start.

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -5,13 +5,14 @@ use std::collections::hash_map::Entry;
 
 use ahash::HashMap;
 use parking_lot::Mutex;
-use re_log::ResultExt;
+
+use re_log::ResultExt as _;
+use re_video::{DecodeSettings, StableIndexDeque, VideoDataDescription};
 
 use crate::{
     RenderContext,
     resource_managers::{GpuTexture2D, SourceImageDataFormat},
 };
-use re_video::{DecodeSettings, StableIndexDeque, VideoDataDescription};
 
 /// Error that can occur during playing videos.
 #[derive(thiserror::Error, Debug, Clone)]

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -250,7 +250,7 @@ impl VideoPlayer {
             // because decoding all the samples between the previous sample and the requested
             // one would mean decoding and immediately discarding more frames than we need.
             if self.last_requested_gop_idx.saturating_add(1) != requested_gop_idx {
-                self.reset()?;
+                self.reset(video_description)?;
             }
         } else if requested_sample_idx != self.last_requested_sample_idx {
             let requested_sample = video_description
@@ -282,7 +282,7 @@ impl VideoPlayer {
                 // seeking backwards!
                 // Therefore, it's important to compare presentation timestamps instead of sample indices.
                 // (comparing decode timestamps should be equivalent to comparing sample indices)
-                self.reset()?;
+                self.reset(video_description)?;
             }
         }
 
@@ -370,8 +370,11 @@ impl VideoPlayer {
     }
 
     /// Reset the video decoder and discard all frames.
-    fn reset(&mut self) -> Result<(), VideoPlayerError> {
-        self.chunk_decoder.reset()?;
+    pub fn reset(
+        &mut self,
+        video_descr: &re_video::VideoDataDescription,
+    ) -> Result<(), VideoPlayerError> {
+        self.chunk_decoder.reset(video_descr)?;
         self.last_requested_gop_idx = GopIndex::MAX;
         self.last_requested_sample_idx = SampleIndex::MAX;
         self.last_enqueued_gop_idx = None;

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -2,10 +2,7 @@ use std::time::Duration;
 
 use web_time::Instant;
 
-use re_video::{
-    GopIndex, SampleIndex, StableIndexDeque, Time,
-    decode::{DecodeSettings, FrameInfo},
-};
+use re_video::{DecodeSettings, FrameInfo, GopIndex, SampleIndex, StableIndexDeque, Time};
 
 use super::{VideoFrameTexture, chunk_decoder::VideoSampleDecoder};
 use crate::{
@@ -79,8 +76,8 @@ impl VideoPlayer {
             description.human_readable_codec_string()
         );
 
-        if let Some(stsd) = description.stsd.as_ref() {
-            if let Some(bit_depth) = stsd.contents.bit_depth() {
+        if let Some(details) = description.encoding_details.as_ref() {
+            if let Some(bit_depth) = details.bit_depth {
                 #[allow(clippy::comparison_chain)]
                 if bit_depth < 8 {
                     re_log::warn_once!("{debug_name} has unusual bit_depth of {bit_depth}");
@@ -93,7 +90,7 @@ impl VideoPlayer {
         }
 
         let chunk_decoder = VideoSampleDecoder::new(debug_name.clone(), |on_output| {
-            re_video::decode::new_decoder(&debug_name, description, decode_settings, on_output)
+            re_video::new_decoder(&debug_name, description, decode_settings, on_output)
         })?;
 
         Ok(Self {

--- a/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
@@ -194,7 +194,7 @@ fn size_from_blob(blob: &[u8], media_type: &MediaType) -> Option<[u32; 2]> {
         re_tracing::profile_scope!("video");
         re_video::VideoDataDescription::load_from_bytes(blob, media_type)
             .ok()
-            .and_then(|video| video.coded_dimensions)
+            .and_then(|video| video.encoding_details.map(|e| e.coded_dimensions))
             .map(|[w, h]| [w as _, h as _])
     } else {
         None

--- a/crates/viewer/re_viewer/src/startup_options.rs
+++ b/crates/viewer/re_viewer/src/startup_options.rs
@@ -48,7 +48,7 @@ pub struct StartupOptions {
     ///
     /// By default uses the last provided setting, which is `auto` if never configured.
     /// This also can be changed in the viewer's option menu.
-    pub video_decoder_hw_acceleration: Option<re_video::decode::DecodeHardwareAcceleration>,
+    pub video_decoder_hw_acceleration: Option<re_video::DecodeHardwareAcceleration>,
 
     /// External interactions with the Viewer host (JS, custom egui app, notebook, etc.).
     pub on_event: Option<ViewerEventCallback>,

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -190,7 +190,7 @@ fn video_section_ui(ui: &mut Ui, app_options: &mut AppOptions) {
     // This affects only the web target, so we don't need to show it on native.
     #[cfg(target_arch = "wasm32")]
     {
-        use re_video::decode::DecodeHardwareAcceleration;
+        use re_video::DecodeHardwareAcceleration;
 
         let hardware_acceleration = &mut app_options.video_decoder_hw_acceleration;
         ui.horizontal(|ui| {
@@ -222,7 +222,7 @@ fn video_section_ui(ui: &mut Ui, app_options: &mut AppOptions) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn ffmpeg_path_status_ui(ui: &mut Ui, app_options: &AppOptions) {
-    use re_video::decode::{FFmpegVersion, FFmpegVersionParseError};
+    use re_video::{FFmpegVersion, FFmpegVersionParseError};
     use std::task::Poll;
 
     let path = app_options

--- a/crates/viewer/re_viewer_context/src/cache/video_asset_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_asset_cache.rs
@@ -10,7 +10,7 @@ use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_renderer::{external::re_video::VideoLoadError, video::Video};
 use re_types::{ComponentDescriptor, components::MediaType};
-use re_video::decode::DecodeSettings;
+use re_video::DecodeSettings;
 
 use crate::{Cache, cache::filter_blob_removed_events, image_info::StoredBlobCacheKey};
 

--- a/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
@@ -533,6 +533,8 @@ impl Cache for VideoStreamCache {
                             &event.chunk
                         };
 
+                        let encoding_details_before = video_data.encoding_details.clone();
+
                         if let Err(err) = read_samples_from_chunk(
                             *timeline,
                             chunk,
@@ -542,6 +544,10 @@ impl Cache for VideoStreamCache {
                             re_log::error_once!(
                                 "Failed to read process additional incoming video samples: {err}"
                             );
+                        }
+
+                        if encoding_details_before != video_data.encoding_details {
+                            video_renderer.reset_all_decoders();
                         }
                     }
                     re_chunk_store::ChunkStoreDiffKind::Deletion => {

--- a/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
@@ -198,33 +198,22 @@ fn load_video_data_from_chunks(
 
     // Extract all video samples.
     let mut video_sample_buffers = StableIndexDeque::new();
-    let mut samples = StableIndexDeque::with_capacity(sample_chunks.len()); // Number of video chunks is minimum number of samples.
-    let mut gops = StableIndexDeque::new();
+    let mut video_descr = re_video::VideoDataDescription {
+        codec,
+        encoding_details: None, // Unknown so far, we'll find out later.
+        timescale: timescale_for_timeline(store, timeline),
+        duration: None, // Streams have to be assumed to be open ended, so we don't have a duration.
+        gops: StableIndexDeque::new(),
+        samples: StableIndexDeque::with_capacity(sample_chunks.len()), // Number of video chunks is minimum number of samples.
+        samples_statistics: re_video::SamplesStatistics::NO_BFRAMES, // TODO(#10090): No b-frames for now.
+        mp4_tracks: std::iter::once((0, Some(re_video::TrackKind::Video))).collect(),
+    };
 
     for chunk in sample_chunks {
-        read_samples_from_chunk(
-            timeline,
-            chunk,
-            codec,
-            &mut video_sample_buffers,
-            &mut samples,
-            &mut gops,
-        )?;
+        read_samples_from_chunk(timeline, chunk, &mut video_descr, &mut video_sample_buffers)?;
     }
 
-    Ok((
-        re_video::VideoDataDescription {
-            codec,
-            encoding_details: None, // Unknown so far, we'll find out later.
-            timescale: timescale_for_timeline(store, timeline),
-            duration: None, // Streams have to be assumed to be open ended, so we don't have a duration.
-            gops,
-            samples,
-            samples_statistics: re_video::SamplesStatistics::NO_BFRAMES, // TODO(#10090): No b-frames for now.
-            mp4_tracks: std::iter::once((0, Some(re_video::TrackKind::Video))).collect(),
-        },
-        video_sample_buffers,
-    ))
+    Ok((video_descr, video_sample_buffers))
 }
 
 fn timescale_for_timeline(
@@ -243,15 +232,24 @@ fn timescale_for_timeline(
 /// Rejects out of order samples - new samples must have a higher timestamp than the previous ones.
 /// Since samples within a chunk are guaranteed to be ordered, this can only happen if a new chunk
 /// is inserted that has is timestamped to be older than the data in the last added chunk.
+///
+/// Encoding details are automatically updated whenever detected.
+/// Changes of encoding details over time will trigger a warning.
 fn read_samples_from_chunk(
     timeline: TimelineName,
     chunk: &re_chunk::Chunk,
-    codec: re_video::VideoCodec,
+    video_descr: &mut re_video::VideoDataDescription,
     chunk_buffers: &mut StableIndexDeque<SampleBuffer>,
-    samples: &mut StableIndexDeque<re_video::SampleMetadata>,
-    gops: &mut StableIndexDeque<re_video::GroupOfPictures>,
 ) -> Result<(), VideoStreamProcessingError> {
     re_tracing::profile_function!();
+
+    let re_video::VideoDataDescription {
+        codec,
+        samples,
+        gops,
+        encoding_details,
+        ..
+    } = video_descr;
 
     let sample_descr = VideoStream::descriptor_sample();
     let Some(raw_array) = chunk.raw_component_array(&sample_descr) else {
@@ -335,6 +333,7 @@ fn read_samples_from_chunk(
                 let sample_idx = sample_base_idx + idx;
                 let byte_offset = offsets[idx] as usize;
                 let byte_length = lengths[idx];
+                let sample_bytes = &values[byte_offset..(byte_offset + byte_length)];
 
                 // Note that the conversion of this time value is already handled by `VideoDataDescription::timescale`:
                 // For sequence time we use a scale of 1, for nanoseconds time we use a scale of 1_000_000_000.
@@ -344,13 +343,32 @@ fn read_samples_from_chunk(
                 debug_assert!(decode_timestamp > previous_max_presentation_timestamp);
                 previous_max_presentation_timestamp = decode_timestamp;
 
-                let is_sync_result = re_video::is_sample_start_of_gop(
-                    &values[byte_offset..(byte_offset + byte_length)],
-                    codec,
-                );
-                // TODO(andreas): Do something with the error?
-                // Detecting too few GOPs is better than too many since it merely means that the decoder has more work to do to get to a given frame.
-                let is_sync = is_sync_result.unwrap_or(false);
+                let is_sync = match re_video::detect_gop_start(sample_bytes, *codec) {
+                    Ok(re_video::GopStartDetection::StartOfGop(new_encoding_details)) => {
+                        if encoding_details.as_ref() != Some(&new_encoding_details) {
+                            if let Some(old_encoding_details) = encoding_details.as_ref() {
+                                re_log::warn_once!(
+                                    "Detected change of video encoding properties (like size, bit depth, compression etc.) over time. \
+                                    This is not supported and may cause playback issues."
+                                );
+                                re_log::trace!(
+                                    "Previous encoding details: {:?}\n\nNew encoding details: {:?}",
+                                    old_encoding_details,
+                                    new_encoding_details
+                                );
+                            }
+                            *encoding_details = Some(new_encoding_details);
+                        }
+
+                        true
+                    }
+                    Ok(re_video::GopStartDetection::NotStartOfGop) => { false },
+
+                    Err(err) => {
+                        re_log::error_once!("Failed to detect GOP for video sample: {err}");
+                        false
+                    }
+                };
 
                 if is_sync {
                     // Last GOP extends until here now
@@ -518,10 +536,8 @@ impl Cache for VideoStreamCache {
                         if let Err(err) = read_samples_from_chunk(
                             *timeline,
                             chunk,
-                            video_data.codec,
+                            video_data,
                             video_sample_buffers,
-                            &mut video_data.samples,
-                            &mut video_data.gops,
                         ) {
                             re_log::error_once!(
                                 "Failed to read process additional incoming video samples: {err}"

--- a/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
@@ -13,7 +13,7 @@ use re_chunk::{ChunkId, EntityPath, TimelineName};
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::{EntityPathHash, TimeType};
 use re_types::{archetypes::VideoStream, components};
-use re_video::{StableIndexDeque, decode::DecodeSettings};
+use re_video::{DecodeSettings, StableIndexDeque};
 
 use crate::Cache;
 
@@ -215,8 +215,7 @@ fn load_video_data_from_chunks(
     Ok((
         re_video::VideoDataDescription {
             codec,
-            stsd: None,             // Only mp4s have this.
-            coded_dimensions: None, // Unknown so far.
+            encoding_details: None, // Unknown so far, we'll find out later.
             timescale: timescale_for_timeline(store, timeline),
             duration: None, // Streams have to be assumed to be open ended, so we don't have a duration.
             gops,
@@ -250,7 +249,7 @@ fn read_samples_from_chunk(
     codec: re_video::VideoCodec,
     chunk_buffers: &mut StableIndexDeque<SampleBuffer>,
     samples: &mut StableIndexDeque<re_video::SampleMetadata>,
-    gops: &mut StableIndexDeque<re_video::demux::GroupOfPictures>,
+    gops: &mut StableIndexDeque<re_video::GroupOfPictures>,
 ) -> Result<(), VideoStreamProcessingError> {
     re_tracing::profile_function!();
 
@@ -360,7 +359,7 @@ fn read_samples_from_chunk(
                     }
 
                     // New gop starts at this frame.
-                    gops.push_back(re_video::demux::GroupOfPictures {
+                    gops.push_back(re_video::GroupOfPictures {
                         decode_start_time: decode_timestamp,
                         sample_range: sample_idx..(sample_idx + 1),
                     });

--- a/tests/python/video_ffmpeg/main.py
+++ b/tests/python/video_ffmpeg/main.py
@@ -12,7 +12,9 @@ def capture_webcam_h264() -> None:
     """Capture webcam and stream H.264 encoded video to Rerun with proper timing."""
 
     # Initialize Rerun
-    rr.init("rerun_example_webcam_h264_stream", spawn=True)
+    rr.init("rerun_example_webcam_h264_stream")
+    rr.spawn()
+    # rr.serve_web()
 
     # Target FPS for timing calculations
     target_fps = 30


### PR DESCRIPTION
### Related

* important piece of https://github.com/rerun-io/rerun/issues/7484

### What

In order to enable streaming on the web we have to extract a fully qualified codec descriptor string, as [specified by the webcodecs codec registry](https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry)

Doing so means that we have to even deeper inspect the video bistream and extract this information on-the-fly.
Setting the stage:
* for mp4, this information is readily available as part of the STDS box which in turn for HEVC/AVC contains the AVCC box
    * presence of AVCC box implies that the bitstream is in AVCC (also known as HVCC  for HEVC, but essentially the same) rather than Annex B
         * WebCodec can handle both, phew!
* we _already_ startd doing some inspection of the bitstream, namely we extract group-of-pictures (GOP)
    * for AVC/h264 every GOP starting sample (== `is_sync`) is required to contain an IDR frame AND an  Sequence Parameter Set (SPS)
    * SPS is sufficient for getting the codec string and has other juicy information we'd like to have around!

Therefore, this PR:
* ...further evolves `VideoDataDescription` to not be as little reliant on AVCC, splitting out the optional `VideoEncodingDetails` (Q: better name? it's not like we're encoding something, it's more like some loosy goose information on _what_ got encoded _how_)
* ...enhances GOP detection to produce `VideoEncodingDetails`
    * a side effect is that we have now more powerful parsing for  `VideoEncodingDetails` and have more things available more often \o/. Let's make use of that in to-be-added ui!
* ...resets decoders whenever `VideoEncodingDetails` changes
    * we regard changes to `VideoEncodingDetails` over time as a bug and will always use the latest found `VideoEncodingDetails`

All this causes some shuffling around. The fact that I changed namespaces a bit didn't help either, but the arbitrary split between `decode` and `demux` didn't age well. I'll clean this up further in a follow-up.

---

Sideffect, more information from MP4 with H.264:

Before:
![image](https://github.com/user-attachments/assets/bb689539-bfec-4e60-a104-72ad277c0324)

After:
![image](https://github.com/user-attachments/assets/5c57b229-3674-4d62-89dc-5da884e40cd3)

