### PR TITLE
Disable gRPC server history for Spawn/CLI

### DIFF
--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -417,11 +417,15 @@ impl RecordingStreamBuilder {
     /// You can limit the amount of data buffered by the gRPC server using [`Self::serve_grpc_opts`],
     /// with the `server_memory_limit` argument. Once the memory limit is reached, the earliest logged data
     /// will be dropped. Static data is never dropped.
+    ///
+    /// It is highly recommended that you use [`Self::serve_grpc_opts`] and set the memory limit to `0B`
+    /// if both the server and client are running on the same machine, otherwise you're potentially
+    /// doubling your memory usage!
     pub fn serve_grpc(self) -> RecordingStreamResult<RecordingStream> {
         self.serve_grpc_opts(
             "0.0.0.0",
             crate::DEFAULT_SERVER_PORT,
-            re_memory::MemoryLimit::from_fraction_of_total(0.75),
+            re_memory::MemoryLimit::from_fraction_of_total(0.25),
         )
     }
 
@@ -437,6 +441,9 @@ impl RecordingStreamBuilder {
     /// The gRPC server will buffer all log data in memory so that late connecting viewers will get all the data.
     /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
     /// Once reached, the earliest logged data will be dropped. Static data is never dropped.
+    ///
+    /// It is highly recommended that you set the memory limit to `0B` if both the server and client are running
+    /// on the same machine, otherwise you're potentially doubling your memory usage!
     pub fn serve_grpc_opts(
         self,
         bind_ip: impl AsRef<str>,

--- a/crates/top/re_sdk/src/spawn.rs
+++ b/crates/top/re_sdk/src/spawn.rs
@@ -29,6 +29,14 @@ pub struct SpawnOptions {
     /// Defaults to `75%`.
     pub memory_limit: String,
 
+    /// An upper limit on how much memory the gRPC server running
+    /// in the same process as the Rerun Viewer should use.
+    /// When this limit is reached, Rerun will drop the oldest data.
+    /// Example: `16GB` or `50%` (of system total).
+    ///
+    /// Defaults to `0B`.
+    pub server_memory_limit: String,
+
     /// Specifies the name of the Rerun executable.
     ///
     /// You can omit the `.exe` suffix on Windows.
@@ -64,6 +72,7 @@ impl Default for SpawnOptions {
             port: re_grpc_server::DEFAULT_SERVER_PORT,
             wait_for_bind: false,
             memory_limit: "75%".into(),
+            server_memory_limit: "0B".into(),
             executable_name: RERUN_BINARY.into(),
             executable_path: None,
             extra_args: Vec::new(),
@@ -202,6 +211,7 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
     let port = opts.port;
     let connect_addr = opts.connect_addr();
     let memory_limit = &opts.memory_limit;
+    let server_memory_limit = &opts.server_memory_limit;
     let executable_path = opts.executable_path();
 
     // TODO(#4019): application-level handshake
@@ -284,6 +294,7 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
         .stdin(std::process::Stdio::null())
         .arg(format!("--port={port}"))
         .arg(format!("--memory-limit={memory_limit}"))
+        .arg(format!("--server-memory-limit={server_memory_limit}"))
         .arg("--expect-data-soon");
 
     if opts.hide_welcome_screen {

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -117,7 +117,7 @@ Example: `16GB` or `50%` (of system total)."
 
     #[clap(
         long,
-        default_value = "25%",
+        default_value = "0B",
         long_help = r"An upper limit on how much memory the gRPC server (`--serve-web`) should use.
 The server buffers log messages for the benefit of late-arriving viewers.
 When this limit is reached, Rerun will drop the oldest data.

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -60,7 +60,7 @@ The Rerun command-line interface:
 > When this limit is reached, Rerun will drop the oldest data.
 > Example: `16GB` or `50%` (of system total).
 >
-> [Default: `25%`]
+> [Default: `0B`]
 
 * `--persist-state <PERSIST_STATE>`
 > Whether the Rerun Viewer should persist the state of the viewer to disk.

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -447,6 +447,9 @@ extern void rr_recording_stream_connect_grpc(
 /// The gRPC server will buffer all log data in memory so that late connecting viewers will get all the data.
 /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
 /// Once reached, the earliest logged data will be dropped. Static data is never dropped.
+/// 
+/// It is highly recommended that you set the memory limit to `0B` if both the server and client are running
+/// on the same machine, otherwise you're potentially doubling your memory usage!
 extern void rr_recording_stream_serve_grpc(
     rr_recording_stream stream, rr_string bind_ip, uint16_t port, rr_string server_memory_limit,
     rr_error* error

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -129,6 +129,14 @@ typedef struct rr_spawn_options {
     /// Defaults to `75%` if null.
     rr_string memory_limit;
 
+    /// An upper limit on how much memory the gRPC server running
+    /// in the same process as the Rerun Viewer should use.
+    /// When this limit is reached, Rerun will drop the oldest data.
+    /// Example: `16GB` or `50%` (of system total).
+    ///
+    /// Defaults to `0B` if null.
+    rr_string server_memory_limit;
+
     /// Hide the normal Rerun welcome screen.
     bool hide_welcome_screen;
 

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -447,7 +447,7 @@ extern void rr_recording_stream_connect_grpc(
 /// The gRPC server will buffer all log data in memory so that late connecting viewers will get all the data.
 /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
 /// Once reached, the earliest logged data will be dropped. Static data is never dropped.
-/// 
+///
 /// It is highly recommended that you set the memory limit to `0B` if both the server and client are running
 /// on the same machine, otherwise you're potentially doubling your memory usage!
 extern void rr_recording_stream_serve_grpc(

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -166,12 +166,15 @@ namespace rerun {
         /// You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
         /// Once reached, the earliest logged data will be dropped. Static data is never dropped.
         ///
+        /// It is highly recommended that you set the memory limit to `0B` if both the server and client are running
+        /// on the same machine, otherwise you're potentially doubling your memory usage!
+        ///
         /// Returns the URI of the gRPC server so you can connect to it from a viewer.
         ///
         /// This function returns immediately.
         Result<std::string> serve_grpc(
             std::string_view bind_ip = "0.0.0.0", uint16_t port = 9876,
-            std::string_view server_memory_limit = "75%"
+            std::string_view server_memory_limit = "25%"
         ) const;
 
         /// Spawns a new Rerun Viewer process from an executable available in PATH, then connects to it

--- a/rerun_cpp/src/rerun/spawn_options.cpp
+++ b/rerun_cpp/src/rerun/spawn_options.cpp
@@ -6,6 +6,7 @@ namespace rerun {
     void SpawnOptions::fill_rerun_c_struct(rr_spawn_options& spawn_opts) const {
         spawn_opts.port = port;
         spawn_opts.memory_limit = detail::to_rr_string(memory_limit);
+        spawn_opts.server_memory_limit = detail::to_rr_string(server_memory_limit);
         spawn_opts.hide_welcome_screen = hide_welcome_screen;
         spawn_opts.detach_process = detach_process;
         spawn_opts.executable_name = detail::to_rr_string(executable_name);

--- a/rerun_cpp/src/rerun/spawn_options.hpp
+++ b/rerun_cpp/src/rerun/spawn_options.hpp
@@ -26,6 +26,14 @@ namespace rerun {
         /// Defaults to `75%` if unset.
         std::string_view memory_limit = "75%";
 
+        /// An upper limit on how much memory the gRPC server running
+        /// in the same process as the Rerun Viewer should use.
+        /// When this limit is reached, Rerun will drop the oldest data.
+        /// Example: `16GB` or `50%` (of system total).
+        ///
+        /// Defaults to `0B`.
+        std::string_view server_memory_limit = "0B";
+
         /// Hide the normal Rerun welcome screen.
         ///
         /// Defaults to `false` if unset.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -673,6 +673,7 @@ def cleanup_if_forked_child() -> None:
 def spawn(
     port: int = 9876,
     memory_limit: str = ...,
+    server_memory_limit: str = ...,
     hide_welcome_screen: bool = False,
     detach_process: bool = True,
     executable_name: str = ...,

--- a/rerun_py/rerun_sdk/rerun/_spawn.py
+++ b/rerun_py/rerun_sdk/rerun/_spawn.py
@@ -7,6 +7,7 @@ def _spawn_viewer(
     *,
     port: int = 9876,
     memory_limit: str = "75%",
+    server_memory_limit: str = "0B",
     hide_welcome_screen: bool = False,
     detach_process: bool = True,
 ) -> None:
@@ -25,6 +26,13 @@ def _spawn_viewer(
         An upper limit on how much memory the Rerun Viewer should use.
         When this limit is reached, Rerun will drop the oldest data.
         Example: `16GB` or `50%` (of system total).
+    server_memory_limit:
+        An upper limit on how much memory the gRPC server running
+        in the same process as the Rerun Viewer should use.
+        When this limit is reached, Rerun will drop the oldest data.
+        Example: `16GB` or `50%` (of system total).
+
+        Defaults to `0B`.
     hide_welcome_screen:
         Hide the normal Rerun welcome screen.
     detach_process:
@@ -43,5 +51,9 @@ def _spawn_viewer(
     new_env["RERUN_APP_ONLY"] = "true"
 
     rerun_bindings.spawn(
-        port=port, memory_limit=memory_limit, hide_welcome_screen=hide_welcome_screen, detach_process=detach_process
+        port=port,
+        memory_limit=memory_limit,
+        server_memory_limit=server_memory_limit,
+        hide_welcome_screen=hide_welcome_screen,
+        detach_process=detach_process,
     )

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -650,7 +650,7 @@ class RecordingStream:
         *,
         grpc_port: int | None = None,
         default_blueprint: BlueprintLike | None = None,
-        server_memory_limit: str = "75%",
+        server_memory_limit: str = "25%",
     ) -> str:
         """
         Serve log-data over gRPC.
@@ -661,8 +661,8 @@ class RecordingStream:
         You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
         Once reached, the earliest logged data will be dropped. Static data is never dropped.
 
-        It is highly recommended that you set the memory limit to `0B` if both the server and client are running in the
-        same process, otherwise you're potentially doubling your memory usage!
+        It is highly recommended that you set the memory limit to `0B` if both the server and client are running
+        on the same machine, otherwise you're potentially doubling your memory usage!
 
         Returns the URI of the server so you can connect the viewer to it.
 

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -661,6 +661,9 @@ class RecordingStream:
         You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
         Once reached, the earliest logged data will be dropped. Static data is never dropped.
 
+        It is highly recommended that you set the memory limit to `0B` if both the server and client are running in the
+        same process, otherwise you're potentially doubling your memory usage!
+
         Returns the URI of the server so you can connect the viewer to it.
 
         This function returns immediately.

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -289,8 +289,8 @@ def serve_grpc(
     You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
     Once reached, the earliest logged data will be dropped. Static data is never dropped.
 
-    It is highly recommended that you set the memory limit to `0B` if both the server and client are running in the
-    same process, otherwise you're potentially doubling your memory usage!
+    It is highly recommended that you set the memory limit to `0B` if both the server and client are running
+    on the same machine, otherwise you're potentially doubling your memory usage!
 
     Returns the URI of the server so you can connect the viewer to it.
 
@@ -500,6 +500,7 @@ def spawn(
     port: int = 9876,
     connect: bool = True,
     memory_limit: str = "75%",
+    server_memory_limit: str = "0B",
     hide_welcome_screen: bool = False,
     detach_process: bool = True,
     default_blueprint: BlueprintLike | None = None,
@@ -523,6 +524,13 @@ def spawn(
         An upper limit on how much memory the Rerun Viewer should use.
         When this limit is reached, Rerun will drop the oldest data.
         Example: `16GB` or `50%` (of system total).
+    server_memory_limit:
+        An upper limit on how much memory the gRPC server running
+        in the same process as the Rerun Viewer should use.
+        When this limit is reached, Rerun will drop the oldest data.
+        Example: `16GB` or `50%` (of system total).
+
+        Defaults to `0B`.
     hide_welcome_screen:
         Hide the normal Rerun welcome screen.
     detach_process:
@@ -544,7 +552,11 @@ def spawn(
         return
 
     _spawn_viewer(
-        port=port, memory_limit=memory_limit, hide_welcome_screen=hide_welcome_screen, detach_process=detach_process
+        port=port,
+        memory_limit=memory_limit,
+        server_memory_limit=server_memory_limit,
+        hide_welcome_screen=hide_welcome_screen,
+        detach_process=detach_process,
     )
 
     if connect:

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -289,6 +289,9 @@ def serve_grpc(
     You can limit the amount of data buffered by the gRPC server with the `server_memory_limit` argument.
     Once reached, the earliest logged data will be dropped. Static data is never dropped.
 
+    It is highly recommended that you set the memory limit to `0B` if both the server and client are running in the
+    same process, otherwise you're potentially doubling your memory usage!
+
     Returns the URI of the server so you can connect the viewer to it.
 
     This function returns immediately. In order to keep the server running, you must keep the Python process running

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -596,10 +596,21 @@ fn send_mem_sink_as_default_blueprint(
 
 /// Spawn a new viewer.
 #[pyfunction]
-#[pyo3(signature = (port = 9876, memory_limit = "75%".to_owned(), hide_welcome_screen = false, detach_process = true, executable_name = "rerun".to_owned(), executable_path = None, extra_args = vec![], extra_env = vec![]))]
+#[pyo3(signature = (
+    port = 9876,
+    memory_limit = "75%".to_owned(),
+    server_memory_limit = "0B".to_owned(),
+    hide_welcome_screen = false,
+    detach_process = true,
+    executable_name = "rerun".to_owned(),
+    executable_path = None,
+    extra_args = vec![],
+    extra_env = vec![],
+))]
 fn spawn(
     port: u16,
     memory_limit: String,
+    server_memory_limit: String,
     hide_welcome_screen: bool,
     detach_process: bool,
     executable_name: String,
@@ -611,6 +622,7 @@ fn spawn(
         port,
         wait_for_bind: true,
         memory_limit,
+        server_memory_limit,
         hide_welcome_screen,
         detach_process,
         executable_name,


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/10298#issuecomment-2987837283

### What

* Changes the default server memory limit to `0B` in:
  * Python, C++, Rust `spawn`
  * CLI

