### PR TITLE
Fix Chunk Store issues that went under the radar

### DIFF
--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -71,15 +71,6 @@ impl ChunkStore {
 
             let row_id_range_per_component = chunk.row_id_range_per_component();
 
-            if chunk.num_components() == 0 {
-                // A static chunk without any components would be dangling from the start.
-                // Our dangling logic retrieves relevant chunks by component descriptors,
-                // so it would never be able to find it. So we never add that chunk in the
-                // first place.
-                re_log::debug_once!("Ignoring static chunk without component.");
-                return Ok(Vec::new());
-            }
-
             let mut overwritten_chunk_ids = HashMap::default();
 
             for (component_desc, list_array) in chunk.components().iter() {
@@ -972,11 +963,7 @@ mod tests {
             let chunk = Arc::new(chunk);
 
             let events = store.insert_chunk(&chunk)?;
-            assert!(
-                events.len() == 1
-                    && events[0].chunk.id() == chunk.id()
-                    && events[0].kind == ChunkStoreDiffKind::Addition,
-            );
+            assert!(events.is_empty());
         }
         {
             let entity_path = EntityPath::from("/frame-nr-row-no-components");
@@ -986,11 +973,7 @@ mod tests {
             let chunk = Arc::new(chunk);
 
             let events = store.insert_chunk(&chunk)?;
-            assert!(
-                events.len() == 1
-                    && events[0].chunk.id() == chunk.id()
-                    && events[0].kind == ChunkStoreDiffKind::Addition,
-            );
+            assert!(events.is_empty());
         }
         {
             let entity_path = EntityPath::from("/both-log-frame-row-no-components");
@@ -1000,11 +983,7 @@ mod tests {
             let chunk = Arc::new(chunk);
 
             let events = store.insert_chunk(&chunk)?;
-            assert!(
-                events.len() == 1
-                    && events[0].chunk.id() == chunk.id()
-                    && events[0].kind == ChunkStoreDiffKind::Addition,
-            );
+            assert!(events.is_empty());
         }
 
         Ok(())


### PR DESCRIPTION
Fixes main:
* A merge race broke the test suites, which ended up hiding some real issues
* Previous PR revealed a long dormant bug that was hidden behind an extremely coarse `retain`
* If we forbid empty static chunks, let's just forbid empty chunks altogether