### PR TITLE
Generate one partition stream per partition ID in query provider

### DIFF
--- a/crates/store/re_datafusion/src/dataframe_query_provider.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_provider.rs
@@ -13,10 +13,9 @@ use itertools::Itertools as _;
 use re_dataframe::{QueryEngine, QueryExpression, StorageEngine};
 use re_protos::manifest_registry::v1alpha1::DATASET_MANIFEST_ID_FIELD_NAME;
 
+#[derive(Debug)]
 pub struct DataframeQueryTableProvider {
     pub schema: SchemaRef,
-    query_expression: QueryExpression,
-    // query_engines: BTreeMap<String, QueryEngine<StorageEngine>>,
     partition_streams: Vec<Arc<DataframePartitionStream>>,
 }
 
@@ -56,7 +55,6 @@ impl DataframeQueryTableProvider {
 
         Ok(Self {
             schema,
-            query_expression,
             partition_streams,
         })
     }
@@ -128,15 +126,6 @@ impl PartitionStream for DataframePartitionStream {
 impl std::fmt::Debug for DataframePartitionStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DataframePartitionStream")
-            .field("schema", &self.schema)
-            .field("query_expression", &self.query_expression)
-            .finish()
-    }
-}
-
-impl std::fmt::Debug for DataframeQueryTableProvider {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DataframeQueryTableProvider")
             .field("schema", &self.schema)
             .field("query_expression", &self.query_expression)
             .finish()

--- a/crates/store/re_datafusion/src/dataframe_query_provider.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_provider.rs
@@ -29,7 +29,7 @@ pub struct DataframePartitionStream {
 impl DataframeQueryTableProvider {
     pub fn new(
         query_engines: BTreeMap<String, QueryEngine<StorageEngine>>,
-        query_expression: QueryExpression,
+        query_expression: &QueryExpression,
     ) -> Result<Self, DataFusionError> {
         let all_schemas = query_engines
             .values()

--- a/crates/store/re_datafusion/src/dataframe_query_provider.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_provider.rs
@@ -10,14 +10,21 @@ use datafusion::{
     physical_plan::{stream::RecordBatchStreamAdapter, streaming::PartitionStream},
 };
 use itertools::Itertools as _;
-
 use re_dataframe::{QueryEngine, QueryExpression, StorageEngine};
 use re_protos::manifest_registry::v1alpha1::DATASET_MANIFEST_ID_FIELD_NAME;
 
 pub struct DataframeQueryTableProvider {
     pub schema: SchemaRef,
     query_expression: QueryExpression,
-    query_engines: BTreeMap<String, QueryEngine<StorageEngine>>,
+    // query_engines: BTreeMap<String, QueryEngine<StorageEngine>>,
+    partition_streams: Vec<Arc<DataframePartitionStream>>,
+}
+
+pub struct DataframePartitionStream {
+    pub schema: SchemaRef,
+    query_expression: QueryExpression,
+    query_engine: QueryEngine<StorageEngine>,
+    partition_id: String,
 }
 
 impl DataframeQueryTableProvider {
@@ -31,14 +38,26 @@ impl DataframeQueryTableProvider {
             .collect::<Vec<_>>();
 
         let merged = Schema::try_merge(all_schemas)?;
+        let schema = Arc::new(prepend_string_column_schema(
+            &merged,
+            DATASET_MANIFEST_ID_FIELD_NAME,
+        ));
+
+        let partition_streams = query_engines
+            .into_iter()
+            .map(|(partition_id, query_engine)| DataframePartitionStream {
+                schema: Arc::clone(&schema),
+                query_expression: query_expression.clone(),
+                query_engine,
+                partition_id,
+            })
+            .map(Arc::new)
+            .collect();
 
         Ok(Self {
-            schema: Arc::new(prepend_string_column_schema(
-                &merged,
-                DATASET_MANIFEST_ID_FIELD_NAME,
-            )),
-            query_engines,
+            schema,
             query_expression,
+            partition_streams,
         })
     }
 }
@@ -48,61 +67,70 @@ impl TryFrom<DataframeQueryTableProvider> for Arc<dyn TableProvider> {
 
     fn try_from(value: DataframeQueryTableProvider) -> Result<Self, Self::Error> {
         let schema = Arc::clone(&value.schema);
-        let partition_stream = Arc::new(value);
-        let table = StreamingTable::try_new(schema, vec![partition_stream])?;
+
+        let partition_streams = value
+            .partition_streams
+            .into_iter()
+            .map(|p| p as Arc<dyn PartitionStream>)
+            .collect();
+        let table = StreamingTable::try_new(schema, partition_streams)?;
 
         Ok(Arc::new(table))
     }
 }
 
-impl PartitionStream for DataframeQueryTableProvider {
+impl PartitionStream for DataframePartitionStream {
     fn schema(&self) -> &SchemaRef {
         &self.schema
     }
 
     fn execute(&self, _ctx: Arc<datafusion::execution::TaskContext>) -> SendableRecordBatchStream {
-        let engines = self.query_engines.clone();
+        let partition_id = self.partition_id.clone();
+        let query_engine = self.query_engine.clone();
         let query_expression = self.query_expression.clone();
 
         let mut partition_id_columns: HashMap<String, (Field, ArrayRef)> = HashMap::new();
 
         let target_schema = self.schema.clone();
-        let stream = futures_util::stream::iter(engines.into_iter().flat_map(
-            move |(partition_id, query_engine)| {
-                let (pid_field, pid_array) = partition_id_columns
-                    .entry(partition_id.clone())
-                    .or_insert_with(|| {
-                        // The batches returned by re_dataframe are guaranteed to always have a
-                        // single row in them. This will change some day, hopefully, but it's been
-                        // true for years so we should at least leverage it for now.
-                        (
-                            Field::new(DATASET_MANIFEST_ID_FIELD_NAME, DataType::Utf8, false),
-                            Arc::new(StringArray::from(vec![partition_id.clone()]))
-                                as Arc<dyn Array>,
-                        )
-                    });
-                let (pid_field, pid_array) = (pid_field.clone(), pid_array.clone());
 
-                let inner_schema = target_schema.clone();
-                query_engine
-                    .query(query_expression.clone())
-                    .into_batch_iter()
-                    .map(move |batch| {
-                        align_record_batch_to_schema(
-                            &prepend_partition_id_column(
-                                &batch,
-                                pid_field.clone(),
-                                pid_array.clone(),
-                            )?,
-                            &inner_schema,
-                        )
-                    })
-            },
-        ));
+        let stream = futures_util::stream::iter({
+            let (pid_field, pid_array) = partition_id_columns
+                .entry(partition_id.clone())
+                .or_insert_with(|| {
+                    // The batches returned by re_dataframe are guaranteed to always have a
+                    // single row in them. This will change some day, hopefully, but it's been
+                    // true for years so we should at least leverage it for now.
+                    (
+                        Field::new(DATASET_MANIFEST_ID_FIELD_NAME, DataType::Utf8, false),
+                        Arc::new(StringArray::from(vec![partition_id.clone()])) as Arc<dyn Array>,
+                    )
+                });
+            let (pid_field, pid_array) = (pid_field.clone(), pid_array.clone());
+
+            let inner_schema = target_schema.clone();
+            query_engine
+                .query(query_expression.clone())
+                .into_batch_iter()
+                .map(move |batch| {
+                    align_record_batch_to_schema(
+                        &prepend_partition_id_column(&batch, pid_field.clone(), pid_array.clone())?,
+                        &inner_schema,
+                    )
+                })
+        });
 
         let adapter = RecordBatchStreamAdapter::new(Arc::clone(&self.schema), stream);
 
         Box::pin(adapter)
+    }
+}
+
+impl std::fmt::Debug for DataframePartitionStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DataframePartitionStream")
+            .field("schema", &self.schema)
+            .field("query_expression", &self.query_expression)
+            .finish()
     }
 }
 

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -440,7 +440,7 @@ impl PyDataframeQueryView {
             .collect();
 
         let provider: Arc<dyn TableProvider> =
-            DataframeQueryTableProvider::new(query_engines, self_.query_expression.clone())
+            DataframeQueryTableProvider::new(query_engines, &self_.query_expression)
                 .map_err(to_py_err)?
                 .try_into()
                 .map_err(to_py_err)?;


### PR DESCRIPTION
### Related

https://linear.app/rerun/issue/DPF-1796/niko-feedback-triage-sandbox-todo

### What

This PR changes the way we handle partition streams in a query provider. Now we create one `PartitionStream` per partition ID in the data platform. This gives a performance improvement because (a) we no longer have to do a flat map from partition + chunk -> single iterator and (b) allows for greater splitting up of the data processing in datafusion since we now have more than one output stream.

Prior to this change, running the benchmarks locally against `droid:raw`:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Group/Function     ┃ droid:raw ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Droid                        │           │
│   droid:count_gripper_closes │ 3220.73ms │
└──────────────────────────────┴───────────┘
```

With this change:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Benchmark Group/Function     ┃ droid:raw ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ Droid                        │           │
│   droid:count_gripper_closes │ 656.21ms  │
└──────────────────────────────┴───────────┘
```

I have also validated that the dataframes returned from this call is unchanged.