### PR TITLE
Rerun py avoid duplicated recording streams

### DIFF
--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -35,9 +35,9 @@ use re_sorbet::{
     ColumnSelector, ComponentColumnSelector, SorbetColumnDescriptors, TimeColumnSelector,
 };
 
+use super::utils::py_rerun_warn;
 use crate::catalog::to_py_err;
 use crate::{catalog::PyCatalogClient, utils::get_tokio_runtime};
-
 /// Register the `rerun.dataframe` module.
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySchema>()?;
@@ -55,16 +55,6 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(crate::dataframe::load_recording, m)?)?;
 
     Ok(())
-}
-
-fn py_rerun_warn(msg: &std::ffi::CStr) -> PyResult<()> {
-    Python::with_gil(|py| {
-        let warning_type = PyModule::import(py, "rerun")?
-            .getattr("error_utils")?
-            .getattr("RerunWarning")?;
-        PyErr::warn(py, &warning_type, msg, 0)?;
-        Ok(())
-    })
 }
 
 /// The descriptor of an index column.

--- a/rerun_py/src/utils.rs
+++ b/rerun_py/src/utils.rs
@@ -1,6 +1,6 @@
-use std::{future::Future, sync::OnceLock};
 use pyo3::{Python, prelude::*};
 use std::ffi::CString;
+use std::{future::Future, sync::OnceLock};
 use tokio::runtime::Runtime;
 
 /// Utility to get the Tokio Runtime from Python
@@ -34,7 +34,7 @@ pub fn py_rerun_warn(msg: &std::ffi::CStr) -> PyResult<()> {
     })
 }
 
-pub fn py_log_warn(msg: &str) -> PyResult<()>{
+pub fn py_log_warn(msg: &str) -> PyResult<()> {
     re_log::warn!(msg);
     let csmsg;
     let cmsg = match CString::new(msg) {

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -50,3 +50,14 @@ def test_expected_warnings() -> None:
         lambda: rr.log("world/image", rr.Pinhole(focal_length=3)),
         "Must provide one of principal_point, resolution, or width/height)",
     )
+    expect_warning(
+        _duplicated_recording,
+        "already exists, will ignore creation and return existing recording.",
+    )
+
+
+def _duplicated_recording() -> None:
+    """A special case of creating duplicated streams and logging information, it causes a hang, this test is for this case."""
+    application_id = "test_app_id"
+    rr.init(application_id)
+    rr.init(application_id)


### PR DESCRIPTION
### Related

* Closes #9948


### What

* The hang in the issue #9948 is caused when trying to insert duplicated recording, and since we don't need this behavior, just avoid inserting the new recording. The real reason for hang not known yet, but it's not replicated in PyTests.

* Moved the py_rerun_warn function from `rerun_py/src/dataframe.rs` to `rerun_py/src/utils.rs`  for readability.

* Added a new function that does both logging the warning using `re_log::warn` macro and `PyErr::warn` to detect the warning in python as using `re_log::warn` macro alone isn't enough to detect the warning in python, and using PyErr::warn doesn't log the warning as per your code convention. I suggest to use this function for other warnings in the python bridge

* Added a unit test for detecting the warning of duplicated recording stream. Unforntually the hanging behavior can't be replicated in PyTests, still not sure why.


