### PR TITLE
Add `FillMode` to `Capsules3D`

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/capsules3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/capsules3d.fbs
@@ -51,20 +51,23 @@ table Capsules3D (
 
   // --- Optional ---
 
-  // TODO(#1361): Add fill_mode component, or whatever succeeds it in case a wireframe
-  // or other alternate rendering is wanted.
+  /// Optional radii for the lines used when the cylinder is rendered as a wireframe.
+  line_radii: [rerun.components.Radius] ("attr.rerun.component_optional", nullable, order: 3000);
+
+  /// Optionally choose whether the cylinders are drawn with lines or solid.
+  fill_mode: rerun.components.FillMode ("attr.rerun.component_optional", nullable, order: 3100);
 
   /// Optional text labels for the capsules, which will be located at their centers.
-  labels: [rerun.components.Text] ("attr.rerun.component_optional", nullable, order: 3100);
+  labels: [rerun.components.Text] ("attr.rerun.component_optional", nullable, order: 3200);
 
   /// Whether the text labels should be shown.
   ///
   /// If not set, labels will automatically appear when there is exactly one label for this entity
   /// or the number of instances on this entity is under a certain threshold.
-  show_labels: rerun.components.ShowLabels ("attr.rerun.component_optional", nullable, order: 3200);
+  show_labels: rerun.components.ShowLabels ("attr.rerun.component_optional", nullable, order: 3300);
 
   /// Optional class ID for the ellipsoids.
   ///
   /// The class ID provides colors and labels if not specified explicitly.
-  class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3300);
+  class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -104,6 +104,12 @@ pub struct Capsules3D {
     /// Optional colors for the capsules.
     pub colors: Option<SerializedComponentBatch>,
 
+    /// Optional radii for the lines used when the cylinder is rendered as a wireframe.
+    pub line_radii: Option<SerializedComponentBatch>,
+
+    /// Optionally choose whether the cylinders are drawn with lines or solid.
+    pub fill_mode: Option<SerializedComponentBatch>,
+
     /// Optional text labels for the capsules, which will be located at their centers.
     pub labels: Option<SerializedComponentBatch>,
 
@@ -192,6 +198,30 @@ impl Capsules3D {
         }
     }
 
+    /// Returns the [`ComponentDescriptor`] for [`Self::line_radii`].
+    ///
+    /// The corresponding component is [`crate::components::Radius`].
+    #[inline]
+    pub fn descriptor_line_radii() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: Some("rerun.components.Radius".into()),
+            archetype_field_name: "line_radii".into(),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::fill_mode`].
+    ///
+    /// The corresponding component is [`crate::components::FillMode`].
+    #[inline]
+    pub fn descriptor_fill_mode() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+            component_name: Some("rerun.components.FillMode".into()),
+            archetype_field_name: "fill_mode".into(),
+        }
+    }
+
     /// Returns the [`ComponentDescriptor`] for [`Self::labels`].
     ///
     /// The corresponding component is [`crate::components::Text`].
@@ -256,18 +286,20 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             Capsules3D::descriptor_rotation_axis_angles(),
             Capsules3D::descriptor_quaternions(),
+            Capsules3D::descriptor_line_radii(),
+            Capsules3D::descriptor_fill_mode(),
             Capsules3D::descriptor_labels(),
             Capsules3D::descriptor_show_labels(),
             Capsules3D::descriptor_class_ids(),
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 12usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             Capsules3D::descriptor_lengths(),
@@ -277,6 +309,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
             Capsules3D::descriptor_indicator(),
             Capsules3D::descriptor_rotation_axis_angles(),
             Capsules3D::descriptor_quaternions(),
+            Capsules3D::descriptor_line_radii(),
+            Capsules3D::descriptor_fill_mode(),
             Capsules3D::descriptor_labels(),
             Capsules3D::descriptor_show_labels(),
             Capsules3D::descriptor_class_ids(),
@@ -284,8 +318,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
     });
 
 impl Capsules3D {
-    /// The total number of components in the archetype: 2 required, 3 recommended, 5 optional
-    pub const NUM_COMPONENTS: usize = 10usize;
+    /// The total number of components in the archetype: 2 required, 3 recommended, 7 optional
+    pub const NUM_COMPONENTS: usize = 12usize;
 }
 
 /// Indicator component for the [`Capsules3D`] [`::re_types_core::Archetype`]
@@ -366,6 +400,16 @@ impl ::re_types_core::Archetype for Capsules3D {
         let colors = arrays_by_descr
             .get(&Self::descriptor_colors())
             .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_colors()));
+        let line_radii = arrays_by_descr
+            .get(&Self::descriptor_line_radii())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_line_radii())
+            });
+        let fill_mode = arrays_by_descr
+            .get(&Self::descriptor_fill_mode())
+            .map(|array| {
+                SerializedComponentBatch::new(array.clone(), Self::descriptor_fill_mode())
+            });
         let labels = arrays_by_descr
             .get(&Self::descriptor_labels())
             .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_labels()));
@@ -386,6 +430,8 @@ impl ::re_types_core::Archetype for Capsules3D {
             rotation_axis_angles,
             quaternions,
             colors,
+            line_radii,
+            fill_mode,
             labels,
             show_labels,
             class_ids,
@@ -405,6 +451,8 @@ impl ::re_types_core::AsComponents for Capsules3D {
             self.rotation_axis_angles.clone(),
             self.quaternions.clone(),
             self.colors.clone(),
+            self.line_radii.clone(),
+            self.fill_mode.clone(),
             self.labels.clone(),
             self.show_labels.clone(),
             self.class_ids.clone(),
@@ -431,6 +479,8 @@ impl Capsules3D {
             rotation_axis_angles: None,
             quaternions: None,
             colors: None,
+            line_radii: None,
+            fill_mode: None,
             labels: None,
             show_labels: None,
             class_ids: None,
@@ -471,6 +521,14 @@ impl Capsules3D {
             colors: Some(SerializedComponentBatch::new(
                 crate::components::Color::arrow_empty(),
                 Self::descriptor_colors(),
+            )),
+            line_radii: Some(SerializedComponentBatch::new(
+                crate::components::Radius::arrow_empty(),
+                Self::descriptor_line_radii(),
+            )),
+            fill_mode: Some(SerializedComponentBatch::new(
+                crate::components::FillMode::arrow_empty(),
+                Self::descriptor_fill_mode(),
             )),
             labels: Some(SerializedComponentBatch::new(
                 crate::components::Text::arrow_empty(),
@@ -524,6 +582,12 @@ impl Capsules3D {
             self.colors
                 .map(|colors| colors.partitioned(_lengths.clone()))
                 .transpose()?,
+            self.line_radii
+                .map(|line_radii| line_radii.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.fill_mode
+                .map(|fill_mode| fill_mode.partitioned(_lengths.clone()))
+                .transpose()?,
             self.labels
                 .map(|labels| labels.partitioned(_lengths.clone()))
                 .transpose()?,
@@ -556,6 +620,8 @@ impl Capsules3D {
         let len_rotation_axis_angles = self.rotation_axis_angles.as_ref().map(|b| b.array.len());
         let len_quaternions = self.quaternions.as_ref().map(|b| b.array.len());
         let len_colors = self.colors.as_ref().map(|b| b.array.len());
+        let len_line_radii = self.line_radii.as_ref().map(|b| b.array.len());
+        let len_fill_mode = self.fill_mode.as_ref().map(|b| b.array.len());
         let len_labels = self.labels.as_ref().map(|b| b.array.len());
         let len_show_labels = self.show_labels.as_ref().map(|b| b.array.len());
         let len_class_ids = self.class_ids.as_ref().map(|b| b.array.len());
@@ -566,6 +632,8 @@ impl Capsules3D {
             .or(len_rotation_axis_angles)
             .or(len_quaternions)
             .or(len_colors)
+            .or(len_line_radii)
+            .or(len_fill_mode)
             .or(len_labels)
             .or(len_show_labels)
             .or(len_class_ids)
@@ -644,6 +712,36 @@ impl Capsules3D {
         self
     }
 
+    /// Optional radii for the lines used when the cylinder is rendered as a wireframe.
+    #[inline]
+    pub fn with_line_radii(
+        mut self,
+        line_radii: impl IntoIterator<Item = impl Into<crate::components::Radius>>,
+    ) -> Self {
+        self.line_radii = try_serialize_field(Self::descriptor_line_radii(), line_radii);
+        self
+    }
+
+    /// Optionally choose whether the cylinders are drawn with lines or solid.
+    #[inline]
+    pub fn with_fill_mode(mut self, fill_mode: impl Into<crate::components::FillMode>) -> Self {
+        self.fill_mode = try_serialize_field(Self::descriptor_fill_mode(), [fill_mode]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::FillMode`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_fill_mode`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_fill_mode(
+        mut self,
+        fill_mode: impl IntoIterator<Item = impl Into<crate::components::FillMode>>,
+    ) -> Self {
+        self.fill_mode = try_serialize_field(Self::descriptor_fill_mode(), fill_mode);
+        self
+    }
+
     /// Optional text labels for the capsules, which will be located at their centers.
     #[inline]
     pub fn with_labels(
@@ -702,6 +800,8 @@ impl ::re_byte_size::SizeBytes for Capsules3D {
             + self.rotation_axis_angles.heap_size_bytes()
             + self.quaternions.heap_size_bytes()
             + self.colors.heap_size_bytes()
+            + self.line_radii.heap_size_bytes()
+            + self.fill_mode.heap_size_bytes()
             + self.labels.heap_size_bytes()
             + self.show_labels.heap_size_bytes()
             + self.class_ids.heap_size_bytes()

--- a/crates/store/re_types/src/reflection/mod.rs
+++ b/crates/store/re_types/src/reflection/mod.rs
@@ -1470,9 +1470,17 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     .into(), display_name : "Colors", component_name :
                     "rerun.components.Color".into(), docstring_md :
                     "Optional colors for the capsules.", is_required : false, },
-                    ArchetypeFieldReflection { name : "labels".into(), display_name :
-                    "Labels", component_name : "rerun.components.Text".into(),
+                    ArchetypeFieldReflection { name : "line_radii".into(), display_name :
+                    "Line radii", component_name : "rerun.components.Radius".into(),
                     docstring_md :
+                    "Optional radii for the lines used when the cylinder is rendered as a wireframe.",
+                    is_required : false, }, ArchetypeFieldReflection { name : "fill_mode"
+                    .into(), display_name : "Fill mode", component_name :
+                    "rerun.components.FillMode".into(), docstring_md :
+                    "Optionally choose whether the cylinders are drawn with lines or solid.",
+                    is_required : false, }, ArchetypeFieldReflection { name : "labels"
+                    .into(), display_name : "Labels", component_name :
+                    "rerun.components.Text".into(), docstring_md :
                     "Optional text labels for the capsules, which will be located at their centers.",
                     is_required : false, }, ArchetypeFieldReflection { name :
                     "show_labels".into(), display_name : "Show labels", component_name :

--- a/crates/viewer/re_view_spatial/src/proc_mesh.rs
+++ b/crates/viewer/re_view_spatial/src/proc_mesh.rs
@@ -66,7 +66,8 @@ pub enum ProcMeshKey {
         /// flat faces.
         subdivisions: usize,
 
-        /// If true, then when a wireframe mesh is generated
+        /// If true, wireframe meshes are generated with reduced complexity,
+        /// showing a minimal set of lines that outline the shape.
         axes_only: bool,
     },
 
@@ -78,7 +79,8 @@ pub enum ProcMeshKey {
         /// The cylinder is approximated as a mesh with (N + 1) × 4 flat faces.
         subdivisions: usize,
 
-        /// If true, then when a wireframe mesh is generated
+        /// If true, wireframe meshes are generated with reduced complexity,
+        /// showing a minimal set of lines that outline the shape.
         axes_only: bool,
     },
 }

--- a/crates/viewer/re_view_spatial/src/proc_mesh.rs
+++ b/crates/viewer/re_view_spatial/src/proc_mesh.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use glam::{Vec3, Vec3A, uvec3, vec3};
-use hexasphere::BaseShape;
+use hexasphere::{BaseShape, Subdivided};
 use itertools::Itertools as _;
 use ordered_float::NotNan;
 use smallvec::smallvec;
@@ -65,6 +65,9 @@ pub enum ProcMeshKey {
         /// The cylinder part of the capsule is approximated as a mesh with (N + 1) × 4
         /// flat faces.
         subdivisions: usize,
+
+        /// If true, then when a wireframe mesh is generated
+        axes_only: bool,
     },
 
     /// The cylinder always has radius 1. It should be scaled to obtain the desired radius.
@@ -74,6 +77,8 @@ pub enum ProcMeshKey {
         ///
         /// The cylinder is approximated as a mesh with (N + 1) × 4 flat faces.
         subdivisions: usize,
+
+        /// If true, then when a wireframe mesh is generated
         axes_only: bool,
     },
 }
@@ -93,6 +98,7 @@ impl ProcMeshKey {
             Self::Cube => macaw::BoundingBox::from_center_size(Vec3::splat(0.0), Vec3::splat(1.0)),
             Self::Capsule {
                 subdivisions: _,
+                axes_only: _,
                 length,
             } => macaw::BoundingBox::from_min_max(
                 Vec3::new(-1.0, -1.0, -1.0),
@@ -147,11 +153,6 @@ pub struct SolidMesh {
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 enum GenError {
-    /// The requested drawing primitive type (solid or wireframe) is not supported
-    /// for the given [`ProcMeshKey`],
-    #[error("creating a wireframe mesh is not supported")]
-    UnimplementedWireframe,
-
     /// Either the GPU mesh could not be allocated,
     /// or the generated mesh was not well-formed.
     #[error(transparent)]
@@ -181,16 +182,7 @@ impl WireframeCache {
 
                 re_log::trace!("Generating wireframe mesh {key:?}…");
 
-                match generate_wireframe(&key, render_ctx) {
-                    Ok(mesh) => Some(Arc::new(mesh)),
-                    Err(err) => {
-                        re_log::warn!(
-                            "Failed to generate mesh {key:?}: {}",
-                            re_error::format_ref(&err)
-                        );
-                        None
-                    }
-                }
+                Some(Arc::new(generate_wireframe(&key, render_ctx)))
             })
             .clone()
     }
@@ -209,10 +201,7 @@ impl Cache for WireframeCache {
 /// Generate a wireframe mesh without caching.
 ///
 /// Note: The unstructured error type here is used only for logging.
-fn generate_wireframe(
-    key: &ProcMeshKey,
-    render_ctx: &RenderContext,
-) -> Result<WireframeMesh, GenError> {
+fn generate_wireframe(key: &ProcMeshKey, render_ctx: &RenderContext) -> WireframeMesh {
     re_tracing::profile_function!();
 
     // In the future, render_ctx will be used to allocate GPU memory for the mesh.
@@ -297,13 +286,17 @@ fn generate_wireframe(
             }
         }
         ProcMeshKey::Capsule {
-            length: _,
-            subdivisions: _,
+            length,
+            subdivisions,
+            axes_only,
         } => {
-            // No visualizer asks for these yet, because they are unimplemented.
-            // Implementing them will require writing a new capsule wireframe algorithm
-            // that agrees with the solid algorithm.
-            return Err(GenError::UnimplementedWireframe);
+            let line_strips = capsule_wireframe_lines(length.into_inner(), subdivisions, axes_only);
+
+            WireframeMesh {
+                bbox: key.simple_bounding_box(),
+                vertex_count: line_strips.iter().map(|s| s.len()).sum(),
+                line_strips,
+            }
         }
         ProcMeshKey::Cylinder {
             subdivisions,
@@ -374,7 +367,84 @@ fn generate_wireframe(
         }
     };
 
-    Ok(mesh)
+    mesh
+}
+
+fn capsule_wireframe_lines(length: f32, subdiv: usize, axes_only: bool) -> Vec<Vec<Vec3>> {
+    let mut line_strips = Vec::new();
+
+    let n = ((subdiv + 1) * 4).max(3);
+    let delta = std::f32::consts::TAU / n as f32;
+
+    let z_top = length;
+    let z_bot = 0.0;
+
+    let mut top_loop = Vec::with_capacity(n + 1);
+    let mut bottom_loop = Vec::with_capacity(n + 1);
+    for i in 0..=n {
+        let theta = i as f32 * delta;
+
+        // add top/bottom rim points
+        top_loop.push(Vec3::new(theta.cos(), theta.sin(), z_top));
+        bottom_loop.push(Vec3::new(theta.cos(), theta.sin(), z_bot));
+    }
+
+    line_strips.push(top_loop);
+    line_strips.push(bottom_loop);
+
+    // side spokes
+    let num_spokes = if axes_only { 4 } else { n };
+    let delta_spoke = std::f32::consts::TAU / num_spokes as f32;
+    for i in 0..num_spokes {
+        let theta = i as f32 * delta_spoke;
+        let rim = Vec3::new(theta.cos(), theta.sin(), 0.0);
+        line_strips.push(vec![rim.with_z(z_bot), rim.with_z(z_top)]);
+    }
+
+    // add the hemispherical caps, by taking a sphere and chopping it in two
+    let sphere: Subdivided<(), OctahedronBase> = Subdivided::new(subdiv, |_| ());
+
+    // choose which edges to emit
+    let mut tmp = Vec::new();
+    let indices: Vec<u32> = if axes_only {
+        sphere.get_major_edges_line_indices(&mut tmp, 1, |v| v.push(0));
+        tmp
+    } else {
+        sphere.get_all_line_indices(1, |v| v.push(0))
+    };
+
+    // we split the sphere up into strips, each strip ends in point at index 0
+    // so we split the indices on index 0.
+    let pts = sphere.raw_points();
+    for strip in indices.split(|&i| i == 0) {
+        let mut prev_top: Option<Vec3> = None;
+        let mut prev_bottom: Option<Vec3> = None;
+
+        for &idx in strip {
+            let p = pts[idx as usize - 1];
+            let v_top = Vec3::new(p.x, p.y, p.z + z_top);
+            let v_bottom = Vec3::new(p.x, p.y, p.z);
+
+            if let Some(p0) = prev_top {
+                // connect previous top to this top
+                if p0.z >= z_top && v_top.z >= z_top {
+                    line_strips.push(vec![p0, v_top]);
+                }
+            }
+
+            if let Some(p0) = prev_bottom {
+                // connect previous bottom to this bottom
+                if p0.z <= z_bot && v_bottom.z <= z_bot {
+                    line_strips.push(vec![p0, v_bottom]);
+                }
+            }
+
+            prev_top = Some(v_top);
+            prev_bottom = Some(v_bottom);
+        }
+    }
+
+    line_strips
 }
 
 // ----------------------------------------------------------------------------
@@ -470,6 +540,7 @@ fn generate_solid(key: &ProcMeshKey, render_ctx: &RenderContext) -> Result<Solid
         ProcMeshKey::Capsule {
             length,
             subdivisions,
+            axes_only: _, // no effect on solid mesh
         } => {
             // Design note: there are two reasons why this uses `macaw` instead of `hexasphere`.
             //

--- a/docs/content/reference/types/archetypes/capsules3d.md
+++ b/docs/content/reference/types/archetypes/capsules3d.md
@@ -25,6 +25,8 @@ Orienting and placing capsules forms a separate transform that is applied prior 
 ### Optional
 * `rotation_axis_angles`: [`PoseRotationAxisAngle`](../components/pose_rotation_axis_angle.md)
 * `quaternions`: [`PoseRotationQuat`](../components/pose_rotation_quat.md)
+* `line_radii`: [`Radius`](../components/radius.md)
+* `fill_mode`: [`FillMode`](../components/fill_mode.md)
 * `labels`: [`Text`](../components/text.md)
 * `show_labels`: [`ShowLabels`](../components/show_labels.md)
 * `class_ids`: [`ClassId`](../components/class_id.md)

--- a/docs/content/reference/types/components/fill_mode.md
+++ b/docs/content/reference/types/components/fill_mode.md
@@ -42,5 +42,6 @@ uint8
 ## Used by
 
 * [`Boxes3D`](../archetypes/boxes3d.md)
+* [`Capsules3D`](../archetypes/capsules3d.md)
 * [`Cylinders3D`](../archetypes/cylinders3d.md?speculative-link)
 * [`Ellipsoids3D`](../archetypes/ellipsoids3d.md)

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.cpp
@@ -25,6 +25,12 @@ namespace rerun::archetypes {
                 .value_or_throw();
         archetype.colors =
             ComponentBatch::empty<rerun::components::Color>(Descriptor_colors).value_or_throw();
+        archetype.line_radii =
+            ComponentBatch::empty<rerun::components::Radius>(Descriptor_line_radii)
+                .value_or_throw();
+        archetype.fill_mode =
+            ComponentBatch::empty<rerun::components::FillMode>(Descriptor_fill_mode)
+                .value_or_throw();
         archetype.labels =
             ComponentBatch::empty<rerun::components::Text>(Descriptor_labels).value_or_throw();
         archetype.show_labels =
@@ -38,7 +44,7 @@ namespace rerun::archetypes {
 
     Collection<ComponentColumn> Capsules3D::columns(const Collection<uint32_t>& lengths_) {
         std::vector<ComponentColumn> columns;
-        columns.reserve(10);
+        columns.reserve(12);
         if (lengths.has_value()) {
             columns.push_back(lengths.value().partitioned(lengths_).value_or_throw());
         }
@@ -56,6 +62,12 @@ namespace rerun::archetypes {
         }
         if (colors.has_value()) {
             columns.push_back(colors.value().partitioned(lengths_).value_or_throw());
+        }
+        if (line_radii.has_value()) {
+            columns.push_back(line_radii.value().partitioned(lengths_).value_or_throw());
+        }
+        if (fill_mode.has_value()) {
+            columns.push_back(fill_mode.value().partitioned(lengths_).value_or_throw());
         }
         if (labels.has_value()) {
             columns.push_back(labels.value().partitioned(lengths_).value_or_throw());
@@ -92,6 +104,12 @@ namespace rerun::archetypes {
         if (colors.has_value()) {
             return columns(std::vector<uint32_t>(colors.value().length(), 1));
         }
+        if (line_radii.has_value()) {
+            return columns(std::vector<uint32_t>(line_radii.value().length(), 1));
+        }
+        if (fill_mode.has_value()) {
+            return columns(std::vector<uint32_t>(fill_mode.value().length(), 1));
+        }
         if (labels.has_value()) {
             return columns(std::vector<uint32_t>(labels.value().length(), 1));
         }
@@ -112,7 +130,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<ComponentBatch> cells;
-        cells.reserve(10);
+        cells.reserve(12);
 
         if (archetype.lengths.has_value()) {
             cells.push_back(archetype.lengths.value());
@@ -131,6 +149,12 @@ namespace rerun {
         }
         if (archetype.colors.has_value()) {
             cells.push_back(archetype.colors.value());
+        }
+        if (archetype.line_radii.has_value()) {
+            cells.push_back(archetype.line_radii.value());
+        }
+        if (archetype.fill_mode.has_value()) {
+            cells.push_back(archetype.fill_mode.value());
         }
         if (archetype.labels.has_value()) {
             cells.push_back(archetype.labels.value());

--- a/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/capsules3d.hpp
@@ -8,6 +8,7 @@
 #include "../component_column.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
+#include "../components/fill_mode.hpp"
 #include "../components/length.hpp"
 #include "../components/pose_rotation_axis_angle.hpp"
 #include "../components/pose_rotation_quat.hpp"
@@ -101,6 +102,12 @@ namespace rerun::archetypes {
         /// Optional colors for the capsules.
         std::optional<ComponentBatch> colors;
 
+        /// Optional radii for the lines used when the cylinder is rendered as a wireframe.
+        std::optional<ComponentBatch> line_radii;
+
+        /// Optionally choose whether the cylinders are drawn with lines or solid.
+        std::optional<ComponentBatch> fill_mode;
+
         /// Optional text labels for the capsules, which will be located at their centers.
         std::optional<ComponentBatch> labels;
 
@@ -150,6 +157,14 @@ namespace rerun::archetypes {
         /// `ComponentDescriptor` for the `colors` field.
         static constexpr auto Descriptor_colors = ComponentDescriptor(
             ArchetypeName, "colors", Loggable<rerun::components::Color>::ComponentName
+        );
+        /// `ComponentDescriptor` for the `line_radii` field.
+        static constexpr auto Descriptor_line_radii = ComponentDescriptor(
+            ArchetypeName, "line_radii", Loggable<rerun::components::Radius>::ComponentName
+        );
+        /// `ComponentDescriptor` for the `fill_mode` field.
+        static constexpr auto Descriptor_fill_mode = ComponentDescriptor(
+            ArchetypeName, "fill_mode", Loggable<rerun::components::FillMode>::ComponentName
         );
         /// `ComponentDescriptor` for the `labels` field.
         static constexpr auto Descriptor_labels = ComponentDescriptor(
@@ -260,6 +275,31 @@ namespace rerun::archetypes {
         /// Optional colors for the capsules.
         Capsules3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// Optional radii for the lines used when the cylinder is rendered as a wireframe.
+        Capsules3D with_line_radii(const Collection<rerun::components::Radius>& _line_radii) && {
+            line_radii =
+                ComponentBatch::from_loggable(_line_radii, Descriptor_line_radii).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// Optionally choose whether the cylinders are drawn with lines or solid.
+        Capsules3D with_fill_mode(const rerun::components::FillMode& _fill_mode) && {
+            fill_mode =
+                ComponentBatch::from_loggable(_fill_mode, Descriptor_fill_mode).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `fill_mode` in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_fill_mode` should
+        /// be used when logging a single row's worth of data.
+        Capsules3D with_many_fill_mode(const Collection<rerun::components::FillMode>& _fill_mode
+        ) && {
+            fill_mode =
+                ComponentBatch::from_loggable(_fill_mode, Descriptor_fill_mode).value_or_throw();
             return std::move(*this);
         }
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d.py
@@ -93,6 +93,8 @@ class Capsules3D(Capsules3DExt, Archetype):
             rotation_axis_angles=None,
             quaternions=None,
             colors=None,
+            line_radii=None,
+            fill_mode=None,
             labels=None,
             show_labels=None,
             class_ids=None,
@@ -116,6 +118,8 @@ class Capsules3D(Capsules3DExt, Archetype):
         rotation_axis_angles: datatypes.RotationAxisAngleArrayLike | None = None,
         quaternions: datatypes.QuaternionArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
+        line_radii: datatypes.Float32ArrayLike | None = None,
+        fill_mode: components.FillModeLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
@@ -145,6 +149,10 @@ class Capsules3D(Capsules3DExt, Archetype):
             If no rotation is specified, the capsules align with the +Z axis of the local coordinate system.
         colors:
             Optional colors for the capsules.
+        line_radii:
+            Optional radii for the lines used when the cylinder is rendered as a wireframe.
+        fill_mode:
+            Optionally choose whether the cylinders are drawn with lines or solid.
         labels:
             Optional text labels for the capsules, which will be located at their centers.
         show_labels:
@@ -168,6 +176,8 @@ class Capsules3D(Capsules3DExt, Archetype):
                 "rotation_axis_angles": rotation_axis_angles,
                 "quaternions": quaternions,
                 "colors": colors,
+                "line_radii": line_radii,
+                "fill_mode": fill_mode,
                 "labels": labels,
                 "show_labels": show_labels,
                 "class_ids": class_ids,
@@ -197,6 +207,8 @@ class Capsules3D(Capsules3DExt, Archetype):
         rotation_axis_angles: datatypes.RotationAxisAngleArrayLike | None = None,
         quaternions: datatypes.QuaternionArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
+        line_radii: datatypes.Float32ArrayLike | None = None,
+        fill_mode: components.FillModeArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         show_labels: datatypes.BoolArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
@@ -229,6 +241,10 @@ class Capsules3D(Capsules3DExt, Archetype):
             If no rotation is specified, the capsules align with the +Z axis of the local coordinate system.
         colors:
             Optional colors for the capsules.
+        line_radii:
+            Optional radii for the lines used when the cylinder is rendered as a wireframe.
+        fill_mode:
+            Optionally choose whether the cylinders are drawn with lines or solid.
         labels:
             Optional text labels for the capsules, which will be located at their centers.
         show_labels:
@@ -252,6 +268,8 @@ class Capsules3D(Capsules3DExt, Archetype):
                 rotation_axis_angles=rotation_axis_angles,
                 quaternions=quaternions,
                 colors=colors,
+                line_radii=line_radii,
+                fill_mode=fill_mode,
                 labels=labels,
                 show_labels=show_labels,
                 class_ids=class_ids,
@@ -268,6 +286,8 @@ class Capsules3D(Capsules3DExt, Archetype):
             "rotation_axis_angles": rotation_axis_angles,
             "quaternions": quaternions,
             "colors": colors,
+            "line_radii": line_radii,
+            "fill_mode": fill_mode,
             "labels": labels,
             "show_labels": show_labels,
             "class_ids": class_ids,
@@ -359,6 +379,24 @@ class Capsules3D(Capsules3DExt, Archetype):
         converter=components.ColorBatch._converter,  # type: ignore[misc]
     )
     # Optional colors for the capsules.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    line_radii: components.RadiusBatch | None = field(
+        metadata={"component": True},
+        default=None,
+        converter=components.RadiusBatch._converter,  # type: ignore[misc]
+    )
+    # Optional radii for the lines used when the cylinder is rendered as a wireframe.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    fill_mode: components.FillModeBatch | None = field(
+        metadata={"component": True},
+        default=None,
+        converter=components.FillModeBatch._converter,  # type: ignore[misc]
+    )
+    # Optionally choose whether the cylinders are drawn with lines or solid.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### Related

* Part of #1361
* Part of #8538 

### What

Adds the `FillMode` component to the `Capsules3D` archetype, now that we can duplicate the `Radius` component for `line_radii`