### PR TITLE
Switch from `indicators` to `relevant_archetypes`

### DIFF
--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -95,6 +95,7 @@ pub trait Component: Loggable {
 
 pub type UnorderedComponentDescriptorSet = IntSet<ComponentDescriptor>;
 
+// TODO(#10460): Can we replace this with `BTreeSet<ComponentIdentifier>` here?
 pub type ComponentDescriptorSet = std::collections::BTreeSet<ComponentDescriptor>;
 
 re_string_interner::declare_new_type!(

--- a/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -289,7 +289,7 @@ impl IdentifiedViewSystem for AxisLengthDetector {
 impl VisualizerSystem for AxisLengthDetector {
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
         let mut query_info = VisualizerQueryInfo::from_archetype::<Transform3D>();
-        query_info.indicators = Default::default();
+        query_info.relevant_archetypes = Default::default();
 
         query_info
             .required

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -44,7 +44,7 @@ impl VisualizerSystem for SeriesLinesSystem {
             .queried
             .extend(archetypes::SeriesLines::all_components().iter().cloned());
 
-        query_info.indicators = [archetypes::SeriesLines::descriptor_indicator()].into();
+        query_info.relevant_archetypes = std::iter::once(archetypes::SeriesLines::name()).collect();
 
         query_info
     }

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -44,7 +44,8 @@ impl VisualizerSystem for SeriesPointsSystem {
             .queried
             .extend(archetypes::SeriesPoints::all_components().iter().cloned());
 
-        query_info.indicators = [archetypes::SeriesPoints::descriptor_indicator()].into();
+        query_info.relevant_archetypes =
+            std::iter::once(archetypes::SeriesPoints::name()).collect();
 
         query_info
     }

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -26,6 +26,15 @@ pub fn test_clear_series_points_and_line() {
 fn test_clear_series_points_and_line_impl(two_series_per_entity: bool) {
     let mut test_context = TestContext::new_with_view_class::<TimeSeriesView>();
 
+    // TODO(#10512): Potentially fix up this after we have "markers".
+    // There are some intricacies involved with this test. `SeriesLines` and
+    // `SeriesPoints` can both be logged without any associated data (all
+    // fields are optional). Now that indicators are gone, no data is logged
+    // at all when no fields are specified.
+    //
+    // The reason why `SeriesLines` still shows up is because it is the fallback
+    // visualizer for scalar values. We force `SeriesPoints` to have data, by
+    // explicitly setting the marker shape to circle.
     test_context.log_entity("plots/line", |builder| {
         builder.with_archetype(
             RowId::new(),
@@ -37,7 +46,8 @@ fn test_clear_series_points_and_line_impl(two_series_per_entity: bool) {
         builder.with_archetype(
             RowId::new(),
             TimePoint::default(),
-            &re_types::archetypes::SeriesPoints::new(),
+            &re_types::archetypes::SeriesPoints::new()
+                .with_markers([re_types::components::MarkerShape::Circle]),
         )
     });
 

--- a/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
+++ b/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
@@ -24,6 +24,7 @@ impl std::ops::Deref for MaybeVisualizableEntities {
     }
 }
 
+// TODO(#8129): Rename to `RelevantEntities`?
 /// List of entities that match the indicator components of a visualizer.
 ///
 /// In order to be a match the entity must have at some point in time on any timeline had any of

--- a/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
+++ b/crates/viewer/re_viewer_context/src/typed_entity_collections.rs
@@ -24,11 +24,10 @@ impl std::ops::Deref for MaybeVisualizableEntities {
     }
 }
 
-// TODO(#8129): Rename to `RelevantEntities`?
-/// List of entities that match the indicator components of a visualizer.
+/// List of entities that contain archetypes that are relevant for a visualizer.
 ///
-/// In order to be a match the entity must have at some point in time on any timeline had any of
-/// the indicator components specified by the respective visualizer system.
+/// In order to be a match the entity must have at some point in time on any timeline had any
+/// component that had an associated archetype as specified by the respective visualizer system.
 #[derive(Default, Clone, Debug)]
 pub struct IndicatedEntities(pub IntSet<EntityPath>);
 

--- a/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use nohash_hasher::IntSet;
+use re_chunk::ArchetypeName;
 use re_types::{Archetype, ComponentDescriptor, ComponentDescriptorSet};
 
 use crate::{
@@ -39,7 +41,8 @@ impl FromIterator<ComponentDescriptor> for SortedComponentDescriptorSet {
 pub struct VisualizerQueryInfo {
     /// These are not required, but if _any_ of these are found, it is a strong indication that this
     /// system should be active (if also the `required_components` are found).
-    pub indicators: ComponentDescriptorSet,
+    // TODO(#8129): Consider making this a proper struct to make the semantics of `Default::default()` clearer.
+    pub relevant_archetypes: IntSet<ArchetypeName>,
 
     /// Returns the minimal set of components that the system _requires_ in order to be instantiated.
     ///
@@ -56,7 +59,7 @@ pub struct VisualizerQueryInfo {
 impl VisualizerQueryInfo {
     pub fn from_archetype<A: Archetype>() -> Self {
         Self {
-            indicators: std::iter::once(A::indicator().descriptor).collect(),
+            relevant_archetypes: std::iter::once(A::name()).collect(),
             required: A::required_components().iter().cloned().collect(),
             queried: A::all_components().iter().cloned().collect(),
         }
@@ -64,7 +67,7 @@ impl VisualizerQueryInfo {
 
     pub fn empty() -> Self {
         Self {
-            indicators: ComponentDescriptorSet::default(),
+            relevant_archetypes: Default::default(),
             required: ComponentDescriptorSet::default(),
             queried: SortedComponentDescriptorSet::default(),
         }

--- a/examples/rust/custom_view/src/points3d_color_visualizer.rs
+++ b/examples/rust/custom_view/src/points3d_color_visualizer.rs
@@ -36,7 +36,7 @@ impl VisualizerSystem for Points3DColorVisualizer {
         } else {
             // Instead, our custom query here is solely interested in Points3D's colors.
             VisualizerQueryInfo {
-                indicators: Default::default(),
+                relevant_archetypes: Default::default(),
                 required: std::iter::once(rerun::Points3D::descriptor_colors()).collect(),
                 queried: std::iter::once(rerun::Points3D::descriptor_colors()).collect(),
             }


### PR DESCRIPTION
### Related

* Part of #6889.
* Part of #8129.
* Potential follow-up: #10512

### What

This PR changes the way entities are "indicated" from looking at `indicators` to looking at the `relevant_archetypes` names. This change also surface one change in our behavior:

"Marker" archetypes such as `SeriesPoints` and `SeriesLines` without any values set (for example when using `Self::new()`) will be empty and therefore not show up in the viewer unless specifically mentioned. For now there are several workarounds:
* explicitly set a field
* create a visualizer override in a blueprint
* implement "marker" components: #10512 
