### PR TITLE
Fix SDK's Redap TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8717,6 +8717,7 @@ dependencies = [
  "re_uri",
  "re_video",
  "re_web_viewer_server",
+ "rustls",
  "strum",
  "strum_macros",
  "thiserror 1.0.65",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,6 +292,7 @@ roxmltree = "0.19.0"
 rust-format = "0.3"
 rustdoc-json = "0.9.4"
 rustdoc-types = "0.35.0"
+rustls = { version = "0.23", default-features = false }
 seq-macro = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -85,6 +85,7 @@ pyo3 = { workspace = true, features = [
   "chrono",    #TODO(#9317): migrate to jiff when upgrading to pyo3 0.24
 ] }
 rand = { workspace = true, features = ["std", "std_rng"] }
+rustls = { workspace = true, features = ["ring"] }
 strum.workspace = true
 strum_macros.workspace = true
 uuid.workspace = true

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -35,6 +35,13 @@ impl PyCatalogClientInternal {
     #[new]
     #[pyo3(text_signature = "(self, addr, token=None)")]
     fn new(py: Python<'_>, addr: String, token: Option<String>) -> PyResult<Self> {
+        // NOTE: The entire TLS stack expects this global variable to be set. It doesn't matter
+        // what we set it to. But we have to set it, or we will crash at runtime, as soon as
+        // anything tries to do anything TLS-related.
+        // This used to be implicitly done by `object_store`, just by virtue of depending on it,
+        // but we removed that unused dependency, so now we must do it ourselves.
+        _ = rustls::crypto::ring::default_provider().install_default();
+
         let origin = addr.as_str().parse::<re_uri::Origin>().map_err(to_py_err)?;
 
         let connection_registry = re_grpc_client::ConnectionRegistry::new();


### PR DESCRIPTION
* https://github.com/rerun-io/rerun/pull/10237 broke the client because `object_store` was implicitly setting the global TLS var...