### PR TITLE
Remove usage of `unwrap()` in `re_sdk`

### DIFF
--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -10,8 +10,6 @@
 #![doc = document_features::document_features!()]
 //!
 
-// TODO(#6330): remove unwrap()
-#![allow(clippy::unwrap_used)]
 #![warn(missing_docs)] // Let's keep the this crate well-documented!
 
 // ----------------

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -1032,8 +1032,10 @@ impl RecordingStream {
             .flatten()
             .map_or(sink, |path| {
                 re_log::info!("Forcing FileSink because of env-var {ENV_FORCE_SAVE}={path:?}");
-                // `unwrap` is ok since this force sinks are only used in tests.
-                Box::new(crate::sink::FileSink::new(path).unwrap()) as Box<dyn LogSink>
+                Box::new(
+                    crate::sink::FileSink::new(path)
+                        .expect("Failed to create FileSink for forced test path"),
+                ) as Box<dyn LogSink>
             });
 
         let stream =

--- a/crates/top/re_sdk/src/spawn.rs
+++ b/crates/top/re_sdk/src/spawn.rs
@@ -77,12 +77,18 @@ impl Default for SpawnOptions {
 impl SpawnOptions {
     /// Resolves the final connect address value.
     pub fn connect_addr(&self) -> std::net::SocketAddr {
-        std::net::SocketAddr::new("127.0.0.1".parse().unwrap(), self.port)
+        std::net::SocketAddr::new(
+            "127.0.0.1".parse().expect("Failed to parse ip address"),
+            self.port,
+        )
     }
 
     /// Resolves the final listen address value.
     pub fn listen_addr(&self) -> std::net::SocketAddr {
-        std::net::SocketAddr::new("0.0.0.0".parse().unwrap(), self.port)
+        std::net::SocketAddr::new(
+            "0.0.0.0".parse().expect("Failed to parse ip address"),
+            self.port,
+        )
     }
 
     /// Resolves the final executable path.

--- a/crates/top/re_sdk/src/spawn.rs
+++ b/crates/top/re_sdk/src/spawn.rs
@@ -78,7 +78,7 @@ impl SpawnOptions {
     /// Resolves the final connect address value.
     pub fn connect_addr(&self) -> std::net::SocketAddr {
         std::net::SocketAddr::new(
-            "127.0.0.1".parse().expect("Failed to parse ip address"),
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)),
             self.port,
         )
     }
@@ -86,7 +86,7 @@ impl SpawnOptions {
     /// Resolves the final listen address value.
     pub fn listen_addr(&self) -> std::net::SocketAddr {
         std::net::SocketAddr::new(
-            "0.0.0.0".parse().expect("Failed to parse ip address"),
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
             self.port,
         )
     }


### PR DESCRIPTION
### Related

* Part of https://github.com/rerun-io/rerun/issues/6330

### What

- Remove allow directive & TODO comment from re_sdk/src/lib.rs
- Remove usage of `unwrap()` and replace with `expect()` and a descriptive message

`cargo clippy -p re_sdk` and `cargo build -p re_sdk` both pass with no warnings