### PR TITLE
Reduce recording properties logging output in Rust SDK

### DIFF
--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -940,7 +940,7 @@ impl RecordingStreamInner {
             // We pre-populate the batcher with a chunk the contains the recording
             // properties, so that these get automatically sent to the sink.
 
-            re_log::debug!(properties = ?properties, "adding recording properties to batcher");
+            re_log::trace!(properties = ?properties, "adding recording properties to batcher");
 
             let properties_chunk = Chunk::builder(EntityPath::recording_properties())
                 .with_archetype(RowId::new(), TimePoint::default(), properties)


### PR DESCRIPTION
### What

Removes the following debugging message from the Rust SDK. We have been fine with logging the properties in an initial batch for some time now.

```
[2025-06-27T15:02:09Z DEBUG re_sdk::recording_stream] adding recording properties to batcher properties=RecordingProperties { start_time: Some(SerializedComponentBatch { array: PrimitiveArray<Int64>
    [
      1751036529142816000,
    ], descriptor: ComponentDescriptor { archetype: Some("rerun.archetypes.RecordingProperties"), component: "RecordingProperties:start_time", component_type: Some("rerun.components.Timestamp") } }), name: None }
```
