### PR TITLE
Removes remnants of indicators from dataframe queries and viewer

### DIFF
--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -107,7 +107,6 @@ impl Chunk {
                         // Setting them all to `false` at least ensures they aren't written to the arrow metadata:
                         // TODO(#8744): figure out what to do here
                         is_static: false,
-                        is_indicator: false,
                         is_tombstone: false,
                         is_semantically_empty: false,
                     };

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -286,9 +286,6 @@ pub struct ColumnMetadata {
     /// Whether this column represents static data.
     pub is_static: bool,
 
-    /// Whether this column represents an indicator component.
-    pub is_indicator: bool,
-
     /// Whether this column represents a `Clear`-related component.
     ///
     /// `Clear`: [`re_types_core::archetypes::Clear`]
@@ -693,8 +690,6 @@ impl ChunkStore {
             .get(entity_path)
             .is_some_and(|per_descr| per_descr.get(component_descr).is_some());
 
-        let is_indicator = component_descr.is_indicator_component();
-
         use re_types_core::Archetype as _;
         let is_tombstone = re_types_core::archetypes::Clear::all_components()
             .iter()
@@ -702,7 +697,6 @@ impl ChunkStore {
 
         Some(ColumnMetadata {
             is_static,
-            is_indicator,
             is_tombstone,
             is_semantically_empty: *is_semantically_empty,
         })

--- a/crates/store/re_chunk_store/tests/dataframe.rs
+++ b/crates/store/re_chunk_store/tests/dataframe.rs
@@ -110,7 +110,6 @@ fn schema_for_query() -> anyhow::Result<()> {
             ),
         )])),
         include_semantically_empty_columns: false,
-        include_indicator_columns: false,
         include_tombstone_columns: false,
         include_static_columns: StaticColumnSelection::Both,
         filtered_index: Some(TimelineName::new("frame_nr")),

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -456,7 +456,6 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                                     component_type: None,
                                     store_datatype: ArrowDataType::Null,
                                     is_static: false,
-                                    is_indicator: false,
                                     is_tombstone: false,
                                     is_semantically_empty: false,
                                 }),

--- a/crates/store/re_sorbet/src/column_descriptor.rs
+++ b/crates/store/re_sorbet/src/column_descriptor.rs
@@ -177,7 +177,6 @@ fn test_schema_over_ipc() {
             is_static: true,
             is_tombstone: false,
             is_semantically_empty: false,
-            is_indicator: true,
         }),
     ];
 

--- a/crates/store/re_sorbet/src/component_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/component_column_descriptor.rs
@@ -51,12 +51,6 @@ pub struct ComponentColumnDescriptor {
     //TODO(#10315): fix this footgun
     pub is_static: bool,
 
-    /// Whether this column represents an indicator component.
-    ///
-    /// *IMPORTANT*: this is not always accurate, see [`crate::ChunkBatch::chunk_schema`].
-    //TODO(#10315): fix this footgun
-    pub is_indicator: bool,
-
     /// Whether this column represents a [`Clear`]-related components.
     ///
     /// [`Clear`]: re_types_core::archetypes::Clear
@@ -89,7 +83,6 @@ impl Ord for ComponentColumnDescriptor {
             component_type,
             store_datatype: _,
             is_static: _,
-            is_indicator: _,
             is_tombstone: _,
             is_semantically_empty: _,
         } = self;
@@ -113,7 +106,6 @@ impl std::fmt::Display for ComponentColumnDescriptor {
             component_type: _,
             store_datatype: _,
             is_static,
-            is_indicator: _,
             is_tombstone: _,
             is_semantically_empty: _,
         } = self;
@@ -202,7 +194,6 @@ impl ComponentColumnDescriptor {
             component_type,
             store_datatype: _,
             is_static,
-            is_indicator,
             is_tombstone,
             is_semantically_empty,
         } = self;
@@ -238,9 +229,6 @@ impl ComponentColumnDescriptor {
 
         if *is_static {
             metadata.insert("rerun:is_static".to_owned(), "true".to_owned());
-        }
-        if *is_indicator {
-            metadata.insert("rerun:is_indicator".to_owned(), "true".to_owned());
         }
         if *is_tombstone {
             metadata.insert("rerun:is_tombstone".to_owned(), "true".to_owned());
@@ -327,7 +315,6 @@ impl ComponentColumnDescriptor {
             component,
             component_type: field.get_opt("rerun:component_type").map(Into::into),
             is_static: field.get_bool("rerun:is_static"),
-            is_indicator: field.get_bool("rerun:is_indicator"),
             is_tombstone: field.get_bool("rerun:is_tombstone"),
             is_semantically_empty: field.get_bool("rerun:is_semantically_empty"),
         };

--- a/crates/store/re_sorbet/src/migrations/v0_0_2__to__v0_1_0.rs
+++ b/crates/store/re_sorbet/src/migrations/v0_0_2__to__v0_1_0.rs
@@ -72,7 +72,6 @@ fn rewire_tagged_components(batch: &RecordBatch) -> RecordBatch {
 
             if field.name().ends_with("Indicator") {
                 let field_name = field.name();
-                // TODO(#8129): Remove indicator components
                 re_log::debug_once!(
                     "Moving indicator from field to component metadata field: {field_name}"
                 );
@@ -112,7 +111,6 @@ fn rewire_tagged_components(batch: &RecordBatch) -> RecordBatch {
                     }
                     (None, Some(archetype_field)) => (None, archetype_field, Some(component)),
                     (maybe_archetype, None) if component.ends_with("Indicator") => {
-                        // TODO(#8129): For now, this renames the indicator column metadata. Eventually, we want to remove the column altogether.
                         re_log::debug_once!(
                             "Moving indicator to component field: {component}"
                         );

--- a/crates/store/re_sorbet/src/schema_builder.rs
+++ b/crates/store/re_sorbet/src/schema_builder.rs
@@ -88,14 +88,12 @@ impl SchemaBuilder {
                                 component: _,
 
                                 is_static,
-                                is_indicator,
                                 is_tombstone,
                                 is_semantically_empty,
                             } = component_column_descriptor;
 
                             *is_static = metadata.is_static;
                             *is_semantically_empty = metadata.is_semantically_empty;
-                            *is_indicator = component_descriptor.is_indicator_component();
                             *is_tombstone = re_types_core::archetypes::Clear::all_components()
                                 .iter()
                                 .any(|descr| descr == &component_descriptor);

--- a/crates/store/re_types_core/src/component_descriptor.rs
+++ b/crates/store/re_types_core/src/component_descriptor.rs
@@ -85,12 +85,6 @@ impl ComponentDescriptor {
         self.sanity_check();
         self.component.as_str()
     }
-
-    /// Is this an indicator component for an archetype?
-    // TODO(#8129): Remove when we remove tagging.
-    pub fn is_indicator_component(&self) -> bool {
-        self.component.ends_with("Indicator")
-    }
 }
 
 impl re_byte_size::SizeBytes for ComponentDescriptor {

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -119,10 +119,7 @@ impl Verifier {
             return Ok(());
         }
 
-        if column_descriptor
-            .component_descriptor()
-            .is_indicator_component()
-        {
+        if component.starts_with("rerun.components.") && component.ends_with("Indicator") {
             // Lacks reflection and data
             anyhow::bail!(
                 "Indicators are deprecated and should be removed on ingestion in re_sorbet."

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -44,7 +44,6 @@ pub fn sorted_component_list_by_archetype_for_ui<'a>(
 ) -> ArchetypeComponentMap {
     let mut map = iter
         .into_iter()
-        .filter(|d| !d.is_indicator_component())
         .fold(ArchetypeComponentMap::default(), |mut acc, descriptor| {
             acc.entry(descriptor.archetype)
                 .or_default()

--- a/crates/viewer/re_dataframe_ui/src/header_tooltip.rs
+++ b/crates/viewer/re_dataframe_ui/src/header_tooltip.rs
@@ -52,7 +52,6 @@ fn column_descriptor_ui(ui: &mut egui::Ui, column: &ColumnDescriptorRef<'_>, col
                 archetype,
                 component,
                 is_static: _,
-                is_indicator: _,
                 is_tombstone: _,
                 is_semantically_empty: _,
             } = desc;
@@ -132,7 +131,6 @@ fn extras_column_descriptor_ui(
         ColumnDescriptorRef::Component(desc) => {
             // TODO(#10315): these are sometimes inaccurate.
             header_property_ui(ui, "Is static", desc.is_static.to_string());
-            header_property_ui(ui, "Is indicator", desc.is_indicator.to_string());
             header_property_ui(ui, "Is tombstone", desc.is_tombstone.to_string());
             header_property_ui(ui, "Is empty", desc.is_semantically_empty.to_string());
         }

--- a/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
+++ b/crates/viewer/re_dataframe_ui/src/table_blueprint.rs
@@ -180,7 +180,6 @@ fn test_default_column_display_name() {
                 component_type: Some("rerun.components.Timestamp".into()),
                 archetype: Some("rerun.archetypes.RecordingInfo".into()),
                 is_static: false,
-                is_indicator: false,
                 is_tombstone: false,
                 is_semantically_empty: false
             },
@@ -198,7 +197,6 @@ fn test_default_column_display_name() {
                 archetype: None,
                 component: "building".into(),
                 is_static: false,
-                is_indicator: false,
                 is_tombstone: false,
                 is_semantically_empty: false
             },

--- a/crates/viewer/re_dataframe_ui/tests/column_header_tooltips.rs
+++ b/crates/viewer/re_dataframe_ui/tests/column_header_tooltips.rs
@@ -87,7 +87,6 @@ fn test_fields() -> Vec<(Field, &'static str)> {
         archetype: Some(ArchetypeName::new("ArchetypeName")),
         component: ComponentIdentifier::from("component_identifier"),
         is_static: false,
-        is_indicator: false,
         is_tombstone: false,
         is_semantically_empty: false,
     };

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_chunk_component_column_with_extras.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_chunk_component_column_with_extras.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:402bd2e4b4a3e7e7cd031b6cd72c50d72635ce184361199f5da7af76897dd24e
-size 89450
+oid sha256:f5b8de938b0a1bf772c7b1ef03e51ee32d4efe117b658ef4f6302ae18dab21e9
+size 87414

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_dataframe_component_column_with_extras.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_dataframe_component_column_with_extras.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4cdc0ebf5b0ffb5036acbbebd514f21676cb1cae0c55c5407d3111b81f7ca06
-size 99050
+oid sha256:58066327814f026f1539da24e88e712c8259057b6ee941c962f7a7ccfea3ed1d
+size 97024

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_raw_field_user_and_sorbet_metadata_with_extras.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_raw_field_user_and_sorbet_metadata_with_extras.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1bbfddd5a94a06254f6fc61710c948075856a2f60f0ae001db838573e75ee41c
-size 75201
+oid sha256:e92bc96db191813a32ad2b67136ece85d79b7f96aaa3b809ca7fbed21e1a60f7
+size 73144

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_raw_field_user_metadata_with_extras.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_raw_field_user_metadata_with_extras.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a24b159af170a526c12a04e4b9ca98c858f3523a3f4cc32eec5fa65679a7c77
-size 64150
+oid sha256:ac27bb70f47bc475c3bf7a72a5894fdc79796497aec4567009db25f4751ba052
+size 62073

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_raw_field_with_extras.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_raw_field_with_extras.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82c70287f5ba2b8d93664c55a09397f1fc8bdf60f8215920b78d71f3cf84a8ed
-size 59991
+oid sha256:ac05acadfd1394cd1764d9ad61bdc2d7fa763cbca0280fc0e10f71041a412a9b
+size 57920

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_row_field_nullable_with_extras.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/header_tooltip_row_field_nullable_with_extras.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82c70287f5ba2b8d93664c55a09397f1fc8bdf60f8215920b78d71f3cf84a8ed
-size 59991
+oid sha256:ac05acadfd1394cd1764d9ad61bdc2d7fa763cbca0280fc0e10f71041a412a9b
+size 57920

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -231,7 +231,7 @@ impl Server {
                     re_log::warn_once!(
                         "Encountered unexpected indicator column name: {}",
                         desc.column_name(BatchType::Dataframe)
-                    )
+                    );
                 }
                 !is_indicator
             } else {

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -222,10 +222,18 @@ impl Server {
                 entity_path.starts_with(&std::iter::once(EntityPathPart::properties()).collect())
             }) {
                 // Property column, just hide indicator components
-                //TODO(#8129): remove this when we no longer have indicator components
-                !desc
+                // TODO(grtlr): Indicators are gone, but since servers might still
+                // have this column we keep this check for now.
+                let is_indicator = desc
                     .column_name(BatchType::Dataframe)
-                    .ends_with("Indicator")
+                    .ends_with("Indicator");
+                if is_indicator {
+                    re_log::warn_once!(
+                        "Encountered unexpected indicator column name: {}",
+                        desc.column_name(BatchType::Dataframe)
+                    )
+                }
+                !is_indicator
             } else {
                 matches!(
                     desc.display_name().as_str(),

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -188,13 +188,11 @@ fn visualized_components_by_archetype(
             else {
                 // TODO(andreas): In theory this is perfectly valid: A visualizer may be interested in an untagged component!
                 // Practically this never happens and we don't handle this in the ui here yet.
-                if !descr.is_indicator_component() {
-                    re_log::warn_once!(
-                        "Visualizer {} queried untagged component {}. It won't show in the defaults ui.",
-                        id,
-                        descr
-                    );
-                }
+                re_log::warn_once!(
+                    "Visualizer {} queried untagged component {}. It won't show in the defaults ui.",
+                    id,
+                    descr
+                );
                 continue;
             };
 

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -199,10 +199,6 @@ fn visualizer_components(
     .values()
     .flatten()
     {
-        if component_descr.is_indicator_component() {
-            continue;
-        }
-
         // TODO(andreas): What about annotation context?
 
         // Query all the sources for our value.

--- a/crates/viewer/re_view_dataframe/src/view_class.rs
+++ b/crates/viewer/re_view_dataframe/src/view_class.rs
@@ -152,7 +152,6 @@ Configure in the selection panel:
             filtered_index_values: None,
             using_index_values: None,
             include_semantically_empty_columns: false,
-            include_indicator_columns: false,
             include_tombstone_columns: false,
             include_static_columns: re_chunk_store::StaticColumnSelection::Both,
         };

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -236,13 +236,11 @@ impl Query {
         // Filter component
         //
 
-        let mut all_components = ctx
+        let all_components = ctx
             .recording_engine()
             .store()
             .all_components_on_timeline_sorted(timeline, &filter_entity)
             .unwrap_or_default();
-
-        all_components.retain(|descr| !descr.is_indicator_component());
 
         // The list of suggested components is built as follows:
         // - consider all component descriptors that have an archetype
@@ -260,10 +258,9 @@ impl Query {
                     })
                 })
                 .flat_map(|(archetype, archetype_reflection)| {
-                    archetype_reflection.required_fields().filter_map(|field| {
-                        let descr = field.component_descriptor(*archetype);
-                        (!descr.is_indicator_component()).then_some(descr)
-                    })
+                    archetype_reflection
+                        .required_fields()
+                        .map(|field| field.component_descriptor(*archetype))
                 })
                 .filter_map(|c| all_components.contains(&c).then_some(c.component))
                 .collect::<ComponentIdentifierSet>()

--- a/crates/viewer/re_view_spatial/tests/snapshots/video_asset_H264_beyond_end.png
+++ b/crates/viewer/re_view_spatial/tests/snapshots/video_asset_H264_beyond_end.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93f3c8310d9be9dcfa5a6d9c05b837c711ff5e4b61d55e4848c9e19b7b43bab6
-size 128091
+oid sha256:eec4ed75952b8f2da6246bee472ead3c974ff1b15d9ffbcb7382eb2df10af443
+size 128061

--- a/crates/viewer/re_viewer_context/src/tables.rs
+++ b/crates/viewer/re_viewer_context/src/tables.rs
@@ -66,7 +66,6 @@ impl TableStore {
                 is_static: true,
                 is_tombstone: false,
                 is_semantically_empty: false,
-                is_indicator: false,
             });
 
             descriptors.push(descriptor);
@@ -85,7 +84,6 @@ impl TableStore {
                 is_static: true,
                 is_tombstone: false,
                 is_semantically_empty: false,
-                is_indicator: false,
             });
 
             let data = ListArray::new(
@@ -111,7 +109,6 @@ impl TableStore {
                 is_static: true,
                 is_tombstone: false,
                 is_semantically_empty: false,
-                is_indicator: false,
             });
 
             let data = ListArray::new(
@@ -144,7 +141,6 @@ impl TableStore {
                 is_static: true,
                 is_tombstone: false,
                 is_semantically_empty: false,
-                is_indicator: false,
             });
 
             descriptors.push(descriptor);

--- a/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
@@ -14,6 +14,8 @@ use crate::{
 #[derive(Debug, Clone, Default)]
 pub struct SortedComponentDescriptorSet(linked_hash_map::LinkedHashMap<ComponentDescriptor, ()>);
 
+pub type UnorderedArchetypeSet = IntSet<ArchetypeName>;
+
 impl SortedComponentDescriptorSet {
     pub fn insert(&mut self, k: ComponentDescriptor) -> Option<()> {
         self.0.insert(k, ())
@@ -41,8 +43,7 @@ impl FromIterator<ComponentDescriptor> for SortedComponentDescriptorSet {
 pub struct VisualizerQueryInfo {
     /// These are not required, but if _any_ of these are found, it is a strong indication that this
     /// system should be active (if also the `required_components` are found).
-    // TODO(#8129): Consider making this a proper struct to make the semantics of `Default::default()` clearer.
-    pub relevant_archetypes: IntSet<ArchetypeName>,
+    pub relevant_archetypes: UnorderedArchetypeSet,
 
     /// Returns the minimal set of components that the system _requires_ in order to be instantiated.
     ///

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -713,11 +713,6 @@ mod tests {
                         "Scenario {i}"
                     );
 
-                    if component_descr.is_indicator_component() {
-                        // Ignore indicators for overrides.
-                        continue;
-                    }
-
                     assert!(
                         expected_overrides.remove(component_descr),
                         "Scenario {i}: expected override for {component_descr} at {override_path:?} but got none"

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -489,7 +489,6 @@ class Recording:
         index: str | None,
         contents: ViewContentsLike,
         include_semantically_empty_columns: bool = False,
-        include_indicator_columns: bool = False,
         include_tombstone_columns: bool = False,
     ) -> RecordingView:
         """
@@ -524,10 +523,6 @@ class Recording:
             Whether to include columns that are semantically empty, by default `False`.
 
             Semantically empty columns are components that are `null` or empty `[]` for every row in the recording.
-        include_indicator_columns : bool, optional
-            Whether to include indicator columns, by default `False`.
-
-            Indicator columns are components used to represent the presence of an archetype within an entity.
         include_tombstone_columns : bool, optional
             Whether to include tombstone columns, by default `False`.
 
@@ -1280,7 +1275,6 @@ class DatasetEntry(Entry):
         index: str | None,
         contents: Any,
         include_semantically_empty_columns: bool = False,
-        include_indicator_columns: bool = False,
         include_tombstone_columns: bool = False,
     ) -> DataframeQueryView:
         """
@@ -1315,10 +1309,6 @@ class DatasetEntry(Entry):
             Whether to include columns that are semantically empty, by default `False`.
 
             Semantically empty columns are components that are `null` or empty `[]` for every row in the recording.
-        include_indicator_columns : bool, optional
-            Whether to include indicator columns, by default `False`.
-
-            Indicator columns are components used to represent the presence of an archetype within an entity.
         include_tombstone_columns : bool, optional
             Whether to include tombstone columns, by default `False`.
 

--- a/rerun_py/rerun_sdk/rerun/dataframe.py
+++ b/rerun_py/rerun_sdk/rerun/dataframe.py
@@ -107,14 +107,7 @@ def send_record_batch(batch: pa.RecordBatch, rec: Optional[RecordingStream] = No
 
 
 def send_dataframe(df: pa.RecordBatchReader | pa.Table, rec: Optional[RecordingStream] = None) -> None:
-    """
-    Coerce a pyarrow `RecordBatchReader` or `Table` to Rerun structure.
-
-    If this `Table` came from a call to [`RecordingView.view`][rerun.dataframe.RecordingView.view], you
-    will want to make sure the `view` call includes `include_indicator_columns = True` or else the
-    viewer will not know about the archetypes in the data.
-
-    """
+    """Coerce a pyarrow `RecordBatchReader` or `Table` to Rerun structure."""
     if isinstance(df, pa.Table):
         df = df.to_reader()
 

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -45,7 +45,6 @@ impl PyDataframeQueryView {
         index: Option<String>,
         contents: Py<PyAny>,
         include_semantically_empty_columns: bool,
-        include_indicator_columns: bool,
         include_tombstone_columns: bool,
         py: Python<'_>,
     ) -> PyResult<Self> {
@@ -68,7 +67,6 @@ impl PyDataframeQueryView {
             query_expression: QueryExpression {
                 view_contents: Some(view_contents),
                 include_semantically_empty_columns,
-                include_indicator_columns,
                 include_tombstone_columns,
                 include_static_columns: if static_only {
                     re_chunk_store::StaticColumnSelection::StaticOnly

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -420,10 +420,6 @@ impl PyDatasetEntry {
     ///     Whether to include columns that are semantically empty, by default `False`.
     ///
     ///     Semantically empty columns are components that are `null` or empty `[]` for every row in the recording.
-    /// include_indicator_columns : bool, optional
-    ///     Whether to include indicator columns, by default `False`.
-    ///
-    ///     Indicator columns are components used to represent the presence of an archetype within an entity.
     /// include_tombstone_columns : bool, optional
     ///     Whether to include tombstone columns, by default `False`.
     ///
@@ -434,13 +430,11 @@ impl PyDatasetEntry {
     /// -------
     /// DataframeQueryView
     ///     The view of the dataset.
-    #[expect(clippy::fn_params_excessive_bools)]
     #[pyo3(signature = (
         *,
         index,
         contents,
         include_semantically_empty_columns = false,
-        include_indicator_columns = false,
         include_tombstone_columns = false,
     ))]
     fn dataframe_query_view(
@@ -448,7 +442,6 @@ impl PyDatasetEntry {
         index: Option<String>,
         contents: Py<PyAny>,
         include_semantically_empty_columns: bool,
-        include_indicator_columns: bool,
         include_tombstone_columns: bool,
         py: Python<'_>,
     ) -> PyResult<PyDataframeQueryView> {
@@ -457,7 +450,6 @@ impl PyDatasetEntry {
             index,
             contents,
             include_semantically_empty_columns,
-            include_indicator_columns,
             include_tombstone_columns,
             py,
         )

--- a/rerun_py/src/dataframe/component_columns.rs
+++ b/rerun_py/src/dataframe/component_columns.rs
@@ -79,14 +79,6 @@ impl PyComponentColumnDescriptor {
     fn is_static(&self) -> bool {
         self.0.is_static
     }
-
-    /// Whether the column is an indicator column.
-    ///
-    /// This property is read-only.
-    #[getter]
-    fn is_indicator(&self) -> bool {
-        self.0.component_descriptor().is_indicator_component()
-    }
 }
 
 impl From<PyComponentColumnDescriptor> for ComponentColumnDescriptor {

--- a/rerun_py/src/dataframe/recording.rs
+++ b/rerun_py/src/dataframe/recording.rs
@@ -167,10 +167,6 @@ impl PyRecording {
     ///     Whether to include columns that are semantically empty, by default `False`.
     ///
     ///     Semantically empty columns are components that are `null` or empty `[]` for every row in the recording.
-    /// include_indicator_columns : bool, optional
-    ///     Whether to include indicator columns, by default `False`.
-    ///
-    ///     Indicator columns are components used to represent the presence of an archetype within an entity.
     /// include_tombstone_columns : bool, optional
     ///     Whether to include tombstone columns, by default `False`.
     ///
@@ -199,7 +195,6 @@ impl PyRecording {
         index,
         contents,
         include_semantically_empty_columns = false,
-        include_indicator_columns = false,
         include_tombstone_columns = false,
     ))]
     fn view(
@@ -207,7 +202,6 @@ impl PyRecording {
         index: Option<&str>,
         contents: Bound<'_, PyAny>,
         include_semantically_empty_columns: bool,
-        include_indicator_columns: bool,
         include_tombstone_columns: bool,
     ) -> PyResult<PyRecordingView> {
         let static_only = index.is_none();
@@ -226,7 +220,6 @@ impl PyRecording {
         let query = QueryExpression {
             view_contents: Some(contents),
             include_semantically_empty_columns,
-            include_indicator_columns,
             include_tombstone_columns,
             include_static_columns: if static_only {
                 StaticColumnSelection::StaticOnly


### PR DESCRIPTION
### Related

* Part of #6889.
* Closes #8129.
* [x] Merge after #10583
* [x] Merge after #10581

### What

This removes the remaining reference to indicators from our codebase. Most notably this removes indicators from the dataframe queries and the UI.

This should be fine because:
* We drop indicator columns during Sorbet migration
* By default indicators where not shown anyways
* And they were omitted in queries by default too.

> [!IMPORTANT]
> There is some risk that this PR will make indicators appear again, so we should choose a good time to merge this PR. If they show up again then let's fix the root cause (i.e. migration logic).

### TODO

* [x] full-check
* [x] Dataplatform companion PR: https://github.com/rerun-io/dataplatform/pull/1234
