### PR TITLE
Always bootstrap secondaries in plot view

### DIFF
--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -1,13 +1,16 @@
 use itertools::Itertools as _;
 
-use re_chunk_store::{RangeQuery, RowId};
+use re_chunk_store::{LatestAtQuery, RangeQuery, RowId};
 use re_log_types::{EntityPath, TimeInt};
 use re_types::{
     Archetype as _,
     archetypes::{self},
     components::{AggregationPolicy, Color, Name, SeriesVisible, StrokeWidth},
 };
-use re_view::{RangeResultsExt as _, range_with_blueprint_resolved_data};
+use re_view::{
+    RangeResultsExt as _, latest_at_with_blueprint_resolved_data,
+    range_with_blueprint_resolved_data,
+};
 use re_viewer_context::external::re_entity_db::InstancePath;
 use re_viewer_context::{
     IdentifiedViewSystem, QueryContext, TypedComponentFallbackProvider, ViewContext, ViewQuery,
@@ -228,9 +231,29 @@ impl SeriesLinesSystem {
                 allocate_plot_points(&query, &default_point, &all_scalar_chunks, num_series);
 
             collect_scalars(&all_scalar_chunks, &mut points_per_series);
+
+            // The plot view visualizes scalar data within a specific time range, without any kind
+            // of time-alignment / bootstrapping behavior:
+            // * For the scalar themselves, this is what you want: if you're trying to plot some
+            //   data between t=100 and t=200, you don't want to display a point from t=20 (and
+            //   _extended bounds_ will take care of lines crossing the limit).
+            // * For the secondary components (colors, radii, names, etc), this is a problem
+            //   though: you don't want your plot to change color depending on what the currently
+            //   visible time range is! Secondary components have to be bootstrapped.
+            let query_shadowed_components = false;
+            let bootstrapped_results = latest_at_with_blueprint_resolved_data(
+                ctx,
+                None,
+                &LatestAtQuery::new(query.timeline, query.range.min()),
+                data_result,
+                archetypes::SeriesLines::all_components().iter(),
+                query_shadowed_components,
+            );
+
             collect_colors(
                 entity_path,
                 &query,
+                &bootstrapped_results,
                 &results,
                 &all_scalar_chunks,
                 &mut points_per_series,
@@ -238,6 +261,7 @@ impl SeriesLinesSystem {
             );
             collect_radius_ui(
                 &query,
+                &bootstrapped_results,
                 &results,
                 &all_scalar_chunks,
                 &mut points_per_series,
@@ -247,9 +271,14 @@ impl SeriesLinesSystem {
 
             // Now convert the `PlotPoints` into `Vec<PlotSeries>`
             let aggregation_policy_descr = archetypes::SeriesLines::descriptor_aggregation_policy();
-            let aggregator = results
+            let aggregator = bootstrapped_results
                 .get_optional_chunks(aggregation_policy_descr.clone())
                 .iter()
+                .chain(
+                    results
+                        .get_optional_chunks(aggregation_policy_descr.clone())
+                        .iter(),
+                )
                 .find(|chunk| !chunk.is_empty())
                 .and_then(|chunk| {
                     chunk
@@ -311,6 +340,7 @@ impl SeriesLinesSystem {
 
             let series_visibility = collect_series_visibility(
                 &query,
+                &bootstrapped_results,
                 &results,
                 num_series,
                 archetypes::SeriesLines::descriptor_visible_series(),
@@ -318,6 +348,7 @@ impl SeriesLinesSystem {
             let series_names = collect_series_name(
                 self,
                 &query_ctx,
+                &bootstrapped_results,
                 &results,
                 num_series,
                 &archetypes::SeriesLines::descriptor_names(),

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -1,10 +1,11 @@
-use re_chunk_store::RowId;
-use re_log_types::TimePoint;
+use re_chunk_store::{RowId, external::re_chunk::ChunkBuilder};
+use re_log_types::{EntityPath, TimePoint, Timeline};
 use re_test_context::{TestContext, external::egui_kittest::SnapshotOptions};
 use re_test_viewport::TestContextExt as _;
+use re_types::{Archetype as _, blueprint::components::Corner2D};
 use re_view_time_series::TimeSeriesView;
 use re_viewer_context::{ViewClass as _, ViewId};
-use re_viewport_blueprint::ViewBlueprint;
+use re_viewport_blueprint::{ViewBlueprint, ViewContents};
 
 fn color_gradient0(step: i64) -> re_types::components::Color {
     re_types::components::Color::from_rgb((step * 8) as u8, 255 - (step * 8) as u8, 0)
@@ -356,5 +357,89 @@ fn run_view_ui_and_save_snapshot(
     harness.snapshot_options(
         name,
         &SnapshotOptions::new().failed_pixel_count_threshold(num_allowed_broken_pixels),
+    );
+}
+
+#[test]
+fn test_bootstrapped_secondaries() {
+    for partial_range in [false, true] {
+        test_bootstrapped_secondaries_impl(partial_range);
+    }
+}
+
+fn test_bootstrapped_secondaries_impl(partial_range: bool) {
+    let mut test_context = TestContext::new_with_view_class::<TimeSeriesView>();
+
+    fn with_scalar(builder: ChunkBuilder, value: i64) -> ChunkBuilder {
+        builder.with_archetype(
+            RowId::new(),
+            TimePoint::from([(Timeline::log_tick(), value)]),
+            &re_types::archetypes::Scalars::new([value as f64]),
+        )
+    }
+
+    test_context.log_entity("scalars", |builder| {
+        let mut builder = builder.with_archetype(
+            RowId::new(),
+            TimePoint::from([(Timeline::log_tick(), 45)]),
+            &re_types::archetypes::SeriesLines::new()
+                .with_widths([5.0])
+                .with_colors([re_types::components::Color::from_rgb(255, 0, 255)])
+                .with_names(["muh_scalars"]),
+        );
+        for i in 0..10 {
+            builder = with_scalar(builder, i * 10);
+        }
+        builder
+    });
+
+    let view_id = test_context.setup_viewport_blueprint(|ctx, blueprint| {
+        let view = ViewBlueprint::new_with_root_wildcard(TimeSeriesView::identifier());
+
+        if partial_range {
+            let override_path =
+                ViewContents::override_path_for_entity(view.id, &EntityPath::from("scalars"));
+            ctx.save_blueprint_archetype(
+                override_path.clone(),
+                &re_types::blueprint::archetypes::VisibleTimeRanges::new([
+                    re_types::blueprint::components::VisibleTimeRange(
+                        re_types::datatypes::VisibleTimeRange {
+                            timeline: "log_tick".into(),
+                            range: re_types::datatypes::TimeRange {
+                                start: re_types::datatypes::TimeRangeBoundary::Absolute(70.into()),
+                                end: re_types::datatypes::TimeRangeBoundary::Infinite,
+                            },
+                        },
+                    ),
+                ]),
+            );
+        }
+
+        {
+            let property_path = re_viewport_blueprint::entity_path_for_view_property(
+                view.id,
+                ctx.store_context.blueprint.tree(),
+                re_types::blueprint::archetypes::PlotLegend::name(),
+            );
+            ctx.save_blueprint_archetype(
+                property_path,
+                &re_types::blueprint::archetypes::PlotLegend::new().with_visible(false),
+            );
+        }
+
+        blueprint.add_view_at_root(view)
+    });
+
+    let name = if partial_range {
+        "bootstrapped_secondaries_partial"
+    } else {
+        "bootstrapped_secondaries_full"
+    };
+    run_view_ui_and_save_snapshot(
+        &mut test_context,
+        view_id,
+        name,
+        egui::vec2(300.0, 300.0),
+        0,
     );
 }

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -2,7 +2,6 @@ use re_chunk_store::{RowId, external::re_chunk::ChunkBuilder};
 use re_log_types::{EntityPath, TimePoint, Timeline};
 use re_test_context::{TestContext, external::egui_kittest::SnapshotOptions};
 use re_test_viewport::TestContextExt as _;
-use re_types::Archetype as _;
 use re_view_time_series::TimeSeriesView;
 use re_viewer_context::{ViewClass as _, ViewId};
 use re_viewport_blueprint::{ViewBlueprint, ViewContents};

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -2,7 +2,7 @@ use re_chunk_store::{RowId, external::re_chunk::ChunkBuilder};
 use re_log_types::{EntityPath, TimePoint, Timeline};
 use re_test_context::{TestContext, external::egui_kittest::SnapshotOptions};
 use re_test_viewport::TestContextExt as _;
-use re_types::{Archetype as _, blueprint::components::Corner2D};
+use re_types::Archetype as _;
 use re_view_time_series::TimeSeriesView;
 use re_viewer_context::{ViewClass as _, ViewId};
 use re_viewport_blueprint::{ViewBlueprint, ViewContents};
@@ -440,6 +440,6 @@ fn test_bootstrapped_secondaries_impl(partial_range: bool) {
         view_id,
         name,
         egui::vec2(300.0, 300.0),
-        0,
+        2,
     );
 }

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -379,14 +379,23 @@ fn test_bootstrapped_secondaries_impl(partial_range: bool) {
     }
 
     test_context.log_entity("scalars", |builder| {
-        let mut builder = builder.with_archetype(
-            RowId::new(),
-            TimePoint::from([(Timeline::log_tick(), 45)]),
-            &re_types::archetypes::SeriesLines::new()
-                .with_widths([5.0])
-                .with_colors([re_types::components::Color::from_rgb(255, 0, 255)])
-                .with_names(["muh_scalars"]),
-        );
+        let mut builder = builder
+            .with_archetype(
+                RowId::new(),
+                TimePoint::from([(Timeline::log_tick(), 0)]),
+                &re_types::archetypes::SeriesLines::new()
+                    .with_widths([5.0])
+                    .with_colors([re_types::components::Color::from_rgb(0, 255, 255)])
+                    .with_names(["muh_scalars"]),
+            )
+            .with_archetype(
+                RowId::new(),
+                TimePoint::from([(Timeline::log_tick(), 45)]),
+                &re_types::archetypes::SeriesLines::new()
+                    .with_widths([5.0])
+                    .with_colors([re_types::components::Color::from_rgb(255, 0, 255)])
+                    .with_names(["muh_scalars"]),
+            );
         for i in 0..10 {
             builder = with_scalar(builder, i * 10);
         }

--- a/crates/viewer/re_view_time_series/tests/basic.rs
+++ b/crates/viewer/re_view_time_series/tests/basic.rs
@@ -386,7 +386,7 @@ fn test_bootstrapped_secondaries_impl(partial_range: bool) {
                 &re_types::archetypes::SeriesLines::new()
                     .with_widths([5.0])
                     .with_colors([re_types::components::Color::from_rgb(0, 255, 255)])
-                    .with_names(["muh_scalars"]),
+                    .with_names(["muh_scalars_from_0"]),
             )
             .with_archetype(
                 RowId::new(),
@@ -394,7 +394,7 @@ fn test_bootstrapped_secondaries_impl(partial_range: bool) {
                 &re_types::archetypes::SeriesLines::new()
                     .with_widths([5.0])
                     .with_colors([re_types::components::Color::from_rgb(255, 0, 255)])
-                    .with_names(["muh_scalars"]),
+                    .with_names(["muh_scalars_from_45"]),
             );
         for i in 0..10 {
             builder = with_scalar(builder, i * 10);
@@ -421,18 +421,6 @@ fn test_bootstrapped_secondaries_impl(partial_range: bool) {
                         },
                     ),
                 ]),
-            );
-        }
-
-        {
-            let property_path = re_viewport_blueprint::entity_path_for_view_property(
-                view.id,
-                ctx.store_context.blueprint.tree(),
-                re_types::blueprint::archetypes::PlotLegend::name(),
-            );
-            ctx.save_blueprint_archetype(
-                property_path,
-                &re_types::blueprint::archetypes::PlotLegend::new().with_visible(false),
             );
         }
 

--- a/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_full.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_full.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87aef24d147d6de0afc23a1cc627697e7e49eed4e66fd7663576336d858ab4f7
-size 13626
+oid sha256:99b5361be00bac0ccbe9496bb7f350663f10dd78eaafebb8ef51c15f0f14feed
+size 13835

--- a/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_full.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_full.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87aef24d147d6de0afc23a1cc627697e7e49eed4e66fd7663576336d858ab4f7
+size 13626

--- a/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_full.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_full.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99b5361be00bac0ccbe9496bb7f350663f10dd78eaafebb8ef51c15f0f14feed
-size 13835
+oid sha256:3f59cd0fb20dd254a83ad61061e8fb6342475c3f7f58fec19759f39ca7b53b60
+size 16607

--- a/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_partial.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_partial.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a86aae175aa5145d25c9b84bc3c1a47f49b5702896974e8d72743a12c5ae9e27
+size 14556

--- a/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_partial.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/bootstrapped_secondaries_partial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a86aae175aa5145d25c9b84bc3c1a47f49b5702896974e8d72743a12c5ae9e27
-size 14556
+oid sha256:0f524612830392d890fc1eaaeeaba3d73f73f613612015ef37db5c812e331454
+size 18056

--- a/crates/viewer/re_view_time_series/tests/snapshots/point_properties_two_series_per_entity.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/point_properties_two_series_per_entity.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66c59772663c5609d4d801af30b6d0339533dbfb47894aa79984a11c05e88e19
-size 36958
+oid sha256:52ecc6d39a567fb03a9ca6581518b78b3695f8bcd6e4ac0cc0487c4c71cd40ad
+size 36939


### PR DESCRIPTION
The plot view visualizes scalar data within a specific time range, without any kind of time-alignment / bootstrapping behavior:
* For the scalar themselves, this is what you want: if you're trying to plot some data between t=100 and t=200, you don't want to display a point from t=20 (and _extended bounds_ will take care of lines crossing the limit).
* For the secondary components (colors, radii, names, etc), this is a problem though: you don't want your plot to change color depending on what the currently visible time range is! Secondary components have to be bootstrapped.

Before:

https://github.com/user-attachments/assets/4ad5e448-e6a9-46ed-bb02-7c88cb8cd3d1

After:

https://github.com/user-attachments/assets/03030ff5-d836-4e9f-9e70-2871c7afbdcc



