### PR TITLE
Fix `VideoStream` stuttering on web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8208,6 +8208,7 @@ dependencies = [
  "serde",
  "thiserror 1.0.65",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8184,6 +8184,7 @@ dependencies = [
 name = "re_video"
 version = "0.24.0-alpha.1+dev"
 dependencies = [
+ "ahash",
  "bit-vec",
  "cfg_aliases",
  "criterion",
@@ -8206,6 +8207,7 @@ dependencies = [
  "re_span",
  "re_tracing",
  "serde",
+ "smallvec",
  "thiserror 1.0.65",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/crates/utils/re_video/Cargo.toml
+++ b/crates/utils/re_video/Cargo.toml
@@ -80,6 +80,7 @@ dav1d = { workspace = true, optional = true, default-features = false, features 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys.workspace = true
 wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = [
   "DomException",
   "EncodedVideoChunk",

--- a/crates/utils/re_video/Cargo.toml
+++ b/crates/utils/re_video/Cargo.toml
@@ -47,6 +47,7 @@ re_log.workspace = true
 re_span.workspace = true
 re_tracing.workspace = true
 
+ahash.workspace = true
 bit-vec.workspace = true
 crossbeam.workspace = true
 econtext.workspace = true
@@ -56,6 +57,7 @@ once_cell.workspace = true
 parking_lot.workspace = true
 poll-promise.workspace = true
 re_mp4.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
 web-time.workspace = true
 

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -914,10 +914,8 @@ impl AsyncDecoder for FFmpegCliH264Decoder {
     }
 
     fn min_num_samples_to_enqueue_ahead(&self) -> usize {
-        // TODO(#8848): On some videos (which??) we need to enqueue more samples, otherwise ffmpeg will not provide us with any frames.
-        // The observed behavior is that we continuously get frames that are N* frames older than what we enqueued,
-        // never reaching the frames of all currently enqueued GOPs prior.
-        // (The same happens with webcodec decoder on Safari for affected videos)
+        // Until FFmpeg's stdin isn't closed, we don't get the last few frames.
+        // By supplying more than we need we can workaround this a bit.
         //
         // *: N is 16 for ffmpeg 7.1, tested on Mac & Windows. For ffmpeg 6.1.2 on Linux it was found to be 18.
         18

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -172,7 +172,8 @@ pub trait AsyncDecoder: Send + Sync {
     /// Called after submitting the last chunk.
     ///
     /// Should flush all pending frames.
-    /// If new chunks are submitted after this, the decoder has to be reset.
+    /// If you plan on sending more chunks after calling `end_of_video`,
+    /// you MUST call [`Self::reset`] FIRST.
     ///
     /// Implementation note:
     /// As of writing there's two decoders that have requirements on what happens for new frames after `end_of_video`

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -172,7 +172,12 @@ pub trait AsyncDecoder: Send + Sync {
     /// Called after submitting the last chunk.
     ///
     /// Should flush all pending frames.
-    /// The next submitted chunk is guaranteed to be a key frame.
+    /// If new chunks are submitted after this, the decoder has to be reset.
+    ///
+    /// Implementation note:
+    /// As of writing there's two decoders that have requirements on what happens for new frames after `end_of_video`
+    /// * WebCodec: The next submitted chunk has to be a key frame.
+    /// * FFmpeg-executable: We've shut down stdin, thus we need to restart the process. Doing this without the full context of `reset` is not possible right now.
     fn end_of_video(&mut self) -> Result<()> {
         Ok(())
     }

--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -172,6 +172,7 @@ pub trait AsyncDecoder: Send + Sync {
     /// Called after submitting the last chunk.
     ///
     /// Should flush all pending frames.
+    /// The next submitted chunk is guaranteed to be a key frame.
     fn end_of_video(&mut self) -> Result<()> {
         Ok(())
     }
@@ -391,9 +392,11 @@ pub struct FrameInfo {
     /// None = unknown.
     pub frame_nr: Option<u32>,
 
-    /// Time at which this sample appears in the frame stream, in time units.
+    /// Time at which this frame appears in the frame stream, in time units.
     ///
     /// The frame should be shown at this time.
+    /// We expect this timestamp to be identical with a the presentation timestamp of the [`crate::Chunk`]
+    /// which is associated with this frame.
     /// Often synonymous with `composition_timestamp`.
     ///
     /// `decode_timestamp <= presentation_timestamp`

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -376,8 +376,8 @@ fn init_video_decoder(
                     (None, None) => {
                         // This unfortunately happens every now and then for our video stream demo.
                         re_log::debug_once!("WebCodec decoded video frame for which we didn't have any corresponding frame info.
-                                This happens when the decoder emits more frames than we expected.
-                                This is due to interpolation in the decoder or if a video sample corresponds to more than one video frame which Rerun doesn't support."
+This happens when the decoder emits more frames than we expected which can occur if the sample
+contains more frames than expected (invalid input data) or the decoder interpolates frames unexpectedly."
                             );
                         return;
                     }

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -181,11 +181,14 @@ impl AsyncDecoder for WebVideoDecoder {
         // > Let timestamp and duration be the timestamp and duration from the EncodedVideoChunk associated with output.
         //
         // However, in practice, the timestamps received are often off by more than can be just explained with
-        // the wasm->js->wasm transition (which is bound to mess with accuracy) and the fact that
+        // the wasm->js->wasm transition (which is bound to mess with accuracy a little bit) and the fact that
         // WebCodec specifies timestamps to be internally represented as i64.
         // In chrome this is likely related to this bug:
         // https://issues.chromium.org/issues/40925070
         // (comments describe that decoders may mess with the timestamps)
+        //
+        // Timestamps are never fully made up: if we add a large offset and remove it on receive again,
+        // we will never fall below that offset, i.e. it is passed through.
         //
         // Therefore we make a best-effort attempt:
         // * use whole numbered microseconds since first frame

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -359,9 +359,7 @@ fn init_video_decoder(
                         web_timestamp_us,
                         frame_info,
                     }) => {
-                        let infos = pending_frame_infos
-                            .entry(web_timestamp_us)
-                            .or_insert(smallvec::SmallVec::default());
+                        let infos = pending_frame_infos.entry(web_timestamp_us).or_default();
                         infos.push(frame_info);
                     }
 

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -220,8 +220,6 @@ impl AsyncDecoder for WebVideoDecoder {
         if let Some(duration) = video_chunk.duration {
             let duration_micros = 1e-3 * duration.duration(self.timescale).as_nanos() as f64;
             web_chunk.set_duration(duration_micros);
-        } else {
-            web_chunk.set_duration(1.0 / 30.0 * 1000.0 * 1000.0);
         }
 
         let web_chunk = EncodedVideoChunk::new(&web_chunk)

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -336,7 +336,7 @@ fn init_video_decoder(
                 .range(..=web_timestamp_us)
                 .next_back()
                 .map(|(k, _)| *k);
-            let loopup_timestamp_us = if Some(web_timestamp_us) == timestamp_smaller_equal {
+            let lookup_timestamp_us = if Some(web_timestamp_us) == timestamp_smaller_equal {
                 web_timestamp_us
             } else {
                 let timestamp_bigger = pending_frame_info
@@ -365,16 +365,16 @@ fn init_video_decoder(
                 }
             };
 
-            if loopup_timestamp_us as f64 != web_timestamp_us_raw {
+            if lookup_timestamp_us as f64 != web_timestamp_us_raw {
                 re_log::trace!(
-                    "WebCodec's decoded frame hat a PTS of {web_timestamp_us_raw}us, but we the closest we had was {loopup_timestamp_us}us. Abs difference: {}us",
-                    (web_timestamp_us_raw - loopup_timestamp_us as f64).abs()
+                    "WebCodec's decoded frame hat a PTS of {web_timestamp_us_raw}us, but we the closest we had was {lookup_timestamp_us}us. Abs difference: {}us",
+                    (web_timestamp_us_raw - lookup_timestamp_us as f64).abs()
                 );
             }
 
-            let Some(info) = pending_frame_info.remove(&loopup_timestamp_us) else {
+            let Some(info) = pending_frame_info.remove(&lookup_timestamp_us) else {
                 re_log::error_once!(
-                    "Determined video frame info for PTS {loopup_timestamp_us}us doesn't exist. This is an implementation error in Rerun.",
+                    "Determined video frame info for PTS {lookup_timestamp_us}us doesn't exist. This is an implementation error in Rerun.",
                 );
                 return;
             };

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -258,6 +258,12 @@ impl AsyncDecoder for WebVideoDecoder {
             self.decoder = init_video_decoder(self.on_output.clone(), output_callback_rx)?;
         };
 
+        // For all we know, the first frame timestamp may have changed.
+        self.first_frame_pts = video_descr
+            .samples
+            .front()
+            .map_or(Time::ZERO, |s| s.presentation_timestamp);
+
         let encoding_details = video_descr
             .encoding_details
             .as_ref()

--- a/crates/utils/re_video/src/decode/webcodecs.rs
+++ b/crates/utils/re_video/src/decode/webcodecs.rs
@@ -397,7 +397,13 @@ fn init_video_decoder(
             match pending_frame_infos.entry(web_timestamp_us) {
                 Entry::Occupied(mut entry) => {
                     let infos = entry.get_mut();
-                    debug_assert!(!infos.is_empty(), "Frame info lists should never be empty.");
+                    if infos.is_empty() {
+                        entry.remove();
+                        re_log::error_once!(
+                            "No more frame infos for timestamp {web_timestamp_us}. This is an implementation bug."
+                        );
+                        return;
+                    }
 
                     // If there's several frame infos for the same timestamp,
                     // use the oldest one.

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -26,6 +26,11 @@ struct DecoderOutput {
     /// Therefore, we have to be careful not to assume that an incoming frame isn't in the past even on a freshly
     /// reset decoder.
     /// See also <https://github.com/rerun-io/rerun/issues/7961>
+    ///
+    /// Note that this technically a bug in their respective WebCodec implementations as the spec says
+    /// (<https://www.w3.org/TR/webcodecs/#dom-videodecoder-decode>):
+    /// > VideoDecoder requires that frames are output in the order they expect to be presented, commonly known as presentation order.
+    /// Either way, being robust against this seems like a good idea!
     frames_by_pts: BTreeMap<Time, Frame>,
 
     /// Set on error; reset on success.

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -29,7 +29,7 @@ struct DecoderOutput {
     ///
     /// Note that this technically a bug in their respective WebCodec implementations as the spec says
     /// (<https://www.w3.org/TR/webcodecs/#dom-videodecoder-decode>):
-    /// > VideoDecoder requires that frames are output in the order they expect to be presented, commonly known as presentation order.
+    /// `VideoDecoder` requires that frames are output in the order they expect to be presented, commonly known as presentation order.
     /// Either way, being robust against this seems like a good idea!
     frames_by_pts: BTreeMap<Time, Frame>,
 

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -592,9 +592,9 @@ impl VideoPlayer {
 
             let sample_idx_end = video_description.samples.next_index();
             for (_, sample) in video_description.samples.iter_index_range_clamped(
-                &(sample_idx_end.saturating_sub(allowed_delay)..sample_idx_end),
+                &(sample_idx_end.saturating_sub(allowed_delay + 1)..sample_idx_end),
             ) {
-                if sample.presentation_timestamp == last_decoded_frame_pts {
+                if sample.presentation_timestamp <= last_decoded_frame_pts {
                     return DecoderDelayState::UpToDateToleratedEdgeOfLiveStream;
                 }
             }

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -488,8 +488,10 @@ impl VideoPlayer {
                 self.reset(video_description)?;
             }
         }
-        // Previously signaled the end of the video, but encountering new frames now.
-        else if self.signaled_end_of_video && last_enqueued.sample_idx < requested.sample_idx {
+        // Previously signaled the end of the video, but encountering frames that are newer than the last enqueued.
+        else if self.signaled_end_of_video
+            && last_enqueued.sample_idx + 1 < video_description.samples.next_index()
+        {
             self.reset(video_description)?;
         }
 

--- a/examples/python/camera_video_stream/camera_video_stream.py
+++ b/examples/python/camera_video_stream/camera_video_stream.py
@@ -48,7 +48,7 @@ def setup_camera_input(video_device: str | None = None) -> av.container.InputCon
         return av.open(f"video={video_device}", format="dshow")
     else:
         if video_device is None:
-            video_device = "0"
+            video_device = "/dev/video0"
 
         return av.open(video_device, format="v4l2")
 


### PR DESCRIPTION
### Related

* Fixes #10564

### What

Fix stutter issues that are caused by unexpected presentation timestamp mismatch.
The main source for this was issues with our microsecond conversion: floats are cut off to integers when going through WebCodec and we blindly trusted the values on the other end and we really need the original PTS in our player.
When addressing this by pushing frame infos to the output callback, I originally didn't consider that:
* decoder reset may not recreate the output callback, therefore causing spurious old frame infos to be in the callback's frame-info queue. It's important to reset that queue as well
* either due to user input error or rounding issues, we may have several frame infos with the same micro-second timestamp. We have to handle this gracefully

Fixes end-of-video issues when continuing a video after all
* WebCodec insists that the next frame is a key frame, if not things go ugly
* our ffmpeg decoder was just broken for a frame sometimes before auto-resetting

Fixes unhandled WebCodec abort exception handling for when `flush` is followed by `reset`.

---

* [x] full check
* [x] round of testing on Mac, including Safari

---

## Other notes on experiments

### Earlier misconceptions

For quite a while I thought that this part of the spec was violated by browsers
> Let timestamp and duration be the timestamp and duration from the EncodedVideoChunk associated with output.
(https://www.w3.org/TR/webcodecs/#output-videoframes)
However, that is *not* the case for all I can tell now. All browsers do pass the _integer part_ of the timestamp faithfully through. The other errors we had on our side caused some confusion, but with more debug output I cleared out those false conclusions.


### Can we detect number of frames in packages?

This is a potential error mode that I thought might be happening for a while, but didn't. Still it would be interesting to detect this:

I tried to evolve our GOP detection code to more arbitrary package inspection and then warn about frame counts - code [here](https://github.com/rerun-io/rerun/commit/7a6e81d7b946cba0f1149384ec599bde8a9abe3c).
Unfortunately, my "detection" says there's 5 frames in each package of `video_stream_synthetic.py`. We don't get that many frames back from any decoder and we also also logged the exact number of frame-samples we expected (120).
The problem seems to be that the packages are sliced internally - the nal type I checked is indeed dubbed `SliceLayerWithoutPartitioningNonIdr`. Curiously `SliceLayerWithoutPartitioningIdr` on the other hand only ever shows once :face_with_raised_eyebrow: 
I double checked by hexdumping the last frame of `video_stream_synthetic.py` - it's just 378 bytes and indeed we have 5x `00 00 01 41` which each indicates an non-idr slice. I suspect that depending on codec metadata varying number of slices are expected per frame.