### PR TITLE
Make `GpuCpuReadbackBelt` easier & safer to use

### DIFF
--- a/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
@@ -15,6 +15,9 @@ struct PendingReadbackRange {
     identifier: GpuReadbackIdentifier,
     buffer_range: Range<wgpu::BufferAddress>,
     user_data: GpuReadbackUserDataStorage,
+
+    /// The frame index when the readback was scheduled.
+    scheduled_frame_index: u64,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -161,6 +164,7 @@ impl Chunk {
         size_in_bytes: wgpu::BufferAddress,
         identifier: GpuReadbackIdentifier,
         user_data: GpuReadbackUserDataStorage,
+        scheduled_frame_index: u64,
     ) -> GpuReadbackBuffer {
         debug_assert!(size_in_bytes <= self.remaining_capacity());
 
@@ -170,6 +174,7 @@ impl Chunk {
             identifier,
             buffer_range: buffer_range.clone(),
             user_data,
+            scheduled_frame_index,
         });
 
         let buffer = GpuReadbackBuffer {
@@ -297,7 +302,7 @@ impl GpuReadbackBelt {
             }
         };
 
-        let buffer_slice = chunk.allocate(size_in_bytes, identifier, user_data);
+        let buffer_slice = chunk.allocate(size_in_bytes, identifier, user_data, self.frame_index);
         self.active_chunks.push(chunk);
 
         buffer_slice
@@ -358,14 +363,19 @@ impl GpuReadbackBelt {
         }
     }
 
-    /// Try to receive a pending data readback with the given identifier and the given user data type.
+    /// Try to receive a pending data readback with the given identifier and user data type,
+    /// calling a callback on the first result that is available.
     ///
-    /// Reports the oldest received data with the given identifier & type.
     /// *Most likely* subsequent calls will return data from newer submissions. But there is no *strict* guarantee for this.
     /// It could in theory happen that a readback is scheduled after a previous one, but finishes before it!
+    /// While there's no documented case of this reordering ever happening, your data handling code should handle this gracefully.
     ///
     /// ATTENTION: Do NOT assume any alignment on the slice passed to `on_data_received`.
     /// See this issue on [Alignment guarantees for mapped buffers](https://github.com/gfx-rs/wgpu/issues/3508).
+    ///
+    /// Note that [`Self::begin_frame`] will discard stale data automatically, preventing leaks for any
+    /// scheduled reads that are never queried.
+    // TODO(andreas): Can above mentioned recording _actually_ happen? How contrived does a setup have to be for this?
     pub fn readback_next_available<UserDataType: 'static, Ret>(
         &mut self,
         identifier: GpuReadbackIdentifier,
@@ -374,7 +384,61 @@ impl GpuReadbackBelt {
         re_tracing::profile_function!();
 
         self.receive_chunks();
+        self.readback_next_available_internal(identifier, callback)
+            .map(|(result, _)| result)
+    }
 
+    /// Try to receive a pending data readback with the given identifier and user data type,
+    /// calling a callback on all results that are available, but returning only the callback result that is associated with
+    /// the newest scheduled read.
+    ///
+    /// *Most likely* subsequent calls will return data from newer submissions. But there is no *strict* guarantee for this.
+    /// It could in theory happen that a readback is scheduled after a previous one, but finishes before it!
+    /// While there's no documented case of this reordering ever happening, your data handling code should handle this gracefully.
+    ///
+    /// Note that [`Self::begin_frame`] will discard stale data automatically, preventing leaks for any
+    /// scheduled reads that are never queried.
+    ///
+    /// # Implementation notes
+    ///
+    /// The callback being called for all results and not just the newest is an artifact of our zero-copy implementation:
+    /// Whenever inspecting a result, we hold a pointer directly to the mapped GPU data.
+    /// Moving on to the next result without discarding the previous means we'd potentially have two pointers
+    /// to the same mapped GPU buffer. This is possible, but inevitably leads to more `unsafe` & more complex code
+    /// for something that is expected to be a very rare occurrence.
+    //
+    // TODO(andreas): Can above mentioned recording _actually_ happen? How contrived does a setup have to be for this?
+    pub fn readback_newest_available<UserDataType: 'static, Ret>(
+        &mut self,
+        identifier: GpuReadbackIdentifier,
+        callback: impl Fn(&[u8], Box<UserDataType>) -> Ret,
+    ) -> Option<Ret> {
+        re_tracing::profile_function!();
+
+        self.receive_chunks();
+
+        let mut last_result = None;
+        let mut last_scheduled_frame_index = 0;
+
+        while let Some((result, scheduled_frame_index)) =
+            self.readback_next_available_internal::<UserDataType, Ret>(identifier, &callback)
+        {
+            // There could be several results from the same frame. Use the most recently received one in that case.
+            if scheduled_frame_index >= last_scheduled_frame_index {
+                last_result = Some(result);
+                last_scheduled_frame_index = scheduled_frame_index;
+            }
+        }
+
+        last_result
+    }
+
+    /// Returns result + frame index for when the request was scheduled.
+    fn readback_next_available_internal<UserDataType: 'static, Ret>(
+        &mut self,
+        identifier: GpuReadbackIdentifier,
+        callback: impl FnOnce(&[u8], Box<UserDataType>) -> Ret,
+    ) -> Option<(Ret, u64)> {
         // Search for the user data in the readback chunks.
         // A linear search is suited best since we expect both the number of pending chunks (typically just one or two!)
         // as well as the number of readbacks per chunk to be small!
@@ -385,11 +449,14 @@ impl GpuReadbackBelt {
                     continue;
                 }
 
-                let result = {
+                let (result, scheduled_frame_index) = {
                     let range = chunk.ranges_in_use.swap_remove(range_index);
                     let slice = chunk.buffer.slice(range.buffer_range.clone());
                     let data = slice.get_mapped_range();
-                    callback(&data, range.user_data.downcast::<UserDataType>().unwrap())
+                    (
+                        callback(&data, range.user_data.downcast::<UserDataType>().unwrap()),
+                        range.scheduled_frame_index,
+                    )
                 };
 
                 // If this was the last range from this chunk, the chunk is ready for re-use!
@@ -397,7 +464,7 @@ impl GpuReadbackBelt {
                     let chunk = self.received_chunks.swap_remove(chunk_index);
                     self.reuse_chunk(chunk);
                 }
-                return Some(result);
+                return Some((result, scheduled_frame_index));
             }
         }
 

--- a/crates/viewer/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/viewer/re_renderer/src/draw_phases/picking_layer.rs
@@ -400,10 +400,9 @@ impl PickingLayerProcessor {
         ctx: &RenderContext,
         identifier: GpuReadbackIdentifier,
     ) -> Option<PickingResult<T>> {
-        let mut result = None;
-        ctx.gpu_readback_belt
-            .lock()
-            .readback_data::<ReadbackBeltMetadata<T>>(identifier, |data, metadata| {
+        ctx.gpu_readback_belt.lock().readback_next_available(
+            identifier,
+            |data, metadata: Box<ReadbackBeltMetadata<T>>| {
                 // Assert that our texture data reinterpretation works out from a pixel size point of view.
                 debug_assert_eq!(
                     Self::PICKING_LAYER_DEPTH_FORMAT
@@ -446,15 +445,15 @@ impl PickingLayerProcessor {
                     picking_depth_data = picking_depth_data.into_iter().step_by(4).collect();
                 }
 
-                result = Some(PickingResult {
+                PickingResult {
                     picking_id_data,
                     picking_depth_data,
                     user_data: metadata.user_data,
                     rect: metadata.picking_rect,
                     world_from_cropped_projection: metadata.world_from_cropped_projection,
-                });
-            });
-        result
+                }
+            },
+        )
     }
 }
 

--- a/crates/viewer/re_renderer/src/draw_phases/picking_layer.rs
+++ b/crates/viewer/re_renderer/src/draw_phases/picking_layer.rs
@@ -388,19 +388,16 @@ impl PickingLayerProcessor {
         Ok(())
     }
 
-    /// Returns the oldest received picking results for a given identifier and user data type.
-    ///
-    /// It is recommended to call this method repeatedly until it returns `None` to ensure that all
-    /// pending data is flushed.
+    /// Returns the latest available picking result for a given identifier and user data type.
     ///
     /// Ready data that hasn't been retrieved for more than a frame will be discarded.
     ///
     /// See also [`crate::view_builder::ViewBuilder::schedule_picking_rect`]
-    pub fn next_readback_result<T: 'static + Send + Sync>(
+    pub fn readback_result<T: 'static + Send + Sync>(
         ctx: &RenderContext,
         identifier: GpuReadbackIdentifier,
     ) -> Option<PickingResult<T>> {
-        ctx.gpu_readback_belt.lock().readback_next_available(
+        ctx.gpu_readback_belt.lock().readback_newest_available(
             identifier,
             |data, metadata: Box<ReadbackBeltMetadata<T>>| {
                 // Assert that our texture data reinterpretation works out from a pixel size point of view.

--- a/crates/viewer/re_renderer/src/draw_phases/screenshot.rs
+++ b/crates/viewer/re_renderer/src/draw_phases/screenshot.rs
@@ -131,11 +131,9 @@ impl ScreenshotProcessor {
         identifier: GpuReadbackIdentifier,
         on_screenshot: impl FnOnce(&[u8], glam::UVec2, T),
     ) -> Option<()> {
-        let mut screenshot_was_available = None;
-        ctx.gpu_readback_belt
-            .lock()
-            .readback_data::<ReadbackBeltMetadata<T>>(identifier, |data: &[u8], metadata| {
-                screenshot_was_available = Some(());
+        ctx.gpu_readback_belt.lock().readback_next_available(
+            identifier,
+            |data: &[u8], metadata: Box<ReadbackBeltMetadata<T>>| {
                 let buffer_info =
                     Texture2DBufferInfo::new(Self::SCREENSHOT_COLOR_FORMAT, metadata.extent);
                 let texture_data = buffer_info.remove_padding(data);
@@ -144,7 +142,7 @@ impl ScreenshotProcessor {
                     glam::uvec2(metadata.extent.width, metadata.extent.height),
                     metadata.user_data,
                 );
-            });
-        screenshot_was_available
+            },
+        )
     }
 }

--- a/crates/viewer/re_renderer_examples/picking.rs
+++ b/crates/viewer/re_renderer_examples/picking.rs
@@ -101,8 +101,8 @@ impl framework::Example for Picking {
         _time: &framework::Time,
         pixels_per_point: f32,
     ) -> anyhow::Result<Vec<framework::ViewDrawResult>> {
-        while let Some(picking_result) =
-            PickingLayerProcessor::next_readback_result::<()>(re_ctx, READBACK_IDENTIFIER)
+        if let Some(picking_result) =
+            PickingLayerProcessor::readback_result::<()>(re_ctx, READBACK_IDENTIFIER)
         {
             // Grab the middle pixel. usually we'd want to do something clever that snaps the closest object of interest.
             let picked_id = picking_result.picked_id(picking_result.rect.extent / 2);

--- a/crates/viewer/re_view_map/src/map_view.rs
+++ b/crates/viewer/re_view_map/src/map_view.rs
@@ -577,14 +577,10 @@ fn picking_gpu(
 ) -> Option<InstancePathHash> {
     re_tracing::profile_function!();
 
-    // Only look at newest available result, discard everything else.
-    let mut gpu_picking_result = None;
-    while let Some(picking_result) = re_renderer::PickingLayerProcessor::next_readback_result::<()>(
+    let gpu_picking_result = re_renderer::PickingLayerProcessor::readback_result::<()>(
         render_ctx,
         gpu_readback_identifier,
-    ) {
-        gpu_picking_result = Some(picking_result);
-    }
+    );
 
     if let Some(gpu_picking_result) = gpu_picking_result {
         // TODO(ab, andreas): the block inside this particular branch is so reusable, it should probably live on re_renderer! (on picking result?)

--- a/crates/viewer/re_view_spatial/src/picking.rs
+++ b/crates/viewer/re_view_spatial/src/picking.rs
@@ -193,13 +193,8 @@ fn picking_gpu(
 ) -> Option<PickingRayHit> {
     re_tracing::profile_function!();
 
-    // Only look at newest available result, discard everything else.
-    let mut gpu_picking_result = None;
-    while let Some(picking_result) =
-        PickingLayerProcessor::next_readback_result::<()>(render_ctx, gpu_readback_identifier)
-    {
-        gpu_picking_result = Some(picking_result);
-    }
+    let gpu_picking_result =
+        PickingLayerProcessor::readback_result::<()>(render_ctx, gpu_readback_identifier);
 
     if let Some(gpu_picking_result) = gpu_picking_result {
         // First, figure out where on the rect the cursor is by now.

--- a/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
@@ -526,7 +526,8 @@ fn pixel_value_string_from_gpu_texture(
 
     // First check if we have a result ready to read.
     // Keep in mind that copy operation may have required row-padding, use `buffer_info` to get the right values.
-    let readback_result_rgb = readback_belt.readback_next_available(
+    // Readbacks from GPU might come in bursts for all sort of reasons. So make sure we only look at the latest result.
+    let readback_result_rgb = readback_belt.readback_newest_available(
         readback_id,
         |data, userdata: Box<TextureReadbackUserdata>| {
             debug_assert!(data.len() == userdata.buffer_info.buffer_size_padded as usize);

--- a/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
@@ -526,28 +526,30 @@ fn pixel_value_string_from_gpu_texture(
 
     // First check if we have a result ready to read.
     // Keep in mind that copy operation may have required row-padding, use `buffer_info` to get the right values.
-    let mut readback_result_rgb = None;
-    readback_belt.readback_data::<TextureReadbackUserdata>(readback_id, |data, userdata| {
-        debug_assert!(data.len() == userdata.buffer_info.buffer_size_padded as usize);
+    let readback_result_rgb = readback_belt.readback_next_available(
+        readback_id,
+        |data, userdata: Box<TextureReadbackUserdata>| {
+            debug_assert!(data.len() == userdata.buffer_info.buffer_size_padded as usize);
 
-        // Try to find the pixel at the mouse position.
-        // If our position isn't available, just clamp to the edge of the area.
-        let data_pos = (pixel_pos - userdata.readback_rect.min())
-            .clamp(
-                glam::IVec2::ZERO,
-                // Exclusive the size of the area we're reading back.
-                userdata.readback_rect.extent.as_ivec2() - glam::IVec2::ONE,
-            )
-            .as_uvec2();
-        let start_index =
-            (data_pos.x * 4 + userdata.buffer_info.bytes_per_row_padded * data_pos.y) as usize;
+            // Try to find the pixel at the mouse position.
+            // If our position isn't available, just clamp to the edge of the area.
+            let data_pos = (pixel_pos - userdata.readback_rect.min())
+                .clamp(
+                    glam::IVec2::ZERO,
+                    // Exclusive the size of the area we're reading back.
+                    userdata.readback_rect.extent.as_ivec2() - glam::IVec2::ONE,
+                )
+                .as_uvec2();
+            let start_index =
+                (data_pos.x * 4 + userdata.buffer_info.bytes_per_row_padded * data_pos.y) as usize;
 
-        readback_result_rgb = Some([
-            data[start_index],
-            data[start_index + 1],
-            data[start_index + 2],
-        ]);
-    });
+            [
+                data[start_index],
+                data[start_index + 1],
+                data[start_index + 2],
+            ]
+        },
+    );
 
     // Then enqueue a new readback.
     //


### PR DESCRIPTION
Some improvements while working on
* https://github.com/rerun-io/rerun/pull/10483

While texture pixel readback had indeed a very very subtle bug in thus far it didn't flush out the readback queue, this had not effect in practice. The interface additions make it harder to run into this