### PR TITLE
Partition URL UDF

### DIFF
--- a/rerun_py/rerun_sdk/rerun/utilities/datafusion/functions/url_generation.py
+++ b/rerun_py/rerun_sdk/rerun/utilities/datafusion/functions/url_generation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pyarrow as pa
+from datafusion import Expr, ScalarUDF, col, udf
+from rerun_bindings import DatasetEntry
+
+
+def partition_url(
+    dataset: DatasetEntry, partition_id_col: str | Expr | None = None, timestamp_col: str | Expr | None = None
+) -> Expr:
+    """
+    Compute the URL for a partition within a dataset.
+
+    This is a Rerun focused DataFusion function that will create a DataFusion
+    expression for the partition URL.
+
+    To manually invoke the underlying UDF, see `partition_url_udf` or
+    `partition_url_with_timeref_udf`.
+
+    Parameters
+    ----------
+    dataset:
+        The input Rerun Dataset.
+    partition_id_col:
+        The column containing the partition ID. If not provided, it will assume
+        a default value of `rerun_partition_id`. You may pass either a DataFusion
+        expression or a string column name.
+    timestamp_col:
+        If this parameter is passed in, generate a URL that will jump to a
+        specific timestamp within the partition.
+
+    """
+    if partition_id_col is None:
+        partition_id_col = col("rerun_partition_id")
+    if isinstance(partition_id_col, str):
+        partition_id_col = col(partition_id_col)
+
+    if timestamp_col is not None:
+        if isinstance(timestamp_col, str):
+            timestamp_col = col(timestamp_col)
+
+        inner_udf = partition_url_with_timeref_udf(dataset)
+        return inner_udf(partition_id_col, timestamp_col).alias("partition_url_with_timestamp")
+
+    inner_udf = partition_url_udf(dataset)
+    return inner_udf(partition_id_col).alias("partition_url")
+
+
+def partition_url_udf(dataset: DatasetEntry) -> ScalarUDF:
+    """
+    Create a UDF to the URL for a partition within a Dataset.
+
+    This function will generate a UDF that expects one column of input,
+    a string containing the Partition ID.
+    """
+
+    def inner_udf(partition_id_arr: pa.Array) -> pa.Array:
+        return pa.compute.binary_join_element_wise(
+            dataset.partition_url(""),
+            partition_id_arr,
+            "",  # Required for join
+        )
+
+    return udf(inner_udf, [pa.string()], pa.string(), "stable")
+
+
+def partition_url_with_timeref_udf(dataset: DatasetEntry) -> ScalarUDF:
+    """
+    Create a UDF to the URL for a partition within a Dataset with timestamp.
+
+    This function will generate a UDF that expects two columns of input,
+    a string containing the Partition ID and the timestamp in nanoseconds.
+    """
+
+    def inner_udf(partition_id_arr: pa.Array, timestamp_arr: pa.Array) -> pa.Array:
+        timestamp_us = pa.compute.cast(timestamp_arr, pa.timestamp("us"))
+
+        timestamp_us = pa.compute.strftime(
+            timestamp_us,
+            "%Y-%m-%dT%H:%M:%SZ",
+        )
+
+        return pa.compute.binary_join_element_wise(
+            dataset.partition_url(""),
+            partition_id_arr,
+            "#when=real_time@",
+            timestamp_us,
+            "",  # Required for join
+        )
+
+    return udf(inner_udf, [pa.string(), pa.timestamp("ns")], pa.string(), "stable")


### PR DESCRIPTION
### Related

Relates to https://linear.app/rerun/issue/DPF-1757/udfs-embedded-in-notebooks

### What

This PR adds DataFusion UDFs for adding partition IDs to a DataFrame. It supports adding with or without a timestamp column.

In the old version of the droid dataset we would have

```python
def partition_url(partition_id_arr):
    """Create a URL for linking back to the partition from inside the viewer."""
    return pa.array(f"rerun+http://localhost:51234/dataset/{dataset.id}?partition_id={pid}" for pid in partition_id_arr)

def partition_url_with_timeref(partition_id_arr, time):
    """Create a URL for linking back to the partition from inside the viewer."""
    return pa.array(f"rerun+http://localhost:51234/dataset/{dataset.id}?partition_id={pid}#when=real_time@{ts.as_py().isoformat()}Z" for pid,ts in zip(partition_id_arr, time))

partition_url_udf = df.udf(partition_url, [pa.string()], pa.string(), 'stable')
partition_url_with_timeref_udf = df.udf(partition_url_with_timeref, [pa.string(), pa.timestamp('ns')], pa.string(), 'stable')

# some time later
grip_time_table = grip_time_table.with_column("partition_url", partition_url_udf(df.col("rerun_partition_id")))

# some time later
joined = (additional_data
    .join(best_match_per_partition, left_on='real_time', right_on='timepoint', how="left")
    .sort(df.col("distance"))
).with_column("url", partition_url_with_timeref_udf(df.col("rerun_partition_id"), df.col("real_time")))
```

And with the new version this would be

```python
from rerun.utilities.datafusion.functions.url_generation import partition_url

grip_time_table = grip_time_table.with_column("partition_url", partition_url(dataset))

# some time later

joined = (additional_data
    .join(best_match_per_partition, left_on='real_time', right_on='timepoint', how="left")
    .sort(df.col("distance"))
).with_column("url", partition_url(dataset, timestamp_col="real_time"))
```

This has been tested against `main` on `rerun` and `dataplatform`