### PR TITLE
Show loading screen when starting viewer with a URL

### DIFF
--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1561,7 +1561,7 @@ impl App {
                             &self.rx_log,
                             &self.command_sender,
                             &WelcomeScreenState {
-                                hide: self.startup_options.hide_welcome_screen,
+                                hide_examples: self.startup_options.hide_welcome_screen,
                                 opacity: self.welcome_screen_opacity(egui_ctx),
                             },
                             is_history_enabled,

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -104,8 +104,8 @@ impl Default for AppState {
 }
 
 pub(crate) struct WelcomeScreenState {
-    /// The normal welcome screen should be hidden. Show a fallback "no data ui" instead.
-    pub hide: bool,
+    /// The normal examples screen should be hidden. Show a fallback "no data ui" instead.
+    pub hide_examples: bool,
 
     /// The opacity of the welcome screen during fade-in.
     pub opacity: f32,
@@ -641,6 +641,7 @@ impl AppState {
                                         command_sender,
                                         welcome_screen_state,
                                         is_history_enabled,
+                                        &rx_log.sources(),
                                     );
                                 } else {
                                     redap_servers.server_central_panel_ui(&ctx, ui, origin);

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -57,20 +57,8 @@ fn loading_receivers_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
         .collect();
 
     for source in ctx.connected_receivers.sources() {
-        let string = match source.as_ref() {
-            // We only show things we know are very-soon-to-be recordings:
-            SmartChannelSource::File(path) => format!("Loading {}…", path.display()),
-            SmartChannelSource::RrdHttpStream { url, .. } => format!("Loading {url}…"),
-            SmartChannelSource::RedapGrpcStream { uri, .. } => format!("Loading {uri}…"),
-
-            SmartChannelSource::RrdWebEventListener
-            | SmartChannelSource::JsChannel { .. }
-            | SmartChannelSource::MessageProxy { .. }
-            | SmartChannelSource::Sdk
-            | SmartChannelSource::Stdin => {
-                // These show up in the top panel - see `top_panel.rs`.
-                continue;
-            }
+        let Some(string) = source.loading_string() else {
+            continue;
         };
 
         // Only show if we don't have a recording for this source,

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -117,7 +117,7 @@ fn recording_list_ui(
     if ctx.storage_context.tables.is_empty()
         && servers.is_empty()
         && local_recordings.is_empty()
-        && welcome_screen_state.hide
+        && welcome_screen_state.hide_examples
     {
         ui.list_item().interactive(false).show_flat(
             ui,
@@ -163,7 +163,7 @@ fn recording_list_ui(
     if (ctx
         .app_options()
         .include_rerun_examples_button_in_recordings_panel
-        && !welcome_screen_state.hide)
+        && !welcome_screen_state.hide_examples)
         || !example_recordings.is_empty()
     {
         let item = Item::RedapServer(EXAMPLES_ORIGIN.clone());

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -279,7 +279,7 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
     }
 
     fn source_label(ui: &mut egui::Ui, source: &SmartChannelSource) -> egui::Response {
-        let response = ui.label(status_string(source));
+        let response = ui.label(source.status_string());
 
         let tooltip = match source {
             SmartChannelSource::File(_)
@@ -299,34 +299,6 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
             response.on_hover_text(tooltip)
         } else {
             response
-        }
-    }
-
-    fn status_string(source: &SmartChannelSource) -> String {
-        match source {
-            re_smart_channel::SmartChannelSource::File(path) => {
-                format!("Loading {}…", path.display())
-            }
-            re_smart_channel::SmartChannelSource::Stdin => "Loading stdin…".to_owned(),
-            re_smart_channel::SmartChannelSource::RrdHttpStream { url, .. } => {
-                format!("Waiting for data on {url}…")
-            }
-            re_smart_channel::SmartChannelSource::MessageProxy(uri) => {
-                format!("Waiting for data on {uri}…")
-            }
-            re_smart_channel::SmartChannelSource::RedapGrpcStream { uri, .. } => {
-                format!(
-                    "Waiting for data on {}…",
-                    uri.clone().without_query_and_fragment()
-                )
-            }
-            re_smart_channel::SmartChannelSource::RrdWebEventListener
-            | re_smart_channel::SmartChannelSource::JsChannel { .. } => {
-                "Waiting for logging data…".to_owned()
-            }
-            re_smart_channel::SmartChannelSource::Sdk => {
-                "Waiting for logging data from SDK".to_owned()
-            }
         }
     }
 }

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
@@ -37,7 +37,11 @@ pub fn loading_text_for_data_sources(log_sources: &[Arc<SmartChannelSource>]) ->
                 return Some(format!("Connecting to {url} …"));
             }
 
-            SmartChannelSource::RrdWebEventListener | SmartChannelSource::JsChannel { .. } => {
+            SmartChannelSource::RrdWebEventListener => {
+                // Waiting on notebook data.
+            }
+
+            SmartChannelSource::JsChannel { .. } => {
                 return Some("Loading…".to_owned());
             }
 

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use re_smart_channel::SmartChannelSource;
+use re_ui::{DesignTokens, UiExt as _};
+
+/// Show a loading screen for when we are connecting to a data source.
+pub fn loading_data_ui(ui: &mut egui::Ui, loading_text: &str) {
+    ui.center("loading_data_ui_contents", |ui| {
+        ui.add(
+            egui::Label::new(
+                egui::RichText::new(loading_text).text_style(DesignTokens::welcome_screen_body()),
+            )
+            .wrap(),
+        );
+
+        ui.add_space(50.0);
+
+        let (_id, rect) = ui.allocate_space(egui::Vec2::splat(100.0));
+        egui::Spinner::new().paint_at(ui, rect);
+    });
+}
+
+pub fn loading_text_for_data_sources(log_sources: &[Arc<SmartChannelSource>]) -> Option<String> {
+    // If there's several data sources that should show a loading text, pick the first one.
+    for source in log_sources {
+        match source.as_ref() {
+            SmartChannelSource::File(path) => {
+                if let Some(path_str) = path.to_str() {
+                    return Some(format!("Loading {path_str}…",));
+                }
+            }
+
+            SmartChannelSource::RrdHttpStream { url, .. } => {
+                return Some(format!("Connecting to {url}…"));
+            }
+
+            SmartChannelSource::RrdWebEventListener | SmartChannelSource::JsChannel { .. } => {
+                return Some("Loading…".to_owned());
+            }
+
+            SmartChannelSource::Sdk
+            | SmartChannelSource::Stdin
+            | SmartChannelSource::MessageProxy(..) => {
+                // These sources may or may not send data, so stick with regular welcome screen until we know better.
+            }
+
+            SmartChannelSource::RedapGrpcStream { uri, .. } => {
+                if uri.origin != *re_redap_browser::EXAMPLES_ORIGIN {
+                    return Some(format!("Connecting to {}…", uri.origin));
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use egui::Widget as _;
 use re_smart_channel::SmartChannelSource;
 use re_ui::{DesignTokens, UiExt as _};
 
@@ -8,7 +7,7 @@ use re_ui::{DesignTokens, UiExt as _};
 pub fn loading_data_ui(ui: &mut egui::Ui, loading_text: &str) {
     ui.center("loading_data_ui_contents", |ui| {
         ui.vertical_centered(|ui| {
-            egui::Spinner::new().size(100.0).ui(ui);
+            ui.add(egui::Spinner::new().size(100.0));
 
             ui.add_space(50.0);
 
@@ -26,36 +25,8 @@ pub fn loading_data_ui(ui: &mut egui::Ui, loading_text: &str) {
 pub fn loading_text_for_data_sources(log_sources: &[Arc<SmartChannelSource>]) -> Option<String> {
     // If there's several data sources that should show a loading text, pick the first one.
     for source in log_sources {
-        match source.as_ref() {
-            SmartChannelSource::File(path) => {
-                if let Some(path_str) = path.to_str() {
-                    return Some(format!("Loading {path_str} …",));
-                }
-            }
-
-            SmartChannelSource::RrdHttpStream { url, .. } => {
-                return Some(format!("Connecting to {url} …"));
-            }
-
-            SmartChannelSource::RrdWebEventListener => {
-                // Waiting on notebook data.
-            }
-
-            SmartChannelSource::JsChannel { .. } => {
-                return Some("Loading…".to_owned());
-            }
-
-            SmartChannelSource::Sdk
-            | SmartChannelSource::Stdin
-            | SmartChannelSource::MessageProxy(..) => {
-                // These sources may or may not send data, so stick with regular welcome screen until we know better.
-            }
-
-            SmartChannelSource::RedapGrpcStream { uri, .. } => {
-                if uri.origin != *re_redap_browser::EXAMPLES_ORIGIN {
-                    return Some(format!("Connecting to {} …", uri.origin));
-                }
-            }
+        if let Some(loading_text) = source.loading_string() {
+            return Some(loading_text);
         }
     }
 

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/loading_data_ui.rs
@@ -1,22 +1,25 @@
 use std::sync::Arc;
 
+use egui::Widget as _;
 use re_smart_channel::SmartChannelSource;
 use re_ui::{DesignTokens, UiExt as _};
 
 /// Show a loading screen for when we are connecting to a data source.
 pub fn loading_data_ui(ui: &mut egui::Ui, loading_text: &str) {
     ui.center("loading_data_ui_contents", |ui| {
-        ui.add(
-            egui::Label::new(
-                egui::RichText::new(loading_text).text_style(DesignTokens::welcome_screen_body()),
-            )
-            .wrap(),
-        );
+        ui.vertical_centered(|ui| {
+            egui::Spinner::new().size(100.0).ui(ui);
 
-        ui.add_space(50.0);
+            ui.add_space(50.0);
 
-        let (_id, rect) = ui.allocate_space(egui::Vec2::splat(100.0));
-        egui::Spinner::new().paint_at(ui, rect);
+            ui.add(
+                egui::Label::new(
+                    egui::RichText::new(loading_text)
+                        .text_style(DesignTokens::welcome_screen_body()),
+                )
+                .wrap(),
+            );
+        });
     });
 }
 
@@ -26,12 +29,12 @@ pub fn loading_text_for_data_sources(log_sources: &[Arc<SmartChannelSource>]) ->
         match source.as_ref() {
             SmartChannelSource::File(path) => {
                 if let Some(path_str) = path.to_str() {
-                    return Some(format!("Loading {path_str}…",));
+                    return Some(format!("Loading {path_str} …",));
                 }
             }
 
             SmartChannelSource::RrdHttpStream { url, .. } => {
-                return Some(format!("Connecting to {url}…"));
+                return Some(format!("Connecting to {url} …"));
             }
 
             SmartChannelSource::RrdWebEventListener | SmartChannelSource::JsChannel { .. } => {
@@ -46,7 +49,7 @@ pub fn loading_text_for_data_sources(log_sources: &[Arc<SmartChannelSource>]) ->
 
             SmartChannelSource::RedapGrpcStream { uri, .. } => {
                 if uri.origin != *re_redap_browser::EXAMPLES_ORIGIN {
-                    return Some(format!("Connecting to {}…", uri.origin));
+                    return Some(format!("Connecting to {} …", uri.origin));
                 }
             }
         }

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/mod.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/mod.rs
@@ -1,8 +1,12 @@
 mod example_section;
+mod loading_data_ui;
 mod no_data_ui;
 mod welcome_section;
 
+use std::sync::Arc;
+
 use example_section::{ExampleSection, MIN_COLUMN_WIDTH};
+use re_smart_channel::SmartChannelSource;
 use welcome_section::welcome_section_ui;
 
 use crate::app_state::WelcomeScreenState;
@@ -24,6 +28,7 @@ impl WelcomeScreen {
         command_sender: &re_viewer_context::CommandSender,
         welcome_screen_state: &WelcomeScreenState,
         is_history_enabled: bool,
+        log_sources: &[Arc<SmartChannelSource>],
     ) {
         if welcome_screen_state.opacity <= 0.0 {
             return;
@@ -49,7 +54,11 @@ impl WelcomeScreen {
                     ..Default::default()
                 }
                 .show(ui, |ui| {
-                    if welcome_screen_state.hide {
+                    if let Some(loading_text) =
+                        loading_data_ui::loading_text_for_data_sources(log_sources)
+                    {
+                        loading_data_ui::loading_data_ui(ui, &loading_text);
+                    } else if welcome_screen_state.hide_examples {
                         no_data_ui::no_data_ui(ui);
                     } else {
                         self.example_page.ui(


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/10574 

### What

Previously, when starting the viewer with a data source attached we'd show the welcome screen (or data ui respectively in the notebook). This is irritating because it doesn't give any feedback the ongoing loading process.


https://github.com/user-attachments/assets/aba635c0-9807-456d-920b-b942a146ca4c

Design isn't great, might need some @gavrelina love later on.

* [x] test behavior from url locally
* [x] test for no change in behavior without a url
* [x] test for no behavior change when using spawn from sdk
* [x] test behavior in a notebook