### PR TITLE
Introduce a way to accurately determine a store schema based on a stream of chunks

### DIFF
--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -19,7 +19,6 @@ mod drop_time_range;
 mod events;
 mod gc;
 mod query;
-mod schema_builder;
 mod stats;
 mod store;
 mod subscribers;
@@ -31,7 +30,6 @@ pub use self::{
     },
     events::{ChunkCompactionReport, ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent},
     gc::{GarbageCollectionOptions, GarbageCollectionTarget},
-    schema_builder::SchemaBuilder,
     stats::{ChunkStoreChunkStats, ChunkStoreStats},
     store::{
         ChunkStore, ChunkStoreConfig, ChunkStoreGeneration, ChunkStoreHandle, ColumnIdentifier,

--- a/crates/store/re_sorbet/src/chunk_batch.rs
+++ b/crates/store/re_sorbet/src/chunk_batch.rs
@@ -62,7 +62,7 @@ impl ChunkBatch {
     /// only be derived from an entire chunk store (e.g. a column is static if _any_ chunk
     /// containing that column is static).
     ///
-    /// See `re_chunk_store::ChunkStore::schema` or `re_chunk_store::SchemaBuilder` to compute
+    /// See `re_chunk_store::ChunkStore::schema` or [`crate::SchemaBuilder`] to compute
     /// schemas with accurate metadata.
     #[inline]
     pub fn chunk_schema(&self) -> &ChunkSchema {
@@ -79,6 +79,12 @@ impl ChunkBatch {
     #[inline]
     pub fn entity_path(&self) -> &EntityPath {
         self.schema.entity_path()
+    }
+
+    /// Is this chunk static?
+    #[inline]
+    pub fn is_static(&self) -> bool {
+        self.schema.is_static()
     }
 
     #[inline]

--- a/crates/store/re_sorbet/src/chunk_schema.rs
+++ b/crates/store/re_sorbet/src/chunk_schema.rs
@@ -1,7 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
 use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
-
 use re_log_types::EntityPath;
 use re_types_core::ChunkId;
 
@@ -104,6 +103,12 @@ impl ChunkSchema {
     #[inline]
     pub fn entity_path(&self) -> &EntityPath {
         &self.entity_path
+    }
+
+    /// Is this chunk static?
+    #[inline]
+    pub fn is_static(&self) -> bool {
+        self.chunk_columns.indices.is_empty()
     }
 
     /// The heap size of this chunk in bytes, if known.

--- a/crates/store/re_sorbet/src/lib.rs
+++ b/crates/store/re_sorbet/src/lib.rs
@@ -24,6 +24,7 @@ mod ipc;
 mod metadata;
 mod migration;
 mod row_id_column_descriptor;
+mod schema_builder;
 mod selectors;
 mod sorbet_batch;
 mod sorbet_columns;
@@ -46,6 +47,7 @@ pub use self::{
         MissingMetadataKey,
     },
     row_id_column_descriptor::{RowIdColumnDescriptor, WrongDatatypeError},
+    schema_builder::SchemaBuilder,
     selectors::{
         ColumnSelector, ColumnSelectorParseError, ComponentColumnSelector, TimeColumnSelector,
     },


### PR DESCRIPTION
### Related

- related to https://github.com/rerun-io/rerun/issues/10315
- sibling https://github.com/rerun-io/dataplatform/pull/990

### What

This PR introduces `re_sorbet::SchemaBuilder()` to accurately compute store schema based on a stream of chunks.

Background:
- Store schema are needed in the context of the dataframe API
- Previously, we used `ChunkStore` facilities to compute the schema (which was accurate)
- Because `redap` operates on a `Stream` of chunk, it instead used `SchemaBuilder:try_merge` on per-chunk schema.
- This approach yields *wrong* result, see #10315.
- This PR introduces the required tool to fix redap.