### PR TITLE
Remove `:` after visualizer in selection panel

### DIFF
--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -124,7 +124,7 @@ pub fn visualizer_ui_impl(
                     .show_flat(
                         ui,
                         list_item::LabelContent::new(
-                            RichText::new(format!("{visualizer_id}:")).size(10.0).color(
+                            RichText::new(format!("{visualizer_id}")).size(10.0).color(
                                 design_tokens_of_visuals(ui.visuals()).list_item_strong_text,
                             ),
                         )


### PR DESCRIPTION
### What

This removes the colon after the name of the visualizer in the "Visualizers" section of the selection panel.
