### PR TITLE
Auto render juypyter notebooks with rerun specified formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8689,6 +8689,7 @@ version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "chrono",
+ "comfy-table",
  "crossbeam",
  "datafusion",
  "datafusion-ffi",
@@ -8712,6 +8713,7 @@ dependencies = [
  "re_chunk_store",
  "re_dataframe",
  "re_datafusion",
+ "re_format_arrow",
  "re_grpc_client",
  "re_grpc_server",
  "re_log",

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -55,6 +55,7 @@ re_chunk.workspace = true
 re_chunk_store.workspace = true
 re_dataframe.workspace = true
 re_datafusion.workspace = true
+re_format_arrow.workspace = true
 re_grpc_client.workspace = true
 re_grpc_server = { workspace = true, optional = true }
 re_log = { workspace = true, features = ["setup"] }
@@ -70,6 +71,7 @@ re_web_viewer_server = { workspace = true, optional = true }
 
 arrow = { workspace = true, features = ["pyarrow"] }
 chrono.workspace = true #TODO(#9317): migrate to jiff when upgrading to pyo3 0.24
+comfy-table.workspace = true
 crossbeam.workspace = true
 datafusion.workspace = true
 datafusion-ffi.workspace = true

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -8,7 +8,7 @@ use pyo3::{
 use re_protos::catalog::v1alpha1::{EntryFilter, EntryKind};
 
 use crate::catalog::{
-    ConnectionHandle, PyDatasetEntry, PyEntry, PyEntryId, PyTableEntry, to_py_err,
+    ConnectionHandle, PyDatasetEntry, PyEntry, PyEntryId, PyRerunHtmlTable, PyTableEntry, to_py_err,
 };
 
 /// Client for a remote Rerun catalog server.
@@ -59,6 +59,19 @@ impl PyCatalogClientInternal {
             .import("datafusion")
             .and_then(|datafusion| Ok(datafusion.getattr("SessionContext")?.call0()?.unbind()))
             .ok();
+
+        // Set up our renderer by default since we've already established datafusion
+        // is installed.
+        let html_renderer = PyRerunHtmlTable::new(None, None);
+
+        let format_fn = py
+            .import("datafusion")
+            .and_then(|datafusion| datafusion.getattr("html_formatter"))
+            .and_then(|html_formatter| html_formatter.getattr("set_formatter"));
+
+        if let Ok(format_fn) = format_fn {
+            let _ = format_fn.call1((html_renderer,))?;
+        }
 
         Ok(Self {
             origin,

--- a/rerun_py/src/catalog/dataframe_rendering.rs
+++ b/rerun_py/src/catalog/dataframe_rendering.rs
@@ -1,0 +1,133 @@
+use arrow::datatypes::Schema;
+use arrow::pyarrow::FromPyArrow;
+use arrow::record_batch::RecordBatch;
+use comfy_table::Table;
+use pyo3::{Bound, PyAny, PyResult, pyclass, pymethods};
+use re_arrow_util::format_data_type;
+use re_format_arrow::{RecordBatchFormatOpts, format_record_batch_opts};
+
+#[pyclass(name = "RerunHtmlTable")]
+#[derive(Clone)]
+pub struct PyRerunHtmlTable {
+    max_width: Option<usize>,
+    max_height: Option<usize>,
+}
+
+impl PyRerunHtmlTable {
+    fn build_table_container_start(&self) -> String {
+        let max_width = self
+            .max_width
+            .map(|mw| format!("max-width: {}px;", mw))
+            .unwrap_or_default();
+        let max_height = self
+            .max_height
+            .map(|mh| format!("max-height: {}px;", mh))
+            .unwrap_or_default();
+
+        format!(
+            r#"
+            <div style="width: 100%; {} {} overflow: auto; border: 1px solid #ccc;">
+            <table style="border-collapse: collapse; min-width: 100%">
+            "#,
+            max_width, max_height
+        )
+    }
+
+    fn build_table_container_end(&self) -> String {
+        r#"
+        </table>
+        </div>
+        "#
+        .to_string()
+    }
+
+    fn build_table_header(&self, schema: &Schema) -> String {
+        let cells = schema
+            .fields()
+            .iter()
+            .map(|field| {
+                format!(
+                    "<th style=\"font-weight: normal;\"><strong>{}</strong><br>{}</th>",
+                    field.name(),
+                    format_data_type(field.data_type())
+                )
+            })
+            .collect::<Vec<String>>();
+
+        format!("<thead><tr>{}</tr></thead>", cells.join(""))
+    }
+
+    fn build_table_body(&self, tables: Vec<Table>) -> Vec<String> {
+        let mut results = vec!["<tbody".to_string()];
+
+        for table in tables {
+            let rows = table
+                .row_iter()
+                .map(|row| {
+                    let cells = row
+                        .cell_iter()
+                        .map(|cell| format!("<td>{}</td>", cell.content().replace("\n", "<br>")))
+                        .collect::<Vec<_>>()
+                        .join("");
+
+                    format!("<tr>{}</tr>\n", cells)
+                })
+                .collect::<Vec<_>>();
+            results.extend(rows);
+        }
+
+        results.push("</tbody>".to_string());
+
+        results
+    }
+}
+
+#[pymethods]
+impl PyRerunHtmlTable {
+    #[new]
+    #[pyo3(signature = (max_width=None, max_height=None))]
+    fn new(max_width: Option<usize>, max_height: Option<usize>) -> Self {
+        Self {
+            max_height: max_height,
+            max_width: max_width,
+        }
+    }
+
+    fn format_html<'py>(
+        &self,
+        batches: Vec<Bound<'py, PyAny>>,
+        schema: &Bound<'py, PyAny>,
+        has_more: bool,
+        table_uuid: &str,
+    ) -> PyResult<String> {
+        let batch_opts = RecordBatchFormatOpts::default();
+
+        let tables = batches
+            .into_iter()
+            .map(|batch| RecordBatch::from_pyarrow_bound(&batch))
+            .collect::<PyResult<Vec<RecordBatch>>>()?
+            .into_iter()
+            .map(|batch| format_record_batch_opts(&batch, &batch_opts))
+            .filter(|table| !table.is_empty())
+            .collect::<Vec<_>>();
+
+        let schema = Schema::from_pyarrow_bound(schema)?;
+
+        if tables.is_empty() {
+            return Ok("No data to display.".to_string());
+        }
+
+        let mut html_result = Vec::default();
+
+        html_result.push(self.build_table_container_start());
+        html_result.push(self.build_table_header(&schema));
+        html_result.extend(self.build_table_body(tables));
+        html_result.push(self.build_table_container_end());
+
+        if has_more {
+            html_result.push("<div>Data truncated due to size.</div>".to_string());
+        }
+
+        Ok(html_result.join("\n"))
+    }
+}

--- a/rerun_py/src/catalog/dataframe_rendering.rs
+++ b/rerun_py/src/catalog/dataframe_rendering.rs
@@ -86,13 +86,15 @@ impl PyRerunHtmlTable {
 impl PyRerunHtmlTable {
     #[new]
     #[pyo3(signature = (max_width=None, max_height=None))]
-    fn new(max_width: Option<usize>, max_height: Option<usize>) -> Self {
+    pub fn new(max_width: Option<usize>, max_height: Option<usize>) -> Self {
         Self {
             max_height: max_height,
             max_width: max_width,
         }
     }
 
+    // The keyword arguments must match the expected overrides
+    #[expect(unused_variables)]
     fn format_html<'py>(
         &self,
         batches: Vec<Bound<'py, PyAny>>,

--- a/rerun_py/src/catalog/mod.rs
+++ b/rerun_py/src/catalog/mod.rs
@@ -3,6 +3,7 @@
 mod catalog_client;
 mod connection_handle;
 mod dataframe_query;
+mod dataframe_rendering;
 mod dataset_entry;
 mod entry;
 mod errors;
@@ -21,6 +22,7 @@ use crate::catalog::dataframe_query::PyDataframeQueryView;
 
 pub(crate) use catalog_client::PyCatalogClientInternal;
 pub(crate) use connection_handle::ConnectionHandle;
+pub(crate) use dataframe_rendering::PyRerunHtmlTable;
 pub(crate) use dataset_entry::PyDatasetEntry;
 pub(crate) use entry::{PyEntry, PyEntryId, PyEntryKind};
 pub(crate) use errors::to_py_err;
@@ -42,6 +44,7 @@ pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()>
     m.add_class::<PyDataframeQueryView>()?;
 
     m.add_class::<PyVectorDistanceMetric>()?;
+    m.add_class::<PyRerunHtmlTable>()?;
 
     Ok(())
 }


### PR DESCRIPTION
### Related

https://linear.app/rerun/issue/DPF-1796/niko-feedback-triage-1

### What

This PR adds in a simpler html formatter for the jupyter notebook displays. It also leverages the existing formatting code in `re_format_arrow` so that we truncate data in the same way in jupyter notebooks as we do in the terminal.

Attached is a screenshot of the updated table display.

<img width="1057" alt="Screenshot 2025-06-23 at 9 37 42 PM" src="https://github.com/user-attachments/assets/9227e8d1-095c-4dde-9b70-49fe84138e23" />
