### PR TITLE
Show a blinking orange dot in debug builds on multi-pass egui frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,7 +2912,7 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 [[package]]
 name = "ecolor"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -2929,7 +2929,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2989,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -3072,7 +3072,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "ahash",
  "egui",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "dify",
  "eframe",
@@ -3177,7 +3177,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3294,7 +3294,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.31.1"
-source = "git+https://github.com/emilk/egui.git?branch=main#ae8363ddb53675b1892c2f069e88c77469b5fceb"
+source = "git+https://github.com/emilk/egui.git?branch=main#d770cd53a6827f9895fad3901256c5803f28f4e2"
 
 [[package]]
 name = "equivalent"

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -118,6 +118,10 @@ fn top_bar_ui(
                 latency_snapshot_button_ui(ui, latency_snapshot);
             }
         }
+
+        if cfg!(debug_assertions) {
+            multi_pass_warning_dot_ui(ui);
+        }
     }
 
     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
@@ -173,6 +177,58 @@ fn top_bar_ui(
             });
         }
     });
+}
+
+/// Show an orange dot to warn about multi-pass layout in egui.
+///
+/// If it is shown, it means something called `egui::Context::request_discard` the previous pass,
+/// causing a multi-pass layout frame in egui.
+/// This is used to cover up some visual glitches, but it is also
+/// a bit costly and we shouldn't do it too often.
+///
+/// An infrequent blinking of the dot (e.g. when opening a new panel) is expected,
+/// but it should not be sustained.
+fn multi_pass_warning_dot_ui(ui: &mut egui::Ui) {
+    let is_multi_pass = 0 < ui.ctx().current_pass_index();
+
+    // Showing the dot just one frame is not enough (e.g. easily missed at 120Hz),
+    // so we blink it up and then fade it out quickly.
+
+    let now = ui.ctx().input(|i| i.time);
+    let last_multipass_time = ui.data_mut(|data| {
+        let last_multipass_time = data
+            .get_temp_mut_or_insert_with(egui::Id::new("last_multipass_time"), || {
+                f64::NEG_INFINITY
+            });
+        if is_multi_pass {
+            *last_multipass_time = now;
+        }
+        *last_multipass_time
+    });
+    let time_since_last_multipass = (now - last_multipass_time) as f32;
+
+    let intensity = egui::remap_clamp(time_since_last_multipass, 0.0..=0.5, 1.0..=0.0);
+
+    let radius = 5.0 * egui::emath::ease_in_ease_out(intensity);
+
+    let (response, painter) = ui.allocate_painter(egui::Vec2::splat(12.0), egui::Sense::hover());
+
+    if intensity <= 0.0 {
+        // Nothing to show, but we still allocate space so we can show a tooltip to developers
+        // who wondered what the hell that blinking orange dot was
+    } else {
+        // Paint dot:
+        painter.circle_filled(response.rect.center(), radius, egui::Color32::ORANGE);
+
+        // Make sure we ask for a repaint so we can animate the dot fading out:
+        ui.ctx().request_repaint();
+    }
+
+    response.on_hover_text(
+        "A blinking orange dot appears here in debug builds whenever request_discard is called.\n\
+        It is expect that the dot appears occasionally, e.g. when showing a new panel for the first time.\n\
+        However, it should not be sustained, as that would indicate a performance bug.",
+    );
 }
 
 fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>) {


### PR DESCRIPTION
### Related
* https://github.com/rerun-io/rerun/pull/10406
* https://github.com/emilk/egui/pull/7276

### What

Show an orange dot to warn about multi-pass layout in egui.

If it is shown, it means something called `egui::Context::request_discard` the previous pass,
causing a multi-pass layout frame in egui.
This is used to cover up some visual glitches, but it is also
a bit costly and we shouldn't do it too often.

An infrequent blinking of the dot (e.g. when opening a new panel) is expected,
but it should not be sustained.


![blink-dot](https://github.com/user-attachments/assets/599cd46e-e087-44a3-9153-b746005df319)

In this example the selection panel (outside the frame) shows a `ListItem` scope for the first time, which results in a single multi-pass frame.