### PR TITLE
Fix deadlock while preserving recording isolation

### DIFF
--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -816,11 +816,7 @@ impl RecordingStream {
     pub fn ref_count(&self) -> usize {
         match &self.inner {
             Either::Left(strong) => Arc::strong_count(strong),
-            Either::Right(weak) => weak
-                .upgrade()
-                .map_or(0, |this: Arc<Option<RecordingStreamInner>>| {
-                    Arc::strong_count(&this)
-                }),
+            Either::Right(weak) => weak.strong_count(),
         }
     }
 }

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -811,6 +811,18 @@ impl RecordingStream {
             },
         }
     }
+
+    /// Returns the current reference count of the [`RecordingStream`].
+    pub fn ref_count(&self) -> usize {
+        match &self.inner {
+            Either::Left(strong) => Arc::strong_count(strong),
+            Either::Right(weak) => weak
+                .upgrade()
+                .map_or(0, |this: Arc<Option<RecordingStreamInner>>| {
+                    Arc::strong_count(&this)
+                }),
+        }
+    }
 }
 
 // TODO(#5335): shutdown flushing behavior is too brittle.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -654,6 +654,9 @@ class PyBinarySinkStorage:
 # init
 #
 
+def flush_and_cleanup_orphaned_recordings() -> None:
+    """Flush and then cleanup any orphaned recordings."""
+
 def new_recording(
     application_id: str,
     recording_id: Optional[str] = None,

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -311,14 +311,14 @@ def init(
     if strict is not None:
         set_strict_mode(strict)
 
+    # Always check whether we are a forked child when calling init. This should have happened
+    # via `_register_on_fork` but it's worth being conservative.
+    cleanup_if_forked_child()
+
     # Rerun is being re-initialized. We may have recordings from a previous call to init that are lingering.
     # Clean them up now to avoid memory leaks. This could cause a problem if we call rr.init() from inside a
     # destructor during shutdown, but that seems like a fair compromise.
     bindings.flush_and_cleanup_orphaned_recordings()
-
-    # Always check whether we are a forked child when calling init. This should have happened
-    # via `_register_on_fork` but it's worth being conservative.
-    cleanup_if_forked_child()
 
     if recording_id is not None:
         recording_id = str(recording_id)

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -229,8 +229,9 @@ def init(
 
     For more advanced use cases, e.g. multiple recordings setups, see [`rerun.RecordingStream`][].
 
-    To deal with accumulation of recording state on re-initialization, this function will
-    have the side-effect of flushing all existing recordings and cleaning up any orphaned global recordings.
+    To deal with accumulation of recording state when calling init() multiple times, this function will
+    have the side-effect of flushing all existing recordings. After flushing, any recordings which
+    are otherwise orphaned will also be destructed to free resources, close open file-descriptors, etc.
 
     !!! Warning
         If you don't specify a `recording_id`, it will default to a random value that is generated once

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -280,19 +280,6 @@ fn new_recording(
         default_store_id(py, StoreKind::Recording, &application_id)
     };
 
-    // NOTE: The Rust-side of the bindings must be in control of the lifetimes of the recordings!
-    // Check if recording already exists first.
-    // NOTE: This is scoped in order to release the Mutex locked by `all_recordings` as soon as possible
-    /*
-    if let Some(existing_recording) = all_recordings().get(&recording_id) {
-        utils::py_rerun_warn(
-            format!("Recording with id: {} already exists, will ignore creation and return existing recording.",
-            &recording_id).as_str()
-        )?;
-        return Ok(PyRecordingStream(existing_recording.clone()));
-    }
-    */
-
     let mut batcher_config = re_chunk::ChunkBatcherConfig::from_env().unwrap_or_default();
     let on_release = |chunk| {
         GARBAGE_QUEUE.0.send(chunk).ok();

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -3,9 +3,9 @@
 #![allow(clippy::too_many_arguments)] // We used named arguments, so this is fine
 #![allow(unsafe_op_in_unsafe_fn)] // False positive due to #[pyfunction] macro
 
+use std::borrow::Borrow as _;
 use std::io::IsTerminal as _;
 use std::path::PathBuf;
-use std::{borrow::Borrow as _, collections::HashMap};
 
 use arrow::array::RecordBatch as ArrowRecordBatch;
 use itertools::Itertools as _;
@@ -16,7 +16,6 @@ use pyo3::{
 };
 use re_sdk::ComponentDescriptor;
 
-use super::utils;
 use re_log::ResultExt as _;
 use re_log_types::LogMsg;
 use re_log_types::{BlueprintActivationCommand, EntityPathPart, StoreKind};
@@ -52,9 +51,8 @@ use crate::dataframe::PyRecording;
 // Python GC is doing, which obviously leads to very bad things :tm:.
 //
 // TODO(#2116): drop unused recordings
-fn all_recordings() -> parking_lot::MutexGuard<'static, HashMap<StoreId, RecordingStream>> {
-    static ALL_RECORDINGS: OnceCell<parking_lot::Mutex<HashMap<StoreId, RecordingStream>>> =
-        OnceCell::new();
+fn all_recordings() -> parking_lot::MutexGuard<'static, Vec<RecordingStream>> {
+    static ALL_RECORDINGS: OnceCell<parking_lot::Mutex<Vec<RecordingStream>>> = OnceCell::new();
     ALL_RECORDINGS.get_or_init(Default::default).lock()
 }
 
@@ -285,6 +283,7 @@ fn new_recording(
     // NOTE: The Rust-side of the bindings must be in control of the lifetimes of the recordings!
     // Check if recording already exists first.
     // NOTE: This is scoped in order to release the Mutex locked by `all_recordings` as soon as possible
+    /*
     if let Some(existing_recording) = all_recordings().get(&recording_id) {
         utils::py_rerun_warn(
             format!("Recording with id: {} already exists, will ignore creation and return existing recording.",
@@ -292,6 +291,7 @@ fn new_recording(
         )?;
         return Ok(PyRecordingStream(existing_recording.clone()));
     }
+    */
 
     let mut batcher_config = re_chunk::ChunkBatcherConfig::from_env().unwrap_or_default();
     let on_release = |chunk| {
@@ -322,7 +322,7 @@ fn new_recording(
     }
 
     // NOTE: The Rust-side of the bindings must be in control of the lifetimes of the recordings!
-    all_recordings().insert(recording_id, recording.clone());
+    all_recordings().push(recording.clone());
 
     Ok(PyRecordingStream(recording))
 }
@@ -375,7 +375,7 @@ fn new_blueprint(
     }
 
     // NOTE: The Rust-side of the bindings must be in control of the lifetimes of the recordings!
-    all_recordings().insert(blueprint_id, blueprint.clone());
+    all_recordings().push(blueprint.clone());
 
     Ok(PyRecordingStream(blueprint))
 }
@@ -397,7 +397,7 @@ fn shutdown(py: Python<'_>) {
         // Calling `disconnect()` will already take care of flushing everything that can be flushed,
         // and cleaning up everything that can be safely cleaned up, anyhow.
         // Whatever's left can wait for the OS to clean it up.
-        for (_, recording) in all_recordings().iter() {
+        for recording in all_recordings().iter() {
             recording.disconnect();
         }
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -253,7 +253,7 @@ fn rerun_bindings(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 // --- Init ---
-/// Flush and then cleanup any orphaned recordings
+/// Flush and then cleanup any orphaned recordings.
 #[pyfunction]
 fn flush_and_cleanup_orphaned_recordings(py: Python<'_>) {
     // Start by clearing the current global data recording. Otherwise this holds

--- a/rerun_py/src/utils.rs
+++ b/rerun_py/src/utils.rs
@@ -43,6 +43,7 @@ pub fn py_rerun_warn_cstr(msg: &std::ffi::CStr) -> PyResult<()> {
 }
 
 /// Logs a warning using rerun logging system and issues the warning to python runtime.
+#[allow(dead_code)]
 pub fn py_rerun_warn(msg: &str) -> PyResult<()> {
     let cmsg = CString::new(msg)?;
     py_rerun_warn_cstr(&cmsg)

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -60,17 +60,12 @@ def test_init_twice() -> None:
     # Using default recording id
     rr.init("rerun_example_test_app_id")
     recording_id = rr.get_recording_id()
-    expect_warning(
-        lambda: rr.init("rerun_example_test_app_id"),
-        f"Recording with id: {recording_id} already exists, will ignore creation and return existing recording.",
-    )
+
+    rr.init("rerun_example_test_app_id")
     assert recording_id == rr.get_recording_id()
 
     # Using a custom recording id
     recording_id = "test_recording_id"
     rr.init("rerun_example_test_app_id", recording_id=recording_id)
-    expect_warning(
-        lambda: rr.init("rerun_example_test_app_id", recording_id=recording_id),
-        f"Recording with id: {recording_id} already exists, will ignore creation and return existing recording.",
-    )
+    rr.init("rerun_example_test_app_id", recording_id=recording_id)
     assert recording_id == rr.get_recording_id()

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-import rerun as rr
 from rerun.error_utils import RerunWarning
+
+import rerun as rr
 
 rr.init("rerun_example_exceptions", spawn=False)
 # Make sure strict mode isn't leaking in from another context
@@ -50,22 +51,3 @@ def test_expected_warnings() -> None:
         lambda: rr.log("world/image", rr.Pinhole(focal_length=3)),
         "Must provide one of principal_point, resolution, or width/height)",
     )
-
-
-def test_init_twice() -> None:
-    """Regression test for #9948: creating the same recording twice caused hangs in the past (should instead warn)."""
-    # Always set strict mode to false in case it leaked from another test
-    rr.set_strict_mode(False)
-
-    # Using default recording id
-    rr.init("rerun_example_test_app_id")
-    recording_id = rr.get_recording_id()
-
-    rr.init("rerun_example_test_app_id")
-    assert recording_id == rr.get_recording_id()
-
-    # Using a custom recording id
-    recording_id = "test_recording_id"
-    rr.init("rerun_example_test_app_id", recording_id=recording_id)
-    rr.init("rerun_example_test_app_id", recording_id=recording_id)
-    assert recording_id == rr.get_recording_id()

--- a/rerun_py/tests/unit/test_expected_warnings.py
+++ b/rerun_py/tests/unit/test_expected_warnings.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
-from rerun.error_utils import RerunWarning
-
 import rerun as rr
+from rerun.error_utils import RerunWarning
 
 rr.init("rerun_example_exceptions", spawn=False)
 # Make sure strict mode isn't leaking in from another context

--- a/rerun_py/tests/unit/test_multi_stream.py
+++ b/rerun_py/tests/unit/test_multi_stream.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import tempfile
+
+import rerun as rr
+
+
+def test_isolated_streams() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rec1_path = f"{tmpdir}/rec1.rrd"
+        rec2_path = f"{tmpdir}/rec2.rrd"
+
+        rec1 = rr.RecordingStream("rerun_example")
+        rec1.log("/data1", rr.TextLog("Data1"))
+        rec1.save(rec1_path)
+
+        rec2 = rr.RecordingStream("rerun_example")
+        rec2.log("/data2", rr.TextLog("Data2"))
+        rec2.save(rec2_path)
+
+        rec1_data = rr.dataframe.load_recording(rec1_path)
+        rec2_data = rr.dataframe.load_recording(rec2_path)
+
+        assert rec1_data.view(index="log_tick", contents="/data1").select().read_all().num_rows == 1
+        assert rec2_data.view(index="log_tick", contents="/data2").select().read_all().num_rows == 1

--- a/rerun_py/tests/unit/test_multi_stream.py
+++ b/rerun_py/tests/unit/test_multi_stream.py
@@ -5,6 +5,25 @@ import tempfile
 import rerun as rr
 
 
+def test_init_twice() -> None:
+    """Regression test for #9948: creating the same recording twice caused hangs in the past (should instead warn)."""
+    # Always set strict mode to false in case it leaked from another test
+    rr.set_strict_mode(False)
+
+    # Using default recording id
+    rr.init("rerun_example_test_app_id")
+    recording_id = rr.get_recording_id()
+
+    rr.init("rerun_example_test_app_id")
+    assert recording_id == rr.get_recording_id()
+
+    # Using a custom recording id
+    recording_id = "test_recording_id"
+    rr.init("rerun_example_test_app_id", recording_id=recording_id)
+    rr.init("rerun_example_test_app_id", recording_id=recording_id)
+    assert recording_id == rr.get_recording_id()
+
+
 def test_isolated_streams() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         rec1_path = f"{tmpdir}/rec1.rrd"

--- a/rerun_py/tests/unit/test_multi_stream.py
+++ b/rerun_py/tests/unit/test_multi_stream.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import platform
 import tempfile
 
 import rerun as rr
-import platform
 
 
 def test_init_twice() -> None:
@@ -53,7 +53,7 @@ def test_cleanup_reinit() -> None:
         def is_file_open(file_path: str) -> bool:
             file_path = os.path.realpath(file_path)
 
-            fd_dir = f"/proc/self/fd"
+            fd_dir = "/proc/self/fd"
             if not os.path.isdir(fd_dir):
                 return False  # Only works on platforms with /proc
 

--- a/rerun_py/tests/unit/test_multi_stream.py
+++ b/rerun_py/tests/unit/test_multi_stream.py
@@ -29,11 +29,11 @@ def test_isolated_streams() -> None:
         rec1_path = f"{tmpdir}/rec1.rrd"
         rec2_path = f"{tmpdir}/rec2.rrd"
 
-        rec1 = rr.RecordingStream("rerun_example")
+        rec1 = rr.RecordingStream("rerun_example_multi_stream")
         rec1.log("/data1", rr.TextLog("Data1"))
         rec1.save(rec1_path)
 
-        rec2 = rr.RecordingStream("rerun_example")
+        rec2 = rr.RecordingStream("rerun_example_multi_stream")
         rec2.log("/data2", rr.TextLog("Data2"))
         rec2.save(rec2_path)
 


### PR DESCRIPTION
### Related

- Resoles: https://github.com/rerun-io/rerun/issues/10562
- Resolves: https://github.com/rerun-io/rerun/issues/10561
- While fixing the dead-lock originally addressed in: https://github.com/rerun-io/rerun/pull/10201

### Also
In order to preserve backwards compatibility in environments where `rr.init()` was depended upon to clean up existing resources semi-deterministically due to creation of a new stream, this now does a cleanup sweep of any recordings that only exist in the all_recordings list.