### PR TITLE
Max image dimension subscriber (used for heuristics) now fully supports `VideoStream`

### DIFF
--- a/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
@@ -2,21 +2,21 @@ use nohash_hasher::IntMap;
 use once_cell::sync::OnceCell;
 
 use re_chunk_store::{ChunkStore, ChunkStoreSubscriberHandle, PerStoreChunkSubscriber};
-use re_log_types::{EntityPath, StoreId};
+use re_log_types::{EntityPath, EntityPathHash, StoreId};
 use re_types::{
-    Archetype as _, Component as _, Loggable as _, archetypes,
-    components::{Blob, ImageFormat, MediaType},
+    Archetype as _, ArchetypeName, Component as _, Loggable as _, archetypes, components,
     external::image,
 };
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, Default)]
     pub struct ImageTypes: u8 {
-        const IMAGE = 0b0001;
-        const ENCODED_IMAGE = 0b0010;
-        const SEGMENTATION_IMAGE = 0b0100;
+        const IMAGE = 0b1;
+        const ENCODED_IMAGE = 0b10;
+        const SEGMENTATION_IMAGE = 0b100;
         const DEPTH_IMAGE = 0b1000;
-        const VIDEO = 0b10000;
+        const VIDEO_ASSET = 0b10000;
+        const VIDEO_STREAM = 0b100000;
     }
 }
 
@@ -31,6 +31,15 @@ pub struct MaxDimensions {
 #[derive(Default, Clone)]
 pub struct MaxImageDimensionsStoreSubscriber {
     max_dimensions: IntMap<EntityPath, MaxDimensions>,
+
+    /// Keep track of all known video codecs.
+    ///
+    /// This makes it easy to access this minimal piece of information
+    /// without doing a costly query which isn't possible inside of subscribers.
+    /// Video codec per entity is expected to never change, doing so is regarded as user error.
+    ///
+    /// Note that this could be a separate subscriber, but it wasn't necessary so far.
+    video_codecs: IntMap<EntityPathHash, components::VideoCodec>,
 }
 
 impl MaxImageDimensionsStoreSubscriber {
@@ -72,96 +81,129 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
                 continue;
             }
 
-            // Handle `Image`, `DepthImage`, `SegmentationImage`…
             let chunk = &event.diff.chunk;
             let components = chunk.components();
-            for image_format_list_array in components.get_by_component_name(ImageFormat::name()) {
-                for new_dim in image_format_list_array.iter().filter_map(|array| {
-                    array.and_then(|array| {
-                        let array = arrow::array::ArrayRef::from(array);
-                        ImageFormat::from_arrow(&array).ok()?.into_iter().next()
-                    })
-                }) {
-                    let max_dim = self
-                        .max_dimensions
-                        .entry(chunk.entity_path().clone())
-                        .or_default();
+            let entity_path = chunk.entity_path();
 
-                    max_dim.width = max_dim.width.max(new_dim.width);
-                    max_dim.height = max_dim.height.max(new_dim.height);
+            // Handle new video codecs first since we do a lookup on this later.
+            if components.contains_key(&archetypes::VideoStream::descriptor_codec()) {
+                for codec in chunk.iter_component::<components::VideoCodec>(
+                    &archetypes::VideoStream::descriptor_codec(),
+                ) {
+                    let Some(codec) = codec.first() else {
+                        continue;
+                    }; // Ignore both empty arrays and multiple codecs per row.
+                    if let Some(existing_codec) =
+                        self.video_codecs.insert(entity_path.hash(), *codec)
+                    {
+                        if existing_codec != *codec {
+                            re_log::warn!(
+                                "Overwriting existing video codec for entity path {:?} from {:?} to {:?}. Video codec per entity is expected to never change.",
+                                entity_path,
+                                existing_codec,
+                                codec,
+                            );
+                        }
+                    }
                 }
             }
 
-            if components.has_component_with_archetype_name(archetypes::Image::name()) {
-                self.max_dimensions
-                    .entry(chunk.entity_path().clone())
-                    .or_default()
-                    .image_types
-                    .insert(ImageTypes::IMAGE);
-            }
+            for (descr, list_array) in components.iter() {
+                let Some(archetype_name) = descr.archetype_name else {
+                    // Don't care about non-builtin types, therefore archetype name should be present.
+                    continue;
+                };
 
-            if components.has_component_with_archetype_name(archetypes::SegmentationImage::name()) {
-                self.max_dimensions
-                    .entry(chunk.entity_path().clone())
-                    .or_default()
-                    .image_types
-                    .insert(ImageTypes::SEGMENTATION_IMAGE);
-            }
-            if components.has_component_with_archetype_name(archetypes::DepthImage::name()) {
-                self.max_dimensions
-                    .entry(chunk.entity_path().clone())
-                    .or_default()
-                    .image_types
-                    .insert(ImageTypes::DEPTH_IMAGE);
-            }
-
-            // Handle `ImageEncoded`, `AssetVideo`…
-            for (blob_descr, _blob_list_array) in components
+                // First try to detect the type of image.
+                let Some(image_type) = [
+                    (archetypes::Image::name(), ImageTypes::IMAGE),
+                    (
+                        archetypes::SegmentationImage::name(),
+                        ImageTypes::SEGMENTATION_IMAGE,
+                    ),
+                    (archetypes::EncodedImage::name(), ImageTypes::ENCODED_IMAGE),
+                    (archetypes::DepthImage::name(), ImageTypes::DEPTH_IMAGE),
+                    (archetypes::AssetVideo::name(), ImageTypes::VIDEO_ASSET),
+                    (archetypes::VideoStream::name(), ImageTypes::VIDEO_STREAM),
+                ]
                 .iter()
-                .filter(|(descr, _)| descr.component_name == Some(Blob::name()))
-            {
-                let blobs = chunk.iter_slices::<&[u8]>(blob_descr.clone());
+                .find_map(|(image_archetype_name, image_type)| {
+                    (&archetype_name == image_archetype_name).then_some(*image_type)
+                }) else {
+                    // Early out if there's no image type detected.
+                    continue;
+                };
 
-                let media_type_descr = components.keys().find(|desc| {
-                    desc.component_name == Some(MediaType::name())
-                        && desc.archetype_name == blob_descr.archetype_name
-                });
-                let media_types = media_type_descr.map_or(Vec::new(), |media_type_descr| {
-                    chunk
-                        .iter_slices::<String>(media_type_descr.clone())
-                        .collect()
-                });
-                for (blob, media_type) in itertools::izip!(
-                    blobs,
-                    media_types
-                        .into_iter()
-                        .map(Some)
-                        .chain(std::iter::repeat(None))
-                ) {
-                    if let Some(blob) = blob.first() {
-                        let media_type =
-                            media_type.and_then(|v| v.first().map(|v| MediaType(v.clone().into())));
-                        let Some(media_type) = MediaType::or_guess_from_data(media_type, blob)
-                        else {
+                let max_dim = self.max_dimensions.entry(entity_path.clone()).or_default();
+                max_dim.image_types.insert(image_type);
+
+                // Size detection for various types of components.
+                if descr.component_name == Some(components::ImageFormat::name()) {
+                    for new_dim in list_array.iter().filter_map(|array| {
+                        array.and_then(|array| {
+                            let array = arrow::array::ArrayRef::from(array);
+                            components::ImageFormat::from_arrow(&array)
+                                .ok()?
+                                .into_iter()
+                                .next()
+                        })
+                    }) {
+                        max_dim.width = max_dim.width.max(new_dim.width);
+                        max_dim.height = max_dim.height.max(new_dim.height);
+                    }
+                } else if descr.component_name == Some(components::Blob::name()) {
+                    let blobs = chunk.iter_slices::<&[u8]>(descr.clone());
+
+                    // Is there a media type paired up with this blob?
+                    let media_type_descr = components.keys().find(|desc| {
+                        desc.component_name == Some(components::MediaType::name())
+                            && desc.archetype_name == descr.archetype_name
+                    });
+                    let media_types = media_type_descr.map_or(Vec::new(), |media_type_descr| {
+                        chunk
+                            .iter_slices::<String>(media_type_descr.clone())
+                            .collect()
+                    });
+                    for (blob, media_type) in itertools::izip!(
+                        blobs,
+                        media_types
+                            .into_iter()
+                            .map(Some)
+                            .chain(std::iter::repeat(None))
+                    ) {
+                        let Some(blob) = blob.first() else {
                             continue;
                         };
 
-                        if let Some([width, height]) =
-                            size_from_blob(blob, &media_type, chunk.entity_path())
-                        {
-                            let max_dim = self
-                                .max_dimensions
-                                .entry(chunk.entity_path().clone())
-                                .or_default();
+                        let media_type = media_type.and_then(|v| {
+                            v.first().map(|v| components::MediaType(v.clone().into()))
+                        });
+                        if let Some([width, height]) = try_size_from_blob(
+                            blob,
+                            media_type,
+                            archetype_name,
+                            &entity_path.to_string(),
+                        ) {
                             max_dim.width = max_dim.width.max(width);
                             max_dim.height = max_dim.height.max(height);
+                        }
+                    }
+                } else if descr.component_name == Some(components::VideoSample::name()) {
+                    let Some(video_codec) = self.video_codecs.get(&entity_path.hash()).copied()
+                    else {
+                        // Codec is typically logged earlier.
+                        continue;
+                    };
 
-                            // TODO(andreas): this should be part of the Blob component's tag instead.
-                            if media_type.is_image() {
-                                max_dim.image_types.insert(ImageTypes::ENCODED_IMAGE);
-                            } else if media_type.is_video() {
-                                max_dim.image_types.insert(ImageTypes::VIDEO);
-                            }
+                    for sample in chunk.iter_slices::<&[u8]>(descr.clone()) {
+                        let Some(sample) = sample.first() else {
+                            continue;
+                        };
+                        if let Some([width, height]) =
+                            try_size_from_video_stream_sample(sample, video_codec)
+                        {
+                            max_dim.width = max_dim.width.max(width);
+                            max_dim.height = max_dim.height.max(height);
                         }
                     }
                 }
@@ -170,39 +212,54 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
     }
 }
 
-fn size_from_blob(
+fn try_size_from_blob(
     blob: &[u8],
-    media_type: &MediaType,
-    entity_path: &EntityPath,
+    media_type: Option<components::MediaType>,
+    archetype_name: ArchetypeName,
+    debug_name: &str,
 ) -> Option<[u32; 2]> {
     re_tracing::profile_function!();
 
-    if media_type.is_image() {
+    if archetype_name == archetypes::EncodedImage::name() {
         re_tracing::profile_scope!("image");
 
-        let image_bytes = blob;
+        let media_type = components::MediaType::or_guess_from_data(media_type, blob);
+        let mut reader = image::ImageReader::new(std::io::Cursor::new(blob));
 
-        let mut reader = image::ImageReader::new(std::io::Cursor::new(image_bytes));
-
-        if let Some(format) = image::ImageFormat::from_mime_type(&media_type.0) {
+        if let Some(format) = media_type.and_then(|mt| image::ImageFormat::from_mime_type(&mt.0)) {
+            reader.set_format(format);
+        } else if let Ok(format) = image::guess_format(blob) {
+            // Weirdly enough, `reader.decode` doesn't do this for us.
             reader.set_format(format);
         }
 
-        if reader.format().is_none() {
-            if let Ok(format) = image::guess_format(image_bytes) {
-                // Weirdly enough, `reader.decode` doesn't do this for us.
-                reader.set_format(format);
-            }
-        }
-
         reader.into_dimensions().ok().map(|size| size.into())
-    } else if media_type.is_video() {
-        re_tracing::profile_scope!("video");
-        re_video::VideoDataDescription::load_from_bytes(blob, media_type, &entity_path.to_string())
+    } else if archetype_name == archetypes::AssetVideo::name() {
+        re_tracing::profile_scope!("video asset");
+
+        let media_type = components::MediaType::or_guess_from_data(media_type, blob)?;
+        re_video::VideoDataDescription::load_from_bytes(blob, media_type.as_str(), debug_name)
             .ok()
             .and_then(|video| video.encoding_details.map(|e| e.coded_dimensions))
             .map(|[w, h]| [w as _, h as _])
     } else {
         None
+    }
+}
+
+fn try_size_from_video_stream_sample(
+    sample: &[u8],
+    video_codec: components::VideoCodec,
+) -> Option<[u32; 2]> {
+    let codec = match video_codec {
+        components::VideoCodec::H264 => re_video::VideoCodec::H264,
+    };
+
+    match re_video::detect_gop_start(sample, codec).ok()? {
+        re_video::GopStartDetection::StartOfGop(descr) => Some([
+            descr.coded_dimensions[0] as _,
+            descr.coded_dimensions[1] as _,
+        ]),
+        re_video::GopStartDetection::NotStartOfGop => None,
     }
 }

--- a/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
@@ -98,7 +98,7 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
                     {
                         if existing_codec != *codec {
                             re_log::warn!(
-                                "Overwriting existing video codec for entity path {:?} from {:?} to {:?}. Video codec per entity is expected to never change.",
+                                "Changing video codec for entity path {:?} from {:?} to {:?}. This is unexpected, video codecs should remain constant per entity.",
                                 entity_path,
                                 existing_codec,
                                 codec,

--- a/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_view_spatial/src/max_image_dimension_subscriber.rs
@@ -125,6 +125,7 @@ impl PerStoreChunkSubscriber for MaxImageDimensionsStoreSubscriber {
                     (archetypes::DepthImage::name(), ImageTypes::DEPTH_IMAGE),
                     (archetypes::AssetVideo::name(), ImageTypes::VIDEO_ASSET),
                     (archetypes::VideoStream::name(), ImageTypes::VIDEO_STREAM),
+                    // TODO(#9046): handle encoded depth images.
                 ]
                 .iter()
                 .find_map(|(image_archetype_name, image_type)| {
@@ -220,6 +221,7 @@ fn try_size_from_blob(
 ) -> Option<[u32; 2]> {
     re_tracing::profile_function!();
 
+    // TODO(#9046): handle encoded depth images.
     if archetype_name == archetypes::EncodedImage::name() {
         re_tracing::profile_scope!("image");
 

--- a/crates/viewer/re_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_view_spatial/src/view_2d.rs
@@ -305,7 +305,8 @@ impl NonNestedImageCounts {
     fn increment_count(&mut self, dims: &MaxDimensions) {
         self.color += dims.image_types.contains(ImageTypes::IMAGE) as usize
             + dims.image_types.contains(ImageTypes::ENCODED_IMAGE) as usize
-            + dims.image_types.contains(ImageTypes::VIDEO) as usize;
+            + dims.image_types.contains(ImageTypes::VIDEO_ASSET) as usize
+            + dims.image_types.contains(ImageTypes::VIDEO_STREAM) as usize;
         self.depth += dims.image_types.contains(ImageTypes::DEPTH_IMAGE) as usize;
         self.segmentation += dims.image_types.contains(ImageTypes::SEGMENTATION_IMAGE) as usize;
     }


### PR DESCRIPTION
### Related

* part of polishing for https://github.com/rerun-io/rerun/issues/7484

### What

This solves issues when view spawning with video stream would have the wrong dimensions.
Plus general improvements to how it works in an all-tagged world.