### PR TITLE
Tsaucer/bump tower http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,11 +990,10 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -1010,20 +1009,19 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -5032,9 +5030,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -6800,7 +6798,7 @@ dependencies = [
  "re_log",
  "serde",
  "thiserror 1.0.65",
- "tonic 0.12.3",
+ "tonic",
 ]
 
 [[package]]
@@ -7172,7 +7170,7 @@ dependencies = [
  "re_tuid",
  "tokio",
  "tokio-stream",
- "tonic 0.12.3",
+ "tonic",
  "wasm-bindgen-futures",
 ]
 
@@ -7316,9 +7314,9 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
- "tonic 0.12.3",
+ "tonic",
  "tonic-web-wasm-client",
- "tower 0.5.2",
+ "tower",
  "url",
  "wasm-bindgen-futures",
 ]
@@ -7347,7 +7345,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.12.3",
+ "tonic",
  "tonic-web",
  "tower-http",
 ]
@@ -7498,7 +7496,7 @@ dependencies = [
  "re_tuid",
  "serde",
  "thiserror 1.0.65",
- "tonic 0.12.3",
+ "tonic",
  "url",
 ]
 
@@ -7593,7 +7591,7 @@ dependencies = [
  "re_viewer_context",
  "serde",
  "thiserror 1.0.65",
- "tonic 0.12.3",
+ "tonic",
  "url",
 ]
 
@@ -8603,7 +8601,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8766,7 +8764,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
- "tonic 0.12.3",
+ "tonic",
  "url",
  "uuid",
 ]
@@ -9147,9 +9145,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.18"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
@@ -10167,12 +10165,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -10238,11 +10235,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -10258,31 +10254,11 @@ dependencies = [
  "pin-project",
  "prost",
  "rustls-native-certs",
- "rustls-pemfile",
  "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "percent-encoding",
- "pin-project",
- "tokio-stream",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10290,9 +10266,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -10314,7 +10290,7 @@ dependencies = [
  "http-body",
  "pin-project",
  "tokio-stream",
- "tonic 0.13.1",
+ "tonic",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10322,9 +10298,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5ca6e7bdd0042c440d36b6df97c1436f1d45871ce18298091f114004b1beb4"
+checksum = "66e3bb7acca55e6790354be650f4042d418fcf8e2bc42ac382348f2b6bf057e5"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -10336,33 +10312,13 @@ dependencies = [
  "httparse",
  "js-sys",
  "pin-project",
- "thiserror 1.0.65",
- "tonic 0.12.3",
+ "thiserror 2.0.7",
+ "tonic",
  "tower-service",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -10373,11 +10329,15 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.9.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6800,7 +6800,7 @@ dependencies = [
  "re_log",
  "serde",
  "thiserror 1.0.65",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -7172,7 +7172,7 @@ dependencies = [
  "re_tuid",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "wasm-bindgen-futures",
 ]
 
@@ -7316,7 +7316,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tonic-web-wasm-client",
  "tower 0.5.2",
  "url",
@@ -7347,7 +7347,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.12.3",
  "tonic-web",
  "tower-http",
 ]
@@ -7498,7 +7498,7 @@ dependencies = [
  "re_tuid",
  "serde",
  "thiserror 1.0.65",
- "tonic",
+ "tonic 0.12.3",
  "url",
 ]
 
@@ -7593,7 +7593,7 @@ dependencies = [
  "re_viewer_context",
  "serde",
  "thiserror 1.0.65",
- "tonic",
+ "tonic 0.12.3",
  "url",
 ]
 
@@ -8766,7 +8766,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "url",
  "uuid",
 ]
@@ -10270,6 +10270,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10285,19 +10304,17 @@ dependencies = [
 
 [[package]]
 name = "tonic-web"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+checksum = "774cad0f35370f81b6c59e3a1f5d0c3188bdb4a2a1b8b7f0921c860bfbd3aec6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
- "http-body-util",
  "pin-project",
  "tokio-stream",
- "tonic",
- "tower-http",
+ "tonic 0.13.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10320,7 +10337,7 @@ dependencies = [
  "js-sys",
  "pin-project",
  "thiserror 1.0.65",
- "tonic",
+ "tonic 0.12.3",
  "tower-service",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -10365,15 +10382,13 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
  "http",
- "http-body",
- "http-body-util",
  "pin-project-lite",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,10 +325,10 @@ tokio-util = { version = "0.7.12", default-features = false }
 toml = { version = "0.8.10", default-features = false }
 tonic = { version = "0.12.3", default-features = false }
 tonic-build = { version = "0.12.3", default-features = false }
-tonic-web = "0.12"
+tonic-web = "0.13"
 tonic-web-wasm-client = "0.6"
 tower = "0.5"
-tower-http = "0.5"
+tower-http = "0.6"
 tracing = { version = "0.1", default-features = false }
 type-map = "0.5"
 typenum = "1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,10 +323,10 @@ tokio = { version = "1.44.2", default-features = false }
 tokio-stream = "0.1.16"
 tokio-util = { version = "0.7.12", default-features = false }
 toml = { version = "0.8.10", default-features = false }
-tonic = { version = "0.12.3", default-features = false }
-tonic-build = { version = "0.12.3", default-features = false }
-tonic-web = "0.13"
-tonic-web-wasm-client = "0.6"
+tonic = { version = "0.13.1", default-features = false }
+tonic-build = { version = "0.13.1", default-features = false }
+tonic-web = "0.13.1"
+tonic-web-wasm-client = "0.7.1"
 tower = "0.5"
 tower-http = "0.6"
 tracing = { version = "0.1", default-features = false }

--- a/crates/store/re_grpc_client/Cargo.toml
+++ b/crates/store/re_grpc_client/Cargo.toml
@@ -45,7 +45,6 @@ url.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tonic = { workspace = true, default-features = false, features = [
   "transport",
-  "tls",
   "tls-native-roots",
 ] }
 

--- a/crates/store/re_grpc_client/src/connection_client.rs
+++ b/crates/store/re_grpc_client/src/connection_client.rs
@@ -54,7 +54,7 @@ impl<T> GenericConnectionClient<T> {
 
 impl<T> GenericConnectionClient<T>
 where
-    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T: tonic::client::GrpcService<tonic::body::Body>,
     T::Error: Into<StdError>,
     T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
     <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -159,7 +159,7 @@ pub(crate) async fn client(
     let auth = AuthDecorator::new(token);
 
     let middlewares = tower::ServiceBuilder::new()
-        .layer(tonic::service::interceptor::interceptor(auth))
+        .layer(tonic::service::interceptor::InterceptorLayer::new(auth))
         // TODO(cmc): figure out how we integrate redap_telemetry in mainline Rerun
         // .layer(redap_telemetry::new_grpc_tracing_layer())
         // .layer(redap_telemetry::TracingInjectorInterceptor::new_layer())
@@ -197,7 +197,7 @@ pub(crate) async fn client(
     let auth = AuthDecorator::new(token);
 
     let middlewares = tower::ServiceBuilder::new()
-        .layer(tonic::service::interceptor::interceptor(auth))
+        .layer(tonic::service::interceptor::InterceptorLayer::new(auth))
         // TODO(cmc): figure out how we integrate redap_telemetry in mainline Rerun
         // .layer(redap_telemetry::new_grpc_tracing_layer())
         // .layer(redap_telemetry::TracingInjectorInterceptor::new_layer())

--- a/crates/store/re_grpc_server/Cargo.toml
+++ b/crates/store/re_grpc_server/Cargo.toml
@@ -38,7 +38,7 @@ re_uri.workspace = true
 anyhow.workspace = true
 crossbeam.workspace = true
 parking_lot.workspace = true
-tonic = { workspace = true, default-features = false, features = ["transport"] }
+tonic = { workspace = true, default-features = false, features = ["transport", "router"] }
 tonic-web.workspace = true
 tower-http = { workspace = true, features = ["cors"] }
 

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -81,8 +81,7 @@ async fn serve_impl(
     shutdown: shutdown::Shutdown,
 ) -> anyhow::Result<()> {
     let tcp_listener = TcpListener::bind(addr).await?;
-    let incoming =
-        TcpIncoming::from_listener(tcp_listener, true, None).map_err(|err| anyhow::anyhow!(err))?;
+    let incoming = TcpIncoming::from(tcp_listener).with_nodelay(Some(true));
 
     let connect_addr = if addr.ip().is_loopback() || addr.ip().is_unspecified() {
         format!("rerun+http://127.0.0.1:{}/proxy", addr.port())

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
@@ -396,7 +396,7 @@ pub mod catalog_service_client {
     }
     impl<T> CatalogServiceClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -417,12 +417,12 @@ pub mod catalog_service_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
+                    http::Request<tonic::body::Body>,
                     Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                        <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                     >,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
                 Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             CatalogServiceClient::new(InterceptedService::new(inner, interceptor))
@@ -674,7 +674,7 @@ pub mod catalog_service_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -936,7 +936,7 @@ pub mod catalog_service_server {
                     Box::pin(fut)
                 }
                 _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
+                    let mut response = http::Response::new(tonic::body::Body::default());
                     let headers = response.headers_mut();
                     headers.insert(
                         tonic::Status::GRPC_STATUS,

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -309,7 +309,7 @@ pub mod frontend_service_client {
     }
     impl<T> FrontendServiceClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -330,12 +330,12 @@ pub mod frontend_service_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
+                    http::Request<tonic::body::Body>,
                     Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                        <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                     >,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
                 Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             FrontendServiceClient::new(InterceptedService::new(inner, interceptor))
@@ -1228,7 +1228,7 @@ pub mod frontend_service_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -2220,7 +2220,7 @@ pub mod frontend_service_server {
                     Box::pin(fut)
                 }
                 _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
+                    let mut response = http::Response::new(tonic::body::Body::default());
                     let headers = response.headers_mut();
                     headers.insert(
                         tonic::Status::GRPC_STATUS,

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -1030,7 +1030,7 @@ pub mod manifest_registry_service_client {
     }
     impl<T> ManifestRegistryServiceClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -1051,12 +1051,12 @@ pub mod manifest_registry_service_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
+                    http::Request<tonic::body::Body>,
                     Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                        <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                     >,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
                 Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ManifestRegistryServiceClient::new(InterceptedService::new(inner, interceptor))
@@ -1709,7 +1709,7 @@ pub mod manifest_registry_service_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -2390,7 +2390,7 @@ pub mod manifest_registry_service_server {
                     Box::pin(fut)
                 }
                 _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
+                    let mut response = http::Response::new(tonic::body::Body::default());
                     let headers = response.headers_mut();
                     headers.insert(
                         tonic::Status::GRPC_STATUS,

--- a/crates/store/re_protos/src/v1alpha1/rerun.redap_tasks.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.redap_tasks.v1alpha1.rs
@@ -180,7 +180,7 @@ pub mod tasks_service_client {
     }
     impl<T> TasksServiceClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -201,12 +201,12 @@ pub mod tasks_service_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
+                    http::Request<tonic::body::Body>,
                     Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                        <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                     >,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
                 Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             TasksServiceClient::new(InterceptedService::new(inner, interceptor))
@@ -438,7 +438,7 @@ pub mod tasks_service_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -614,7 +614,7 @@ pub mod tasks_service_server {
                     Box::pin(fut)
                 }
                 _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
+                    let mut response = http::Response::new(tonic::body::Body::default());
                     let headers = response.headers_mut();
                     headers.insert(
                         tonic::Status::GRPC_STATUS,

--- a/crates/store/re_protos/src/v1alpha1/rerun.sdk_comms.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.sdk_comms.v1alpha1.rs
@@ -137,7 +137,7 @@ pub mod message_proxy_service_client {
     }
     impl<T> MessageProxyServiceClient<T>
     where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T: tonic::client::GrpcService<tonic::body::Body>,
         T::Error: Into<StdError>,
         T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
         <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
@@ -158,12 +158,12 @@ pub mod message_proxy_service_client {
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
             T: tonic::codegen::Service<
-                    http::Request<tonic::body::BoxBody>,
+                    http::Request<tonic::body::Body>,
                     Response = http::Response<
-                        <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                        <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
                     >,
                 >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+            <T as tonic::codegen::Service<http::Request<tonic::body::Body>>>::Error:
                 Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MessageProxyServiceClient::new(InterceptedService::new(inner, interceptor))
@@ -396,7 +396,7 @@ pub mod message_proxy_service_server {
         B: Body + std::marker::Send + 'static,
         B::Error: Into<StdError> + std::marker::Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
+        type Response = http::Response<tonic::body::Body>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
         fn poll_ready(
@@ -579,7 +579,7 @@ pub mod message_proxy_service_server {
                     Box::pin(fut)
                 }
                 _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
+                    let mut response = http::Response::new(tonic::body::Body::default());
                     let headers = response.headers_mut();
                     headers.insert(
                         tonic::Status::GRPC_STATUS,

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,7 @@ skip-tree = [
   { name = "walkers" },   # TODO(#7876): suppress that when `walkers` is updated
   { name = "windows" },   # Latest sysinfo uses 0.57 max, latest wgpu uses 0.58. See also https://github.com/GuillaumeGomez/sysinfo/pull/1338.
   { name = "zbus" },      # Old version via rfd
+  { name = "rand" },      # DF and object store are on different versions
 ]
 
 [licenses]


### PR DESCRIPTION
This PR updates a few dependencies, `tonic` and `tower-http`. It requires regenerating the proto files.