### PR TITLE
Add --connect documentation to the CLI reference

### DIFF
--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -105,6 +105,14 @@ The Rerun command-line interface:
 > `rerun --serve-grpc` will act like a proxy, listening for incoming gRPC connection from logging SDKs, and forwarding it to Rerun viewers.
 > [Default: `false`]
 
+* `--connect <CONNECT>`
+> Do not attempt to start a new server, instead try to connect to an existing one.
+>
+> Optionally accepts a URL to a gRPC server.
+>
+> The scheme must be one of `rerun://`, `rerun+http://`, or `rerun+https://`, and the pathname must be `/proxy`.
+> [Default: `rerun+http://127.0.0.1:9876/proxy`]
+
 * `--expect-data-soon <EXPECT_DATA_SOON>`
 > This is a hint that we expect a recording to stream in very soon.
 >


### PR DESCRIPTION
### What

This is a small change so instead of creating an issue and doing some back and forth, you all can decide if it's necessary 😁 

#7149 added the CLI manual and I didn't see why `--connect` would have been intentionally omitted.
So I added its documentation from the [entrypoint](https://github.com/rerun-io/rerun/blob/1438dd212900b95a40d8d7d585f127dd11e4fb2c/crates/top/rerun/src/commands/entrypoint.rs#L189) as other options here look to have done.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
