### PR TITLE
Blink help buttons until the user clicks one of them

### DIFF
--- a/crates/viewer/re_ui/examples/re_ui_example/main.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/main.rs
@@ -204,6 +204,9 @@ impl eframe::App for ExampleApp {
             ui.horizontal(|ui| {
                 ui.label("Toggle switch:");
                 ui.toggle_switch(8.0, &mut self.dummy_bool);
+                ui.help_button(|ui| {
+                    ui.label("This some help text.");
+                });
             });
             ui.label(format!("Latest command: {}", self.latest_cmd));
 
@@ -486,6 +489,10 @@ impl egui_tiles::Behavior<Tab> for MyTileTreeBehavior {
         _tile_id: egui_tiles::TileId,
         _pane: &mut Tab,
     ) -> egui_tiles::UiResponse {
+        ui.help_button(|ui| {
+            ui.label("This some help text.");
+        });
+
         egui::Frame::new().inner_margin(4.0).show(ui, |ui| {
             egui::warn_if_debug_build(ui);
             ui.label("Hover me for a tooltip")
@@ -514,6 +521,10 @@ impl egui_tiles::Behavior<Tab> for MyTileTreeBehavior {
 
             ui.error_label("This is an example of a long error label.");
             ui.warning_label("This is an example of a long warning label.");
+        });
+
+        ui.help_button(|ui| {
+            ui.label("This some help text.");
         });
 
         Default::default()

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -1076,13 +1076,14 @@ pub trait UiExt {
         }
     }
 
-    /// The help menu appears when clicked and/or hovered
+    /// Shows a `?` help button that will show a help UI when clicked.
+    ///
+    /// The help buttons will all blink periodically until the user has clicked _any_ help button at least once.
+    /// This is to teach users where they can find help.
     fn help_button(&mut self, help_ui: impl FnOnce(&mut egui::Ui)) -> egui::Response {
-        let mut help_ui: Option<_> = Some(help_ui);
-
         let ui = self.ui_mut();
 
-        // If we never showed the help before, we want to animate it to draw attention:
+        // Have we ever shown any help UI anywhere?
         let has_shown_help_id = egui::Id::new("has_shown_help");
         let has_been_shown: bool =
             ui.data_mut(|d| *d.get_persisted_mut_or_default(has_shown_help_id));
@@ -1095,23 +1096,9 @@ pub trait UiExt {
             let menu_button = egui::containers::menu::MenuButton::from_button(
                 ui.small_icon_button_widget(&icons::HELP, "Help"),
             );
-            let button_response = menu_button
-                .ui(ui, |ui| {
-                    if let Some(help_ui) = help_ui.take() {
-                        help_ui(ui);
-                        if !has_been_shown {
-                            // Remember that the user has found and used the help button at least once,
-                            // to stop it from animating in the future:
-                            ui.data_mut(|d| {
-                                d.insert_persisted(has_shown_help_id, true);
-                            });
-                        }
-                    }
-                })
-                .0;
 
-            if let Some(help_ui) = help_ui.take() {
-                button_response.on_hover_ui(|ui| {
+            menu_button
+                .ui(ui, |ui| {
                     help_ui(ui);
                     if !has_been_shown {
                         // Remember that the user has found and used the help button at least once,
@@ -1121,9 +1108,7 @@ pub trait UiExt {
                         });
                     }
                 })
-            } else {
-                button_response
-            }
+                .0
         })
         .inner
     }


### PR DESCRIPTION
### What
I've noticed a lot of our users have missed the `?` help icon in our views.

This PR attempts to remedy this by sotly blinking the icons occasionally, until the user clicks at least one of them, thus teaching the user that there is help to find, and where to find it.

Once one help button has been clicked, no help button will ever blink again (unless the user runs `rerun reset`).