### PR TITLE
Update version dropdown when deploying latest Python docs

### DIFF
--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -93,7 +93,7 @@ jobs:
           process_gcloudignore: false
           parent: false
 
-      - name: "Update latest"
+      - name: "Update latest index.html"
         if: ${{ inputs.UPDATE_LATEST }}
         run: |
           cat <<EOF > index.html
@@ -116,6 +116,26 @@ jobs:
           EOF
 
           gsutil cp ./index.html gs://rerun-docs/docs/python/stable/
+
+      - name: "Update versions.json"
+        if: ${{ inputs.UPDATE_LATEST }}
+        run: |
+          VERSION=${{ inputs.PY_DOCS_VERSION_NAME }}
+
+          echo "download existing"
+          gsutil cp gs://rerun-docs/docs/python/versions.json ./
+          cat versions.json
+
+          echo "remove `stable` alias"
+          jq -c 'map(.aliases |= map(select(. != "stable")))' versions.json > versions.json.new
+          cat versions.json.new
+
+          echo "prepend new version with `stable` alias"
+          jq -c --arg v "0.24.0" '[{ version: $v, title: $v, aliases: ["stable"] }] + .' versions.json.new > versions.json
+          cat versions.json
+
+          echo "overwrite the file on gcs"
+          gsutil cp ./versions.json gs://rerun-docs/docs/python/
 
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This is a long-overdue follow-up to https://github.com/rerun-io/rerun/pull/10240, where we stopped using `mike` which was responsible for updating the `versions.json` file. It will now be updated again when we release new versions