### PR TITLE
Stop emitting Sorbet migration errors for general record batches

### DIFF
--- a/crates/store/re_sorbet/src/migrations/mod.rs
+++ b/crates/store/re_sorbet/src/migrations/mod.rs
@@ -133,6 +133,12 @@ pub fn migrate_record_batch(mut batch: RecordBatch) -> RecordBatch {
                 batch
             }
         },
+        Err(Error::MissingVersion) => {
+            // TODO(grtlr): We need to handle arbitrary record batches and
+            // we don't want to spam the viewer with useless warnings.
+            re_log::debug!("Encountered record batch without 'sorbet:version' metadata");
+            batch
+        }
         Err(err) => {
             re_log::error_once!("Skipping migrations due to error: {err}");
             batch


### PR DESCRIPTION
### What

The viewer would output migration errors for record batches that are missing a Sorbet version. Long term we need to get the Sorbet <-> Record batch story straight, but for now we simply ignore the error on a missing `sorbet:version` metadata field.
