### PR TITLE
Make it possible to configure batcher explicitly via python APIs

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable, Iterator, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Callable, Optional, Self
 
@@ -614,6 +614,84 @@ class PyRecordingStream:
         Calling operations such as flush or set_sink will result in an error.
         """
 
+class ChunkBatcherConfig:
+    """Defines the different batching thresholds used within the RecordingStream."""
+
+    def __init__(
+        self,
+        flush_tick: Optional[int | float | timedelta] = None,
+        flush_num_bytes: Optional[int] = None,
+        flush_num_rows: Optional[int] = None,
+        chunk_max_rows_if_unsorted: Optional[int] = None,
+    ) -> None:
+        """
+        Initialize the chunk batcher configuration.
+
+        Parameters
+        ----------
+        flush_tick : Optional[int | float | timedelta], optional
+            Duration of the periodic tick, by default `None`.
+            Equivalent to setting: `_RERUN_FLUSH_TICK_SECS` environment variable.
+
+        flush_num_bytes : Optional[int], optional
+            Flush if the accumulated payload has a size in bytes equal or greater than this, by default `None`.
+            Equivalent to setting: `_RERUN_FLUSH_NUM_BYTES` environment variable.
+
+        flush_num_rows : Optional[int], optional
+            Flush if the accumulated payload has a number of rows equal or greater than this, by default `None`.
+            Equivalent to setting: `_RERUN_FLUSH_NUM_ROWS` environment variable.
+
+        chunk_max_rows_if_unsorted : Optional[int], optional
+            Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted,
+            by default `None`.
+            Equivalent to setting: `_RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.
+
+        """
+
+    @property
+    def flush_tick(self) -> timedelta:
+        """
+        Duration of the periodic tick.
+
+        Equivalent to setting:_`RERUN_FLUSH_TICK_SECS` environment variable.
+        """
+
+    @property
+    def flush_num_bytes(self) -> Optional[int]:
+        """
+        Flush if the accumulated payload has a size in bytes equal or greater than this.
+
+        Equivalent to setting:_`RERUN_FLUSH_NUM_BYTES` environment variable.
+        """
+
+    @property
+    def flush_num_rows(self) -> Optional[int]:
+        """
+        Flush if the accumulated payload has a number of rows equal or greater than this.
+
+        Equivalent to setting:_`RERUN_FLUSH_NUM_ROWS` environment variable.
+        """
+
+    @property
+    def chunk_max_rows_if_unsorted(self) -> Optional[int]:
+        """
+        Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted.
+
+        Equivalent to setting:_`RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.
+        """
+
+    def DEFAULT() -> ChunkBatcherConfig:
+        """Default configuration, applicable to most use cases."""
+
+    def LOW_LATENCY() -> ChunkBatcherConfig:
+        """Low-latency configuration, preferred when streaming directly to a viewer."""
+
+    def ALWAYS() -> ChunkBatcherConfig:
+        """Always flushes ASAP."""
+
+    def NEVER() -> ChunkBatcherConfig:
+        """Never flushes unless manually told to (or hitting one the builtin invariants)."""
+
 class PyMemorySinkStorage:
     def concat_as_bytes(self, concat: Optional[PyMemorySinkStorage] = None) -> bytes:
         """
@@ -658,6 +736,7 @@ def new_recording(
     make_thread_default: bool = True,
     default_enabled: bool = True,
     send_properties: bool = True,
+    batcher_config: Optional[ChunkBatcherConfig] = None,
 ) -> PyRecordingStream:
     """Create a new recording stream."""
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -653,7 +653,7 @@ class ChunkBatcherConfig:
         """Duration of the periodic tick."""
 
     @flush_tick.setter
-    def flush_tick(self, value: float | int | timedelta):
+    def flush_tick(self, value: float | int | timedelta) -> None:
         """
         Duration of the periodic tick.
 
@@ -661,11 +661,11 @@ class ChunkBatcherConfig:
         """
 
     @property
-    def flush_num_bytes(self) -> Optional[int]:
+    def flush_num_bytes(self) -> int:
         """Flush if the accumulated payload has a size in bytes equal or greater than this."""
 
     @flush_num_bytes.setter
-    def flush_num_bytes(self, value: Optional[int]):
+    def flush_num_bytes(self, value: int) -> None:
         """
         Flush if the accumulated payload has a size in bytes equal or greater than this.
 
@@ -673,11 +673,11 @@ class ChunkBatcherConfig:
         """
 
     @property
-    def flush_num_rows(self) -> Optional[int]:
+    def flush_num_rows(self) -> int:
         """Flush if the accumulated payload has a number of rows equal or greater than this."""
 
     @flush_num_rows.setter
-    def flush_num_rows(self, value: Optional[int]):
+    def flush_num_rows(self, value: int) -> None:
         """
         Flush if the accumulated payload has a number of rows equal or greater than this.
 
@@ -685,11 +685,11 @@ class ChunkBatcherConfig:
         """
 
     @property
-    def chunk_max_rows_if_unsorted(self) -> Optional[int]:
+    def chunk_max_rows_if_unsorted(self) -> int:
         """Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted."""
 
     @chunk_max_rows_if_unsorted.setter
-    def chunk_max_rows_if_unsorted(self, value: Optional[int]):
+    def chunk_max_rows_if_unsorted(self, value: int) -> None:
         """
         Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted.
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -619,29 +619,29 @@ class ChunkBatcherConfig:
 
     def __init__(
         self,
-        flush_tick: Optional[int | float | timedelta] = None,
-        flush_num_bytes: Optional[int] = None,
-        flush_num_rows: Optional[int] = None,
-        chunk_max_rows_if_unsorted: Optional[int] = None,
+        flush_tick: int | float | timedelta | None = None,
+        flush_num_bytes: int | None = None,
+        flush_num_rows: int | None = None,
+        chunk_max_rows_if_unsorted: int | None = None,
     ) -> None:
         """
         Initialize the chunk batcher configuration.
 
         Parameters
         ----------
-        flush_tick : Optional[int | float | timedelta], optional
+        flush_tick : int | float | timedelta | None
             Duration of the periodic tick, by default `None`.
             Equivalent to setting: `RERUN_FLUSH_TICK_SECS` environment variable.
 
-        flush_num_bytes : Optional[int], optional
+        flush_num_bytes : int | None
             Flush if the accumulated payload has a size in bytes equal or greater than this, by default `None`.
             Equivalent to setting: `RERUN_FLUSH_NUM_BYTES` environment variable.
 
-        flush_num_rows : Optional[int], optional
+        flush_num_rows : int | None
             Flush if the accumulated payload has a number of rows equal or greater than this, by default `None`.
             Equivalent to setting: `RERUN_FLUSH_NUM_ROWS` environment variable.
 
-        chunk_max_rows_if_unsorted : Optional[int], optional
+        chunk_max_rows_if_unsorted : int | None
             Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted,
             by default `None`.
             Equivalent to setting: `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -650,7 +650,11 @@ class ChunkBatcherConfig:
 
     @property
     def flush_tick(self) -> timedelta:
-        """Duration of the periodic tick."""
+        """
+        Duration of the periodic tick.
+
+        Equivalent to setting: `RERUN_FLUSH_TICK_SECS` environment variable.
+        """
 
     @flush_tick.setter
     def flush_tick(self, value: float | int | timedelta) -> None:
@@ -662,7 +666,11 @@ class ChunkBatcherConfig:
 
     @property
     def flush_num_bytes(self) -> int:
-        """Flush if the accumulated payload has a size in bytes equal or greater than this."""
+        """
+        Flush if the accumulated payload has a size in bytes equal or greater than this.
+
+        Equivalent to setting: `RERUN_FLUSH_NUM_BYTES` environment variable.
+        """
 
     @flush_num_bytes.setter
     def flush_num_bytes(self, value: int) -> None:
@@ -674,7 +682,11 @@ class ChunkBatcherConfig:
 
     @property
     def flush_num_rows(self) -> int:
-        """Flush if the accumulated payload has a number of rows equal or greater than this."""
+        """
+        Flush if the accumulated payload has a number of rows equal or greater than this.
+
+        Equivalent to setting: `RERUN_FLUSH_NUM_ROWS` environment variable.
+        """
 
     @flush_num_rows.setter
     def flush_num_rows(self, value: int) -> None:
@@ -686,7 +698,11 @@ class ChunkBatcherConfig:
 
     @property
     def chunk_max_rows_if_unsorted(self) -> int:
-        """Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted."""
+        """
+        Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted.
+
+        Equivalent to setting: `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.
+        """
 
     @chunk_max_rows_if_unsorted.setter
     def chunk_max_rows_if_unsorted(self, value: int) -> None:

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -631,64 +631,84 @@ class ChunkBatcherConfig:
         ----------
         flush_tick : Optional[int | float | timedelta], optional
             Duration of the periodic tick, by default `None`.
-            Equivalent to setting: `_RERUN_FLUSH_TICK_SECS` environment variable.
+            Equivalent to setting: `RERUN_FLUSH_TICK_SECS` environment variable.
 
         flush_num_bytes : Optional[int], optional
             Flush if the accumulated payload has a size in bytes equal or greater than this, by default `None`.
-            Equivalent to setting: `_RERUN_FLUSH_NUM_BYTES` environment variable.
+            Equivalent to setting: `RERUN_FLUSH_NUM_BYTES` environment variable.
 
         flush_num_rows : Optional[int], optional
             Flush if the accumulated payload has a number of rows equal or greater than this, by default `None`.
-            Equivalent to setting: `_RERUN_FLUSH_NUM_ROWS` environment variable.
+            Equivalent to setting: `RERUN_FLUSH_NUM_ROWS` environment variable.
 
         chunk_max_rows_if_unsorted : Optional[int], optional
             Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted,
             by default `None`.
-            Equivalent to setting: `_RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.
+            Equivalent to setting: `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.
 
         """
 
     @property
     def flush_tick(self) -> timedelta:
+        """Duration of the periodic tick."""
+
+    @flush_tick.setter
+    def flush_tick(self, value: float | int | timedelta):
         """
         Duration of the periodic tick.
 
-        Equivalent to setting:_`RERUN_FLUSH_TICK_SECS` environment variable.
+        Equivalent to setting: `RERUN_FLUSH_TICK_SECS` environment variable.
         """
 
     @property
     def flush_num_bytes(self) -> Optional[int]:
+        """Flush if the accumulated payload has a size in bytes equal or greater than this."""
+
+    @flush_num_bytes.setter
+    def flush_num_bytes(self, value: Optional[int]):
         """
         Flush if the accumulated payload has a size in bytes equal or greater than this.
 
-        Equivalent to setting:_`RERUN_FLUSH_NUM_BYTES` environment variable.
+        Equivalent to setting: `RERUN_FLUSH_NUM_BYTES` environment variable.
         """
 
     @property
     def flush_num_rows(self) -> Optional[int]:
+        """Flush if the accumulated payload has a number of rows equal or greater than this."""
+
+    @flush_num_rows.setter
+    def flush_num_rows(self, value: Optional[int]):
         """
         Flush if the accumulated payload has a number of rows equal or greater than this.
 
-        Equivalent to setting:_`RERUN_FLUSH_NUM_ROWS` environment variable.
+        Equivalent to setting: `RERUN_FLUSH_NUM_ROWS` environment variable.
         """
 
     @property
     def chunk_max_rows_if_unsorted(self) -> Optional[int]:
+        """Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted."""
+
+    @chunk_max_rows_if_unsorted.setter
+    def chunk_max_rows_if_unsorted(self, value: Optional[int]):
         """
         Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted.
 
-        Equivalent to setting:_`RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.
+        Equivalent to setting: `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.
         """
 
+    @staticmethod
     def DEFAULT() -> ChunkBatcherConfig:
         """Default configuration, applicable to most use cases."""
 
+    @staticmethod
     def LOW_LATENCY() -> ChunkBatcherConfig:
         """Low-latency configuration, preferred when streaming directly to a viewer."""
 
+    @staticmethod
     def ALWAYS() -> ChunkBatcherConfig:
         """Always flushes ASAP."""
 
+    @staticmethod
     def NEVER() -> ChunkBatcherConfig:
         """Never flushes unless manually told to (or hitting one the builtin invariants)."""
 

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -153,6 +153,7 @@ from .memory import (
 )
 from .recording_stream import (
     BinaryStream as BinaryStream,
+    ChunkBatcherConfig as ChunkBatcherConfig,
     RecordingStream as RecordingStream,
     binary_stream as binary_stream,
     get_application_id as get_application_id,

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -16,6 +16,9 @@ from typing_extensions import deprecated
 import rerun as rr
 from rerun import bindings
 from rerun.memory import MemoryRecording
+from rerun_bindings import (
+    ChunkBatcherConfig as ChunkBatcherConfig,
+)
 
 if TYPE_CHECKING:
     from rerun import AsComponents, BlueprintLike, ComponentColumn, DescribedComponentBatch
@@ -39,6 +42,7 @@ def new_recording(
     make_thread_default: bool = False,
     spawn: bool = False,
     default_enabled: bool = True,
+    batcher_config: ChunkBatcherConfig | None = None,
 ) -> RecordingStream:
     """
     Creates a new recording with a user-chosen application id (name) that can be used to log data.
@@ -117,6 +121,7 @@ def new_recording(
         make_default=make_default,
         make_thread_default=make_thread_default,
         default_enabled=default_enabled,
+        batcher_config=batcher_config,
     )
 
     if spawn:
@@ -302,7 +307,8 @@ class RecordingStream:
     Micro-batching using both space and time triggers (whichever comes first) is done automatically
     in a dedicated background thread.
 
-    You can configure the frequency of the batches using the following environment variables:
+    You can configure the frequency of the batches using the `batcher_config` parameter when creating
+    the RecordingStream, or via tthe following environment variables:
 
     - `RERUN_FLUSH_TICK_SECS`:
         Flush frequency in seconds (default: `0.2` (200ms)).
@@ -322,6 +328,7 @@ class RecordingStream:
         make_thread_default: bool = False,
         default_enabled: bool = True,
         send_properties: bool = True,
+        batcher_config: ChunkBatcherConfig | None = None,
     ) -> None:
         """
         Creates a new recording stream with a user-chosen application id (name) that can be used to log data.
@@ -383,6 +390,8 @@ class RecordingStream:
             Can be overridden with the RERUN env-var, e.g. `RERUN=on` or `RERUN=off`.
         send_properties
             Immediately send the recording properties to the viewer (default: True)
+        batcher_config
+            Optional configuration for the chunk batcher.
 
         Returns
         -------
@@ -411,6 +420,7 @@ class RecordingStream:
             make_thread_default=make_thread_default,
             default_enabled=default_enabled,
             send_properties=send_properties,
+            batcher_config=batcher_config,
         )
 
         self._prev: RecordingStream | None = None

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -11,14 +11,14 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
 
 import numpy as np
+from rerun_bindings import (
+    ChunkBatcherConfig as ChunkBatcherConfig,
+)
 from typing_extensions import deprecated
 
 import rerun as rr
 from rerun import bindings
 from rerun.memory import MemoryRecording
-from rerun_bindings import (
-    ChunkBatcherConfig as ChunkBatcherConfig,
-)
 
 if TYPE_CHECKING:
     from rerun import AsComponents, BlueprintLike, ComponentColumn, DescribedComponentBatch
@@ -107,6 +107,8 @@ def new_recording(
     default_enabled
         Should Rerun logging be on by default?
         Can be overridden with the RERUN env-var, e.g. `RERUN=on` or `RERUN=off`.
+    batcher_config
+        Optional configuration for the chunk batcher.
 
     Returns
     -------
@@ -308,7 +310,7 @@ class RecordingStream:
     in a dedicated background thread.
 
     You can configure the frequency of the batches using the `batcher_config` parameter when creating
-    the RecordingStream, or via tthe following environment variables:
+    the RecordingStream, or via the following environment variables:
 
     - `RERUN_FLUSH_TICK_SECS`:
         Flush frequency in seconds (default: `0.2` (200ms)).

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -289,9 +289,9 @@ enum DurationLike {
 impl DurationLike {
     fn into_duration(self) -> time::Duration {
         match self {
-            DurationLike::Int(i) => time::Duration::from_secs(i as u64),
-            DurationLike::Float(f) => time::Duration::from_secs_f64(f),
-            DurationLike::Duration(d) => d,
+            Self::Int(i) => time::Duration::from_secs(i as u64),
+            Self::Float(f) => time::Duration::from_secs_f64(f),
+            Self::Duration(d) => d,
         }
     }
 }
@@ -311,19 +311,19 @@ impl PyChunkBatcherConfig {
     ///
     /// Parameters
     /// ----------
-    /// flush_tick : Optional[int | float | timedelta], optional
+    /// flush_tick : int | float | timedelta | None
     ///     Duration of the periodic tick, by default `None`.
     ///     Equivalent to setting: `RERUN_FLUSH_TICK_SECS` environment variable.
     ///
-    /// flush_num_bytes : Optional[int], optional
+    /// flush_num_bytes : int | None
     ///     Flush if the accumulated payload has a size in bytes equal or greater than this, by default `None`.
     ///     Equivalent to setting: `RERUN_FLUSH_NUM_BYTES` environment variable.
     ///
-    /// flush_num_rows : Optional[int], optional
+    /// flush_num_rows : int | None
     ///     Flush if the accumulated payload has a number of rows equal or greater than this, by default `None`.
     ///     Equivalent to setting: `RERUN_FLUSH_NUM_ROWS` environment variable.
     ///
-    /// chunk_max_rows_if_unsorted : Optional[int], optional
+    /// chunk_max_rows_if_unsorted : int | None
     ///     Split a chunk if it contains >= rows than this threshold and one or more of its timelines are unsorted,
     ///     by default `None`.
     ///     Equivalent to setting: `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED` environment variable.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::too_many_arguments)] // We used named arguments, so this is fine
 #![allow(unsafe_op_in_unsafe_fn)] // False positive due to #[pyfunction] macro
 
+use core::time;
 use std::borrow::Borrow as _;
 use std::io::IsTerminal as _;
 use std::path::PathBuf;
@@ -14,6 +15,7 @@ use pyo3::{
     prelude::*,
     types::{PyBytes, PyDict},
 };
+use re_chunk::ChunkBatcherConfig;
 use re_sdk::ComponentDescriptor;
 
 use re_log::ResultExt as _;
@@ -158,6 +160,7 @@ fn rerun_bindings(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyFileSink>()?;
     m.add_class::<PyGrpcSink>()?;
     m.add_class::<PyComponentDescriptor>()?;
+    m.add_class::<PyChunkBatcherConfig>()?;
 
     // If this is a special RERUN_APP_ONLY context (launched via .spawn), we
     // can bypass everything else, which keeps us from preparing an SDK session
@@ -276,6 +279,100 @@ fn flush_and_cleanup_orphaned_recordings(py: Python<'_>) {
     });
 }
 
+/// Defines the different batching thresholds used within the RecordingStream.
+#[pyclass(name = "ChunkBatcherConfig")]
+#[derive(Clone)]
+pub struct PyChunkBatcherConfig(ChunkBatcherConfig);
+
+#[pymethods]
+impl PyChunkBatcherConfig {
+    #[new]
+    fn new(
+        flush_tick: Option<time::Duration>,
+        flush_num_bytes: Option<u64>,
+        flush_num_rows: Option<u64>,
+        chunk_max_rows_if_unsorted: Option<u64>,
+    ) -> Self {
+        let default = ChunkBatcherConfig::DEFAULT;
+
+        Self(ChunkBatcherConfig {
+            flush_tick: flush_tick.unwrap_or(default.flush_tick),
+            flush_num_bytes: flush_num_bytes.unwrap_or(default.flush_num_bytes),
+            flush_num_rows: flush_num_rows.unwrap_or(default.flush_num_rows),
+            chunk_max_rows_if_unsorted: chunk_max_rows_if_unsorted
+                .unwrap_or(default.chunk_max_rows_if_unsorted),
+            ..default
+        })
+    }
+
+    #[getter]
+    fn get_flush_tick(&self) -> time::Duration {
+        self.0.flush_tick
+    }
+
+    #[setter]
+    fn set_flush_tick(&mut self, flush_tick: Option<time::Duration>) {
+        self.0.flush_tick = flush_tick.unwrap_or(ChunkBatcherConfig::DEFAULT.flush_tick);
+    }
+
+    #[getter]
+    fn get_flush_num_bytes(&self) -> u64 {
+        self.0.flush_num_bytes
+    }
+
+    #[setter]
+    fn set_flush_num_bytes(&mut self, flush_num_bytes: Option<u64>) {
+        self.0.flush_num_bytes =
+            flush_num_bytes.unwrap_or(ChunkBatcherConfig::DEFAULT.flush_num_bytes);
+    }
+
+    #[getter]
+    fn get_flush_num_rows(&self) -> u64 {
+        self.0.flush_num_rows
+    }
+
+    #[setter]
+    fn set_flush_num_rows(&mut self, flush_num_rows: Option<u64>) {
+        self.0.flush_num_rows =
+            flush_num_rows.unwrap_or(ChunkBatcherConfig::DEFAULT.flush_num_rows);
+    }
+
+    #[getter]
+    fn get_chunk_max_rows_if_unsorted(&self) -> u64 {
+        self.0.chunk_max_rows_if_unsorted
+    }
+
+    #[setter]
+    fn set_chunk_max_rows_if_unsorted(&mut self, chunk_max_rows_if_unsorted: Option<u64>) {
+        self.0.chunk_max_rows_if_unsorted = chunk_max_rows_if_unsorted
+            .unwrap_or(ChunkBatcherConfig::DEFAULT.chunk_max_rows_if_unsorted);
+    }
+
+    #[allow(non_snake_case)]
+    #[staticmethod]
+    fn DEFAULT() -> Self {
+        Self(ChunkBatcherConfig::DEFAULT)
+    }
+
+    #[allow(non_snake_case)]
+    #[staticmethod]
+    fn LOW_LATENCY() -> Self {
+        Self(ChunkBatcherConfig::LOW_LATENCY)
+    }
+
+    #[allow(non_snake_case)]
+    #[staticmethod]
+    fn ALWAYS() -> Self {
+        Self(ChunkBatcherConfig::ALWAYS)
+    }
+
+    #[allow(non_snake_case)]
+    #[staticmethod]
+    fn NEVER() -> Self {
+        Self(ChunkBatcherConfig::NEVER)
+    }
+}
+
 /// Create a new recording stream.
 #[allow(clippy::fn_params_excessive_bools)]
 #[allow(clippy::struct_excessive_bools)]
@@ -287,6 +384,7 @@ fn flush_and_cleanup_orphaned_recordings(py: Python<'_>) {
     make_thread_default=true,
     default_enabled=true,
     send_properties=true,
+    batcher_config=None,
 ))]
 fn new_recording(
     py: Python<'_>,
@@ -296,6 +394,7 @@ fn new_recording(
     make_thread_default: bool,
     default_enabled: bool,
     send_properties: bool,
+    batcher_config: Option<PyChunkBatcherConfig>,
 ) -> PyResult<PyRecordingStream> {
     let recording_id = if let Some(recording_id) = recording_id {
         StoreId::from_string(StoreKind::Recording, recording_id)
@@ -309,12 +408,18 @@ fn new_recording(
     };
     hooks.on_release = Some(on_release.into());
 
-    let recording = RecordingStreamBuilder::new(application_id)
+    let mut builder = RecordingStreamBuilder::new(application_id)
         .batcher_hooks(hooks)
         .store_id(recording_id.clone())
         .store_source(re_log_types::StoreSource::PythonSdk(python_version(py)))
         .default_enabled(default_enabled)
-        .send_properties(send_properties)
+        .send_properties(send_properties);
+
+    if let Some(batcher_config) = batcher_config {
+        builder = builder.batcher_config(batcher_config.0);
+    }
+
+    let recording = builder
         .buffered()
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -310,6 +310,8 @@ impl PyChunkBatcherConfig {
     )]
     /// Initialize the chunk batcher onfiguration.
     ///
+    /// Check out <https://rerun.io/docs/reference/sdk/micro-batching> for more information.
+    ///
     /// Parameters
     /// ----------
     /// flush_tick : int | float | timedelta | None

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -336,7 +336,12 @@ impl PyChunkBatcherConfig {
         flush_num_rows: Option<u64>,
         chunk_max_rows_if_unsorted: Option<u64>,
     ) -> Self {
-        let default = ChunkBatcherConfig::DEFAULT;
+        let default = ChunkBatcherConfig::from_env().unwrap_or_else(|_| {
+            re_log::warn!(
+                "couldn't init ChunkBatcherConfig from environment, falling back to defaults"
+            );
+            ChunkBatcherConfig::DEFAULT
+        });
 
         Self(ChunkBatcherConfig {
             flush_tick: flush_tick

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -304,6 +304,7 @@ pub struct PyChunkBatcherConfig(ChunkBatcherConfig);
 #[pymethods]
 impl PyChunkBatcherConfig {
     #[new]
+    #[pyo3(signature = (flush_tick=None, flush_num_bytes=None, flush_num_rows=None, chunk_max_rows_if_unsorted=None))]
     #[pyo3(
         text_signature = "(self, flush_tick=None, flush_num_bytes=None, flush_num_rows=None, chunk_max_rows_if_unsorted=None)"
     )]

--- a/rerun_py/tests/unit/test_batcher_config.py
+++ b/rerun_py/tests/unit/test_batcher_config.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+
+import rerun as rr
+
+
+def log_and_get_size(rec: rr.RecordingStream, path) -> int:
+    """Helper function to log a message and sleep for a short duration."""
+    rec.log("/data1", rr.Scalars(1))
+    time.sleep(0.1)
+
+    return os.stat(path).st_size
+
+
+def test_flush_always() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rec_path = f"{tmpdir}/rec.rrd"
+
+        rec = rr.RecordingStream(
+            "rerun_example_multi_stream",
+            batcher_config=rr.ChunkBatcherConfig.ALWAYS(),
+        )
+        rec.save(rec_path)
+
+        sz1 = log_and_get_size(rec, rec_path)
+        sz2 = log_and_get_size(rec, rec_path)
+
+        assert sz2 > sz1, "Expected the file size to increase"
+
+
+def test_flush_never() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rec_path = f"{tmpdir}/rec.rrd"
+
+        rec = rr.RecordingStream(
+            "rerun_example_multi_stream",
+            batcher_config=rr.ChunkBatcherConfig.NEVER(),
+        )
+        rec.save(rec_path)
+
+        sz1 = log_and_get_size(rec, rec_path)
+        sz2 = log_and_get_size(rec, rec_path)
+        sz3 = log_and_get_size(rec, rec_path)
+
+        assert sz2 == sz1, "Expected the file size to stay the same"
+        assert sz3 == sz2, "Expected the file size to stay the same"
+
+        rec.flush(blocking=True)
+
+        sz4 = os.stat(rec_path).st_size
+
+        assert sz4 > sz3, "Expected the file size to increase after explicit flush"
+
+
+def test_flush_custom() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rec_path = f"{tmpdir}/rec.rrd"
+
+        batcher_config = rr.ChunkBatcherConfig.NEVER()
+        batcher_config.flush_num_rows = 3
+
+        rec = rr.RecordingStream(
+            "rerun_example_multi_stream",
+            batcher_config=batcher_config,
+        )
+        rec.save(rec_path)
+
+        sz1 = log_and_get_size(rec, rec_path)
+        sz2 = log_and_get_size(rec, rec_path)
+        sz3 = log_and_get_size(rec, rec_path)
+
+        assert sz2 == sz1, "Expected the file size to stay the same after two logs"
+        assert sz3 > sz2, "Expected the file size to increase after the third log"

--- a/rerun_py/tests/unit/test_batcher_config.py
+++ b/rerun_py/tests/unit/test_batcher_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import tempfile
 import time
+from datetime import timedelta
 
 import rerun as rr
 
@@ -13,6 +14,38 @@ def log_and_get_size(rec: rr.RecordingStream, path) -> int:
     time.sleep(0.1)
 
     return os.stat(path).st_size
+
+
+def test_getter_setter() -> None:
+    config = rr.ChunkBatcherConfig(
+        flush_tick=0.12,
+        flush_num_bytes=123,
+        flush_num_rows=456,
+        chunk_max_rows_if_unsorted=789,
+    )
+
+    assert config.flush_tick == timedelta(seconds=0.12)
+    assert config.flush_num_bytes == 123
+    assert config.flush_num_rows == 456
+    assert config.chunk_max_rows_if_unsorted == 789
+
+    config.flush_tick = 1
+    assert config.flush_tick == timedelta(seconds=1)
+
+    config.flush_tick = 2.1
+    assert config.flush_tick == timedelta(seconds=2.1)
+
+    config.flush_tick = timedelta(seconds=3.5)
+    assert config.flush_tick == timedelta(seconds=3.5)
+
+    config.flush_num_bytes = 321
+    assert config.flush_num_bytes == 321
+
+    config.flush_num_rows = 654
+    assert config.flush_num_rows == 654
+
+    config.chunk_max_rows_if_unsorted = 987
+    assert config.chunk_max_rows_if_unsorted == 987
 
 
 def test_flush_always() -> None:

--- a/rerun_py/tests/unit/test_batcher_config.py
+++ b/rerun_py/tests/unit/test_batcher_config.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 import rerun as rr
 
 
-def log_and_get_size(rec: rr.RecordingStream, path) -> int:
+def log_and_get_size(rec: rr.RecordingStream, path: str) -> int:
     """Helper function to log a message and sleep for a short duration."""
     rec.log("/data1", rr.Scalars(1))
     time.sleep(0.1)
@@ -29,10 +29,12 @@ def test_getter_setter() -> None:
     assert config.flush_num_rows == 456
     assert config.chunk_max_rows_if_unsorted == 789
 
-    config.flush_tick = 1
+    # Mypy isn't happy about this, but other linters do not complain.
+    config.flush_tick = 1  # type: ignore[assignment]
     assert config.flush_tick == timedelta(seconds=1)
 
-    config.flush_tick = 2.1
+    # Mypy isn't happy about this, but other linters do not complain.
+    config.flush_tick = 2.1  # type: ignore[assignment]
     assert config.flush_tick == timedelta(seconds=2.1)
 
     config.flush_tick = timedelta(seconds=3.5)

--- a/rerun_py/tests/unit/test_batcher_config.py
+++ b/rerun_py/tests/unit/test_batcher_config.py
@@ -50,6 +50,27 @@ def test_getter_setter() -> None:
     assert config.chunk_max_rows_if_unsorted == 987
 
 
+def test_partial_overrides() -> None:
+    from unittest.mock import patch
+
+    with patch.dict(os.environ, {"RERUN_FLUSH_TICK_SECS": "42", "RERUN_FLUSH_NUM_ROWS": "666"}):
+        assert "RERUN_FLUSH_TICK_SECS" in os.environ
+        assert "RERUN_FLUSH_NUM_ROWS" in os.environ
+
+        config = rr.ChunkBatcherConfig(
+            flush_num_bytes=123,
+            chunk_max_rows_if_unsorted=789,
+        )
+
+        assert config.flush_tick == timedelta(seconds=42)
+        assert config.flush_num_bytes == 123
+        assert config.flush_num_rows == 666
+        assert config.chunk_max_rows_if_unsorted == 789
+
+    assert "RERUN_FLUSH_TICK_SECS" not in os.environ
+    assert "RERUN_FLUSH_NUM_ROWS" not in os.environ
+
+
 def test_flush_always() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         rec_path = f"{tmpdir}/rec.rrd"


### PR DESCRIPTION
### What
We changed the behavior of the batcher in: https://github.com/rerun-io/rerun/pull/10620

However, the only way to override this behavior was to set environment variables, which can be tricky/annoying in some circumstances. This plumbs through the configuration settings so that this can be specified explicitly now.