### PR TITLE
Fix `set_time_ctrl` not doing anything when called twice

### DIFF
--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -148,7 +148,7 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
     # Use `self.send` instead, events from which are handled in `on_custom_message` in `widget.ts`.
     # To expose it bi-directionally, add a Viewer event for it instead.
     # This makes the asynchronous communication between the Viewer and SDK more explicit, leading to fewer surprises.
-    # 
+    #
     # Example: `set_time_ctrl` uses `self.send`, and the state of the timeline is exposed via Viewer events.
 
     _width = traitlets.Int(allow_none=True).tag(sync=True)
@@ -256,10 +256,10 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
         self._panel_states = new_panel_states
 
     def set_time_ctrl(self, timeline: str | None, time: int | None, play: bool) -> None:
-        self.send({"type":"time_ctrl", "timeline":timeline, "time":time, "play":play})
+        self.send({"type": "time_ctrl", "timeline": timeline, "time": time, "play": play})
 
     def set_active_recording(self, recording_id: str) -> None:
-        self.send({"type":"recording_id", "recording_id":recording_id})
+        self.send({"type": "recording_id", "recording_id": recording_id})
 
     def _on_raw_event(self, callback: Callable[[str], None]) -> None:
         """Register a set of callbacks with this instance of the Viewer."""


### PR DESCRIPTION
To repro the original issue on `main`:
1. call `viewer.set_time_ctrl`
2. move the time cursor in the viewer somewhere else
3. call `viewer_set_time_ctrl` again with _the same arguments_ (same time/timeline)

(3) would not adjust the time cursor like in step (1). This is due to `_time_ctrl` being _stateful_, but not bidirectionally synchronized between the Viewer and SDK. Moving the time cursor doesn't update the `_time_ctrl` value back in Python land, and so the `_time_ctrl` value in (3) isn't changed from (1), resulting in no state update for the Viewer.

For these kinds of things it makes more sense to use custom messages for SDK->Viewer uni-directional things. For Viewer->SDK, we have events exposed for timeline state, which are correctly fired whenever a user input in the Viewer results in the state changing.