### PR TITLE
Add snippet demonstrating re-muxing of `VideoStream` data

### DIFF
--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -59,9 +59,7 @@ TODO(#10422): fix above if ticket is outdated.
 ### Remuxing video streams
 
 Sample data from [`VideoStream`](../reference/types/archetypes/video_stream.md) can be queried
-and remuxed to mp4 without re-encoding the video as demonstrated in this sample:
-
-snippet: archetypes/video_stream_query_and_mux
+and remuxed to mp4 without re-encoding the video as demonstrated in [this sample](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/archetypes/video_stream_query_and_mux.py#speculative-link).
 
 Check the [doc page on retrieving data](../../content/howto/get-data-out.md) to learn more about dataframe queries in general.
 

--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -39,7 +39,7 @@ video asset file to be in Viewer memory before decoding can begin.
 
 Refer to the [video camera streaming](https://github.com/rerun-io/rerun/blob/latest/examples/python/camera_video_stream?speculative-link) example to learn how to stream live video to Rerun.
 
-Current limitations:
+Current limitations of `VideoStream`:
 * [#9815](https://github.com/rerun-io/rerun/issues/9815): Decoding on native is generally slower than decoding in the browser right now.
   This can cause increased latency and in some cases may even stop video playback.
 * [#10184](https://github.com/rerun-io/rerun/issues/10184), [#10185](https://github.com/rerun-io/rerun/issues/10185), [#10186](https://github.com/rerun-io/rerun/issues/10186): [`VideoStream`](../reference/types/archetypes/video_stream.md) only supports H.264 at this point.
@@ -55,6 +55,15 @@ TODO(#10186): fix above if ticket is outdated.
 TODO(#10090): fix above if ticket is outdated.
 TODO(#10422): fix above if ticket is outdated.
 -->
+
+### Remuxing video streams
+
+Sample data from [`VideoStream`](../reference/types/archetypes/video_stream.md) can be queried
+and remuxed to mp4 without re-encoding the video as demonstrated in this sample:
+
+snippet: archetypes/video_stream_query_and_mux
+
+Check the [doc page on retrieving data](../../content/howto/get-data-out.md) to learn more about dataframe queries in general.
 
 
 ## Video files

--- a/docs/snippets/all/archetypes/video_stream_query_and_mux.py
+++ b/docs/snippets/all/archetypes/video_stream_query_and_mux.py
@@ -1,0 +1,97 @@
+"""Query video stream from a recording and mux it to an mp4 video file."""
+
+import argparse
+import io
+import sys
+from fractions import Fraction
+
+import av
+import rerun as rr
+from pyarrow import ChunkedArray
+
+
+def read_h264_samples_from_rrd(rrd_path: str, video_entity: str, timeline: str) -> tuple[ChunkedArray, ChunkedArray]:
+    """Load recording data and query video stream."""
+
+    recording = rr.dataframe.load_recording(rrd_path)
+    view = recording.view(index=timeline, contents=video_entity)
+
+    # Make sure this is H.264 encoded.
+    # For that we just read out the first codec value batch and check whether it's H.264.
+    codec = view.select(f"{video_entity}:VideoStream:codec")
+    first_codec_batch = codec.read_next_batch()
+    if first_codec_batch is None:
+        raise ValueError(f"There's no video stream codec specified at {video_entity} for timeline {timeline}.")
+    codec_value = first_codec_batch.column(0)[0][0].as_py()
+    if codec_value != rr.VideoCodec.H264.value:
+        raise ValueError(
+            f"Video stream codec is not H.264 at {video_entity} for timeline {timeline}. "
+            f"Got {hex(codec_value)}, but the value for H.264 is {hex(rr.VideoCodec.H264.value)}."
+        )
+    else:
+        print(f"Video stream codec is H.264 at {video_entity} for timeline {timeline}.")
+
+    # Get the video stream
+    timestamps_and_samples = view.select(timeline, f"{video_entity}:VideoStream:sample").read_all()
+    times = timestamps_and_samples[0]
+    samples = timestamps_and_samples[1]
+
+    print(f"Retrieved {len(samples)} video samples.")
+
+    return times, samples
+
+
+def mux_h264_to_mp4(times: ChunkedArray, samples: ChunkedArray, output_path: str) -> None:
+    """Mux H.264 Annex B samples to an mp4 file using PyAV."""
+    # See https://pyav.basswood-io.com/docs/stable/cookbook/basics.html#remuxing
+
+    # Flatten out sample list into a single byte buffer.
+    sample_bytes = samples.combine_chunks().flatten(recursive=True)
+    sample_bytes = io.BytesIO(sample_bytes.buffers()[1])
+
+    # Setup samples as input container.
+    input_container = av.open(sample_bytes, mode="r", format="h264")  # Input is AnnexB H.264 stream.
+    input_stream = input_container.streams.video[0]
+    input_stream.time_base = Fraction(1, 1_000_000_000)  # Assuming duration timestamps in nanoseconds.
+
+    # Setup output container.
+    output_container = av.open(output_path, mode="w")
+    output_stream = output_container.add_stream_from_template(input_stream)
+
+    # Demux and mux packets.
+    for packet, time in zip(input_container.demux(input_stream), times):
+        packet.pts = int(time.value)
+        packet.dts = packet.pts  # dts == pts since there's no B-frames.
+        packet.stream = output_stream
+        output_container.mux(packet)
+
+    input_container.close()
+    output_container.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query video stream from a recording and mux it to an mp4 video file.")
+    parser.add_argument("input_rrd", type=str, help="Path to the input .rrd recording file")
+    parser.add_argument(
+        "-o", "--output", type=str, default="output.mp4", help="Output mp4 file path (default: output.mp4)"
+    )
+    parser.add_argument(
+        "--video-entity", type=str, default="video_stream", help="Video entity path to query (default: video_stream)"
+    )
+    parser.add_argument("--timeline", type=str, default="time", help="Name of the timeline to query (default: time)")
+    args = parser.parse_args()
+
+    # Load recording data
+    print(f"Loading recording from: {args.input_rrd}")
+    times, samples = read_h264_samples_from_rrd(args.input_rrd, args.video_entity, args.timeline)
+
+    print(f"Creating video file: {args.output}")
+    mux_h264_to_mp4(times, samples, args.output)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nOperation cancelled by user.")
+        sys.exit(0)

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -183,6 +183,11 @@ features = [
   "cpp",  # Not implemented
   "rust", # Not implemented
 ]
+"archetypes/video_stream_query_and_mux" = [
+  "py",   # Doesn't produce an rrd file.
+  "cpp",  # Not implemented
+  "rust", # Not implemented
+]
 "migration/log_line" = [ # Not a complete example -- just a single log line
   "cpp",
   "rust",


### PR DESCRIPTION
Given that it can take any rrd and extract video from it it's a little bit more than an example even, it's almost a utility!

I tested it with an rrd from `video_stream_synthetic.py` as well as an rrd from our internal dataplatform demo (using the work-in-progress video stream version)

Example invocations:
```sh
python docs/snippets/all/archetypes/video_stream_query_and_mux.py video_stream_synthetic.rrd
python docs/snippets/all/archetypes/video_stream_query_and_mux.py "Wed_Apr_19_16 45 35_2023.rrd" --timeline real_time --entity camera/wrist --output wed.mp4
```

Help text:
```
usage: video_stream_query_and_mux.py [-h] [-o OUTPUT] [--entity ENTITY] [--timeline TIMELINE] input_rrd

Query video stream from a recording and mux it to an mp4 video file.

positional arguments:
  input_rrd             Path to the input .rrd recording file

options:
  -h, --help            show this help message and exit
  -o OUTPUT, --output OUTPUT
                        Output mp4 file path (default: output.mp4)
  --entity ENTITY       Video entity path to query (default: video_stream)
  --timeline TIMELINE   Name of the timeline to query (default: time)
```


I figured this is such an important piece, it belongs to the video reference page!