### PR TITLE
Remove indicator component UI from `DataPath`

### DIFF
--- a/crates/store/re_types_core/src/component_descriptor.rs
+++ b/crates/store/re_types_core/src/component_descriptor.rs
@@ -93,15 +93,6 @@ impl ComponentDescriptor {
         self.component.ends_with("Indicator")
     }
 
-    /// If this is an indicator component, for which archetype?
-    // TODO(#8129): Remove
-    pub fn indicator_component_archetype_short_name(&self) -> Option<String> {
-        ComponentType::new(&self.component)
-            .short_name()
-            .strip_suffix("Indicator")
-            .map(|name| name.to_owned())
-    }
-
     /// Returns the fully-qualified name, e.g. `rerun.archetypes.Points3D:positions#rerun.components.Position3D`.
     ///
     /// The result explicitly contains the [`ComponentType`], so in most cases [`ComponentDescriptor::display_name`] should be used instead.

--- a/crates/viewer/re_data_ui/src/component_path.rs
+++ b/crates/viewer/re_data_ui/src/component_path.rs
@@ -20,38 +20,30 @@ impl DataUi for ComponentPath {
 
         let engine = db.storage_engine();
 
-        if let Some(archetype_name) =
-            component_descriptor.indicator_component_archetype_short_name()
-        {
-            ui.label(format!(
-                "Indicator component for the {archetype_name} archetype"
-            ));
-        } else {
-            let results = engine
-                .cache()
-                .latest_at(query, entity_path, [component_descriptor]);
+        let results = engine
+            .cache()
+            .latest_at(query, entity_path, [component_descriptor]);
 
-            if let Some(unit) = results.components.get(component_descriptor) {
-                crate::ComponentPathLatestAtResults {
-                    component_path: self.clone(),
-                    unit,
-                }
-                .data_ui(ctx, ui, ui_layout, query, db);
-            } else if ctx.recording().tree().subtree(entity_path).is_some() {
-                if engine.store().entity_has_component_on_timeline(
-                    &query.timeline(),
-                    entity_path,
-                    component_descriptor,
-                ) {
-                    ui.label("<unset>");
-                } else {
-                    ui.label(format!(
-                        "Entity {entity_path:?} has no component {component_descriptor:?}"
-                    ));
-                }
-            } else {
-                ui.error_label(format!("Unknown component path: {self}"));
+        if let Some(unit) = results.components.get(component_descriptor) {
+            crate::ComponentPathLatestAtResults {
+                component_path: self.clone(),
+                unit,
             }
+            .data_ui(ctx, ui, ui_layout, query, db);
+        } else if ctx.recording().tree().subtree(entity_path).is_some() {
+            if engine.store().entity_has_component_on_timeline(
+                &query.timeline(),
+                entity_path,
+                component_descriptor,
+            ) {
+                ui.label("<unset>");
+            } else {
+                ui.label(format!(
+                    "Entity {entity_path:?} has no component {component_descriptor:?}"
+                ));
+            }
+        } else {
+            ui.error_label(format!("Unknown component path: {self}"));
         }
     }
 }


### PR DESCRIPTION
### Related

* Part of #6889.
* Part of #8129.
### What

We should not be showing indicators in the UI anymore anyways, so might as well remove this.
