### PR TITLE
reduce the need for .into on EntityPath in tests

### DIFF
--- a/crates/store/re_chunk/examples/chunk_latest_at.rs
+++ b/crates/store/re_chunk/examples/chunk_latest_at.rs
@@ -24,7 +24,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn create_chunk() -> anyhow::Result<Chunk> {
-    let mut chunk = Chunk::builder("my/entity".into())
+    let mut chunk = Chunk::builder("my/entity")
         .with_component_batches(
             RowId::new(),
             [

--- a/crates/store/re_chunk/examples/chunk_range.rs
+++ b/crates/store/re_chunk/examples/chunk_range.rs
@@ -27,7 +27,7 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn create_chunk() -> anyhow::Result<Chunk> {
-    let mut chunk = Chunk::builder("my/entity".into())
+    let mut chunk = Chunk::builder("my/entity")
         .with_component_batches(
             RowId::new(),
             [

--- a/crates/store/re_chunk/src/builder.rs
+++ b/crates/store/re_chunk/src/builder.rs
@@ -24,16 +24,16 @@ pub struct ChunkBuilder {
 impl Chunk {
     /// Initializes a new [`ChunkBuilder`].
     #[inline]
-    pub fn builder(entity_path: EntityPath) -> ChunkBuilder {
-        ChunkBuilder::new(ChunkId::new(), entity_path)
+    pub fn builder(entity_path: impl Into<EntityPath>) -> ChunkBuilder {
+        ChunkBuilder::new(ChunkId::new(), entity_path.into())
     }
 
     /// Initializes a new [`ChunkBuilder`].
     ///
     /// The final [`Chunk`] will have the specified `id`.
     #[inline]
-    pub fn builder_with_id(id: ChunkId, entity_path: EntityPath) -> ChunkBuilder {
-        ChunkBuilder::new(id, entity_path)
+    pub fn builder_with_id(id: ChunkId, entity_path: impl Into<EntityPath>) -> ChunkBuilder {
+        ChunkBuilder::new(id, entity_path.into())
     }
 }
 

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -375,7 +375,7 @@ mod tests {
         ];
         let labels5 = &[MyLabel("d".into())];
 
-        let chunk1 = Chunk::builder(entity_path.into())
+        let chunk1 = Chunk::builder(entity_path)
             .with_component_batches(
                 row_id1,
                 timepoint1,
@@ -396,7 +396,7 @@ mod tests {
             )
             .build()?;
 
-        let chunk2 = Chunk::builder(entity_path.into())
+        let chunk2 = Chunk::builder(entity_path)
             .with_component_batches(
                 row_id4,
                 timepoint4,
@@ -419,7 +419,7 @@ mod tests {
             assert!(chunk1.concatenable(&chunk2));
 
             let got = chunk1.concatenated(&chunk2).unwrap();
-            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+            let expected = Chunk::builder_with_id(got.id(), entity_path)
                 .with_sparse_component_batches(
                     row_id1,
                     timepoint1,
@@ -489,7 +489,7 @@ mod tests {
             assert!(chunk2.concatenable(&chunk1));
 
             let got = chunk2.concatenated(&chunk1).unwrap();
-            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+            let expected = Chunk::builder_with_id(got.id(), entity_path)
                 .with_sparse_component_batches(
                     row_id4,
                     timepoint4,
@@ -602,7 +602,7 @@ mod tests {
         let labels4 = &[MyLabel("d".into())];
         let labels5 = &[MyLabel("e".into())];
 
-        let chunk1 = Chunk::builder(entity_path.into())
+        let chunk1 = Chunk::builder(entity_path)
             .with_component_batches(
                 row_id1,
                 timepoint1,
@@ -626,7 +626,7 @@ mod tests {
             )
             .build()?;
 
-        let chunk2 = Chunk::builder(entity_path.into())
+        let chunk2 = Chunk::builder(entity_path)
             .with_component_batches(
                 row_id4,
                 timepoint4,
@@ -652,7 +652,7 @@ mod tests {
             assert!(chunk1.concatenable(&chunk2));
 
             let got = chunk1.concatenated(&chunk2).unwrap();
-            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+            let expected = Chunk::builder_with_id(got.id(), entity_path)
                 .with_sparse_component_batches(
                     row_id1,
                     timepoint1,
@@ -722,7 +722,7 @@ mod tests {
             assert!(chunk2.concatenable(&chunk1));
 
             let got = chunk2.concatenated(&chunk1).unwrap();
-            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+            let expected = Chunk::builder_with_id(got.id(), entity_path)
                 .with_sparse_component_batches(
                     row_id4,
                     timepoint4,
@@ -814,7 +814,7 @@ mod tests {
             let points1 = &[MyPoint::new(1.0, 1.0)];
             let points2 = &[MyPoint::new(2.0, 2.0)];
 
-            let chunk1 = Chunk::builder(entity_path1.into())
+            let chunk1 = Chunk::builder(entity_path1)
                 .with_component_batches(
                     row_id1,
                     timepoint1,
@@ -822,7 +822,7 @@ mod tests {
                 )
                 .build()?;
 
-            let chunk2 = Chunk::builder(entity_path2.into())
+            let chunk2 = Chunk::builder(entity_path2)
                 .with_component_batches(
                     row_id2,
                     timepoint2,
@@ -853,7 +853,7 @@ mod tests {
             let points1 = &[MyPoint::new(1.0, 1.0)];
             let points2 = &[MyPoint::new(2.0, 2.0)];
 
-            let chunk1 = Chunk::builder(entity_path.into())
+            let chunk1 = Chunk::builder(entity_path)
                 .with_component_batches(
                     row_id1,
                     timepoint1,
@@ -861,7 +861,7 @@ mod tests {
                 )
                 .build()?;
 
-            let chunk2 = Chunk::builder(entity_path.into())
+            let chunk2 = Chunk::builder(entity_path)
                 .with_component_batches(
                     row_id2,
                     timepoint2,
@@ -894,7 +894,7 @@ mod tests {
             let points64bit =
                 <MyPoint64 as re_types_core::ComponentBatch>::to_arrow(&MyPoint64::new(1.0, 1.0))?;
 
-            let chunk1 = Chunk::builder(entity_path.into())
+            let chunk1 = Chunk::builder(entity_path)
                 .with_row(
                     row_id1,
                     timepoint1,
@@ -904,7 +904,7 @@ mod tests {
                 )
                 .build()?;
 
-            let chunk2 = Chunk::builder(entity_path.into())
+            let chunk2 = Chunk::builder(entity_path)
                 .with_row(
                     row_id2,
                     timepoint2,

--- a/crates/store/re_chunk/src/slice.rs
+++ b/crates/store/re_chunk/src/slice.rs
@@ -867,7 +867,7 @@ mod tests {
         let labels4 = &[MyLabel("d".into())];
         let labels5 = &[MyLabel("e".into())];
 
-        let mut chunk = Chunk::builder(entity_path.into())
+        let mut chunk = Chunk::builder(entity_path)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint4,
@@ -989,7 +989,7 @@ mod tests {
         let labels4 = &[MyLabel("d".into())];
         let labels5 = &[MyLabel("e".into())];
 
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -1120,7 +1120,7 @@ mod tests {
         let labels4 = &[MyLabel("d".into())];
         let labels5 = &[MyLabel("e".into())];
 
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint_static.clone(),
@@ -1254,7 +1254,7 @@ mod tests {
         let labels4 = &[MyLabel("d".into())];
         let labels5 = &[MyLabel("e".into())];
 
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -1403,7 +1403,7 @@ mod tests {
         let labels4 = &[MyLabel("d".into())];
         let labels5 = &[MyLabel("e".into())];
 
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,

--- a/crates/store/re_chunk/tests/latest_at.rs
+++ b/crates/store/re_chunk/tests/latest_at.rs
@@ -53,7 +53,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id1,
             timepoint1,
@@ -77,7 +77,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
     {
         let query = LatestAtQuery::new(TimelineName::new("frame"), 2);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -99,7 +99,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
     {
         let query = LatestAtQuery::new(TimelineName::new("frame"), 4);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -112,7 +112,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -125,7 +125,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -141,7 +141,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
     {
         let query = LatestAtQuery::new(TimelineName::new("frame"), 6);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id3,
                 timepoint3,
@@ -154,7 +154,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -167,7 +167,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -218,7 +218,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id2,
             timepoint2,
@@ -242,7 +242,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
     {
         let query = LatestAtQuery::new(TimelineName::log_time(), 1000);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -264,7 +264,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
     {
         let query = LatestAtQuery::new(TimelineName::log_time(), 1050);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -277,7 +277,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -290,7 +290,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -306,7 +306,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
     {
         let query = LatestAtQuery::new(TimelineName::log_time(), 1100);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id3,
                 timepoint3,
@@ -319,7 +319,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -332,7 +332,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -372,7 +372,7 @@ fn static_sorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id1,
             timepoint.clone(),
@@ -396,7 +396,7 @@ fn static_sorted() -> anyhow::Result<()> {
     for frame_nr in [2, 4, 6] {
         let query = LatestAtQuery::new(TimelineName::new("frame"), frame_nr);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id3,
                 timepoint.clone(),
@@ -409,7 +409,7 @@ fn static_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
@@ -422,7 +422,7 @@ fn static_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
@@ -462,7 +462,7 @@ fn static_unsorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id3,
             timepoint.clone(),
@@ -486,7 +486,7 @@ fn static_unsorted() -> anyhow::Result<()> {
     for log_time in [1000, 1050, 1100] {
         let query = LatestAtQuery::new(TimelineName::log_time(), log_time);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id3,
                 timepoint.clone(),
@@ -499,7 +499,7 @@ fn static_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
@@ -512,7 +512,7 @@ fn static_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),

--- a/crates/store/re_chunk/tests/range.rs
+++ b/crates/store/re_chunk/tests/range.rs
@@ -56,7 +56,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id1,
             timepoint1,
@@ -81,7 +81,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
         let query =
             RangeQuery::with_extras(TimelineName::new("frame"), ResolvedTimeRange::EVERYTHING);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -103,7 +103,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -116,7 +116,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -137,7 +137,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
         let expected = chunk.emptied();
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -150,7 +150,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -201,7 +201,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id2,
             timepoint2,
@@ -226,7 +226,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
         let query =
             RangeQuery::with_extras(TimelineName::log_time(), ResolvedTimeRange::EVERYTHING);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id1,
                 timepoint1,
@@ -248,7 +248,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -261,7 +261,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -282,7 +282,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
         let expected = chunk.emptied();
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -295,7 +295,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
@@ -335,7 +335,7 @@ fn static_sorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id1,
             timepoint.clone(),
@@ -362,7 +362,7 @@ fn static_sorted() -> anyhow::Result<()> {
     ];
 
     for query in queries {
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id3,
                 timepoint.clone(),
@@ -375,7 +375,7 @@ fn static_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
@@ -388,7 +388,7 @@ fn static_sorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
@@ -428,7 +428,7 @@ fn static_unsorted() -> anyhow::Result<()> {
         MyLabel("c".into()),
     ];
 
-    let chunk = Chunk::builder(ENTITY_PATH.into())
+    let chunk = Chunk::builder(ENTITY_PATH)
         .with_component_batches(
             row_id3,
             timepoint.clone(),
@@ -455,7 +455,7 @@ fn static_unsorted() -> anyhow::Result<()> {
     ];
 
     for query in queries {
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id3,
                 timepoint.clone(),
@@ -468,7 +468,7 @@ fn static_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_points(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
@@ -481,7 +481,7 @@ fn static_unsorted() -> anyhow::Result<()> {
             .build_with_datatypes(&datatypes())?;
         query_and_compare((MyPoints::descriptor_colors(), &query), &chunk, &expected);
 
-        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
+        let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH)
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),

--- a/crates/store/re_chunk_store/src/subscribers.rs
+++ b/crates/store/re_chunk_store/src/subscribers.rs
@@ -379,7 +379,7 @@ mod tests {
         let timeline_other = Timeline::new_duration("other");
         let timeline_yet_another = Timeline::new_sequence("yet_another");
 
-        let chunk = Chunk::builder("entity_a".into())
+        let chunk = Chunk::builder("entity_a")
             .with_component_batch(
                 RowId::new(),
                 TimePoint::from_iter([
@@ -399,7 +399,7 @@ mod tests {
                 .map(|i| MyPoint::new(0.0, i as f32))
                 .collect();
             let colors = vec![MyColor::from(0xFF0000FF)];
-            Chunk::builder("entity_b".into())
+            Chunk::builder("entity_b")
                 .with_component_batches(
                     RowId::new(),
                     TimePoint::from_iter([
@@ -419,7 +419,7 @@ mod tests {
         let chunk = {
             let num_instances = 6;
             let colors = vec![MyColor::from(0x00DD00FF); num_instances];
-            Chunk::builder("entity_b".into())
+            Chunk::builder("entity_b")
                 .with_component_batches(
                     RowId::new(),
                     TimePoint::default(),

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -293,7 +293,7 @@ fn log_episode_task(
         .and_then(|c| c.downcast_array_ref::<Int64Array>())
         .with_context(|| "Failed to get task_index field from dataset!")?;
 
-    let mut chunk = Chunk::builder("task".into());
+    let mut chunk = Chunk::builder("task");
     let mut row_id = RowId::new();
     let mut time_int = TimeInt::ZERO;
 
@@ -330,7 +330,7 @@ fn load_episode_images(
         .and_then(|a| a.downcast_array_ref::<BinaryArray>())
         .with_context(|| format!("Failed to get binary data from image feature: {observation}"))?;
 
-    let mut chunk = Chunk::builder(observation.into());
+    let mut chunk = Chunk::builder(observation);
     let mut row_id = RowId::new();
 
     for frame_idx in 0..image_bytes.len() {
@@ -359,7 +359,7 @@ fn load_episode_depth_images(
         .and_then(|a| a.downcast_array_ref::<BinaryArray>())
         .with_context(|| format!("Failed to get binary data from image feature: {observation}"))?;
 
-    let mut chunk = Chunk::builder(observation.into());
+    let mut chunk = Chunk::builder(observation);
     let mut row_id = RowId::new();
 
     for frame_idx in 0..image_bytes.len() {
@@ -429,7 +429,7 @@ fn load_episode_video(
     };
 
     // Put video asset into its own (static) chunk since it can be fairly large.
-    let video_asset_chunk = Chunk::builder(entity_path.into())
+    let video_asset_chunk = Chunk::builder(entity_path)
         .with_archetype(RowId::new(), TimePoint::default(), &video_asset)
         .build()?;
 

--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -221,12 +221,12 @@ impl UrdfTree {
 
     fn get_joint_path(&self, joint: &Joint) -> EntityPath {
         let parent_path = self.get_link_path_by_name(&joint.parent.link);
-        parent_path / &joint.name
+        parent_path / EntityPathPart::new(&joint.name)
     }
 
     fn get_link_path_by_name(&self, link_name: &str) -> EntityPath {
         if let Some(parent_joint) = self.get_parent_of_link(link_name) {
-            self.get_joint_path(parent_joint) / link_name
+            self.get_joint_path(parent_joint) / EntityPathPart::new(link_name)
         } else {
             format!("{}/{link_name}", self.name).into()
         }
@@ -279,7 +279,7 @@ fn walk_tree(
         .get(link_name)
         .with_context(|| format!("Link {link_name:?} missing from map"))?;
     debug_assert_eq!(link_name, link.name);
-    let link_path = parent_path / link_name;
+    let link_path = parent_path / EntityPathPart::new(link_name);
 
     log_link(urdf_tree, tx, store_id, link, &link_path)?;
 
@@ -289,7 +289,7 @@ fn walk_tree(
     };
 
     for joint in joints {
-        let joint_path = &link_path / &joint.name;
+        let joint_path = &link_path / EntityPathPart::new(&joint.name);
         log_joint(tx, store_id, &joint_path, joint)?;
 
         // Recurse
@@ -419,7 +419,7 @@ fn log_link(
             material,
         } = visual;
         let name = name.clone().unwrap_or_else(|| format!("visual_{i}"));
-        let vis_entity = link_entity / name;
+        let vis_entity = link_entity / EntityPathPart::new(name);
 
         // We need to look up the material by name, because the `Visuals::Material`
         // only has a name, no color or texture.
@@ -446,7 +446,7 @@ fn log_link(
             geometry,
         } = collision;
         let name = name.clone().unwrap_or_else(|| format!("collision_{i}"));
-        let collision_entity = link_entity / name;
+        let collision_entity = link_entity / EntityPathPart::new(name);
 
         send_transform(tx, store_id, collision_entity.clone(), origin)?;
 

--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -221,12 +221,12 @@ impl UrdfTree {
 
     fn get_joint_path(&self, joint: &Joint) -> EntityPath {
         let parent_path = self.get_link_path_by_name(&joint.parent.link);
-        parent_path / EntityPathPart::new(&joint.name)
+        parent_path / &joint.name
     }
 
     fn get_link_path_by_name(&self, link_name: &str) -> EntityPath {
         if let Some(parent_joint) = self.get_parent_of_link(link_name) {
-            self.get_joint_path(parent_joint) / EntityPathPart::new(link_name)
+            self.get_joint_path(parent_joint) / link_name
         } else {
             format!("{}/{link_name}", self.name).into()
         }
@@ -279,7 +279,7 @@ fn walk_tree(
         .get(link_name)
         .with_context(|| format!("Link {link_name:?} missing from map"))?;
     debug_assert_eq!(link_name, link.name);
-    let link_path = parent_path / EntityPathPart::new(link_name);
+    let link_path = parent_path / link_name;
 
     log_link(urdf_tree, tx, store_id, link, &link_path)?;
 
@@ -289,7 +289,7 @@ fn walk_tree(
     };
 
     for joint in joints {
-        let joint_path = &link_path / EntityPathPart::new(&joint.name);
+        let joint_path = &link_path / &joint.name;
         log_joint(tx, store_id, &joint_path, joint)?;
 
         // Recurse
@@ -419,7 +419,7 @@ fn log_link(
             material,
         } = visual;
         let name = name.clone().unwrap_or_else(|| format!("visual_{i}"));
-        let vis_entity = link_entity / EntityPathPart::new(name);
+        let vis_entity = link_entity / name;
 
         // We need to look up the material by name, because the `Visuals::Material`
         // only has a name, no color or texture.
@@ -446,7 +446,7 @@ fn log_link(
             geometry,
         } = collision;
         let name = name.clone().unwrap_or_else(|| format!("collision_{i}"));
-        let collision_entity = link_entity / EntityPathPart::new(name);
+        let collision_entity = link_entity / name;
 
         send_transform(tx, store_id, collision_entity.clone(), origin)?;
 

--- a/crates/store/re_entity_db/examples/memory_usage.rs
+++ b/crates/store/re_entity_db/examples/memory_usage.rs
@@ -117,7 +117,7 @@ fn log_messages() {
 
     {
         let used_bytes_start = live_bytes();
-        let chunk = Chunk::builder("points".into())
+        let chunk = Chunk::builder("points")
             .with_component_batches(
                 RowId::new(),
                 [build_frame_nr(TimeInt::ZERO)],
@@ -145,7 +145,7 @@ fn log_messages() {
 
     {
         let used_bytes_start = live_bytes();
-        let chunk = Chunk::builder("points".into())
+        let chunk = Chunk::builder("points")
             .with_component_batches(
                 RowId::new(),
                 [build_frame_nr(TimeInt::ZERO)],

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -885,7 +885,7 @@ mod tests {
         for _ in 0..n {
             messages.push(LogMsg::ArrowMsg(
                 store_id.clone(),
-                re_chunk::Chunk::builder("test_entity".into())
+                re_chunk::Chunk::builder("test_entity")
                     .with_archetype(
                         re_chunk::RowId::new(),
                         re_log_types::TimePoint::default().with(
@@ -934,7 +934,7 @@ mod tests {
         for _ in 0..n {
             messages.push(LogMsg::ArrowMsg(
                 store_id.clone(),
-                re_chunk::Chunk::builder("test_entity".into())
+                re_chunk::Chunk::builder("test_entity")
                     .with_archetype(
                         re_chunk::RowId::new(),
                         re_log_types::TimePoint::default().with(

--- a/crates/store/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/store/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -152,7 +152,7 @@ fn mono_points_arrow(c: &mut Criterion) {
 
 fn mono_points_arrow_batched(c: &mut Criterion) {
     fn generate_chunk() -> Chunk {
-        let mut builder = Chunk::builder("points".into());
+        let mut builder = Chunk::builder("points");
         for _ in 0..NUM_POINTS {
             builder = builder.with_component_batches(
                 RowId::ZERO,

--- a/crates/store/re_log_encoding/src/codec/wire/mod.rs
+++ b/crates/store/re_log_encoding/src/codec/wire/mod.rs
@@ -30,7 +30,7 @@ mod tests {
         let points1 = &[MyPoint::new(1.0, 1.0)];
         let points2 = &[MyPoint::new(2.0, 2.0)];
 
-        Chunk::builder("mypoints".into())
+        Chunk::builder("mypoints")
             .with_component_batches(
                 row_id1,
                 timepoint1,

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -363,7 +363,7 @@ mod tests {
     pub fn fake_log_messages() -> Vec<LogMsg> {
         let store_id = StoreId::random(StoreKind::Blueprint);
 
-        let arrow_msg = re_chunk::Chunk::builder("test_entity".into())
+        let arrow_msg = re_chunk::Chunk::builder("test_entity")
             .with_archetype(
                 re_chunk::RowId::new(),
                 re_log_types::TimePoint::default().with(

--- a/crates/store/re_log_encoding/tests/arrow_encode_roundtrip.rs
+++ b/crates/store/re_log_encoding/tests/arrow_encode_roundtrip.rs
@@ -16,7 +16,7 @@ fn encode_roundtrip() {
         TimePoint::default().with(Timeline::new_sequence("my_index"), time)
     }
 
-    let chunk = Chunk::builder("points".into())
+    let chunk = Chunk::builder("points")
         .with_archetype(
             RowId::new(),
             timepoint(1),

--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -491,6 +491,24 @@ impl std::ops::Div<EntityPathPart> for &EntityPath {
     }
 }
 
+impl std::ops::Div<&str> for &EntityPath {
+    type Output = EntityPath;
+
+    #[inline]
+    fn div(self, other: &str) -> Self::Output {
+        self.join(&EntityPath::from(other))
+    }
+}
+
+impl std::ops::Div<&str> for EntityPath {
+    type Output = Self;
+
+    #[inline]
+    fn div(self, other: &str) -> Self::Output {
+        self.join(&Self::from(other))
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 use re_types_core::Loggable;

--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -761,7 +761,7 @@ mod tests {
 
     #[test]
     fn test_strip_prefix() {
-        let entity_path = EntityPath::properties() / EntityPathPart::from("episode");
+        let entity_path = EntityPath::properties() / "episode";
         assert_eq!(entity_path.to_string(), "/__properties/episode");
         assert_eq!(
             entity_path.strip_prefix(&EntityPath::properties()),

--- a/crates/store/re_query/examples/query_latest_at.rs
+++ b/crates/store/re_query/examples/query_latest_at.rs
@@ -117,7 +117,7 @@ fn store() -> anyhow::Result<ChunkStoreHandle> {
     {
         let timepoint = [build_frame_nr(123)];
 
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 RowId::new(),
                 timepoint,

--- a/crates/store/re_query/examples/query_range.rs
+++ b/crates/store/re_query/examples/query_range.rs
@@ -108,7 +108,7 @@ fn store() -> anyhow::Result<ChunkStoreHandle> {
     {
         let timepoint = [build_frame_nr(123)];
 
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 RowId::new(),
                 timepoint,
@@ -124,7 +124,7 @@ fn store() -> anyhow::Result<ChunkStoreHandle> {
     {
         let timepoint = [build_frame_nr(423)];
 
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 RowId::new(),
                 timepoint,

--- a/crates/store/re_query/tests/latest_at.rs
+++ b/crates/store/re_query/tests/latest_at.rs
@@ -31,7 +31,7 @@ fn simple_query() {
     let points1 = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
     let row_id2 = RowId::new();
     let colors2 = vec![MyColor::from_rgb(255, 0, 0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(row_id1, timepoint, &MyPoints::new(points1.clone()))
         .with_archetype(
             row_id2,
@@ -80,7 +80,7 @@ fn simple_query_with_differently_tagged_components() {
         })
         .unwrap();
 
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(row_id1, timepoint, &MyPoints::new(points1.clone()))
         .with_archetype(row_id2, timepoint, &points2_serialized)
         .build()
@@ -126,7 +126,7 @@ fn static_query() {
 
     let row_id1 = RowId::new();
     let points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(row_id1, timepoint, &MyPoints::new(points.clone()))
         .build()
         .unwrap();
@@ -134,7 +134,7 @@ fn static_query() {
 
     let row_id2 = RowId::new();
     let colors = vec![MyColor::from_rgb(255, 0, 0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(
             row_id2,
             TimePoint::default(),
@@ -184,7 +184,7 @@ fn invalidation() {
 
         let row_id1 = RowId::new();
         let points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id1,
                 present_data_timepoint.clone(),
@@ -196,7 +196,7 @@ fn invalidation() {
 
         let row_id2 = RowId::new();
         let colors = vec![MyColor::from_rgb(1, 2, 3)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id2,
                 present_data_timepoint.clone(),
@@ -224,7 +224,7 @@ fn invalidation() {
         // Modify the PoV component
         let row_id3 = RowId::new();
         let points = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id3,
                 present_data_timepoint.clone(),
@@ -250,7 +250,7 @@ fn invalidation() {
         // Modify the optional component
         let row_id4 = RowId::new();
         let colors = vec![MyColor::from_rgb(4, 5, 6), MyColor::from_rgb(7, 8, 9)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id4,
                 present_data_timepoint.clone(),
@@ -278,7 +278,7 @@ fn invalidation() {
         // Modify the PoV component
         let row_id5 = RowId::new();
         let points_past = vec![MyPoint::new(100.0, 200.0), MyPoint::new(300.0, 400.0)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id5,
                 past_data_timepoint.clone(),
@@ -308,7 +308,7 @@ fn invalidation() {
         // Modify the optional component
         let row_id6 = RowId::new();
         let colors_past = vec![MyColor::from_rgb(10, 11, 12), MyColor::from_rgb(13, 14, 15)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id6,
                 past_data_timepoint.clone(),
@@ -338,7 +338,7 @@ fn invalidation() {
         // Modify the PoV component
         let row_id7 = RowId::new();
         let points_future = vec![MyPoint::new(1000.0, 2000.0), MyPoint::new(3000.0, 4000.0)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id7,
                 future_data_timepoint.clone(),
@@ -366,7 +366,7 @@ fn invalidation() {
         // Modify the optional component
         let row_id8 = RowId::new();
         let colors_future = vec![MyColor::from_rgb(16, 17, 18)];
-        let chunk = Chunk::builder(entity_path.into())
+        let chunk = Chunk::builder(entity_path)
             .with_archetype(
                 row_id8,
                 future_data_timepoint.clone(),
@@ -455,7 +455,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id1 = RowId::new();
     let points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(row_id1, static_, &MyPoints::new(points.clone()))
         .build()
         .unwrap();
@@ -477,7 +477,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id2 = RowId::new();
     let colors = vec![MyColor::from_rgb(255, 0, 0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(
             row_id2,
             frame2,
@@ -503,7 +503,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id3 = RowId::new();
     let colors = vec![MyColor::from_rgb(0, 0, 255)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(
             row_id3,
             frame3,
@@ -529,7 +529,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id4 = RowId::new();
     let colors = vec![MyColor::from_rgb(0, 255, 0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(
             row_id4,
             frame3,
@@ -570,7 +570,7 @@ fn static_invalidation() {
 
     let row_id1 = RowId::new();
     let points = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(row_id1, static_.clone(), &MyPoints::new(points.clone()))
         .build()
         .unwrap();
@@ -592,7 +592,7 @@ fn static_invalidation() {
 
     let row_id2 = RowId::new();
     let colors = vec![MyColor::from_rgb(255, 0, 0)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(
             row_id2,
             static_.clone(),
@@ -618,7 +618,7 @@ fn static_invalidation() {
 
     let row_id3 = RowId::new();
     let colors = vec![MyColor::from_rgb(0, 0, 255)];
-    let chunk = Chunk::builder(entity_path.into())
+    let chunk = Chunk::builder(entity_path)
         .with_archetype(
             row_id3,
             static_.clone(),

--- a/crates/store/re_query/tests/range.rs
+++ b/crates/store/re_query/tests/range.rs
@@ -536,7 +536,7 @@ fn invalidation() {
 
         let row_id1 = RowId::new();
         let points1 = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
-        let chunk1 = Chunk::builder(entity_path.into())
+        let chunk1 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id1,
                 present_data_timepoint.clone(),
@@ -548,7 +548,7 @@ fn invalidation() {
 
         let row_id2 = RowId::new();
         let colors2 = vec![MyColor::from_rgb(1, 2, 3)];
-        let chunk2 = Chunk::builder(entity_path.into())
+        let chunk2 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id2,
                 present_data_timepoint.clone(),
@@ -578,7 +578,7 @@ fn invalidation() {
         // Modify the PoV component
         let row_id3 = RowId::new();
         let points3 = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
-        let chunk3 = Chunk::builder(entity_path.into())
+        let chunk3 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id3,
                 present_data_timepoint.clone(),
@@ -607,7 +607,7 @@ fn invalidation() {
         // Modify the optional component
         let row_id4 = RowId::new();
         let colors4 = vec![MyColor::from_rgb(4, 5, 6), MyColor::from_rgb(7, 8, 9)];
-        let chunk4 = Chunk::builder(entity_path.into())
+        let chunk4 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id4,
                 present_data_timepoint.clone(),
@@ -639,7 +639,7 @@ fn invalidation() {
         // Modify the PoV component
         let points5 = vec![MyPoint::new(100.0, 200.0), MyPoint::new(300.0, 400.0)];
         let row_id5 = RowId::new();
-        let chunk5 = Chunk::builder(entity_path.into())
+        let chunk5 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id5,
                 past_data_timepoint.clone(),
@@ -678,7 +678,7 @@ fn invalidation() {
         // Modify the optional component
         let row_id6 = RowId::new();
         let colors6 = vec![MyColor::from_rgb(10, 11, 12), MyColor::from_rgb(13, 14, 15)];
-        let chunk6 = Chunk::builder(entity_path.into())
+        let chunk6 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id6,
                 past_data_timepoint.clone(),
@@ -715,7 +715,7 @@ fn invalidation() {
         // Modify the PoV component
         let row_id7 = RowId::new();
         let points7 = vec![MyPoint::new(1000.0, 2000.0), MyPoint::new(3000.0, 4000.0)];
-        let chunk7 = Chunk::builder(entity_path.into())
+        let chunk7 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id7,
                 future_data_timepoint.clone(),
@@ -751,7 +751,7 @@ fn invalidation() {
         // Modify the optional component
         let row_id8 = RowId::new();
         let colors8 = vec![MyColor::from_rgb(16, 17, 18)];
-        let chunk8 = Chunk::builder(entity_path.into())
+        let chunk8 = Chunk::builder(entity_path)
             .with_archetype(
                 row_id8,
                 future_data_timepoint.clone(),
@@ -848,7 +848,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id1 = RowId::new();
     let points1 = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
-    let chunk1 = Chunk::builder(entity_path.into())
+    let chunk1 = Chunk::builder(entity_path)
         .with_archetype(row_id1, static_, &MyPoints::new(points1.clone()))
         .build()
         .unwrap();
@@ -869,7 +869,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id2 = RowId::new();
     let colors2 = vec![MyColor::from_rgb(255, 0, 0)];
-    let chunk2 = Chunk::builder(entity_path.into())
+    let chunk2 = Chunk::builder(entity_path)
         .with_archetype(
             row_id2,
             frame2,
@@ -893,7 +893,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id3 = RowId::new();
     let colors3 = vec![MyColor::from_rgb(0, 0, 255)];
-    let chunk3 = Chunk::builder(entity_path.into())
+    let chunk3 = Chunk::builder(entity_path)
         .with_archetype(
             row_id3,
             frame3,
@@ -918,7 +918,7 @@ fn invalidation_of_future_optionals() {
 
     let row_id4 = RowId::new();
     let colors4 = vec![MyColor::from_rgb(0, 255, 0)];
-    let chunk4 = Chunk::builder(entity_path.into())
+    let chunk4 = Chunk::builder(entity_path)
         .with_archetype(
             row_id4,
             frame3,
@@ -960,7 +960,7 @@ fn invalidation_static() {
 
     let row_id1 = RowId::new();
     let points1 = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
-    let chunk1 = Chunk::builder(entity_path.into())
+    let chunk1 = Chunk::builder(entity_path)
         .with_archetype(row_id1, static_.clone(), &MyPoints::new(points1.clone()))
         .build()
         .unwrap();
@@ -981,7 +981,7 @@ fn invalidation_static() {
 
     let row_id2 = RowId::new();
     let colors2 = vec![MyColor::from_rgb(255, 0, 0)];
-    let chunk2 = Chunk::builder(entity_path.into())
+    let chunk2 = Chunk::builder(entity_path)
         .with_archetype(
             row_id2,
             static_.clone(),
@@ -1005,7 +1005,7 @@ fn invalidation_static() {
 
     let row_id3 = RowId::new();
     let colors3 = vec![MyColor::from_rgb(0, 0, 255)];
-    let chunk3 = Chunk::builder(entity_path.into())
+    let chunk3 = Chunk::builder(entity_path)
         .with_archetype(
             row_id3,
             static_,

--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -24,15 +24,10 @@ fn basic_blueprint_panel_should_match_snapshot() {
     test_context.log_entity("/entity1", add_point_to_chunk_builder);
     test_context.log_entity("/entity2", add_point_to_chunk_builder);
 
-    test_context.setup_viewport_blueprint(|_, blueprint| {
-        blueprint.add_views(
-            std::iter::once(ViewBlueprint::new(
-                re_view_spatial::SpatialView3D::identifier(),
-                RecommendedView::root(),
-            )),
-            None,
-            None,
-        );
+    test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
+            re_view_spatial::SpatialView3D::identifier(),
+        ))
     });
 
     let blueprint_tree = BlueprintTree::default();
@@ -58,13 +53,11 @@ fn collapse_expand_all_blueprint_panel_should_match_snapshot() {
         let view_id = ViewId::hashed_from_str("some-view-id-hash");
 
         test_context.setup_viewport_blueprint(|_ctx, blueprint| {
-            let view = ViewBlueprint::new_with_id(
+            blueprint.add_view_at_root(ViewBlueprint::new_with_id(
                 re_view_spatial::SpatialView3D::identifier(),
                 RecommendedView::root(),
                 view_id,
-            );
-
-            blueprint.add_views(std::iter::once(view), None, None);
+            ))
 
             // TODO(ab): add containers in the hierarchy (requires work on the container API,
             // currently very cumbersome to use for testing purposes).

--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -20,9 +20,9 @@ fn basic_blueprint_panel_should_match_snapshot() {
 
     test_context.register_view_class::<re_view_spatial::SpatialView3D>();
 
-    test_context.log_entity("/entity0".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/entity1".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/entity2".into(), add_point_to_chunk_builder);
+    test_context.log_entity("/entity0", add_point_to_chunk_builder);
+    test_context.log_entity("/entity1", add_point_to_chunk_builder);
+    test_context.log_entity("/entity2", add_point_to_chunk_builder);
 
     test_context.setup_viewport_blueprint(|_, blueprint| {
         blueprint.add_views(
@@ -51,9 +51,9 @@ fn collapse_expand_all_blueprint_panel_should_match_snapshot() {
 
         test_context.register_view_class::<re_view_spatial::SpatialView3D>();
 
-        test_context.log_entity("/path/to/entity0".into(), add_point_to_chunk_builder);
-        test_context.log_entity("/path/to/entity1".into(), add_point_to_chunk_builder);
-        test_context.log_entity("/another/way/to/entity2".into(), add_point_to_chunk_builder);
+        test_context.log_entity("/path/to/entity0", add_point_to_chunk_builder);
+        test_context.log_entity("/path/to/entity1", add_point_to_chunk_builder);
+        test_context.log_entity("/another/way/to/entity2", add_point_to_chunk_builder);
 
         let view_id = ViewId::hashed_from_str("some-view-id-hash");
 
@@ -142,9 +142,9 @@ fn setup_filter_test(query: Option<&str>) -> (TestContext, BlueprintTree) {
     let mut test_context = TestContext::default();
     test_context.register_view_class::<re_view_spatial::SpatialView3D>();
 
-    test_context.log_entity("/path/to/left".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/path/to/right".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/path/is/outside".into(), add_point_to_chunk_builder);
+    test_context.log_entity("/path/to/left", add_point_to_chunk_builder);
+    test_context.log_entity("/path/to/right", add_point_to_chunk_builder);
+    test_context.log_entity("/path/is/outside", add_point_to_chunk_builder);
 
     test_context.setup_viewport_blueprint(|_, blueprint| {
         blueprint.add_views(

--- a/crates/viewer/re_blueprint_tree/tests/range_selection_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/range_selection_test.rs
@@ -19,7 +19,7 @@ fn test_range_selection_in_blueprint_tree() {
     test_context.register_view_class::<re_view_spatial::SpatialView3D>();
 
     for i in 0..=10 {
-        test_context.log_entity(format!("/entity{i}").into(), add_point_to_chunk_builder);
+        test_context.log_entity(format!("/entity{i}"), add_point_to_chunk_builder);
     }
 
     test_context.setup_viewport_blueprint(|_, blueprint| {

--- a/crates/viewer/re_blueprint_tree/tests/range_selection_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/range_selection_test.rs
@@ -7,10 +7,10 @@ use re_chunk_store::RowId;
 use re_chunk_store::external::re_chunk::ChunkBuilder;
 use re_log_types::{Timeline, build_frame_nr};
 use re_types::archetypes::Points3D;
-use re_viewer_context::test_context::TestContext;
-use re_viewer_context::{Contents, RecommendedView, ViewClass as _, VisitorControlFlow};
-use re_viewport_blueprint::test_context_ext::TestContextExt as _;
-use re_viewport_blueprint::{ViewBlueprint, ViewportBlueprint};
+use re_viewer_context::{Contents, ViewClass as _, VisitorControlFlow, test_context::TestContext};
+use re_viewport_blueprint::{
+    ViewBlueprint, ViewportBlueprint, test_context_ext::TestContextExt as _,
+};
 
 #[test]
 fn test_range_selection_in_blueprint_tree() {
@@ -22,15 +22,10 @@ fn test_range_selection_in_blueprint_tree() {
         test_context.log_entity(format!("/entity{i}"), add_point_to_chunk_builder);
     }
 
-    test_context.setup_viewport_blueprint(|_, blueprint| {
-        blueprint.add_views(
-            std::iter::once(ViewBlueprint::new(
-                re_view_spatial::SpatialView3D::identifier(),
-                RecommendedView::root(),
-            )),
-            None,
-            None,
-        );
+    test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
+            re_view_spatial::SpatialView3D::identifier(),
+        ))
     });
 
     let mut blueprint_tree = BlueprintTree::default();

--- a/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
@@ -123,7 +123,7 @@ fn test_context(test_case: &TestCase) -> TestContext {
     }
 
     test_context.setup_viewport_blueprint(|_, blueprint| {
-        let view = ViewBlueprint::new_with_id(
+        blueprint.add_view_at_root(ViewBlueprint::new_with_id(
             re_view_spatial::SpatialView3D::identifier(),
             RecommendedView {
                 origin: test_case.origin.clone(),
@@ -133,9 +133,7 @@ fn test_context(test_case: &TestCase) -> TestContext {
                     .expect("invalid entity filter"),
             },
             ViewId::hashed_from_str(VIEW_ID),
-        );
-
-        blueprint.add_views(std::iter::once(view), None, None);
+        ));
     });
 
     test_context

--- a/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
@@ -114,11 +114,11 @@ fn test_context(test_case: &TestCase) -> TestContext {
     match test_case.recording_kind {
         RecordingKind::Empty => {}
         RecordingKind::Regular => {
-            test_context.log_entity("/path/to/left".into(), add_point_to_chunk_builder);
-            test_context.log_entity("/path/to/right".into(), add_point_to_chunk_builder);
-            test_context.log_entity("/path/to/the/void".into(), add_point_to_chunk_builder);
-            test_context.log_entity("/path/onto/their/coils".into(), add_point_to_chunk_builder);
-            test_context.log_entity("/center/way".into(), add_point_to_chunk_builder);
+            test_context.log_entity("/path/to/left", add_point_to_chunk_builder);
+            test_context.log_entity("/path/to/right", add_point_to_chunk_builder);
+            test_context.log_entity("/path/to/the/void", add_point_to_chunk_builder);
+            test_context.log_entity("/path/onto/their/coils", add_point_to_chunk_builder);
+            test_context.log_entity("/center/way", add_point_to_chunk_builder);
         }
     }
 

--- a/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
+++ b/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
@@ -196,7 +196,7 @@ fn test_default_column_display_name() {
             &re_sorbet::ComponentColumnDescriptor {
                 store_datatype: arrow::datatypes::DataType::Binary, // ignored
                 component_type: None,
-                entity_path: EntityPath::properties() / EntityPathPart::from("episode"),
+                entity_path: EntityPath::properties() / "episode",
                 archetype: None,
                 component: "building".into(),
                 is_static: false,

--- a/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
+++ b/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
@@ -170,8 +170,6 @@ pub fn default_display_name_for_column(desc: &ColumnDescriptorRef<'_>) -> String
 
 #[test]
 fn test_default_column_display_name() {
-    use re_log_types::EntityPathPart;
-
     // Built-in recording property:
     assert_eq!(
         default_display_name_for_column(&ColumnDescriptorRef::Component(

--- a/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
+++ b/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
@@ -208,7 +208,7 @@ mod tests {
         // 2x: single chunk with two events for both t0 and t1.
         for i in 1..=2 {
             store.insert_chunk(&Arc::new(
-                Chunk::builder("/".into())
+                Chunk::builder("/")
                     .with_component_batches(
                         RowId::new(),
                         [(t0, i), (t1, i)],
@@ -226,12 +226,12 @@ mod tests {
         // Events at a child path.
         // One chunk with one event at t0, one chunk with two events at t1
         store.insert_chunk(&Arc::new(
-            Chunk::builder("/parent/child".into())
+            Chunk::builder("/parent/child")
                 .with_component_batches(RowId::new(), [(t0, 0)], [component_batch.clone()])
                 .build()?,
         ))?;
         store.insert_chunk(&Arc::new(
-            Chunk::builder("/parent/child".into())
+            Chunk::builder("/parent/child")
                 .with_component_batches(RowId::new(), [(t1, 1)], [component_batch.clone()])
                 .with_component_batches(RowId::new(), [(t1, 3)], [component_batch])
                 .build()?,

--- a/crates/viewer/re_time_panel/tests/time_panel_filter_tests.rs
+++ b/crates/viewer/re_time_panel/tests/time_panel_filter_tests.rs
@@ -92,15 +92,15 @@ pub fn test_various_filter_insta_snapshot() {
 fn prepare_test_context() -> TestContext {
     let mut test_context = TestContext::default();
 
-    test_context.log_entity("/path/to/left".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/path/to/right".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/path/to/the/void".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/path/onto/their/coils".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/center/way".into(), add_point_to_chunk_builder);
+    test_context.log_entity("/path/to/left", add_point_to_chunk_builder);
+    test_context.log_entity("/path/to/right", add_point_to_chunk_builder);
+    test_context.log_entity("/path/to/the/void", add_point_to_chunk_builder);
+    test_context.log_entity("/path/onto/their/coils", add_point_to_chunk_builder);
+    test_context.log_entity("/center/way", add_point_to_chunk_builder);
 
     // also populate some "intermediate" entities so we see components
-    test_context.log_entity("/path".into(), add_point_to_chunk_builder);
-    test_context.log_entity("/path/to".into(), add_point_to_chunk_builder);
+    test_context.log_entity("/path", add_point_to_chunk_builder);
+    test_context.log_entity("/path/to", add_point_to_chunk_builder);
 
     test_context
 }

--- a/crates/viewer/re_time_panel/tests/time_panel_tests.rs
+++ b/crates/viewer/re_time_panel/tests/time_panel_tests.rs
@@ -20,7 +20,7 @@ pub fn time_panel_two_sections_should_match_snapshot() {
 
     let points1 = MyPoint::from_iter(0..1);
     for i in 0..2 {
-        test_context.log_entity(format!("/entity/{i}").into(), |mut builder| {
+        test_context.log_entity(format!("/entity/{i}"), |mut builder| {
             for frame in [10, 11, 12, 15, 18, 100, 102, 104].map(|frame| frame + i) {
                 builder = builder.with_sparse_component_batches(
                     RowId::new(),
@@ -57,7 +57,7 @@ pub fn time_panel_dense_data_should_match_snapshot() {
         rng_seed.wrapping_mul(0x2545_f491_4f6c_dd1d)
     };
 
-    test_context.log_entity("/entity".into(), |mut builder| {
+    test_context.log_entity("/entity", |mut builder| {
         for frame in 0..1_000 {
             if rng() & 0b1 == 0 {
                 continue;
@@ -106,7 +106,7 @@ pub fn run_time_panel_filter_tests(filter_active: bool, query: &str, snapshot_na
 
     let points1 = MyPoint::from_iter(0..1);
     for i in 0..2 {
-        test_context.log_entity(format!("/entity/{i}").into(), |mut builder| {
+        test_context.log_entity(format!("/entity/{i}"), |mut builder| {
             builder = builder.with_sparse_component_batches(
                 RowId::new(),
                 [build_frame_nr(1)],
@@ -118,7 +118,7 @@ pub fn run_time_panel_filter_tests(filter_active: bool, query: &str, snapshot_na
     }
 
     for i in 0..2 {
-        test_context.log_entity(format!("/path/{i}").into(), |mut builder| {
+        test_context.log_entity(format!("/path/{i}"), |mut builder| {
             builder = builder.with_sparse_component_batches(
                 RowId::new(),
                 [build_frame_nr(1)],

--- a/crates/viewer/re_view_dataframe/tests/basic.rs
+++ b/crates/viewer/re_view_dataframe/tests/basic.rs
@@ -6,7 +6,7 @@ use re_types::archetypes::Scalars;
 use re_ui::UiExt as _;
 use re_view_dataframe::DataframeView;
 use re_viewer_context::test_context::TestContext;
-use re_viewer_context::{RecommendedView, ViewClass as _, ViewId};
+use re_viewer_context::{ViewClass as _, ViewId};
 use re_viewport_blueprint::ViewBlueprint;
 use re_viewport_blueprint::test_context_ext::TestContextExt as _;
 
@@ -84,13 +84,9 @@ fn get_test_context() -> TestContext {
 
 fn setup_blueprint(test_context: &mut TestContext, timeline_name: &TimelineName) -> ViewId {
     test_context.setup_viewport_blueprint(|ctx, blueprint| {
-        let view_blueprint = ViewBlueprint::new(
+        let view_id = blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
             re_view_dataframe::DataframeView::identifier(),
-            RecommendedView::root(),
-        );
-
-        let view_id = view_blueprint.id;
-        blueprint.add_views(std::iter::once(view_blueprint), None, None);
+        ));
 
         // the dataframe view to the desired timeline
         let query = re_view_dataframe::Query::from_blueprint(ctx, view_id);

--- a/crates/viewer/re_view_dataframe/tests/basic.rs
+++ b/crates/viewer/re_view_dataframe/tests/basic.rs
@@ -17,11 +17,11 @@ pub fn test_null_timeline() {
     let timeline_a = Timeline::new_sequence("timeline_a");
     let timeline_b = Timeline::new_sequence("timeline_b");
 
-    test_context.log_entity("first".into(), |builder| {
+    test_context.log_entity("first", |builder| {
         builder.with_archetype(RowId::new(), [(timeline_a, 0)], &Scalars::single(10.0))
     });
 
-    test_context.log_entity("second".into(), |builder| {
+    test_context.log_entity("second", |builder| {
         builder.with_archetype(
             RowId::new(),
             [(timeline_a, 1), (timeline_b, 10)],
@@ -44,7 +44,7 @@ pub fn test_unknown_timeline() {
 
     let timeline = Timeline::new_sequence("existing_timeline");
 
-    test_context.log_entity("some_entity".into(), |builder| {
+    test_context.log_entity("some_entity", |builder| {
         builder
             .with_archetype(RowId::new(), [(timeline, 0)], &Scalars::single(10.0))
             .with_archetype(RowId::new(), [(timeline, 1)], &Scalars::single(20.0))

--- a/crates/viewer/re_view_graph/tests/basic.rs
+++ b/crates/viewer/re_view_graph/tests/basic.rs
@@ -21,7 +21,7 @@ pub fn coincident_nodes() {
     test_context.register_view_class::<re_view_graph::GraphView>();
 
     let timepoint = TimePoint::from([(test_context.active_timeline(), 1)]);
-    test_context.log_entity(name.into(), |builder| {
+    test_context.log_entity(name, |builder| {
         builder
             .with_archetype(
                 RowId::new(),
@@ -53,7 +53,7 @@ pub fn self_and_multi_edges() {
         .unwrap();
 
     let timepoint = TimePoint::from([(test_context.active_timeline(), 1)]);
-    test_context.log_entity(name.into(), |builder| {
+    test_context.log_entity(name, |builder| {
         builder
             .with_archetype(
                 RowId::new(),
@@ -101,7 +101,7 @@ pub fn multi_graphs() {
         .unwrap();
 
     let timepoint = TimePoint::from([(test_context.active_timeline(), 1)]);
-    test_context.log_entity("graph1".into(), |builder| {
+    test_context.log_entity("graph1", |builder| {
         builder
             .with_archetype(
                 RowId::new(),
@@ -114,7 +114,7 @@ pub fn multi_graphs() {
                 &archetypes::GraphEdges::new([("A", "B")]),
             )
     });
-    test_context.log_entity("graph2".into(), |builder| {
+    test_context.log_entity("graph2", |builder| {
         builder
             .with_archetype(
                 RowId::new(),

--- a/crates/viewer/re_view_graph/tests/basic.rs
+++ b/crates/viewer/re_view_graph/tests/basic.rs
@@ -7,7 +7,7 @@ use re_log_types::TimePoint;
 use re_types::archetypes;
 use re_view_graph::GraphView;
 use re_viewer_context::test_context::HarnessExt as _;
-use re_viewer_context::{RecommendedView, ViewClass as _, test_context::TestContext};
+use re_viewer_context::{ViewClass as _, test_context::TestContext};
 use re_viewport_blueprint::{ViewBlueprint, test_context_ext::TestContextExt as _};
 
 #[test]
@@ -133,15 +133,10 @@ pub fn multi_graphs() {
 }
 
 fn run_graph_view_and_save_snapshot(test_context: &mut TestContext, name: &str, size: Vec2) {
-    let view_id = test_context.setup_viewport_blueprint(|_, blueprint| {
-        let view_blueprint = ViewBlueprint::new(
+    let view_id = test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
             re_view_graph::GraphView::identifier(),
-            RecommendedView::root(),
-        );
-
-        let view_id = view_blueprint.id;
-        blueprint.add_views(std::iter::once(view_blueprint), None, None);
-        view_id
+        ))
     });
 
     let mut harness = test_context

--- a/crates/viewer/re_view_spatial/tests/annotations.rs
+++ b/crates/viewer/re_view_spatial/tests/annotations.rs
@@ -14,7 +14,7 @@ pub fn test_annotations() {
         use ndarray::{Array, ShapeBuilder as _, s};
 
         // Log an annotation context to assign a label and color to each class
-        test_context.log_entity("/".into(), |builder| {
+        test_context.log_entity("/", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -27,7 +27,7 @@ pub fn test_annotations() {
         });
 
         // Log a batch of 2 rectangles with different `class_ids`
-        test_context.log_entity("detections".into(), |builder| {
+        test_context.log_entity("detections", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -39,7 +39,7 @@ pub fn test_annotations() {
             )
         });
 
-        test_context.log_entity("segmentation/image".into(), |builder| {
+        test_context.log_entity("segmentation/image", |builder| {
             let mut image = Array::<u8, _>::zeros((200, 300).f());
             image.slice_mut(s![50..100, 50..120]).fill(1);
             image.slice_mut(s![100..180, 130..280]).fill(2);

--- a/crates/viewer/re_view_spatial/tests/annotations.rs
+++ b/crates/viewer/re_view_spatial/tests/annotations.rs
@@ -2,7 +2,7 @@ use re_chunk_store::RowId;
 use re_log_types::TimePoint;
 use re_view_spatial::SpatialView2D;
 use re_viewer_context::test_context::{HarnessExt as _, TestContext};
-use re_viewer_context::{RecommendedView, ViewClass as _, ViewId};
+use re_viewer_context::{ViewClass as _, ViewId};
 use re_viewport_blueprint::ViewBlueprint;
 use re_viewport_blueprint::test_context_ext::TestContextExt as _;
 
@@ -54,7 +54,11 @@ pub fn test_annotations() {
         });
     }
 
-    let view_id = setup_blueprint(&mut test_context);
+    let view_id = test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
+            re_view_spatial::SpatialView2D::identifier(),
+        ))
+    });
     run_view_ui_and_save_snapshot(
         &mut test_context,
         view_id,
@@ -78,20 +82,6 @@ fn get_test_context() -> TestContext {
     re_data_ui::register_component_uis(&mut test_context.component_ui_registry);
 
     test_context
-}
-
-fn setup_blueprint(test_context: &mut TestContext) -> ViewId {
-    test_context.setup_viewport_blueprint(|_ctx, blueprint| {
-        let view_blueprint = ViewBlueprint::new(
-            re_view_spatial::SpatialView2D::identifier(),
-            RecommendedView::root(),
-        );
-
-        let view_id = view_blueprint.id;
-        blueprint.add_views(std::iter::once(view_blueprint), None, None);
-
-        view_id
-    })
 }
 
 fn run_view_ui_and_save_snapshot(

--- a/crates/viewer/re_view_spatial/tests/draw_order.rs
+++ b/crates/viewer/re_view_spatial/tests/draw_order.rs
@@ -14,7 +14,7 @@ pub fn test_draw_order() {
         use ndarray::{Array, ShapeBuilder as _, s};
 
         // Large gray background
-        test_context.log_entity("2d_layering/background".into(), |builder| {
+        test_context.log_entity("2d_layering/background", |builder| {
             let mut image = Array::<u8, _>::zeros((256, 512, 3).f());
             image.fill(64);
 
@@ -31,7 +31,7 @@ pub fn test_draw_order() {
         });
 
         // Smaller gradient in the middle
-        test_context.log_entity("2d_layering/middle_gradient".into(), |builder| {
+        test_context.log_entity("2d_layering/middle_gradient", |builder| {
             let mut image = Array::<u8, _>::zeros((256, 256, 3).f());
             image
                 .slice_mut(s![.., .., 0])
@@ -53,7 +53,7 @@ pub fn test_draw_order() {
         });
 
         // Slightly smaller blue in the middle, on the same layer as the previous.
-        test_context.log_entity("2d_layering/middle_blue".into(), |builder| {
+        test_context.log_entity("2d_layering/middle_blue", |builder| {
             let mut image = Array::<u8, _>::zeros((192, 192, 3).f());
             image.slice_mut(s![.., .., 2]).fill(255);
 
@@ -69,7 +69,7 @@ pub fn test_draw_order() {
             )
         });
 
-        test_context.log_entity("2d_layering/lines_behind_rect".into(), |builder| {
+        test_context.log_entity("2d_layering/lines_behind_rect", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -83,41 +83,35 @@ pub fn test_draw_order() {
             )
         });
 
-        test_context.log_entity(
-            "2d_layering/rect_between_top_and_middle".into(),
-            |builder| {
-                builder.with_archetype(
-                    RowId::new(),
-                    TimePoint::default(),
-                    &re_types::archetypes::Boxes2D::from_mins_and_sizes(
-                        [(64.0, 32.0)],
-                        [(256.0, 128.0)],
-                    )
-                    .with_draw_order(1.5)
-                    .with_colors([0x000000FF]),
+        test_context.log_entity("2d_layering/rect_between_top_and_middle", |builder| {
+            builder.with_archetype(
+                RowId::new(),
+                TimePoint::default(),
+                &re_types::archetypes::Boxes2D::from_mins_and_sizes(
+                    [(64.0, 32.0)],
+                    [(256.0, 128.0)],
                 )
-            },
-        );
+                .with_draw_order(1.5)
+                .with_colors([0x000000FF]),
+            )
+        });
 
-        test_context.log_entity(
-            "2d_layering/points_between_top_and_middle".into(),
-            |builder| {
-                builder.with_archetype(
-                    RowId::new(),
-                    TimePoint::default(),
-                    &re_types::archetypes::Points2D::new((0..16 * 16).map(|i| i as f32).map(|i| {
-                        (
-                            32.0 + (i as i32 / 16) as f32 * 16.0,
-                            32.0 + (i as i32 % 16) as f32 * 16.0,
-                        )
-                    }))
-                    .with_draw_order(1.51),
-                )
-            },
-        );
+        test_context.log_entity("2d_layering/points_between_top_and_middle", |builder| {
+            builder.with_archetype(
+                RowId::new(),
+                TimePoint::default(),
+                &re_types::archetypes::Points2D::new((0..16 * 16).map(|i| i as f32).map(|i| {
+                    (
+                        32.0 + (i as i32 / 16) as f32 * 16.0,
+                        32.0 + (i as i32 % 16) as f32 * 16.0,
+                    )
+                }))
+                .with_draw_order(1.51),
+            )
+        });
 
         // Small white square on top
-        test_context.log_entity("2d_layering/top".into(), |builder| {
+        test_context.log_entity("2d_layering/top", |builder| {
             let mut image = Array::<u8, _>::zeros((128, 128, 3).f());
             image.fill(255);
 
@@ -134,7 +128,7 @@ pub fn test_draw_order() {
         });
 
         // 2D arrow sandwitched across
-        test_context.log_entity("2d_layering/arrow2d_between".into(), |builder| {
+        test_context.log_entity("2d_layering/arrow2d_between", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),

--- a/crates/viewer/re_view_spatial/tests/draw_order.rs
+++ b/crates/viewer/re_view_spatial/tests/draw_order.rs
@@ -1,10 +1,8 @@
 use re_chunk_store::RowId;
 use re_log_types::TimePoint;
 use re_view_spatial::SpatialView2D;
-use re_viewer_context::test_context::TestContext;
-use re_viewer_context::{RecommendedView, ViewClass as _, ViewId};
-use re_viewport_blueprint::ViewBlueprint;
-use re_viewport_blueprint::test_context_ext::TestContextExt as _;
+use re_viewer_context::{ViewClass as _, ViewId, test_context::TestContext};
+use re_viewport_blueprint::{ViewBlueprint, test_context_ext::TestContextExt as _};
 
 #[test]
 pub fn test_draw_order() {
@@ -141,7 +139,11 @@ pub fn test_draw_order() {
         });
     }
 
-    let view_id = setup_blueprint(&mut test_context);
+    let view_id = test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
+            re_view_spatial::SpatialView2D::identifier(),
+        ))
+    });
     run_view_ui_and_save_snapshot(
         &mut test_context,
         view_id,
@@ -159,20 +161,6 @@ fn get_test_context() -> TestContext {
     test_context.register_view_class::<re_view_spatial::SpatialView2D>();
 
     test_context
-}
-
-fn setup_blueprint(test_context: &mut TestContext) -> ViewId {
-    test_context.setup_viewport_blueprint(|_ctx, blueprint| {
-        let view_blueprint = ViewBlueprint::new(
-            re_view_spatial::SpatialView2D::identifier(),
-            RecommendedView::root(),
-        );
-
-        let view_id = view_blueprint.id;
-        blueprint.add_views(std::iter::once(view_blueprint), None, None);
-
-        view_id
-    })
 }
 
 fn run_view_ui_and_save_snapshot(

--- a/crates/viewer/re_view_spatial/tests/transform_clamping.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_clamping.rs
@@ -11,7 +11,7 @@ pub fn test_transform_clamping() {
     let mut test_context = get_test_context();
 
     {
-        test_context.log_entity("boxes/clamped_colors".into(), |builder| {
+        test_context.log_entity("boxes/clamped_colors", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -20,7 +20,7 @@ pub fn test_transform_clamping() {
             )
         });
 
-        test_context.log_entity("boxes/ignored_colors".into(), |builder| {
+        test_context.log_entity("boxes/ignored_colors", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -32,7 +32,7 @@ pub fn test_transform_clamping() {
             )
         });
 
-        test_context.log_entity("boxes/more_transforms_than_sizes".into(), |builder| {
+        test_context.log_entity("boxes/more_transforms_than_sizes", |builder| {
             builder
                 .with_archetype(
                     RowId::new(),
@@ -55,7 +55,7 @@ pub fn test_transform_clamping() {
                 )
         });
 
-        test_context.log_entity("boxes/no_primaries".into(), |builder| {
+        test_context.log_entity("boxes/no_primaries", |builder| {
             builder
                 .with_archetype(
                     RowId::new(),
@@ -74,7 +74,7 @@ pub fn test_transform_clamping() {
     }
 
     {
-        test_context.log_entity("spheres/clamped_colors".into(), |builder| {
+        test_context.log_entity("spheres/clamped_colors", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -86,7 +86,7 @@ pub fn test_transform_clamping() {
             )
         });
 
-        test_context.log_entity("spheres/ignored_colors".into(), |builder| {
+        test_context.log_entity("spheres/ignored_colors", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -98,7 +98,7 @@ pub fn test_transform_clamping() {
             )
         });
 
-        test_context.log_entity("spheres/more_transforms_than_sizes".into(), |builder| {
+        test_context.log_entity("spheres/more_transforms_than_sizes", |builder| {
             builder
                 .with_archetype(
                     RowId::new(),
@@ -117,7 +117,7 @@ pub fn test_transform_clamping() {
                 )
         });
 
-        test_context.log_entity("spheres/no_primaries".into(), |builder| {
+        test_context.log_entity("spheres/no_primaries", |builder| {
             builder
                 .with_archetype(
                     RowId::new(),

--- a/crates/viewer/re_view_spatial/tests/transform_hierarchy.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_hierarchy.rs
@@ -1,10 +1,8 @@
 use re_chunk_store::RowId;
 use re_log_types::{EntityPath, TimePoint, Timeline};
 use re_view_spatial::SpatialView3D;
-use re_viewer_context::test_context::TestContext;
-use re_viewer_context::{RecommendedView, ViewClass as _, ViewId};
-use re_viewport_blueprint::ViewBlueprint;
-use re_viewport_blueprint::test_context_ext::TestContextExt as _;
+use re_viewer_context::{ViewClass as _, ViewId, test_context::TestContext};
+use re_viewport_blueprint::{ViewBlueprint, test_context_ext::TestContextExt as _};
 
 #[test]
 pub fn test_transform_hierarchy() {
@@ -157,10 +155,8 @@ fn get_test_context() -> TestContext {
 
 fn setup_blueprint(test_context: &mut TestContext) -> ViewId {
     test_context.setup_viewport_blueprint(|_ctx, blueprint| {
-        let view_blueprint = ViewBlueprint::new(
-            re_view_spatial::SpatialView3D::identifier(),
-            RecommendedView::root(),
-        );
+        let view_blueprint =
+            ViewBlueprint::new_with_root_wildcard(re_view_spatial::SpatialView3D::identifier());
 
         let view_id = view_blueprint.id;
         blueprint.add_views(std::iter::once(view_blueprint), None, None);

--- a/crates/viewer/re_view_spatial/tests/transform_hierarchy.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_hierarchy.rs
@@ -13,7 +13,7 @@ pub fn test_transform_hierarchy() {
     let timeline_step = Timeline::new_sequence("step");
 
     // The Rerun logo obj's convention is y up.
-    test_context.log_entity("/".into(), |builder| {
+    test_context.log_entity("/", |builder| {
         builder.with_archetype(
             RowId::new(),
             TimePoint::default(),
@@ -27,7 +27,7 @@ pub fn test_transform_hierarchy() {
 
         let mut path: EntityPath = "/".into();
 
-        path = path.join(&"translate".into());
+        path = path / "translate";
         test_context.log_entity(path.clone(), |builder| {
             builder.with_archetype(
                 RowId::new(),
@@ -36,7 +36,7 @@ pub fn test_transform_hierarchy() {
             )
         });
 
-        path = path.join(&"translate_back".into());
+        path = path / "translate_back";
         test_context.log_entity(path.clone(), |builder| {
             builder.with_archetype(
                 RowId::new(),
@@ -45,7 +45,7 @@ pub fn test_transform_hierarchy() {
             )
         });
 
-        path = path.join(&"scale".into());
+        path = path / "scale";
         test_context.log_entity(path.clone(), |builder| {
             builder.with_archetype(
                 RowId::new(),
@@ -54,7 +54,7 @@ pub fn test_transform_hierarchy() {
             )
         });
 
-        path = path.join(&"scale_back_mat3x3".into());
+        path = path / "scale_back_mat3x3";
         test_context.log_entity(path.clone(), |builder| {
             builder.with_archetype(
                 RowId::new(),
@@ -67,7 +67,7 @@ pub fn test_transform_hierarchy() {
             )
         });
 
-        path = path.join(&"rotate_axis_origin".into());
+        path = path / "rotate_axis_origin";
         test_context.log_entity(path.clone(), |builder| {
             builder.with_archetype(
                 RowId::new(),
@@ -81,7 +81,7 @@ pub fn test_transform_hierarchy() {
             )
         });
 
-        path = path.join(&"rotate_quat".into());
+        path = path / "rotate_quat";
         test_context.log_entity(path.clone(), |builder| {
             builder.with_archetype(
                 RowId::new(),
@@ -96,7 +96,7 @@ pub fn test_transform_hierarchy() {
             )
         });
 
-        path = path.join(&"rotate_mat3x3".into());
+        path = path / "rotate_mat3x3";
         test_context.log_entity(path.clone(), |builder| {
             builder.with_archetype(
                 RowId::new(),
@@ -122,7 +122,7 @@ pub fn test_transform_hierarchy() {
                 .unwrap();
             let obj_path = workspace_dir.join("tests/assets/rerun.obj");
 
-            path = path.join(&"asset".into());
+            path = path / "asset";
             test_context.log_entity(path.clone(), |builder| {
                 builder.with_archetype(
                     RowId::new(),

--- a/crates/viewer/re_view_spatial/tests/transform_tree_origins.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_tree_origins.rs
@@ -15,7 +15,7 @@ pub fn test_transform_tree_origins() {
     let mut test_context = get_test_context();
 
     {
-        test_context.log_entity("/".into(), |builder| {
+        test_context.log_entity("/", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -24,7 +24,7 @@ pub fn test_transform_tree_origins() {
         });
 
         // Setup points, all are in the center of their own space:
-        test_context.log_entity("sun".into(), |builder| {
+        test_context.log_entity("sun", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -34,7 +34,7 @@ pub fn test_transform_tree_origins() {
             )
         });
 
-        test_context.log_entity("sun/planet".into(), |builder| {
+        test_context.log_entity("sun/planet", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -45,7 +45,7 @@ pub fn test_transform_tree_origins() {
         });
 
         // Add a bunch of small cubes around the planet, to test that poses are handled correctly.
-        test_context.log_entity("sun/planet/cuberoids".into(), |builder| {
+        test_context.log_entity("sun/planet/cuberoids", |builder| {
             builder
                 .with_archetype(
                     RowId::new(),
@@ -65,7 +65,7 @@ pub fn test_transform_tree_origins() {
                 )
         });
 
-        test_context.log_entity("sun/planet/moon".into(), |builder| {
+        test_context.log_entity("sun/planet/moon", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -81,7 +81,7 @@ pub fn test_transform_tree_origins() {
         let angles = (0..=100).map(|i| i as f32 * 0.01 * std::f32::consts::TAU);
         let circle: Vec<_> = angles.map(|angle| [angle.sin(), angle.cos()]).collect();
 
-        test_context.log_entity("sun/planet_path".into(), |builder| {
+        test_context.log_entity("sun/planet_path", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -95,7 +95,7 @@ pub fn test_transform_tree_origins() {
             )
         });
 
-        test_context.log_entity("sun/planet/moon_path".into(), |builder| {
+        test_context.log_entity("sun/planet/moon_path", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -111,7 +111,7 @@ pub fn test_transform_tree_origins() {
         let r_moon = 5.0_f32;
         let r_planet = 2.0_f32;
 
-        test_context.log_entity("sun/planet".into(), |builder| {
+        test_context.log_entity("sun/planet", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -125,7 +125,7 @@ pub fn test_transform_tree_origins() {
             )
         });
 
-        test_context.log_entity("sun/planet/moon".into(), |builder| {
+        test_context.log_entity("sun/planet/moon", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),

--- a/crates/viewer/re_view_spatial/tests/transform_tree_origins.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_tree_origins.rs
@@ -172,16 +172,13 @@ fn get_test_context() -> TestContext {
 
 fn setup_blueprint(test_context: &mut TestContext, origin: &str) -> ViewId {
     test_context.setup_viewport_blueprint(|_ctx, blueprint| {
-        let view = ViewBlueprint::new(
+        blueprint.add_view_at_root(ViewBlueprint::new(
             re_view_spatial::SpatialView3D::identifier(),
             RecommendedView {
                 origin: origin.into(),
                 query_filter: "+ /**".parse().expect("valid query filter"),
             },
-        );
-        let id = view.id;
-        blueprint.add_views(std::iter::once(view), None, None);
-        id
+        ))
     })
 }
 

--- a/crates/viewer/re_view_spatial/tests/visible_time_range.rs
+++ b/crates/viewer/re_view_spatial/tests/visible_time_range.rs
@@ -6,7 +6,7 @@ use re_chunk_store::RowId;
 use re_log_types::{EntityPath, TimeInt, TimePoint, TimeReal, Timeline};
 use re_types::{Archetype as _, archetypes::Points2D, datatypes::VisibleTimeRange};
 use re_view_spatial::SpatialView2D;
-use re_viewer_context::{RecommendedView, ViewClass as _, ViewId, test_context::TestContext};
+use re_viewer_context::{ViewClass as _, ViewId, test_context::TestContext};
 use re_viewport_blueprint::{ViewBlueprint, test_context_ext::TestContextExt as _};
 
 fn intra_timestamp_data(test_context: &mut TestContext) {
@@ -322,11 +322,9 @@ fn setup_blueprint(
     green_time_range: Option<VisibleTimeRange>,
 ) -> ViewId {
     test_context.setup_viewport_blueprint(|ctx, blueprint| {
-        let view_blueprint =
-            ViewBlueprint::new(SpatialView2D::identifier(), RecommendedView::root());
-
-        let view_id = view_blueprint.id;
-        blueprint.add_views(std::iter::once(view_blueprint), None, None);
+        let view_id = blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
+            SpatialView2D::identifier(),
+        ));
 
         // Set the bounds such that the points are fully visible, that way we get more pixels contributing to the output.
         let property_path = re_viewport_blueprint::entity_path_for_view_property(

--- a/crates/viewer/re_view_spatial/tests/visible_time_range.rs
+++ b/crates/viewer/re_view_spatial/tests/visible_time_range.rs
@@ -182,24 +182,21 @@ fn visible_timerange_data(test_context: &mut TestContext) {
             );
 
             for y in [y_green, y_red] {
-                test_context.log_entity(
-                    format!("point_{:02}_{:02}", i, y as i32).into(),
-                    |builder| {
-                        builder.with_archetype(
-                            RowId::new(),
-                            TimePoint::default(),
-                            &re_types::archetypes::Points2D::new([(x, y)])
-                                .with_colors([0x555555FF])
-                                .with_radii([4.0])
-                                .with_draw_order(1.0),
-                        )
-                    },
-                );
+                test_context.log_entity(format!("point_{:02}_{:02}", i, y as i32), |builder| {
+                    builder.with_archetype(
+                        RowId::new(),
+                        TimePoint::default(),
+                        &re_types::archetypes::Points2D::new([(x, y)])
+                            .with_colors([0x555555FF])
+                            .with_radii([4.0])
+                            .with_draw_order(1.0),
+                    )
+                });
             }
 
             {
                 let time_point = time_point.clone();
-                test_context.log_entity("red".into(), |builder| {
+                test_context.log_entity("red", |builder| {
                     builder.with_archetype(
                         RowId::new(),
                         time_point,
@@ -211,7 +208,7 @@ fn visible_timerange_data(test_context: &mut TestContext) {
                 });
             }
 
-            test_context.log_entity("green".into(), |builder| {
+            test_context.log_entity("green", |builder| {
                 builder.with_archetype(
                     RowId::new(),
                     time_point,

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -25,14 +25,14 @@ pub fn test_clear_series_points_and_line() {
 fn test_clear_series_points_and_line_impl(two_series_per_entity: bool) {
     let mut test_context = get_test_context();
 
-    test_context.log_entity("plots/line".into(), |builder| {
+    test_context.log_entity("plots/line", |builder| {
         builder.with_archetype(
             RowId::new(),
             TimePoint::default(),
             &re_types::archetypes::SeriesLines::new(),
         )
     });
-    test_context.log_entity("plots/point".into(), |builder| {
+    test_context.log_entity("plots/point", |builder| {
         builder.with_archetype(
             RowId::new(),
             TimePoint::default(),
@@ -45,7 +45,7 @@ fn test_clear_series_points_and_line_impl(two_series_per_entity: bool) {
 
         match i {
             15 => {
-                test_context.log_entity("plots".into(), |builder| {
+                test_context.log_entity("plots", |builder| {
                     builder.with_archetype(
                         RowId::new(),
                         timepoint,
@@ -66,10 +66,10 @@ fn test_clear_series_points_and_line_impl(two_series_per_entity: bool) {
                     re_types::archetypes::Scalars::single((i as f64 / 5.0).sin())
                 };
 
-                test_context.log_entity("plots/line".into(), |builder| {
+                test_context.log_entity("plots/line", |builder| {
                     builder.with_archetype(RowId::new(), timepoint.clone(), &data)
                 });
-                test_context.log_entity("plots/point".into(), |builder| {
+                test_context.log_entity("plots/point", |builder| {
                     builder.with_archetype(RowId::new(), timepoint, &data)
                 });
             }
@@ -145,7 +145,7 @@ fn test_line_properties_impl(multiple_properties: bool, multiple_scalars: bool) 
             .with_colors([re_types::components::Color::from_rgb(255, 0, 255)])
             .with_names(["static"])
     };
-    test_context.log_entity("entity_static_props".into(), |builder| {
+    test_context.log_entity("entity_static_props", |builder| {
         builder.with_archetype(RowId::new(), TimePoint::default(), &properties_static)
     });
 
@@ -166,10 +166,10 @@ fn test_line_properties_impl(multiple_properties: bool, multiple_scalars: bool) 
         };
 
         let (scalars_static, scalars_dynamic) = scalars_for_properties_test(step, multiple_scalars);
-        test_context.log_entity("entity_static_props".into(), |builder| {
+        test_context.log_entity("entity_static_props", |builder| {
             builder.with_archetype(RowId::new(), timepoint.clone(), &scalars_static)
         });
-        test_context.log_entity("entity_dynamic_props".into(), |builder| {
+        test_context.log_entity("entity_dynamic_props", |builder| {
             builder
                 .with_archetype(RowId::new(), timepoint.clone(), &properties)
                 .with_archetype(RowId::new(), timepoint, &scalars_dynamic)
@@ -203,7 +203,7 @@ fn test_per_series_visibility() {
     ] {
         let mut test_context = get_test_context();
 
-        test_context.log_entity("plots".into(), |builder| {
+        test_context.log_entity("plots", |builder| {
             builder.with_archetype(
                 RowId::new(),
                 TimePoint::default(),
@@ -214,7 +214,7 @@ fn test_per_series_visibility() {
         for step in 0..32 {
             let timepoint = TimePoint::from([(test_context.active_timeline(), step)]);
             let (scalars, _) = scalars_for_properties_test(step, true);
-            test_context.log_entity("plots".into(), |builder| {
+            test_context.log_entity("plots", |builder| {
                 builder.with_archetype(RowId::new(), timepoint.clone(), &scalars)
             });
         }
@@ -274,7 +274,7 @@ fn test_point_properties_impl(multiple_properties: bool, multiple_scalars: bool)
             .with_names(["static"])
     };
 
-    test_context.log_entity("entity_static_props".into(), |builder| {
+    test_context.log_entity("entity_static_props", |builder| {
         builder.with_archetype(RowId::new(), TimePoint::default(), &static_props)
     });
 
@@ -299,10 +299,10 @@ fn test_point_properties_impl(multiple_properties: bool, multiple_scalars: bool)
         };
 
         let (scalars_static, scalars_dynamic) = scalars_for_properties_test(step, multiple_scalars);
-        test_context.log_entity("entity_static_props".into(), |builder| {
+        test_context.log_entity("entity_static_props", |builder| {
             builder.with_archetype(RowId::new(), timepoint.clone(), &scalars_static)
         });
-        test_context.log_entity("entity_dynamic_props".into(), |builder| {
+        test_context.log_entity("entity_dynamic_props", |builder| {
             builder
                 .with_archetype(RowId::new(), timepoint.clone(), &properties)
                 .with_archetype(RowId::new(), timepoint, &scalars_dynamic)

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -2,7 +2,7 @@ use re_chunk_store::RowId;
 use re_log_types::TimePoint;
 use re_view_time_series::TimeSeriesView;
 use re_viewer_context::{
-    RecommendedView, ViewClass as _, ViewId,
+    ViewClass as _, ViewId,
     test_context::{HarnessExt as _, TestContext},
 };
 use re_viewport_blueprint::{ViewBlueprint, test_context_ext::TestContextExt as _};
@@ -339,13 +339,9 @@ fn get_test_context() -> TestContext {
 
 fn setup_blueprint(test_context: &mut TestContext) -> ViewId {
     test_context.setup_viewport_blueprint(|_ctx, blueprint| {
-        let view_blueprint =
-            ViewBlueprint::new(TimeSeriesView::identifier(), RecommendedView::root());
-
-        let view_id = view_blueprint.id;
-        blueprint.add_views(std::iter::once(view_blueprint), None, None);
-
-        view_id
+        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(
+            TimeSeriesView::identifier(),
+        ))
     })
 }
 

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -344,10 +344,10 @@ impl TestContext {
     /// The provided closure should add content using the [`ChunkBuilder`] passed as argument.
     pub fn log_entity(
         &mut self,
-        entity_path: EntityPath,
+        entity_path: impl Into<EntityPath>,
         build_chunk: impl FnOnce(ChunkBuilder) -> ChunkBuilder,
     ) {
-        let builder = build_chunk(Chunk::builder(entity_path));
+        let builder = build_chunk(Chunk::builder(entity_path.into()));
         self.recording_store
             .add_chunk(&Arc::new(
                 builder.build().expect("chunk should be successfully built"),

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -347,7 +347,7 @@ impl TestContext {
         entity_path: impl Into<EntityPath>,
         build_chunk: impl FnOnce(ChunkBuilder) -> ChunkBuilder,
     ) {
-        let builder = build_chunk(Chunk::builder(entity_path.into()));
+        let builder = build_chunk(Chunk::builder(entity_path));
         self.recording_store
             .add_chunk(&Arc::new(
                 builder.build().expect("chunk should be successfully built"),

--- a/crates/viewer/re_viewport_blueprint/src/ui/add_view_or_container_modal.rs
+++ b/crates/viewer/re_viewport_blueprint/src/ui/add_view_or_container_modal.rs
@@ -2,7 +2,7 @@
 
 use re_ui::UiExt as _;
 use re_viewer_context::{
-    ContainerId, RecommendedView, ViewerContext, blueprint_id_to_tile_id, icon_for_container_kind,
+    ContainerId, ViewerContext, blueprint_id_to_tile_id, icon_for_container_kind,
 };
 
 use crate::{ViewBlueprint, ViewportBlueprint};
@@ -108,7 +108,7 @@ fn modal_ui(
     for view in ctx
         .view_class_registry()
         .iter_registry()
-        .map(|entry| ViewBlueprint::new(entry.identifier, RecommendedView::root()))
+        .map(|entry| ViewBlueprint::new_with_root_wildcard(entry.identifier))
     {
         let icon = view.class(ctx.view_class_registry()).icon();
         let title = view.class(ctx.view_class_registry()).display_name();

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -68,6 +68,14 @@ impl ViewBlueprint {
         Self::new_with_id(view_class, recommended, ViewId::random())
     }
 
+    /// Creates a new [`ViewBlueprint`] with a single [`ViewContents`] containing everything under the root.
+    ///
+    /// This [`ViewBlueprint`] is ephemeral. If you want to make it permanent, you
+    /// must call [`Self::save_to_blueprint_store`].
+    pub fn new_with_root_wildcard(view_class: ViewClassIdentifier) -> Self {
+        Self::new(view_class, RecommendedView::root())
+    }
+
     /// Creates a new [`ViewBlueprint`] with a single [`ViewContents`], using the provided id.
     ///
     /// Useful for testing contexts where random ids are not desired. Avoid using in production
@@ -514,7 +522,7 @@ mod tests {
         );
 
         // Basic blueprint - a single view that queries everything.
-        let view = ViewBlueprint::new("3D".into(), RecommendedView::root());
+        let view = ViewBlueprint::new_with_root_wildcard("3D".into());
         let override_root = ViewContents::override_path_for_entity(view.id, &EntityPath::root());
 
         // Things needed to resolve properties:

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -657,7 +657,7 @@ mod tests {
         for entity_path in ["parent", "parent/skipped/child1", "parent/skipped/child2"] {
             let row_id = RowId::new();
             let point = MyPoint::new(1.0, 2.0);
-            let chunk = Chunk::builder(entity_path.into())
+            let chunk = Chunk::builder(entity_path)
                 .with_component_batch(
                     row_id,
                     timepoint.clone(),

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -417,7 +417,6 @@ impl ViewportBlueprint {
     /// Add a set of views to the viewport.
     ///
     /// The view is added to the root container, or, if provided, to a given parent container.
-    /// The list of created view IDs is returned.
     ///
     /// Note that this doesn't focus the corresponding tab. Use [`Self::focus_tab`] with the returned ID
     /// if needed.
@@ -434,6 +433,15 @@ impl ViewportBlueprint {
                 position_in_parent,
             });
         }
+    }
+
+    /// Add a single view to the viewport to the root container.
+    ///
+    /// Returns the ID of the added view.
+    pub fn add_view_at_root(&self, view: ViewBlueprint) -> ViewId {
+        let view_id = view.id;
+        self.add_views(std::iter::once(view), None, None);
+        view_id
     }
 
     /// Returns an iterator over all the contents (views and containers) in the viewport.

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -78,7 +78,7 @@ fn hash_and_log(
         .with_media_type(rerun::MediaType::TEXT);
 
     let entity_path = EntityPath::from_file_path(filepath);
-    let entity_path = format!("{entity_path}/hashed").into();
+    let entity_path = format!("{entity_path}/hashed");
     let chunk = Chunk::builder(entity_path)
         .with_archetype(RowId::new(), TimePoint::default(), &doc)
         .build()?;

--- a/tests/python/release_checklist/check_blueprint_overrides.py
+++ b/tests/python/release_checklist/check_blueprint_overrides.py
@@ -46,7 +46,7 @@ def run(args: Namespace) -> None:
             rrb.TextDocumentView(origin="readme", name="Instructions"),
             rrb.TimeSeriesView(
                 name="Plots",
-                defaults=[rr.SeriesPoints.from_fields(colors=[0, 0, 255])],
+                defaults=[rr.SeriesLines.from_fields(colors=[0, 0, 255])],
                 overrides={
                     "plots/cos": [
                         rrb.VisualizerOverrides("SeriesPoints"),


### PR DESCRIPTION
addressing two annoyances:
* excessive amount of `.into` for `EntityPath` handling
* making it easier to set up single view blueprints