### PR TITLE
Build wheel index on main

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -164,3 +164,14 @@ jobs:
       PLATFORM: linux-x64
       WHEEL_ARTIFACT_NAME: linux-x64-wheel
     secrets: inherit
+
+  generate-pip-index:
+    name: "Generate Pip Index"
+    needs:
+      [
+        build-wheel-linux-x64,
+      ]
+    uses: ./.github/workflows/reusable_pip_index.yml
+    with:
+      CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
+    secrets: inherit

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -167,10 +167,7 @@ jobs:
 
   generate-pip-index:
     name: "Generate Pip Index"
-    needs:
-      [
-        build-wheel-linux-x64,
-      ]
+    needs: [build-wheel-linux-x64]
     uses: ./.github/workflows/reusable_pip_index.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}


### PR DESCRIPTION
Attempt to build wheel index in push to `main`.

#### Background

We have a wheel index for our nightly and releases on our build server. They offer a facility to install wheels for specific commit without knowing the full path to said wheels. We currently dont have that for push to `main`. We currently only build notebook and linux-x86 on main, but that exactly what we need for dataplatform deployment. Having a wheel index would enable deploying from any ✅  `main` commit.