### PR TITLE
Provide descriptor-aware `AnyValues` example in snippets

### DIFF
--- a/docs/snippets/all/tutorials/any_values.cpp
+++ b/docs/snippets/all/tutorials/any_values.cpp
@@ -15,14 +15,23 @@ arrow::Status run_main() {
     arrow::DoubleBuilder confidences_builder;
     ARROW_RETURN_NOT_OK(confidences_builder.AppendValues({1.2, 3.4, 5.6}));
     ARROW_RETURN_NOT_OK(confidences_builder.Finish(&arrow_array));
-    auto confidences =
-        rerun::ComponentBatch::from_arrow_array(std::move(arrow_array), "confidence");
+    auto confidences = rerun::ComponentBatch::from_arrow_array(
+        std::move(arrow_array),
+        rerun::ComponentDescriptor("confidence")
+            .with_component_name(rerun::Loggable<rerun::components::Scalar>::ComponentName)
+    );
 
     arrow::StringBuilder description_builder;
     ARROW_RETURN_NOT_OK(description_builder.Append("Bla bla bla…"));
     ARROW_RETURN_NOT_OK(description_builder.Finish(&arrow_array));
-    auto description =
-        rerun::ComponentBatch::from_arrow_array(std::move(arrow_array), "description");
+    auto description = rerun::ComponentBatch::from_arrow_array(
+        std::move(arrow_array),
+        rerun::ComponentDescriptor("description")
+            .with_component_name(
+
+                rerun::Loggable<rerun::components::Text>::ComponentName
+            )
+    );
     // URIs will become clickable links
     arrow::StringBuilder homepage_builder;
     ARROW_RETURN_NOT_OK(homepage_builder.Append("https://www.rerun.io"));

--- a/docs/snippets/all/tutorials/any_values.py
+++ b/docs/snippets/all/tutorials/any_values.py
@@ -7,10 +7,14 @@ rr.init("rerun_example_any_values", spawn=True)
 rr.log(
     "any_values",
     rr.AnyValues(
-        confidence=[1.2, 3.4, 5.6],
-        description="Bla bla bla…",
         # URIs will become clickable links
         homepage="https://www.rerun.io",
         repository="https://github.com/rerun-io/rerun",
+    )
+    .with_field(
+        rr.ComponentDescriptor("confidence", component_name=rr.components.ScalarBatch._COMPONENT_NAME), [1.2, 3.4, 5.6]
+    )
+    .with_field(
+        rr.ComponentDescriptor("description", component_name=rr.components.TextBatch._COMPONENT_NAME), "Bla bla bla…"
     ),
 )

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 import pyarrow as pa
@@ -260,6 +260,13 @@ class AnyValues(AsComponents):
                 batch = AnyBatchValue(name, value, drop_untyped_nones=drop_untyped_nones)
                 if batch.is_valid():
                     self.component_batches.append(DescribedComponentBatch(batch, batch.descriptor))
+
+    def with_field(self, descriptor: str | ComponentDescriptor, value: Any, drop_untyped_nones: bool = True) -> Self:
+        """Adds an `AnyValueBatch` to this `AnyValues` bundle."""
+        batch = AnyBatchValue(descriptor, value, drop_untyped_nones=drop_untyped_nones)
+        if batch.is_valid():
+            self.component_batches.append(DescribedComponentBatch(batch, batch.descriptor))
+        return self
 
     def as_component_batches(self) -> list[DescribedComponentBatch]:
         return self.component_batches

--- a/tests/assets/rrd/snippets/tutorials/any_values.rrd
+++ b/tests/assets/rrd/snippets/tutorials/any_values.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02cc15ee33994478b3a1b66e14b7afab6b3dea58446d39c273936773f18ff29d
-size 3770
+oid sha256:6a394194add958a1fc32d4df07567852091f91bef3030b12c985de0658885feb
+size 3786


### PR DESCRIPTION
### Related

* Part of #6889.
* Part of #9340.

### What

Title. Also fixes CI.

> [!IMPORTANT]
> This changes our baseline `.rrd` file from the `any_values` snippet, to show more powerful tagged components.

### TODO

* [x] full-check