### PR TITLE
Unify component information in selection panel and header popups

### DIFF
--- a/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
@@ -633,12 +633,7 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
                 is_semantically_empty,
             } = desc;
 
-            header_property_ui(ui, "Type", "component");
-            header_property_ui(
-                ui,
-                "Component type",
-                component_type.map(|a| a.as_str()).unwrap_or("-"),
-            );
+            header_property_ui(ui, "Column type", "Component");
             header_property_ui(ui, "Entity path", entity_path.to_string());
             datatype_ui(ui, &column.display_name(), store_datatype);
             header_property_ui(
@@ -646,10 +641,11 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
                 "Archetype",
                 archetype.map(|a| a.full_name()).unwrap_or("-"),
             );
+            header_property_ui(ui, "Component", desc.component_descriptor().component);
             header_property_ui(
                 ui,
-                "Archetype field",
-                desc.component_descriptor().archetype_field_name(),
+                "Component type",
+                component_type.map(|a| a.as_str()).unwrap_or("-"),
             );
 
             if false {

--- a/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
@@ -12,7 +12,7 @@ use re_format::format_uint;
 use re_log_types::{EntryId, TimelineName, Timestamp};
 use re_sorbet::{ColumnDescriptorRef, SorbetSchema};
 use re_ui::menu::menu_style;
-use re_ui::{ContextExt as _, UiExt as _, icons};
+use re_ui::{UiExt as _, icons};
 use re_viewer_context::{AsyncRuntimeHandle, ViewerContext};
 
 use crate::datafusion_adapter::DataFusionAdapter;
@@ -641,7 +641,7 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
                 "Archetype",
                 archetype.map(|a| a.full_name()).unwrap_or("-"),
             );
-            header_property_ui(ui, "Component", desc.component_descriptor().component);
+            header_property_ui(ui, "Component", component);
             header_property_ui(
                 ui,
                 "Component type",
@@ -654,12 +654,6 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>) {
                 header_property_ui(ui, "Indicator", is_indicator.to_string());
                 header_property_ui(ui, "Tombstone", is_tombstone.to_string());
                 header_property_ui(ui, "Empty", is_semantically_empty.to_string());
-            }
-
-            if cfg!(debug_assertions) {
-                ui.add_space(8.0);
-                ui.label(ui.ctx().warning_text("Only in debug builds:"));
-                header_property_ui(ui, "component", component);
             }
         }
     }

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -211,8 +211,8 @@ impl SelectionPanel {
                 }
 
                 ui.list_item_flat_noninteractive(
-                    PropertyContent::new("Archetype field")
-                        .value_text(component_descriptor.archetype_field_name()),
+                    PropertyContent::new("Component")
+                        .value_text(component_descriptor.component.as_str()),
                 );
 
                 if let Some(component_type) = component_type {

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -190,7 +190,7 @@ impl SelectionPanel {
 
                 let ComponentDescriptor {
                     archetype: archetype_name,
-                    component: _,
+                    component,
                     component_type,
                 } = component_descriptor;
 
@@ -211,8 +211,7 @@ impl SelectionPanel {
                 }
 
                 ui.list_item_flat_noninteractive(
-                    PropertyContent::new("Component")
-                        .value_text(component_descriptor.component.as_str()),
+                    PropertyContent::new("Component").value_text(component.as_str()),
                 );
 
                 if let Some(component_type) = component_type {


### PR DESCRIPTION
### Related

* Follow up of #10245

### What

Discussion: https://rerunio.slack.com/archives/C033K5VS2KD/p1751035525843599

This unifies the Datafusion widget column header popup and the selection panel to use the new Component descriptor nomenclature.

### Screenshots


| Column header popup | Selection panel |
|--------|--------|
| <img width="309" alt="image" src="https://github.com/user-attachments/assets/5b6f120a-1126-4858-983e-901e05cabf93" /> | <img width="294" alt="image" src="https://github.com/user-attachments/assets/669be686-6e16-42c8-a6be-f9a60c7366df" /> |

