### PR TITLE
Remove `split_indicators` from `ChunkBatcher`

### DIFF
--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -240,48 +240,6 @@ impl Chunk {
     pub fn concatenable(&self, rhs: &Self) -> bool {
         self.same_entity_paths(rhs) && self.same_timelines(rhs) && self.same_datatypes(rhs)
     }
-
-    // TODO(#8129): This will not be needed anymore.
-    /// Moves all indicator components from `self` into a new, dedicated chunk.
-    ///
-    /// The new chunk contains only the first index from each index column, and all the indicators,
-    /// packed in a single row.
-    /// Beware: `self` might be left with no component columns at all after this operation.
-    ///
-    /// This greatly reduces the overhead of indicators, both in the row-oriented and
-    /// column-oriented APIs.
-    /// See <https://github.com/rerun-io/rerun/issues/8768> for further rationale.
-    pub fn split_indicators(&mut self) -> Option<Self> {
-        let indicators: ChunkComponents = self
-            .components
-            .iter()
-            .filter(|&(descr, _list_array)| descr.is_indicator_component())
-            .filter(|&(_descr, list_array)| (!list_array.is_empty()))
-            .map(|(descr, list_array)| (descr.clone(), list_array.slice(0, 1)))
-            .collect();
-        if indicators.is_empty() {
-            return None;
-        }
-
-        let timelines = self
-            .timelines
-            .iter()
-            .map(|(timeline, time_column)| (*timeline, time_column.row_sliced(0, 1)))
-            .collect();
-
-        if let Ok(chunk) = Self::from_auto_row_ids(
-            ChunkId::new(),
-            self.entity_path.clone(),
-            timelines,
-            indicators,
-        ) {
-            self.components
-                .retain(|desc, _per_desc| !desc.is_indicator_component());
-            return Some(chunk);
-        }
-
-        None
-    }
 }
 
 impl TimeColumn {

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -124,6 +124,9 @@ impl Verifier {
             .is_indicator_component()
         {
             // Lacks reflection and data
+            anyhow::bail!(
+                "Indicators are deprecated and should be removed on ingestion in re_sorbet."
+            );
         } else {
             // Verify data
             let component_reflection = self


### PR DESCRIPTION
### Related

* Part of #6889.
* Part of #8129.

### What

Removes unnecessary logic that would split a chunk into two if indicators were present. Also adds a check to `rerun rrd verify` for indicator components.
