### PR TITLE
Rename the 'Welcome screen' option to 'Rerun examples' 

### DIFF
--- a/crates/viewer/re_global_context/src/app_options.rs
+++ b/crates/viewer/re_global_context/src/app_options.rs
@@ -14,7 +14,8 @@ pub struct AppOptions {
     pub show_metrics: bool,
 
     /// Include the "Welcome screen" application in the recordings panel?
-    pub include_welcome_screen_button_in_recordings_panel: bool,
+    #[serde(alias = "include_welcome_screen_button_in_recordings_panel")]
+    pub include_rerun_examples_button_in_recordings_panel: bool,
 
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
@@ -71,7 +72,7 @@ impl Default for AppOptions {
 
             show_metrics: cfg!(debug_assertions),
 
-            include_welcome_screen_button_in_recordings_panel: true,
+            include_rerun_examples_button_in_recordings_panel: true,
 
             show_picking_debug_overlay: false,
 

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -161,7 +161,7 @@ fn recording_list_ui(
     // Always show welcome screen last, if at all:
     if (ctx
         .app_options()
-        .include_welcome_screen_button_in_recordings_panel
+        .include_rerun_examples_button_in_recordings_panel
         && !welcome_screen_state.hide)
         || !example_recordings.is_empty()
     {

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -80,8 +80,8 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
     }
 
     ui.re_checkbox(
-        &mut app_options.include_welcome_screen_button_in_recordings_panel,
-        "Show 'Welcome screen' button",
+        &mut app_options.include_rerun_examples_button_in_recordings_panel,
+        "Show 'Rerun examples' button",
     );
 
     ui.re_checkbox(&mut app_options.show_metrics, "Show performance metrics")


### PR DESCRIPTION
… for consistency

