### PR TITLE
Add `set_sinks` to C++ `RecordingStream`

### DIFF
--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -135,6 +135,7 @@ pub mod external {
     pub use re_log;
     pub use re_log_encoding;
     pub use re_log_types;
+    pub use re_uri;
 
     pub use re_chunk::external::*;
     pub use re_log::external::*;

--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -155,6 +155,12 @@ impl_multi_sink_tuple!(A, B, C, D);
 impl_multi_sink_tuple!(A, B, C, D, E);
 impl_multi_sink_tuple!(A, B, C, D, E, F);
 
+impl IntoMultiSink for Vec<Box<dyn LogSink>> {
+    fn into_multi_sink(self) -> MultiSink {
+        MultiSink::new(self)
+    }
+}
+
 impl private::Sealed for crate::sink::FileSink {}
 
 impl MultiSinkCompatible for crate::sink::FileSink {}

--- a/docs/snippets/all/howto/set_sinks.cpp
+++ b/docs/snippets/all/howto/set_sinks.cpp
@@ -1,0 +1,21 @@
+#include <rerun.hpp>
+#include <rerun/demo_utils.hpp>
+
+using namespace rerun::demo;
+
+int main() {
+    // Create a new `RecordingStream` which sends data over gRPC to the viewer process.
+    const auto rec = rerun::RecordingStream("rerun_example_set_sinks");
+    rec.set_sinks(
+        rerun::GrpcSink(),
+        rerun::FileSink("data.rrd")
+    ).exit_on_failure();
+
+    // Create some data using the `grid` utility function.
+    std::vector<rerun::Position3D> points = grid3d<rerun::Position3D, float>(-10.f, 10.f, 10);
+    std::vector<rerun::Color> colors = grid3d<rerun::Color, uint8_t>(0, 255, 10);
+
+    // Log the "my_points" entity with our data, using the `Points3D` archetype.
+    rec.log("my_points", rerun::Points3D(points).with_colors(colors).with_radii({0.5f}));
+}
+

--- a/rerun_cpp/src/rerun/log_sink.cpp
+++ b/rerun_cpp/src/rerun/log_sink.cpp
@@ -1,0 +1,29 @@
+#include "log_sink.hpp"
+#include "string_utils.hpp"
+#include "c/rerun.h"
+
+#include <cassert>
+
+namespace rerun {
+    namespace detail {
+        rr_log_sink to_rr_log_sink(LogSink sink) {
+            rr_log_sink out;
+            switch (sink.kind) {
+                case LogSink::Kind::Grpc:
+                    out.kind = RR_LOG_SINK_KIND_GRPC;
+                    out.grpc = rr_grpc_sink{
+                        detail::to_rr_string(sink.grpc.url),
+                        sink.grpc.flush_timeout_sec,
+                    };
+                    break;
+                case LogSink::Kind::File:
+                    out.kind = RR_LOG_SINK_KIND_FILE;
+                    out.file = rr_file_sink{detail::to_rr_string(sink.file.path)};
+                    break;
+                default:
+                    assert(false && "unreachable");
+            }
+            return out;
+        }
+    }
+}

--- a/rerun_cpp/src/rerun/log_sink.hpp
+++ b/rerun_cpp/src/rerun/log_sink.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <string_view>
+
+struct rr_log_sink;
+
+namespace rerun {
+    struct LogSink;
+
+    // TODO: document
+    
+    struct GrpcSink {
+        std::string_view url  = "rerun+http://127.0.0.1:9876/proxy";
+        float flush_timeout_sec = 3.0;
+
+        inline operator LogSink() const;
+    };
+
+    struct FileSink {
+        std::string_view path;
+
+        inline operator LogSink() const;
+    };
+
+    struct LogSink {
+        enum class Kind {
+            Grpc = 0,
+            File = 1,
+        };
+
+        Kind kind;
+        union {
+            GrpcSink grpc;
+            FileSink file;
+        };
+    };
+
+
+    inline GrpcSink::operator LogSink() const {
+        LogSink sink{};
+        sink.kind = LogSink::Kind::Grpc;
+        sink.grpc = GrpcSink{url, flush_timeout_sec};
+        return sink;
+    }
+
+    inline FileSink::operator LogSink() const {
+        LogSink sink{};
+        sink.kind = LogSink::Kind::File;
+        sink.file = FileSink{path};
+        return sink;
+    }
+
+    namespace detail {
+        rr_log_sink to_rr_log_sink(LogSink sink);
+    };
+};

--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -3,6 +3,7 @@
 #include "c/rerun.h"
 #include "component_batch.hpp"
 #include "config.hpp"
+#include "log_sink.hpp"
 #include "sdk_info.hpp"
 #include "string_utils.hpp"
 
@@ -104,6 +105,19 @@ namespace rerun {
                 return current_recording;
             }
         }
+    }
+
+    Error RecordingStream::try_set_sinks(const LogSink* sinks, uint32_t num_sinks) const {
+        rr_error status = {};
+
+        std::vector<rr_log_sink> c_sinks;
+        c_sinks.reserve(num_sinks);
+        for (uint32_t i = 0; i < num_sinks; i++) {
+            c_sinks.push_back(detail::to_rr_log_sink(sinks[i]));
+        }
+        rr_recording_stream_set_sinks(_id, c_sinks.data(), c_sinks.size(), &status);
+
+        return status;
     }
 
     Error RecordingStream::connect_grpc(std::string_view url, float flush_timeout_sec) const {

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -336,6 +336,65 @@ void test_logging_to_grpc_connection(const char* url, const rerun::RecordingStre
     }
 }
 
+SCENARIO("RecordingStream can construct LogSinks", TEST_TAG) {
+    const char* url = "rerun+http://127.0.0.1:9876/proxy";
+    const char* invalid_url = "definitely not valid!";
+    const char* test_path = "build/test_output";
+    fs::create_directories(test_path);
+
+    std::string test_rrd0 = std::string(test_path) + "test-file-log-sink-0.rrd";
+
+    fs::remove(test_rrd0);
+
+    GIVEN("a new RecordingStream") {
+        rerun::RecordingStream stream("test-local");
+
+        AND_GIVEN("valid save path" << test_rrd0) {
+            AND_GIVEN("a directory already existing at this path") {
+                fs::create_directory(test_rrd0);
+                THEN("set_sinks(FileSink) call fails") {
+                    CHECK(
+                          stream.set_sinks(rerun::FileSink{test_rrd0}).code ==
+                          rerun::ErrorCode::RecordingStreamSaveFailure
+                    );
+                }
+            }
+            THEN("set_sinks(FileSink) call returns no error") {
+                CHECK(
+                      stream.set_sinks(rerun::FileSink{test_rrd0}).code ==
+                      rerun::ErrorCode::Ok
+                );
+            }
+        }
+
+        AND_GIVEN("an invalid url" << invalid_url) {
+            THEN("set_sinks(GrpcSink) call fails") {
+                CHECK(
+                    stream.set_sinks(rerun::GrpcSink{invalid_url}).code ==
+                    rerun::ErrorCode::InvalidServerUrl
+                );
+            }
+        }
+        AND_GIVEN("a valid url" << url) {
+            THEN("set_sinks(GrpcSink) call returns no error") {
+                CHECK(
+                    stream.set_sinks(rerun::GrpcSink{url}).code ==
+                    rerun::ErrorCode::Ok
+                );
+            }
+        }
+
+        AND_GIVEN("both a url" << url << "and a save path" << test_rrd0) {
+            THEN("set_sinks(GrpcSink, FileSink) call returns no error") {
+                CHECK(
+                    stream.set_sinks(rerun::GrpcSink{url}, rerun::FileSink{test_rrd0}).code ==
+                    rerun::ErrorCode::Ok
+                );
+            }
+        }
+    }
+}
+
 SCENARIO("RecordingStream can connect over grpc", TEST_TAG) {
     const char* url = "rerun+http://127.0.0.1:9876/proxy";
     GIVEN("a new RecordingStream") {


### PR DESCRIPTION
Adds `set_sinks` to the C++ API:

```cpp
rerun::RecordingStream stream("test");
stream.set_sinks(rerun::GrpcSink(), rerun::FileSink("data.rrd"));
```