### PR TITLE
Regression-proof error constants for re_auth

### DIFF
--- a/crates/utils/re_auth/src/lib.rs
+++ b/crates/utils/re_auth/src/lib.rs
@@ -24,3 +24,18 @@ pub use error::Error;
 pub use provider::{Claims, RedapProvider, VerificationOptions};
 #[cfg(not(target_arch = "wasm32"))]
 pub use service::server;
+
+/// The error message in Tonic's gRPC status when the token is malformed or invalid in some way.
+///
+/// The associated status code will always be `Unauthenticated`.
+pub const ERROR_MESSAGE_MALFORMED_CREDENTIALS: &str = "malformed auth token";
+
+/// The error message in Tonic's gRPC status when no token was found.
+///
+/// The associated status code will always be `Unauthenticated`.
+pub const ERROR_MESSAGE_MISSING_CREDENTIALS: &str = "missing credentials";
+
+/// The error message in Tonic's gRPC status when a _valid token_ did not have the required permissions.
+///
+/// The associated status code will always be `Unauthenticated`.
+pub const ERROR_MESSAGE_INVALID_CREDENTIALS: &str = "invalid credentials";

--- a/crates/utils/re_auth/src/service/server.rs
+++ b/crates/utils/re_auth/src/service/server.rs
@@ -43,13 +43,16 @@ impl Interceptor for Authenticator {
         let mut req = req;
 
         if let Some(token_metadata) = req.metadata().get(AUTHORIZATION_KEY) {
-            let token = Jwt::try_from(token_metadata)
-                .map_err(|_err| Status::unauthenticated("malformed auth token"))?;
+            let token = Jwt::try_from(token_metadata).map_err(|_err| {
+                Status::unauthenticated(crate::ERROR_MESSAGE_MALFORMED_CREDENTIALS)
+            })?;
 
             let claims = self
                 .secret_key
                 .verify(&token, VerificationOptions::default())
-                .map_err(|_err| Status::unauthenticated("invalid credentials"))?;
+                .map_err(|_err| {
+                    Status::unauthenticated(crate::ERROR_MESSAGE_INVALID_CREDENTIALS)
+                })?;
 
             req.extensions_mut().insert(UserContext {
                 user_id: claims.sub,

--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -50,7 +50,7 @@ impl EntryError {
     pub fn is_missing_token(&self) -> bool {
         if let Self::TonicError(status) = self {
             status.code() == tonic::Code::Unauthenticated
-                && status.message() == "missing credentials"
+                && status.message() == re_auth::ERROR_MESSAGE_MISSING_CREDENTIALS
         } else {
             false
         }
@@ -59,7 +59,7 @@ impl EntryError {
     pub fn is_wrong_token(&self) -> bool {
         if let Self::TonicError(status) = self {
             status.code() == tonic::Code::Unauthenticated
-                && status.message() == "invalid credentials"
+                && status.message() == re_auth::ERROR_MESSAGE_INVALID_CREDENTIALS
         } else {
             false
         }


### PR DESCRIPTION
Just in case, to prevent silly UI regressions while we work on :sparkles: real auth :sparkles:. 

* Sibling: https://github.com/rerun-io/dataplatform/pull/1355