### PR TITLE
Slightly nicer video error messages

### DIFF
--- a/crates/top/rerun_c/src/video.rs
+++ b/crates/top/rerun_c/src/video.rs
@@ -44,7 +44,7 @@ pub extern "C" fn rr_video_asset_read_frame_timestamps_nanos(
         Err(err) => {
             CError::new(
                 CErrorCode::VideoLoadError,
-                &format!("Failed to load video data: {err}"),
+                &format!("Failed to play video: {err}"),
             )
             .write_error(error);
             return std::ptr::null_mut();

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -46,7 +46,7 @@ pub fn video_asset_result_ui(
             // See also `MediaTypeIsNotAVideo` case above.
         }
         Err(err) => {
-            let error_message = format!("Failed to load video: {err}");
+            let error_message = format!("Failed to play: {err}");
             if ui_layout.is_single_line() {
                 ui.error_with_details_on_hover(error_message);
             } else {

--- a/crates/viewer/re_view_spatial/src/visualizers/video/video_stream.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/video/video_stream.rs
@@ -106,7 +106,7 @@ impl VisualizerSystem for VideoStreamVisualizer {
                         &mut self.data,
                         highlight,
                         world_from_entity,
-                        format!("Failed to load video stream at {entity_path:?}: {err}"),
+                        format!("Failed to play video at {entity_path:?}: {err}"),
                         video_resolution,
                         entity_path,
                     );

--- a/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_stream_cache.rs
@@ -124,19 +124,16 @@ pub struct VideoStreamCache(HashMap<VideoStreamKey, VideoStreamCacheEntry>);
 
 #[derive(thiserror::Error, Debug)]
 pub enum VideoStreamProcessingError {
-    #[error("No video frame chunks found.")]
+    #[error("No video samples.")]
     NoVideoSamplesFound,
 
-    #[error("Frame chunks present, but arrow type but unexpected arrow type: {0:?}")]
+    #[error("Unexpected arrow type for video sample {0:?}")]
     InvalidVideoSampleType(arrow::datatypes::DataType),
-
-    #[error("Expected only a single video sample per timestep")]
-    MultipleVideoSamplesPerTimestep,
 
     #[error("No codec specified.")]
     MissingCodec,
 
-    #[error("Failed reading codec: {0}")]
+    #[error("Failed to read codec - {0}")]
     FailedReadingCodec(re_chunk::ChunkError),
 }
 


### PR DESCRIPTION
Found status quo a bit annoying while testing

Example for just logging a codec, but no samples.
Before:
<img width="769" height="412" alt="image" src="https://github.com/user-attachments/assets/2e246022-f970-4fbc-9715-5af70721181a" />


After:
<img width="713" height="402" alt="image" src="https://github.com/user-attachments/assets/79f232c8-eac4-41a6-aadb-dc0d81456327" />


would be nice to highlight the entity path part a bit different, but that needs too much digging for me right now.