### PR TITLE
Don't check wheels for push-to-main pip-index

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -171,4 +171,5 @@ jobs:
     uses: ./.github/workflows/reusable_pip_index.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
+      CHECK: false # we don't build wheels for all platforms on push-to-main
     secrets: inherit

--- a/.github/workflows/reusable_pip_index.yml
+++ b/.github/workflows/reusable_pip_index.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: ""
+      CHECK:
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-pip-index
@@ -61,4 +65,4 @@ jobs:
             --title "Commit: $commit" \
             --dir "commit/$commit/wheels" \
             --upload \
-            --check
+            ${{ inputs.CHECK == 'true' && '--check' || '' }}


### PR DESCRIPTION
### Related

- Follow up to https://github.com/rerun-io/rerun/pull/10278

### What

Do not check that we have all wheels built when generating pip index on push-to-main, 'cause we definitely don't.