### PR TITLE
Revert removal of `DecodeError::Chunk`

### DIFF
--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -82,6 +82,9 @@ pub enum DecodeError {
     #[error("Sorbet error: {0}")]
     SorbetError(#[from] re_sorbet::SorbetError),
 
+    #[error("Failed to read chunk: {0}")]
+    Chunk(#[from] re_chunk::ChunkError),
+
     #[error("Arrow error: {0}")]
     Arrow(#[from] arrow::error::ArrowError),
 


### PR DESCRIPTION
### Related

* https://github.com/rerun-io/rerun/pull/10173

### What

The removal of this variant led to breakage on the dataplatform side.
