### PR TITLE
Fix integer overflow in `TimeSeriesView` for too large timestamps

### DIFF
--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -912,7 +912,7 @@ fn nanos_grid_spacer(
 
 fn round_nanos_to_start_of_day(ns: i64) -> i64 {
     let nanos_per_day = 24 * 60 * 60 * 1_000_000_000;
-    (ns + nanos_per_day / 2) / nanos_per_day * nanos_per_day
+    (ns.saturating_add(nanos_per_day / 2)) / nanos_per_day * nanos_per_day
 }
 
 impl TypedComponentFallbackProvider<Corner2D> for TimeSeriesView {


### PR DESCRIPTION
### What

This avoids overflow of timestamps in the `TimeSeriesView`
