### PR TITLE
Remove hacks to half-buggily-support undef behavior (duped Row IDs)

### DIFF
--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -284,7 +284,6 @@ impl ChunkStore {
             for chunk_id in self
                 .chunk_ids_per_min_row_id
                 .values()
-                .flatten()
                 .filter(|chunk_id| !protected_chunk_ids.contains(chunk_id))
             {
                 if let Some(chunk) = self.chunks_per_chunk_id.get(chunk_id) {
@@ -373,10 +372,8 @@ impl ChunkStore {
             if !chunk_ids_dangling.is_empty() {
                 re_tracing::profile_scope!("dangling");
 
-                chunk_ids_per_min_row_id.retain(|_row_id, chunk_ids| {
-                    chunk_ids.retain(|chunk_id| !chunk_ids_dangling.contains(chunk_id));
-                    !chunk_ids.is_empty()
-                });
+                chunk_ids_per_min_row_id
+                    .retain(|_row_id, chunk_id| !chunk_ids_dangling.contains(chunk_id));
 
                 // Component-less indices
                 for temporal_chunk_ids_per_timeline in temporal_chunk_ids_per_entity.values_mut() {

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -427,10 +427,7 @@ pub struct ChunkStore {
     /// All [`ChunkId`]s currently in the store, indexed by the smallest [`RowId`] in each of them.
     ///
     /// This is effectively all chunks in global data order. Used for garbage collection.
-    ///
-    /// This is a map of vecs instead of individual [`ChunkId`] in order to better support
-    /// duplicated [`RowId`]s.
-    pub(crate) chunk_ids_per_min_row_id: BTreeMap<RowId, Vec<ChunkId>>,
+    pub(crate) chunk_ids_per_min_row_id: BTreeMap<RowId, ChunkId>,
 
     /// All temporal [`ChunkId`]s for all entities on all timelines, further indexed by [`ComponentDescriptor`].
     ///
@@ -549,7 +546,7 @@ impl std::fmt::Display for ChunkStore {
         f.write_str(&indent::indent_all_by(4, "}\n"))?;
 
         f.write_str(&indent::indent_all_by(4, "chunks: [\n"))?;
-        for chunk_id in chunk_id_per_min_row_id.values().flatten() {
+        for chunk_id in chunk_id_per_min_row_id.values() {
             if let Some(chunk) = chunks_per_chunk_id.get(chunk_id) {
                 if let Some(width) = f.width() {
                     let chunk_width = width.saturating_sub(8);

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -356,8 +356,17 @@ impl ChunkStore {
         };
 
         self.chunks_per_chunk_id.insert(chunk.id(), chunk.clone());
-        self.chunk_ids_per_min_row_id
-            .insert(row_id_range.0, chunk.id());
+        if self
+            .chunk_ids_per_min_row_id
+            .insert(row_id_range.0, chunk.id())
+            .is_some()
+        {
+            re_log::warn!(
+                chunk_id = %chunk.id(),
+                row_id = %row_id_range.0,
+                "detected duplicated RowId in the data, this will lead to undefined behavior"
+            );
+        }
 
         for (name, columns) in chunk.timelines() {
             let new_typ = columns.timeline().typ();


### PR DESCRIPTION
See https://github.com/rerun-io/rerun/pull/10594#discussion_r2198334520:
> Note: this is technically incorrect because it doesn't account for the vector within `chunk_ids_per_min_row_id`, except that vector doesn't make any sense to begin with. I'm going to remove it entirely tomorrow: going out of our way to pseudo-support undefined behavior (duplicated Row IDs) is unproductive at best, non-sensical at worst.
