### PR TITLE
Revert "Release 0.24.0-alpha.5"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "animated_urdf"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "clock"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -2050,7 +2050,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "custom_callback"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "bincode",
  "mimalloc",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "custom_data_loader"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "re_build_tools",
  "rerun",
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "custom_store_subscriber"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "re_build_tools",
  "rerun",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "custom_view"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "mimalloc",
  "rerun",
@@ -2140,7 +2140,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "dataframe_query"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "itertools 0.14.0",
  "rerun",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "dna"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "itertools 0.14.0",
  "rand",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "extend_viewer_ui"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "mimalloc",
  "rerun",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "graph_lattice"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -4456,7 +4456,7 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "incremental_logging"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "log_benchmark"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "log_file"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -5185,14 +5185,14 @@ dependencies = [
 
 [[package]]
 name = "minimal"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "rerun",
 ]
 
 [[package]]
 name = "minimal_options"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -5202,7 +5202,7 @@ dependencies = [
 
 [[package]]
 name = "minimal_serve"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "rerun",
 ]
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "objectron"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -6181,7 +6181,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plot_dashboard_stress"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -6692,7 +6692,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "raw_mesh"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "re_analytics"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "crossbeam",
  "directories",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "re_arrow_util"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -6762,7 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "re_auth"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
@@ -6775,7 +6775,7 @@ dependencies = [
 
 [[package]]
 name = "re_blueprint_tree"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "egui",
  "egui_kittest",
@@ -6801,7 +6801,7 @@ dependencies = [
 
 [[package]]
 name = "re_build_info"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "re_byte_size",
  "serde",
@@ -6809,7 +6809,7 @@ dependencies = [
 
 [[package]]
 name = "re_build_tools"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -6822,7 +6822,7 @@ dependencies = [
 
 [[package]]
 name = "re_byte_size"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "half",
@@ -6831,7 +6831,7 @@ dependencies = [
 
 [[package]]
 name = "re_capabilities"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "document-features",
  "egui",
@@ -6840,14 +6840,14 @@ dependencies = [
 
 [[package]]
 name = "re_case"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "convert_case",
 ]
 
 [[package]]
 name = "re_chunk"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6878,7 +6878,7 @@ dependencies = [
 
 [[package]]
 name = "re_chunk_store"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6910,7 +6910,7 @@ dependencies = [
 
 [[package]]
 name = "re_chunk_store_ui"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "egui",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "re_component_ui"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "egui",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "re_context_menu"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "egui",
  "egui_tiles",
@@ -6973,7 +6973,7 @@ dependencies = [
 
 [[package]]
 name = "re_crash_handler"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "backtrace",
  "econtext",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "re_data_loader"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7020,7 +7020,7 @@ dependencies = [
 
 [[package]]
 name = "re_data_source"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -7041,7 +7041,7 @@ dependencies = [
 
 [[package]]
 name = "re_data_ui"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7074,7 +7074,7 @@ dependencies = [
 
 [[package]]
 name = "re_dataframe"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "re_dataframe_ui"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "arrow",
@@ -7130,7 +7130,7 @@ dependencies = [
 
 [[package]]
 name = "re_datafusion"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "re_dev_tools"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "argh",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "re_entity_db"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7216,21 +7216,21 @@ dependencies = [
 
 [[package]]
 name = "re_error"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "re_format"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "re_format_arrow"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "comfy-table",
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "re_global_context"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7277,7 +7277,7 @@ dependencies = [
 
 [[package]]
 name = "re_grpc_client"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "async-stream",
@@ -7306,7 +7306,7 @@ dependencies = [
 
 [[package]]
 name = "re_grpc_server"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -7336,7 +7336,7 @@ dependencies = [
 
 [[package]]
 name = "re_int_histogram"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "criterion",
  "insta",
@@ -7347,7 +7347,7 @@ dependencies = [
 
 [[package]]
 name = "re_log"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "env_filter",
  "env_logger",
@@ -7361,7 +7361,7 @@ dependencies = [
 
 [[package]]
 name = "re_log_encoding"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "bytes",
@@ -7393,7 +7393,7 @@ dependencies = [
 
 [[package]]
 name = "re_log_types"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "arrow",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "re_memory"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "backtrace",
@@ -7465,7 +7465,7 @@ dependencies = [
 
 [[package]]
 name = "re_protos"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "jiff",
@@ -7487,7 +7487,7 @@ dependencies = [
 
 [[package]]
 name = "re_protos_builder"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "camino",
  "prost-build",
@@ -7497,7 +7497,7 @@ dependencies = [
 
 [[package]]
 name = "re_query"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7552,7 +7552,7 @@ dependencies = [
 
 [[package]]
 name = "re_redap_browser"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "datafusion",
@@ -7583,7 +7583,7 @@ dependencies = [
 
 [[package]]
 name = "re_renderer"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7633,7 +7633,7 @@ dependencies = [
 
 [[package]]
 name = "re_renderer_examples"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "re_sdk"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "const_format",
@@ -7692,7 +7692,7 @@ dependencies = [
 
 [[package]]
 name = "re_selection_panel"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "egui",
@@ -7723,7 +7723,7 @@ dependencies = [
 
 [[package]]
 name = "re_smart_channel"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "crossbeam",
  "parking_lot",
@@ -7735,7 +7735,7 @@ dependencies = [
 
 [[package]]
 name = "re_sorbet"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "itertools 0.14.0",
@@ -7755,14 +7755,14 @@ dependencies = [
 
 [[package]]
 name = "re_span"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "re_string_interner"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "nohash-hasher",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "re_time_panel"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "criterion",
@@ -7805,7 +7805,7 @@ dependencies = [
 
 [[package]]
 name = "re_tracing"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "puffin",
  "puffin_http",
@@ -7816,7 +7816,7 @@ dependencies = [
 
 [[package]]
 name = "re_tuid"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -7831,7 +7831,7 @@ dependencies = [
 
 [[package]]
 name = "re_types"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "array-init",
@@ -7876,7 +7876,7 @@ dependencies = [
 
 [[package]]
 name = "re_types_builder"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "camino",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "re_types_core"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7931,7 +7931,7 @@ dependencies = [
 
 [[package]]
 name = "re_ui"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7967,7 +7967,7 @@ dependencies = [
 
 [[package]]
 name = "re_uri"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "re_log",
  "re_log_types",
@@ -7979,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "re_video"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "bit-vec",
  "cfg_aliases",
@@ -8009,7 +8009,7 @@ dependencies = [
 
 [[package]]
 name = "re_view"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "egui",
@@ -8032,7 +8032,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_bar_chart"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "egui",
  "egui_plot",
@@ -8050,7 +8050,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_dataframe"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8078,7 +8078,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_graph"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "egui",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_map"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "bytemuck",
  "egui",
@@ -8129,7 +8129,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_spatial"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8174,7 +8174,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_tensor"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -8198,7 +8198,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_text_document"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "egui",
  "egui_commonmark",
@@ -8213,7 +8213,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_text_log"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "egui",
  "egui_extras",
@@ -8233,7 +8233,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_time_series"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "egui",
  "egui_plot",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewer"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8343,7 +8343,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewer_context"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8404,7 +8404,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewport"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "egui",
@@ -8427,7 +8427,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewport_blueprint"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "arrow",
@@ -8454,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "re_web_viewer_server"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "document-features",
  "re_analytics",
@@ -8627,7 +8627,7 @@ dependencies = [
 
 [[package]]
 name = "rerun"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "rerun-cli"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "document-features",
  "mimalloc",
@@ -8693,7 +8693,7 @@ dependencies = [
 
 [[package]]
 name = "rerun-loader-rust-file"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "argh",
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_c"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "ahash",
  "arrow",
@@ -8717,7 +8717,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_py"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "arrow",
  "chrono",
@@ -8861,7 +8861,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_annotation_context"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8871,7 +8871,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_arrows2d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_arrows3d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8891,7 +8891,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_boxes2d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_boxes3d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8911,7 +8911,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_depth_image"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8922,7 +8922,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_image"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8935,7 +8935,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_line_strips2d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8945,7 +8945,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_line_strips3d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8955,7 +8955,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_pinhole"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8965,7 +8965,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_points2d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8975,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_points3d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8985,7 +8985,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_segmentation_image"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -8996,7 +8996,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_tensor"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9007,7 +9007,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_text_document"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9017,7 +9017,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_text_log"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9027,7 +9027,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_transform3d"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9037,7 +9037,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_view_coordinates"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9047,7 +9047,7 @@ dependencies = [
 
 [[package]]
 name = "roundtrip_visible_time_ranges"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9069,7 +9069,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "run_wasm"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "cargo-run-wasm",
  "pico-args",
@@ -9427,7 +9427,7 @@ dependencies = [
 
 [[package]]
 name = "shared_recording"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "rerun",
 ]
@@ -9596,7 +9596,7 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "snippets"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "itertools 0.14.0",
  "ndarray",
@@ -9620,7 +9620,7 @@ dependencies = [
 
 [[package]]
 name = "spawn_viewer"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "rerun",
 ]
@@ -9700,7 +9700,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdio"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "rerun",
 ]
@@ -9857,7 +9857,7 @@ dependencies = [
 
 [[package]]
 name = "template"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "rerun",
 ]
@@ -9873,7 +9873,7 @@ dependencies = [
 
 [[package]]
 name = "test_api"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9888,7 +9888,7 @@ dependencies = [
 
 [[package]]
 name = "test_data_density_graph"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "rand",
@@ -9898,7 +9898,7 @@ dependencies = [
 
 [[package]]
 name = "test_image_memory"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "mimalloc",
  "re_format",
@@ -9907,7 +9907,7 @@ dependencies = [
 
 [[package]]
 name = "test_pinhole_projection"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -9918,7 +9918,7 @@ dependencies = [
 
 [[package]]
 name = "test_send_columns"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "re_chunk",
  "rerun",
@@ -9926,7 +9926,7 @@ dependencies = [
 
 [[package]]
 name = "test_ui_wakeup"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -10648,7 +10648,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "viewer_callbacks"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = [
  "mimalloc",
  "rerun",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ include = [
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rerun-io/rerun"
 rust-version = "1.85"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 
 [workspace.metadata.cargo-shear]
 ignored = [
@@ -56,87 +56,87 @@ ignored = [
 # re_log_types 0.3.0-alpha.0, NOT 0.3.0-alpha.4 even though it is newer and semver-compatible.
 
 # crates/build:
-re_build_info = { path = "crates/build/re_build_info", version = "=0.24.0-alpha.5", default-features = false }
-re_build_tools = { path = "crates/build/re_build_tools", version = "=0.24.0-alpha.5", default-features = false }
-re_dev_tools = { path = "crates/build/re_dev_tools", version = "=0.24.0-alpha.5", default-features = false }
-re_protos_builder = { path = "crates/build/re_protos_builder", version = "=0.24.0-alpha.5", default-features = false }
-re_types_builder = { path = "crates/build/re_types_builder", version = "=0.24.0-alpha.5", default-features = false }
+re_build_info = { path = "crates/build/re_build_info", version = "=0.24.0-alpha.1", default-features = false }
+re_build_tools = { path = "crates/build/re_build_tools", version = "=0.24.0-alpha.1", default-features = false }
+re_dev_tools = { path = "crates/build/re_dev_tools", version = "=0.24.0-alpha.1", default-features = false }
+re_protos_builder = { path = "crates/build/re_protos_builder", version = "=0.24.0-alpha.1", default-features = false }
+re_types_builder = { path = "crates/build/re_types_builder", version = "=0.24.0-alpha.1", default-features = false }
 
 # crates/store:
-re_chunk = { path = "crates/store/re_chunk", version = "=0.24.0-alpha.5", default-features = false }
-re_chunk_store = { path = "crates/store/re_chunk_store", version = "=0.24.0-alpha.5", default-features = false }
-re_data_loader = { path = "crates/store/re_data_loader", version = "=0.24.0-alpha.5", default-features = false }
-re_data_source = { path = "crates/store/re_data_source", version = "=0.24.0-alpha.5", default-features = false }
-re_dataframe = { path = "crates/store/re_dataframe", version = "=0.24.0-alpha.5", default-features = false }
-re_datafusion = { path = "crates/store/re_datafusion", version = "=0.24.0-alpha.5", default-features = false }
-re_entity_db = { path = "crates/store/re_entity_db", version = "=0.24.0-alpha.5", default-features = false }
-re_format_arrow = { path = "crates/store/re_format_arrow", version = "=0.24.0-alpha.5", default-features = false }
-re_grpc_client = { path = "crates/store/re_grpc_client", version = "=0.24.0-alpha.5", default-features = false }
-re_grpc_server = { path = "crates/store/re_grpc_server", version = "=0.24.0-alpha.5", default-features = false }
-re_protos = { path = "crates/store/re_protos", version = "=0.24.0-alpha.5", default-features = false }
-re_log_encoding = { path = "crates/store/re_log_encoding", version = "=0.24.0-alpha.5", default-features = false }
-re_log_types = { path = "crates/store/re_log_types", version = "=0.24.0-alpha.5", default-features = false }
-re_query = { path = "crates/store/re_query", version = "=0.24.0-alpha.5", default-features = false }
-re_sorbet = { path = "crates/store/re_sorbet", version = "=0.24.0-alpha.5", default-features = false }
-re_types = { path = "crates/store/re_types", version = "=0.24.0-alpha.5", default-features = false }
-re_types_core = { path = "crates/store/re_types_core", version = "=0.24.0-alpha.5", default-features = false }
+re_chunk = { path = "crates/store/re_chunk", version = "=0.24.0-alpha.1", default-features = false }
+re_chunk_store = { path = "crates/store/re_chunk_store", version = "=0.24.0-alpha.1", default-features = false }
+re_data_loader = { path = "crates/store/re_data_loader", version = "=0.24.0-alpha.1", default-features = false }
+re_data_source = { path = "crates/store/re_data_source", version = "=0.24.0-alpha.1", default-features = false }
+re_dataframe = { path = "crates/store/re_dataframe", version = "=0.24.0-alpha.1", default-features = false }
+re_datafusion = { path = "crates/store/re_datafusion", version = "=0.24.0-alpha.1", default-features = false }
+re_entity_db = { path = "crates/store/re_entity_db", version = "=0.24.0-alpha.1", default-features = false }
+re_format_arrow = { path = "crates/store/re_format_arrow", version = "=0.24.0-alpha.1", default-features = false }
+re_grpc_client = { path = "crates/store/re_grpc_client", version = "=0.24.0-alpha.1", default-features = false }
+re_grpc_server = { path = "crates/store/re_grpc_server", version = "=0.24.0-alpha.1", default-features = false }
+re_protos = { path = "crates/store/re_protos", version = "=0.24.0-alpha.1", default-features = false }
+re_log_encoding = { path = "crates/store/re_log_encoding", version = "=0.24.0-alpha.1", default-features = false }
+re_log_types = { path = "crates/store/re_log_types", version = "=0.24.0-alpha.1", default-features = false }
+re_query = { path = "crates/store/re_query", version = "=0.24.0-alpha.1", default-features = false }
+re_sorbet = { path = "crates/store/re_sorbet", version = "=0.24.0-alpha.1", default-features = false }
+re_types = { path = "crates/store/re_types", version = "=0.24.0-alpha.1", default-features = false }
+re_types_core = { path = "crates/store/re_types_core", version = "=0.24.0-alpha.1", default-features = false }
 
 # crates/top:
-re_sdk = { path = "crates/top/re_sdk", version = "=0.24.0-alpha.5", default-features = false }
-rerun = { path = "crates/top/rerun", version = "=0.24.0-alpha.5", default-features = false }
-rerun_c = { path = "crates/top/rerun_c", version = "=0.24.0-alpha.5", default-features = false }
-rerun-cli = { path = "crates/top/rerun-cli", version = "=0.24.0-alpha.5", default-features = false }
+re_sdk = { path = "crates/top/re_sdk", version = "=0.24.0-alpha.1", default-features = false }
+rerun = { path = "crates/top/rerun", version = "=0.24.0-alpha.1", default-features = false }
+rerun_c = { path = "crates/top/rerun_c", version = "=0.24.0-alpha.1", default-features = false }
+rerun-cli = { path = "crates/top/rerun-cli", version = "=0.24.0-alpha.1", default-features = false }
 
 # crates/utils:
-re_analytics = { path = "crates/utils/re_analytics", version = "=0.24.0-alpha.5", default-features = false }
-re_arrow_util = { path = "crates/utils/re_arrow_util", version = "=0.24.0-alpha.5", default-features = false }
-re_auth = { path = "crates/utils/re_auth", version = "=0.24.0-alpha.5", default-features = false }
-re_byte_size = { path = "crates/utils/re_byte_size", version = "=0.24.0-alpha.5", default-features = false }
-re_capabilities = { path = "crates/utils/re_capabilities", version = "=0.24.0-alpha.5", default-features = false }
-re_case = { path = "crates/utils/re_case", version = "=0.24.0-alpha.5", default-features = false }
-re_crash_handler = { path = "crates/utils/re_crash_handler", version = "=0.24.0-alpha.5", default-features = false }
-re_error = { path = "crates/utils/re_error", version = "=0.24.0-alpha.5", default-features = false }
-re_format = { path = "crates/utils/re_format", version = "=0.24.0-alpha.5", default-features = false }
-re_int_histogram = { path = "crates/utils/re_int_histogram", version = "=0.24.0-alpha.5", default-features = false }
-re_log = { path = "crates/utils/re_log", version = "=0.24.0-alpha.5", default-features = false }
-re_memory = { path = "crates/utils/re_memory", version = "=0.24.0-alpha.5", default-features = false }
-re_span = { path = "crates/utils/re_span", version = "=0.24.0-alpha.5", default-features = false }
-re_smart_channel = { path = "crates/utils/re_smart_channel", version = "=0.24.0-alpha.5", default-features = false }
-re_string_interner = { path = "crates/utils/re_string_interner", version = "=0.24.0-alpha.5", default-features = false }
-re_tracing = { path = "crates/utils/re_tracing", version = "=0.24.0-alpha.5", default-features = false }
-re_tuid = { path = "crates/utils/re_tuid", version = "=0.24.0-alpha.5", default-features = false }
-re_uri = { path = "crates/utils/re_uri", version = "=0.24.0-alpha.5", default-features = false }
-re_video = { path = "crates/utils/re_video", version = "=0.24.0-alpha.5", default-features = false }
+re_analytics = { path = "crates/utils/re_analytics", version = "=0.24.0-alpha.1", default-features = false }
+re_arrow_util = { path = "crates/utils/re_arrow_util", version = "=0.24.0-alpha.1", default-features = false }
+re_auth = { path = "crates/utils/re_auth", version = "=0.24.0-alpha.1", default-features = false }
+re_byte_size = { path = "crates/utils/re_byte_size", version = "=0.24.0-alpha.1", default-features = false }
+re_capabilities = { path = "crates/utils/re_capabilities", version = "=0.24.0-alpha.1", default-features = false }
+re_case = { path = "crates/utils/re_case", version = "=0.24.0-alpha.1", default-features = false }
+re_crash_handler = { path = "crates/utils/re_crash_handler", version = "=0.24.0-alpha.1", default-features = false }
+re_error = { path = "crates/utils/re_error", version = "=0.24.0-alpha.1", default-features = false }
+re_format = { path = "crates/utils/re_format", version = "=0.24.0-alpha.1", default-features = false }
+re_int_histogram = { path = "crates/utils/re_int_histogram", version = "=0.24.0-alpha.1", default-features = false }
+re_log = { path = "crates/utils/re_log", version = "=0.24.0-alpha.1", default-features = false }
+re_memory = { path = "crates/utils/re_memory", version = "=0.24.0-alpha.1", default-features = false }
+re_span = { path = "crates/utils/re_span", version = "=0.24.0-alpha.1", default-features = false }
+re_smart_channel = { path = "crates/utils/re_smart_channel", version = "=0.24.0-alpha.1", default-features = false }
+re_string_interner = { path = "crates/utils/re_string_interner", version = "=0.24.0-alpha.1", default-features = false }
+re_tracing = { path = "crates/utils/re_tracing", version = "=0.24.0-alpha.1", default-features = false }
+re_tuid = { path = "crates/utils/re_tuid", version = "=0.24.0-alpha.1", default-features = false }
+re_uri = { path = "crates/utils/re_uri", version = "=0.24.0-alpha.1", default-features = false }
+re_video = { path = "crates/utils/re_video", version = "=0.24.0-alpha.1", default-features = false }
 
 # crates/viewer:
-re_blueprint_tree = { path = "crates/viewer/re_blueprint_tree", version = "=0.24.0-alpha.5", default-features = false }
-re_redap_browser = { path = "crates/viewer/re_redap_browser", version = "=0.24.0-alpha.5", default-features = false }
-re_component_ui = { path = "crates/viewer/re_component_ui", version = "=0.24.0-alpha.5", default-features = false }
-re_context_menu = { path = "crates/viewer/re_context_menu", version = "=0.24.0-alpha.5", default-features = false }
-re_chunk_store_ui = { path = "crates/viewer/re_chunk_store_ui", version = "=0.24.0-alpha.5", default-features = false }
-re_dataframe_ui = { path = "crates/viewer/re_dataframe_ui", version = "=0.24.0-alpha.5", default-features = false }
-re_data_ui = { path = "crates/viewer/re_data_ui", version = "=0.24.0-alpha.5", default-features = false }
-re_global_context = { path = "crates/viewer/re_global_context", version = "=0.24.0-alpha.5", default-features = false }
-re_renderer = { path = "crates/viewer/re_renderer", version = "=0.24.0-alpha.5", default-features = false }
-re_renderer_examples = { path = "crates/viewer/re_renderer_examples", version = "=0.24.0-alpha.5", default-features = false }
-re_selection_panel = { path = "crates/viewer/re_selection_panel", version = "=0.24.0-alpha.5", default-features = false }
-re_time_panel = { path = "crates/viewer/re_time_panel", version = "=0.24.0-alpha.5", default-features = false }
-re_ui = { path = "crates/viewer/re_ui", version = "=0.24.0-alpha.5", default-features = false }
-re_view = { path = "crates/viewer/re_view", version = "=0.24.0-alpha.5", default-features = false }
-re_view_bar_chart = { path = "crates/viewer/re_view_bar_chart", version = "=0.24.0-alpha.5", default-features = false }
-re_view_spatial = { path = "crates/viewer/re_view_spatial", version = "=0.24.0-alpha.5", default-features = false }
-re_view_dataframe = { path = "crates/viewer/re_view_dataframe", version = "=0.24.0-alpha.5", default-features = false }
-re_view_graph = { path = "crates/viewer/re_view_graph", version = "=0.24.0-alpha.5", default-features = false }
-re_view_map = { path = "crates/viewer/re_view_map", version = "=0.24.0-alpha.5", default-features = false }
-re_view_tensor = { path = "crates/viewer/re_view_tensor", version = "=0.24.0-alpha.5", default-features = false }
-re_view_text_document = { path = "crates/viewer/re_view_text_document", version = "=0.24.0-alpha.5", default-features = false }
-re_view_text_log = { path = "crates/viewer/re_view_text_log", version = "=0.24.0-alpha.5", default-features = false }
-re_view_time_series = { path = "crates/viewer/re_view_time_series", version = "=0.24.0-alpha.5", default-features = false }
-re_viewer = { path = "crates/viewer/re_viewer", version = "=0.24.0-alpha.5", default-features = false }
-re_viewer_context = { path = "crates/viewer/re_viewer_context", version = "=0.24.0-alpha.5", default-features = false }
-re_viewport = { path = "crates/viewer/re_viewport", version = "=0.24.0-alpha.5", default-features = false }
-re_viewport_blueprint = { path = "crates/viewer/re_viewport_blueprint", version = "=0.24.0-alpha.5", default-features = false }
-re_web_viewer_server = { path = "crates/viewer/re_web_viewer_server", version = "=0.24.0-alpha.5", default-features = false }
+re_blueprint_tree = { path = "crates/viewer/re_blueprint_tree", version = "=0.24.0-alpha.1", default-features = false }
+re_redap_browser = { path = "crates/viewer/re_redap_browser", version = "=0.24.0-alpha.1", default-features = false }
+re_component_ui = { path = "crates/viewer/re_component_ui", version = "=0.24.0-alpha.1", default-features = false }
+re_context_menu = { path = "crates/viewer/re_context_menu", version = "=0.24.0-alpha.1", default-features = false }
+re_chunk_store_ui = { path = "crates/viewer/re_chunk_store_ui", version = "=0.24.0-alpha.1", default-features = false }
+re_dataframe_ui = { path = "crates/viewer/re_dataframe_ui", version = "=0.24.0-alpha.1", default-features = false }
+re_data_ui = { path = "crates/viewer/re_data_ui", version = "=0.24.0-alpha.1", default-features = false }
+re_global_context = { path = "crates/viewer/re_global_context", version = "=0.24.0-alpha.1", default-features = false }
+re_renderer = { path = "crates/viewer/re_renderer", version = "=0.24.0-alpha.1", default-features = false }
+re_renderer_examples = { path = "crates/viewer/re_renderer_examples", version = "=0.24.0-alpha.1", default-features = false }
+re_selection_panel = { path = "crates/viewer/re_selection_panel", version = "=0.24.0-alpha.1", default-features = false }
+re_time_panel = { path = "crates/viewer/re_time_panel", version = "=0.24.0-alpha.1", default-features = false }
+re_ui = { path = "crates/viewer/re_ui", version = "=0.24.0-alpha.1", default-features = false }
+re_view = { path = "crates/viewer/re_view", version = "=0.24.0-alpha.1", default-features = false }
+re_view_bar_chart = { path = "crates/viewer/re_view_bar_chart", version = "=0.24.0-alpha.1", default-features = false }
+re_view_spatial = { path = "crates/viewer/re_view_spatial", version = "=0.24.0-alpha.1", default-features = false }
+re_view_dataframe = { path = "crates/viewer/re_view_dataframe", version = "=0.24.0-alpha.1", default-features = false }
+re_view_graph = { path = "crates/viewer/re_view_graph", version = "=0.24.0-alpha.1", default-features = false }
+re_view_map = { path = "crates/viewer/re_view_map", version = "=0.24.0-alpha.1", default-features = false }
+re_view_tensor = { path = "crates/viewer/re_view_tensor", version = "=0.24.0-alpha.1", default-features = false }
+re_view_text_document = { path = "crates/viewer/re_view_text_document", version = "=0.24.0-alpha.1", default-features = false }
+re_view_text_log = { path = "crates/viewer/re_view_text_log", version = "=0.24.0-alpha.1", default-features = false }
+re_view_time_series = { path = "crates/viewer/re_view_time_series", version = "=0.24.0-alpha.1", default-features = false }
+re_viewer = { path = "crates/viewer/re_viewer", version = "=0.24.0-alpha.1", default-features = false }
+re_viewer_context = { path = "crates/viewer/re_viewer_context", version = "=0.24.0-alpha.1", default-features = false }
+re_viewport = { path = "crates/viewer/re_viewport", version = "=0.24.0-alpha.1", default-features = false }
+re_viewport_blueprint = { path = "crates/viewer/re_viewport_blueprint", version = "=0.24.0-alpha.1", default-features = false }
+re_web_viewer_server = { path = "crates/viewer/re_web_viewer_server", version = "=0.24.0-alpha.1", default-features = false }
 
 # Rerun crates in other repos:
 re_mp4 = "0.3.0"

--- a/examples/rust/animated_urdf/Cargo.toml
+++ b/examples/rust/animated_urdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animated_urdf"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_callback/Cargo.toml
+++ b/examples/rust/custom_callback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_callback"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_data_loader/Cargo.toml
+++ b/examples/rust/custom_data_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_data_loader"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_store_subscriber/Cargo.toml
+++ b/examples/rust/custom_store_subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_store_subscriber"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_view/Cargo.toml
+++ b/examples/rust/custom_view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_view"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/dataframe_query/Cargo.toml
+++ b/examples/rust/dataframe_query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dataframe_query"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/dna/Cargo.toml
+++ b/examples/rust/dna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dna"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/extend_viewer_ui/Cargo.toml
+++ b/examples/rust/extend_viewer_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extend_viewer_ui"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/external_data_loader/Cargo.toml
+++ b/examples/rust/external_data_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rerun-loader-rust-file"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/graph_lattice/Cargo.toml
+++ b/examples/rust/graph_lattice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph_lattice"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/incremental_logging/Cargo.toml
+++ b/examples/rust/incremental_logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental_logging"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/log_file/Cargo.toml
+++ b/examples/rust/log_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "log_file"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/minimal/Cargo.toml
+++ b/examples/rust/minimal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal_options"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/minimal_serve/Cargo.toml
+++ b/examples/rust/minimal_serve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal_serve"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objectron"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw_mesh"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/shared_recording/Cargo.toml
+++ b/examples/rust/shared_recording/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared_recording"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/spawn_viewer/Cargo.toml
+++ b/examples/rust/spawn_viewer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spawn_viewer"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/stdio/Cargo.toml
+++ b/examples/rust/stdio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdio"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/template/Cargo.toml
+++ b/examples/rust/template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "template"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/viewer_callbacks/Cargo.toml
+++ b/examples/rust/viewer_callbacks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viewer_callbacks"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/pixi.lock
+++ b/pixi.lock
@@ -2543,7 +2543,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/e8/85835077b782555d6b3416874b702ea6ebd7db1f145283c9252968670dd5/rpds_py-0.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e6/ee/69e498a892f208bd1da4104d4b9be887f8611bf4942144718b6738482250/safetensors-0.4.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: git+https://github.com/facebookresearch/segment-anything.git#dca509fe793f601edb92606367a655c15ac00fdf
+      - pypi: git+https://github.com/facebookresearch/segment-anything#dca509fe793f601edb92606367a655c15ac00fdf
       - pypi: https://files.pythonhosted.org/packages/40/b0/4562db6223154aa4e22f939003cb92514c79f3d4dccca3444253fd17f902/Send2Trash-1.8.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/25/aa/53f145e5a610a49af9ac49f2f1be1ec8659ebd5c393d66ac94e57c83b00e/shapely-2.0.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
@@ -2621,8 +2621,8 @@ environments:
       - pypi: ./examples/python/shared_recording
       - pypi: ./examples/python/stdio
       - pypi: ./examples/python/structure_from_motion
-      - pypi: rerun_notebook
-      - pypi: rerun_py
+      - pypi: ./rerun_notebook
+      - pypi: ./rerun_py
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.31-hee1f4ab_5.conda
@@ -2929,7 +2929,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/6a/2c9fdcc6d235ac0d61ec4fd9981184689c3e682abd05e3caa49bccb9c298/rpds_py-0.20.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/08/8c/ece3bf8756506a890bd980eca02f47f9d98dfbf5ce16eda1368f53560f67/safetensors-0.4.5-cp311-cp311-macosx_11_0_arm64.whl
-      - pypi: git+https://github.com/facebookresearch/segment-anything.git#dca509fe793f601edb92606367a655c15ac00fdf
+      - pypi: git+https://github.com/facebookresearch/segment-anything#dca509fe793f601edb92606367a655c15ac00fdf
       - pypi: https://files.pythonhosted.org/packages/40/b0/4562db6223154aa4e22f939003cb92514c79f3d4dccca3444253fd17f902/Send2Trash-1.8.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/63/e182e43081fffa0a2d970c480f2ef91647a6ab94098f61748c23c2a485f2/shapely-2.0.6-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
@@ -3006,8 +3006,8 @@ environments:
       - pypi: ./examples/python/shared_recording
       - pypi: ./examples/python/stdio
       - pypi: ./examples/python/structure_from_motion
-      - pypi: rerun_notebook
-      - pypi: rerun_py
+      - pypi: ./rerun_notebook
+      - pypi: ./rerun_py
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.31-h459cf4e_5.conda
@@ -3304,7 +3304,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/ec/77d0674f9af4872919f3738018558dd9d37ad3f7ad792d062eadd4af7cba/rpds_py-0.20.0-cp311-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6d/41/948c96c8a7e9fef57c2e051f1871c108a6dbbc6d285598bdb1d89b98617c/safetensors-0.4.5-cp311-none-win_amd64.whl
-      - pypi: git+https://github.com/facebookresearch/segment-anything.git#dca509fe793f601edb92606367a655c15ac00fdf
+      - pypi: git+https://github.com/facebookresearch/segment-anything#dca509fe793f601edb92606367a655c15ac00fdf
       - pypi: https://files.pythonhosted.org/packages/40/b0/4562db6223154aa4e22f939003cb92514c79f3d4dccca3444253fd17f902/Send2Trash-1.8.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/5a/6a67d929c467a1973b6bb9f0b00159cc343b02bf9a8d26db1abd2f87aa23/shapely-2.0.6-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl
@@ -3381,8 +3381,8 @@ environments:
       - pypi: ./examples/python/shared_recording
       - pypi: ./examples/python/stdio
       - pypi: ./examples/python/structure_from_motion
-      - pypi: rerun_notebook
-      - pypi: rerun_py
+      - pypi: ./rerun_notebook
+      - pypi: ./rerun_py
   examples-pypi:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -4867,8 +4867,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6e/52/2da48b35193e39ac53cfb141467d9f259851522d0e8c87153f0ba4205fb1/wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/3f/dbafccf19cfeca25bbabf6f2dd81796b7218f768ec400f043edc767015a6/zstandard-0.23.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: rerun_notebook
-      - pypi: rerun_py
+      - pypi: ./rerun_notebook
+      - pypi: ./rerun_py
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.9.5-py311hcd402e7_0.conda
@@ -5191,8 +5191,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7f/a7/f1212ba098f3de0fd244e2de0f8791ad2539c03bef6c05a9fcb03e45b089/wrapt-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/63/b6/677e65c095d8e12b66b8f862b069bcf1f1d781b9c9c6f12eb55000d57583/zstandard-0.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: rerun_notebook
-      - pypi: rerun_py
+      - pypi: ./rerun_notebook
+      - pypi: ./rerun_py
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.5-py311h05b510d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
@@ -5490,8 +5490,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0f/16/ea627d7817394db04518f62934a5de59874b587b792300991b3c347ff5e0/wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/46/66d5b55f4d737dd6ab75851b224abf0afe5774976fe511a54d2eb9063a41/zstandard-0.23.0-cp311-cp311-macosx_11_0_arm64.whl
-      - pypi: rerun_notebook
-      - pypi: rerun_py
+      - pypi: ./rerun_notebook
+      - pypi: ./rerun_py
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.9.5-py311ha68e1ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
@@ -5791,8 +5791,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cf/c3/0084351951d9579ae83a3d9e38c140371e4c6b038136909235079f2e6e78/wrapt-1.16.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/be/a2/4272175d47c623ff78196f3c10e9dc7045c1b9caf3735bf041e65271eca4/zstandard-0.23.0-cp311-cp311-win_amd64.whl
-      - pypi: rerun_notebook
-      - pypi: rerun_py
+      - pypi: ./rerun_notebook
+      - pypi: ./rerun_py
   py-docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -11619,6 +11619,19 @@ packages:
   - html5lib ; extra == 'html5lib'
   - lxml ; extra == 'lxml'
   requires_python: '>=3.6.0'
+- pypi: https://files.pythonhosted.org/packages/ff/2e/abfed7a721928e14aeb900182ff695be474c4ee5f07ef0874cc5ecd5b0b1/betterproto-1.2.5.tar.gz
+  name: betterproto
+  version: 1.2.5
+  sha256: 74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d
+  requires_dist:
+  - dataclasses ; python_full_version < '3.7'
+  - backports-datetime-fromisoformat ; python_full_version < '3.7'
+  - grpclib
+  - stringcase
+  - black ; extra == 'compiler'
+  - jinja2 ; extra == 'compiler'
+  - protobuf ; extra == 'compiler'
+  requires_python: '>=3.6'
 - pypi: https://files.pythonhosted.org/packages/ff/2e/abfed7a721928e14aeb900182ff695be474c4ee5f07ef0874cc5ecd5b0b1/betterproto-1.2.5.tar.gz
   name: betterproto
   version: 1.2.5
@@ -26906,6 +26919,15 @@ packages:
   version: 1.16.2
   sha256: 4f9481f5841b0b8fb7b271b0414b394b503405260a6ee0cf2c330a5420d19b64
   requires_dist:
+  - dataclasses ; python_full_version == '3.6.*'
+  - dataclasses-json>=0.0.25
+  - deprecated
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
+  name: pygltflib
+  version: 1.16.2
+  sha256: 4f9481f5841b0b8fb7b271b0414b394b503405260a6ee0cf2c330a5420d19b64
+  requires_dist:
   - dataclasses-json>=0.0.25
   - deprecated
   - dataclasses ; python_full_version == '3.6.*'
@@ -27709,10 +27731,10 @@ packages:
   - hatch ; extra == 'dev'
   - jupyterlab ; extra == 'dev'
   - watchfiles ; extra == 'dev'
-- pypi: rerun_notebook
+- pypi: ./rerun_notebook
   name: rerun-notebook
-  version: 0.24.0a5
-  sha256: 56ff2da3001301e91acfc4478a89cbbeb7eba98e43630b9df66fe173646f49fc
+  version: 0.24.0a1+dev
+  sha256: 6f36c1848bb89622aa53fd747da3b12721c9b387f75bc38ec6acd7aee75c6e1d
   requires_dist:
   - anywidget
   - jupyter-ui-poll
@@ -27772,10 +27794,10 @@ packages:
   - pytest==7.1.2 ; extra == 'tests'
   - rerun-notebook==0.23.4a2 ; extra == 'notebook'
   requires_python: '>=3.9'
-- pypi: rerun_py
+- pypi: ./rerun_py
   name: rerun-sdk
-  version: 0.24.0a5
-  sha256: 8002f2e78a9e0a54fba2a9653a0aa275d73cbbe24146f6d8739aa3e0bdc52df4
+  version: 0.24.0a1+dev
+  sha256: b9daa6c2b4c0a3451a73e1bc2c75322443da1f074406d2a93d3d975f08222be4
   requires_dist:
   - attrs>=23.1.0
   - numpy>=2
@@ -27783,7 +27805,7 @@ packages:
   - pyarrow>=18.0.0
   - typing-extensions>=4.5
   - pytest==7.1.2 ; extra == 'tests'
-  - rerun-notebook==0.24.0a5 ; extra == 'notebook'
+  - rerun-notebook==0.24.0a1+dev ; extra == 'notebook'
   requires_python: '>=3.9'
   editable: true
 - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl

--- a/rerun_cpp/src/rerun/c/sdk_info.h
+++ b/rerun_cpp/src/rerun/c/sdk_info.h
@@ -2,7 +2,7 @@
 ///
 /// This should match the string returned by `rr_version_string` (C) or `rerun::version_string` (C++).
 /// If not, the SDK's binary and the C header are out of sync.
-#define RERUN_SDK_HEADER_VERSION "0.24.0-alpha.5"
+#define RERUN_SDK_HEADER_VERSION "0.24.0-alpha.1+dev"
 
 /// Major version of the Rerun C SDK.
 #define RERUN_SDK_HEADER_VERSION_MAJOR 0

--- a/rerun_js/web-viewer-react/README.md
+++ b/rerun_js/web-viewer-react/README.md
@@ -35,7 +35,7 @@ export default function App() {
 ```
 
 The `rrd` in the snippet above should be a URL pointing to either:
-- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.24.0-alpha.5/examples/dna.rrd>
+- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.24.0-alpha.1/examples/dna.rrd>
 - A gRPC connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk/operating-modes#serve) API
 
 If `rrd` is not set, the Viewer will display the same welcome screen as <https://app.rerun.io>.

--- a/rerun_js/web-viewer-react/package.json
+++ b/rerun_js/web-viewer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rerun-io/web-viewer-react",
-  "version": "0.24.0-alpha.5",
+  "version": "0.24.0-alpha.1+dev",
   "description": "Embed the Rerun web viewer in your React app",
   "licenses": [
     {
@@ -41,7 +41,7 @@
     "tsconfig.json"
   ],
   "dependencies": {
-    "@rerun-io/web-viewer": "0.24.0-alpha.5",
+    "@rerun-io/web-viewer": "0.24.0-alpha.1",
     "@types/react": "^18.2.33",
     "react": "^18.2.0"
   },

--- a/rerun_js/web-viewer/README.md
+++ b/rerun_js/web-viewer/README.md
@@ -28,7 +28,7 @@ This means that:
 
 ## Usage
 
-The entrypoint for this packages is the [`WebViewer`](https://ref.rerun.io/docs/js/0.24.0-alpha.5/web-viewer/classes/WebViewer.html) class.
+The entrypoint for this packages is the [`WebViewer`](https://ref.rerun.io/docs/js/0.24.0-alpha.1/web-viewer/classes/WebViewer.html) class.
 The web viewer is an object which manages a canvas element:
 
 ```js
@@ -44,7 +44,7 @@ viewer.stop();
 ```
 
 The `rrd` in the snippet above should be a URL pointing to either:
-- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.24.0-alpha.5/examples/dna.rrd>
+- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.24.0-alpha.1/examples/dna.rrd>
 - A gRPC connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk/operating-modes#serve) API
 
 If `rrd` is not set, the Viewer will display the same welcome screen as <https://app.rerun.io>.

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -274,7 +274,7 @@ function delay(ms: number) {
  * ```
  *
  * Data may be provided to the Viewer as:
- * - An HTTP file URL, e.g. `viewer.start("https://app.rerun.io/version/0.24.0-alpha.5/examples/dna.rrd")`
+ * - An HTTP file URL, e.g. `viewer.start("https://app.rerun.io/version/0.24.0-alpha.1/examples/dna.rrd")`
  * - A Rerun gRPC URL, e.g. `viewer.start("rerun+http://127.0.0.1:9876/proxy")`
  * - A stream of log messages, via {@link WebViewer.open_channel}.
  *

--- a/rerun_js/web-viewer/package.json
+++ b/rerun_js/web-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rerun-io/web-viewer",
-  "version": "0.24.0-alpha.5",
+  "version": "0.24.0-alpha.1+dev",
   "description": "Embed the Rerun web viewer in your app",
   "licenses": [
     {

--- a/rerun_notebook/pyproject.toml
+++ b/rerun_notebook/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rerun-notebook"
 description = "Implementation helper for running rerun-sdk in notebooks"
-version = "0.24.0-alpha.5"
+version = "0.24.0-alpha.1+dev"
 dependencies = ["anywidget", "jupyter-ui-poll"]
 readme = "README.md"
 keywords = ["rerun", "notebook"]

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -36,7 +36,7 @@ text = "MIT OR Apache-2.0"
 
 [project.optional-dependencies]
 tests = ["pytest==7.1.2"]
-notebook = ["rerun-notebook==0.24.0-alpha.5"]
+notebook = ["rerun-notebook==0.24.0-alpha.1+dev"]
 
 [project.urls]
 documentation = "https://www.rerun.io/docs"

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -8,8 +8,8 @@ from uuid import UUID
 
 import numpy as np
 
-__version__ = "0.24.0-alpha.5"
-__version_info__ = (0, 24, 0, "alpha.5")
+__version__ = "0.24.0-alpha.1+dev"
+__version_info__ = (0, 24, 0, "alpha.1")
 
 
 if sys.version_info < (3, 9):  # noqa: UP036


### PR DESCRIPTION
Reverts rerun-io/rerun#10458

We can't merge a failed alpha release
- We have no docs, which breaks links
- The version doesn't contain `+dev`

Among other things