### PR TITLE
Use new archetype name layout in defaults ui

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -190,7 +190,7 @@ fn component_list_ui(
                 if archetype.is_none() && components_by_archetype.len() == 1 {
                     // They are all without archetype, so we can skip the label.
                 } else {
-                    archetype_label_ui(ui, archetype);
+                    archetype_label_lit_item_ui(ui, archetype);
                 }
 
                 for (component_descr, unit) in components {
@@ -276,7 +276,7 @@ fn component_list_ui(
     );
 }
 
-fn archetype_label_ui(ui: &mut egui::Ui, archetype: &Option<ArchetypeName>) {
+pub fn archetype_label_lit_item_ui(ui: &mut egui::Ui, archetype: &Option<ArchetypeName>) {
     ui.list_item()
         .with_y_offset(1.0)
         .with_height(20.0)

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -190,7 +190,7 @@ fn component_list_ui(
                 if archetype.is_none() && components_by_archetype.len() == 1 {
                     // They are all without archetype, so we can skip the label.
                 } else {
-                    archetype_label_lit_item_ui(ui, archetype);
+                    archetype_label_list_item_ui(ui, archetype);
                 }
 
                 for (component_descr, unit) in components {
@@ -276,7 +276,7 @@ fn component_list_ui(
     );
 }
 
-pub fn archetype_label_lit_item_ui(ui: &mut egui::Ui, archetype: &Option<ArchetypeName>) {
+pub fn archetype_label_list_item_ui(ui: &mut egui::Ui, archetype: &Option<ArchetypeName>) {
     ui.list_item()
         .with_y_offset(1.0)
         .with_height(20.0)

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -31,6 +31,7 @@ pub use crate::tensor::tensor_summary_ui_grid_contents;
 pub use component::ComponentPathLatestAtResults;
 pub use component_ui_registry::{add_to_registry, register_component_uis};
 pub use image::image_preview_ui;
+pub use instance_path::archetype_label_lit_item_ui;
 use re_types_core::ArchetypeName;
 use re_types_core::reflection::Reflection;
 

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::tensor::tensor_summary_ui_grid_contents;
 pub use component::ComponentPathLatestAtResults;
 pub use component_ui_registry::{add_to_registry, register_component_uis};
 pub use image::image_preview_ui;
-pub use instance_path::archetype_label_lit_item_ui;
+pub use instance_path::archetype_label_list_item_ui;
 use re_types_core::ArchetypeName;
 use re_types_core::reflection::Reflection;
 

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -8,7 +8,7 @@ use re_chunk_store::LatestAtQuery;
 use re_data_ui::{DataUi as _, archetype_label_list_item_ui};
 use re_log_types::EntityPath;
 use re_types_core::ComponentDescriptor;
-use re_types_core::reflection::ComponentDescriptorExt;
+use re_types_core::reflection::ComponentDescriptorExt as _;
 use re_ui::{SyntaxHighlighting as _, UiExt as _, list_item::LabelContent};
 use re_viewer_context::{
     ComponentUiTypes, QueryContext, SystemCommand, SystemCommandSender as _, UiLayout, ViewContext,

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -5,9 +5,10 @@ use itertools::Itertools as _;
 
 use re_chunk::{ArchetypeName, Chunk, ComponentIdentifier, ComponentType, RowId};
 use re_chunk_store::LatestAtQuery;
-use re_data_ui::DataUi as _;
+use re_data_ui::{DataUi as _, archetype_label_lit_item_ui};
 use re_log_types::EntityPath;
 use re_types_core::ComponentDescriptor;
+use re_types_core::reflection::ComponentDescriptorExt;
 use re_ui::{SyntaxHighlighting as _, UiExt as _, list_item::LabelContent};
 use re_viewer_context::{
     ComponentUiTypes, QueryContext, SystemCommand, SystemCommandSender as _, UiLayout, ViewContext,
@@ -123,8 +124,7 @@ fn active_default_ui(
                 // `active_defaults` is sorted by descriptor which in turn sorts by archetype name,
                 // so we can just check if the previous archetype name is different from the current one.
                 if let Some(archetype_name) = component_descr.archetype {
-                    ui.add_space(4.0);
-                    ui.label(archetype_name.syntax_highlighted(ui.style()));
+                    archetype_label_lit_item_ui(ui, &Some(archetype_name));
                     previous_archetype_name = Some(archetype_name);
                 }
             }
@@ -144,17 +144,15 @@ fn active_default_ui(
             };
 
             let response = ui.list_item_flat_noninteractive(
-                re_ui::list_item::PropertyContent::new(
-                    component_descr.component.syntax_highlighted(ui.style()),
-                )
-                .min_desired_width(150.0)
-                .action_button(&re_ui::icons::CLOSE, "Clear blueprint component", || {
-                    ctx.clear_blueprint_component(
-                        view.defaults_path.clone(),
-                        component_descr.clone(),
-                    );
-                })
-                .value_fn(|ui, _| value_fn(ui)),
+                re_ui::list_item::PropertyContent::new(component_descr.archetype_field_name())
+                    .min_desired_width(150.0)
+                    .action_button(&re_ui::icons::CLOSE, "Clear blueprint component", || {
+                        ctx.clear_blueprint_component(
+                            view.defaults_path.clone(),
+                            component_descr.clone(),
+                        );
+                    })
+                    .value_fn(|ui, _| value_fn(ui)),
             );
 
             if let Some(component_type) = component_descr.component_type {

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -5,7 +5,7 @@ use itertools::Itertools as _;
 
 use re_chunk::{ArchetypeName, Chunk, ComponentIdentifier, ComponentType, RowId};
 use re_chunk_store::LatestAtQuery;
-use re_data_ui::{DataUi as _, archetype_label_lit_item_ui};
+use re_data_ui::{DataUi as _, archetype_label_list_item_ui};
 use re_log_types::EntityPath;
 use re_types_core::ComponentDescriptor;
 use re_types_core::reflection::ComponentDescriptorExt;
@@ -124,7 +124,7 @@ fn active_default_ui(
                 // `active_defaults` is sorted by descriptor which in turn sorts by archetype name,
                 // so we can just check if the previous archetype name is different from the current one.
                 if let Some(archetype_name) = component_descr.archetype {
-                    archetype_label_lit_item_ui(ui, &Some(archetype_name));
+                    archetype_label_list_item_ui(ui, &Some(archetype_name));
                     previous_archetype_name = Some(archetype_name);
                 }
             }
@@ -309,8 +309,9 @@ fn add_popup_ui(
     for (archetype_name, components) in components_to_show_in_add_menu {
         ui.menu_button(archetype_name.syntax_highlighted(ui.style()), |ui| {
             for entry in components {
+                let descriptor = entry.descriptor(archetype_name);
                 if ui
-                    .button(entry.component.syntax_highlighted(ui.style()))
+                    .button(descriptor.archetype_field_name())
                     .on_hover_ui(|ui| {
                         entry.component_type.data_ui_recording(
                             ctx.viewer_ctx,
@@ -324,7 +325,7 @@ fn add_popup_ui(
                         ctx,
                         defaults_path,
                         &query_context,
-                        entry.descriptor(archetype_name),
+                        descriptor,
                         entry.visualizer_identifier,
                         visualizers,
                     );


### PR DESCRIPTION
### Related

- closes https://github.com/rerun-io/rerun/issues/10454

### What

Makes the defaults ui look nicer and more in line:
<img width="300" height="170" alt="Screenshot 2025-07-14 at 12 25 59" src="https://github.com/user-attachments/assets/bd918a89-91c1-4f33-8a2f-82e46bff27b6" />

