### PR TITLE
Remove perf regression alerts

### DIFF
--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -148,26 +148,6 @@ jobs:
           destination: "rerun-builds/benches/"
           process_gcloudignore: false
 
-      - name: Alert on regression
-        # https://github.com/benchmark-action/github-action-benchmark
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Rust Benchmark
-          tool: "cargo"
-          output-file-path: /tmp/${{ env.SHORT_SHA }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-          # Show alert with commit comment on detecting possible performance regression
-          comment-on-alert: true
-          alert-threshold: "125%"
-          fail-on-alert: false
-          comment-always: false # Generates too much GitHub notification spam
-
-          # Don't push to gh-pages
-          save-data-file: false
-          auto-push: false
-          skip-fetch-gh-pages: true
-
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -169,27 +169,6 @@ jobs:
 
             ${{ steps.measure.outputs.comparison }}
 
-      - name: Alert on regression
-        if: github.ref == 'refs/heads/main'
-        # https://github.com/benchmark-action/github-action-benchmark
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Sizes
-          tool: customSmallerIsBetter
-          output-file-path: /tmp/data.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-          # Show alert with commit on detecting possible size regression
-          comment-on-alert: true
-          alert-threshold: "110%"
-          fail-on-alert: false
-          comment-always: false # Generates too much GitHub notification spam
-
-          # Don't push to gh-pages
-          save-data-file: false
-          auto-push: false
-          skip-fetch-gh-pages: true
-
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
           pixi-version: v0.41.4


### PR DESCRIPTION
These things don't work if a `gh-pages` branch doesn't exist, and I don't want to keep an empty one around. A GH action should not need 10 different configuration options just to say "don't use git". We need a different solution for this.

Besides, I don't think I've actually seen a size/perf regression alert in any PR for a very long time. Typically the changes are so small that it won't show up, but the changes are still there. It's a lot more productive to monitor our graphs periodically:

https://build.rerun.io