### PR TITLE
Don't style (&describe) missing video samples like an error

### DIFF
--- a/crates/viewer/re_view_spatial/src/pickable_textured_rect.rs
+++ b/crates/viewer/re_view_spatial/src/pickable_textured_rect.rs
@@ -14,8 +14,8 @@ pub enum PickableRectSourceData {
     /// The rectangle is a frame in a video.
     Video,
 
-    /// The rectangle represents an error icon.
-    ErrorPlaceholder,
+    /// The rectangle represents an placeholder icon.
+    Placeholder,
 }
 
 /// Image rectangle that can be picked in the view.

--- a/crates/viewer/re_view_spatial/src/pickable_textured_rect.rs
+++ b/crates/viewer/re_view_spatial/src/pickable_textured_rect.rs
@@ -14,7 +14,7 @@ pub enum PickableRectSourceData {
     /// The rectangle is a frame in a video.
     Video,
 
-    /// The rectangle represents an placeholder icon.
+    /// The rectangle represents a placeholder icon.
     Placeholder,
 }
 

--- a/crates/viewer/re_view_spatial/src/picking_ui.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui.rs
@@ -256,7 +256,7 @@ fn get_pixel_picking_info(
             .and_then(|picked_rect| {
                 if matches!(
                     picked_rect.source_data,
-                    PickableRectSourceData::ErrorPlaceholder
+                    PickableRectSourceData::Placeholder { .. }
                 ) {
                     return None;
                 }

--- a/crates/viewer/re_view_spatial/src/picking_ui.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui.rs
@@ -254,10 +254,7 @@ fn get_pixel_picking_info(
         iter_pickable_rects(&system_output.view_systems)
             .find(|i| i.ent_path.hash() == hit.instance_path_hash.entity_path_hash)
             .and_then(|picked_rect| {
-                if matches!(
-                    picked_rect.source_data,
-                    PickableRectSourceData::Placeholder { .. }
-                ) {
+                if matches!(picked_rect.source_data, PickableRectSourceData::Placeholder) {
                     return None;
                 }
 

--- a/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
@@ -34,8 +34,8 @@ pub fn textured_rect_hover_ui(
     let depth_meter = match &source_data {
         PickableRectSourceData::Image { depth_meter, .. } => *depth_meter,
         PickableRectSourceData::Video { .. } => None,
-        PickableRectSourceData::ErrorPlaceholder => {
-            // No point in zooming into an error placeholder!
+        PickableRectSourceData::Placeholder { .. } => {
+            // No point in zooming into a placeholder!
             return;
         }
     };

--- a/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui_pixel.rs
@@ -34,7 +34,7 @@ pub fn textured_rect_hover_ui(
     let depth_meter = match &source_data {
         PickableRectSourceData::Image { depth_meter, .. } => *depth_meter,
         PickableRectSourceData::Video { .. } => None,
-        PickableRectSourceData::Placeholder { .. } => {
+        PickableRectSourceData::Placeholder => {
             // No point in zooming into a placeholder!
             return;
         }

--- a/crates/viewer/re_view_spatial/src/visualizers/video/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/video/mod.rs
@@ -117,6 +117,7 @@ enum VideoPlaybackIssueSeverity {
     Informational,
 }
 
+#[expect(clippy::too_many_arguments)]
 fn show_video_playback_issue(
     ctx: &ViewContext<'_>,
     visualizer_data: &mut SpatialViewVisualizerData,

--- a/crates/viewer/re_view_spatial/src/visualizers/video/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/video/mod.rs
@@ -104,12 +104,26 @@ fn visualize_video_frame_texture(
     }
 }
 
-fn show_video_error(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VideoPlaybackIssueSeverity {
+    /// The video can't be played back due to a proper error.
+    ///
+    /// E.g. invalid data provided, decoder problems, not supported etc.
+    Error,
+
+    /// The video can't be played back right now, but it may not actually be an error.
+    ///
+    /// E.g. not having the necessary data yet.
+    Informational,
+}
+
+fn show_video_playback_issue(
     ctx: &ViewContext<'_>,
     visualizer_data: &mut SpatialViewVisualizerData,
     highlight: &re_viewer_context::ViewOutlineMasks,
     world_from_entity: glam::Affine3A,
     error_string: String,
+    severity: VideoPlaybackIssueSeverity,
     video_size: glam::Vec2,
     entity_path: &EntityPath,
 ) {
@@ -198,9 +212,14 @@ fn show_video_error(
         ),
         egui::vec2(video_error_rect_size.x * 3.0, video_error_rect_size.y),
     );
+
+    let style = match severity {
+        VideoPlaybackIssueSeverity::Error => UiLabelStyle::Error,
+        VideoPlaybackIssueSeverity::Informational => UiLabelStyle::Default,
+    };
     visualizer_data.ui_labels.push(UiLabel {
         text: error_string,
-        style: UiLabelStyle::Error,
+        style,
         target: UiLabelTarget::Rect(label_target_rect),
         labeled_instance: re_entity_db::InstancePathHash::entity_all(entity_path),
     });
@@ -224,7 +243,7 @@ fn show_video_error(
         PickableTexturedRect {
             ent_path: entity_path.clone(),
             textured_rect: error_rect,
-            source_data: PickableRectSourceData::ErrorPlaceholder,
+            source_data: PickableRectSourceData::Placeholder,
         },
         ctx.view_class_identifier,
     );

--- a/crates/viewer/re_view_spatial/src/visualizers/video/video_frame_reference.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/video/video_frame_reference.rs
@@ -22,7 +22,10 @@ use crate::{
         SpatialViewVisualizerData,
         entity_iterator::{self, process_archetype},
         filter_visualizable_2d_entities,
-        video::{show_video_error, video_stream_id, visualize_video_frame_texture},
+        video::{
+            VideoPlaybackIssueSeverity, show_video_playback_issue, video_stream_id,
+            visualize_video_frame_texture,
+        },
     },
 };
 
@@ -166,12 +169,13 @@ impl VideoFrameReferenceVisualizer {
 
         match query_result {
             None => {
-                show_video_error(
+                show_video_playback_issue(
                     ctx.view_ctx,
                     &mut self.data,
                     spatial_ctx.highlight,
                     world_from_entity,
                     format!("No video asset at {video_reference:?}"),
+                    VideoPlaybackIssueSeverity::Informational,
                     video_resolution,
                     entity_path,
                 );
@@ -212,12 +216,13 @@ impl VideoFrameReferenceVisualizer {
                             if err.should_request_more_frames() {
                                 ctx.view_ctx.egui_ctx().request_repaint();
                             }
-                            show_video_error(
+                            show_video_playback_issue(
                                 ctx.view_ctx,
                                 &mut self.data,
                                 spatial_ctx.highlight,
                                 world_from_entity,
                                 err.to_string(),
+                                VideoPlaybackIssueSeverity::Error,
                                 video_resolution,
                                 entity_path,
                             );
@@ -225,12 +230,13 @@ impl VideoFrameReferenceVisualizer {
                     }
                 }
                 Err(err) => {
-                    show_video_error(
+                    show_video_playback_issue(
                         ctx.view_ctx,
                         &mut self.data,
                         spatial_ctx.highlight,
                         world_from_entity,
                         err.to_string(),
+                        VideoPlaybackIssueSeverity::Error,
                         video_resolution,
                         entity_path,
                     );


### PR DESCRIPTION
Before:
<img width="713" height="402" alt="466967029-79f232c8-eac4-41a6-aadb-dc0d81456327" src="https://github.com/user-attachments/assets/9a2174fc-8a1c-456b-8984-d39ab6e4ae5e" />

After:
<img width="720" height="550" alt="image" src="https://github.com/user-attachments/assets/5811c57e-5e00-4ca8-ba27-872fcb6c94f7" />


Issue is that missing video samples may be entirely transitional, so not actually an error. Making look like an error is irritating at best
