### PR TITLE
Support callbacks in React

### DIFF
--- a/crates/viewer/re_viewer/src/event.rs
+++ b/crates/viewer/re_viewer/src/event.rs
@@ -6,6 +6,7 @@
 // NOTE: Any changes to the type definitions in this file must be replicated in:
 // - rerun_js/web-viewer/index.ts (ViewerEvent)
 // - rerun_py/rerun_sdk/rerun/event.py (ViewerEvent)
+// Important: The event names defined here are transformed to `snake_case` on the JS side.
 
 use std::rc::Rc;
 

--- a/rerun_js/web-viewer-react/index.js
+++ b/rerun_js/web-viewer-react/index.js
@@ -43,7 +43,7 @@ export default class WebViewer extends React.Component {
   componentDidMount() {
     startViewer(
       this.#handle,
-      /** @type {HTMLDivElement} */(this.#parent.current),
+      /** @type {HTMLDivElement} */ (this.#parent.current),
       () => this.props,
     );
   }
@@ -65,7 +65,7 @@ export default class WebViewer extends React.Component {
       this.#handle = new rerun.WebViewer();
       startViewer(
         this.#handle,
-        /** @type {HTMLDivElement} */(this.#parent.current),
+        /** @type {HTMLDivElement} */ (this.#parent.current),
         () => this.props,
       );
     } else {

--- a/rerun_js/web-viewer-react/index.js
+++ b/rerun_js/web-viewer-react/index.js
@@ -43,7 +43,7 @@ export default class WebViewer extends React.Component {
   componentDidMount() {
     startViewer(
       this.#handle,
-      /** @type {HTMLDivElement} */ (this.#parent.current),
+      /** @type {HTMLDivElement} */(this.#parent.current),
       () => this.props,
     );
   }
@@ -65,7 +65,7 @@ export default class WebViewer extends React.Component {
       this.#handle = new rerun.WebViewer();
       startViewer(
         this.#handle,
-        /** @type {HTMLDivElement} */ (this.#parent.current),
+        /** @type {HTMLDivElement} */(this.#parent.current),
         () => this.props,
       );
     } else {
@@ -135,7 +135,6 @@ function startViewer(handle, parent, getProps) {
     if (key.startsWith("on")) {
       /** @type {any} */
       const event = pascalToSnake(key.slice(2));
-      console.log(key, event);
       /** @type {any} */
       const callback = /** @type {any} */ (getProps())[key];
       handle.on(event, callback);

--- a/rerun_js/web-viewer-react/package.json
+++ b/rerun_js/web-viewer-react/package.json
@@ -37,6 +37,7 @@
     "index.d.ts",
     "index.d.ts.map",
     "index.js",
+    "types.d.ts",
     "package.json",
     "tsconfig.json"
   ],

--- a/rerun_js/web-viewer-react/types.d.ts
+++ b/rerun_js/web-viewer-react/types.d.ts
@@ -1,0 +1,21 @@
+
+import type { WebViewerEvents } from "@rerun-io/web-viewer";
+
+type PascalCase<S extends string> = S extends `${infer P1}_${infer P2}`
+  ? `${Capitalize<P1>}${PascalCase<P2>}`
+  : Capitalize<S>;
+
+type WithValue = {
+  [K in keyof WebViewerEvents as WebViewerEvents[K] extends void ? never : `on${PascalCase<K>}`]?: (event: WebViewerEvents[K]) => void;
+
+}
+
+type WithoutValue = {
+  [K in keyof WebViewerEvents as WebViewerEvents[K] extends void ? `on${PascalCase<K>}` : never]?: () => void;
+
+}
+
+export type ViewerEvents = WithValue & WithoutValue;
+
+
+

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -126,6 +126,8 @@ export interface AppOptions extends WebViewerOptions {
 }
 
 // Types are based on `crates/viewer/re_viewer/src/event.rs`.
+// Important: The event names defined here are `snake_case` versions
+// of their `PascalCase` counterparts on the Rust side.
 /** An event produced in the Viewer. */
 export type ViewerEvent =
   | PlayEvent

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -351,7 +351,7 @@ export class WebViewer {
       // for notebooks/gradio, we can avoid a whole layer
       // of serde by sending over the raw json directly,
       // which will be deserialized in Python instead
-      this.#_dispatch_raw_event(event_json);
+      this.#dispatch_raw_event(event_json);
 
       // for JS users, we dispatch the parsed event
       let event: ViewerEvent = JSON.parse(event_json);
@@ -384,10 +384,9 @@ export class WebViewer {
     return;
   }
 
-  #_raw_events: Set<(event_json: string) => void> = new Set();
-
-  #_dispatch_raw_event(event_json: string) {
-    for (const callback of this.#_raw_events) {
+  #raw_events: Set<(event_json: string) => void> = new Set();
+  #dispatch_raw_event(event_json: string) {
+    for (const callback of this.#raw_events) {
       callback(event_json);
     }
   }
@@ -399,8 +398,8 @@ export class WebViewer {
   // 
   // Do not change this without searching for grepping for usage!
   private _on_raw_event(callback: (event: string) => void): () => void {
-    this.#_raw_events.add(callback);
-    return () => this.#_raw_events.delete(callback);
+    this.#raw_events.add(callback);
+    return () => this.#raw_events.delete(callback);
   }
 
   #event_map: Map<


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/10495

```
pixi run js-build-all
pixi run yarn --cwd rerun_js workspaces run pack
```
Produces `rerun_js/web-viewer/web-viewer.tar.gz` and `rerun_js/web-viewer-react/web-viewer-react.tar.gz`

These can be installed into e.g. https://github.com/rerun-io/web-viewer-react-example by running:
```
npm i # base dependencies
npm i ../rerun/rerun_js/web-viewer/web-viewer.tar.gz
npm i ../rerun/rerun_js/web-viewer-react/web-viewer-react.tar.gz
```

Afterwards run the example as normal. You can find the new callback props available on the `WebViewer` component, e.g. `onPlay`, `onTimeUpdate`, etc.

## Implementation details

I felt bad about adding another layer of stuff that anyone working on events has to deal with, so this requires no effort whatsoever to maintain.

The callback prop types are generated automatically from `@rerun-io/web-viewer` event types. When a callback prop is registered, the prop name is transformed to the event name (remove `on` prefix, snake_case it), which is then directly registered on the underlying `WebViewer` instance. This way we don't need to maintain a list of events on the React side, it stays up to date automatically as new events are added in the non-React package.