### PR TITLE
Add "refresh" copy on hover

### DIFF
--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -97,15 +97,14 @@ impl Server {
             "__entries",
         )
         .title(self.origin.host.to_string())
-        .title_button(ItemActionButton::new(
-            &re_ui::icons::RESET,
-            "Refresh collection",
-            || {
+        .title_button(
+            ItemActionButton::new(&re_ui::icons::RESET, "Refresh server", || {
                 ctx.command_sender
                     .send(Command::RefreshCollection(self.origin.clone()))
                     .ok();
-            },
-        ))
+            })
+            .hover_text("Refresh server"),
+        )
         .column_blueprint(|desc| {
             let mut blueprint = ColumnBlueprint::default();
 
@@ -155,15 +154,14 @@ impl Server {
             dataset.name(),
         )
         .title(dataset.name())
-        .title_button(ItemActionButton::new(
-            &re_ui::icons::RESET,
-            "Refresh collection",
-            || {
+        .title_button(
+            ItemActionButton::new(&re_ui::icons::RESET, "Refresh dataset", || {
                 ctx.command_sender
                     .send(Command::RefreshCollection(self.origin.clone()))
                     .ok();
-            },
-        ))
+            })
+            .hover_text("Refresh dataset"),
+        )
         .column_blueprint(|desc| {
             let mut name = default_display_name_for_column(desc);
 


### PR DESCRIPTION
Following Niko's feedback for day 3: https://linear.app/rerun/issue/DPF-1796/niko-feedback-triage

it was not clear what does refresh icon do. Adding hover. 
>UX: want on hover description of what this action does

Even better solution to come later: 
- https://linear.app/rerun/issue/DPF-1801/bottom-panel
