### PR TITLE
Add `to_arrow_reader()` to `TableEntry` and `DataFusionTable`

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1378,6 +1378,9 @@ class TableEntry(Entry):
     def df(self) -> Any:
         """Registers the table with the DataFusion context and return a DataFrame."""
 
+    def to_arrow_reader(self) -> pa.RecordBatchReader:
+        """Convert this table to a [`pyarrow.RecordBatchReader`][]."""
+
 class DataframeQueryView:
     def filter_partition_id(self, partition_id: str, *args: Iterable[str]) -> Self:
         """Filter by one or more partition ids. All partition ids are included if not specified."""
@@ -1582,6 +1585,9 @@ class DataFusionTable:
 
     def df(self) -> Any:
         """Register this view to the global DataFusion context and return a DataFrame."""
+
+    def to_arrow_reader(self) -> pa.RecordBatchReader:
+        """Convert this table to a [`pyarrow.RecordBatchReader`][]."""
 
     @property
     def name(self) -> str:

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -1,7 +1,10 @@
 //! Methods for handling Arrow datamodel log ingest
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
+use arrow::array::RecordBatchIterator;
+use arrow::record_batch::RecordBatchReader;
 use arrow::{
     array::{
         ArrayData as ArrowArrayData, ArrayRef as ArrowArrayRef, ListArray as ArrowListArray,
@@ -11,6 +14,7 @@ use arrow::{
     datatypes::Field as ArrowField,
     pyarrow::PyArrowType,
 };
+use datafusion::prelude::SessionContext;
 use pyo3::{
     Bound, PyAny, PyResult,
     exceptions::PyRuntimeError,
@@ -21,6 +25,8 @@ use re_arrow_util::ArrowArrayDowncastRef as _;
 use re_chunk::{Chunk, ChunkError, ChunkId, PendingRow, RowId, TimeColumn, TimelineName};
 use re_log_types::TimePoint;
 use re_sdk::{ComponentDescriptor, EntityPath, Timeline, external::nohash_hasher::IntMap};
+
+use crate::catalog::to_py_err;
 
 /// Perform Python-to-Rust conversion for a `ComponentDescriptor`.
 pub fn descriptor_to_rust(component_descr: &Bound<'_, PyAny>) -> PyResult<ComponentDescriptor> {
@@ -169,4 +175,30 @@ pub fn build_chunk_from_components(
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
     Ok(chunk)
+}
+
+/// Convert a Datafusion table provider to an Arrow `RecordBatchReader`.
+//TODO(ab): WARNING — this reads the entire table into memory
+pub async fn datafusion_table_provider_to_arrow_reader(
+    table_provider: Arc<dyn datafusion::catalog::TableProvider + Send>,
+) -> PyResult<Box<dyn RecordBatchReader + Send>> {
+    let schema = table_provider.schema();
+
+    let session_context = SessionContext::new();
+    session_context
+        .register_table("__table__", table_provider)
+        .map_err(to_py_err)?;
+
+    let record_batches = session_context
+        .table("__table__")
+        .await
+        .map_err(to_py_err)?
+        .collect()
+        .await
+        .map_err(to_py_err)?;
+
+    Ok(Box::new(RecordBatchIterator::new(
+        record_batches.into_iter().map(Result::Ok),
+        schema,
+    )))
 }

--- a/rerun_py/src/catalog/datafusion_table.rs
+++ b/rerun_py/src/catalog/datafusion_table.rs
@@ -1,13 +1,17 @@
 use std::sync::Arc;
 
+use arrow::array::RecordBatchReader;
+use arrow::pyarrow::PyArrowType;
 use datafusion::catalog::TableProvider;
 use datafusion_ffi::table_provider::FFI_TableProvider;
 use pyo3::prelude::PyAnyMethods as _;
 use pyo3::types::PyCapsule;
 use pyo3::{Bound, Py, PyAny, PyRef, PyResult, Python, pyclass, pymethods};
+use tracing::instrument;
 
+use crate::arrow::datafusion_table_provider_to_arrow_reader;
 use crate::catalog::PyCatalogClientInternal;
-use crate::utils::get_tokio_runtime;
+use crate::utils::{get_tokio_runtime, wait_for_future};
 
 #[pyclass(frozen, name = "DataFusionTable")]
 pub struct PyDataFusionTable {
@@ -52,6 +56,22 @@ impl PyDataFusionTable {
         let df = ctx.call_method1("table", (name.clone(),))?;
 
         Ok(df)
+    }
+
+    /// Convert this table to a [`pyarrow.RecordBatchReader`][].
+    #[instrument(skip_all)]
+    fn to_arrow_reader<'py>(
+        self_: PyRef<'py, Self>,
+        py: Python<'py>,
+    ) -> PyResult<PyArrowType<Box<dyn RecordBatchReader + Send>>> {
+        let table_provider = Arc::clone(&self_.provider);
+
+        let reader = wait_for_future(
+            py,
+            datafusion_table_provider_to_arrow_reader(table_provider),
+        )?;
+
+        Ok(PyArrowType(reader))
     }
 
     /// Name of this table.


### PR DESCRIPTION
### Related

- follow up to https://github.com/rerun-io/rerun/pull/10390

### What

This PR adds:
- `TableEntry.to_arrow_reader()`
- `DataFusionTable.to_arrow_reader()`

These match the recently introduced `DataframeQueryView.to_arrow_reader()`.

The implementation isn't any less poor that before, aka everything is loaded in memory.