### PR TITLE
Remove unneeded edit ui warning

### DIFF
--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -663,9 +663,6 @@ impl ComponentUiRegistry {
         // We use the component type to identify which UI to show.
         // (but for saving back edit results, we need the full descriptor)
         let Some(ui_identifier) = component_descr.component_type else {
-            re_log::warn_once!(
-                "Cannot show edit ui for descriptors without component type: {component_descr}"
-            );
             return false;
         };
 


### PR DESCRIPTION
### What

The warning here is unnecessary. As the comment above this check states it's not a problem to opt-out of showing an edit UI in this place.
