### PR TITLE
Fix H.264 with b-frames not decoding last few frames on native

### DIFF
--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -194,8 +194,8 @@ struct FFmpegProcessAndListener {
 
     /// Number of samples submitted to ffmpeg that has not yet been outputted by ffmpeg.
     ///
-    /// This is a counter for debugging purposes only.
-    outstanding_frames: Arc<AtomicI32>,
+    /// This counter is for debugging purposes only.
+    num_outstanding_frames: Arc<AtomicI32>,
 
     /// If true, the write thread will not report errors. Used upon exit, so the write thread won't log spam on the hung up stdin.
     stdin_shutdown: Arc<AtomicBool>,
@@ -346,7 +346,7 @@ impl FFmpegProcessAndListener {
 
         Ok(Self {
             ffmpeg,
-            outstanding_frames,
+            num_outstanding_frames: outstanding_frames,
             frame_info_tx,
             frame_data_tx,
             listen_thread: Some(listen_thread),
@@ -379,7 +379,7 @@ impl FFmpegProcessAndListener {
                 },
             )
         } else {
-            self.outstanding_frames.fetch_add(1, Ordering::Relaxed);
+            self.num_outstanding_frames.fetch_add(1, Ordering::Relaxed);
 
             Ok(())
         }
@@ -450,7 +450,7 @@ impl Drop for FFmpegProcessAndListener {
 
         re_log::trace!(
             "Outstanding frames after shutting down ffmpeg: {}",
-            self.outstanding_frames.load(Ordering::Relaxed)
+            self.num_outstanding_frames.load(Ordering::Relaxed)
         );
     }
 }

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -558,7 +558,7 @@ impl FrameBuffer {
                 } else {
                     // This is the first frame we're receiving since the last decoder reset.
                     // We expect to always start at a sync-frame.
-                    // Sync frames should have DTS == PTS, therefore the first frame info should be correct.
+                    // Note that sync frames do _not_ imply DTS == PTS since DTS may start with a negative offset for some videos.
                     debug_assert!(
                         frame_info.is_sync,
                         "Expected first received frame after a decoder reset to be a sync-frame (start of group of pictures)."

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -193,6 +193,8 @@ struct FFmpegProcessAndListener {
     write_thread: Option<std::thread::JoinHandle<()>>,
 
     /// Number of samples submitted to ffmpeg that has not yet been outputted by ffmpeg.
+    ///
+    /// This is a counter for debugging purposes only.
     outstanding_frames: Arc<AtomicI32>,
 
     /// If true, the write thread will not report errors. Used upon exit, so the write thread won't log spam on the hung up stdin.
@@ -516,68 +518,66 @@ fn write_ffmpeg_input(
 struct FrameBuffer {
     /// Received frame-infos, waiting to be matched to output frames.
     ///
-    /// Sorted by their presentation timestamp.
-    pending: BTreeMap<Time, FFmpegFrameInfo>,
+    /// Sorted by their frame number.
+    pending: BTreeMap<u32, FFmpegFrameInfo>,
 
-    /// Hightess DTC (Decoder timestamp) encountered so far.
-    highest_dts: Time,
+    /// The frame number of the next frame if we had any so far.
+    next_frame_nr: Option<u32>,
 }
 
 impl FrameBuffer {
     fn new() -> Self {
         Self {
             pending: BTreeMap::new(),
-            highest_dts: Time::MIN,
+            next_frame_nr: None,
         }
     }
 
     fn on_frame(
         &mut self,
-        debug_name: &str,
         pixel_format: &PixelFormat,
         frame_info_rx: &Receiver<FFmpegFrameInfo>,
         frame: ffmpeg_sidecar::event::OutputVideoFrame,
     ) -> Option<Frame> {
+        // ffmpeg gives us raw images, but we have to pair them up with frame infos.
+        //
         // We input frames into ffmpeg in decode (DTS) order, and so that's
         // also the order we will receive the `FrameInfo`s from `frame_info_rx`.
+        //
         // However, `ffmpeg` will re-order the frames to output them in presentation (PTS) order.
         // We want to accurately match the `FrameInfo` with its corresponding output frame.
         // To do that, we need to buffer frames that come out of ffmpeg.
-        //
-        // How do we know how large this buffer needs to be?
-        // Whenever the highest known DTS is behind the PTS, we need to wait until the DTS catches up.
-        // Otherwise, we'd assign the wrong PTS to the frame that just came in.
         let frame_info = loop {
-            let oldest_pts_in_buffer = self.pending.first_key_value().map(|(pts, _)| *pts);
-            let is_caught_up = oldest_pts_in_buffer.is_some_and(|pts| pts <= self.highest_dts);
-            if is_caught_up {
-                // There must be an element here, otherwise we wouldn't be here.
-                #[expect(clippy::unwrap_used)]
-                break self.pending.pop_first().unwrap().1;
-            } else {
-                // We're behind:
+            let oldest_pending = self.pending.first_entry();
 
-                let Ok(frame_info) = frame_info_rx.try_recv() else {
-                    re_log::trace!("frame-tx channel closed, stopping ffmpeg decoder");
-                    return None;
+            if let Some(oldest_pending) = oldest_pending {
+                let frame_info = oldest_pending.get();
+
+                let is_next_expected_frame = if let Some(next_frame_nr) = self.next_frame_nr {
+                    frame_info.frame_nr == next_frame_nr
+                } else {
+                    // This is the first frame we're receiving since the last decoder reset.
+                    // We expect to always start at a sync-frame.
+                    // Sync frames should have DTS == PTS, therefore the first frame info should be correct.
+                    debug_assert!(
+                        frame_info.is_sync,
+                        "Expected first received frame after a decoder reset to be a sync-frame (start of group of pictures)."
+                    );
+                    true
                 };
 
-                // If the decode timestamp did not increase, we're probably seeking backwards!
-                // We'd expect the video player to do a reset prior to that and close the channel as part of that, but we may not have noticed that in here yet!
-                // In any case, we'll have to just run with this as the new highest timestamp, not much else we can do.
-                if self.highest_dts > frame_info.decode_timestamp {
-                    re_log::warn!(
-                        "Video decode timestamps are expected to monotonically increase unless there was a decoder reset.\n\
-                                It went from {:?} to {:?} for the decoder of {debug_name}. This is probably a bug in Rerun.",
-                        self.highest_dts,
-                        frame_info.decode_timestamp
-                    );
+                if is_next_expected_frame {
+                    self.next_frame_nr = Some(frame_info.frame_nr + 1);
+                    break oldest_pending.remove_entry().1;
                 }
-                self.highest_dts = frame_info.decode_timestamp;
+            };
 
-                self.pending
-                    .insert(frame_info.presentation_timestamp, frame_info);
-            }
+            // We haven't received the frame info for this frame yet.
+            let Ok(frame_info) = frame_info_rx.recv() else {
+                re_log::trace!("frame-tx channel closed, stopping ffmpeg decoder");
+                return None;
+            };
+            self.pending.insert(frame_info.frame_nr, frame_info);
         };
 
         let ffmpeg_sidecar::event::OutputVideoFrame {
@@ -729,8 +729,7 @@ fn read_ffmpeg_output(
 
                 let frame_num = ffmpeg_frame.frame_num; // sequence-number made up by ffmpeg sidecar.
 
-                let frame =
-                    buffer.on_frame(debug_name, pixel_format, frame_info_rx, ffmpeg_frame)?;
+                let frame = buffer.on_frame(pixel_format, frame_info_rx, ffmpeg_frame)?;
 
                 {
                     // Log

--- a/crates/viewer/re_view_spatial/tests/snapshots/video_asset_H264_beyond_end.png
+++ b/crates/viewer/re_view_spatial/tests/snapshots/video_asset_H264_beyond_end.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93f3c8310d9be9dcfa5a6d9c05b837c711ff5e4b61d55e4848c9e19b7b43bab6
+size 128091

--- a/crates/viewer/re_view_spatial/tests/video.rs
+++ b/crates/viewer/re_view_spatial/tests/video.rs
@@ -314,8 +314,11 @@ fn test_video(video_type: VideoType, codec: VideoCodec) {
         });
 
     for seek_location in VideoTestSeekLocation::ALL {
-        if codec == VideoCodec::H264 && seek_location == VideoTestSeekLocation::BeyondEnd {
-            // TODO(#8073): H264 decoder never finishes for the last few frames.
+        if codec == VideoCodec::H264
+            && seek_location == VideoTestSeekLocation::BeyondEnd
+            && video_type == VideoType::VideoStream
+        {
+            // TODO(#8073): H264 decoder never finishes for the last few frames for video streams.
             continue;
         }
 


### PR DESCRIPTION
### Related

* Closes almost #8073
    * technically this closes the original issue, but `VideoStream` still has still problem for incoming data as we never call `end_of_video` which for ffmpeg specifically means we never receive the last few frames. A follow-up PR will address those peculiarities

### What

The issue came down to problems in our frame-info to frame assignment: we get a stream of presentation frame data from ffmpeg without any metadata. Therefore, we have to figure out which frame belongs to which metadata.
We tried to account for DTS reordering by looking at the DTS/PTS relationship, but this turned out to be error prone since we falsely assumed that DTS catching up with PTS is the significant event for synchronization. However, by now we already have frame numbers in PTS order, so instead basing our assignment logic on that fixes the issue and has much simpler logic.

Tested with various H.264 videos on Windows & Mac