### PR TITLE
Fix transform order for arkit example

### DIFF
--- a/examples/python/arkit_scenes/arkit_scenes/__main__.py
+++ b/examples/python/arkit_scenes/arkit_scenes/__main__.py
@@ -67,16 +67,15 @@ def log_annotated_bboxes(annotation: dict[str, Any]) -> None:
 
         half_size = 0.5 * np.array(label_info["segments"]["obbAligned"]["axesLengths"]).reshape(-1, 3)[0]
         centroid = np.array(label_info["segments"]["obbAligned"]["centroid"]).reshape(-1, 3)[0]
-        mat3x3 = np.array(label_info["segments"]["obbAligned"]["normalizedAxes"]).reshape(3, 3)
+        mat3x3 = np.array(label_info["segments"]["obbAligned"]["normalizedAxes"]).reshape(3, 3).T
 
         rr.log(
             f"world/annotations/box-{uid}-{label}",
             rr.Boxes3D(
                 half_sizes=half_size,
-                centers=centroid,
                 labels=label,
             ),
-            rr.InstancePoses3D(mat3x3=mat3x3),
+            rr.InstancePoses3D(translations=centroid, mat3x3=mat3x3),
             static=True,
         )
 


### PR DESCRIPTION
This is in line with what we wrote in the migration guide: a consequence of tagged component handling is that the transforms on boxes & the transforms on instance poses no longer overlap (they were the same before!). This means that we had to establish an order for these. And if you're unlucky - like arkit example - that order is not what you had in mind!


Back to normal:

<img width="1790" height="955" alt="image" src="https://github.com/user-attachments/assets/535dccc9-888c-4341-9942-c1a733e15aac" />
