### PR TITLE
Experimental connection status inspection for Rust gRPC connections

### DIFF
--- a/crates/top/re_sdk/src/binary_stream_sink.rs
+++ b/crates/top/re_sdk/src/binary_stream_sink.rs
@@ -101,4 +101,8 @@ impl LogSink for BinaryStreamSink {
 
     #[inline]
     fn flush_blocking(&self) {}
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/crates/top/re_sdk/src/grpc_server.rs
+++ b/crates/top/re_sdk/src/grpc_server.rs
@@ -80,6 +80,10 @@ impl crate::sink::LogSink for GrpcServerSink {
             re_log::error_once!("Failed to flush: {err}");
         }
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl Drop for GrpcServerSink {

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -71,6 +71,10 @@ impl crate::sink::LogSink for re_log_encoding::FileSink {
     fn flush_blocking(&self) {
         Self::flush_blocking(self);
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 // ---------------
@@ -87,7 +91,7 @@ pub mod sink {
         MultiSink,
     };
 
-    pub use crate::log_sink::GrpcSink;
+    pub use crate::log_sink::{GrpcSink, GrpcSinkConnectionFailure, GrpcSinkConnectionState};
 
     #[cfg(not(target_arch = "wasm32"))]
     pub use re_log_encoding::{FileSink, FileSinkError};

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -982,6 +982,7 @@ impl RecordingStreamInner {
 enum Command {
     RecordMsg(LogMsg),
     SwapSink(Box<dyn LogSink>),
+    InspectSink(Box<dyn FnOnce(&dyn LogSink) + Send + 'static>),
     Flush(Sender<()>),
     PopPendingChunks,
     Shutdown,
@@ -1479,6 +1480,9 @@ fn forwarding_thread(
 
                 *sink = new_sink;
             }
+            Command::InspectSink(f) => {
+                f(sink.as_ref());
+            }
             Command::Flush(oneshot) => {
                 re_log::trace!("Flushing…");
                 // Flush the underlying sink if possible.
@@ -1863,6 +1867,20 @@ impl RecordingStream {
         let sink = sinks.into_multi_sink();
 
         self.set_sink(Box::new(sink));
+    }
+
+    /// Asynchronously calls a method that has read access to the currently active sink.
+    ///
+    /// Since a recording stream's sink is owned by a different thread there is no guarantee when
+    /// the callback is going to be called.
+    /// It's advised to return as quickly as possible from the callback since
+    /// as long as the callback doesn't return, the sink will not receive any new data,
+    ///
+    /// # Experimental
+    ///
+    /// This is an experimental API and may change in future releases.
+    pub fn inspect_sink(&self, f: impl FnOnce(&dyn LogSink) + Send + 'static) {
+        self.with(|inner| inner.cmds_tx.send(Command::InspectSink(Box::new(f))).ok());
     }
 
     /// Swaps the underlying sink for a [`crate::log_sink::GrpcSink`] sink pre-configured to use

--- a/docs/snippets/all/howto/check_connection_status.rs
+++ b/docs/snippets/all/howto/check_connection_status.rs
@@ -1,0 +1,40 @@
+//! Continuously print the connection status of a pending gRPC connection.
+//!
+//! This feature is experimental and may change in future releases.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_check_connection_status")
+        .connect_grpc()?;
+
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    loop {
+        let tx = tx.clone();
+        rec.inspect_sink(move |sink| {
+            let grpc_sink = sink
+                .as_any()
+                .downcast_ref::<rerun::sink::GrpcSink>()
+                .expect("Expected a GrpcSink");
+            tx.send(grpc_sink.status()).ok();
+        });
+
+        if let Ok(status) = rx.recv_timeout(std::time::Duration::from_secs(1)) {
+            println!("Connection status: {:?}", status);
+
+            if matches!(
+                status,
+                rerun::sink::GrpcSinkConnectionState::Disconnected(_)
+            ) {
+                println!("Connection lost, exiting");
+                break;
+            }
+        } else {
+            println!("No connection status received for 1s, exiting");
+            break;
+        }
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Related

* Part of https://github.com/rerun-io/rerun/issues/2353

### What

Experimental (!!) API for checking the connection status of `connect_grpc`. Comes with a small example snippet.

I was wondering how hard this is to do.. answer is: so-so! What makes this tricky is that today the recording sink is fully owned by the "forwarding thread" which makes sense if you zoom out a bit, but makes it hard to synchronously inspect a sink.
We could make that possible by putting the sink behind an `Arc<Mutex<the_sink>>` but that ofc means that we then have to lock a mutex instead which isn't great either.

Anyways, I think what I put up here is still not terrible and usable for Rust experts. Maybe there's more we should do to mark this as proper experimental until we come up with a proper x-language design? 🤔 