### PR TITLE
Add duration field to the recording UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7032,6 +7032,7 @@ dependencies = [
  "egui_extras",
  "egui_plot",
  "itertools 0.14.0",
+ "jiff",
  "re_arrow_util",
  "re_byte_size",
  "re_capabilities",

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -47,3 +47,4 @@ egui.workspace = true
 itertools.workspace = true
 rexif.workspace = true
 unindent.workspace = true
+jiff.workspace = true

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -85,6 +85,32 @@ impl crate::DataUi for EntityDb {
                 }
             }
 
+            // Duration block: show HH:MM:SS.MS between timeline start and end using time_range_for
+            if let Some(timeline_name) = self.timelines().keys().find(|k| **k == re_log_types::TimelineName::log_time()) {
+                if let Some(range) = self.time_range_for(timeline_name) {
+                    let duration = range.max().as_i64() - range.min().as_i64();
+                    if duration > 0 {
+                        let duration = std::time::Duration::from_nanos(duration as u64);
+                        let hours = duration.as_secs() / 3600;
+                        let minutes = (duration.as_secs() % 3600) / 60;
+                        let seconds = duration.as_secs() % 60;
+                        let millis = duration.subsec_millis();
+                        let duration_str = if hours > 0 {
+                            format!("{}h {}m {:02}.{:03}s", hours, minutes, seconds, millis)
+                        } else if minutes > 0 {
+                            format!("{}m {:02}.{:03}s", minutes, seconds, millis)
+                        } else {
+                            format!("{:02}.{:03}s", seconds, millis)
+                        };
+                        ui.grid_left_hand_label("Duration");
+                        ui.label(duration_str)
+                            .on_hover_text("Duration between the earliest and latest timestamps on the 'log_time' timeline.");
+                        ui.end_row();
+                    }
+                }
+            }
+
+
             {
                 ui.grid_left_hand_label("Size");
                 ui.label(re_format::format_bytes(self.total_size_bytes() as _))


### PR DESCRIPTION
This is just a small QoL improvement. I found myself looking for this many times when comparing recordings. In particular, I wanted to see the duration of a recording to help compare the sizes between different recordings (I'm evaluating the storage saved by using video).

Take this PR as more of a suggestion, both for the feature and for the actual implementation, as I'm a rust novice and unaware of the general PR process.

Here's a video showing how it works. I skip ahead to show how it ticks over 1 minute.
https://drive.google.com/file/d/1sEGz_6GoJGdZ6XeJ-5VwZh-jZshLtLy0/view?usp=sharing

And a screenshot showing the duration field:
![image](https://github.com/user-attachments/assets/f114d9b2-471b-40ff-afbc-b5aa8d33a020)
![image](https://github.com/user-attachments/assets/48fa2794-33a4-4426-b6fc-a23adaacc147)
