### PR TITLE
Make `VideoStream::sample` optional so it's easy to log codec only once

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/video_stream.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/video_stream.fbs
@@ -17,6 +17,13 @@ table VideoStream (
 ) {
     // --- Required ---
 
+    /// The codec used to encode the video chunks.
+    ///
+    /// This property is expected to be constant over time and is ideally logged statically once per stream.
+    codec: rerun.components.VideoCodec ("attr.rerun.component_required", order: 1000);
+
+    // --- Recommended ---
+
     /// Video sample data (also known as "video chunk").
     ///
     /// The current timestamp is used as presentation timestamp (PTS) for all data in this sample.
@@ -34,12 +41,7 @@ table VideoStream (
     /// (this restriction may be relaxed in the future for some codecs).
     ///
     /// See [components.VideoCodec] for codec specific requirements.
-    sample: rerun.components.VideoSample ("attr.rerun.component_required", required, order: 1000);
-
-    /// The codec used to encode the video chunks.
-    ///
-    /// This property is expected to be constant over time and is ideally logged statically once per stream.
-    codec: rerun.components.VideoCodec ("attr.rerun.component_required", order: 1100);
+    sample: rerun.components.VideoSample ("attr.rerun.component_recommended", nullable, order: 2000);
 
     // --- Optional ---
 
@@ -49,5 +51,5 @@ table VideoStream (
     ///
     /// Objects with higher values are drawn on top of those with lower values.
     /// Defaults to `-15.0`.
-    draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 2100);
+    draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3000);
 }

--- a/crates/store/re_types/src/archetypes/video_stream.rs
+++ b/crates/store/re_types/src/archetypes/video_stream.rs
@@ -32,6 +32,11 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ⚠️ **This type is _unstable_ and may change significantly in a way that the data won't be backwards compatible.**
 #[derive(Clone, Debug, Default)]
 pub struct VideoStream {
+    /// The codec used to encode the video chunks.
+    ///
+    /// This property is expected to be constant over time and is ideally logged statically once per stream.
+    pub codec: Option<SerializedComponentBatch>,
+
     /// Video sample data (also known as "video chunk").
     ///
     /// The current timestamp is used as presentation timestamp (PTS) for all data in this sample.
@@ -50,11 +55,6 @@ pub struct VideoStream {
     /// See [`components::VideoCodec`][crate::components::VideoCodec] for codec specific requirements.
     pub sample: Option<SerializedComponentBatch>,
 
-    /// The codec used to encode the video chunks.
-    ///
-    /// This property is expected to be constant over time and is ideally logged statically once per stream.
-    pub codec: Option<SerializedComponentBatch>,
-
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
@@ -63,18 +63,6 @@ pub struct VideoStream {
 }
 
 impl VideoStream {
-    /// Returns the [`ComponentDescriptor`] for [`Self::sample`].
-    ///
-    /// The corresponding component is [`crate::components::VideoSample`].
-    #[inline]
-    pub fn descriptor_sample() -> ComponentDescriptor {
-        ComponentDescriptor {
-            archetype_name: Some("rerun.archetypes.VideoStream".into()),
-            component_name: Some("rerun.components.VideoSample".into()),
-            archetype_field_name: "sample".into(),
-        }
-    }
-
     /// Returns the [`ComponentDescriptor`] for [`Self::codec`].
     ///
     /// The corresponding component is [`crate::components::VideoCodec`].
@@ -84,6 +72,18 @@ impl VideoStream {
             archetype_name: Some("rerun.archetypes.VideoStream".into()),
             component_name: Some("rerun.components.VideoCodec".into()),
             archetype_field_name: "codec".into(),
+        }
+    }
+
+    /// Returns the [`ComponentDescriptor`] for [`Self::sample`].
+    ///
+    /// The corresponding component is [`crate::components::VideoSample`].
+    #[inline]
+    pub fn descriptor_sample() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.VideoStream".into()),
+            component_name: Some("rerun.components.VideoSample".into()),
+            archetype_field_name: "sample".into(),
         }
     }
 
@@ -110,16 +110,16 @@ impl VideoStream {
     }
 }
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| [VideoStream::descriptor_codec()]);
+
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             VideoStream::descriptor_sample(),
-            VideoStream::descriptor_codec(),
+            VideoStream::descriptor_indicator(),
         ]
     });
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
-    once_cell::sync::Lazy::new(|| [VideoStream::descriptor_indicator()]);
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| [VideoStream::descriptor_draw_order()]);
@@ -127,15 +127,15 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]>
 static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            VideoStream::descriptor_sample(),
             VideoStream::descriptor_codec(),
+            VideoStream::descriptor_sample(),
             VideoStream::descriptor_indicator(),
             VideoStream::descriptor_draw_order(),
         ]
     });
 
 impl VideoStream {
-    /// The total number of components in the archetype: 2 required, 1 recommended, 1 optional
+    /// The total number of components in the archetype: 1 required, 2 recommended, 1 optional
     pub const NUM_COMPONENTS: usize = 4usize;
 }
 
@@ -190,20 +190,20 @@ impl ::re_types_core::Archetype for VideoStream {
         re_tracing::profile_function!();
         use ::re_types_core::{Loggable as _, ResultExt as _};
         let arrays_by_descr: ::nohash_hasher::IntMap<_, _> = arrow_data.into_iter().collect();
-        let sample = arrays_by_descr
-            .get(&Self::descriptor_sample())
-            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_sample()));
         let codec = arrays_by_descr
             .get(&Self::descriptor_codec())
             .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_codec()));
+        let sample = arrays_by_descr
+            .get(&Self::descriptor_sample())
+            .map(|array| SerializedComponentBatch::new(array.clone(), Self::descriptor_sample()));
         let draw_order = arrays_by_descr
             .get(&Self::descriptor_draw_order())
             .map(|array| {
                 SerializedComponentBatch::new(array.clone(), Self::descriptor_draw_order())
             });
         Ok(Self {
-            sample,
             codec,
+            sample,
             draw_order,
         })
     }
@@ -215,8 +215,8 @@ impl ::re_types_core::AsComponents for VideoStream {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.sample.clone(),
             self.codec.clone(),
+            self.sample.clone(),
             self.draw_order.clone(),
         ]
         .into_iter()
@@ -230,13 +230,10 @@ impl ::re_types_core::ArchetypeReflectionMarker for VideoStream {}
 impl VideoStream {
     /// Create a new `VideoStream`.
     #[inline]
-    pub fn new(
-        sample: impl Into<crate::components::VideoSample>,
-        codec: impl Into<crate::components::VideoCodec>,
-    ) -> Self {
+    pub fn new(codec: impl Into<crate::components::VideoCodec>) -> Self {
         Self {
-            sample: try_serialize_field(Self::descriptor_sample(), [sample]),
             codec: try_serialize_field(Self::descriptor_codec(), [codec]),
+            sample: None,
             draw_order: None,
         }
     }
@@ -252,13 +249,13 @@ impl VideoStream {
     pub fn clear_fields() -> Self {
         use ::re_types_core::Loggable as _;
         Self {
-            sample: Some(SerializedComponentBatch::new(
-                crate::components::VideoSample::arrow_empty(),
-                Self::descriptor_sample(),
-            )),
             codec: Some(SerializedComponentBatch::new(
                 crate::components::VideoCodec::arrow_empty(),
                 Self::descriptor_codec(),
+            )),
+            sample: Some(SerializedComponentBatch::new(
+                crate::components::VideoSample::arrow_empty(),
+                Self::descriptor_sample(),
             )),
             draw_order: Some(SerializedComponentBatch::new(
                 crate::components::DrawOrder::arrow_empty(),
@@ -286,11 +283,11 @@ impl VideoStream {
         I: IntoIterator<Item = usize> + Clone,
     {
         let columns = [
-            self.sample
-                .map(|sample| sample.partitioned(_lengths.clone()))
-                .transpose()?,
             self.codec
                 .map(|codec| codec.partitioned(_lengths.clone()))
+                .transpose()?,
+            self.sample
+                .map(|sample| sample.partitioned(_lengths.clone()))
                 .transpose()?,
             self.draw_order
                 .map(|draw_order| draw_order.partitioned(_lengths.clone()))
@@ -312,15 +309,37 @@ impl VideoStream {
     pub fn columns_of_unit_batches(
         self,
     ) -> SerializationResult<impl Iterator<Item = ::re_types_core::SerializedComponentColumn>> {
-        let len_sample = self.sample.as_ref().map(|b| b.array.len());
         let len_codec = self.codec.as_ref().map(|b| b.array.len());
+        let len_sample = self.sample.as_ref().map(|b| b.array.len());
         let len_draw_order = self.draw_order.as_ref().map(|b| b.array.len());
         let len = None
-            .or(len_sample)
             .or(len_codec)
+            .or(len_sample)
             .or(len_draw_order)
             .unwrap_or(0);
         self.columns(std::iter::repeat(1).take(len))
+    }
+
+    /// The codec used to encode the video chunks.
+    ///
+    /// This property is expected to be constant over time and is ideally logged statically once per stream.
+    #[inline]
+    pub fn with_codec(mut self, codec: impl Into<crate::components::VideoCodec>) -> Self {
+        self.codec = try_serialize_field(Self::descriptor_codec(), [codec]);
+        self
+    }
+
+    /// This method makes it possible to pack multiple [`crate::components::VideoCodec`] in a single component batch.
+    ///
+    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_codec`] should
+    /// be used when logging a single row's worth of data.
+    #[inline]
+    pub fn with_many_codec(
+        mut self,
+        codec: impl IntoIterator<Item = impl Into<crate::components::VideoCodec>>,
+    ) -> Self {
+        self.codec = try_serialize_field(Self::descriptor_codec(), codec);
+        self
     }
 
     /// Video sample data (also known as "video chunk").
@@ -358,28 +377,6 @@ impl VideoStream {
         self
     }
 
-    /// The codec used to encode the video chunks.
-    ///
-    /// This property is expected to be constant over time and is ideally logged statically once per stream.
-    #[inline]
-    pub fn with_codec(mut self, codec: impl Into<crate::components::VideoCodec>) -> Self {
-        self.codec = try_serialize_field(Self::descriptor_codec(), [codec]);
-        self
-    }
-
-    /// This method makes it possible to pack multiple [`crate::components::VideoCodec`] in a single component batch.
-    ///
-    /// This only makes sense when used in conjunction with [`Self::columns`]. [`Self::with_codec`] should
-    /// be used when logging a single row's worth of data.
-    #[inline]
-    pub fn with_many_codec(
-        mut self,
-        codec: impl IntoIterator<Item = impl Into<crate::components::VideoCodec>>,
-    ) -> Self {
-        self.codec = try_serialize_field(Self::descriptor_codec(), codec);
-        self
-    }
-
     /// An optional floating point value that specifies the 2D drawing order.
     ///
     /// Objects with higher values are drawn on top of those with lower values.
@@ -407,8 +404,8 @@ impl VideoStream {
 impl ::re_byte_size::SizeBytes for VideoStream {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
-        self.sample.heap_size_bytes()
-            + self.codec.heap_size_bytes()
+        self.codec.heap_size_bytes()
+            + self.sample.heap_size_bytes()
             + self.draw_order.heap_size_bytes()
     }
 }

--- a/crates/store/re_types/src/reflection/mod.rs
+++ b/crates/store/re_types/src/reflection/mod.rs
@@ -2332,16 +2332,16 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                 scope: None,
                 view_types: &["Spatial2DView", "Spatial3DView"],
                 fields: vec![
-                    ArchetypeFieldReflection { name : "sample".into(), display_name :
-                    "Sample", component_name : "rerun.components.VideoSample".into(),
+                    ArchetypeFieldReflection { name : "codec".into(), display_name :
+                    "Codec", component_name : "rerun.components.VideoCodec".into(),
                     docstring_md :
-                    "Video sample data (also known as \"video chunk\").\n\nThe current timestamp is used as presentation timestamp (PTS) for all data in this sample.\nThere is currently no way to log differing decoding timestamps, meaning\nthat there is no support for B-frames.\nSee <https://github.com/rerun-io/rerun/issues/10090> for more details.\n\nUnlike any other data in Rerun, video samples are not allowed to be logged out of order,\nas this may break live video playback.\nI.e. any appended sample should have a timestamp greater than all previously logged samples.\n\nThe samples are expected to be encoded using the `codec` field.\nEach video sample must contain enough data for exactly one video frame\n(this restriction may be relaxed in the future for some codecs).\n\nSee [`components.VideoCodec`](https://rerun.io/docs/reference/types/components/video_codec?speculative-link) for codec specific requirements.",
-                    is_required : true, }, ArchetypeFieldReflection { name : "codec"
-                    .into(), display_name : "Codec", component_name :
-                    "rerun.components.VideoCodec".into(), docstring_md :
                     "The codec used to encode the video chunks.\n\nThis property is expected to be constant over time and is ideally logged statically once per stream.",
-                    is_required : true, }, ArchetypeFieldReflection { name : "draw_order"
-                    .into(), display_name : "Draw order", component_name :
+                    is_required : true, }, ArchetypeFieldReflection { name : "sample"
+                    .into(), display_name : "Sample", component_name :
+                    "rerun.components.VideoSample".into(), docstring_md :
+                    "Video sample data (also known as \"video chunk\").\n\nThe current timestamp is used as presentation timestamp (PTS) for all data in this sample.\nThere is currently no way to log differing decoding timestamps, meaning\nthat there is no support for B-frames.\nSee <https://github.com/rerun-io/rerun/issues/10090> for more details.\n\nUnlike any other data in Rerun, video samples are not allowed to be logged out of order,\nas this may break live video playback.\nI.e. any appended sample should have a timestamp greater than all previously logged samples.\n\nThe samples are expected to be encoded using the `codec` field.\nEach video sample must contain enough data for exactly one video frame\n(this restriction may be relaxed in the future for some codecs).\n\nSee [`components.VideoCodec`](https://rerun.io/docs/reference/types/components/video_codec?speculative-link) for codec specific requirements.",
+                    is_required : false, }, ArchetypeFieldReflection { name :
+                    "draw_order".into(), display_name : "Draw order", component_name :
                     "rerun.components.DrawOrder".into(), docstring_md :
                     "An optional floating point value that specifies the 2D drawing order.\n\nObjects with higher values are drawn on top of those with lower values.\nDefaults to `-15.0`.",
                     is_required : false, },

--- a/docs/content/reference/types/archetypes/video_stream.md
+++ b/docs/content/reference/types/archetypes/video_stream.md
@@ -16,8 +16,10 @@ TODO(#7484): Add snippet.
 
 ## Fields
 ### Required
-* `sample`: [`VideoSample`](../components/video_sample.md)
 * `codec`: [`VideoCodec`](../components/video_codec.md)
+
+### Recommended
+* `sample`: [`VideoSample`](../components/video_sample.md)
 
 ### Optional
 * `draw_order`: [`DrawOrder`](../components/draw_order.md)

--- a/rerun_cpp/src/rerun/archetypes/video_stream.cpp
+++ b/rerun_cpp/src/rerun/archetypes/video_stream.cpp
@@ -8,10 +8,10 @@
 namespace rerun::archetypes {
     VideoStream VideoStream::clear_fields() {
         auto archetype = VideoStream();
-        archetype.sample = ComponentBatch::empty<rerun::components::VideoSample>(Descriptor_sample)
-                               .value_or_throw();
         archetype.codec =
             ComponentBatch::empty<rerun::components::VideoCodec>(Descriptor_codec).value_or_throw();
+        archetype.sample = ComponentBatch::empty<rerun::components::VideoSample>(Descriptor_sample)
+                               .value_or_throw();
         archetype.draw_order =
             ComponentBatch::empty<rerun::components::DrawOrder>(Descriptor_draw_order)
                 .value_or_throw();
@@ -21,11 +21,11 @@ namespace rerun::archetypes {
     Collection<ComponentColumn> VideoStream::columns(const Collection<uint32_t>& lengths_) {
         std::vector<ComponentColumn> columns;
         columns.reserve(4);
-        if (sample.has_value()) {
-            columns.push_back(sample.value().partitioned(lengths_).value_or_throw());
-        }
         if (codec.has_value()) {
             columns.push_back(codec.value().partitioned(lengths_).value_or_throw());
+        }
+        if (sample.has_value()) {
+            columns.push_back(sample.value().partitioned(lengths_).value_or_throw());
         }
         if (draw_order.has_value()) {
             columns.push_back(draw_order.value().partitioned(lengths_).value_or_throw());
@@ -38,11 +38,11 @@ namespace rerun::archetypes {
     }
 
     Collection<ComponentColumn> VideoStream::columns() {
-        if (sample.has_value()) {
-            return columns(std::vector<uint32_t>(sample.value().length(), 1));
-        }
         if (codec.has_value()) {
             return columns(std::vector<uint32_t>(codec.value().length(), 1));
+        }
+        if (sample.has_value()) {
+            return columns(std::vector<uint32_t>(sample.value().length(), 1));
         }
         if (draw_order.has_value()) {
             return columns(std::vector<uint32_t>(draw_order.value().length(), 1));
@@ -60,11 +60,11 @@ namespace rerun {
         std::vector<ComponentBatch> cells;
         cells.reserve(4);
 
-        if (archetype.sample.has_value()) {
-            cells.push_back(archetype.sample.value());
-        }
         if (archetype.codec.has_value()) {
             cells.push_back(archetype.codec.value());
+        }
+        if (archetype.sample.has_value()) {
+            cells.push_back(archetype.sample.value());
         }
         if (archetype.draw_order.has_value()) {
             cells.push_back(archetype.draw_order.value());

--- a/rerun_cpp/src/rerun/archetypes/video_stream.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_stream.hpp
@@ -31,6 +31,11 @@ namespace rerun::archetypes {
     /// ⚠ **This type is _unstable_ and may change significantly in a way that the data won't be backwards compatible.**
     ///
     struct VideoStream {
+        /// The codec used to encode the video chunks.
+        ///
+        /// This property is expected to be constant over time and is ideally logged statically once per stream.
+        std::optional<ComponentBatch> codec;
+
         /// Video sample data (also known as "video chunk").
         ///
         /// The current timestamp is used as presentation timestamp (PTS) for all data in this sample.
@@ -49,11 +54,6 @@ namespace rerun::archetypes {
         /// See `components::VideoCodec` for codec specific requirements.
         std::optional<ComponentBatch> sample;
 
-        /// The codec used to encode the video chunks.
-        ///
-        /// This property is expected to be constant over time and is ideally logged statically once per stream.
-        std::optional<ComponentBatch> codec;
-
         /// An optional floating point value that specifies the 2D drawing order.
         ///
         /// Objects with higher values are drawn on top of those with lower values.
@@ -69,13 +69,13 @@ namespace rerun::archetypes {
         /// The name of the archetype as used in `ComponentDescriptor`s.
         static constexpr const char ArchetypeName[] = "rerun.archetypes.VideoStream";
 
-        /// `ComponentDescriptor` for the `sample` field.
-        static constexpr auto Descriptor_sample = ComponentDescriptor(
-            ArchetypeName, "sample", Loggable<rerun::components::VideoSample>::ComponentName
-        );
         /// `ComponentDescriptor` for the `codec` field.
         static constexpr auto Descriptor_codec = ComponentDescriptor(
             ArchetypeName, "codec", Loggable<rerun::components::VideoCodec>::ComponentName
+        );
+        /// `ComponentDescriptor` for the `sample` field.
+        static constexpr auto Descriptor_sample = ComponentDescriptor(
+            ArchetypeName, "sample", Loggable<rerun::components::VideoSample>::ComponentName
         );
         /// `ComponentDescriptor` for the `draw_order` field.
         static constexpr auto Descriptor_draw_order = ComponentDescriptor(
@@ -89,12 +89,8 @@ namespace rerun::archetypes {
         VideoStream& operator=(const VideoStream& other) = default;
         VideoStream& operator=(VideoStream&& other) = default;
 
-        explicit VideoStream(
-            rerun::components::VideoSample _sample, rerun::components::VideoCodec _codec
-        )
-            : sample(ComponentBatch::from_loggable(std::move(_sample), Descriptor_sample)
-                         .value_or_throw()),
-              codec(ComponentBatch::from_loggable(std::move(_codec), Descriptor_codec)
+        explicit VideoStream(rerun::components::VideoCodec _codec)
+            : codec(ComponentBatch::from_loggable(std::move(_codec), Descriptor_codec)
                         .value_or_throw()) {}
 
         /// Update only some specific fields of a `VideoStream`.
@@ -104,6 +100,23 @@ namespace rerun::archetypes {
 
         /// Clear all the fields of a `VideoStream`.
         static VideoStream clear_fields();
+
+        /// The codec used to encode the video chunks.
+        ///
+        /// This property is expected to be constant over time and is ideally logged statically once per stream.
+        VideoStream with_codec(const rerun::components::VideoCodec& _codec) && {
+            codec = ComponentBatch::from_loggable(_codec, Descriptor_codec).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `codec` in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_codec` should
+        /// be used when logging a single row's worth of data.
+        VideoStream with_many_codec(const Collection<rerun::components::VideoCodec>& _codec) && {
+            codec = ComponentBatch::from_loggable(_codec, Descriptor_codec).value_or_throw();
+            return std::move(*this);
+        }
 
         /// Video sample data (also known as "video chunk").
         ///
@@ -132,23 +145,6 @@ namespace rerun::archetypes {
         /// be used when logging a single row's worth of data.
         VideoStream with_many_sample(const Collection<rerun::components::VideoSample>& _sample) && {
             sample = ComponentBatch::from_loggable(_sample, Descriptor_sample).value_or_throw();
-            return std::move(*this);
-        }
-
-        /// The codec used to encode the video chunks.
-        ///
-        /// This property is expected to be constant over time and is ideally logged statically once per stream.
-        VideoStream with_codec(const rerun::components::VideoCodec& _codec) && {
-            codec = ComponentBatch::from_loggable(_codec, Descriptor_codec).value_or_throw();
-            return std::move(*this);
-        }
-
-        /// This method makes it possible to pack multiple `codec` in a single component batch.
-        ///
-        /// This only makes sense when used in conjunction with `columns`. `with_codec` should
-        /// be used when logging a single row's worth of data.
-        VideoStream with_many_codec(const Collection<rerun::components::VideoCodec>& _codec) && {
-            codec = ComponentBatch::from_loggable(_codec, Descriptor_codec).value_or_throw();
             return std::move(*this);
         }
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_stream.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_stream.py
@@ -39,9 +39,9 @@ class VideoStream(Archetype):
 
     def __init__(
         self: Any,
-        sample: datatypes.BlobLike,
         codec: components.VideoCodecLike,
         *,
+        sample: datatypes.BlobLike | None = None,
         draw_order: datatypes.Float32Like | None = None,
     ) -> None:
         """
@@ -49,6 +49,10 @@ class VideoStream(Archetype):
 
         Parameters
         ----------
+        codec:
+            The codec used to encode the video chunks.
+
+            This property is expected to be constant over time and is ideally logged statically once per stream.
         sample:
             Video sample data (also known as "video chunk").
 
@@ -66,10 +70,6 @@ class VideoStream(Archetype):
             (this restriction may be relaxed in the future for some codecs).
 
             See [`components.VideoCodec`][rerun.components.VideoCodec] for codec specific requirements.
-        codec:
-            The codec used to encode the video chunks.
-
-            This property is expected to be constant over time and is ideally logged statically once per stream.
         draw_order:
             An optional floating point value that specifies the 2D drawing order.
 
@@ -80,15 +80,15 @@ class VideoStream(Archetype):
 
         # You can define your own __init__ function as a member of VideoStreamExt in video_stream_ext.py
         with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(sample=sample, codec=codec, draw_order=draw_order)
+            self.__attrs_init__(codec=codec, sample=sample, draw_order=draw_order)
             return
         self.__attrs_clear__()
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""
         self.__attrs_init__(
-            sample=None,
             codec=None,
+            sample=None,
             draw_order=None,
         )
 
@@ -104,8 +104,8 @@ class VideoStream(Archetype):
         cls,
         *,
         clear_unset: bool = False,
-        sample: datatypes.BlobLike | None = None,
         codec: components.VideoCodecLike | None = None,
+        sample: datatypes.BlobLike | None = None,
         draw_order: datatypes.Float32Like | None = None,
     ) -> VideoStream:
         """
@@ -115,6 +115,10 @@ class VideoStream(Archetype):
         ----------
         clear_unset:
             If true, all unspecified fields will be explicitly cleared.
+        codec:
+            The codec used to encode the video chunks.
+
+            This property is expected to be constant over time and is ideally logged statically once per stream.
         sample:
             Video sample data (also known as "video chunk").
 
@@ -132,10 +136,6 @@ class VideoStream(Archetype):
             (this restriction may be relaxed in the future for some codecs).
 
             See [`components.VideoCodec`][rerun.components.VideoCodec] for codec specific requirements.
-        codec:
-            The codec used to encode the video chunks.
-
-            This property is expected to be constant over time and is ideally logged statically once per stream.
         draw_order:
             An optional floating point value that specifies the 2D drawing order.
 
@@ -147,8 +147,8 @@ class VideoStream(Archetype):
         inst = cls.__new__(cls)
         with catch_and_log_exceptions(context=cls.__name__):
             kwargs = {
-                "sample": sample,
                 "codec": codec,
+                "sample": sample,
                 "draw_order": draw_order,
             }
 
@@ -170,8 +170,8 @@ class VideoStream(Archetype):
     def columns(
         cls,
         *,
-        sample: datatypes.BlobArrayLike | None = None,
         codec: components.VideoCodecArrayLike | None = None,
+        sample: datatypes.BlobArrayLike | None = None,
         draw_order: datatypes.Float32ArrayLike | None = None,
     ) -> ComponentColumnList:
         """
@@ -184,6 +184,10 @@ class VideoStream(Archetype):
 
         Parameters
         ----------
+        codec:
+            The codec used to encode the video chunks.
+
+            This property is expected to be constant over time and is ideally logged statically once per stream.
         sample:
             Video sample data (also known as "video chunk").
 
@@ -201,10 +205,6 @@ class VideoStream(Archetype):
             (this restriction may be relaxed in the future for some codecs).
 
             See [`components.VideoCodec`][rerun.components.VideoCodec] for codec specific requirements.
-        codec:
-            The codec used to encode the video chunks.
-
-            This property is expected to be constant over time and is ideally logged statically once per stream.
         draw_order:
             An optional floating point value that specifies the 2D drawing order.
 
@@ -216,8 +216,8 @@ class VideoStream(Archetype):
         inst = cls.__new__(cls)
         with catch_and_log_exceptions(context=cls.__name__):
             inst.__attrs_init__(
-                sample=sample,
                 codec=codec,
+                sample=sample,
                 draw_order=draw_order,
             )
 
@@ -225,7 +225,7 @@ class VideoStream(Archetype):
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        kwargs = {"sample": sample, "codec": codec, "draw_order": draw_order}
+        kwargs = {"codec": codec, "sample": sample, "draw_order": draw_order}
         columns = []
 
         for batch in batches:
@@ -256,6 +256,17 @@ class VideoStream(Archetype):
         indicator_column = cls.indicator().partition(np.zeros(len(sizes)))
         return ComponentColumnList([indicator_column] + columns)
 
+    codec: components.VideoCodecBatch | None = field(
+        metadata={"component": True},
+        default=None,
+        converter=components.VideoCodecBatch._converter,  # type: ignore[misc]
+    )
+    # The codec used to encode the video chunks.
+    #
+    # This property is expected to be constant over time and is ideally logged statically once per stream.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
     sample: components.VideoSampleBatch | None = field(
         metadata={"component": True},
         default=None,
@@ -277,17 +288,6 @@ class VideoStream(Archetype):
     # (this restriction may be relaxed in the future for some codecs).
     #
     # See [`components.VideoCodec`][rerun.components.VideoCodec] for codec specific requirements.
-    #
-    # (Docstring intentionally commented out to hide this field from the docs)
-
-    codec: components.VideoCodecBatch | None = field(
-        metadata={"component": True},
-        default=None,
-        converter=components.VideoCodecBatch._converter,  # type: ignore[misc]
-    )
-    # The codec used to encode the video chunks.
-    #
-    # This property is expected to be constant over time and is ideally logged statically once per stream.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/tests/python/video_ffmpeg/main.py
+++ b/tests/python/video_ffmpeg/main.py
@@ -16,6 +16,9 @@ def capture_webcam_h264() -> None:
     rr.spawn()
     # rr.serve_web()
 
+    # Log the stream's codec once. It never changes to mark it as static.
+    rr.log("video_stream", rr.VideoStream(rr.components.VideoCodec.H264), static=True)
+
     # Target FPS for timing calculations
     target_fps = 30
     frame_duration = 1.0 / target_fps
@@ -135,9 +138,7 @@ def capture_webcam_h264() -> None:
                     # We have a complete frame, send it to Rerun
                     frame_time += frame_duration
                     rr.set_time("video_time", duration=frame_time)
-                    rr.log(
-                        "video_stream", rr.VideoStream(sample=current_frame_data, codec=rr.components.VideoCodec.H264)
-                    )
+                    rr.log("video_stream", rr.VideoStream.from_fields(sample=current_frame_data))
 
                     # Start new frame
                     current_frame_data = nal_data

--- a/tests/python/video_mcap/main.py
+++ b/tests/python/video_mcap/main.py
@@ -13,6 +13,7 @@ mcap_path = sys.argv[1]
 rr.init("rerun_example_mcap_video", spawn=True)
 rr.set_time("time", timestamp=0)
 
+rr.log("video_stream", rr.VideoStream(rr.components.VideoCodec.H264), static=True)
 
 with open(mcap_path, "rb") as f:
     reader = make_reader(f)
@@ -28,7 +29,7 @@ with open(mcap_path, "rb") as f:
             print(f"First 16 bytes: {' '.join(f'{b:02x}' for b in video_msg.data[:16])}")
 
             rr.set_time("time", timestamp=video_msg.timestamp.seconds + video_msg.timestamp.nanos / 1_000_000_000.0)
-            rr.log("video_stream", rr.VideoStream(sample=video_msg.data, codec=rr.components.VideoCodec.H264))
+            rr.log("video_stream", rr.VideoStream.from_fields(sample=video_msg.data))
 
             # Slowing down for debugging in-viewer chunk compaction.
             time.sleep(0.005)


### PR DESCRIPTION
### Related

* part of #7484

### What

found interface restrictions so far too limiting when doing proper examples