### PR TITLE
Update class initialization in `rerun_notebook/example.ipynb`

### DIFF
--- a/rerun_notebook/example.ipynb
+++ b/rerun_notebook/example.ipynb
@@ -11,6 +11,7 @@
     "from rerun_notebook import Viewer\n",
     "\n",
     "Viewer(\n",
+    "    width=\"auto\", height=\"auto\",\n",
     "    url=\"https://app.rerun.io/version/nightly/examples/raw_mesh.rrd\",\n",
     "    panel_states={\n",
     "        \"blueprint\": \"hidden\",\n",


### PR DESCRIPTION
### Related
Old signature of inialization of `Viewer` class:
https://github.com/rerun-io/rerun/blob/82d45ce7de4334a64c52f14bff61fe030aa664b1/rerun_notebook/src/rerun_notebook/__init__.py#L177-L185
The new signature
https://github.com/rerun-io/rerun/blob/a1bce5156d46c9d4c9e5610c46bcae47fd09acf4/rerun_notebook/src/rerun_notebook/__init__.py#L179-L188
### What

Fixes `rerun_notebook/example.ipynb` breaking due to reliance on older signature.