### PR TITLE
Add support for querying static chunks only

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -259,6 +259,10 @@ pub struct QueryExpression {
 }
 
 impl QueryExpression {
+    pub fn is_static(&self) -> bool {
+        self.filtered_index.is_none()
+    }
+
     pub fn min_latest_at(&self) -> Option<LatestAtQuery> {
         let index = self.filtered_index?;
 

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -387,7 +387,7 @@ message QueryLatestAt {
   // Which index column should we perform the query on? E.g. `log_time`.
   //
   // Leave this empty to query for static data.
-  optional rerun.common.v1alpha1.IndexColumnSelector index = 1;
+  rerun.common.v1alpha1.IndexColumnSelector index = 1;
 
   // What index value are we looking for?
   //

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -385,9 +385,13 @@ message Query {
 // This has the exact same semantics as the query of the same name on our `ChunkStore`.
 message QueryLatestAt {
   // Which index column should we perform the query on? E.g. `log_time`.
-  rerun.common.v1alpha1.IndexColumnSelector index = 1;
+  //
+  // Leave this empty to query for static data.
+  optional rerun.common.v1alpha1.IndexColumnSelector index = 1;
 
   // What index value are we looking for?
+  //
+  // Leave this empty to query for static data.
   optional int64 at = 2;
 
   // Which components are we interested in?

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -259,6 +259,7 @@ pub struct QueryLatestAt {
     ///
     /// Use `None` for static only data.
     pub index: Option<String>,
+
     /// The timestamp to query at.
     ///
     /// Use `TimeInt::STATIC` to query for static only data.

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -169,20 +169,7 @@ impl TryFrom<crate::manifest_registry::v1alpha1::Query> for Query {
 impl From<Query> for crate::manifest_registry::v1alpha1::Query {
     fn from(value: Query) -> Self {
         crate::manifest_registry::v1alpha1::Query {
-            latest_at: value.latest_at.map(|latest_at| {
-                crate::manifest_registry::v1alpha1::QueryLatestAt {
-                    index: latest_at.index.map(|index| {
-                        let timeline: TimelineName = index.into();
-                        timeline.into()
-                    }),
-                    at: if latest_at.at.is_static() {
-                        None
-                    } else {
-                        Some(latest_at.at.as_i64())
-                    },
-                    fuzzy_descriptors: latest_at.fuzzy_descriptors,
-                }
-            }),
+            latest_at: value.latest_at.map(Into::into),
             range: value
                 .range
                 .map(|range| crate::manifest_registry::v1alpha1::QueryRange {
@@ -293,6 +280,23 @@ impl QueryLatestAt {
 
     pub fn is_static(&self) -> bool {
         self.index.is_none() && self.at.is_static()
+    }
+}
+
+impl From<QueryLatestAt> for crate::manifest_registry::v1alpha1::QueryLatestAt {
+    fn from(value: QueryLatestAt) -> Self {
+        crate::manifest_registry::v1alpha1::QueryLatestAt {
+            index: value.index.map(|index| {
+                let timeline: TimelineName = index.into();
+                timeline.into()
+            }),
+            at: if value.at.is_static() {
+                None
+            } else {
+                Some(value.at.as_i64())
+            },
+            fuzzy_descriptors: value.fuzzy_descriptors,
+        }
     }
 }
 

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -100,10 +100,7 @@ impl TryFrom<crate::manifest_registry::v1alpha1::Query> for Query {
                 Ok::<QueryLatestAt, tonic::Status>(QueryLatestAt {
                     index: latest_at
                         .index
-                        .and_then(|index| index.timeline.map(|timeline| timeline.name))
-                        .ok_or_else(|| {
-                            tonic::Status::invalid_argument("index is required for latest_at query")
-                        })?,
+                        .and_then(|index| index.timeline.map(|timeline| timeline.name)),
                     at: latest_at
                         .at
                         .ok_or_else(|| tonic::Status::invalid_argument("at is required"))?,
@@ -173,8 +170,8 @@ impl From<Query> for crate::manifest_registry::v1alpha1::Query {
         crate::manifest_registry::v1alpha1::Query {
             latest_at: value.latest_at.map(|latest_at| {
                 crate::manifest_registry::v1alpha1::QueryLatestAt {
-                    index: Some({
-                        let timeline: TimelineName = latest_at.index.into();
+                    index: latest_at.index.map(|index| {
+                        let timeline: TimelineName = index.into();
                         timeline.into()
                     }),
                     at: Some(latest_at.at),
@@ -266,7 +263,7 @@ pub struct FuzzyComponentDescriptor {
 
 #[derive(Debug, Clone)]
 pub struct QueryLatestAt {
-    pub index: String,
+    pub index: Option<String>,
     pub at: i64,
     pub fuzzy_descriptors: Vec<String>,
     // TODO(cmc): I shall bring that back into a more structured form later.

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -280,7 +280,7 @@ impl QueryLatestAt {
     }
 
     pub fn is_static(&self) -> bool {
-        self.index.is_none() && self.at.is_static()
+        self.index.is_none()
     }
 }
 
@@ -291,11 +291,7 @@ impl From<QueryLatestAt> for crate::manifest_registry::v1alpha1::QueryLatestAt {
                 let timeline: TimelineName = index.into();
                 timeline.into()
             }),
-            at: if value.at.is_static() {
-                None
-            } else {
-                Some(value.at.as_i64())
-            },
+            at: Some(value.at.as_i64()),
             fuzzy_descriptors: value.fuzzy_descriptors,
         }
     }

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -626,9 +626,13 @@ impl ::prost::Name for Query {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct QueryLatestAt {
     /// Which index column should we perform the query on? E.g. `log_time`.
+    ///
+    /// Leave this empty to query for static data.
     #[prost(message, optional, tag = "1")]
     pub index: ::core::option::Option<super::super::common::v1alpha1::IndexColumnSelector>,
     /// What index value are we looking for?
+    ///
+    /// Leave this empty to query for static data.
     #[prost(int64, optional, tag = "2")]
     pub at: ::core::option::Option<i64>,
     /// Which components are we interested in?

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -15,7 +15,7 @@ use re_chunk_store::{ChunkStore, QueryExpression};
 use re_dataframe::ChunkStoreHandle;
 use re_grpc_client::{ConnectionClient, ConnectionRegistryHandle};
 use re_log_encoding::codec::wire::decoder::Decode as _;
-use re_log_types::{ApplicationId, EntryId, StoreId, StoreInfo, StoreKind, StoreSource, TimeInt};
+use re_log_types::{ApplicationId, EntryId, StoreId, StoreInfo, StoreKind, StoreSource};
 use re_protos::catalog::v1alpha1::ext::DatasetDetails;
 use re_protos::common::v1alpha1::ext::ScanParameters;
 use re_protos::manifest_registry::v1alpha1::RegisterWithDatasetResponse;
@@ -649,17 +649,13 @@ impl ConnectionHandle {
 
 fn query_from_query_expression(query_expression: &QueryExpression) -> Query {
     let latest_at = if query_expression.is_static() {
-        Some(QueryLatestAt {
-            index: None,
-            at: TimeInt::STATIC.as_i64(),
-            fuzzy_descriptors: vec![], // TODO(jleibs): support this
-        })
+        Some(QueryLatestAt::new_static())
     } else {
         query_expression
             .min_latest_at()
             .map(|latest_at| QueryLatestAt {
                 index: Some(latest_at.timeline().to_string()),
-                at: latest_at.at().as_i64(),
+                at: latest_at.at(),
                 fuzzy_descriptors: vec![], // TODO(jleibs): support this
             })
     };

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -423,9 +423,7 @@ impl PyDataframeQueryView {
         let chunk_stores = connection.get_chunks_for_dataframe_query(
             py,
             dataset_id,
-            &self_.query_expression.view_contents,
-            self_.query_expression.min_latest_at(),
-            self_.query_expression.max_range(),
+            &self_.query_expression,
             self_.partition_ids.as_slice(),
         )?;
 
@@ -496,9 +494,7 @@ impl PyDataframeQueryView {
         connection.get_chunk_ids_for_dataframe_query(
             py,
             dataset_id,
-            &self_.query_expression.view_contents,
-            self_.query_expression.min_latest_at(),
-            self_.query_expression.max_range(),
+            &self_.query_expression,
             self_.partition_ids.as_slice(),
         )
     }


### PR DESCRIPTION
### Related

- Follow up to #10332 
- Sibling https://github.com/rerun-io/dataplatform/pull/1032
### What

This PR adds support for querying stats chunks only in the grpc supporting structure, and use it for the dataframe query.

DNM:
- [x] chained
- [x] dataplatform update needed