### PR TITLE
Notebook Build Fix

### DIFF
--- a/docs/snippets/all/archetypes/image_advanced.py
+++ b/docs/snippets/all/archetypes/image_advanced.py
@@ -22,14 +22,14 @@ rr.init("rerun_example_image_advanced", spawn=True)
 rr.log("from_file", rr.EncodedImage(path=file_path))
 
 # Read with Pillow and NumPy, and log the image.
-image = np.array(PILImage.open(file_path))
-rr.log("from_pillow_rgba", rr.Image(image))
+image_data = np.array(PILImage.open(file_path))
+rr.log("from_pillow_rgba", rr.Image(image_data))
 
 # Drop the alpha channel from the image.
-image_rgb = image[..., :3]
+image_rgb = image_data[..., :3]
 rr.log("from_pillow_rgb", rr.Image(image_rgb))
 
 # Read with OpenCV.
-image = cv2.imread(file_path)
+image_cv = cv2.imread(file_path)
 # OpenCV uses BGR ordering, we need to make this known to Rerun.
-rr.log("from_opencv", rr.Image(image, color_model="BGR"))
+rr.log("from_opencv", rr.Image(image_cv, color_model="BGR"))

--- a/rerun_notebook/pyproject.toml
+++ b/rerun_notebook/pyproject.toml
@@ -35,7 +35,6 @@ artifacts = [
 [tool.hatch.build.hooks.jupyter-builder]
 build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = ["src/rerun_notebook/static/widget.js"]
-skip-if-exists = ["src/rerun_notebook/static/widget.js"]
 dependencies = ["hatch-jupyter-builder>=0.5.0"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -86,7 +86,7 @@ def build_image_stack(image: Image) -> list[tuple[int | None, Image]]:
     return image_stack
 
 
-def image_from_clipboard() -> Image:
+def image_from_clipboard() -> Image | None:
     """
     Get image from the clipboard.
 
@@ -114,7 +114,12 @@ def image_from_clipboard() -> Image:
         os.unlink(filepath)
         return im
     else:
-        return PIL.ImageGrab.grabclipboard()
+        # On windows might return a list, of files,
+        # so return None signaling no image found.
+        content = PIL.ImageGrab.grabclipboard()
+        if isinstance(content, list):
+            return None
+        return content
 
 
 class Uploader:

--- a/tests/python/test_api/test_api.py
+++ b/tests/python/test_api/test_api.py
@@ -89,10 +89,10 @@ def run_segmentation() -> None:
 
 
 def small_image() -> None:
-    img = [
+    img = np.array([
         [[255, 0, 0], [0, 255, 0], [0, 0, 255]],
         [[0, 0, 255], [255, 0, 0], [0, 255, 0]],
-    ]
+    ])
     rr.log("small_image", rr.Image(img))
 
 


### PR DESCRIPTION
### Related
Closes #10708 in a not totally satisfying way. Running this through CI so I can download the cloud wheels to confirm what I've seen locally. This will also only trigger a PR build, so might not be totally convincing it fixes the release build variant.

### What
I don't have a full root cause. Lots of discussion in the ticket.
Basically our [release build](https://github.com/rerun-io/rerun/blob/d01c23ed92fa2cc77405198ae8f81e3c1cee1d11/scripts/ci/build_and_upload_wheels.py#L72-L77) incorporates different things than our PR build of the wheels, which is why we haven't seen this before.

We updated our packaged contents [here](https://github.com/rerun-io/rerun/blob/a1bce5156d46c9d4c9e5610c46bcae47fd09acf4/rerun_notebook/pyproject.toml#L30) but haven't done a PR wheel build since then. It looks like something gets built without the maturin release flag and we have symbol collisions. If we  remove the skip if then things get rebuilt and look consistent.

Also a small commit because our push hooks were upset.