### PR TITLE
Source physical column names from the original `RecordBatch`es

### DIFF
--- a/crates/viewer/re_dataframe_ui/src/datafusion_adapter.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_adapter.rs
@@ -1,15 +1,18 @@
-use crate::RequestedObject;
-use crate::table_blueprint::{EntryLinksSpec, PartitionLinksSpec, SortBy, TableBlueprint};
-use arrow::datatypes::DataType;
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Fields};
 use datafusion::common::{DataFusionError, TableReference};
 use datafusion::functions::expr_fn::concat;
 use datafusion::logical_expr::{col as datafusion_col, lit};
 use datafusion::prelude::{SessionContext, cast, encode};
 use parking_lot::Mutex;
+
 use re_log_types::Timestamp;
 use re_sorbet::{BatchType, SorbetBatch};
 use re_viewer_context::AsyncRuntimeHandle;
-use std::sync::Arc;
+
+use crate::RequestedObject;
+use crate::table_blueprint::{EntryLinksSpec, PartitionLinksSpec, SortBy, TableBlueprint};
 
 /// Make sure we escape column names correctly for datafusion.
 ///
@@ -76,11 +79,12 @@ impl DataFusionQuery {
         }
     }
 
-    /// Execute the query and produce a vector of [`SorbetBatch`]s.
+    /// Execute the query and produce a vector of [`SorbetBatch`]s along with physical columns
+    /// names.
     ///
     /// Note: the future returned by this function must be `'static`, so it takes `self`. Use
     /// `clone()` as required.
-    async fn execute(self) -> Result<Vec<SorbetBatch>, DataFusionError> {
+    async fn execute(self) -> Result<(Vec<SorbetBatch>, Fields), DataFusionError> {
         let mut dataframe = self.session_ctx.table(self.table_ref).await?;
 
         let DataFusionQueryData {
@@ -127,12 +131,20 @@ impl DataFusionQuery {
 
         if let Some(sort_by) = sort_by {
             dataframe = dataframe.sort(vec![
-                col(&sort_by.column).sort(sort_by.direction.is_ascending(), true),
+                col(&sort_by.column_physical_name).sort(sort_by.direction.is_ascending(), true),
             ])?;
         }
 
         // collect
         let record_batches = dataframe.collect().await?;
+
+        // IMPORTANT: fields must be copied here *before* converting to `SorbetBatch`, because that
+        // conversion modifies the field names. As a result, the schema contained in a `SorbetBatch`
+        // cannot be used to derive the physical column names as seen by DataFusion.
+        let fields = record_batches
+            .first()
+            .map(|record_batch| record_batch.schema().fields.clone())
+            .unwrap_or_default();
 
         // convert to SorbetBatch
         let sorbet_batches = record_batches
@@ -143,7 +155,7 @@ impl DataFusionQuery {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|err| DataFusionError::External(err.into()))?;
 
-        Ok(sorbet_batches)
+        Ok((sorbet_batches, fields))
     }
 }
 
@@ -161,7 +173,8 @@ impl PartialEq for DataFusionQuery {
     }
 }
 
-type RequestedSorbetBatches = RequestedObject<Result<Vec<SorbetBatch>, DataFusionError>>;
+type RequestedSorbetBatches =
+    RequestedObject<Result<(Vec<SorbetBatch>, arrow::datatypes::Fields), DataFusionError>>;
 
 /// Helper struct to manage the datafusion async query and the resulting `SorbetBatch`.
 #[derive(Clone)]
@@ -175,7 +188,7 @@ pub struct DataFusionAdapter {
     query: DataFusionQuery,
 
     // Used to have something to display while the new dataframe is being queried.
-    pub last_sorbet_batches: Option<Vec<SorbetBatch>>,
+    pub last_sorbet_batches: Option<(Vec<SorbetBatch>, Fields)>,
 
     // TODO(ab, lucasmerlin): this `Mutex` is only needed because of the `Clone` bound in egui
     // so we should clean that up if the bound is lifted.

--- a/crates/viewer/re_dataframe_ui/src/datafusion_adapter.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_adapter.rs
@@ -138,7 +138,7 @@ impl DataFusionQuery {
         // collect
         let record_batches = dataframe.collect().await?;
 
-        // IMPORTANT: fields must be copied here *before* converting to `SorbetBatch`, because that
+        // TODO(#10421) IMPORTANT: fields must be copied here *before* converting to `SorbetBatch`, because that
         // conversion modifies the field names. As a result, the schema contained in a `SorbetBatch`
         // cannot be used to derive the physical column names as seen by DataFusion.
         let fields = record_batches

--- a/crates/viewer/re_dataframe_ui/src/datafusion_adapter.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_adapter.rs
@@ -138,9 +138,9 @@ impl DataFusionQuery {
         // collect
         let record_batches = dataframe.collect().await?;
 
-        // TODO(#10421) IMPORTANT: fields must be copied here *before* converting to `SorbetBatch`, because that
-        // conversion modifies the field names. As a result, the schema contained in a `SorbetBatch`
-        // cannot be used to derive the physical column names as seen by DataFusion.
+        // TODO(#10421) IMPORTANT: fields must be copied here *before* converting to `SorbetBatch`,
+        // because that conversion modifies the field names. As a result, the schema contained in a
+        // `SorbetBatch` cannot be used to derive the physical column names as seen by DataFusion.
         let fields = record_batches
             .first()
             .map(|record_batch| record_batch.schema().fields.clone())

--- a/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
+++ b/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
@@ -42,7 +42,7 @@ impl SortDirection {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SortBy {
-    pub column: String,
+    pub column_physical_name: String,
     pub direction: SortDirection,
 }
 


### PR DESCRIPTION
### Related

* closes https://github.com/rerun-io/rerun/issues/10427
* fix bug introduced by https://github.com/rerun-io/rerun/pull/10365
* detailed explanation https://github.com/rerun-io/rerun/pull/10365#issuecomment-3028018582
* related https://github.com/rerun-io/rerun/issues/10421

### What

The `DatafusionTableWidget` needs the physical names of the underlying columns in order to emit column references that DataFusion will understand. Previously, we'd extract `arrow::datatypes::Fields` from the `SorbetBatch`es. However, since #10365, the `Fields` are tempered with in the migration process, making them no longer suitable to extract column physical names.

As a work-around, this PR sources the `Fields` from the original `RecordBatch`es, _before_ conversion to `SorbetBatch`es. 
