### PR TITLE
Dynamically Set Active Partition URL and Select Time Window

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,8 +11,10 @@ extend-exclude = [
   "rerun_cpp/src/rerun/archetypes/image.hpp",     # TODO(emilk): remove once we remove from_greyscale8
   "rerun_cpp/src/rerun/archetypes/image_ext.cpp", # TODO(emilk): remove once we remove from_greyscale8
   "rerun_cpp/src/rerun/third_party/cxxopts.hpp",
+  "*.png",
+  "*.mp4",
+  "*.rrd",
 ]
-
 
 [default.extend-words]
 lod = "lod"     # level-of-detail

--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -780,7 +780,7 @@ impl QuotedObject {
         //   -> this means that there's no non-move constructors/assignments
         // * we really want to make sure that the object is movable, therefore creating a move ctor
         //   -> this means that there's no implicit move assignment.
-        // Therefore, we have to define all five move/copy  constructors/assignments.
+        // Therefore, we have to define all five move/copy constructors/assignments.
         let hpp = quote! {
             #hpp_includes
 

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -396,7 +396,7 @@ export class WebViewer {
   // NOTE: Callbacks passed to this function must NOT invoke any viewer methods!
   //       The `setTimeout` is omitted to avoid the 1-tick delay, as it is unnecessary,
   //       because this is only meant to be used for sending events to Jupyter/Gradio.
-  // 
+  //
   // Do not change this without searching for grepping for usage!
   private _on_raw_event(callback: (event: string) => void): () => void {
     this.#_raw_events.add(callback);

--- a/rerun_notebook/src/js/widget.ts
+++ b/rerun_notebook/src/js/widget.ts
@@ -20,8 +20,6 @@ interface WidgetModel {
 
   _url?: string;
   _panel_states?: PanelStates;
-  _time_ctrl: [timeline: string | null, time: number | null, play: boolean];
-  _recording_id?: string;
 
   _fallback_token?: string;
 }
@@ -38,7 +36,6 @@ class ViewerWidget {
 
   constructor(model: AnyModel<WidgetModel>) {
     this.url = model.get("_url");
-    model.on("change:_url", this.on_change_url);
 
     this.panel_states = model.get("_panel_states");
     model.on("change:_panel_states", this.on_change_panel_states);
@@ -104,12 +101,6 @@ class ViewerWidget {
     }
   };
 
-  on_change_url = (_: unknown, new_url?: Opt<string>) => {
-    if (this.url) this.viewer.close(this.url);
-    if (new_url) this.viewer.open(new_url);
-    this.url = new_url;
-  };
-
   on_change_panel_states = (
     _: unknown,
     new_panel_states?: Opt<PanelStates>,
@@ -141,6 +132,10 @@ class ViewerWidget {
       }
       case "recording_id": {
         this.set_recording_id(msg.recording_id ?? null)
+        break;
+      }
+      case "partition_url": {
+        this.set_partition_url(msg.partition_url ?? null)
         break;
       }
       default: {
@@ -188,7 +183,15 @@ class ViewerWidget {
 
     this.viewer.set_active_recording_id(recording_id);
   };
+
+  set_partition_url(partition_url: string | null){
+    if (this.url) this.viewer.close(this.url);
+    if (partition_url) this.viewer.open(partition_url);
+    this.url = partition_url;
+  };
 }
+
+
 
 const render: Render<WidgetModel> = ({ model, el }) => {
   el.classList.add("rerun_notebook");
@@ -212,5 +215,6 @@ function error_boundary<Fn extends (...args: any[]) => any>(f: Fn): Fn {
 
   return wrapper as any;
 }
+
 
 export default { render: error_boundary(render) };

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -261,8 +261,8 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
     def set_active_recording(self, recording_id: str) -> None:
         self.send({"type": "recording_id", "recording_id": recording_id})
 
-    def set_active_partition_uri(self, partition_uri: str) -> None:
-        self._partition_uri = partition_uri
+    def set_active_partition_url(self, partition_url: str) -> None:
+        self._partition_url = partition_url
 
     def _on_raw_event(self, callback: Callable[[str], None]) -> None:
         """Register a set of callbacks with this instance of the Viewer."""

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -261,6 +261,9 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
     def set_active_recording(self, recording_id: str) -> None:
         self.send({"type": "recording_id", "recording_id": recording_id})
 
+    def set_active_partition_uri(self, partition_uri: str) -> None:
+        self._partition_uri = partition_uri
+
     def _on_raw_event(self, callback: Callable[[str], None]) -> None:
         """Register a set of callbacks with this instance of the Viewer."""
         # TODO(jan): maybe allow unregister by making this a map instead

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -154,6 +154,8 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
     _width = traitlets.Int(allow_none=True).tag(sync=True)
     _height = traitlets.Int(allow_none=True).tag(sync=True)
 
+    # TODO(nick): This traitlet is only used for initialization
+    # we should figure out how to pass directly and remove it
     _url = traitlets.Unicode(allow_none=True).tag(sync=True)
 
     _panel_states = traitlets.Dict(
@@ -262,7 +264,7 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
         self.send({"type": "recording_id", "recording_id": recording_id})
 
     def set_active_partition_url(self, url: str) -> None:
-        self._partition_url = url
+        self.send({"type": "partition_url", "partition_url": url})
 
     def _on_raw_event(self, callback: Callable[[str], None]) -> None:
         """Register a set of callbacks with this instance of the Viewer."""

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -261,8 +261,8 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
     def set_active_recording(self, recording_id: str) -> None:
         self.send({"type": "recording_id", "recording_id": recording_id})
 
-    def set_active_partition_url(self, partition_url: str) -> None:
-        self._partition_url = partition_url
+    def set_active_partition_url(self, url: str) -> None:
+        self._partition_url = url
 
     def _on_raw_event(self, callback: Callable[[str], None]) -> None:
         """Register a set of callbacks with this instance of the Viewer."""

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1211,7 +1211,6 @@ class DatasetEntry(Entry):
             The start time for the partition.
             Integer for ticks, or datetime/nanoseconds for timestamps.
 
-
         end: int | datetime | None
             The end time for the partition.
             Integer for ticks, or datetime/nanoseconds for timestamps.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -606,7 +606,7 @@ def load_archive(path_to_rrd: str | os.PathLike[str]) -> RRDArchive:
     """
 
 # AI generated stubs for `PyRecordingStream` related class and functions
-# TODO(#9187): this will be entirely replaced with `RecordingStream` is qitself written in Rust
+# TODO(#9187): this will be entirely replaced when `RecordingStream` is itself written in Rust
 class PyRecordingStream:
     def is_forked_child(self) -> bool:
         """

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -606,8 +606,7 @@ def load_archive(path_to_rrd: str | os.PathLike[str]) -> RRDArchive:
     """
 
 # AI generated stubs for `PyRecordingStream` related class and functions
-# TODO(#9187): this will be entirely replaced with `RecordingStream` is itself written in Rust
-
+# TODO(#9187): this will be entirely replaced with `RecordingStream` is qitself written in Rust
 class PyRecordingStream:
     def is_forked_child(self) -> bool:
         """
@@ -1190,8 +1189,49 @@ class DatasetEntry(Entry):
     def partition_table(self) -> DataFusionTable:
         """Return the partition table as a Datafusion table provider."""
 
-    def partition_url(self, partition_id: str) -> str:
-        """Return the URL for the given partition."""
+    def partition_url(
+        self,
+        partition_id: str,
+        timeline: str | None = None,
+        start: datetime | int | None = None,
+        end: datetime | int | None = None,
+    ) -> str:
+        """
+        Return the URL for the given partition.
+
+        Parameters
+        ----------
+        partition_id: str
+            The ID of the partition to get the URL for.
+
+        timeline: str | None
+            The name of the timeline to display.
+
+        start: int | datetime | None
+            The start time for the partition.
+            Integer for ticks, or datetime/nanoseconds for timestamps.
+
+
+        end: int | datetime | None
+            The end time for the partition.
+            Integer for ticks, or datetime/nanoseconds for timestamps.
+
+        Examples
+        --------
+        # With ticks
+        >>> start_tick, end_time = 0, 10
+        >>> dataset.partition_url("some_id", "log_tick", start_tick, end_time)
+
+        # With timestamps
+        >>> start_time, end_time = datetime.now() - timedelta(seconds=4), datetime.now()
+        >>> dataset.partition_url("some_id", "real_time", start_time, end_time)
+
+        Returns
+        -------
+        str
+            The URL for the given partition.
+
+        """
 
     def register(self, recording_uri: str, timeout_secs: int = 60) -> str:
         """

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -363,7 +363,7 @@ class Viewer:
     def set_active_partition_url(
         self,
         *,
-        partition_url: str,
+        url: str,
     ) -> None:
         """
         Set the active partition url for the viewer.
@@ -372,12 +372,12 @@ class Viewer:
 
         Parameters
         ----------
-        partition_url: str
+        url: str
             The URL of the partition to set the viewer to.
 
         """
 
-        self._viewer.set_active_partition_url(partition_url)
+        self._viewer.set_active_partition_url(url)
 
     @deprecated_param("nanoseconds", use_instead="duration or timestamp", since="0.23.0")
     @deprecated_param("seconds", use_instead="duration or timestamp", since="0.23.0")

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -368,8 +368,6 @@ class Viewer:
         """
         Set the active partition url for the viewer.
 
-        This is equivalent to clicking on the partition in the dataset table.
-
         Parameters
         ----------
         url: str

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -360,6 +360,25 @@ class Viewer:
 
         self._viewer.set_active_recording(recording_id)
 
+    def set_active_partition_uri(
+        self,
+        *,
+        partition_uri: str,
+    ) -> None:
+        """
+        Set the active partition uri for the viewer.
+
+        This is equivalent to clicking on the partition in the dataset table.
+
+        Parameters
+        ----------
+        partition_uri: str
+            The URI of the partition to set the viewer to.
+
+        """
+
+        self._viewer.set_active_recording(recording_id)
+
     @deprecated_param("nanoseconds", use_instead="duration or timestamp", since="0.23.0")
     @deprecated_param("seconds", use_instead="duration or timestamp", since="0.23.0")
     def set_time_ctrl(

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -360,24 +360,24 @@ class Viewer:
 
         self._viewer.set_active_recording(recording_id)
 
-    def set_active_partition_uri(
+    def set_active_partition_url(
         self,
         *,
-        partition_uri: str,
+        partition_url: str,
     ) -> None:
         """
-        Set the active partition uri for the viewer.
+        Set the active partition url for the viewer.
 
         This is equivalent to clicking on the partition in the dataset table.
 
         Parameters
         ----------
-        partition_uri: str
-            The URI of the partition to set the viewer to.
+        partition_url: str
+            The URL of the partition to set the viewer to.
 
         """
 
-        self._viewer.set_active_recording(recording_id)
+        self._viewer.set_active_partition_url(partition_url)
 
     @deprecated_param("nanoseconds", use_instead="duration or timestamp", since="0.23.0")
     @deprecated_param("seconds", use_instead="duration or timestamp", since="0.23.0")

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -163,7 +163,40 @@ impl PyDatasetEntry {
         })
     }
 
-    /// Return the URL for the given partition.
+    // Return the URL for the given partition.
+    //
+    // Parameters
+    // ----------
+    // partition_id: str
+    //     The ID of the partition to get the URL for.
+    //
+    // timeline: str | None
+    //     The name of the timeline to display.
+    //
+    // start: int | datetime | None
+    //     The start time for the partition.
+    //     Integer for ticks, or datetime/nanoseconds for timestamps.
+    //
+    // end: int | datetime | None
+    //     The end time for the partition.
+    //     Integer for ticks, or datetime/nanoseconds for timestamps.
+    //
+    // Examples
+    // --------
+    // # With ticks
+    // >>> start_tick, end_time = 0, 10
+    // >>> dataset.partition_url("some_id", "log_tick", start_tick, end_time)
+    //
+    // # With timestamps
+    // >>> start_time, end_time = datetime.now() - timedelta(seconds=4), datetime.now()
+    // >>> dataset.partition_url("some_id", "real_time", start_time, end_time)
+    //
+    // Returns
+    // -------
+    // str
+    //     The URL for the given partition.
+    //
+    //
     #[pyo3(signature = (partition_id, timeline=None, start=None, end=None))]
     fn partition_url(
         self_: PyRef<'_, Self>,

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -163,40 +163,39 @@ impl PyDatasetEntry {
         })
     }
 
-    // Return the URL for the given partition.
-    //
-    // Parameters
-    // ----------
-    // partition_id: str
-    //     The ID of the partition to get the URL for.
-    //
-    // timeline: str | None
-    //     The name of the timeline to display.
-    //
-    // start: int | datetime | None
-    //     The start time for the partition.
-    //     Integer for ticks, or datetime/nanoseconds for timestamps.
-    //
-    // end: int | datetime | None
-    //     The end time for the partition.
-    //     Integer for ticks, or datetime/nanoseconds for timestamps.
-    //
-    // Examples
-    // --------
-    // # With ticks
-    // >>> start_tick, end_time = 0, 10
-    // >>> dataset.partition_url("some_id", "log_tick", start_tick, end_time)
-    //
-    // # With timestamps
-    // >>> start_time, end_time = datetime.now() - timedelta(seconds=4), datetime.now()
-    // >>> dataset.partition_url("some_id", "real_time", start_time, end_time)
-    //
-    // Returns
-    // -------
-    // str
-    //     The URL for the given partition.
-    //
-    //
+    /// Return the URL for the given partition.
+    ///
+    /// Parameters
+    /// ----------
+    /// partition_id: str
+    ///     The ID of the partition to get the URL for.
+    ///
+    /// timeline: str | None
+    ///     The name of the timeline to display.
+    ///
+    /// start: int | datetime | None
+    ///     The start time for the partition.
+    ///     Integer for ticks, or datetime/nanoseconds for timestamps.
+    ///
+    /// end: int | datetime | None
+    ///     The end time for the partition.
+    ///     Integer for ticks, or datetime/nanoseconds for timestamps.
+    ///
+    /// Examples
+    /// --------
+    /// # With ticks
+    /// >>> start_tick, end_time = 0, 10
+    /// >>> dataset.partition_url("some_id", "log_tick", start_tick, end_time)
+    ///
+    /// # With timestamps
+    /// >>> start_time, end_time = datetime.now() - timedelta(seconds=4), datetime.now()
+    /// >>> dataset.partition_url("some_id", "real_time", start_time, end_time)
+    ///
+    /// Returns
+    /// -------
+    /// str
+    ///     The URL for the given partition.
+    ///
     #[pyo3(signature = (partition_id, timeline=None, start=None, end=None))]
     fn partition_url(
         self_: PyRef<'_, Self>,

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -3,8 +3,11 @@ use std::sync::Arc;
 use arrow::array::{RecordBatch, StringArray};
 use arrow::datatypes::{Field, Schema as ArrowSchema};
 use arrow::pyarrow::PyArrowType;
+use pyo3::Bound;
+use pyo3::types::PyAnyMethods;
 use pyo3::{
-    Py, PyAny, PyRef, PyRefMut, PyResult, Python, exceptions::PyRuntimeError, pyclass, pymethods,
+    Py, PyAny, PyRef, PyRefMut, PyResult, Python, exceptions::PyRuntimeError,
+    exceptions::PyValueError, pyclass, pymethods,
 };
 use tokio_stream::StreamExt as _;
 use tracing::instrument;
@@ -161,20 +164,55 @@ impl PyDatasetEntry {
     }
 
     /// Return the URL for the given partition.
-    fn partition_url(self_: PyRef<'_, Self>, partition_id: String) -> String {
+    #[pyo3(signature = (partition_id, timeline=None, start=None, end=None))]
+    fn partition_url(
+        self_: PyRef<'_, Self>,
+        py: Python<'_>,
+        partition_id: String,
+        timeline: Option<&str>,
+        start: Option<Bound<'_, PyAny>>,
+        end: Option<Bound<'_, PyAny>>,
+    ) -> PyResult<String> {
         let super_ = self_.as_super();
         let connection = super_.client.borrow(self_.py()).connection().clone();
 
-        re_uri::DatasetDataUri {
+        // Timeline with default name and no limits overrides blueprint timeline settings
+        // only override if timeline is selected
+        if timeline.is_none() && (start.is_some() || end.is_some()) {
+            return Err(PyValueError::new_err(
+                "If `start` or `end` is specified, `timeline` must also be specified.",
+            ));
+        }
+
+        // Convert Python objects to i64
+        let start_i64 = start
+            .as_ref()
+            .map(|s| py_object_to_i64(py, s))
+            .transpose()?;
+        let end_i64 = end.as_ref().map(|e| py_object_to_i64(py, e)).transpose()?;
+
+        let time_range: Option<re_uri::TimeRange> = match timeline {
+            Some(name) => Some(re_uri::TimeRange {
+                timeline: re_chunk::Timeline::new_timestamp(name),
+                min: start_i64
+                    .map(|start| start.try_into().expect("start time must be valid"))
+                    .unwrap_or(re_log_types::NonMinI64::MIN),
+                max: end_i64
+                    .map(|end| end.try_into().expect("end time must be valid"))
+                    .unwrap_or(re_log_types::NonMinI64::MAX),
+            }),
+            None => None,
+        };
+        Ok(re_uri::DatasetDataUri {
             origin: connection.origin().clone(),
             dataset_id: super_.details.id.id,
             partition_id,
 
-            //TODO(ab): add support for these two
-            time_range: None,
+            time_range: time_range,
+            //TODO(ab): add support for this
             fragment: Default::default(),
         }
-        .to_string()
+        .to_string())
     }
 
     /// Register a RRD URI to the dataset and wait for completion.
@@ -666,4 +704,43 @@ impl PyDatasetEntry {
             Ok(PySchema { schema })
         })
     }
+}
+
+/// Helper function to convert a Python object to i64.
+///
+/// This function attempts to convert various Python types to i64, including:
+/// - Python int
+/// - numpy datetime64 (via timestamp conversion)
+/// - Any object with an `__int__` method
+/// - Any object that can be converted to int via Python's int() function
+fn py_object_to_i64(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<i64> {
+    // First try direct extraction as i64
+    if let Ok(value) = obj.extract::<i64>() {
+        return Ok(value);
+    }
+
+    // Try to extract as Python int first
+    if let Ok(value) = obj.extract::<i32>() {
+        return Ok(value as i64);
+    }
+
+    // Check if it's a numpy datetime64 and try to get timestamp
+    if obj.hasattr("timestamp")? {
+        let timestamp = obj.call_method0("timestamp")?;
+        if let Ok(ts_float) = timestamp.extract::<f64>() {
+            // Convert seconds to nanoseconds (assuming timestamp is in seconds)
+            return Ok((ts_float * 1_000_000_000.0) as i64);
+        }
+    }
+
+    // Try calling __int__ method if it exists
+    if obj.hasattr("__int__")? {
+        let int_result = obj.call_method0("__int__")?;
+        return int_result.extract::<i64>();
+    }
+
+    // As a last resort, try to convert via Python's int() function
+    let int_builtin = py.import("builtins")?.getattr("int")?;
+    let converted = int_builtin.call1((obj,))?;
+    converted.extract::<i64>()
 }

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1257,7 +1257,7 @@ def main() -> None:
                 num_errors += lint_file(filepath, args)
     else:
         for root, dirs, files in os.walk(".", topdown=True):
-            dirs[:] = [d for d in dirs if not should_ignore(d)]
+            dirs[:] = [d for d in dirs if not should_ignore(os.path.join(root, d))]
 
             for filename in files:
                 extension = filename.split(".")[-1]


### PR DESCRIPTION
### What
1. This adds a public method `set_active_partition_url` on the viewer aligned with `set_active_recording_id` to dynamically toggle that
2. This updates `dataset.partition_url` to take in arguments that can constrain the observed time window
3. This fixes a variety of paper cuts related to `pixi run fast-lint` apparently linux users haven't seen these issues even though I think they are actual bugs