### PR TITLE
Improve light mode in a couple of places

### DIFF
--- a/crates/viewer/re_ui/data/light_theme.ron
+++ b/crates/viewer/re_ui/data/light_theme.ron
@@ -80,15 +80,15 @@
 
     // Breadcrumb colors, among other things ("primary" means "selected" in this case):
     "surface_on_primary_hovered": {"color": "{Gray.1000}", "alpha": 25},
-    "text_color_on_primary": {"color": "{Blue.900}"}, // TODO(emilk): unify with selection_stroke_color ?
+    "text_color_on_primary": {"color": "{Blue.900}"},
     "text_color_on_primary_hovered": {"color": "{Gray.1000}"},
     "icon_color_on_primary": {"color": "{Blue.750}"},
     "icon_color_on_primary_hovered": {"color": "{Gray.1000}"},
     "selection_bg_fill": {
-      "color": "{Blue.550}"
+      "color": "{Blue.450}"
     },
     "selection_stroke_color": {
-      "color": "{Blue.900}" // TODO(emilk): should we unify this with text_color_on_primary?
+      "color": "{Blue.900}"
     },
 
     "panel_bg_color": {

--- a/crates/viewer/re_ui/src/list_item/label_content.rs
+++ b/crates/viewer/re_ui/src/list_item/label_content.rs
@@ -13,6 +13,7 @@ pub struct LabelContent<'a> {
     subdued: bool,
     weak: bool,
     italics: bool,
+    strong: bool,
 
     label_style: LabelStyle,
     icon_fn: Option<Box<dyn FnOnce(&mut egui::Ui, egui::Rect, ListVisuals) + 'a>>,
@@ -31,6 +32,7 @@ impl<'a> LabelContent<'a> {
             subdued: false,
             weak: false,
             italics: false,
+            strong: false,
 
             label_style: Default::default(),
             icon_fn: None,
@@ -47,11 +49,7 @@ impl<'a> LabelContent<'a> {
     /// Text will be strong and smaller.
     /// For best results, use this with [`super::ListItem::header`].
     pub fn header(text: impl Into<RichText>) -> Self {
-        Self::new(
-            text.into()
-                .size(DesignTokens::list_header_font_size())
-                .strong(),
-        )
+        Self::new(text.into().size(DesignTokens::list_header_font_size())).strong(true)
     }
 
     /// Set the subdued state of the item.
@@ -82,6 +80,13 @@ impl<'a> LabelContent<'a> {
     #[inline]
     pub fn italics(mut self, italics: bool) -> Self {
         self.italics = italics;
+        self
+    }
+
+    /// Set the text to be strong.
+    #[inline]
+    pub fn strong(mut self, strong: bool) -> Self {
+        self.strong = strong;
         self
     }
 
@@ -186,6 +191,7 @@ impl ListItemContent for LabelContent<'_> {
             subdued,
             weak,
             italics,
+            strong,
             label_style,
             icon_fn,
             buttons_fn,
@@ -211,7 +217,8 @@ impl ListItemContent for LabelContent<'_> {
             text = text.italics();
         }
 
-        let visuals = context.visuals;
+        let mut visuals = context.visuals;
+        visuals.strong |= strong;
 
         let mut text_color = visuals.text_color();
 

--- a/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
@@ -323,7 +323,7 @@ impl egui_table::TableDelegate for DataframeTableDelegate<'_> {
 
             header_ui(ui, table_style, connected_to_next_cell, |ui| {
                 let header_content = |ui: &mut egui::Ui| {
-                    let text = egui::RichText::new(
+                    let mut text = egui::RichText::new(
                         if let ColumnDescriptor::Component(component) = column {
                             component
                                 .component_descriptor()
@@ -333,7 +333,6 @@ impl egui_table::TableDelegate for DataframeTableDelegate<'_> {
                             column.display_name()
                         },
                     )
-                    .strong()
                     .monospace();
                     let archetype = column.archetype_name().map_or("", |a| a.short_name());
 
@@ -351,6 +350,11 @@ impl egui_table::TableDelegate for DataframeTableDelegate<'_> {
                                 component_column_descriptor.component_path(),
                             )),
                     };
+
+                    // If we set strong
+                    if !is_selected {
+                        text = text.strong();
+                    }
 
                     let response = ui
                         .vertical(|ui| {


### PR DESCRIPTION
### Related

* https://github.com/rerun-io/rerun/pull/10107#issuecomment-3074099744

- [x] change font to white (text_color_on_primary)

- [] background for the headers of section "Recordings" "Blueprint" "Streams" "Selection" => make the same as the subheaders of the selection panel (like "Data" and "Properties"

- [] remove the background from under the chevron (collapse/uncollapse)
