### PR TITLE
Link to `Asset3D` in raw_mesh example

### DIFF
--- a/examples/python/raw_mesh/README.md
+++ b/examples/python/raw_mesh/README.md
@@ -8,6 +8,11 @@ channel = "release"
 
 Demonstrates logging of raw 3D mesh data (so-called "triangle soups") with simple material properties and their transform hierarchy.
 
+Note that while this example loads GLTF meshes to illustrate [`Mesh3D`](https://rerun.io/docs/reference/types/archetypes/mesh3d)'s abilitites, you can also send various kinds of mesh assets
+directly via [`Asset3D`](https://rerun.io/docs/reference/types/archetypes/asset3d).
+
+<!-- TODO(#1957): How about we load something elseto avoid confusion? -->
+
 <picture data-inline-viewer="examples/raw_mesh">
   <img src="https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/full.png" alt="">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/480w.png">

--- a/examples/python/raw_mesh/raw_mesh/__main__.py
+++ b/examples/python/raw_mesh/raw_mesh/__main__.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Shows how to use the Rerun SDK to log raw 3D meshes (so-called "triangle soups") and their transform hierarchy."""
+"""
+Shows how to use the Rerun SDK to log raw 3D meshes (so-called "triangle soups") and their transform hierarchy.
+
+Note that while this example loads GLTF meshes to illustrate
+[`Mesh3D`](https://rerun.io/docs/reference/types/archetypes/mesh3d)'s abilitites,
+you can also send various kinds of mesh assets directly via
+[`Asset3D`](https://rerun.io/docs/reference/types/archetypes/asset3d).
+"""
 
 from __future__ import annotations
 

--- a/examples/rust/raw_mesh/README.md
+++ b/examples/rust/raw_mesh/README.md
@@ -6,6 +6,11 @@ thumbnail_dimensions = [480, 480]
 
 This example demonstrates how to use the Rerun SDK to log raw 3D meshes (so-called "triangle soups") and their transform hierarchy. Simple material properties are supported.
 
+Note that while this example loads GLTF meshes to illustrate [`Mesh3D`](https://rerun.io/docs/reference/types/archetypes/mesh3d)'s abilitites, you can also send various kinds of mesh assets
+directly via [`Asset3D`](https://rerun.io/docs/reference/types/archetypes/asset3d).
+
+<!-- TODO(#1957): How about we load something elseto avoid confusion? -->
+
 <picture>
   <img src="https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/full.png" alt="">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/raw_mesh/d5d008b9f1b53753a86efe2580443a9265070b77/480w.png">

--- a/examples/rust/raw_mesh/src/main.rs
+++ b/examples/rust/raw_mesh/src/main.rs
@@ -1,6 +1,11 @@
 //! This example demonstrates how to use the Rerun Rust SDK to log raw 3D meshes (so-called
 //! "triangle soups") and their transform hierarchy.
 //!
+//! Note that while this example loads GLTF meshes to illustrate
+//! [`Mesh3D`](https://rerun.io/docs/reference/types/archetypes/mesh3d)'s abilitites,
+//! you can also send various kinds of mesh assets
+//! directly via [`Asset3D`](https://rerun.io/docs/reference/types/archetypes/asset3d).
+//!
 //! Usage:
 //! ```
 //! cargo run -p raw_mesh <path_to_gltf_scene>


### PR DESCRIPTION
### Related

* part of https://github.com/rerun-io/rerun/issues/1957

### What

overdue missing link
