### PR TITLE
Log a warning when starting the viewer from inside a Docker container

### DIFF
--- a/crates/utils/re_analytics/src/event.rs
+++ b/crates/utils/re_analytics/src/event.rs
@@ -61,6 +61,9 @@ pub struct ViewerStarted {
 
 /// Some sparse information about the runtime environment the viewer is running in.
 pub struct ViewerRuntimeInformation {
+    /// Does it look like the viewer is running inside a Docker container?
+    pub is_docker: bool,
+
     /// Whether the viewer is started directly from within Windows Subsystem for Linux (WSL).
     pub is_wsl: bool,
 
@@ -82,11 +85,13 @@ pub struct ViewerRuntimeInformation {
 impl Properties for ViewerRuntimeInformation {
     fn serialize(self, event: &mut AnalyticsEvent) {
         let Self {
+            is_docker,
             is_wsl,
             graphics_adapter_backend,
             re_renderer_device_tier,
         } = self;
 
+        event.insert("is_docker", is_docker);
         event.insert("is_wsl", is_wsl);
         event.insert("graphics_adapter_backend", graphics_adapter_backend);
         event.insert("re_renderer_device_tier", re_renderer_device_tier);

--- a/crates/viewer/re_viewer/src/docker_detection.rs
+++ b/crates/viewer/re_viewer/src/docker_detection.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::path::Path;
+
+/// Detect if the application is running inside a Docker container
+pub fn is_docker() -> bool {
+    is_dockerenv_present() || is_docker_in_cgroup()
+}
+
+/// Check for the presence of /.dockerenv file (most reliable method)
+fn is_dockerenv_present() -> bool {
+    Path::new("/.dockerenv").exists()
+}
+
+/// Check if 'docker' appears in cgroup information
+fn is_docker_in_cgroup() -> bool {
+    // Try multiple cgroup paths
+    let cgroup_paths = ["/proc/1/cgroup", "/proc/self/cgroup"];
+
+    for path in &cgroup_paths {
+        if let Ok(contents) = fs::read_to_string(path) {
+            if contents.contains("docker") {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/crates/viewer/re_viewer/src/docker_detection.rs
+++ b/crates/viewer/re_viewer/src/docker_detection.rs
@@ -1,27 +1,31 @@
-use std::fs;
-use std::path::Path;
-
 /// Detect if the application is running inside a Docker container
+#[cfg(target_os = "linux")]
 pub fn is_docker() -> bool {
+    /// Check for the presence of /.dockerenv file (most reliable method)
+    fn is_dockerenv_present() -> bool {
+        std::path::Path::new("/.dockerenv").exists()
+    }
+
+    /// Check if 'docker' appears in cgroup information
+    fn is_docker_in_cgroup() -> bool {
+        // Try multiple cgroup paths
+        let cgroup_paths = ["/proc/1/cgroup", "/proc/self/cgroup"];
+
+        for path in &cgroup_paths {
+            if let Ok(contents) = std::fs::read_to_string(path) {
+                if contents.contains("docker") {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     is_dockerenv_present() || is_docker_in_cgroup()
 }
 
-/// Check for the presence of /.dockerenv file (most reliable method)
-fn is_dockerenv_present() -> bool {
-    Path::new("/.dockerenv").exists()
-}
-
-/// Check if 'docker' appears in cgroup information
-fn is_docker_in_cgroup() -> bool {
-    // Try multiple cgroup paths
-    let cgroup_paths = ["/proc/1/cgroup", "/proc/self/cgroup"];
-
-    for path in &cgroup_paths {
-        if let Ok(contents) = fs::read_to_string(path) {
-            if contents.contains("docker") {
-                return true;
-            }
-        }
-    }
+/// Detect if the application is running inside a Docker container
+#[cfg(not(target_os = "linux"))]
+pub fn is_docker() -> bool {
     false
 }

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -8,6 +8,7 @@ mod app_blueprint;
 mod app_state;
 mod background_tasks;
 mod default_views;
+mod docker_detection;
 pub mod env_vars;
 pub mod event;
 mod navigation;

--- a/crates/viewer/re_viewer/src/native.rs
+++ b/crates/viewer/re_viewer/src/native.rs
@@ -16,7 +16,7 @@ pub fn run_native_app(
 ) -> eframe::Result {
     if crate::docker_detection::is_docker() {
         re_log::warn_once!(
-            "It looks like you are running the Rerun Viewer inside a Docker container. This is not officially supported, and may lead to performance issues and bugs.",
+            "It looks like you are running the Rerun Viewer inside a Docker container. This is not officially supported, and may lead to performance issues and bugs. See https://github.com/rerun-io/rerun/issues/6835 for more.",
         );
     }
 

--- a/crates/viewer/re_viewer/src/native.rs
+++ b/crates/viewer/re_viewer/src/native.rs
@@ -14,6 +14,12 @@ pub fn run_native_app(
     app_creator: AppCreator,
     force_wgpu_backend: Option<&str>,
 ) -> eframe::Result {
+    if crate::docker_detection::is_docker() {
+        re_log::warn_once!(
+            "It looks like you are running the Rerun Viewer inside a Docker container. This is not officially supported, and may lead to performance issues and bugs.",
+        );
+    }
+
     let native_options = eframe_options(force_wgpu_backend);
 
     let window_title = "Rerun Viewer";

--- a/crates/viewer/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/event.rs
@@ -41,6 +41,7 @@ pub fn viewer_started(
         url: app_env.url().cloned(),
         app_env: app_env.name(),
         runtime_info: ViewerRuntimeInformation {
+            is_docker: crate::docker_detection::is_docker(),
             is_wsl: super::wsl::is_wsl(),
             graphics_adapter_backend: adapter_backend.to_string(),
             re_renderer_device_tier: device_tier.to_string(),


### PR DESCRIPTION
Running the Rerun Viewer from inside a docker container has several problems:

* File dialogs may not work
* Clipboard may not work
* You may get crashes
* You may see graphics bugs
* You may have performance issues

So let's at least warn the user that this is a bad idea!

I also added `is_docker` to our analytics events so we can see how common this is amongst our users.

## Related
* https://github.com/rerun-io/rerun/issues/6835
* https://github.com/rerun-io/rerun/issues/7324
* https://github.com/rerun-io/rerun/issues/10280

## TODO
* [ ] Test running this from inside a docker container to see that the warning actually show up :)