### PR TITLE
Improve error handling in `air_traffic_data.py`

### DIFF
--- a/examples/python/air_traffic_data/air_traffic_data.py
+++ b/examples/python/air_traffic_data/air_traffic_data.py
@@ -39,22 +39,29 @@ INVOLI_DATASETS = {
 def download_with_progress(url: str, what: str) -> io.BytesIO:
     """Download file with tqdm progress bar."""
     chunk_size = 1024 * 1024
-    resp = requests.get(url, stream=True)
-    total_size = int(resp.headers.get("content-length", 0))
-    with tqdm(
-        desc=f"Downloading {what}…",
-        total=total_size,
-        unit="iB",
-        unit_scale=True,
-        unit_divisor=1024,
-    ) as progress:
-        download_file = io.BytesIO()
-        for data in resp.iter_content(chunk_size):
-            download_file.write(data)
-            progress.update(len(data))
+    try:
+        resp = requests.get(url, stream=True, timeout=30)
+        resp.raise_for_status()
+        total_size = int(resp.headers.get("content-length", 0))
+        with tqdm(
+            desc=f"Downloading {what}…",
+            total=total_size,
+            unit="iB",
+            unit_scale=True,
+            unit_divisor=1024,
+        ) as progress:
+            download_file = io.BytesIO()
+            for data in resp.iter_content(chunk_size):
+                download_file.write(data)
+                progress.update(len(data))
 
-    download_file.seek(0)
-    return download_file
+        if download_file.tell() != total_size and total_size > 0:
+            raise ValueError("Download incomplete: size mismatch")
+
+        download_file.seek(0)
+        return download_file
+    except (requests.RequestException, ValueError) as e:
+        raise RuntimeError(f"Failed to download {what} from {url}: {e}") from e
 
 
 def shapely_geom_to_numpy(geom: shapely.Geometry) -> list[npt.NDArray[np.float64]]:


### PR DESCRIPTION
### What

We are experiencing regular [CI failures on `nightly`](https://github.com/rerun-io/rerun/actions/runs/16408059984/job/46358076542) for the Air Traffic Example, which we suspect to be related to downloading the required data.

This PR adds some basic error handling to catch common HTTP problems, to report errors when they happen as opposed to poisoning data downstream.
