### PR TITLE
Improve table column names

### DIFF
--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -206,6 +206,18 @@ impl EntityPath {
         prefix.len() <= self.len() && self.iter().zip(prefix.iter()).all(|(a, b)| a == b)
     }
 
+    /// If this path starts with the given prefix,
+    /// then return the rest of the path after the prefix.
+    #[inline]
+    pub fn strip_prefix(&self, prefix: &Self) -> Option<Self> {
+        if self.starts_with(prefix) {
+            let remaining_parts = self.parts[prefix.len()..].to_vec();
+            Some(Self::new(remaining_parts))
+        } else {
+            None
+        }
+    }
+
     /// Is this a strict descendant of the given path.
     #[inline]
     pub fn is_descendant_of(&self, other: &Self) -> bool {

--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -740,4 +740,14 @@ mod tests {
         run_test(&[("/", "/"), ("/", "/")]);
         run_test(&[("a/b", "a/b"), ("a/b", "a/b")]);
     }
+
+    #[test]
+    fn test_strip_prefix() {
+        let entity_path = EntityPath::properties() / EntityPathPart::from("episode");
+        assert_eq!(entity_path.to_string(), "/__properties/episode");
+        assert_eq!(
+            entity_path.strip_prefix(&EntityPath::properties()),
+            Some(EntityPath::from("episode"))
+        );
+    }
 }

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -273,24 +273,11 @@ impl ComponentColumnDescriptor {
             BatchType::Dataframe => {
                 let prefix = if let Some(suffix) = self
                     .entity_path
-                    .strip_prefix(&EntityPath::recording_properties())
+                    .strip_prefix(&EntityPath::recording_properties()) // TODO(#10318): remove
+                    .or_else(|| self.entity_path.strip_prefix(&EntityPath::properties()))
                 {
                     if suffix.is_root() {
-                        // Built-in recording properties, like `start_time`:
-                        return self
-                            .component_descriptor()
-                            .archetype_field_name()
-                            .to_owned();
-                    } else {
-                        // Something weird
-                        self.entity_path.to_string()
-                    }
-                } else if let Some(suffix) =
-                    self.entity_path.strip_prefix(&EntityPath::properties())
-                {
-                    // User-defined property
-                    if suffix.is_root() {
-                        // User-defined property at root-level
+                        // Property at root-level (maybe part of `RecordingProperties`, or maybe a user-defined property)
                         "property".to_owned()
                     } else {
                         // User-defined property not at root-level

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -291,7 +291,7 @@ impl ComponentColumnDescriptor {
                         "property".to_owned()
                     } else {
                         // User-defined property not at root-level
-                        format!("property:{suffix}")
+                        format!("property:{}", suffix.to_string().trim_start_matches('/'))
                     }
                 } else {
                     self.entity_path.to_string()
@@ -308,7 +308,7 @@ impl ComponentColumnDescriptor {
                         },
                         self.component_descriptor().archetype_field_name()
                     ),
-                    None => format!("{}:{}", self.entity_path, self.component),
+                    None => format!("{prefix}:{}", self.component),
                 }
             }
         }

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -277,7 +277,10 @@ impl ComponentColumnDescriptor {
                 {
                     if suffix.is_root() {
                         // Built-in recording properties, like `start_time`:
-                        return self.component.to_string();
+                        return self
+                            .component_descriptor()
+                            .archetype_field_name()
+                            .to_owned();
                     } else {
                         // Something weird
                         self.entity_path.to_string()

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -271,11 +271,36 @@ impl ComponentColumnDescriptor {
                 self.component_descriptor().display_name().to_owned()
             }
             BatchType::Dataframe => {
+                let prefix = if let Some(suffix) = self
+                    .entity_path
+                    .strip_prefix(&EntityPath::recording_properties())
+                {
+                    if suffix.is_root() {
+                        // Built-in recording properties, like `start_time`:
+                        return self.component.to_string();
+                    } else {
+                        // Something weird
+                        self.entity_path.to_string()
+                    }
+                } else if let Some(suffix) =
+                    self.entity_path.strip_prefix(&EntityPath::properties())
+                {
+                    // User-defined property
+                    if suffix.is_root() {
+                        // User-defined property at root-level
+                        "property".to_owned()
+                    } else {
+                        // User-defined property not at root-level
+                        format!("property:{suffix}")
+                    }
+                } else {
+                    self.entity_path.to_string()
+                };
+
                 // Each column can be of a different entity
                 match self.archetype {
                     Some(archetype_name) => format!(
-                        "{}:{}:{}",
-                        self.entity_path,
+                        "{prefix}:{}:{}",
                         if short_archetype {
                             archetype_name.short_name()
                         } else {

--- a/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
@@ -583,10 +583,14 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
                 "Archetype field",
                 desc.component_descriptor().archetype_field_name(),
             );
-            header_property_ui(ui, "Static", is_static.to_string());
-            header_property_ui(ui, "Indicator", is_indicator.to_string());
-            header_property_ui(ui, "Tombstone", is_tombstone.to_string());
-            header_property_ui(ui, "Empty", is_semantically_empty.to_string());
+
+            if false {
+                // TODO(#10315): these are sometimes inaccurate. Also, the user don't care.
+                header_property_ui(ui, "Static", is_static.to_string());
+                header_property_ui(ui, "Indicator", is_indicator.to_string());
+                header_property_ui(ui, "Tombstone", is_tombstone.to_string());
+                header_property_ui(ui, "Empty", is_semantically_empty.to_string());
+            }
         }
     }
 }

--- a/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
@@ -10,9 +10,9 @@ use nohash_hasher::IntMap;
 
 use re_log_types::{EntryId, TimelineName};
 use re_sorbet::{ColumnDescriptorRef, SorbetSchema};
-use re_ui::UiExt as _;
 use re_ui::list_item::ItemButton;
 use re_ui::menu::menu_style;
+use re_ui::{ContextExt as _, UiExt as _};
 use re_viewer_context::{AsyncRuntimeHandle, ViewerContext};
 
 use crate::datafusion_adapter::DataFusionAdapter;
@@ -557,8 +557,8 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
                 store_datatype,
                 component_type,
                 entity_path,
-                archetype: archetype_name,
-                component: _component,
+                archetype,
+                component,
                 is_static,
                 is_indicator,
                 is_tombstone,
@@ -576,7 +576,7 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
             header_property_ui(
                 ui,
                 "Archetype",
-                archetype_name.map(|a| a.full_name()).unwrap_or("-"),
+                archetype.map(|a| a.full_name()).unwrap_or("-"),
             );
             header_property_ui(
                 ui,
@@ -590,6 +590,12 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
                 header_property_ui(ui, "Indicator", is_indicator.to_string());
                 header_property_ui(ui, "Tombstone", is_tombstone.to_string());
                 header_property_ui(ui, "Empty", is_semantically_empty.to_string());
+            }
+
+            if cfg!(debug_assertions) {
+                ui.add_space(8.0);
+                ui.label(ui.ctx().warning_text("Only in debug builds:"));
+                header_property_ui(ui, "component", component);
             }
         }
     }

--- a/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
+++ b/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
@@ -187,7 +187,7 @@ fn test_default_column_display_name() {
                 is_semantically_empty: false
             },
         )),
-        "start_time"
+        "property:RecordingProperties:start_time"
     );
 
     // User-defined recoding property:

--- a/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
+++ b/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
@@ -177,10 +177,10 @@ fn test_default_column_display_name() {
         default_display_name_for_column(&ColumnDescriptorRef::Component(
             &re_sorbet::ComponentColumnDescriptor {
                 store_datatype: arrow::datatypes::DataType::Binary, // ignored
-                component_type: Some("rerun.components.Timestamp".into()),
                 entity_path: EntityPath::recording_properties(),
+                component: "RecordingProperties:start_time".into(),
+                component_type: Some("rerun.components.Timestamp".into()),
                 archetype: Some("rerun.archetypes.RecordingProperties".into()),
-                component: "start_time".into(),
                 is_static: false,
                 is_indicator: false,
                 is_tombstone: false,


### PR DESCRIPTION
### Related
* Closes https://linear.app/rerun/issue/OSS-1405/partition-table-view-ignores-column-names-from-server

### What
Adds special handling of column names for recording properties (both built-in and user ones).

Has a test now!


### Future work
* https://github.com/rerun-io/rerun/issues/10391