### PR TITLE
Fix crate publishing caused by `include_bytes` outside of crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8748,7 +8748,6 @@ dependencies = [
  "re_query",
  "re_renderer",
  "re_smart_channel",
- "re_sorbet",
  "re_string_interner",
  "re_tracing",
  "re_types",

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -44,7 +44,6 @@ re_log.workspace = true
 re_query.workspace = true
 re_renderer = { workspace = true, features = ["serde"] }
 re_smart_channel.workspace = true
-re_sorbet.workspace = true
 re_string_interner.workspace = true
 re_tracing.workspace = true
 re_types = { workspace = true, features = ["ecolor", "glam", "image"] }

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -155,13 +155,6 @@ impl StoreHub {
             store_bundle.blueprint_entry(&Self::welcome_screen_blueprint_id());
         (setup_welcome_screen_blueprint)(welcome_screen_blueprint);
 
-        let table_stores = if std::env::var("RERUN_EXPERIMENTAL_TABLE").is_ok() {
-            let table_id = TableId::new("test123".to_owned());
-            std::iter::once((table_id, TableStore::dummy())).collect()
-        } else {
-            TableStores::default()
-        };
-
         Self {
             persistence,
             active_recording_or_table: None,
@@ -177,7 +170,7 @@ impl StoreHub {
             blueprint_last_save: Default::default(),
             blueprint_last_gc: Default::default(),
 
-            table_stores,
+            table_stores: TableStores::default(),
         }
     }
 

--- a/crates/viewer/re_viewer_context/src/tables.rs
+++ b/crates/viewer/re_viewer_context/src/tables.rs
@@ -1,17 +1,12 @@
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, Float32Array, Int64Array, ListArray, RecordBatch};
-use arrow::buffer::OffsetBuffer;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::RecordBatch;
 use datafusion::common::DataFusionError;
 use datafusion::datasource::MemTable;
 use datafusion::prelude::SessionContext;
 
 use re_chunk::external::re_byte_size::SizeBytes as _;
 use re_log_types::TableId;
-use re_sorbet::ComponentColumnDescriptor;
-
-use re_types_core::ComponentBatch as _;
 
 #[derive(Default)]
 pub struct TableStore {
@@ -47,123 +42,6 @@ impl TableStore {
             .register_table(Self::TABLE_NAME, Arc::new(table))?;
 
         Ok(())
-    }
-
-    /// This is just for testing purposes and will go away soon™
-    // TODO(grtlr): This is just for debugging purposes until we can populate the
-    // store from the outside, for example vie GRPC.
-    pub fn dummy() -> Self {
-        let mut descriptors = vec![];
-        let mut columns = vec![];
-
-        {
-            let descriptor = re_sorbet::ColumnDescriptor::Component(ComponentColumnDescriptor {
-                entity_path: re_log_types::EntityPath::from("/some/path"),
-                archetype: Some("archetype".into()),
-                component: "field".into(),
-                component_type: Some("component".into()),
-                store_datatype: arrow::datatypes::DataType::Int64,
-                is_static: true,
-                is_tombstone: false,
-                is_semantically_empty: false,
-            });
-
-            descriptors.push(descriptor);
-            columns.push(Arc::new(Int64Array::from(vec![42])) as ArrayRef);
-        }
-
-        {
-            let field = Arc::new(Field::new("data", DataType::Float32, false));
-
-            let descriptor = re_sorbet::ColumnDescriptor::Component(ComponentColumnDescriptor {
-                entity_path: re_log_types::EntityPath::from("/some/path"),
-                archetype: Some("archetype".into()),
-                component: "short_list".into(),
-                component_type: Some("short_list".into()),
-                store_datatype: arrow::datatypes::DataType::List(field.clone()),
-                is_static: true,
-                is_tombstone: false,
-                is_semantically_empty: false,
-            });
-
-            let data = ListArray::new(
-                field,
-                OffsetBuffer::from_lengths([5]),
-                Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0])),
-                None,
-            );
-
-            descriptors.push(descriptor);
-            columns.push(Arc::new(data) as ArrayRef);
-        }
-
-        {
-            let field = Arc::new(Field::new("data", DataType::Float32, false));
-
-            let descriptor = re_sorbet::ColumnDescriptor::Component(ComponentColumnDescriptor {
-                entity_path: re_log_types::EntityPath::from("/some/path"),
-                archetype: Some("archetype".to_owned().into()),
-                component: "long_list".into(),
-                component_type: Some("long_list".into()),
-                store_datatype: arrow::datatypes::DataType::List(field.clone()),
-                is_static: true,
-                is_tombstone: false,
-                is_semantically_empty: false,
-            });
-
-            let data = ListArray::new(
-                field,
-                OffsetBuffer::from_lengths([500]),
-                Arc::new(Float32Array::from(vec![15.0; 500])),
-                None,
-            );
-
-            descriptors.push(descriptor);
-            columns.push(Arc::new(data) as ArrayRef);
-        }
-
-        {
-            let blob = re_types::components::Blob(re_types::datatypes::Blob::from(
-                include_bytes!("../../re_ui/data/icons/rerun_io.png").to_vec(),
-            ));
-
-            let array = Arc::new(
-                blob.to_arrow_list_array()
-                    .expect("serialization should succeed"),
-            ) as ArrayRef;
-
-            let descriptor = re_sorbet::ColumnDescriptor::Component(ComponentColumnDescriptor {
-                entity_path: re_log_types::EntityPath::from("/some/path"),
-                archetype: Some("archetype".to_owned().into()),
-                component: "thumbnail".into(),
-                component_type: Some("rerun.components.Blob".into()),
-                store_datatype: array.data_type().clone(),
-                is_static: true,
-                is_tombstone: false,
-                is_semantically_empty: false,
-            });
-
-            descriptors.push(descriptor);
-            columns.push(array);
-        }
-
-        let schema = Arc::new(Schema::new_with_metadata(
-            descriptors
-                .iter()
-                .map(|desc| desc.to_arrow_field(re_sorbet::BatchType::Dataframe))
-                .collect::<Vec<_>>(),
-            Default::default(),
-        ));
-
-        let batch =
-            RecordBatch::try_new(schema.clone(), columns).expect("could not create record batch");
-
-        let store = Self::default();
-        store
-            .add_record_batch(batch)
-            .expect("could not add record batch");
-
-        store
     }
 }
 


### PR DESCRIPTION
See build failure here https://github.com/rerun-io/rerun/actions/runs/16236442156/job/45847267954
We accidentally include bytes from outside of the crate which makes it fail to build upon publish.

Removing `RERUN_EXPERIMENTAL_TABLE` altogether, no longer needed.