### PR TITLE
Fetch dataset entries in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7553,6 +7553,7 @@ dependencies = [
  "ahash",
  "datafusion",
  "egui",
+ "futures",
  "itertools 0.14.0",
  "re_auth",
  "re_component_ui",

--- a/crates/viewer/re_redap_browser/Cargo.toml
+++ b/crates/viewer/re_redap_browser/Cargo.toml
@@ -40,6 +40,7 @@ re_viewer_context.workspace = true
 ahash.workspace = true
 datafusion.workspace = true
 egui.workspace = true
+futures.workspace = true
 itertools.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/10419

Not really sure it closes the above. It does in fact fix the waterfall, but @jleibs mentioned changing how `FindEntries` works instead. I chose a dumber approach where I send the requests in parallel and await them all at once.

![image (3)](https://github.com/user-attachments/assets/f2b05077-954a-4c2f-8afe-a444a37ecbb8)
