### PR TITLE
Preserve pathname prefix in re uri

### DIFF
--- a/crates/store/re_grpc_client/src/message_proxy/read.rs
+++ b/crates/store/re_grpc_client/src/message_proxy/read.rs
@@ -38,7 +38,7 @@ async fn stream_async(
     on_msg: Option<Box<dyn Fn() + Send + Sync>>,
 ) -> Result<(), StreamError> {
     let mut client = {
-        let url = uri.origin.as_url();
+        let url = uri.endpoint_url();
 
         #[cfg(target_arch = "wasm32")]
         let tonic_client = {

--- a/crates/store/re_grpc_client/src/message_proxy/write.rs
+++ b/crates/store/re_grpc_client/src/message_proxy/write.rs
@@ -144,7 +144,7 @@ async fn message_proxy_client(
     mut shutdown_rx: Receiver<()>,
     compression: Compression,
 ) {
-    let endpoint = match Endpoint::from_shared(uri.origin.as_url()) {
+    let endpoint = match Endpoint::from_shared(uri.endpoint_url()) {
         Ok(endpoint) => endpoint,
         Err(err) => {
             re_log::error!("Invalid message proxy server endpoint: {err}");

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -34,6 +34,21 @@ impl ProxyUri {
             prefix_segments: None,
         }
     }
+
+    /// Returns the HTTP URL for connecting to this proxy endpoint.
+    /// This includes the path prefix if present.
+    pub fn endpoint_url(&self) -> String {
+        match &self.prefix_segments {
+            None => self.origin.as_url(),
+            Some(segments) => {
+                if segments.is_empty() {
+                    self.origin.as_url()
+                } else {
+                    format!("{}/{}", self.origin.as_url(), segments.join("/"))
+                }
+            }
+        }
+    }
 }
 
 impl std::str::FromStr for ProxyUri {

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -3,15 +3,26 @@ use crate::{Origin, RedapUri};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ProxyUri {
     pub origin: Origin,
-    pub path_prefix: String,
+
+    /// Path segments before the `/proxy` endpoint.
+    ///
+    /// - `None` for URLs like `rerun://host/proxy` (no prefix)
+    /// - `Some(vec!["prefix"])` for URLs like `rerun://host/prefix/proxy`
+    /// - `Some(vec!["a", "b"])` for URLs like `rerun://host/a/b/proxy`
+    pub prefix_segments: Option<Vec<String>>,
 }
 
 impl std::fmt::Display for ProxyUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.path_prefix.is_empty() {
-            write!(f, "{}/proxy", self.origin)
-        } else {
-            write!(f, "{}{}/proxy", self.origin, self.path_prefix)
+        match &self.prefix_segments {
+            None => write!(f, "{}/proxy", self.origin),
+            Some(segments) => {
+                if segments.is_empty() {
+                    write!(f, "{}/proxy", self.origin)
+                } else {
+                    write!(f, "{}/{}/proxy", self.origin, segments.join("/"))
+                }
+            }
         }
     }
 }
@@ -20,7 +31,7 @@ impl ProxyUri {
     pub fn new(origin: Origin) -> Self {
         Self {
             origin,
-            path_prefix: String::new(),
+            prefix_segments: None,
         }
     }
 }

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -3,17 +3,25 @@ use crate::{Origin, RedapUri};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ProxyUri {
     pub origin: Origin,
+    pub path_prefix: String,
 }
 
 impl std::fmt::Display for ProxyUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/proxy", self.origin)
+        if self.path_prefix.is_empty() {
+            write!(f, "{}/proxy", self.origin)
+        } else {
+            write!(f, "{}{}/proxy", self.origin, self.path_prefix)
+        }
     }
 }
 
 impl ProxyUri {
     pub fn new(origin: Origin) -> Self {
-        Self { origin }
+        Self {
+            origin,
+            path_prefix: String::new(),
+        }
     }
 }
 


### PR DESCRIPTION
### Related

* Closes #10373 

### What

This PR implements support for parsing proxy endpoints with arbitrary pathname prefixes in the RedapUri parser, addressing the issue where URLs like rerun+http://host/prefix/proxy would fail to parse