### PR TITLE
Make `DisplayRB` available to all crates via `re_format_arrow`

### DIFF
--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -1337,6 +1337,7 @@ mod tests {
         ChunkStore, ChunkStoreConfig, ChunkStoreHandle, ResolvedTimeRange, TimeInt,
     };
     use re_format_arrow::format_record_batch;
+    use re_format_arrow::test::DisplayRB;
     use re_log_types::{
         EntityPath, Timeline, build_frame_nr, build_log_time,
         example_components::{MyColor, MyLabel, MyPoint, MyPoints},
@@ -1348,17 +1349,6 @@ mod tests {
     use crate::{QueryCache, QueryEngine};
 
     use super::*;
-
-    /// Implement `Display` for `ArrowRecordBatch`
-    struct DisplayRB(ArrowRecordBatch);
-
-    impl std::fmt::Display for DisplayRB {
-        #[inline]
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let width = 200;
-            re_format_arrow::format_record_batch_with_width(&self.0, Some(width)).fmt(f)
-        }
-    }
 
     // NOTE: The best way to understand what these tests are doing is to run them in verbose mode,
     // e.g. `cargo t -p re_dataframe -- --show-output barebones`.

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -439,3 +439,18 @@ fn format_cell(string: String) -> Cell {
         Cell::new(string)
     }
 }
+
+pub mod test {
+    use arrow::record_batch::RecordBatch;
+
+    /// Implement `Display` for `RecordBatch`
+    pub struct DisplayRB(pub RecordBatch);
+
+    impl std::fmt::Display for DisplayRB {
+        #[inline]
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let width = 200;
+            super::format_record_batch_with_width(&self.0, Some(width)).fmt(f)
+        }
+    }
+}

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -440,6 +440,7 @@ fn format_cell(string: String) -> Cell {
     }
 }
 
+/// Provides utilities for formatting arrow data in test contexts.
 pub mod test {
     use arrow::record_batch::RecordBatch;
 


### PR DESCRIPTION
### What

Title. I think we should use this unified and in more places together with `insta::assert_snapshot`.
