### PR TITLE
Fix broken latency measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7316,6 +7316,7 @@ dependencies = [
  "re_memory",
  "re_protos",
  "re_smart_channel",
+ "re_sorbet",
  "re_tracing",
  "re_types",
  "re_uri",

--- a/crates/store/re_grpc_server/Cargo.toml
+++ b/crates/store/re_grpc_server/Cargo.toml
@@ -30,6 +30,7 @@ re_log_types.workspace = true
 re_memory.workspace = true
 re_protos.workspace = true
 re_smart_channel.workspace = true
+re_sorbet.workspace = true
 re_tracing.workspace = true
 re_types.workspace = true
 re_uri.workspace = true

--- a/crates/store/re_sorbet/src/timestamp_metadata.rs
+++ b/crates/store/re_sorbet/src/timestamp_metadata.rs
@@ -5,10 +5,10 @@
 use crate::ArrowBatchMetadata;
 
 /// When was this batch sent by the SDK gRPC log sink?
-pub const KEY_TIMESTAMP_SDK_IPC_ENCODE: &str = "sorbet.timestamp_sdk_ipc_encoded";
+pub const KEY_TIMESTAMP_SDK_IPC_ENCODE: &str = "rerun:timestamp_sdk_ipc_encoded";
 
 /// When was this batch last decoded from IPC bytes by the gRPC server (presumably in the viewer)?
-pub const KEY_TIMESTAMP_VIEWER_IPC_DECODED: &str = "sorbet.timestamp_viewer_ipc_decoded";
+pub const KEY_TIMESTAMP_VIEWER_IPC_DECODED: &str = "rerun:timestamp_viewer_ipc_decoded";
 
 /// We encode time as seconds since the Unix epoch,
 /// with nanosecond precision, e.g. `1700000000.012345678`.

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -374,6 +374,8 @@ impl App {
 
     #[allow(clippy::needless_pass_by_ref_mut)]
     pub fn add_log_receiver(&mut self, rx: re_smart_channel::Receiver<LogMsg>) {
+        re_log::debug!("Adding new log receiver: {:?}", rx.source());
+
         // Make sure we wake up when a message is sent.
         #[cfg(not(target_arch = "wasm32"))]
         let rx = crate::wake_up_ui_thread_on_each_msg(rx, self.egui_ctx.clone());

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -90,32 +90,38 @@ fn top_bar_ui(
     website_link_ui(ui);
 
     if !app.is_screenshotting() {
+        let latency_snapshot = store_context
+            .map(|store_context| store_context.recording.ingestion_stats().latency_snapshot());
+
         if app.app_options().show_metrics {
             ui.separator();
             frame_time_label_ui(ui, app);
             memory_use_label_ui(ui, gpu_resource_stats);
-        }
 
-        let latency_snapshot = store_context
-            .map(|store_context| store_context.recording.ingestion_stats().latency_snapshot());
-
-        if let Some(latency_snapshot) = latency_snapshot {
-            // Should we show the e2e latency?
-
-            // High enough to be consering; low enough to be believable (and almost realtime).
-            let is_latency_interesting = latency_snapshot
-                .e2e
-                .is_some_and(|e2e| app.app_options().warn_e2e_latency < e2e && e2e < 60.0);
-
-            // Avoid flicker by showing the latency for 1 seconds ince it was last deemned interesting:
-
-            if is_latency_interesting {
-                app.latest_latency_interest = web_time::Instant::now();
-            }
-
-            if app.latest_latency_interest.elapsed().as_secs_f32() < 1.0 {
-                ui.separator();
+            if let Some(latency_snapshot) = latency_snapshot {
+                // Always show latency when metrics are enabled:
                 latency_snapshot_button_ui(ui, latency_snapshot);
+            }
+        } else {
+            // Show latency metrics only if high enough to be "interesting":
+            if let Some(latency_snapshot) = latency_snapshot {
+                // Should we show the e2e latency?
+
+                // High enough to be consering; low enough to be believable (and almost realtime).
+                let is_latency_interesting = latency_snapshot
+                    .e2e
+                    .is_some_and(|e2e| app.app_options().warn_e2e_latency < e2e && e2e < 60.0);
+
+                // Avoid flicker by showing the latency for 1 seconds ince it was last deemned interesting:
+
+                if is_latency_interesting {
+                    app.latest_latency_interest = web_time::Instant::now();
+                }
+
+                if app.latest_latency_interest.elapsed().as_secs_f32() < 1.0 {
+                    ui.separator();
+                    latency_snapshot_button_ui(ui, latency_snapshot);
+                }
             }
         }
     }


### PR DESCRIPTION
## What
The decode timestamp was missing in some circumstances. Now it works again.

Test with:

```
pixi run rerun
```

```
cargo run -p log_benchmark --release -- --benchmarks image --connect
```

## Other
* Always show latency metrics when metrics are enabled (and we have a latency measurement)