### PR TITLE
Improve error message for forcing an invalid renderer backend

### DIFF
--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -336,25 +336,43 @@ impl DeviceCaps {
 ///
 /// `re_renderer` should work fine with any instance descriptor, but those are the settings we generally assume.
 pub fn instance_descriptor(force_backend: Option<&str>) -> wgpu::InstanceDescriptor {
+    let supported_backends_str = wgpu::Instance::enabled_backend_features()
+        .iter()
+        .filter_map(|b| match b {
+            wgpu::Backends::VULKAN => Some("vulkan"),
+            wgpu::Backends::METAL => Some("metal"),
+            wgpu::Backends::DX12 => Some("dx12"),
+            wgpu::Backends::GL => Some("gl"),
+            wgpu::Backends::BROWSER_WEBGPU => Some("webgpu"),
+
+            #[expect(clippy::match_same_arms)]
+            wgpu::Backends::NOOP => None, // Don't offer this even if it shows up (it shouldn't).
+            _ => None, // Flag combinations shouldn't show up here.
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
     let backends = if let Some(force_backend) = force_backend {
         if let Some(backend) = parse_graphics_backend(force_backend) {
             if let Err(err) = validate_graphics_backend_applicability(backend) {
                 re_log::error!(
-                    "Failed to force rendering backend parsed from {force_backend:?}: {err}\nUsing default backend instead."
+                    "Failed to force rendering backend parsed from {force_backend:?}: {err} \
+                    Supported on this platform are: {supported_backends_str}."
                 );
-                supported_backends()
+                default_backends()
             } else {
                 re_log::info!("Forcing graphics backend to {backend:?}.");
                 backend.into()
             }
         } else {
             re_log::error!(
-                "Failed to parse rendering backend string {force_backend:?}. Using default backend instead."
+                "Failed to parse rendering backend string {force_backend:?}. \
+                Supported on this platform are: {supported_backends_str}."
             );
-            supported_backends()
+            default_backends()
         }
     } else {
-        supported_backends()
+        default_backends()
     };
 
     wgpu::InstanceDescriptor {
@@ -443,7 +461,7 @@ pub fn select_testing_adapter(instance: &wgpu::Instance) -> wgpu::Adapter {
 /// Backends that are officially supported by `re_renderer`.
 ///
 /// Other backend might work as well, but lack of support isn't regarded as a bug.
-pub fn supported_backends() -> wgpu::Backends {
+pub fn default_backends() -> wgpu::Backends {
     if cfg!(native) {
         // Native: Everything but DX12
         // * Wgpu's DX12 impl isn't in a great shape yet and there's now reason to add more variation


### PR DESCRIPTION
### Related

* tangentially related to https://github.com/rerun-io/rerun/issues/10683

### What

Looks like this on my Windows now:
```
pixi run rerun --renderer software
[2025-07-18T11:47:52Z INFO  re_grpc_server] Listening for gRPC connections on 0.0.0.0:9876. Connect by running `rerun --connect rerun+http://127.0.0.1:9876/proxy`
[2025-07-18T11:47:52Z ERROR re_renderer::device_caps] Failed to parse rendering backend string "software". Supported on this platform are: vulkan, gl.
```