### PR TITLE
Improve table line height logic

### DIFF
--- a/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
@@ -126,6 +126,8 @@ impl DatastoreUi {
 
         self.chunk_list_mode.ui(ui, chunk_store, timestamp_format);
 
+        let table_style = re_ui::TableStyle::Dense;
+
         //
         // Collect chunks based on query mode
         //
@@ -352,9 +354,9 @@ impl DatastoreUi {
                     .striped(true);
 
                 table_builder
-                    .header(tokens.deprecated_table_line_height(), header_ui)
+                    .header(tokens.table_row_height(table_style), header_ui)
                     .body(|body| {
-                        body.rows(tokens.deprecated_table_line_height(), chunks.len(), row_ui);
+                        body.rows(tokens.table_row_height(table_style), chunks.len(), row_ui);
                     });
             });
     }

--- a/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
@@ -51,6 +51,7 @@ impl ChunkUi {
     pub(crate) fn ui(&mut self, ui: &mut egui::Ui, timestamp_format: TimestampFormat) -> bool {
         let tokens = ui.tokens();
 
+        let table_style = re_ui::TableStyle::Dense;
         let should_exit = self.chunk_info_ui(ui);
 
         //
@@ -180,9 +181,9 @@ impl ChunkUi {
                     .striped(true);
 
                 table_builder
-                    .header(tokens.deprecated_table_line_height(), header_ui)
+                    .header(tokens.table_row_height(table_style), header_ui)
                     .body(|body| {
-                        body.rows(tokens.deprecated_table_line_height(), row_ids.len(), row_ui);
+                        body.rows(tokens.table_row_height(table_style), row_ids.len(), row_ui);
                     });
             });
 

--- a/crates/viewer/re_chunk_store_ui/src/sort.rs
+++ b/crates/viewer/re_chunk_store_ui/src/sort.rs
@@ -36,11 +36,12 @@ pub(crate) fn sortable_column_header_ui<T: Default + Copy + PartialEq>(
     label: &'static str,
 ) {
     let tokens = ui.tokens();
+    let table_style = re_ui::TableStyle::Dense;
     let is_sorted = &sort_column.column == column;
     let direction = sort_column.direction;
 
     let (left_clicked, right_clicked) = egui::Sides::new()
-        .height(tokens.deprecated_table_line_height())
+        .height(tokens.table_row_height(table_style))
         .show(
             ui,
             |ui| {

--- a/crates/viewer/re_component_ui/src/geo_line_string.rs
+++ b/crates/viewer/re_component_ui/src/geo_line_string.rs
@@ -21,6 +21,8 @@ fn multiline_view_geo_line_string(
 ) -> egui::Response {
     use egui_extras::Column;
 
+    let table_style = re_ui::TableStyle::Dense;
+
     let tokens = ui.tokens();
 
     // TODO(andreas): Editing this would be nice!
@@ -41,8 +43,8 @@ fn multiline_view_geo_line_string(
             });
         })
         .body(|mut body| {
-            tokens.setup_table_body(&mut body);
-            let row_height = tokens.deprecated_table_line_height();
+            tokens.setup_table_body(&mut body, table_style);
+            let row_height = tokens.table_row_height(table_style);
             body.rows(row_height, value.0.len(), |mut row| {
                 if let Some(pos) = value.0.get(row.index()) {
                     row.col(|ui| {

--- a/crates/viewer/re_component_ui/src/line_strip.rs
+++ b/crates/viewer/re_component_ui/src/line_strip.rs
@@ -24,6 +24,7 @@ fn multiline_view_line_strip_3d(
     use egui_extras::Column;
 
     let tokens = ui.tokens();
+    let table_style = re_ui::TableStyle::Dense;
 
     // TODO(andreas): Editing this would be nice!
     let value = value.as_ref();
@@ -48,8 +49,8 @@ fn multiline_view_line_strip_3d(
             });
         })
         .body(|mut body| {
-            tokens.setup_table_body(&mut body);
-            let row_height = tokens.deprecated_table_line_height();
+            tokens.setup_table_body(&mut body, table_style);
+            let row_height = tokens.table_row_height(table_style);
             body.rows(row_height, value.0.len(), |mut row| {
                 if let Some(pos) = value.0.get(row.index()) {
                     row.col(|ui| {
@@ -88,6 +89,7 @@ fn multiline_view_line_strip_2d(
     use egui_extras::Column;
 
     let tokens = ui.tokens();
+    let table_style = re_ui::TableStyle::Dense;
 
     // TODO(andreas): Editing this would be nice!
     let value = value.as_ref();
@@ -109,8 +111,8 @@ fn multiline_view_line_strip_2d(
             });
         })
         .body(|mut body| {
-            tokens.setup_table_body(&mut body);
-            let row_height = tokens.deprecated_table_line_height();
+            tokens.setup_table_body(&mut body, table_style);
+            let row_height = tokens.table_row_height(table_style);
             body.rows(row_height, value.0.len(), |mut row| {
                 if let Some(pos) = value.0.get(row.index()) {
                     row.col(|ui| {

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -186,7 +186,9 @@ fn class_description_ui(
 
     let use_collapsible = ui_layout == UiLayout::SelectionPanel;
 
-    let row_height = tokens.deprecated_table_line_height();
+    let table_style = re_ui::TableStyle::Dense;
+
+    let row_height = tokens.table_row_height(table_style);
     if !class.keypoint_annotations.is_empty() {
         ui.maybe_collapsing_header(
             use_collapsible,
@@ -230,7 +232,7 @@ fn class_description_ui(
                         });
                     })
                     .body(|mut body| {
-                        tokens.setup_table_body(&mut body);
+                        tokens.setup_table_body(&mut body, table_style);
 
                         // TODO(jleibs): Helper to do this with caching somewhere
                         let keypoint_map: ahash::HashMap<KeypointId, AnnotationInfo> = {
@@ -277,7 +279,8 @@ fn annotation_info_table_ui(
     re_tracing::profile_function!();
 
     let tokens = ui.tokens();
-    let row_height = tokens.deprecated_table_line_height();
+    let table_style = re_ui::TableStyle::Dense;
+    let row_height = tokens.table_row_height(table_style);
 
     ui.spacing_mut().item_spacing.x = 20.0; // column spacing.
 
@@ -304,7 +307,7 @@ fn annotation_info_table_ui(
             });
         })
         .body(|mut body| {
-            tokens.setup_table_body(&mut body);
+            tokens.setup_table_body(&mut body, table_style);
 
             body.rows(row_height, annotation_infos.len(), |mut row| {
                 let info = &annotation_infos[row.index()];
@@ -344,7 +347,7 @@ fn small_color_ui(ui: &mut egui::Ui, info: &AnnotationInfo) {
     let tokens = ui.tokens();
     let size = egui::Vec2::splat(
         tokens
-            .deprecated_table_line_height()
+            .table_row_height(re_ui::TableStyle::Dense)
             .at_most(ui.available_height()),
     );
 

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -162,6 +162,7 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
         } else if ui_layout.is_single_line() {
             ui.label(format!("{} values", re_format::format_uint(num_instances)));
         } else {
+            let table_style = re_ui::TableStyle::Dense;
             ui_layout
                 .table(ui)
                 .resizable(false)
@@ -178,8 +179,8 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
                     });
                 })
                 .body(|mut body| {
-                    tokens.setup_table_body(&mut body);
-                    let row_height = tokens.deprecated_table_line_height();
+                    tokens.setup_table_body(&mut body, table_style);
+                    let row_height = tokens.table_row_height(table_style);
                     body.rows(row_height, num_displayed_rows, |mut row| {
                         let instance = Instance::from(row.index() as u64);
                         row.col(|ui| {

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -196,6 +196,7 @@ fn video_data_ui(ui: &mut egui::Ui, ui_layout: UiLayout, video_descr: &VideoData
 fn samples_table_ui(ui: &mut egui::Ui, video_descr: &VideoDataDescription) {
     re_tracing::profile_function!();
     let tokens = ui.tokens();
+    let table_style = re_ui::TableStyle::Dense;
 
     egui_extras::TableBuilder::new(ui)
         .auto_shrink([false, true])
@@ -231,10 +232,10 @@ fn samples_table_ui(ui: &mut egui::Ui, video_descr: &VideoDataDescription) {
             });
         })
         .body(|mut body| {
-            tokens.setup_table_body(&mut body);
+            tokens.setup_table_body(&mut body, table_style);
 
             body.rows(
-                tokens.deprecated_table_line_height(),
+                tokens.table_row_height(table_style),
                 video_descr.samples.num_elements(),
                 |mut row| {
                     let sample_idx = row.index() + video_descr.samples.min_index();

--- a/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
@@ -205,6 +205,7 @@ impl<'a> DataFusionTableWidget<'a> {
         ui: &mut egui::Ui,
     ) {
         let tokens = ui.tokens();
+        let table_style = re_ui::TableStyle::Spacious;
 
         let Self {
             session_ctx,
@@ -333,7 +334,7 @@ impl<'a> DataFusionTableWidget<'a> {
 
         let mut new_blueprint = table_state.blueprint().clone();
 
-        let mut row_height = viewer_ctx.tokens().table_line_height();
+        let mut row_height = viewer_ctx.tokens().table_row_height(table_style);
 
         // If the first column is a blob, we treat it as a thumbnail and increase the row height.
         // TODO(lucas): This is a band-aid fix and should be replaced with proper table blueprint
@@ -352,6 +353,7 @@ impl<'a> DataFusionTableWidget<'a> {
 
         let mut table_delegate = DataFusionTableDelegate {
             ctx: viewer_ctx,
+            table_style,
             fields,
             migrated_fields,
             display_record_batches: &display_record_batches,
@@ -393,7 +395,7 @@ impl<'a> DataFusionTableWidget<'a> {
             )
             .rect
             .width()
-            + ui.tokens().table_cell_margin().sum().x)
+            + ui.tokens().table_cell_margin(table_style).sum().x)
             .ceil();
 
         egui_table::Table::new()
@@ -528,6 +530,7 @@ enum BottomBarAction {
 
 struct DataFusionTableDelegate<'a> {
     ctx: &'a ViewerContext<'a>,
+    table_style: re_ui::TableStyle,
     fields: &'a Fields,
     migrated_fields: &'a Fields,
     display_record_batches: &'a Vec<DisplayRecordBatch>,
@@ -541,9 +544,10 @@ struct DataFusionTableDelegate<'a> {
 impl egui_table::TableDelegate for DataFusionTableDelegate<'_> {
     fn header_cell_ui(&mut self, ui: &mut egui::Ui, cell: &HeaderCellInfo) {
         let tokens = ui.tokens();
+        let table_style = self.table_style;
 
         if cell.group_index == 0 {
-            header_ui(ui, false, |ui| ui.weak("#"));
+            header_ui(ui, table_style, false, |ui| ui.weak("#"));
         } else {
             ui.set_truncate_style();
             // Offset by one for the row number column.
@@ -561,13 +565,13 @@ impl egui_table::TableDelegate for DataFusionTableDelegate<'_> {
                         .then_some(&sort_by.direction)
                 });
 
-                header_ui(ui, true, |ui| {
+                header_ui(ui, table_style, true, |ui| {
                     egui::Sides::new()
                         .shrink_left()
                         .show(
                             ui,
                             |ui| {
-                                ui.set_height(ui.tokens().table_content_height());
+                                ui.set_height(ui.tokens().table_content_height(table_style));
                                 let response = ui.label(
                                     egui::RichText::new(column_display_name)
                                         .strong()
@@ -584,7 +588,7 @@ impl egui_table::TableDelegate for DataFusionTableDelegate<'_> {
                                 response
                             },
                             |ui| {
-                                ui.set_height(ui.tokens().table_content_height());
+                                ui.set_height(ui.tokens().table_content_height(table_style));
                                 egui::containers::menu::MenuButton::from_button(
                                     ui.small_icon_button_widget(
                                         &re_ui::icons::MORE,
@@ -634,7 +638,7 @@ impl egui_table::TableDelegate for DataFusionTableDelegate<'_> {
     }
 
     fn cell_ui(&mut self, ui: &mut egui::Ui, cell: &CellInfo) {
-        cell_ui(ui, false, |ui| {
+        cell_ui(ui, self.table_style, false, |ui| {
             // find record batch
             let mut row_index = cell.row_nr as usize;
 

--- a/crates/viewer/re_dataframe_ui/src/table_utils.rs
+++ b/crates/viewer/re_dataframe_ui/src/table_utils.rs
@@ -23,8 +23,12 @@ pub fn apply_table_style_fixes(style: &mut Style) {
     style.visuals.widgets.noninteractive.bg_stroke = Stroke::new(0.0, Color32::TRANSPARENT);
 }
 
-pub fn header_title(ui: &mut egui::Ui, title: impl Into<RichText>) -> egui::Response {
-    header_ui(ui, false, |ui| {
+pub fn header_title(
+    ui: &mut egui::Ui,
+    table_style: re_ui::TableStyle,
+    title: impl Into<RichText>,
+) -> egui::Response {
+    header_ui(ui, table_style, false, |ui| {
         ui.monospace(title.into().strong());
     })
     .response
@@ -32,6 +36,7 @@ pub fn header_title(ui: &mut egui::Ui, title: impl Into<RichText>) -> egui::Resp
 
 pub fn header_ui<R>(
     ui: &mut egui::Ui,
+    table_style: re_ui::TableStyle,
     connected_to_next_cell: bool,
     content: impl FnOnce(&mut egui::Ui) -> R,
 ) -> egui::InnerResponse<R> {
@@ -40,7 +45,7 @@ pub fn header_ui<R>(
         .rect_filled(rect, 0.0, ui.tokens().table_header_bg_fill);
 
     let response = Frame::new()
-        .inner_margin(ui.tokens().table_cell_margin())
+        .inner_margin(ui.tokens().table_cell_margin(table_style))
         .show(ui, content);
 
     if !connected_to_next_cell {
@@ -62,11 +67,12 @@ pub fn header_ui<R>(
 
 pub fn cell_ui<R>(
     ui: &mut egui::Ui,
+    table_style: re_ui::TableStyle,
     connected_to_next_cell: bool,
     content: impl FnOnce(&mut egui::Ui) -> R,
 ) -> egui::InnerResponse<R> {
     let response = Frame::new()
-        .inner_margin(ui.tokens().table_cell_margin())
+        .inner_margin(ui.tokens().table_cell_margin(table_style))
         .show(ui, content);
 
     let rect = ui.max_rect();

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -715,6 +715,9 @@ impl DesignTokens {
     pub fn setup_table_body(&self, body: &mut egui_extras::TableBody<'_>, table_style: TableStyle) {
         // Make sure buttons don't visually overflow:
         body.ui_mut().spacing_mut().interact_size.y = self.table_content_height(table_style);
+
+        // No extra spacing between items in the table body - we bake that into the row height.
+        body.ui_mut().spacing_mut().item_spacing.y = 0.0;
     }
 
     /// Layout area to allocate for the collapsing triangle.

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -36,13 +36,11 @@ impl AlertVisuals {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum TableStyle {
     /// Used for presenting a lot of information to the user
-    /// without wasting vertical space,
-    /// like when showing log output.
+    /// without wasting vertical space, like when showing log output.
     #[default]
     Dense,
 
-    /// Used when we want more margins and spacing,
-    /// e.g. in the catalog view.
+    /// Used when we want to fit big, clickable buttons in the table cells.
     Spacious,
 }
 

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -33,6 +33,19 @@ impl AlertVisuals {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum TableStyle {
+    /// Used for presenting a lot of information to the user
+    /// without wasting vertical space,
+    /// like when showing log output.
+    #[default]
+    Dense,
+
+    /// Used when we want more margins and spacing,
+    /// e.g. in the catalog view.
+    Spacious,
+}
+
 /// The look and feel of the UI.
 ///
 /// Not everything is covered by this.
@@ -576,24 +589,27 @@ impl DesignTokens {
         4.0
     }
 
-    pub fn table_cell_margin(&self) -> Margin {
-        Margin::symmetric(8, 6)
+    pub fn table_cell_margin(&self, table_style: TableStyle) -> Margin {
+        match table_style {
+            TableStyle::Dense => Margin::symmetric(8, 2),
+            TableStyle::Spacious => Margin::symmetric(8, 6),
+        }
     }
 
-    pub fn table_line_height(&self) -> f32 {
-        // should be big enough to contain buttons, i.e. egui_style.spacing.interact_size.y
-        // and the cell margin
-        32.0
+    /// Use in cases when we want to make sure we fit a lot of information on screen without wasting vertical space.
+    pub fn table_row_height(&self, table_style: TableStyle) -> f32 {
+        match table_style {
+            TableStyle::Dense => 20.0,
+
+            // Should be big enough to contain buttons, i.e. egui_style.spacing.interact_size.y
+            // and the cell margin.
+            TableStyle::Spacious => 32.0,
+        }
     }
 
     /// Line height - margin
-    pub fn table_content_height(&self) -> f32 {
-        self.table_line_height() - self.table_cell_margin().sum().y
-    }
-
-    // TODO(lucasmerlin): Update all tables to the new design
-    pub fn deprecated_table_line_height(&self) -> f32 {
-        20.0
+    pub fn table_content_height(&self, table_style: TableStyle) -> f32 {
+        self.table_row_height(table_style) - self.table_cell_margin(table_style).sum().y
     }
 
     pub fn table_header_height(&self) -> f32 {
@@ -696,9 +712,9 @@ impl DesignTokens {
 
     pub fn setup_table_header(_header: &mut egui_extras::TableRow<'_, '_>) {}
 
-    pub fn setup_table_body(&self, body: &mut egui_extras::TableBody<'_>) {
+    pub fn setup_table_body(&self, body: &mut egui_extras::TableBody<'_>, table_style: TableStyle) {
         // Make sure buttons don't visually overflow:
-        body.ui_mut().spacing_mut().interact_size.y = self.table_content_height();
+        body.ui_mut().spacing_mut().interact_size.y = self.table_content_height(table_style);
     }
 
     /// Layout area to allocate for the collapsing triangle.

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -596,7 +596,7 @@ impl DesignTokens {
         }
     }
 
-    /// Use in cases when we want to make sure we fit a lot of information on screen without wasting vertical space.
+    /// The total row height, including margin/spacing.
     pub fn table_row_height(&self, table_style: TableStyle) -> f32 {
         match table_style {
             TableStyle::Dense => 20.0,
@@ -607,7 +607,7 @@ impl DesignTokens {
         }
     }
 
-    /// Line height - margin
+    /// The max height of the content.
     pub fn table_content_height(&self, table_style: TableStyle) -> f32 {
         self.table_row_height(table_style) - self.table_cell_margin(table_style).sum().y
     }

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -698,7 +698,7 @@ impl DesignTokens {
 
     pub fn setup_table_body(&self, body: &mut egui_extras::TableBody<'_>) {
         // Make sure buttons don't visually overflow:
-        body.ui_mut().spacing_mut().interact_size.y = self.table_line_height();
+        body.ui_mut().spacing_mut().interact_size.y = self.table_content_height();
     }
 
     /// Layout area to allocate for the collapsing triangle.

--- a/crates/viewer/re_ui/src/lib.rs
+++ b/crates/viewer/re_ui/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::{
     command::{UICommand, UICommandSender},
     command_palette::CommandPalette,
     context_ext::ContextExt,
-    design_tokens::DesignTokens,
+    design_tokens::{DesignTokens, TableStyle},
     help::*,
     hot_reload_design_tokens::design_tokens_of,
     icon_text::*,

--- a/crates/viewer/re_view_dataframe/tests/snapshots/null_timeline.png
+++ b/crates/viewer/re_view_dataframe/tests/snapshots/null_timeline.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59cc5f6be770b27ccbfc0f6586d9bcc00861393f68ef65478711beaf6755a553
-size 14007
+oid sha256:6a3a54613995c3fad528be08bb3a912012291ec809d477e187780658b6aea940
+size 14010

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -283,6 +283,7 @@ fn table_ui(
     scroll_to_row: Option<usize>,
 ) {
     let tokens = ui.tokens();
+    let table_style = re_ui::TableStyle::Dense;
 
     let timelines = state
         .filters
@@ -352,13 +353,15 @@ fn table_ui(
             });
         })
         .body(|mut body| {
-            tokens.setup_table_body(&mut body);
+            tokens.setup_table_body(&mut body, table_style);
 
             body_clip_rect = Some(body.max_rect());
 
             let query = ctx.current_query();
 
-            let row_heights = entries.iter().map(|te| calc_row_height(tokens, te));
+            let row_heights = entries
+                .iter()
+                .map(|te| calc_row_height(tokens, table_style, te));
             body.heterogeneous_rows(row_heights, |mut row| {
                 let entry = &entries[row.index()];
 
@@ -443,11 +446,11 @@ fn table_ui(
     }
 }
 
-fn calc_row_height(tokens: &DesignTokens, entry: &Entry) -> f32 {
+fn calc_row_height(tokens: &DesignTokens, table_style: re_ui::TableStyle, entry: &Entry) -> f32 {
     // Simple, fast, ugly, and functional
     let num_newlines = entry.body.bytes().filter(|&c| c == b'\n').count();
     let num_rows = 1 + num_newlines;
-    num_rows as f32 * tokens.table_line_height()
+    num_rows as f32 * tokens.table_row_height(table_style)
 }
 
 #[test]

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -304,7 +304,7 @@ fn table_ui(
         .auto_shrink([false; 2]) // expand to take up the whole View
         .min_scrolled_height(0.0) // we can go as small as we need to be in order to fit within the view!
         .max_scroll_height(f32::INFINITY) // Fill up whole height
-        .cell_layout(egui::Layout::left_to_right(egui::Align::TOP));
+        .cell_layout(egui::Layout::left_to_right(egui::Align::Center));
 
     if let Some(scroll_to_row) = scroll_to_row {
         table_builder = table_builder.scroll_to_row(scroll_to_row, Some(egui::Align::Center));


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/5589

### What
This defines two table styles, `Dense` and `Spacious`. The result is that we fit more on the screen in the places where it matters:

![image](https://github.com/user-attachments/assets/913dd3f6-ac11-4cb9-9399-22fb67ed9866)

But still have nice spacing in places where we want to:

![image](https://github.com/user-attachments/assets/ac522942-150e-45a4-8aec-e30f0c3c869f)
