### PR TITLE
Make rerun menu scrollable

### DIFF
--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -3,7 +3,7 @@
 #[cfg(debug_assertions)]
 use egui::containers::menu;
 use egui::containers::menu::{MenuButton, MenuConfig};
-use egui::{Button, NumExt as _};
+use egui::{Button, NumExt as _, ScrollArea};
 use re_ui::menu::menu_style;
 use re_ui::{UICommand, UiExt as _};
 use re_viewer_context::StoreContext;
@@ -37,7 +37,12 @@ impl App {
         MenuButton::from_button(Button::image(image))
             .config(MenuConfig::new().style(menu_style()))
             .ui(ui, |ui| {
-                self.rerun_menu_ui(ui, render_state, _store_context);
+                ui.set_max_height(ui.ctx().screen_rect().height());
+                ScrollArea::vertical()
+                    .max_height(ui.ctx().screen_rect().height() - 16.0)
+                    .show(ui, |ui| {
+                        self.rerun_menu_ui(ui, render_state, _store_context);
+                    });
             });
     }
 


### PR DESCRIPTION
### Related

* closes https://github.com/rerun-io/rerun/issues/10634

### What
Makes the menu scrollable if there is not enough space

https://github.com/user-attachments/assets/1f030286-408b-4b4b-a1f7-216f3c17b188

