### PR TITLE
Support flexiable x-axis for bars in BarChart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8395,6 +8395,7 @@ dependencies = [
 name = "re_view_bar_chart"
 version = "0.24.0-alpha.10+dev"
 dependencies = [
+ "arrow",
  "egui",
  "egui_plot",
  "re_chunk_store",

--- a/crates/store/re_types/definitions/rerun/archetypes/bar_chart.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/bar_chart.fbs
@@ -22,4 +22,7 @@ table BarChart (
 
   /// The color of the bar chart
   color: rerun.components.Color ("attr.rerun.component_optional", nullable, order: 2000);
+
+  /// The indexes. Should always be a 1-dimensional tensor (i.e. a vector).
+  indexes: rerun.components.TensorData ("attr.rerun.component_optional", nullable, order: 3000);
 }

--- a/crates/store/re_types/src/reflection/mod.rs
+++ b/crates/store/re_types/src/reflection/mod.rs
@@ -1353,7 +1353,11 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : true, }, ArchetypeFieldReflection { name : "color",
                     display_name : "Color", component_type : "rerun.components.Color"
                     .into(), docstring_md : "The color of the bar chart", is_required :
-                    false, },
+                    false, }, ArchetypeFieldReflection { name : "indexes", display_name :
+                    "Indexes", component_type : "rerun.components.TensorData".into(),
+                    docstring_md :
+                    "The indexes. Should always be a 1-dimensional tensor (i.e. a vector).",
+                    is_required : false, },
                 ],
             },
         ),

--- a/crates/viewer/re_view_bar_chart/Cargo.toml
+++ b/crates/viewer/re_view_bar_chart/Cargo.toml
@@ -27,11 +27,12 @@ re_view.workspace = true
 re_tracing.workspace = true
 re_types = { workspace = true, features = ["egui_plot"] }
 re_ui.workspace = true
-re_viewer_context.workspace = true
+re_viewer_context = { workspace = true }
 re_viewport_blueprint.workspace = true
 
 egui_plot.workspace = true
 egui.workspace = true
+arrow.workspace = true
 
 [dev-dependencies]
 re_viewport = { workspace = true, features = ["testing"] }

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -13,6 +13,7 @@ The x values will be the indices of the array, and the bar heights will be the p
 
 ### Optional
 * `color`: [`Color`](../components/color.md)
+* `indexes`: [`TensorData`](../components/tensor_data.md)
 
 
 ## Can be shown in

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.cpp
@@ -12,17 +12,22 @@ namespace rerun::archetypes {
                                .value_or_throw();
         archetype.color =
             ComponentBatch::empty<rerun::components::Color>(Descriptor_color).value_or_throw();
+        archetype.indexes = ComponentBatch::empty<rerun::components::TensorData>(Descriptor_indexes)
+                                .value_or_throw();
         return archetype;
     }
 
     Collection<ComponentColumn> BarChart::columns(const Collection<uint32_t>& lengths_) {
         std::vector<ComponentColumn> columns;
-        columns.reserve(2);
+        columns.reserve(3);
         if (values.has_value()) {
             columns.push_back(values.value().partitioned(lengths_).value_or_throw());
         }
         if (color.has_value()) {
             columns.push_back(color.value().partitioned(lengths_).value_or_throw());
+        }
+        if (indexes.has_value()) {
+            columns.push_back(indexes.value().partitioned(lengths_).value_or_throw());
         }
         return columns;
     }
@@ -33,6 +38,9 @@ namespace rerun::archetypes {
         }
         if (color.has_value()) {
             return columns(std::vector<uint32_t>(color.value().length(), 1));
+        }
+        if (indexes.has_value()) {
+            return columns(std::vector<uint32_t>(indexes.value().length(), 1));
         }
         return Collection<ComponentColumn>();
     }
@@ -45,13 +53,16 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<ComponentBatch> cells;
-        cells.reserve(2);
+        cells.reserve(3);
 
         if (archetype.values.has_value()) {
             cells.push_back(archetype.values.value());
         }
         if (archetype.color.has_value()) {
             cells.push_back(archetype.color.value());
+        }
+        if (archetype.indexes.has_value()) {
+            cells.push_back(archetype.indexes.value());
         }
 
         return rerun::take_ownership(std::move(cells));

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -42,6 +42,9 @@ namespace rerun::archetypes {
         /// The color of the bar chart
         std::optional<ComponentBatch> color;
 
+        /// The indexes. Should always be a 1-dimensional tensor (i.e. a vector).
+        std::optional<ComponentBatch> indexes;
+
       public:
         /// The name of the archetype as used in `ComponentDescriptor`s.
         static constexpr const char ArchetypeName[] = "rerun.archetypes.BarChart";
@@ -53,6 +56,11 @@ namespace rerun::archetypes {
         /// `ComponentDescriptor` for the `color` field.
         static constexpr auto Descriptor_color = ComponentDescriptor(
             ArchetypeName, "BarChart:color", Loggable<rerun::components::Color>::ComponentType
+        );
+        /// `ComponentDescriptor` for the `indexes` field.
+        static constexpr auto Descriptor_indexes = ComponentDescriptor(
+            ArchetypeName, "BarChart:indexes",
+            Loggable<rerun::components::TensorData>::ComponentType
         );
 
       public: // START of extensions from bar_chart_ext.cpp:
@@ -219,6 +227,21 @@ namespace rerun::archetypes {
         /// be used when logging a single row's worth of data.
         BarChart with_many_color(const Collection<rerun::components::Color>& _color) && {
             color = ComponentBatch::from_loggable(_color, Descriptor_color).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// The indexes. Should always be a 1-dimensional tensor (i.e. a vector).
+        BarChart with_indexes(const rerun::components::TensorData& _indexes) && {
+            indexes = ComponentBatch::from_loggable(_indexes, Descriptor_indexes).value_or_throw();
+            return std::move(*this);
+        }
+
+        /// This method makes it possible to pack multiple `indexes` in a single component batch.
+        ///
+        /// This only makes sense when used in conjunction with `columns`. `with_indexes` should
+        /// be used when logging a single row's worth of data.
+        BarChart with_many_indexes(const Collection<rerun::components::TensorData>& _indexes) && {
+            indexes = ComponentBatch::from_loggable(_indexes, Descriptor_indexes).value_or_throw();
             return std::move(*this);
         }
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -50,7 +50,13 @@ class BarChart(BarChartExt, Archetype):
 
     """
 
-    def __init__(self: Any, values: datatypes.TensorDataLike, *, color: datatypes.Rgba32Like | None = None) -> None:
+    def __init__(
+        self: Any,
+        values: datatypes.TensorDataLike,
+        *,
+        color: datatypes.Rgba32Like | None = None,
+        indexes: datatypes.TensorDataLike | None = None,
+    ) -> None:
         """
         Create a new instance of the BarChart archetype.
 
@@ -60,12 +66,14 @@ class BarChart(BarChartExt, Archetype):
             The values. Should always be a 1-dimensional tensor (i.e. a vector).
         color:
             The color of the bar chart
+        indexes:
+            The indexes. Should always be a 1-dimensional tensor (i.e. a vector).
 
         """
 
         # You can define your own __init__ function as a member of BarChartExt in bar_chart_ext.py
         with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(values=values, color=color)
+            self.__attrs_init__(values=values, color=color, indexes=indexes)
             return
         self.__attrs_clear__()
 
@@ -74,6 +82,7 @@ class BarChart(BarChartExt, Archetype):
         self.__attrs_init__(
             values=None,
             color=None,
+            indexes=None,
         )
 
     @classmethod
@@ -90,6 +99,7 @@ class BarChart(BarChartExt, Archetype):
         clear_unset: bool = False,
         values: datatypes.TensorDataLike | None = None,
         color: datatypes.Rgba32Like | None = None,
+        indexes: datatypes.TensorDataLike | None = None,
     ) -> BarChart:
         """
         Update only some specific fields of a `BarChart`.
@@ -102,6 +112,8 @@ class BarChart(BarChartExt, Archetype):
             The values. Should always be a 1-dimensional tensor (i.e. a vector).
         color:
             The color of the bar chart
+        indexes:
+            The indexes. Should always be a 1-dimensional tensor (i.e. a vector).
 
         """
 
@@ -110,6 +122,7 @@ class BarChart(BarChartExt, Archetype):
             kwargs = {
                 "values": values,
                 "color": color,
+                "indexes": indexes,
             }
 
             if clear_unset:
@@ -132,6 +145,7 @@ class BarChart(BarChartExt, Archetype):
         *,
         values: datatypes.TensorDataArrayLike | None = None,
         color: datatypes.Rgba32ArrayLike | None = None,
+        indexes: datatypes.TensorDataArrayLike | None = None,
     ) -> ComponentColumnList:
         """
         Construct a new column-oriented component bundle.
@@ -147,6 +161,8 @@ class BarChart(BarChartExt, Archetype):
             The values. Should always be a 1-dimensional tensor (i.e. a vector).
         color:
             The color of the bar chart
+        indexes:
+            The indexes. Should always be a 1-dimensional tensor (i.e. a vector).
 
         """
 
@@ -155,13 +171,14 @@ class BarChart(BarChartExt, Archetype):
             inst.__attrs_init__(
                 values=values,
                 color=color,
+                indexes=indexes,
             )
 
         batches = inst.as_component_batches()
         if len(batches) == 0:
             return ComponentColumnList([])
 
-        kwargs = {"BarChart:values": values, "BarChart:color": color}
+        kwargs = {"BarChart:values": values, "BarChart:color": color, "BarChart:indexes": indexes}
         columns = []
 
         for batch in batches:
@@ -206,6 +223,15 @@ class BarChart(BarChartExt, Archetype):
         converter=components.ColorBatch._converter,  # type: ignore[misc]
     )
     # The color of the bar chart
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    indexes: components.TensorDataBatch | None = field(
+        metadata={"component": True},
+        default=None,
+        converter=components.TensorDataBatch._converter,  # type: ignore[misc]
+    )
+    # The indexes. Should always be a 1-dimensional tensor (i.e. a vector).
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### Related

* Part of #7346
* Part of #5622
* Part of #1387

### What

**Support customise x-axis (index) for BarChart**

This draft PR include changes that enable index customization of BarChart.
The index of BarChart has to be 0-indexed continus intagers originally, while a lot of use case require a customized index as in related issues.

This PR include changes to both the BarChart data type as view system. As rerun use BarChart from egui_plot where index is supported, an extra field _indexes_ is add to rerun.BarChart.
