### PR TITLE
AnyValues Edge Cases and Air Traffic Example Fix

### DIFF
--- a/examples/python/air_traffic_data/air_traffic_data.py
+++ b/examples/python/air_traffic_data/air_traffic_data.py
@@ -332,7 +332,7 @@ class MeasurementBatchLogger:
         timestamps = rr.TimeColumn("unix_time", timestamp=df["timestamp"].to_numpy())
         pos = self._proj.transform(df["longitude"], df["latitude"], df["barometric_altitude"])
 
-        raw_coordinates = rr.AnyValues(
+        raw_coordinates = rr.AnyValues.columns(
             latitude=df["latitude"].to_numpy(),
             longitude=df["longitude"].to_numpy(),
             barometric_altitude=df["barometric_altitude"].to_numpy(),
@@ -344,7 +344,7 @@ class MeasurementBatchLogger:
             [
                 *rr.Points3D.columns(positions=np.vstack(pos).T),
                 *rr.GeoPoints.columns(positions=np.vstack((df["latitude"], df["longitude"])).T),
-                *raw_coordinates.columns(),
+                *raw_coordinates,
             ],
         )
 


### PR DESCRIPTION
### Related
Closes #10658 
Somewhat a follow up to #10647 

### What
* I added a check for improper AnyValues usage (providing a value rather than kwarg) and that blew up the example since it was setup wrong
* Debugging this issue I hit
  * Numpy arrays of non-numeric types don't work for dlpack (check for BufferError)
  * Empty AnyValues are valid when used later, so I narrowed my check
  * Add an additional check for empty batches since that combined with my narrow check should prevent foot guns
  * Update our unit tests to better cover this