### PR TITLE
Improve count display in rrd compact and stats

### DIFF
--- a/crates/top/rerun/src/commands/rrd/merge_compact.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_compact.rs
@@ -219,12 +219,13 @@ fn merge_and_compact(
             )
         }
 
+        let msg_count = msg_nr + 1;
         let check_in_interval = 10_000;
-        if (msg_nr + 1) % check_in_interval == 0 {
+        if msg_count % check_in_interval == 0 {
             let msg_per_second = check_in_interval as f64 / last_checkpoint.elapsed().as_secs_f64();
             last_checkpoint = std::time::Instant::now();
             re_log::info!(
-                "processed {msg_nr} messages so far, current speed is {msg_per_second:.2} msg/s"
+                "processed {msg_count} messages so far, current speed is {msg_per_second:.2} msg/s"
             );
             re_tracing::reexports::puffin::GlobalProfiler::lock().new_frame();
         }

--- a/crates/top/rerun/src/commands/rrd/stats.rs
+++ b/crates/top/rerun/src/commands/rrd/stats.rs
@@ -146,13 +146,14 @@ impl StatsCommand {
                 )
             }
 
+            let msg_count = num_msgs + 1;
             let check_in_interval = 10_000;
-            if (num_msgs + 1) % check_in_interval == 0 {
+            if msg_count % check_in_interval == 0 {
                 let msgs_per_sec =
                     check_in_interval as f64 / last_checkpoint.elapsed().as_secs_f64();
                 last_checkpoint = std::time::Instant::now();
                 re_log::info!(
-                    "processed {num_msgs} messages so far, current speed is {msgs_per_sec:.2} msg/s"
+                    "processed {msg_count} messages so far, current speed is {msgs_per_sec:.2} msg/s"
                 );
                 re_tracing::reexports::puffin::GlobalProfiler::lock().new_frame();
             }


### PR DESCRIPTION
### What

Before:
```
[2025-07-17T12:07:13Z INFO  rerun::commands::rrd::merge_compact] processed 9999 messages so far, current speed is 24769.58 msg/s
[2025-07-17T12:07:14Z INFO  rerun::commands::rrd::merge_compact] processed 19999 messages so far, current speed is 27065.47 msg/s
[2025-07-17T12:07:14Z INFO  rerun::commands::rrd::merge_compact] processed 29999 messages so far, current speed is 26820.04 msg/s
[2025-07-17T12:07:14Z INFO  rerun::commands::rrd::merge_compact] processed 39999 messages so far, current speed is 26902.58 msg/s
[2025-07-17T12:07:15Z INFO  rerun::commands::rrd::merge_compact] processed 49999 messages so far, current speed is 26004.71 msg/s
```

After:
```
[2025-07-17T12:26:49Z INFO  rerun::commands::rrd::merge_compact] processed 10000 messages so far, current speed is 28453.17 msg/s
[2025-07-17T12:26:50Z INFO  rerun::commands::rrd::merge_compact] processed 20000 messages so far, current speed is 28111.98 msg/s
[2025-07-17T12:26:50Z INFO  rerun::commands::rrd::merge_compact] processed 30000 messages so far, current speed is 28573.60 msg/s
[2025-07-17T12:26:50Z INFO  rerun::commands::rrd::merge_compact] processed 40000 messages so far, current speed is 29469.11 msg/s
[2025-07-17T12:26:51Z INFO  rerun::commands::rrd::merge_compact] processed 50000 messages so far, current speed is 29718.07 msg/s
```