### PR TITLE
Stop serializing selection state

### DIFF
--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -71,6 +71,13 @@ pub struct AppState {
     view_states: ViewStates,
 
     /// Selection & hovering state.
+    ///
+    /// Not serialized since on startup we have to typically discard it anyways since
+    /// whatever data was selected before is no longer accessible.
+    ///
+    /// For dataplatform use-cases this can even be rather irritating:
+    /// if previously a server was selected, then starting with a URL should no longer select it.
+    #[serde(skip)]
     pub selection_state: ApplicationSelectionState,
 
     /// Item that got focused on the last frame if any.


### PR DESCRIPTION
### Related

* related to https://github.com/rerun-io/rerun/pull/10587

### What

See codecomment for rationale

Selection state is typically cleared out on startup anyways unless you load your data _really_ fast or have some hickup. See https://github.com/rerun-io/rerun/blob/46e0eee0b264eb8c37384aeec9b06450309c493a/crates/viewer/re_viewer_context/src/selection_state.rs#L390