### PR TITLE
Remove unused `ViewContextSystem::compatible_component_set`

### DIFF
--- a/crates/viewer/re_view/src/annotation_scene_context.rs
+++ b/crates/viewer/re_view/src/annotation_scene_context.rs
@@ -1,4 +1,3 @@
-use re_types::{Archetype as _, ComponentDescriptorSet, archetypes::AnnotationContext};
 use re_viewer_context::{
     AnnotationMap, IdentifiedViewSystem, ViewContextSystem, ViewSystemIdentifier,
 };
@@ -13,15 +12,6 @@ impl IdentifiedViewSystem for AnnotationSceneContext {
 }
 
 impl ViewContextSystem for AnnotationSceneContext {
-    fn compatible_component_sets(&self) -> Vec<ComponentDescriptorSet> {
-        vec![
-            AnnotationContext::required_components()
-                .iter()
-                .cloned()
-                .collect(),
-        ]
-    }
-
     fn execute(
         &mut self,
         ctx: &re_viewer_context::ViewContext<'_>,

--- a/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
@@ -3,7 +3,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use ahash::HashMap;
 
 use re_log_types::EntityPathHash;
-use re_types::{ComponentDescriptorSet, Loggable as _, archetypes, components::DrawOrder};
+use re_types::{
+    Archetype as _, ComponentDescriptorSet, Loggable as _, archetypes, components::DrawOrder,
+};
 use re_view::latest_at_with_blueprint_resolved_data;
 use re_viewer_context::{
     IdentifiedViewSystem, QueryContext, ViewContextSystem, ViewSystemIdentifier,
@@ -26,22 +28,21 @@ impl IdentifiedViewSystem for EntityDepthOffsets {
 
 impl ViewContextSystem for EntityDepthOffsets {
     fn compatible_component_sets(&self) -> Vec<ComponentDescriptorSet> {
-        vec![
-            [
-                archetypes::Arrows2D::descriptor_indicator(),
-                archetypes::Boxes2D::descriptor_indicator(),
-                archetypes::DepthImage::descriptor_indicator(),
-                archetypes::EncodedImage::descriptor_indicator(),
-                archetypes::Image::descriptor_indicator(),
-                archetypes::LineStrips2D::descriptor_indicator(),
-                archetypes::Points2D::descriptor_indicator(),
-                archetypes::SegmentationImage::descriptor_indicator(),
-                archetypes::VideoFrameReference::descriptor_indicator(),
-                archetypes::VideoStream::descriptor_indicator(),
-            ]
-            .into_iter()
-            .collect(),
+        [
+            archetypes::Arrows3D::required_components(),
+            archetypes::Boxes2D::required_components(),
+            archetypes::DepthImage::required_components(),
+            archetypes::EncodedImage::required_components(),
+            archetypes::Image::required_components(),
+            archetypes::LineStrips2D::required_components(),
+            archetypes::Points2D::required_components(),
+            archetypes::SegmentationImage::required_components(),
+            archetypes::VideoFrameReference::required_components(),
+            archetypes::VideoStream::required_components(),
         ]
+        .into_iter()
+        .map(|descrs| descrs.iter().cloned().collect())
+        .collect()
     }
 
     fn execute(

--- a/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
@@ -3,9 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use ahash::HashMap;
 
 use re_log_types::EntityPathHash;
-use re_types::{
-    Archetype as _, ComponentDescriptorSet, Loggable as _, archetypes, components::DrawOrder,
-};
+use re_types::{Loggable as _, components::DrawOrder};
 use re_view::latest_at_with_blueprint_resolved_data;
 use re_viewer_context::{
     IdentifiedViewSystem, QueryContext, ViewContextSystem, ViewSystemIdentifier,
@@ -27,24 +25,6 @@ impl IdentifiedViewSystem for EntityDepthOffsets {
 }
 
 impl ViewContextSystem for EntityDepthOffsets {
-    fn compatible_component_sets(&self) -> Vec<ComponentDescriptorSet> {
-        [
-            archetypes::Arrows3D::required_components(),
-            archetypes::Boxes2D::required_components(),
-            archetypes::DepthImage::required_components(),
-            archetypes::EncodedImage::required_components(),
-            archetypes::Image::required_components(),
-            archetypes::LineStrips2D::required_components(),
-            archetypes::Points2D::required_components(),
-            archetypes::SegmentationImage::required_components(),
-            archetypes::VideoFrameReference::required_components(),
-            archetypes::VideoStream::required_components(),
-        ]
-        .into_iter()
-        .map(|descrs| descrs.iter().cloned().collect())
-        .collect()
-    }
-
     fn execute(
         &mut self,
         ctx: &re_viewer_context::ViewContext<'_>,

--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -3,11 +3,7 @@ use nohash_hasher::IntMap;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::{EntityPath, EntityTree};
 use re_log_types::EntityPathHash;
-use re_types::{
-    Archetype as _, ArchetypeName, ComponentDescriptorSet,
-    archetypes::{self, InstancePoses3D, Transform3D},
-    components::ImagePlaneDistance,
-};
+use re_types::{ArchetypeName, archetypes, components::ImagePlaneDistance};
 use re_view::DataResultQuery as _;
 use re_viewer_context::{DataResultTree, IdentifiedViewSystem, ViewContext, ViewContextSystem};
 use vec1::smallvec_v1::SmallVec1;
@@ -157,14 +153,6 @@ impl Default for TransformTreeContext {
 }
 
 impl ViewContextSystem for TransformTreeContext {
-    fn compatible_component_sets(&self) -> Vec<ComponentDescriptorSet> {
-        vec![
-            Transform3D::all_components().iter().cloned().collect(),
-            InstancePoses3D::all_components().iter().cloned().collect(),
-            std::iter::once(archetypes::Pinhole::descriptor_image_from_camera()).collect(),
-        ]
-    }
-
     /// Determines transforms for all entities relative to a space path which serves as the "reference".
     /// I.e. the resulting transforms are "reference from scene"
     ///

--- a/crates/viewer/re_viewer_context/src/view/view_context_system.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_context_system.rs
@@ -1,6 +1,6 @@
 use ahash::HashMap;
 
-use re_types::{ComponentDescriptorSet, ViewClassIdentifier};
+use re_types::ViewClassIdentifier;
 
 use crate::{IdentifiedViewSystem, ViewQuery, ViewSystemExecutionError, ViewSystemIdentifier};
 
@@ -10,17 +10,6 @@ use super::view_context::ViewContext;
 ///
 /// Is always populated before view part systems.
 pub trait ViewContextSystem: Send + Sync {
-    /// Returns all the component sets that the system is compatible with.
-    ///
-    /// If an entity path satisfies any of these sets, then the system will automatically run for
-    /// that entity path.
-    ///
-    /// Return an empty vec to specify that the system should never run automatically for any
-    /// specific entities.
-    /// It may still run once per frame as part of the global context if it has been registered to
-    /// do so, see [`crate::ViewSystemRegistrator`].
-    fn compatible_component_sets(&self) -> Vec<ComponentDescriptorSet>;
-
     /// Queries the chunk store and performs data conversions to make it ready for consumption by scene elements.
     fn execute(&mut self, ctx: &ViewContext<'_>, query: &ViewQuery<'_>);
 


### PR DESCRIPTION
### Related

* Part of: #8129 
* Part of: #6889 

### What

Turns out the `EntityDepthOffsets` system was still indicators driven. This replaces the use of indicators with `required_components`.
