### PR TITLE
Don't fetch gh-pages in benches

### DIFF
--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -166,6 +166,7 @@ jobs:
           # Don't push to gh-pages
           save-data-file: false
           auto-push: false
+          skip-fetch-gh-pages: true
 
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -188,6 +188,7 @@ jobs:
           # Don't push to gh-pages
           save-data-file: false
           auto-push: false
+          skip-fetch-gh-pages: true
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:


### PR DESCRIPTION
We push benches to https://build.rerun.io, but the jobs still attempt to fetch it due to a default configuration value. The `gh-pages` branch no longer exists, so not fetching it should solve that problem