### PR TITLE
Fix time panel archetype name overflowing

### DIFF
--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -831,7 +831,8 @@ impl TimePanel {
         let store = engine.store();
 
         for (archetype, components) in components_for_entity(ctx, store, entity_path) {
-            ui.list_item()
+            let response = ui
+                .list_item()
                 .with_y_offset(1.0)
                 .with_height(20.0)
                 .interactive(false)
@@ -846,6 +847,8 @@ impl TimePanel {
                         .size(10.0),
                     ),
                 );
+
+            self.next_col_right = self.next_col_right.max(response.rect.right());
 
             for component_descr in components {
                 let is_static = store.entity_has_static_component(entity_path, &component_descr);


### PR DESCRIPTION
### Related

- closes https://github.com/rerun-io/rerun/issues/10349

### What

Fixes archetype names overflowing time panel:

<img width="427" alt="Screenshot 2025-06-30 at 15 58 19" src="https://github.com/user-attachments/assets/fa048da4-a2f2-43df-97c5-897e444cea9a" />
