### PR TITLE
fix notification text color

### DIFF
--- a/crates/viewer/re_ui/src/notifications.rs
+++ b/crates/viewer/re_ui/src/notifications.rs
@@ -385,7 +385,7 @@ fn show_notification(
                     ui.horizontal_top(|ui| {
                         ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
                         ui.set_width(270.0);
-                        ui.label(egui::RichText::new(notification.text.clone()).weak());
+                        ui.label(egui::RichText::new(notification.text.clone()));
                     });
 
                     ui.add_space(4.0);


### PR DESCRIPTION
before 

<img width="373" alt="image" src="https://github.com/user-attachments/assets/f33c1d2e-25dd-4cbb-98ad-35cf75e97dc0" />
![image](https://github.com/user-attachments/assets/bf498bd0-b26e-49d1-9a33-900715eb1af7)


after 
<img width="373" alt="image" src="https://github.com/user-attachments/assets/9872d294-1bcb-450b-b278-9f1cdb2fa1dc" />
<img width="357" alt="image" src="https://github.com/user-attachments/assets/d53201e6-b091-483e-8c35-f4f985289e9c" />


It's still okay to have time stamp weak and 0 notifications state weak. 
To improve later => assign a color token instead of using default egui. 

closes https://github.com/rerun-io/rerun/issues/10155
relates to https://github.com/rerun-io/rerun/pull/10107