### PR TITLE
Draft: enable selection of 1phase or 2phase query in the dataframe view

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1276,6 +1276,7 @@ class DatasetEntry(Entry):
         contents: Any,
         include_semantically_empty_columns: bool = False,
         include_tombstone_columns: bool = False,
+        two_phase_query: bool = False,
     ) -> DataframeQueryView:
         """
         Create a [`DataframeQueryView`][rerun.catalog.DataframeQueryView] of the recording according to a particular index and content specification.
@@ -1314,6 +1315,9 @@ class DatasetEntry(Entry):
 
             Tombstone columns are components used to represent clears. However, even without the clear
             tombstone columns, the view will still apply the clear semantics when resolving row contents.
+
+        two_phase_query : bool, optional
+            Whether to use a two-phase query to fetch the data.
 
         Returns
         -------

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -36,6 +36,8 @@ pub struct PyDataframeQueryView {
     ///
     /// If empty, use the whole dataset.
     partition_ids: Vec<String>,
+
+    two_phase_query: bool,
 }
 
 impl PyDataframeQueryView {
@@ -46,6 +48,7 @@ impl PyDataframeQueryView {
         contents: Py<PyAny>,
         include_semantically_empty_columns: bool,
         include_tombstone_columns: bool,
+        two_phase_query: bool,
         py: Python<'_>,
     ) -> PyResult<Self> {
         // Static only implies:
@@ -63,6 +66,7 @@ impl PyDataframeQueryView {
 
         Ok(Self {
             dataset,
+            two_phase_query,
 
             query_expression: QueryExpression {
                 view_contents: Some(view_contents),
@@ -94,6 +98,7 @@ impl PyDataframeQueryView {
             dataset: self.dataset.clone_ref(py),
             query_expression: self.query_expression.clone(),
             partition_ids: self.partition_ids.clone(),
+            two_phase_query: self.two_phase_query,
         };
 
         mutation_fn(&mut copy.query_expression);
@@ -122,6 +127,7 @@ impl PyDataframeQueryView {
         Ok(Self {
             dataset: self.dataset.clone_ref(py),
             query_expression: self.query_expression.clone(),
+            two_phase_query: self.two_phase_query,
             partition_ids,
         })
     }
@@ -491,6 +497,7 @@ impl PyDataframeQueryView {
             dataset_id,
             &self.query_expression,
             self.partition_ids.as_slice(),
+            self.two_phase_query,
         )?;
 
         let query_engines = chunk_stores

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -426,6 +426,9 @@ impl PyDatasetEntry {
     ///     Tombstone columns are components used to represent clears. However, even without the clear
     ///     tombstone columns, the view will still apply the clear semantics when resolving row contents.
     ///
+    /// two_phase_query : bool, optional
+    ///     Whether to use a two-phase query to fetch the data.
+    ///
     /// Returns
     /// -------
     /// DataframeQueryView
@@ -436,6 +439,7 @@ impl PyDatasetEntry {
         contents,
         include_semantically_empty_columns = false,
         include_tombstone_columns = false,
+        two_phase_query = false,
     ))]
     fn dataframe_query_view(
         self_: Py<Self>,
@@ -443,6 +447,7 @@ impl PyDatasetEntry {
         contents: Py<PyAny>,
         include_semantically_empty_columns: bool,
         include_tombstone_columns: bool,
+        two_phase_query: bool,
         py: Python<'_>,
     ) -> PyResult<PyDataframeQueryView> {
         PyDataframeQueryView::new(
@@ -451,6 +456,7 @@ impl PyDatasetEntry {
             contents,
             include_semantically_empty_columns,
             include_tombstone_columns,
+            two_phase_query,
             py,
         )
     }


### PR DESCRIPTION
This is basically revamping @jleibs 's  draft: https://github.com/rerun-io/rerun/pull/10132/files, but I've just added an option to select which query approach to use on the view, to ease testing for myself. This is not something we want to expose in the API, but for benchmarking and perf difference investigation, it's quite helpful. 