### PR TITLE
Adjust wording when hovering empty parent entity in timeline

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -59,7 +59,7 @@ impl DataUi for InstancePath {
             ui_layout.label(
                 ui,
                 format!(
-                    "only subpaths of {self} have components on timeline {:?}",
+                    "{self} has no own components on timeline {:?}, but its children do",
                     query.timeline()
                 ),
             );


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/10451

### What

ticket suggested dropping the message, but given that hovering those dots usually shows something I decided to refrain from it and instead change the wording:

<img width="752" alt="image" src="https://github.com/user-attachments/assets/70d0ceea-b4d4-4108-b03b-7d5026d782ea" />

