### PR TITLE
Make duration handling of video more robust

### DIFF
--- a/crates/utils/re_video/src/demux/mp4.rs
+++ b/crates/utils/re_video/src/demux/mp4.rs
@@ -6,7 +6,7 @@ use super::{GroupOfPictures, SampleMetadata, VideoDataDescription, VideoLoadErro
 
 use crate::{
     StableIndexDeque, Time, Timescale,
-    demux::{ChromaSubsamplingModes, SamplesStatistics, VideoEncodingDetails},
+    demux::{ChromaSubsamplingModes, SamplesStatistics, VideoEncodingDetails, VideoUpdateType},
     h264::encoding_details_from_h264_sps,
 };
 
@@ -29,7 +29,6 @@ impl VideoDataDescription {
         let stsd = track.trak(&mp4).mdia.minf.stbl.stsd.clone();
 
         let timescale = Timescale::new(track.timescale);
-        let duration = Time::new(track.duration as i64);
         let mut samples = StableIndexDeque::<SampleMetadata>::with_capacity(track.samples.len());
         let mut gops = StableIndexDeque::<GroupOfPictures>::new();
         let mut gop_sample_start_index = 0;
@@ -138,9 +137,10 @@ impl VideoDataDescription {
             codec,
             encoding_details: Some(codec_details_from_stds(track, stsd)?),
             timescale: Some(timescale),
-            duration: Some(duration),
+            update_type: VideoUpdateType::NoUpdates {
+                duration: Time::new(track.duration as i64),
+            },
             samples_statistics,
-            last_time_updated_samples: None,
             gops,
             samples,
             mp4_tracks,

--- a/crates/utils/re_video/src/lib.rs
+++ b/crates/utils/re_video/src/lib.rs
@@ -16,6 +16,7 @@ pub use self::{
     demux::{
         ChromaSubsamplingModes, GopIndex, GroupOfPictures, SampleIndex, SampleMetadata,
         SamplesStatistics, VideoCodec, VideoDataDescription, VideoEncodingDetails, VideoLoadError,
+        VideoUpdateType,
     },
 };
 

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -229,8 +229,8 @@ pub fn blob_preview_and_save_ui(
                     if let Some(duration) = video.data_descr().duration() {
                         VideoTimestamp::from_secs(time % duration.as_secs_f64())
                     } else {
-                        // TODO(#7484): show something more useful here
-                        VideoTimestamp::from_nanos(i64::MAX)
+                        // Invalid video or unknown timescale.
+                        VideoTimestamp::from_nanos(0)
                     }
                 });
                 let video_time = re_viewer_context::video_timestamp_component_to_video_time(


### PR DESCRIPTION
How durations are handled for our internal video meta information is a bit brittle right now.
Also, how we distinguish open-ended versus "closed" videos was quite arcane and hard to follow so far. This refactor makes all these things more explicit and a lot more stable.

Draft:
* too close to a release
* not entirely done
* ..really I just put this up because it gives me a ticket number to refer to while doing "zombie todo" cleanup #10459