### PR TITLE
Disable reading/writing timing metadata to/from encoded record batches

### DIFF
--- a/crates/store/re_log_encoding/src/codec/arrow.rs
+++ b/crates/store/re_log_encoding/src/codec/arrow.rs
@@ -3,12 +3,16 @@ use super::CodecError;
 use arrow::array::RecordBatch as ArrowRecordBatch;
 
 // Insert timestamp of when the IPC encoding and decoding took place?
+//
 // This is used for latency measurements, e.g. in gRPC calls.
 // It is slightly wasteful to add it to each chunk, even in an .rrd file,
 // but the benefit is that we'll always have them, whether we're streaming
 // data through gRPC, piping with stdout/stdin, or writing to a file that a viewer is simultaneously reading.
 // However, it messes up our roundtrip unit-tests, so we disable it then.
-const INSERT_TIMING_METADATA: bool = !cfg!(feature = "testing");
+//
+// TODO(emilk, andreas, cmc): This is disabled for now since it messes with our tests and
+// (worse) means that checksums of files become unstable on read _and_ write.
+const INSERT_TIMING_METADATA: bool = false; // !cfg!(feature = "testing");
 
 /// Helper function that serializes given arrow schema and record batch into bytes
 /// using Arrow IPC format.


### PR DESCRIPTION
### Related

* Fixes test regression introduced in https://github.com/rerun-io/rerun/pull/10173

### What

Related internal slack discussion
https://rerunio.slack.com/archives/C07T0LFT5BQ/p1749799544492489

* [x] pass full check ci

cc: @emilk 