### PR TITLE
Add additional Rust test cases for (static) dataframe queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7261,6 +7261,7 @@ dependencies = [
  "re_query",
  "re_sorbet",
  "re_tracing",
+ "re_types",
  "re_types_core",
  "similar-asserts",
  "tokio",

--- a/crates/store/re_chunk_store/tests/dataframe.rs
+++ b/crates/store/re_chunk_store/tests/dataframe.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use re_chunk::{Chunk, RowId, TimelineName};
+use arrow::array::{StringArray, UInt32Array};
+use re_chunk::{Chunk, RowId, TimePoint, TimelineName};
 use re_chunk_store::{
     ChunkStore, ChunkStoreConfig, QueryExpression, StaticColumnSelection, TimeInt,
     ViewContentsSelector,
@@ -10,6 +11,8 @@ use re_log_types::{
     example_components::{MyColor, MyLabel, MyPoint, MyPoints},
 };
 use re_sorbet::ChunkColumnDescriptors;
+use re_types::AsComponents as _;
+use re_types::{AnyValues, ComponentDescriptor};
 
 #[test]
 /// Tests whether the store has the expected schema after populating it with a chunk.
@@ -132,6 +135,116 @@ fn schema_for_query() -> anyhow::Result<()> {
             .collect::<Vec<_>>(),
         // The following should be in lexicographical order!
         vec![MyPoints::descriptor_colors(), MyPoints::descriptor_labels(),]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn schema_static_columns() -> anyhow::Result<()> {
+    re_log::setup_logging();
+
+    let mut store = ChunkStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        ChunkStoreConfig::COMPACTION_DISABLED,
+    );
+
+    let any_values = AnyValues::default()
+        .with_field("yak", Arc::new(StringArray::from(vec!["yuk"])))
+        .with_field("foo", Arc::new(StringArray::from(vec!["bar"])))
+        .with_field("baz", Arc::new(UInt32Array::from(vec![42u32])));
+
+    let entity_path = EntityPath::from("test");
+
+    let chunk0 = Chunk::builder(entity_path.clone())
+        .with_serialized_batches(
+            RowId::new(),
+            TimePoint::default(),
+            any_values.as_serialized_batches(),
+        )
+        .build()?;
+
+    store.insert_chunk(&Arc::new(chunk0))?;
+
+    let frame1 = TimeInt::new_temporal(1);
+    let chunk1 = Chunk::builder(entity_path)
+        .with_archetype(
+            RowId::new(),
+            [build_frame_nr(frame1)],
+            &MyPoints::new(MyPoint::from_iter(0..1)),
+        )
+        .build()?;
+
+    store.insert_chunk(&Arc::new(chunk1))?;
+
+    // Both
+
+    let query = QueryExpression {
+        view_contents: None,
+        include_semantically_empty_columns: false,
+        include_indicator_columns: false,
+        include_tombstone_columns: false,
+        include_static_columns: StaticColumnSelection::Both,
+        filtered_index: None,
+        filtered_index_range: None,
+        filtered_index_values: None,
+        using_index_values: None,
+        filtered_is_not_null: None,
+        sparse_fill_strategy: re_chunk_store::SparseFillStrategy::None,
+        selection: None,
+    };
+
+    let ChunkColumnDescriptors { components, .. } = store.schema_for_query(&query);
+
+    assert_eq!(
+        components
+            .iter()
+            .map(|column| (column.component_descriptor(), column.is_static))
+            .collect::<Vec<_>>(),
+        vec![
+            (ComponentDescriptor::partial("baz"), true),
+            (ComponentDescriptor::partial("foo"), true),
+            (ComponentDescriptor::partial("yak"), true),
+            (MyPoints::descriptor_points(), false),
+        ]
+    );
+
+    // Static
+
+    let query = QueryExpression {
+        include_static_columns: StaticColumnSelection::StaticOnly,
+        ..query
+    };
+
+    let ChunkColumnDescriptors { components, .. } = store.schema_for_query(&query);
+
+    assert_eq!(
+        components
+            .iter()
+            .map(|column| (column.component_descriptor(), column.is_static))
+            .collect::<Vec<_>>(),
+        vec![
+            (ComponentDescriptor::partial("baz"), true),
+            (ComponentDescriptor::partial("foo"), true),
+            (ComponentDescriptor::partial("yak"), true),
+        ]
+    );
+
+    // Non-static
+
+    let query = QueryExpression {
+        include_static_columns: StaticColumnSelection::NonStaticOnly,
+        ..query
+    };
+
+    let ChunkColumnDescriptors { components, .. } = store.schema_for_query(&query);
+
+    assert_eq!(
+        components
+            .iter()
+            .map(|column| (column.component_descriptor(), column.is_static))
+            .collect::<Vec<_>>(),
+        vec![(MyPoints::descriptor_points(), false),]
     );
 
     Ok(())

--- a/crates/store/re_chunk_store/tests/snapshots/dataframe__schema_static_columns-2.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/dataframe__schema_static_columns-2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/store/re_chunk_store/tests/dataframe.rs
+expression: static_only
+snapshot_kind: text
+---
+[
+    "baz",
+    "foo",
+    "yak",
+]

--- a/crates/store/re_chunk_store/tests/snapshots/dataframe__schema_static_columns-3.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/dataframe__schema_static_columns-3.snap
@@ -1,0 +1,8 @@
+---
+source: crates/store/re_chunk_store/tests/dataframe.rs
+expression: non_static_only
+snapshot_kind: text
+---
+[
+    "example.MyPoints:points",
+]

--- a/crates/store/re_chunk_store/tests/snapshots/dataframe__schema_static_columns.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/dataframe__schema_static_columns.snap
@@ -1,0 +1,11 @@
+---
+source: crates/store/re_chunk_store/tests/dataframe.rs
+expression: both_static_and_non_static
+snapshot_kind: text
+---
+[
+    "baz",
+    "foo",
+    "yak",
+    "example.MyPoints:points",
+]

--- a/crates/store/re_dataframe/Cargo.toml
+++ b/crates/store/re_dataframe/Cargo.toml
@@ -45,6 +45,7 @@ rayon.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+re_types.workspace = true
 # External dependencies:
 insta.workspace = true
 similar-asserts.workspace = true

--- a/crates/store/re_dataframe/tests/static.rs
+++ b/crates/store/re_dataframe/tests/static.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use arrow::array::{ListArray, RecordBatchIterator, StringArray, UInt32Array};
+use re_chunk::{ArrowArray as _, Chunk, RowId, TimePoint};
+use re_chunk_store::{ChunkStore, ChunkStoreConfig, QueryExpression};
+use re_dataframe::QueryEngine;
+use re_log_types::EntityPath;
+use re_types::AsComponents as _;
+use re_types::{AnyValues, ComponentDescriptor};
+
+#[test]
+fn query_static_columns() -> anyhow::Result<()> {
+    re_log::setup_logging();
+
+    let store = ChunkStore::new_handle(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        ChunkStoreConfig::COMPACTION_DISABLED,
+    );
+
+    let any_values = AnyValues::default()
+        .with_field("yak", Arc::new(StringArray::from(vec!["yuk"])))
+        .with_field("foo", Arc::new(StringArray::from(vec!["bar"])))
+        .with_field("baz", Arc::new(UInt32Array::from(vec![42u32])));
+
+    let entity_path = EntityPath::from("test");
+
+    let chunk0 = Chunk::builder(entity_path.clone())
+        .with_serialized_batches(
+            RowId::new(),
+            TimePoint::default(),
+            any_values.as_serialized_batches(),
+        )
+        .build()?;
+
+    store.write().insert_chunk(&Arc::new(chunk0))?;
+
+    let engine = QueryEngine::from_store(store);
+
+    let query_expr = QueryExpression {
+        view_contents: None,
+        include_semantically_empty_columns: false,
+        include_indicator_columns: false,
+        include_tombstone_columns: false,
+        include_static_columns: re_chunk_store::StaticColumnSelection::Both,
+        filtered_index: None,
+        filtered_index_range: None,
+        filtered_index_values: None,
+        using_index_values: None,
+        filtered_is_not_null: None,
+        sparse_fill_strategy: re_chunk_store::SparseFillStrategy::None,
+        selection: None,
+    };
+
+    let query_handle = engine.query(query_expr);
+
+    let components = &query_handle.view_contents().components;
+
+    assert_eq!(
+        components
+            .iter()
+            .map(|column| (column.component_descriptor(), column.is_static))
+            .collect::<Vec<_>>(),
+        vec![
+            (ComponentDescriptor::partial("baz"), true),
+            (ComponentDescriptor::partial("foo"), true),
+            (ComponentDescriptor::partial("yak"), true),
+        ]
+    );
+
+    let schema = query_handle.schema().clone();
+
+    let mut reader = RecordBatchIterator::new(query_handle.into_batch_iter().map(Ok), schema);
+
+    let batch = reader.next().expect("there should be at least one batch")?;
+
+    eprintln!("{batch:#?}");
+
+    assert_eq!(batch.num_columns(), 3);
+    assert_eq!(batch.num_rows(), 1);
+
+    let baz = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(0);
+    let baz = baz.as_any().downcast_ref::<UInt32Array>().unwrap();
+    assert_eq!(baz.value(0), 42);
+
+    let foo = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(0);
+    let foo = foo.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(foo.value(0), "bar");
+
+    let yak = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<ListArray>()
+        .unwrap()
+        .value(0);
+    let yak = yak.as_any().downcast_ref::<StringArray>().unwrap();
+    assert_eq!(yak.value(0), "yuk");
+
+    Ok(())
+}

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -80,12 +80,7 @@ impl PyDataframeQueryView {
                 filtered_index_values: None,
                 using_index_values: None,
                 filtered_is_not_null: None,
-                //TODO(#10327): this should not be necessary!
-                sparse_fill_strategy: if static_only {
-                    SparseFillStrategy::LatestAtGlobal
-                } else {
-                    SparseFillStrategy::None
-                },
+                sparse_fill_strategy: SparseFillStrategy::None,
                 selection: None,
             },
             partition_ids: vec![],

--- a/rerun_py/src/dataframe/recording.rs
+++ b/rerun_py/src/dataframe/recording.rs
@@ -238,12 +238,7 @@ impl PyRecording {
             filtered_index_values: None,
             using_index_values: None,
             filtered_is_not_null: None,
-            //TODO(#10327): this should not be necessary!
-            sparse_fill_strategy: if static_only {
-                SparseFillStrategy::LatestAtGlobal
-            } else {
-                SparseFillStrategy::None
-            },
+            sparse_fill_strategy: SparseFillStrategy::None,
             selection: None,
         };
 

--- a/rerun_py/src/dataframe/recording_view.rs
+++ b/rerun_py/src/dataframe/recording_view.rs
@@ -223,9 +223,6 @@ impl PyRecordingView {
         // This is a static selection, so we clear the filtered index
         query_expression.filtered_index = None;
 
-        //TODO(#10327): this should not be necessary!
-        query_expression.sparse_fill_strategy = SparseFillStrategy::LatestAtGlobal;
-
         // If no columns provided, select all static columns
         let static_columns = Self::select_args(args, columns)
             .transpose()

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -464,6 +464,16 @@ def test_dataframe_static(any_value_static_recording: rr.dataframe.Recording) ->
     assert table.column(2).to_pylist()[0] is not None
 
 
+def test_dataframe_static_only(any_value_static_recording: rr.dataframe.Recording) -> None:
+    view = any_value_static_recording.view(index=None, contents="/**")
+
+    table = view.select_static().read_all()
+
+    assert table.column(0).to_pylist()[0] is not None
+    assert table.column(1).to_pylist()[0] is not None
+    assert table.column(2).to_pylist()[0] is not None
+
+
 def test_dataframe_index_no_default(any_value_static_recording: rr.dataframe.Recording) -> None:
     """We specifically want index to not default None. This must be explicitly set to indicate a static query."""
     with pytest.raises(TypeError, match="missing 1 required keyword argument"):

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -461,7 +461,7 @@ def test_dataframe_static(any_value_static_recording: rr.dataframe.Recording) ->
 
     assert table.column(0).to_pylist()[0] is not None
     assert table.column(1).to_pylist()[0] is not None
-    assert table.column(1).to_pylist()[0] is not None
+    assert table.column(2).to_pylist()[0] is not None
 
 
 def test_dataframe_index_no_default(any_value_static_recording: rr.dataframe.Recording) -> None:


### PR DESCRIPTION
### Related

* Part of #10212 
* Related #10332, and transitively
* Related #10193
* Related #10335
* Closes #10327

### What

Additional dataframe query tests in Rust. I had these laying around and I didn't want them to bit rot.

These new test cases are aimed particularly at #10327, which does not seem to need the workaround anymore.
