### PR TITLE
Fix `EntryError` checks missing one kind of tonic status

### DIFF
--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -54,10 +54,11 @@ impl EntryError {
         match self {
             Self::TonicError(status) => Some(status),
             Self::StreamError(StreamError::TonicStatus(status)) => Some(&status.0),
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::StreamError(StreamError::Transport(_)) => None,
             Self::StreamError(
                 StreamError::ConnectionError(_)
                 | StreamError::Tokio(_)
-                | StreamError::Transport(_)
                 | StreamError::CodecError(_)
                 | StreamError::ChunkError(_)
                 | StreamError::DecodeError(_)


### PR DESCRIPTION
### What

Fixes the custom error alert when on missing / wrong tokens:
<img width="373" height="196" alt="Screenshot 2025-07-23 at 16 58 31" src="https://github.com/user-attachments/assets/dffbc374-230d-4770-ac87-93735c1e5bdb" />
