### PR TITLE
Fix:type hint for 3.8

### DIFF
--- a/rerun_py/rerun_bindings/types.py
+++ b/rerun_py/rerun_bindings/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal, Union, List
 
 import numpy as np
 import numpy.typing as npt
@@ -80,7 +80,7 @@ VectorDistanceMetricLike: TypeAlias = Union["VectorDistanceMetric", Literal["L2"
 A type alias for vector distance metrics.
 """
 
-VectorLike = Union[npt.NDArray[np.float64], list[float]]
+VectorLike = Union[npt.NDArray[np.float64], List[float]]
 """
 A type alias for vector-like objects.
 """


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What
Fix type hint in 3.8.
![image](https://github.com/user-attachments/assets/64fc764e-0bb5-47e6-890b-afc863f96515)

Enviroment: ubuntu 20.04   python 3.8.10
simple code for reproduce:
```
import rerun as rr
if __name__ == "__main__":
    rr.connect_grpc("localhost:9876")
```
<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
