### PR TITLE
Fix: don't always pick `/` as the origin when creating new views

### DIFF
--- a/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
+++ b/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
@@ -93,9 +93,9 @@ fn recommended_views_for_selection(ctx: &ContextMenuContext<'_>) -> IntSet<ViewC
         .maybe_visualizable_entities_for_visualizer_systems(&recording.store_id());
 
     for entry in view_class_registry.iter_registry() {
-        let Some(suggested_root) = entry
+        let Some(suggested_origin) = entry
             .class
-            .recommended_root_for_entities(&entities_of_interest, recording)
+            .recommended_origin_for_entities(&entities_of_interest, recording)
         else {
             continue;
         };
@@ -104,7 +104,7 @@ fn recommended_views_for_selection(ctx: &ContextMenuContext<'_>) -> IntSet<ViewC
             &maybe_visualizable_entities,
             recording,
             &view_class_registry.new_visualizer_collection(entry.identifier),
-            &suggested_root,
+            &suggested_origin,
         );
 
         // We consider a view class to be recommended if all selected entities are
@@ -144,7 +144,7 @@ fn create_view_for_selected_entities(
         .viewer_context
         .view_class_registry()
         .get_class_or_log_error(identifier)
-        .recommended_root_for_entities(&entities_of_interest, ctx.viewer_context.recording())
+        .recommended_origin_for_entities(&entities_of_interest, ctx.viewer_context.recording())
         .unwrap_or_else(EntityPath::root);
 
     let mut query_filter = EntityPathFilter::default();

--- a/crates/viewer/re_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_view_spatial/src/view_2d.rs
@@ -108,7 +108,7 @@ impl ViewClass for SpatialView2D {
         re_viewer_context::ViewClassLayoutPriority::High
     }
 
-    fn recommended_root_for_entities(
+    fn recommended_origin_for_entities(
         &self,
         entities: &IntSet<EntityPath>,
         entity_db: &EntityDb,

--- a/crates/viewer/re_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_view_spatial/src/view_3d.rs
@@ -94,7 +94,7 @@ impl ViewClass for SpatialView3D {
         re_viewer_context::ViewClassLayoutPriority::High
     }
 
-    fn recommended_root_for_entities(
+    fn recommended_origin_for_entities(
         &self,
         entities: &IntSet<EntityPath>,
         entity_db: &EntityDb,

--- a/crates/viewer/re_viewer_context/src/view/view_class.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_class.rs
@@ -109,7 +109,7 @@ pub trait ViewClass: Send + Sync {
     ///
     /// This function only considers the transform topology, disregarding the actual visualizability
     /// of the entities (for this, use [`Self::visualizable_filter_context`]).
-    fn recommended_root_for_entities(
+    fn recommended_origin_for_entities(
         &self,
         entities: &IntSet<EntityPath>,
         _entity_db: &re_entity_db::EntityDb,


### PR DESCRIPTION
### What
When creating a new view from a selection of entities (e.g. by right-clicking them and selecting "Add to new view") the origin would always be set to `/` (except for 2D and 3D views). This was quite confusing, at it also meant the new view would be given the name `/`.

Review commit-by-commit!
The first commit is the fix, the second just a naming change.

![image](https://github.com/user-attachments/assets/c367df2e-9eeb-44b5-9301-5e42fa28ae78)
