### PR TITLE
Fix signature for `DatasetEntry.set_default_blueprint_partition_id()`

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1127,11 +1127,11 @@ class DatasetEntry(Entry):
     def default_blueprint_partition_id(self) -> str | None:
         """The default blueprint partition ID for this dataset, if any."""
 
-    def set_default_blueprint_partition_id(self, partition_id: str) -> None:
+    def set_default_blueprint_partition_id(self, partition_id: str | None) -> None:
         """
         Set the default blueprint partition ID for this dataset.
 
-        This fails if the change cannot be made to the remote server.
+        Pass `None` to clear the bluprint. This fails if the change cannot be made to the remote server.
         """
 
     def partition_ids(self) -> list[str]:

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -106,7 +106,7 @@ impl PyDatasetEntry {
 
     /// Set the default blueprint partition ID for this dataset.
     ///
-    /// This fails if the change cannot be made to the remote server.
+    /// Pass `None` to clear the bluprint. This fails if the change cannot be made to the remote server.
     #[pyo3(signature = (partition_id))]
     fn set_default_blueprint_partition_id(
         mut self_: PyRefMut<'_, Self>,


### PR DESCRIPTION
Fix a small mistake in the signature of `DatasetEntry.set_default_blueprint_partition_id()`. `None` is an acceptable input to clear the dataset's blueprint.