### PR TITLE
re_perf_telemetry should not override explicit RUST_LOG entries

### DIFF
--- a/crates/utils/re_perf_telemetry/src/lib.rs
+++ b/crates/utils/re_perf_telemetry/src/lib.rs
@@ -167,3 +167,27 @@ impl From<&TraceHeaders> for opentelemetry::Context {
         propagator.extract(value)
     }
 }
+
+// ---
+
+// Extension to [`tracing_subscriber:EnvFilter`] that allows to 
+// add a directive only if not already present in the base filter
+pub trait EnvFilterExt where Self: Sized {
+    fn add_directive_if_absent(self, base: &str, target: &str, default: &str) -> anyhow::Result<Self>;
+}
+
+impl EnvFilterExt for tracing_subscriber::EnvFilter {
+    fn add_directive_if_absent(
+        self,
+        base: &str,
+        target: &str,
+        default: &str,
+    ) -> anyhow::Result<Self> {
+        if !base.contains(&format!("{target}=")) {
+            let filter = self.add_directive(format!("{target}={default}").parse()?);
+            Ok(filter)
+        } else {
+            Ok(self)
+        }
+    }
+}

--- a/crates/utils/re_perf_telemetry/src/lib.rs
+++ b/crates/utils/re_perf_telemetry/src/lib.rs
@@ -170,10 +170,18 @@ impl From<&TraceHeaders> for opentelemetry::Context {
 
 // ---
 
-// Extension to [`tracing_subscriber:EnvFilter`] that allows to 
+// Extension to [`tracing_subscriber:EnvFilter`] that allows to
 // add a directive only if not already present in the base filter
-pub trait EnvFilterExt where Self: Sized {
-    fn add_directive_if_absent(self, base: &str, target: &str, default: &str) -> anyhow::Result<Self>;
+pub trait EnvFilterExt
+where
+    Self: Sized,
+{
+    fn add_directive_if_absent(
+        self,
+        base: &str,
+        target: &str,
+        default: &str,
+    ) -> anyhow::Result<Self>;
 }
 
 impl EnvFilterExt for tracing_subscriber::EnvFilter {

--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -178,7 +178,6 @@ impl Telemetry {
         }
 
         let create_filter = |base: &str, forced: &str| {
-
             use crate::EnvFilterExt as _;
 
             EnvFilter::new(base)

--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -178,10 +178,6 @@ impl Telemetry {
         }
 
         let create_filter = |base: &str, forced: &str| {
-            // TODO(zehiko) is there a better way to do this?!
-            // Lance traces are all at INFO level and they are over 30% of total spans, hence
-            // disabling them if we're at the INFO level cause we only want them at DEBUG
-            let lance_level = if base == "info" { "off" } else { base };
 
             use crate::EnvFilterExt as _;
 
@@ -213,9 +209,9 @@ impl Telemetry {
                 .add_directive_if_absent(base, "tower_http", forced)?
                 .add_directive_if_absent(base, "tower_web", forced)?
                 //
-                .add_directive_if_absent(base, "lance::index", lance_level)?
-                .add_directive_if_absent(base, "lance::dataset::scanner", lance_level)?
-                .add_directive_if_absent(base, "lance::dataset::builder", lance_level)?
+                .add_directive_if_absent(base, "lance::index", "off")?
+                .add_directive_if_absent(base, "lance::dataset::scanner", "off")?
+                .add_directive_if_absent(base, "lance::dataset::builder", "off")?
                 .add_directive_if_absent(base, "lance_encoding", "off")
         };
 

--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -183,41 +183,40 @@ impl Telemetry {
             // disabling them if we're at the INFO level cause we only want them at DEBUG
             let lance_level = if base == "info" { "off" } else { base };
 
-            Ok::<_, anyhow::Error>(
-                EnvFilter::new(base)
-                    // TODO(cmc): do not override user's choice, bring back the logic from re_log
-                    .add_directive(format!("aws_smithy_runtime={forced}").parse()?)
-                    .add_directive(format!("datafusion={forced}").parse()?)
-                    .add_directive(format!("datafusion_optimizer={forced}").parse()?)
-                    .add_directive(format!("h2={forced}").parse()?)
-                    .add_directive(format!("hyper={forced}").parse()?)
-                    .add_directive(format!("hyper_util={forced}").parse()?)
-                    .add_directive(format!("lance-arrow={forced}").parse()?)
-                    .add_directive(format!("lance-core={forced}").parse()?)
-                    .add_directive(format!("lance-datafusion={forced}").parse()?)
-                    .add_directive(format!("lance-encoding={forced}").parse()?)
-                    .add_directive(format!("lance-file={forced}").parse()?)
-                    .add_directive(format!("lance-index={forced}").parse()?)
-                    .add_directive(format!("lance-io={forced}").parse()?)
-                    .add_directive(format!("lance-linalg={forced}").parse()?)
-                    .add_directive(format!("lance-table={forced}").parse()?)
-                    .add_directive(format!("lance={forced}").parse()?)
-                    .add_directive(format!("opentelemetry-otlp={forced}").parse()?)
-                    .add_directive(format!("opentelemetry={forced}").parse()?)
-                    .add_directive(format!("opentelemetry_sdk={forced}").parse()?)
-                    .add_directive(format!("rustls={forced}").parse()?)
-                    .add_directive(format!("sqlparser={forced}").parse()?)
-                    .add_directive(format!("tonic={forced}").parse()?)
-                    .add_directive(format!("tonic_web={forced}").parse()?)
-                    .add_directive(format!("tower={forced}").parse()?)
-                    .add_directive(format!("tower_http={forced}").parse()?)
-                    .add_directive(format!("tower_web={forced}").parse()?)
-                    //
-                    .add_directive(format!("lance::index={lance_level}").parse()?)
-                    .add_directive(format!("lance::dataset::scanner={lance_level}").parse()?)
-                    .add_directive(format!("lance::dataset::builder={lance_level}").parse()?)
-                    .add_directive("lance_encoding=off".parse()?), // this one is a real nightmare
-            )
+            use crate::EnvFilterExt as _;
+
+            EnvFilter::new(base)
+                .add_directive_if_absent(base, "aws_smithy_runtime", forced)?
+                .add_directive_if_absent(base, "datafusion", forced)?
+                .add_directive_if_absent(base, "datafusion_optimizer", forced)?
+                .add_directive_if_absent(base, "h2", forced)?
+                .add_directive_if_absent(base, "hyper", forced)?
+                .add_directive_if_absent(base, "hyper_util", forced)?
+                .add_directive_if_absent(base, "lance-arrow", forced)?
+                .add_directive_if_absent(base, "lance-core", forced)?
+                .add_directive_if_absent(base, "lance-datafusion", forced)?
+                .add_directive_if_absent(base, "lance-encoding", forced)?
+                .add_directive_if_absent(base, "lance-file", forced)?
+                .add_directive_if_absent(base, "lance-index", forced)?
+                .add_directive_if_absent(base, "lance-io", forced)?
+                .add_directive_if_absent(base, "lance-linalg", forced)?
+                .add_directive_if_absent(base, "lance-table", forced)?
+                .add_directive_if_absent(base, "lance", forced)?
+                .add_directive_if_absent(base, "opentelemetry-otlp", forced)?
+                .add_directive_if_absent(base, "opentelemetry", forced)?
+                .add_directive_if_absent(base, "opentelemetry_sdk", forced)?
+                .add_directive_if_absent(base, "rustls", forced)?
+                .add_directive_if_absent(base, "sqlparser", forced)?
+                .add_directive_if_absent(base, "tonic", forced)?
+                .add_directive_if_absent(base, "tonic_web", forced)?
+                .add_directive_if_absent(base, "tower", forced)?
+                .add_directive_if_absent(base, "tower_http", forced)?
+                .add_directive_if_absent(base, "tower_web", forced)?
+                //
+                .add_directive_if_absent(base, "lance::index", lance_level)?
+                .add_directive_if_absent(base, "lance::dataset::scanner", lance_level)?
+                .add_directive_if_absent(base, "lance::dataset::builder", lance_level)?
+                .add_directive_if_absent(base, "lance_encoding", "off")
         };
 
         // Logging strategy


### PR DESCRIPTION
re_perf_telemetry should not override explicit RUST_LOG entries, this should be in line with what happens in re_log.

### Related
* [dataplatform#1282](https://github.com/rerun-io/dataplatform/issues/1282)

### Testing
If I now run a registration with `RUST_LOG=lance=trace,info`, I get:

```
  2025-07-16T10:53:24.432943Z DEBUG lance::io::exec::scan: Given io_parallelism=8 and num_columns=2 we will read 16 fragments at once while scanning v2 dataset
   [...]
  2025-07-16T10:53:24.433660Z TRACE lance_io::scheduler: Inserting I/O request for 4096 bytes with priority (0,0) into I/O queue
   [...]
  2025-07-16T10:53:24.434321Z DEBUG lance_file::v2::reader: Reading range 0..3 with batch_size 8192 from file with 3 rows and 2 columns into schema with 2 columns
   [...]
  2025-07-16T10:53:24.434853Z TRACE lance_io::scheduler: Inserting I/O request for 96 bytes with priority (0,0) into I/O queue
 [...]

```
