### PR TITLE
Switch lint-rs-files to use edition 2024

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -252,7 +252,7 @@ fast-lint = "python scripts/fast_lint.py"
 lint-codegen = "cargo --quiet run --package re_types_builder -- --check"
 # TODO(jleibs): implement lint-cpp-files
 lint-rerun = "python scripts/lint.py"
-lint-rs-files = "rustfmt --edition 2021 --check"
+lint-rs-files = "rustfmt --edition 2024 --check"
 lint-rs-all = "cargo fmt --check"
 
 lint-typos = "typos"


### PR DESCRIPTION
Needed due to:
- https://github.com/rerun-io/rerun/pull/9942