### PR TITLE
Fix exclusion of recording properties in `ResolvedEntityPathFilter::unresolved`

### DIFF
--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -508,6 +508,8 @@ impl EntityPathFilter {
 impl ResolvedEntityPathFilter {
     /// Turns the resolved filter back into an unresolved filter.
     ///
+    /// The returned [`EntityPathFilter`] will _not_ contain the default exclusion of the recording properties.
+    ///
     /// Warning: Iterating over the rules in the unresolved filter will yield a different order
     /// than the order of the rules in the resolved filter.
     /// To preserve the order, use [`Self::iter_unresolved_expressions`] instead.
@@ -516,7 +518,15 @@ impl ResolvedEntityPathFilter {
             rules: self
                 .rules
                 .iter()
-                .map(|(rule, effect)| (rule.rule.clone(), *effect))
+                .filter_map(|(rule, effect)| {
+                    if rule == &ResolvedEntityPathRule::including_subtree(&EntityPath::properties())
+                        && effect == &RuleEffect::Exclude
+                    {
+                        None
+                    } else {
+                        Some((rule.rule.clone(), *effect))
+                    }
+                })
                 .collect(),
         }
     }

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -1286,4 +1286,85 @@ mod tests {
             "+ /**\n+ /__properties/**"
         );
     }
+
+    #[test]
+    fn test_unresolved() {
+        // We should omit the properties from the unresolved filter.
+        let filter = EntityPathFilter::parse_forgiving(
+            r#"
+        + /**
+        - /__properties/**
+        - /test123
+        + /test345
+        "#,
+        );
+        let resolved = filter.resolve_forgiving(&EntityPathSubs::empty());
+        assert_eq!(
+            resolved.unresolved(),
+            EntityPathFilter::parse_forgiving(
+                r#"
+                + /**
+                - /test123
+                + /test345
+                "#
+            )
+        );
+
+        // If not explicitly mentioned, it should roundtrip.
+        let filter = EntityPathFilter::parse_forgiving(
+            r#"
+        + /**
+        - /test123
+        + /test345
+        "#,
+        );
+        let resolved = filter.resolve_forgiving(&EntityPathSubs::empty());
+        assert_eq!(resolved.unresolved(), filter);
+
+        // If the properties are _included_ they should be present.
+        // We should omit the properties from the unresolved filter.
+        let filter = EntityPathFilter::parse_forgiving(
+            r#"
+        + /**
+        + /__properties/**
+        - /test123
+        + /test345
+        "#,
+        );
+        let resolved = filter.resolve_forgiving(&EntityPathSubs::empty());
+        assert_eq!(
+            resolved.unresolved(),
+            EntityPathFilter::parse_forgiving(
+                r#"
+                + /**
+                + /__properties/**
+                - /test123
+                + /test345
+                "#
+            )
+        );
+
+        // If the subpaths of properties are _excluded_ they should be present.
+        // We should omit the properties from the unresolved filter.
+        let filter = EntityPathFilter::parse_forgiving(
+            r#"
+        + /**
+        - /__properties/test123/**
+        - /test123
+        + /test345
+        "#,
+        );
+        let resolved = filter.resolve_forgiving(&EntityPathSubs::empty());
+        assert_eq!(
+            resolved.unresolved(),
+            EntityPathFilter::parse_forgiving(
+                r#"
+                + /**
+                - /__properties/test123/**
+                - /test123
+                + /test345
+                "#
+            )
+        );
+    }
 }


### PR DESCRIPTION
### Related

* Closes #10304.

### What

Due to the exclusion of the recording properties in the `unresolved` rules of an `ResolvedEntityPathFilter`, a (non-existing) change of the entity path filters was emitted, which caused spamming the blueprint store.

This PR fixes this by removing the recording properties exclusion rule.
