### PR TITLE
Free up memory of inactive recordings

### DIFF
--- a/crates/viewer/re_dataframe_ui/tests/column_header_tooltips.rs
+++ b/crates/viewer/re_dataframe_ui/tests/column_header_tooltips.rs
@@ -69,7 +69,7 @@ fn test_column_header_tooltips() {
 
             harness.run();
             harness.snapshot_options(
-                &format!(
+                format!(
                     "header_tooltip_{description}{}",
                     if show_extras { "_with_extras" } else { "" }
                 ),

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -689,13 +689,13 @@ impl StoreHub {
     pub fn purge_fraction_of_ram(&mut self, fraction_to_purge: f32) {
         re_tracing::profile_function!();
 
+        for cache in self.caches_per_recording.values_mut() {
+            cache.purge_memory();
+        }
+
         let Some(store_id) = self.store_bundle.find_oldest_modified_recording() else {
             return;
         };
-
-        if let Some(caches) = self.caches_per_recording.get_mut(&store_id) {
-            caches.purge_memory();
-        }
 
         let store_bundle = &mut self.store_bundle;
 

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -820,11 +820,14 @@ impl StoreHub {
 
     /// See [`crate::Caches::begin_frame`].
     pub fn begin_frame_caches(&mut self) {
-        if let Some(store_id) = self.active_recording_id().cloned() {
-            if let Some(caches) = self.caches_per_recording.get_mut(&store_id) {
+        self.caches_per_recording.retain(|store_id, caches| {
+            if self.store_bundle.contains(store_id) {
                 caches.begin_frame();
+                true // keep caches for existing recordings
+            } else {
+                false // remove caches for recordings that no longer exist
             }
-        }
+        });
     }
 
     /// Persist any in-use blueprints to durable storage.


### PR DESCRIPTION
### Related
* Related to https://github.com/rerun-io/rerun/issues/10496
* Problems added in https://github.com/rerun-io/rerun/pull/7513

### What
When we want to free up memory, we forgot about caches for other recordings than the current one.
Similarly, each frame we maintain the caches by throwing out unnecessary parts of it, but again we only did it for the currently open recording.
This meant recordings that are "in the background" would still use up a lot of memory.
