### PR TITLE
Implement `FromIterator<SerializedComponentChunk>` for `ChunkComponents`

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -19,7 +19,7 @@ use re_log_types::{
 };
 use re_types_core::{
     ArchetypeName, ComponentDescriptor, ComponentName, DeserializationError, Loggable as _,
-    SerializationError,
+    SerializationError, SerializedComponentColumn,
 };
 
 use crate::{ChunkId, RowId};
@@ -138,6 +138,19 @@ impl FromIterator<(ComponentDescriptor, ArrowListArray)> for ChunkComponents {
         {
             for (component_desc, list_array) in iter {
                 this.insert(component_desc, list_array);
+            }
+        }
+        this
+    }
+}
+
+impl FromIterator<SerializedComponentColumn> for ChunkComponents {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = SerializedComponentColumn>>(iter: T) -> Self {
+        let mut this = Self::default();
+        {
+            for serialized in iter {
+                this.insert(serialized.descriptor, serialized.list_array);
             }
         }
         this

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -417,11 +417,7 @@ fn load_episode_video(
                 re_chunk::ChunkId::new(),
                 entity_path.into(),
                 std::iter::once((*timeline.name(), time_column)).collect(),
-                video_frame_reference_column
-                    .map(|serialized_column| {
-                        (serialized_column.descriptor, serialized_column.list_array)
-                    })
-                    .collect(),
+                video_frame_reference_column.collect(),
             )?)
         }
         Err(err) => {


### PR DESCRIPTION
### What

This implements `FromIterator<SerializedComponentChunk>` for `ChunkComponents`, to make constructing chunks using full columns easier.