### PR TITLE
Add missing word in entity path docs page

### DIFF
--- a/docs/content/concepts/entity-path.md
+++ b/docs/content/concepts/entity-path.md
@@ -43,7 +43,7 @@ Each "part" of a path must be a non-empty string. Any character is allowed, but 
 Characters that need NOT be escaped are letters, numbers, and underscore, dash, and dot (`_`, `-`, `.`).
 Any other character should be escaped, including symbols (`\:`, `\$`, …) and whitespace (`\ `, `\n`, `\t`, …).
 
-You can an arbitrary unicode code point into an entity path using `\u{262E}`.
+You can insert an arbitrary unicode code point into an entity path using `\u{262E}`.
 
 So for instance, `world/3D/My\ Image.jpg/detection` is a valid path (note the escaped space!).
 


### PR DESCRIPTION
Noticed this while reading the docs. I'm not sure this verb is exactly right, feel free to change. Maybe it should be "escape"?