### PR TITLE
Display the partition ID in recording selection panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7051,6 +7051,7 @@ dependencies = [
  "re_types",
  "re_types_core",
  "re_ui",
+ "re_uri",
  "re_video",
  "re_viewer_context",
  "rexif",

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -35,6 +35,7 @@ re_types = { workspace = true, features = [
 ] }
 re_types_core.workspace = true
 re_ui = { workspace = true, features = ["arrow"] }
+re_uri.workspace = true
 re_video = { workspace = true, features = ["ffmpeg"] }
 re_viewer_context.workspace = true
 

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -5,6 +5,7 @@ use re_byte_size::SizeBytes as _;
 use re_chunk_store::ChunkStoreConfig;
 use re_entity_db::EntityDb;
 use re_log_types::StoreKind;
+use re_smart_channel::SmartChannelSource;
 use re_ui::UiExt as _;
 use re_viewer_context::{UiLayout, ViewerContext};
 
@@ -36,6 +37,12 @@ impl crate::DataUi for EntityDb {
             {
                 ui.grid_left_hand_label(&format!("{} ID", self.store_id().kind));
                 ui.label(self.store_id().to_string());
+                ui.end_row();
+            }
+
+            if let Some(SmartChannelSource::RedapGrpcStream { uri: re_uri::DatasetDataUri { partition_id, .. }, .. }) = &self.data_source {
+                ui.grid_left_hand_label("Partition ID");
+                ui.label(partition_id.to_string());
                 ui.end_row();
             }
 
@@ -138,8 +145,8 @@ impl crate::DataUi for EntityDb {
                     re_format::format_uint(chunk_max_rows_if_unsorted),
                     re_format::format_bytes(chunk_max_bytes as _),
                 ))
-                .on_hover_text(
-                    unindent::unindent(&format!("\
+                    .on_hover_text(
+                        unindent::unindent(&format!("\
                         The current compaction configuration for this recording is to merge chunks until they \
                         reach either a maximum of {} rows ({} if unsorted) or {}, whichever comes first.
 
@@ -165,14 +172,14 @@ impl crate::DataUi for EntityDb {
                         `rerun rrd compact` CLI tool if you wish to persist the compacted results, which will \
                         make future runs cheaper.
                         ",
-                        re_format::format_uint(chunk_max_rows),
-                        re_format::format_uint(chunk_max_rows_if_unsorted),
-                        re_format::format_bytes(chunk_max_bytes as _),
-                        ChunkStoreConfig::ENV_CHUNK_MAX_ROWS,
-                        ChunkStoreConfig::ENV_CHUNK_MAX_ROWS_IF_UNSORTED,
-                        ChunkStoreConfig::ENV_CHUNK_MAX_BYTES,
-                    )),
-                );
+                                                    re_format::format_uint(chunk_max_rows),
+                                                    re_format::format_uint(chunk_max_rows_if_unsorted),
+                                                    re_format::format_bytes(chunk_max_bytes as _),
+                                                    ChunkStoreConfig::ENV_CHUNK_MAX_ROWS,
+                                                    ChunkStoreConfig::ENV_CHUNK_MAX_ROWS_IF_UNSORTED,
+                                                    ChunkStoreConfig::ENV_CHUNK_MAX_BYTES,
+                        )),
+                    );
                 ui.end_row();
             }
 


### PR DESCRIPTION
### Related

- Closes #10351
- See discussion https://linear.app/rerun/issue/OSS-1397/internal-recording-id-in-viewer-does-not-match-partition-id

### What

We need `StoreId` to be universal yunique, and partition ID are far from it. For this reason, we do NOT set the store id to the partition id for recording downloaded from servers. As a result, the recording id displayed in the UI (which actually is the store id) does not match the partition id.

This PR addresses this by explicitly displaying the partition ID for recording sourced from servers.

<img width="473" alt="image" src="https://github.com/user-attachments/assets/84d119d1-bd90-45f6-b214-c3e46bd2fbf0" />
