### PR TITLE
Add a 'copy entry url' button next to the name of remote datasets and table

### DIFF
--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -84,7 +84,6 @@ impl Dataset {
 pub struct Table {
     pub table_entry: TableEntry,
 
-    #[expect(dead_code)]
     pub origin: re_uri::Origin,
 }
 

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -207,6 +207,7 @@ impl Server {
             dataset.name(),
         )
         .title(dataset.name())
+        .url(re_uri::EntryUri::new(dataset.origin.clone(), dataset.id()).to_string())
         .column_blueprint(|desc| {
             let mut name = default_display_name_for_column(desc);
 
@@ -264,6 +265,7 @@ impl Server {
             table.name(),
         )
         .title(table.name())
+        .url(re_uri::EntryUri::new(table.origin.clone(), table.id()).to_string())
         .show(viewer_ctx, &self.runtime, ui);
     }
 


### PR DESCRIPTION
### What

Basically this:

<img width="763" alt="image" src="https://github.com/user-attachments/assets/b0fc619a-065b-4eaf-87d4-705f7c32ae4d" />

<br/><br/>
TODO (maybe in another PR): use a better icon, e.g. the small chain links thingy (cc @gavrelina)