### PR TITLE
Add "deep inspection" selection ui for the new `VideoStream` archetype

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -12,7 +12,8 @@ use re_types::{
 use re_ui::{UiExt as _, design_tokens_of_visuals, list_item};
 use re_viewer_context::{
     ColormapWithRange, HoverHighlight, ImageInfo, ImageStatsCache, Item, UiLayout,
-    VideoStreamCache, ViewerContext, gpu_bridge::image_data_range_heuristic, video_time_from_query,
+    VideoStreamCache, ViewerContext, gpu_bridge::image_data_range_heuristic,
+    video_stream_time_from_query,
 };
 
 use crate::{
@@ -613,7 +614,7 @@ fn preview_if_video_stream_ui(
     video_stream_result_ui(ui, ui_layout, &video_stream_result);
     if let Ok(video) = video_stream_result {
         let video = video.read();
-        let time = video_time_from_query(query);
+        let time = video_stream_time_from_query(query);
         let buffers = video.sample_buffers();
         show_decoded_frame_info(ctx, ui, ui_layout, &video.video_renderer, time, &buffers);
     }

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -11,11 +11,15 @@ use re_types::{
 };
 use re_ui::{UiExt as _, design_tokens_of_visuals, list_item};
 use re_viewer_context::{
-    ColormapWithRange, HoverHighlight, ImageInfo, ImageStatsCache, Item, UiLayout, ViewerContext,
-    gpu_bridge::image_data_range_heuristic,
+    ColormapWithRange, HoverHighlight, ImageInfo, ImageStatsCache, Item, UiLayout,
+    VideoStreamCache, ViewerContext, gpu_bridge::image_data_range_heuristic, video_time_from_query,
 };
 
-use crate::{blob::blob_preview_and_save_ui, image::image_preview_ui};
+use crate::{
+    blob::blob_preview_and_save_ui,
+    image::image_preview_ui,
+    video::{show_decoded_frame_info, video_stream_result_ui},
+};
 
 use super::DataUi;
 
@@ -152,8 +156,10 @@ impl DataUi for InstancePath {
                 .flatten()
                 .cloned()
                 .collect::<Vec<_>>();
+
             preview_if_image_ui(ctx, ui, ui_layout, query, entity_path, &components);
             preview_if_blob_ui(ctx, ui, ui_layout, query, entity_path, &components);
+            preview_if_video_stream_ui(ctx, ui, ui_layout, query, entity_path, &components);
         }
     }
 }
@@ -579,6 +585,38 @@ fn preview_single_blob(
     );
 
     Some(())
+}
+
+fn preview_if_video_stream_ui(
+    ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    ui_layout: UiLayout,
+    query: &re_chunk_store::LatestAtQuery,
+    entity_path: &re_log_types::EntityPath,
+    components: &[(ComponentDescriptor, UnitChunkShared)],
+) {
+    if components
+        .iter()
+        .all(|(descr, _chunk)| descr != &archetypes::VideoStream::descriptor_sample())
+    {
+        return;
+    }
+
+    let video_stream_result = ctx.store_context.caches.entry(|c: &mut VideoStreamCache| {
+        c.entry(
+            ctx.recording(),
+            entity_path,
+            query.timeline(),
+            ctx.app_options().video_decoder_settings(),
+        )
+    });
+    video_stream_result_ui(ui, ui_layout, &video_stream_result);
+    if let Ok(video) = video_stream_result {
+        let video = video.read();
+        let time = video_time_from_query(query);
+        let buffers = video.sample_buffers();
+        show_decoded_frame_info(ctx, ui, ui_layout, &video.video_renderer, time, &buffers);
+    }
 }
 
 /// Finds and deserializes the given component type if its descriptor matches the given archetype name.

--- a/crates/viewer/re_view_spatial/src/visualizers/video/video_stream.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/video/video_stream.rs
@@ -7,7 +7,7 @@ use re_viewer_context::{
     IdentifiedViewSystem, MaybeVisualizableEntities, TypedComponentFallbackProvider,
     VideoStreamCache, ViewClass as _, ViewContext, ViewContextCollection, ViewQuery,
     ViewSystemExecutionError, VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo,
-    VisualizerSystem,
+    VisualizerSystem, video_time_from_query,
 };
 
 use crate::{
@@ -114,12 +114,6 @@ impl VisualizerSystem for VideoStreamVisualizer {
                 }
             };
 
-            // Video streams are handled like "infinite" videos both forward and backwards in time.
-            // Therefore, the "time in the video" is whatever time we have on the timeline right now.
-            // Video streams are always using the timeline directly for their timestamps,
-            // therefore, we can use the unaltered time for all timeline types.
-            let video_time = re_video::Time::new(query_context.query.at().as_i64());
-
             let frame_result = {
                 let video = video.read();
 
@@ -130,8 +124,8 @@ impl VisualizerSystem for VideoStreamVisualizer {
                 video.video_renderer.frame_at(
                     ctx.viewer_ctx.render_ctx(),
                     video_stream_id(entity_path, ctx.view_id, Self::identifier()),
-                    video_time,
-                    &video.sample_buffer_slices(),
+                    video_time_from_query(query_context.query),
+                    &video.sample_buffers(),
                 )
             };
 

--- a/crates/viewer/re_view_spatial/src/visualizers/video/video_stream.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/video/video_stream.rs
@@ -7,7 +7,7 @@ use re_viewer_context::{
     IdentifiedViewSystem, MaybeVisualizableEntities, TypedComponentFallbackProvider,
     VideoStreamCache, ViewClass as _, ViewContext, ViewContextCollection, ViewQuery,
     ViewSystemExecutionError, VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo,
-    VisualizerSystem, video_time_from_query,
+    VisualizerSystem, video_stream_time_from_query,
 };
 
 use crate::{
@@ -124,7 +124,7 @@ impl VisualizerSystem for VideoStreamVisualizer {
                 video.video_renderer.frame_at(
                     ctx.viewer_ctx.render_ctx(),
                     video_stream_id(entity_path, ctx.view_id, Self::identifier()),
-                    video_time_from_query(query_context.query),
+                    video_stream_time_from_query(query_context.query),
                     &video.sample_buffers(),
                 )
             };

--- a/crates/viewer/re_viewer_context/src/cache/mod.rs
+++ b/crates/viewer/re_viewer_context/src/cache/mod.rs
@@ -20,7 +20,9 @@ pub use image_decode_cache::ImageDecodeCache;
 pub use image_stats_cache::ImageStatsCache;
 pub use tensor_stats_cache::TensorStatsCache;
 pub use video_asset_cache::VideoAssetCache;
-pub use video_stream_cache::VideoStreamCache;
+pub use video_stream_cache::{
+    SharablePlayableVideoStream, VideoStreamCache, VideoStreamProcessingError,
+};
 
 // ----
 

--- a/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
@@ -42,13 +42,17 @@ pub struct PlayableVideoStream {
 }
 
 impl PlayableVideoStream {
-    pub fn sample_buffer_slices(&self) -> StableIndexDeque<&[u8]> {
+    pub fn sample_buffers(&self) -> StableIndexDeque<&[u8]> {
         StableIndexDeque::from_iter_with_offset(
             self.video_sample_buffers.min_index(),
             self.video_sample_buffers
                 .iter()
                 .map(|b| b.buffer.as_slice()),
         )
+    }
+
+    pub fn video_descr(&self) -> &re_video::VideoDataDescription {
+        self.video_renderer.data_descr()
     }
 }
 

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -43,8 +43,8 @@ pub use self::{
     async_runtime_handle::{AsyncRuntimeError, AsyncRuntimeHandle, WasmNotSend},
     blueprint_helpers::{blueprint_timeline, blueprint_timepoint_for_writes},
     cache::{
-        Cache, Caches, ImageDecodeCache, ImageStatsCache, TensorStatsCache, VideoAssetCache,
-        VideoStreamCache,
+        Cache, Caches, ImageDecodeCache, ImageStatsCache, SharablePlayableVideoStream,
+        TensorStatsCache, VideoAssetCache, VideoStreamCache, VideoStreamProcessingError,
     },
     collapsed_id::{CollapseItem, CollapseScope, CollapsedId},
     component_fallbacks::{
@@ -74,7 +74,7 @@ pub use self::{
     },
     undo::BlueprintUndoState,
     utils::{
-        auto_color_egui, auto_color_for_entity_path, level_to_rich_text,
+        auto_color_egui, auto_color_for_entity_path, level_to_rich_text, video_time_from_query,
         video_timestamp_component_to_video_time,
     },
     view::{

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -74,8 +74,8 @@ pub use self::{
     },
     undo::BlueprintUndoState,
     utils::{
-        auto_color_egui, auto_color_for_entity_path, level_to_rich_text, video_time_from_query,
-        video_timestamp_component_to_video_time,
+        auto_color_egui, auto_color_for_entity_path, level_to_rich_text,
+        video_stream_time_from_query, video_timestamp_component_to_video_time,
     },
     view::{
         DataBasedVisualizabilityFilter, DataResult, IdentifiedViewSystem,

--- a/crates/viewer/re_viewer_context/src/utils/mod.rs
+++ b/crates/viewer/re_viewer_context/src/utils/mod.rs
@@ -4,4 +4,4 @@ mod video;
 
 pub use color::{auto_color_egui, auto_color_for_entity_path};
 pub use text::level_to_rich_text;
-pub use video::{video_time_from_query, video_timestamp_component_to_video_time};
+pub use video::{video_stream_time_from_query, video_timestamp_component_to_video_time};

--- a/crates/viewer/re_viewer_context/src/utils/mod.rs
+++ b/crates/viewer/re_viewer_context/src/utils/mod.rs
@@ -4,4 +4,4 @@ mod video;
 
 pub use color::{auto_color_egui, auto_color_for_entity_path};
 pub use text::level_to_rich_text;
-pub use video::video_timestamp_component_to_video_time;
+pub use video::{video_time_from_query, video_timestamp_component_to_video_time};

--- a/crates/viewer/re_viewer_context/src/utils/video.rs
+++ b/crates/viewer/re_viewer_context/src/utils/video.rs
@@ -15,9 +15,11 @@ pub fn video_timestamp_component_to_video_time(
     }
 }
 
-pub fn video_time_from_query(query: &re_chunk_store::LatestAtQuery) -> re_video::Time {
-    // Video streams are handled like "infinite" videos both forward and backwards in time.
-    // Therefore, the "time in the video" is whatever time we have on the timeline right now.
+/// Extract video stream time from query time.
+///
+/// Video streams are handled like "infinite" videos both forward and backwards in time.
+/// Therefore, the "time in the video" is whatever time we have on the timeline right now.
+pub fn video_stream_time_from_query(query: &re_chunk_store::LatestAtQuery) -> re_video::Time {
     // Video streams are always using the timeline directly for their timestamps,
     // therefore, we can use the unaltered time for all timeline types.
     re_video::Time::new(query.at().as_i64())

--- a/crates/viewer/re_viewer_context/src/utils/video.rs
+++ b/crates/viewer/re_viewer_context/src/utils/video.rs
@@ -14,3 +14,11 @@ pub fn video_timestamp_component_to_video_time(
         re_video::Time((video_timestamp.0.0 as f64 * fps as f64) as i64)
     }
 }
+
+pub fn video_time_from_query(query: &re_chunk_store::LatestAtQuery) -> re_video::Time {
+    // Video streams are handled like "infinite" videos both forward and backwards in time.
+    // Therefore, the "time in the video" is whatever time we have on the timeline right now.
+    // Video streams are always using the timeline directly for their timestamps,
+    // therefore, we can use the unaltered time for all timeline types.
+    re_video::Time::new(query.at().as_i64())
+}


### PR DESCRIPTION
### Related

* part of #7484

### What

Adds UI for `VideoStream`, sharing almost all its code with `VideoAsset` & `VideoFrameReference` :)
![image](https://github.com/user-attachments/assets/f54e8050-0bc5-48c9-bbc2-2b2bb6c94ed6)

Note that video asset's properties are also collapsible now:
![image](https://github.com/user-attachments/assets/8364d774-d175-4d0a-beab-baa36e35580b)

