### PR TITLE
Support loading ROS paths in URDF loader

### DIFF
--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -487,7 +487,7 @@ fn log_link(
 /// TODO(emilk): create a trait for this, so that one can use this URDF loader
 /// from e.g. a ROS-bag loader.
 #[cfg(target_arch = "wasm32")]
-fn load_ros_resource(root_dir: Option<&PathBuf>, resource_path: &str) -> anyhow::Result<Vec<u8>> {
+fn load_ros_resource(_root_dir: Option<&PathBuf>, resource_path: &str) -> anyhow::Result<Vec<u8>> {
     anyhow::bail!("Loading ROS resources is not supported in WebAssembly: {resource_path}");
 }
 


### PR DESCRIPTION
### Related

* Closes #10182 

### What

This attempts to resolve an absolute path to ROS resources by parsing the `package://` uri and using the available ROS environment variables.


Took a while to set up a ROS environment on my my mac, but managed to get it working, and besides the missing collada support (#5251), this resolves all `.stl` files correctly:
![2025-06-15_19-24-26@2x](https://github.com/user-attachments/assets/7bdc49b0-cf1f-4d1f-b76c-c1df98481dc6)
