### PR TITLE
Add tab-bar button to hide a view

### DIFF
--- a/crates/viewer/re_viewport/src/viewport_ui.rs
+++ b/crates/viewer/re_viewport/src/viewport_ui.rs
@@ -588,6 +588,20 @@ impl<'a> egui_tiles::Behavior<ViewId> for TilesDelegate<'a, '_> {
             }
         }
 
+        if 1 < num_views {
+            // Show button to hide this view:
+            let mut visible = true;
+            ui.visibility_toggle_button(&mut visible)
+                .on_hover_text("Hide this view");
+            if !visible {
+                self.viewport_blueprint.set_content_visibility(
+                    self.ctx,
+                    &Contents::View(view_id),
+                    visible,
+                );
+            }
+        }
+
         let view_class = view_blueprint.class(self.ctx.view_class_registry());
 
         // give the view a chance to display some extra UI in the top bar.


### PR DESCRIPTION
I find myself often wanting to hide a specific view or two, and this change makes it easier.

https://github.com/user-attachments/assets/a56fc8f8-c4b3-41f6-ae94-c2ef7830e57d


### Why does the hide-button belong here?

I think it belongs there for the same reason the Maximize-button belongs there: it controls the contents of the viewport.
Same as each application window in Mac or Windows has both a maximize and minimize (=hide) button.

We could hide it behind a `…` menu at some point, if we get too many buttons there.
