### PR TITLE
Always enable `small_rng`, it's free

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,7 +280,7 @@ puffin_http = "0.16"
 pyo3 = "0.24.1"
 pyo3-build-config = "0.24.1"
 quote = "1.0"
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 rand_distr = { version = "0.4", default-features = false }
 rayon = "1.7"
 rexif = "0.7.5"


### PR DESCRIPTION
Main CI is failing because of lacking feature flags because of implicit feature flag intersection shenanigans like every single time.

TODO:
* [x] full-check