### PR TITLE
Source default batcher settings from sink

### DIFF
--- a/crates/store/re_chunk/src/lib.rs
+++ b/crates/store/re_chunk/src/lib.rs
@@ -31,7 +31,8 @@ pub use self::range::{RangeQuery, RangeQueryOptions};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::batcher::{
-    ChunkBatcher, ChunkBatcherConfig, ChunkBatcherError, ChunkBatcherResult, PendingRow,
+    BatcherHooks, ChunkBatcher, ChunkBatcherConfig, ChunkBatcherError, ChunkBatcherResult,
+    PendingRow,
 };
 
 // Re-exports

--- a/crates/store/re_chunk_store/tests/memory_test.rs
+++ b/crates/store/re_chunk_store/tests/memory_test.rs
@@ -69,7 +69,8 @@ fn memory_use<R>(run: impl Fn() -> R) -> (usize, usize) {
 // ----------------------------------------------------------------------------
 
 use re_chunk::{
-    ChunkBatcher, ChunkBatcherConfig, PendingRow, external::crossbeam::channel::TryRecvError,
+    BatcherHooks, ChunkBatcher, ChunkBatcherConfig, PendingRow,
+    external::crossbeam::channel::TryRecvError,
 };
 use re_chunk_store::{ChunkStore, ChunkStoreConfig};
 use re_log_types::{TimePoint, Timeline};
@@ -92,10 +93,13 @@ fn scalar_memory_overhead() {
             ChunkStoreConfig::default(),
         );
 
-        let batcher = ChunkBatcher::new(ChunkBatcherConfig {
-            flush_num_rows: 1000,
-            ..ChunkBatcherConfig::NEVER
-        })
+        let batcher = ChunkBatcher::new(
+            ChunkBatcherConfig {
+                flush_num_rows: 1000,
+                ..ChunkBatcherConfig::NEVER
+            },
+            BatcherHooks::NONE,
+        )
         .unwrap();
 
         for i in 0..NUM_SCALARS {

--- a/crates/store/re_log_types/src/arrow_msg.rs
+++ b/crates/store/re_log_types/src/arrow_msg.rs
@@ -14,7 +14,8 @@ use arrow::array::RecordBatch as ArrowRecordBatch;
 /// every instance.
 /// It is up to the callback implementer to handle this, if needed.
 //
-// TODO(#6412): probably don't need this anymore.
+// As of writing this is used to handle memory that's shared from Python with the
+// Batcher thread - we need special handling for release of potentially Python owned memory.
 #[allow(clippy::type_complexity)]
 #[derive(Clone)]
 pub struct ArrowRecordBatchReleaseCallback(Arc<dyn Fn(ArrowRecordBatch) + Send + Sync>);

--- a/crates/top/re_sdk/src/grpc_server.rs
+++ b/crates/top/re_sdk/src/grpc_server.rs
@@ -1,3 +1,4 @@
+use re_chunk::ChunkBatcherConfig;
 use re_log_types::LogMsg;
 
 /// A [`crate::sink::LogSink`] tied to a hosted Rerun gRPC server.
@@ -79,6 +80,11 @@ impl crate::sink::LogSink for GrpcServerSink {
         if let Err(err) = self.sender.flush_blocking() {
             re_log::error_once!("Failed to flush: {err}");
         }
+    }
+
+    fn default_batcher_config(&self) -> ChunkBatcherConfig {
+        // The GRPC sink is typically used for live streams.
+        ChunkBatcherConfig::LOW_LATENCY
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::Mutex;
+use re_chunk::{BatcherHooks, ChunkBatcherConfig, external::arrow::array::RecordBatch};
 use re_grpc_client::message_proxy::write::{Client as MessageProxyClient, Options};
-use re_log_encoding::encoder::encode_as_bytes_local;
-use re_log_encoding::encoder::{EncodeError, local_raw_encoder};
-use re_log_types::{BlueprintActivationCommand, LogMsg, StoreId};
+use re_log_encoding::encoder::{EncodeError, encode_as_bytes_local, local_raw_encoder};
+use re_log_types::{ArrowRecordBatchReleaseCallback, BlueprintActivationCommand, LogMsg, StoreId};
 
 use crate::RecordingStream;
 
@@ -71,6 +71,11 @@ pub trait LogSink: Send + Sync + 'static {
         }
     }
 
+    /// The default batcher configuration used for new (!) [`RecordingStream`]s with this sink.
+    fn default_batcher_config(&self) -> ChunkBatcherConfig {
+        ChunkBatcherConfig::DEFAULT
+    }
+
     /// As [`std::any::Any`] for dynamic downcasting.
     fn as_any(&self) -> &dyn std::any::Any;
 }
@@ -118,6 +123,64 @@ impl LogSink for MultiSink {
     #[inline]
     fn drain_backlog(&self) -> Vec<LogMsg> {
         Vec::new()
+    }
+
+    fn default_batcher_config(&self) -> ChunkBatcherConfig {
+        let ChunkBatcherConfig {
+            mut flush_tick,
+            mut flush_num_bytes,
+            mut flush_num_rows,
+            mut chunk_max_rows_if_unsorted,
+            mut max_commands_in_flight,
+            mut max_chunks_in_flight,
+            hooks: _,
+        } = ChunkBatcherConfig::DEFAULT;
+
+        let mut insert_hooks = Vec::new();
+        let mut release_hooks = Vec::new();
+
+        // Use a mix of the existing sinks thus that we flush *less* often.
+        // Prefer less flushing since it leads to better chunks.
+        for sink in self.0.lock().iter() {
+            let config = sink.default_batcher_config();
+
+            flush_tick = flush_tick.max(config.flush_tick);
+            flush_num_bytes = flush_num_bytes.max(config.flush_num_bytes);
+            flush_num_rows = flush_num_rows.max(config.flush_num_rows);
+            chunk_max_rows_if_unsorted =
+                chunk_max_rows_if_unsorted.max(config.chunk_max_rows_if_unsorted);
+            max_commands_in_flight = max_commands_in_flight.max(config.max_commands_in_flight);
+            max_chunks_in_flight = max_chunks_in_flight.max(config.max_chunks_in_flight);
+
+            insert_hooks.extend(config.hooks.on_insert.into_iter());
+            release_hooks.extend(config.hooks.on_release.into_iter());
+        }
+
+        // Combine all hooks.
+        let hooks = BatcherHooks {
+            on_insert: Some(Arc::new(move |rows| {
+                for hook in &insert_hooks {
+                    hook(rows);
+                }
+            })),
+            on_release: Some(ArrowRecordBatchReleaseCallback::from(
+                move |record_batch: RecordBatch| {
+                    for hook in &release_hooks {
+                        hook(record_batch.clone()); // RecordBatch clones are shallow.
+                    }
+                },
+            )),
+        };
+
+        ChunkBatcherConfig {
+            flush_tick,
+            flush_num_bytes,
+            flush_num_rows,
+            chunk_max_rows_if_unsorted,
+            max_commands_in_flight,
+            max_chunks_in_flight,
+            hooks,
+        }
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -510,6 +573,11 @@ impl LogSink for GrpcSink {
 
     fn flush_blocking(&self) {
         self.client.flush();
+    }
+
+    fn default_batcher_config(&self) -> ChunkBatcherConfig {
+        // The GRPC sink is typically used for live streams.
+        ChunkBatcherConfig::LOW_LATENCY
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -258,6 +258,10 @@ impl RecordingStreamBuilder {
 
     /// Specifies the configuration of the internal data batching mechanism.
     ///
+    /// If not set, the default configuration for the currently active sink will be used.
+    /// Changing the sink at a later point will *not* change the batcher configuration.
+    /// Any environment variables as specified on [`ChunkBatcherConfig`] will always override respective settings.
+    ///
     /// See [`ChunkBatcher`] & [`ChunkBatcherConfig`] for more information.
     #[inline]
     pub fn batcher_config(mut self, config: ChunkBatcherConfig) -> Self {
@@ -288,14 +292,10 @@ impl RecordingStreamBuilder {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn buffered(self) -> RecordingStreamResult<RecordingStream> {
+        let sink = crate::log_sink::BufferedSink::new();
         let (enabled, store_info, properties, batcher_config) = self.into_args();
         if enabled {
-            RecordingStream::new(
-                store_info,
-                properties,
-                batcher_config,
-                Box::new(crate::log_sink::BufferedSink::new()),
-            )
+            RecordingStream::new(store_info, properties, batcher_config, Box::new(sink))
         } else {
             re_log::debug!("Rerun disabled - call to buffered() ignored");
             Ok(RecordingStream::disabled())
@@ -686,7 +686,14 @@ impl RecordingStreamBuilder {
     ///
     /// This can be used to then construct a [`RecordingStream`] manually using
     /// [`RecordingStream::new`].
-    pub fn into_args(self) -> (bool, StoreInfo, Option<RecordingInfo>, ChunkBatcherConfig) {
+    pub fn into_args(
+        self,
+    ) -> (
+        bool,
+        StoreInfo,
+        Option<RecordingInfo>,
+        Option<ChunkBatcherConfig>,
+    ) {
         let enabled = self.is_enabled();
 
         let Self {
@@ -714,15 +721,6 @@ impl RecordingStreamBuilder {
             store_source,
             store_version: Some(re_build_info::CrateVersion::LOCAL),
         };
-
-        let batcher_config =
-            batcher_config.unwrap_or_else(|| match ChunkBatcherConfig::from_env() {
-                Ok(config) => config,
-                Err(err) => {
-                    re_log::error!("Failed to parse ChunkBatcherConfig from env: {}", err);
-                    ChunkBatcherConfig::default()
-                }
-            });
 
         (
             enabled,
@@ -1009,14 +1007,23 @@ impl RecordingStream {
     ///
     /// You can find sinks in [`crate::sink`].
     ///
+    /// If no batcher configuration is provided, the default batcher configuration for the sink will be used.
+    /// Any environment variables as specified in [`ChunkBatcherConfig`] will always override respective settings.
+    ///
     /// See also: [`RecordingStreamBuilder`].
     #[must_use = "Recording will get closed automatically once all instances of this object have been dropped"]
     pub fn new(
         store_info: StoreInfo,
         recording_info: Option<RecordingInfo>,
-        batcher_config: ChunkBatcherConfig,
+        batcher_config: Option<ChunkBatcherConfig>,
         sink: Box<dyn LogSink>,
     ) -> RecordingStreamResult<Self> {
+        let batcher_config = batcher_config.unwrap_or_else(|| sink.default_batcher_config());
+        let batcher_config = batcher_config.apply_env().unwrap_or_else(|err| {
+            re_log::error!("Failed to parse ChunkBatcherConfig from env: {}", err);
+            batcher_config
+        });
+
         let sink = (store_info.store_id.kind == StoreKind::Recording)
             .then(forced_sink_path)
             .flatten()
@@ -1740,6 +1747,8 @@ impl RecordingStream {
     /// When this function returns, the calling thread is guaranteed that all future record calls
     /// will end up in the new sink.
     ///
+    /// Setting a new sink will not affect the batcher's configuration.
+    ///
     /// ## Data loss
     ///
     /// If the current sink is in a broken state (e.g. a gRPC sink with a broken connection that
@@ -1857,6 +1866,8 @@ impl RecordingStream {
     /// [`RecordingStream`] will now stream data to multiple sinks at the same time.
     ///
     /// Currently only supports [`GrpcSink`][grpc_sink] and [`FileSink`][file_sink].
+    ///
+    /// Setting a new sink will not affect the batcher's configuration.
     ///
     /// [grpc_sink]: crate::sink::GrpcSink
     /// [file_sink]: crate::sink::FileSink

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -1,3 +1,4 @@
+use re_chunk::ChunkBatcherConfig;
 use re_log_types::LogMsg;
 use re_web_viewer_server::{WebViewerServer, WebViewerServerError, WebViewerServerPort};
 
@@ -107,6 +108,11 @@ impl crate::sink::LogSink for WebViewerSink {
         if let Err(err) = self.sender.flush_blocking() {
             re_log::error_once!("Failed to flush: {err}");
         }
+    }
+
+    fn default_batcher_config(&self) -> ChunkBatcherConfig {
+        // The GRPC sink is typically used for live streams.
+        ChunkBatcherConfig::LOW_LATENCY
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/top/rerun/tests/rerun_tests.rs
+++ b/crates/top/rerun/tests/rerun_tests.rs
@@ -5,8 +5,8 @@
 /// See for instance <https://github.com/rerun-io/rerun/issues/4415>.
 #[test]
 fn test_row_id_order() {
-    let mut batcher_config = rerun::log::ChunkBatcherConfig::NEVER;
-    batcher_config.hooks.on_insert = Some(std::sync::Arc::new(|rows| {
+    let mut hooks = re_chunk::BatcherHooks::NONE;
+    hooks.on_insert = Some(std::sync::Arc::new(|rows| {
         if let [.., penultimate, ultimate] = rows {
             assert!(
                 penultimate.row_id <= ultimate.row_id,
@@ -15,7 +15,7 @@ fn test_row_id_order() {
         }
     }));
     let (rec, _mem_storage) = rerun::RecordingStreamBuilder::new("rerun_example_test")
-        .batcher_config(batcher_config)
+        .batcher_hooks(hooks)
         .memory()
         .unwrap();
 

--- a/docs/content/reference/migration/migration-0-24.md
+++ b/docs/content/reference/migration/migration-0-24.md
@@ -17,12 +17,10 @@ To accommodate the new tree keyboard navigation feature, the timeline navigation
 
 Have been removed in favor of `Scalars`, `SeriesLines`, `SeriesPoints` respectively.
 
-## Micro-batcher default flushing duration increased from 8ms to 200ms in many cases
+## Micro-batcher default flushing duration increased from 8ms to 200ms for memory & file recording streams
 
-`RERUN_FLUSH_TICK_SECS` now defaults to 200ms when left unspecified in most cases, instead of 8ms.
-
-Exceptions are recording streams that are initialized (!) with a networking sink
-(e.g. as created by `rr.init()) for which the default remains 8ms.
+`RERUN_FLUSH_TICK_SECS` previously always defaulted to 8ms when left unspecified.
+This now only applies to recording streams that use a GRPC connection, all others default to 200ms.
 
 You can learn more about micro-batching in our [dedicated documentation page](../sdk/micro-batching.md).
 

--- a/docs/content/reference/migration/migration-0-24.md
+++ b/docs/content/reference/migration/migration-0-24.md
@@ -17,6 +17,14 @@ To accommodate the new tree keyboard navigation feature, the timeline navigation
 
 Have been removed in favor of `Scalars`, `SeriesLines`, `SeriesPoints` respectively.
 
+## Micro-batcher default flushing duration increased from 8ms to 200ms in many cases
+
+`RERUN_FLUSH_TICK_SECS` now defaults to 200ms when left unspecified in most cases, instead of 8ms.
+
+Exceptions are recording streams that are initialized (!) with a networking sink
+(e.g. as created by `rr.init()) for which the default remains 8ms.
+
+You can learn more about micro-batching in our [dedicated documentation page](../sdk/micro-batching.md).
 
 ## Combining `InstancePoses3D` with orientations in `Boxes3D`/`Ellipsoids3D`/`Capsules3D` behaves differently in some cases now
 

--- a/docs/content/reference/sdk/micro-batching.md
+++ b/docs/content/reference/sdk/micro-batching.md
@@ -16,7 +16,7 @@ You can configure these thresholds using the following environment variables:
 
 Sets the duration of the periodic tick that triggers the time threshold, in seconds.
 
-Defaults to `RERUN_FLUSH_TICK_SECS=0.2` (200ms) unless the recording stream is created (!) with
+Defaults to `RERUN_FLUSH_TICK_SECS=0.2` (200ms) unless the recording stream uses a
 a networking sink which defaults to `RERUN_FLUSH_TICK_SECS=0.008` (8ms).
 
 #### RERUN_FLUSH_NUM_BYTES

--- a/docs/content/reference/sdk/micro-batching.md
+++ b/docs/content/reference/sdk/micro-batching.md
@@ -16,7 +16,8 @@ You can configure these thresholds using the following environment variables:
 
 Sets the duration of the periodic tick that triggers the time threshold, in seconds.
 
-Defaults to `RERUN_FLUSH_TICK_SECS=0.008` (8ms).
+Defaults to `RERUN_FLUSH_TICK_SECS=0.2` (200ms) unless the recording stream is created (!) with
+a networking sink which defaults to `RERUN_FLUSH_TICK_SECS=0.008` (8ms).
 
 #### RERUN_FLUSH_NUM_BYTES
 

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -305,7 +305,7 @@ class RecordingStream:
     You can configure the frequency of the batches using the following environment variables:
 
     - `RERUN_FLUSH_TICK_SECS`:
-        Flush frequency in seconds (default: `0.05` (50ms)).
+        Flush frequency in seconds (default: `0.2` (200ms)).
     - `RERUN_FLUSH_NUM_BYTES`:
         Flush threshold in bytes (default: `1048576` (1MiB)).
     - `RERUN_FLUSH_NUM_ROWS`:

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -303,14 +303,14 @@ fn new_recording(
         default_store_id(py, StoreKind::Recording, &application_id)
     };
 
-    let mut batcher_config = re_chunk::ChunkBatcherConfig::from_env().unwrap_or_default();
+    let mut hooks = re_chunk::BatcherHooks::NONE;
     let on_release = |chunk| {
         GARBAGE_QUEUE.0.send(chunk).ok();
     };
-    batcher_config.hooks.on_release = Some(on_release.into());
+    hooks.on_release = Some(on_release.into());
 
     let recording = RecordingStreamBuilder::new(application_id)
-        .batcher_config(batcher_config)
+        .batcher_hooks(hooks)
         .store_id(recording_id.clone())
         .store_source(re_log_types::StoreSource::PythonSdk(python_version(py)))
         .default_enabled(default_enabled)
@@ -357,14 +357,14 @@ fn new_blueprint(
     // blueprint id to avoid collisions.
     let blueprint_id = StoreId::random(StoreKind::Blueprint);
 
-    let mut batcher_config = re_chunk::ChunkBatcherConfig::from_env().unwrap_or_default();
+    let mut hooks = re_chunk::BatcherHooks::NONE;
     let on_release = |chunk| {
         GARBAGE_QUEUE.0.send(chunk).ok();
     };
-    batcher_config.hooks.on_release = Some(on_release.into());
+    hooks.on_release = Some(on_release.into());
 
     let blueprint = RecordingStreamBuilder::new(application_id)
-        .batcher_config(batcher_config)
+        .batcher_hooks(hooks)
         .store_id(blueprint_id.clone())
         .store_source(re_log_types::StoreSource::PythonSdk(python_version(py)))
         .default_enabled(default_enabled)


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/10542
* Alternative to https://github.com/rerun-io/rerun/pull/10550

### What

Makes the default flush tick 200ms for file & memory sinks and leaves it at 8ms for grpc sinks.

To facilitate this, I introduced per sink batcher config defaults and had to make the batcher configuration updatable (since Python always first creates a recording stream with a memory sink and then patches it in later). Unfortunately not all config optionscan be updated after the fact, but I think the solution here is good enough for what is practically needed.
