### PR TITLE
Cache old texture pixel readback data to avoid flickering

### DIFF
--- a/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
@@ -549,6 +549,53 @@ fn pixel_value_string_from_gpu_texture(
         ]);
     });
 
+    // Unfortunately, it can happen that GPU readbacks come in bursts one frame and we get thing in the next.
+    // Therefore, we have to keep around the previous result and use that until we get a new one.
+    let readback_result_rgb = {
+        let frame_nr = ui_ctx.cumulative_frame_nr();
+
+        #[derive(Clone)]
+        struct PreviousReadbackResult {
+            frame_nr: u64,
+            interaction_id: re_renderer::GpuReadbackIdentifier,
+            readback_result_rgb: [u8; 3],
+        }
+
+        // Only use the interaction *index* to identify the memory itself so we don't accumulate data indefinitely.
+        // To detect whether the retrieved data belongs to the same interaction we add the full interaction *id* to the cached data.
+        let memory_id = egui::Id::new(interaction_id.interaction_idx);
+        let interaction_id = interaction_id.gpu_readback_id();
+
+        if let Some(readback_result_rgb) = readback_result_rgb {
+            ui_ctx.memory_mut(|m| {
+                m.data.insert_temp(
+                    memory_id,
+                    PreviousReadbackResult {
+                        frame_nr,
+                        interaction_id,
+                        readback_result_rgb,
+                    },
+                );
+            });
+
+            Some(readback_result_rgb)
+        } else {
+            const MAX_FRAMES_WITHOUT_GPU_READBACK: u64 = 3;
+
+            ui_ctx.memory(|m| m.data.get_temp(memory_id)).and_then(
+                |cached: PreviousReadbackResult| {
+                    if cached.interaction_id == interaction_id
+                        && cached.frame_nr + MAX_FRAMES_WITHOUT_GPU_READBACK >= frame_nr
+                    {
+                        Some(cached.readback_result_rgb)
+                    } else {
+                        None
+                    }
+                },
+            )
+        }
+    };
+
     // Then enqueue a new readback.
     //
     // It's quite hard to figure out when we no longer have to do this. The criteria would be roughly:


### PR DESCRIPTION
### Related

* part of https://github.com/rerun-io/rerun/issues/10475

### What

Fixes an issue where we observe gpu texture readbacks, as done on video textures for hover, to have a result one frame and no result the other frame.
We already employ similar mitigation strategy for picking (adjusted to the specific sources of information and interaction logic though)! I looked a bit it into unifying this, but found it to be a bit to complicated to fully generalize. Maybe when we hit this the third time ;-)

While in theory possible on all platforms, we never observed this on 0.23 and do so now only on WebGL. So this is likely related to the wgpu update that happened meanwhile (which had some effect on WebGL work scheduling)