### PR TITLE
Delay showing video wait-for-decoder spinner on seeks

### DIFF
--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -97,7 +97,7 @@ mod gop_detection;
 
 pub use gop_detection::{DetectGopStartError, GopStartDetection, detect_gop_start};
 
-use crate::{Time, VideoDataDescription};
+use crate::{SampleIndex, Time, VideoDataDescription};
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum DecodeError {
@@ -341,13 +341,15 @@ pub struct FrameInfo {
 
     /// Which sample in the video is this from?
     ///
-    /// In MP4, one sample is one frame, but we may be reordering samples when decoding.
+    /// We always assume one sample leads one frame
+    /// (but may provide arbitrary additional information which may be needed for other frames in the GOP).
     ///
     /// This is the order of which the samples appear in the container,
-    /// which is usually ordered by [`Self::latest_decode_timestamp`].
+    /// which is ordered by [`Self::latest_decode_timestamp`].
+    /// I.e. this is NOT ordered by [`Self::presentation_timestamp`].
     ///
     /// None = unknown.
-    pub sample_idx: Option<usize>,
+    pub sample_idx: Option<SampleIndex>,
 
     /// Which frame is this?
     ///

--- a/crates/utils/re_video/src/demux/mod.rs
+++ b/crates/utils/re_video/src/demux/mod.rs
@@ -564,6 +564,20 @@ impl VideoDataDescription {
         )
     }
 
+    /// Returns the sample presenteed directly prior to the given sample.
+    ///
+    /// Remember that samples are ordered in decode timestamp order,
+    /// and that sample presented immediately prior to the given sample may have a higher decode timestamp.
+    /// Therefore, this may be a jump on sample index.
+    pub fn previous_presented_sample(&self, sample: &SampleMetadata) -> Option<&SampleMetadata> {
+        Self::latest_sample_index_at_presentation_timestamp_internal(
+            &self.samples,
+            &self.samples_statistics,
+            sample.presentation_timestamp - Time::new(1),
+        )
+        .and_then(|idx| self.samples.get(idx))
+    }
+
     /// For a given decode (!) timestamp, return the index of the group of pictures (GOP) index containing the given timestamp.
     pub fn gop_index_containing_decode_timestamp(&self, decode_time: Time) -> Option<GopIndex> {
         self.gops.latest_at_idx(

--- a/crates/utils/re_video/src/time.rs
+++ b/crates/utils/re_video/src/time.rs
@@ -26,23 +26,6 @@ const fn const_round_f64(v: f64) -> i64 {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_const_round_f64() {
-        assert_eq!(const_round_f64(1.5), 2);
-        assert_eq!(const_round_f64(2.5), 3);
-        assert_eq!(const_round_f64(1.499999999), 1);
-        assert_eq!(const_round_f64(2.499999999), 2);
-        assert_eq!(const_round_f64(-1.5), -2);
-        assert_eq!(const_round_f64(-2.5), -3);
-        assert_eq!(const_round_f64(-1.499999999), -1);
-        assert_eq!(const_round_f64(-2.499999999), -2);
-    }
-}
-
 impl Time {
     pub const ZERO: Self = Self(0);
     pub const MAX: Self = Self(i64::MAX);
@@ -127,5 +110,22 @@ impl std::ops::Sub for Time {
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
         Self(self.0.saturating_sub(rhs.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_const_round_f64() {
+        assert_eq!(const_round_f64(1.5), 2);
+        assert_eq!(const_round_f64(2.5), 3);
+        assert_eq!(const_round_f64(1.499999999), 1);
+        assert_eq!(const_round_f64(2.499999999), 2);
+        assert_eq!(const_round_f64(-1.5), -2);
+        assert_eq!(const_round_f64(-2.5), -3);
+        assert_eq!(const_round_f64(-1.499999999), -1);
+        assert_eq!(const_round_f64(-2.499999999), -2);
     }
 }

--- a/crates/utils/re_video/src/time.rs
+++ b/crates/utils/re_video/src/time.rs
@@ -14,6 +14,35 @@ impl Timescale {
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Time(pub i64);
 
+/// Round a `f64` to the nearest `i64`.
+///
+/// Does not have exactly the same result as `round`, don't use in contexts where you care!
+/// Workaround for `f64::round` not being `const`.
+const fn const_round_f64(v: f64) -> i64 {
+    if v > 0.0 {
+        (v + 0.5) as i64
+    } else {
+        (v - 0.5) as i64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_const_round_f64() {
+        assert_eq!(const_round_f64(1.5), 2);
+        assert_eq!(const_round_f64(2.5), 3);
+        assert_eq!(const_round_f64(1.499999999), 1);
+        assert_eq!(const_round_f64(2.499999999), 2);
+        assert_eq!(const_round_f64(-1.5), -2);
+        assert_eq!(const_round_f64(-2.5), -3);
+        assert_eq!(const_round_f64(-1.499999999), -1);
+        assert_eq!(const_round_f64(-2.499999999), -2);
+    }
+}
+
 impl Time {
     pub const ZERO: Self = Self(0);
     pub const MAX: Self = Self(i64::MAX);
@@ -32,7 +61,7 @@ impl Time {
 
     #[inline]
     pub const fn from_secs(secs_since_start: f64, timescale: Timescale) -> Self {
-        Self((secs_since_start * timescale.0 as f64 + 0.5) as i64)
+        Self(const_round_f64(secs_since_start * timescale.0 as f64))
     }
 
     #[inline]

--- a/crates/utils/re_video/src/time.rs
+++ b/crates/utils/re_video/src/time.rs
@@ -5,7 +5,7 @@ pub struct Timescale(u64);
 impl Timescale {
     pub const NANOSECOND: Self = Self(1_000_000_000);
 
-    pub fn new(v: u64) -> Self {
+    pub const fn new(v: u64) -> Self {
         Self(v)
     }
 }
@@ -31,22 +31,22 @@ impl Time {
     }
 
     #[inline]
-    pub fn from_secs(secs_since_start: f64, timescale: Timescale) -> Self {
-        Self((secs_since_start * timescale.0 as f64).round() as i64)
+    pub const fn from_secs(secs_since_start: f64, timescale: Timescale) -> Self {
+        Self((secs_since_start * timescale.0 as f64 + 0.5) as i64)
     }
 
     #[inline]
-    pub fn from_millis(millis_since_start: f64, timescale: Timescale) -> Self {
+    pub const fn from_millis(millis_since_start: f64, timescale: Timescale) -> Self {
         Self::from_secs(millis_since_start / 1e3, timescale)
     }
 
     #[inline]
-    pub fn from_micros(micros_since_start: f64, timescale: Timescale) -> Self {
+    pub const fn from_micros(micros_since_start: f64, timescale: Timescale) -> Self {
         Self::from_secs(micros_since_start / 1e6, timescale)
     }
 
     #[inline]
-    pub fn from_nanos(nanos_since_start: i64, timescale: Timescale) -> Self {
+    pub const fn from_nanos(nanos_since_start: i64, timescale: Timescale) -> Self {
         Self::from_secs(nanos_since_start as f64 / 1e9, timescale)
     }
 

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -323,7 +323,7 @@ pub fn show_decoded_frame_info(
     ) {
         Ok(VideoFrameTexture {
             texture,
-            is_pending,
+            decoder_delay_state,
             show_spinner,
             frame_info,
             source_pixel_format,
@@ -369,7 +369,7 @@ pub fn show_decoded_frame_info(
                 )
             };
 
-            if is_pending {
+            if decoder_delay_state.should_rerequest_frame() {
                 ui.ctx().request_repaint(); // Keep polling for an up-to-date texture
             }
 

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -175,16 +175,7 @@ pub fn update_video_texture_with_frame(
         )
     });
 
-    let format = {
-        #[cfg(target_arch = "wasm32")]
-        {
-            copy_web_video_frame_to_texture(render_ctx, source_content, gpu_texture)
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            copy_native_video_frame_to_texture(render_ctx, source_content, gpu_texture)
-        }
-    }?;
+    let format = copy_frame_to_texture(render_ctx, source_content, gpu_texture)?;
 
     target_video_texture.source_pixel_format = format;
     target_video_texture.frame_info = Some(source_info.clone());

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -57,7 +57,7 @@ pub enum DecoderDelayState {
     /// The decoder is caught up with the most recent requested frame.
     UpToDate,
 
-    /// The decoder is caught up within [`chunk_decoder::TOLERATED_OUTPUT_DELAY_IN_NUM_FRAMES`] frames.
+    /// The decoder is caught up within a certain tolerance.
     ///
     /// I.e. the video texture is not the most recently requested frame, but it's quite close.
     UpToDateWithinTolerance,
@@ -70,7 +70,7 @@ pub enum DecoderDelayState {
 }
 
 impl DecoderDelayState {
-    /// Whether a user of [`player::VideoPlayer`] should keep requesting a more up to date video frame even
+    /// Whether a user of a video player should keep requesting a more up to date video frame even
     /// if the requested time has not changed.
     pub fn should_rerequest_frame(&self) -> bool {
         match self {

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -51,13 +51,42 @@ pub enum VideoPlayerError {
 
 pub type FrameDecodingResult = Result<VideoFrameTexture, VideoPlayerError>;
 
+/// Describes whether a decoder is lagging behind or not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecoderDelayState {
+    /// The decoder is caught up with the most recent requested frame.
+    UpToDate,
+
+    /// The decoder is caught up within [`chunk_decoder::TOLERATED_OUTPUT_DELAY_IN_NUM_FRAMES`] frames.
+    ///
+    /// I.e. the video texture is not the most recently requested frame, but it's quite close.
+    UpToDateWithinTolerance,
+
+    /// The decoder is catching up after a long seek.
+    ///
+    /// The video texture is no longer updated until the decoder has caught up.
+    /// This state will only be left after reaching [`DecoderDelayState::UpToDate`] again.
+    Behind,
+}
+
+impl DecoderDelayState {
+    /// Whether a user of [`player::VideoPlayer`] should keep requesting a more up to date video frame even
+    /// if the requested time has not changed.
+    pub fn should_rerequest_frame(&self) -> bool {
+        match self {
+            Self::UpToDate => false,
+            Self::UpToDateWithinTolerance | Self::Behind => true,
+        }
+    }
+}
+
 /// Information about the status of a frame decoding.
 pub struct VideoFrameTexture {
     /// The texture to show.
     pub texture: Option<GpuTexture2D>,
 
     /// If true, the texture is outdated. Keep polling for a fresh one.
-    pub is_pending: bool,
+    pub decoder_delay_state: DecoderDelayState,
 
     /// If true, this texture is so out-dated that it should have a loading spinner on top of it.
     pub show_spinner: bool,

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -2,22 +2,33 @@ use std::time::Duration;
 
 use web_time::Instant;
 
-use re_video::{DecodeSettings, FrameInfo, GopIndex, SampleIndex, StableIndexDeque, Time};
+use re_video::{
+    DecodeSettings, FrameInfo, GopIndex, SampleIndex, StableIndexDeque, Time, Timescale,
+};
 
 use super::{VideoFrameTexture, chunk_decoder::VideoSampleDecoder};
 use crate::{
     RenderContext,
     resource_managers::{GpuTexture2D, SourceImageDataFormat},
-    video::VideoPlayerError,
+    video::{VideoPlayerError, chunk_decoder::update_video_texture_with_frame},
 };
 
-/// Ignore hickups lasting shorter than this.
+/// Don't report hickups lasting shorter than this.
 ///
 /// Delaying error reports (and showing last-good images meanwhile) allows us to skip over
 /// transient errors without flickering.
 ///
 /// Same with showing a spinner: if we show it too fast, it is annoying.
-const DECODING_GRACE_DELAY: Duration = Duration::from_millis(400);
+///
+/// This is wallclock time and independent of how fast a video is being played back.
+const DECODING_GRACE_DELAY_BEFORE_REPORTING: Duration = Duration::from_millis(400);
+
+/// Video time duration we allow to lag behind before no longer updating the output texture.
+///
+/// Note that since this is video time based, not wallclock time.
+/// We can't do wallclock time here since this would because we don't know the playback speed.
+/// Also, hitting the tolerance limit for faster playback is desirable anyways.
+const TOLLERATED_OUTPUT_DELAY: Duration = Duration::from_millis(100);
 
 #[derive(Debug)]
 pub struct TimedDecodingError {
@@ -66,6 +77,9 @@ pub struct VideoPlayer {
     ///
     /// Only fully reset after a successful decode.
     last_error: Option<TimedDecodingError>,
+
+    /// The last time the decoder fully caught up with the frame we want to show, if ever.
+    last_time_caught_up: Option<Instant>,
 }
 
 impl VideoPlayer {
@@ -115,6 +129,8 @@ impl VideoPlayer {
             last_enqueued: None,
 
             last_error: None,
+
+            last_time_caught_up: None,
         })
     }
 
@@ -129,64 +145,90 @@ impl VideoPlayer {
     pub fn frame_at(
         &mut self,
         render_ctx: &RenderContext,
-        video_time: Time,
+        requested_pts: Time,
         video_description: &re_video::VideoDataDescription,
         video_buffers: &StableIndexDeque<&[u8]>,
     ) -> Result<VideoFrameTexture, VideoPlayerError> {
-        if video_time.0 < 0 {
+        if requested_pts.0 < 0 {
             return Err(VideoPlayerError::NegativeTimestamp);
         }
-        let mut presentation_timestamp = video_time;
-        if let Some(duration) = video_description.duration {
-            presentation_timestamp = presentation_timestamp.min(duration); // Don't seek past the end of the video.
-        }
 
-        let error_on_last_frame_at = self.last_error.is_some();
-        self.enqueue_samples(video_description, presentation_timestamp, video_buffers)?;
+        // Find which sample best represents the requested PTS.
+        let requested_sample_idx = video_description
+            .latest_sample_index_at_presentation_timestamp(requested_pts)
+            .ok_or(VideoPlayerError::EmptyVideo)?;
+        let requested_sample = video_description.samples.get(requested_sample_idx); // This is only `None` if we no longer have the sample around.
+        let requested_pts = requested_sample
+            .map(|s| s.presentation_timestamp)
+            .unwrap_or(requested_pts);
 
-        update_video_texture(
-            render_ctx,
-            &self.sample_decoder,
-            &mut self.last_error,
-            &mut self.video_texture,
-            presentation_timestamp,
-        )?;
+        // Ensure we have enough samples enqueued to the decoder to cover the request.
+        // (This method also makes sure that the next few frames become available, so call this even if we already have the frame we want.)
+        self.enqueue_samples(video_description, requested_sample_idx, video_buffers)?;
 
-        let (is_pending, show_spinner) = if let (Some(frame_info), Some(video_gpu_texture)) = (
-            self.video_texture.frame_info.clone(),
-            self.video_texture.texture.clone(),
-        ) {
-            let time_range = frame_info.presentation_time_range();
-            let is_active_frame = time_range.contains(&presentation_timestamp);
+        // Grab best decoded frame for the requested PTS and discard all earlier frames to save memory.
+        if let Some(decoded_frame) = self
+            .sample_decoder
+            .latest_decoded_frame_at_and_drop_earlier_frames(requested_pts)
+        {
+            // Update the texture only if:
+            // * we're not already up to date.
+            let current_frame_info = self.video_texture.frame_info.as_ref();
+            let outdated_frame =
+                current_frame_info.is_none_or(|info| info.presentation_timestamp != requested_pts);
 
-            let is_pending = !is_active_frame;
-            let show_spinner = if is_pending && error_on_last_frame_at {
-                // If we switched from error to pending, clear the texture.
-                // This is important to avoid flickering, in particular when switching from
-                // benign errors like DecodingError::NegativeTimestamp.
-                // If we don't do this, we see the last valid texture which can look really weird.
-                clear_texture(render_ctx, &video_gpu_texture);
-                self.video_texture.frame_info = None;
-                true
-            } else if presentation_timestamp < time_range.start {
-                // We're seeking backwards and somehow forgot to reset.
-                true
-            } else if presentation_timestamp < time_range.end {
-                false // it is an active frame
-            } else if let Some(timescale) = video_description.timescale {
-                let how_outdated = presentation_timestamp - time_range.end;
-                if how_outdated.duration(timescale) < DECODING_GRACE_DELAY {
-                    false // Just outdated by a little bit - show no spinner
-                } else {
-                    true // Very old frame - show spinner
+            // * the decoded frame isn't too far behind.
+            //   This happens when catching up on a seek, very rapid playback or simply too slow decoding.
+            //   Without this tolerance, we'd get a "rubber-band effect" in playback where we show a lot of outdated frames before (hopefully) catching up.
+            //   This is especially common when seeking to the end of a large GOP since the decoder has to start from its beginning.
+            let timescale = video_description.timescale.unwrap_or(Timescale::new(30)); // Assume 30 time units per second if there's no scale. As good as any guess!;
+            let pts_diff = decoded_frame.info.presentation_timestamp - requested_pts;
+            let not_too_far_behind = pts_diff.duration(timescale) <= TOLLERATED_OUTPUT_DELAY;
+
+            if outdated_frame && not_too_far_behind {
+                update_video_texture_with_frame(
+                    render_ctx,
+                    &mut self.video_texture,
+                    &decoded_frame,
+                )?; // Update texture errors are very unusual, error out on those immediately.
+
+                self.video_texture.frame_info = Some(decoded_frame.info.clone());
+            }
+
+            // We apparently recovered from any errors we had previously!
+            // (otherwise we wouldn't have received a frame from the decoder)
+            self.last_error = None;
+        };
+
+        let current_frame_info = self.video_texture.frame_info.as_ref();
+        let is_pending = self.video_texture.texture.is_none()
+            || current_frame_info.is_none_or(|info| info.presentation_timestamp != requested_pts);
+
+        // Decide whether to show a spinner or even error out.
+        let show_spinner = if is_pending {
+            // Might we be pending because of an error?
+            if let Some(last_error) = self.last_error.as_ref() {
+                // If we've been in this error state for a while now, report the error.
+                // (sometimes errors are very transient and we recover from them quickly)
+                if last_error.time_of_first_error.elapsed() > DECODING_GRACE_DELAY_BEFORE_REPORTING
+                {
+                    // Report the error only if we have been in an error state for a certain amount of time.
+                    // Don't immediately report the error, since we might immediately recover from it.
+                    // Otherwise, this would cause aggressive flickering!
+                    return Err(last_error.latest_error.clone());
                 }
-            } else {
-                // TODO(andreas): Too much spinner? configure this from the outside in video time units!
-                true // No timescale - show spinner too often rather than too late
-            };
-            (is_pending, show_spinner)
+            }
+
+            self.video_texture.texture.is_none() ||
+                // Show spinner if we haven't caught up in a while.
+                self
+                    .last_time_caught_up
+                    .is_none_or(|last_time_caught_up| {
+                        last_time_caught_up.elapsed() > DECODING_GRACE_DELAY_BEFORE_REPORTING
+                    })
         } else {
-            (true, true)
+            self.last_time_caught_up = Some(Instant::now());
+            false
         };
 
         Ok(VideoFrameTexture {
@@ -202,7 +244,7 @@ impl VideoPlayer {
     fn enqueue_samples(
         &mut self,
         video_description: &re_video::VideoDataDescription,
-        requested_pts: Time,
+        requested_sample_idx: SampleIndex,
         video_buffers: &StableIndexDeque<&[u8]>,
     ) -> Result<(), VideoPlayerError> {
         re_tracing::profile_function!();
@@ -218,11 +260,6 @@ impl VideoPlayer {
         // We must enqueue samples in decode order, but show them in composition order.
         // In the presence of b-frames this order may be different!
 
-        // Find sample which, when decoded, will be presented at the timestamp the user requested.
-        let requested_sample_idx = video_description
-            .latest_sample_index_at_presentation_timestamp(requested_pts)
-            .ok_or(VideoPlayerError::EmptyVideo)?;
-
         // Find the GOP that contains the sample.
         let requested_gop_idx = video_description
             .gop_index_containing_decode_timestamp(
@@ -235,7 +272,7 @@ impl VideoPlayer {
             gop_idx: requested_gop_idx,
         };
 
-        self.reset_decoder_if_needed(video_description, requested)?;
+        self.handle_errors_and_reset_decoder_if_needed(video_description, requested)?;
 
         // Ensure that we have as many GOPs enqueued currently as needed in order to…
         // * cover the GOP of the requested sample _plus one_ so we can always smoothly transition to the next GOP
@@ -300,7 +337,7 @@ impl VideoPlayer {
     }
 
     #[expect(clippy::if_same_then_else)]
-    fn reset_decoder_if_needed(
+    fn handle_errors_and_reset_decoder_if_needed(
         &mut self,
         video_description: &re_video::VideoDataDescription,
         requested: SampleAndGopIndex,
@@ -341,11 +378,11 @@ impl VideoPlayer {
                 .unwrap_or(Time::MIN);
 
             let requested_sample = video_description.samples.get(requested.sample_idx);
-            let requested_sample_pts = requested_sample
+            let requested_pts = requested_sample
                 .map(|s| s.presentation_timestamp)
                 .unwrap_or(Time::MIN);
 
-            if requested_sample_pts < current_pts {
+            if requested_pts < current_pts {
                 re_log::trace!(
                     "Seeking backwards to sample {} (frame_nr {})",
                     requested.sample_idx,
@@ -437,73 +474,4 @@ impl VideoPlayer {
         // Do *not* reset the error state. We want to keep track of the last error.
         Ok(())
     }
-}
-
-fn update_video_texture(
-    render_ctx: &RenderContext,
-    chunk_decoder: &VideoSampleDecoder,
-    last_error: &mut Option<TimedDecodingError>,
-    video_texture: &mut VideoTexture,
-    presentation_timestamp: Time,
-) -> Result<(), VideoPlayerError> {
-    let result =
-        chunk_decoder.update_video_texture(render_ctx, video_texture, presentation_timestamp);
-
-    match result {
-        Ok(()) => {
-            *last_error = None;
-            Ok(())
-        }
-        Err(err) => {
-            if matches!(err, VideoPlayerError::EmptyBuffer) {
-                // No buffered frames
-
-                // Might this be due to an error?
-                //
-                // We only care about decoding errors when we don't find the requested frame,
-                // since we want to keep playing the video fine even if parts of it are broken.
-                // That said, practically we reset the decoder and thus all frames upon error,
-                // so it doesn't make a lot of difference.
-                if let Some(timed_error) = last_error {
-                    if DECODING_GRACE_DELAY <= timed_error.time_of_first_error.elapsed() {
-                        // Report the error only if we have been in an error state for a certain amount of time.
-                        // Don't immediately report the error, since we might immediately recover from it.
-                        // Otherwise, this would cause aggressive flickering!
-                        return Err(timed_error.latest_error.clone());
-                    }
-                }
-
-                // Don't zeroed the texture, because we may just be behind on decoding
-                // and showing an old frame is better than showing a blank frame,
-                // because it causes "black flashes" to appear
-                Ok(())
-            } else {
-                Err(err)
-            }
-        }
-    }
-}
-
-/// Clears the texture that is shown on pending to black.
-fn clear_texture(render_ctx: &RenderContext, texture: &GpuTexture2D) {
-    // Clear texture is a native only feature, so let's not do that.
-    // before_view_builder_encoder.clear_texture(texture, subresource_range);
-
-    // But our target is also a render target, so just create a dummy renderpass with clear.
-    let mut before_view_builder_encoder =
-        render_ctx.active_frame.before_view_builder_encoder.lock();
-    let _ = before_view_builder_encoder
-        .get()
-        .begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: crate::DebugLabel::from("clear_video_texture").get(),
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &texture.default_view,
-                resolve_target: None,
-                ops: wgpu::Operations::<wgpu::Color> {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
-                    store: wgpu::StoreOp::Store,
-                },
-            })],
-            ..Default::default()
-        });
 }

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -26,7 +26,7 @@ const DECODING_GRACE_DELAY_BEFORE_REPORTING: Duration = Duration::from_millis(40
 /// Video time duration we allow to lag behind before no longer updating the output texture.
 ///
 /// Note that since this is video time based, not wallclock time.
-/// We can't do wallclock time here since this would because we don't know the playback speed.
+/// We can't do wallclock time here since this we don't know the playback speed.
 /// Also, hitting the tolerance limit for faster playback is desirable anyways.
 const TOLLERATED_OUTPUT_DELAY: Duration = Duration::from_millis(100);
 

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -506,16 +506,14 @@ fn update_decoder_delay_state(
         DecoderDelayState::UpToDate | DecoderDelayState::UpToDateWithinTolerance => {
             if up_to_date {
                 DecoderDelayState::UpToDate
+            } else if is_significantly_behind(
+                video_description,
+                requested_sample,
+                last_decoded_frame_pts,
+            ) {
+                DecoderDelayState::Behind
             } else {
-                if is_significantly_behind(
-                    video_description,
-                    requested_sample,
-                    last_decoded_frame_pts,
-                ) {
-                    DecoderDelayState::Behind
-                } else {
-                    DecoderDelayState::UpToDateWithinTolerance
-                }
+                DecoderDelayState::UpToDateWithinTolerance
             }
         }
 

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -27,12 +27,12 @@ const DECODING_GRACE_DELAY_BEFORE_REPORTING: Duration = Duration::from_millis(40
 /// sample order for decoding purposes.
 ///
 /// Discarded alternatives:
-/// * use video time based tollerance:
-///   -> makes it dependend on playback speed whether we hit the threshhold or not
-/// * use a wall clock time based tollerance:
+/// * use video time based tolerance:
+///   -> makes it depend on playback speed whether we hit the threshold or not
+/// * use a wall clock time based tolerance:
 ///   -> any seek operation that leads to waiting for the decoder to catch up,
-///      would cause us to show in-progress frames until the tollerance is hit
-const TOLLERATED_OUTPUT_DELAY_IN_NUM_FRAMES: usize = 3;
+///      would cause us to show in-progress frames until the tolerance is hit
+const TOLERATED_OUTPUT_DELAY_IN_NUM_FRAMES: usize = 3;
 
 #[derive(Debug)]
 pub struct TimedDecodingError {
@@ -511,7 +511,7 @@ fn should_update_video_texture(
             // We're waiting until we're fully caught up before showing any new frames.
             false
         } else {
-            // Figure out how many frames we're behind. If this is higher than a certain tollerance, don't update the texture.
+            // Figure out how many frames we're behind. If this is higher than a certain tolerance, don't update the texture.
             //
             // Since frames aren't in presentation time order and may have varying durations (i.e. the video has variable frame rate),
             // we have to successively use `latest_sample_index_at_presentation_timestamp`:
@@ -524,13 +524,13 @@ fn should_update_video_texture(
                     break false;
                 };
                 if current_sample.presentation_timestamp == decoded_frame_pts {
-                    // This is the frame we actually got and we stayed under the tollerance.
+                    // This is the frame we actually got and we stayed under the tolerance.
                     // This may happen if the load on the decoder fluctuates or it is just about able to keep up with playback.
                     break true;
                 }
 
                 num_frames_behind += 1;
-                if num_frames_behind > TOLLERATED_OUTPUT_DELAY_IN_NUM_FRAMES {
+                if num_frames_behind > TOLERATED_OUTPUT_DELAY_IN_NUM_FRAMES {
                     // Too far behind. Add hysteresis to avoid flipping in and out of this state.
                     *dont_update_texture_until_caught_up = true;
                     break false;

--- a/crates/viewer/re_view_spatial/src/visualizers/video/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/video/mod.rs
@@ -36,7 +36,7 @@ fn visualize_video_frame_texture(
 ) {
     let re_renderer::video::VideoFrameTexture {
         texture,
-        is_pending,
+        decoder_delay_state,
         show_spinner,
         frame_info: _,
         source_pixel_format: _,
@@ -54,7 +54,7 @@ fn visualize_video_frame_texture(
     let extent_u = world_from_entity.transform_vector3(glam::Vec3::X * video_size.x);
     let extent_v = world_from_entity.transform_vector3(glam::Vec3::Y * video_size.y);
 
-    if is_pending {
+    if decoder_delay_state.should_rerequest_frame() {
         // Keep polling for a fresh texture
         ctx.egui_ctx().request_repaint();
     }


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/10294

### What

Compared to 0.24 this refines the behavior on seek: we no longer show the spinner without delay on backwards and cross-gop seeks... which is most seeks
I think there's other more subtle behavior changes there, but when testing before/after that's the one thing that stood out.

Compared to `main` this (additionally) fixes a regression where we'd visibly replay from the start of a GOP on every 
(title and tags are for the 0.24 changelog purpose).

⚠️ This PR alone causes debug_assertion to trigger for all videos with b-frames in Firefox & Safari as well as very occasionally on Chrome. Turns out we stumbled into the cause of github.com/rerun-io/rerun/issues/7961
Separate fix for this is coming right after!

---

After trying more incremental approaches I ended up simplifying & condensing the logic around:
* should the video texture be updated with the incoming frame
* should we show a spinner
* should we wait for more up-to-date frames

all of these questions are related and I found it increasingly hard to reason with what we had in place before. I hope the new code & commentary is not just more robust but also easier to read!
