### PR TITLE
minor: add __repr__ to two classes

### DIFF
--- a/rerun_py/rerun_sdk/rerun/catalog.py
+++ b/rerun_py/rerun_sdk/rerun/catalog.py
@@ -37,6 +37,9 @@ class CatalogClient:
 
         self._raw_client = CatalogClientInternal(address, token)
 
+    def __repr__(self) -> str:
+        return self._raw_client.__repr__()
+
     def all_entries(self) -> list[Entry]:
         """Returns a list of all entries in the catalog."""
         return self._raw_client.all_entries()

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -14,7 +14,6 @@ use crate::catalog::{
 /// Client for a remote Rerun catalog server.
 #[pyclass(name = "CatalogClientInternal")]
 pub struct PyCatalogClientInternal {
-    #[expect(dead_code)]
     origin: re_uri::Origin,
 
     connection: ConnectionHandle,
@@ -270,6 +269,10 @@ impl PyCatalogClientInternal {
                 "DataFusion context not available (the `datafusion` package may need to be installed)".to_owned(),
             ))
         }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("CatalogClient({})", self.origin)
     }
 
     // ---

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -168,6 +168,10 @@ impl PyEntry {
 
         connection.delete_entry(py, entry_id)
     }
+
+    fn __repr__(&self) -> String {
+        format!("Entry({:?}, '{}')", self.details.kind, self.details.name)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes https://github.com/rerun-io/dataplatform/issues/867

Minor quality of life improvement to add `__repr__` to two classes.