### PR TITLE
Disambiguate component entries in selection panel

### DIFF
--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -181,7 +181,7 @@ impl SelectionPanel {
                 ));
 
                 ui.list_item_flat_noninteractive(
-                    PropertyContent::new("Component type").value_text(if is_static {
+                    PropertyContent::new("Temporality").value_text(if is_static {
                         "Static"
                     } else {
                         "Temporal"
@@ -216,8 +216,8 @@ impl SelectionPanel {
                 );
 
                 if let Some(component_type) = component_type {
-                    ui.list_item_flat_noninteractive(PropertyContent::new("Component").value_fn(
-                        |ui, _| {
+                    ui.list_item_flat_noninteractive(
+                        PropertyContent::new("Component type").value_fn(|ui, _| {
                             ui.label(component_type.short_name()).on_hover_ui(|ui| {
                                 ui.spacing_mut().item_spacing.y = 12.0;
 
@@ -237,8 +237,8 @@ impl SelectionPanel {
                                     ui.re_hyperlink("Full documentation", doc_url, true);
                                 }
                             });
-                        },
-                    ));
+                        }),
+                    );
                 }
 
                 list_existing_data_blueprints(ctx, viewport, ui, &entity_path.clone().into());

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -181,7 +181,7 @@ impl SelectionPanel {
                 ));
 
                 ui.list_item_flat_noninteractive(
-                    PropertyContent::new("Temporality").value_text(if is_static {
+                    PropertyContent::new("Index type").value_text(if is_static {
                         "Static"
                     } else {
                         "Temporal"


### PR DESCRIPTION
### Related

* Closes #10361.

### What

This renames "Component type" (used to indicate if a component is "Static" or "Temporal") to "Index type". The freed up "Component type" is then used for the corresponding metadata entry.

~⚠️ Flagging this as somewhat controversial, which is why I'm requesting a review from @jleibs.~ Feedback received.

### Screenshot

<img width="292" alt="image" src="https://github.com/user-attachments/assets/8ba4912f-673d-4d78-adaa-d1eba1384d0c" />


