### PR TITLE
make parking_lot dependency version stricter to prevent import failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,7 +264,7 @@ opentelemetry-appender-tracing = "0.30"
 opentelemetry-otlp = "0.30"
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
 ordered-float = "4.3.0"
-parking_lot = "0.12"
+parking_lot = "0.12.3"
 parquet = { version = "55.1", default-features = false }
 paste = "1.0"
 pathdiff = "0.2"


### PR DESCRIPTION
### Related

Fixes https://github.com/rerun-io/rerun/issues/10731

### What

re_chunk_store depends on `parking_lot::ArcRwLockReadGuard` which was only added in `parking_lot` 0.12.3, but the workspace Cargo.toml specifies the version dependency of `parking_lot` as 0.12
