### PR TITLE
Add `rerun auth` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,12 +7186,18 @@ name = "re_auth"
 version = "0.25.0-alpha.1+dev"
 dependencies = [
  "base64 0.22.1",
+ "ehttp",
+ "indicatif",
  "jsonwebtoken",
  "rand 0.8.5",
  "re_log",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
+ "tiny_http",
  "tonic",
+ "url",
+ "webbrowser",
 ]
 
 [[package]]
@@ -9191,6 +9197,7 @@ dependencies = [
  "puffin",
  "rayon",
  "re_analytics",
+ "re_auth",
  "re_build_info",
  "re_build_tools",
  "re_byte_size",

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -35,7 +35,7 @@ doc = false
 ## so we have all the bells and wistles here, except those that may require extra tools
 ## (like "nasm").
 ## That is: `cargo install rerun-cli --locked` should work for _everyone_.
-default = ["native_viewer", "web_viewer", "map_view"]
+default = ["native_viewer", "web_viewer", "map_view", "auth"]
 
 
 # !!!IMPORTANT!!!
@@ -87,6 +87,8 @@ perf_telemetry = ["rerun/perf_telemetry"]
 # TODO(#4295): web_viewer shouldn't require rerun/sdk
 web_viewer = ["rerun/web_viewer", "rerun/sdk"]
 
+## Support authentication.
+auth = ["rerun/auth"]
 
 [dependencies]
 re_build_info.workspace = true

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -33,6 +33,7 @@ default = [
   "map_view",
   "sdk",
   "server",
+  "auth",
 ]
 
 ## Enable telemetry using our analytics SDK.
@@ -127,6 +128,8 @@ sdk = ["dep:re_sdk", "dep:re_types"]
 ## to the compile time since it requires compiling and bundling the viewer as wasm.
 web_viewer = ["server", "dep:re_web_viewer_server", "re_sdk?/web_viewer"]
 
+auth = ["re_auth/cli"]
+
 [dependencies]
 re_build_info.workspace = true
 re_byte_size.workspace = true
@@ -162,6 +165,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 # Optional dependencies:
 re_analytics = { workspace = true, optional = true }
+re_auth = { workspace = true, optional = true }
 re_chunk_store = { workspace = true, optional = true }
 re_crash_handler = { workspace = true, optional = true }
 re_data_source = { workspace = true, optional = true }

--- a/crates/top/rerun/src/commands/auth.rs
+++ b/crates/top/rerun/src/commands/auth.rs
@@ -1,0 +1,21 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum AuthCommands {
+    /// Log into Rerun.
+    Login(LoginCommand),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct LoginCommand {
+    #[clap(default_value = "http://localhost:6170/login")]
+    login_url: String,
+}
+
+impl AuthCommands {
+    pub fn run(&self) -> Result<(), re_auth::cli::Error> {
+        match self {
+            AuthCommands::Login(args) => re_auth::cli::login(&args.login_url),
+        }
+    }
+}

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -21,6 +21,8 @@ use re_web_viewer_server::WebViewerServerPort;
 #[cfg(feature = "analytics")]
 use crate::commands::AnalyticsCommands;
 
+use super::auth::AuthCommands;
+
 // ---
 
 const LONG_ABOUT: &str = r#"
@@ -548,6 +550,11 @@ enum Command {
     /// Example: `rerun man > docs/content/reference/cli.md`
     #[command(name = "man")]
     Manual,
+
+    /// Authentication with the redap.
+    #[cfg(feature = "auth")]
+    #[command(subcommand)]
+    Auth(AuthCommands),
 }
 
 /// Run the Rerun application and return an exit code.
@@ -632,6 +639,9 @@ where
                 println!("{web_header}\n\n{man}");
                 Ok(())
             }
+
+            // TODO: report nicer errors
+            Command::Auth(cmd) => cmd.run().map_err(Into::into),
         }
     } else {
         #[cfg(all(not(target_arch = "wasm32"), feature = "perf_telemetry"))]

--- a/crates/top/rerun/src/commands/mod.rs
+++ b/crates/top/rerun/src/commands/mod.rs
@@ -21,6 +21,9 @@ impl CallSource {
 
 // ---
 
+#[cfg(feature = "auth")]
+mod auth;
+
 mod entrypoint;
 mod rrd;
 mod stdio;

--- a/crates/utils/re_auth/Cargo.toml
+++ b/crates/utils/re_auth/Cargo.toml
@@ -14,12 +14,35 @@ version.workspace = true
 [lints]
 workspace = true
 
+[features]
+# TODO: remove
+default = ["cli"]
+cli = [
+  "dep:base64",
+  "dep:ehttp",
+  "dep:indicatif",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:tiny_http",
+  "dep:url",
+  "dep:webbrowser",
+]
+
 [dependencies]
 re_log.workspace = true
 
 jsonwebtoken.workspace = true
 thiserror.workspace = true
 tonic.workspace = true
+
+base64 = { workspace = true, optional = true }
+ehttp = { workspace = true, optional = true }
+indicatif = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+serde = { workspace = true, optional = true } 
+tiny_http = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+webbrowser = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 base64.workspace = true

--- a/crates/utils/re_auth/src/cli.rs
+++ b/crates/utils/re_auth/src/cli.rs
@@ -1,0 +1,312 @@
+use std::{
+    collections::HashMap,
+    io::Cursor,
+    sync::mpsc,
+    time::{Duration, Instant},
+};
+
+use base64::prelude::*;
+
+use crate::{Jwt, TokenError, workos};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to bind listener: {0}")]
+    BindError(std::io::Error),
+
+    #[error("HTTP server error: {0}")]
+    HttpError(std::io::Error),
+
+    #[error("failed to open browser: {0}")]
+    WebBrowser(std::io::Error),
+
+    #[error("failed to fetch JWKS: {0}")]
+    JwksFetch(String),
+
+    #[error("request timed out while fetching JWKS")]
+    JwksFetchTimeout,
+
+    #[error("failed to decode JWKS: {0}")]
+    JwksDecode(workos::JwksDecodeError),
+
+    #[error("{0}")]
+    InvalidJwt(TokenError),
+
+    #[error("failed to verify token: {0}")]
+    Verify(#[from] workos::VerifyError),
+
+    #[error("{0}")]
+    Generic(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+trait ResponseCorsExt<R> {
+    fn cors(self) -> Self;
+}
+
+fn header(key: &[u8], value: &[u8]) -> tiny_http::Header {
+    tiny_http::Header::from_bytes(key, value).expect("valid header")
+}
+
+impl<R: std::io::Read> ResponseCorsExt<R> for tiny_http::Response<R> {
+    fn cors(self) -> Self {
+        self.with_header(header(b"Access-Control-Allow-Origin", b"*"))
+            .with_header(header(
+                b"Access-Control-Allow-Methods",
+                b"GET, OPTIONS, HEAD",
+            ))
+            .with_header(header(b"Access-Control-Allow-Headers", b"*"))
+            .with_header(header(b"Access-Control-Max-Age", b"86400"))
+    }
+}
+
+fn fetch_jwks() -> mpsc::Receiver<Result<workos::Jwks, Error>> {
+    let (tx, rx) = mpsc::channel();
+
+    ehttp::fetch(
+        ehttp::Request::get(workos::jwks_url()),
+        move |res| match res {
+            Ok(res) => {
+                let res: workos::JwksResponse = match serde_json::from_slice(&res.bytes) {
+                    Ok(v) => v,
+                    Err(err) => {
+                        tx.send(Err(Error::JwksFetch(err.to_string()))).ok();
+                        return;
+                    }
+                };
+                let jwks = match res.decode() {
+                    Ok(v) => v,
+                    Err(err) => {
+                        tx.send(Err(Error::JwksDecode(err))).ok();
+                        return;
+                    }
+                };
+                tx.send(Ok(jwks)).ok();
+            }
+            Err(err) => {
+                tx.send(Err(Error::JwksFetch(err))).ok();
+            }
+        },
+    );
+
+    rx
+}
+
+pub fn login(login_page_url: &str) -> Result<(), Error> {
+    let p = indicatif::ProgressBar::new_spinner();
+
+    // Login process:
+
+    // 1. Start web server listening for token
+    let server = tiny_http::Server::http("127.0.0.1:0")?;
+    p.inc(1);
+
+    // 2. Open authorization URL in browser
+    let callback_url = format!("http://{}/callback", server.server_addr());
+    let login_url = format!(
+        // TODO: don't hardcode this
+        "{login_page_url}?r={}",
+        BASE64_STANDARD.encode(callback_url.as_bytes()),
+    );
+    p.println("Opening login page in your browser.");
+    p.println("Once you've logged in, the process will continue here.");
+    webbrowser::open(&login_url).map_err(Error::WebBrowser)?;
+    p.inc(1);
+
+    // 3. Wait for callback, then verify and store tokens
+    // While we wait, we can start fetching JWKS in the meantime.
+    let rx = fetch_jwks();
+
+    p.set_message("Waiting for browser...");
+    let auth = loop {
+        p.inc(1);
+        let Some(req) = server
+            .recv_timeout(Duration::from_millis(100))
+            .map_err(Error::HttpError)?
+        else {
+            continue;
+        };
+
+        match req.method() {
+            tiny_http::Method::Get => {}
+            tiny_http::Method::Options => {
+                req.respond(
+                    tiny_http::Response::empty(204)
+                        .cors()
+                        .with_header(header(b"Allow", b"GET, HEAD, OPTIONS")),
+                )
+                .map_err(Error::HttpError)?;
+                continue;
+            }
+            tiny_http::Method::Head => {
+                req.respond(tiny_http::Response::empty(200).cors())
+                    .map_err(Error::HttpError)?;
+                continue;
+            }
+            _ => {
+                req.respond(
+                    tiny_http::Response::empty(405)
+                        .cors()
+                        .with_header(header(b"Allow", b"GET, HEAD, OPTIONS")),
+                )
+                .map_err(Error::HttpError)?;
+                continue;
+            }
+        }
+
+        let url = match url::Url::parse(&format!("http://{}{}", server.server_addr(), req.url())) {
+            Ok(url) => url,
+            Err(_) => {
+                req.respond(tiny_http::Response::empty(400).cors())
+                    .map_err(Error::HttpError)?;
+                continue;
+            }
+        };
+
+        if url.path() != "/callback" {
+            req.respond(tiny_http::Response::empty(404).cors())
+                .map_err(Error::HttpError)?;
+            continue;
+        }
+
+        let Some(serialized_response) = url.query_pairs().find(|(k, _)| k == "t").map(|(_, v)| v)
+        else {
+            req.respond(
+                tiny_http::Response::from_string("missing `t` query param")
+                    .with_status_code(400)
+                    .cors(),
+            )
+            .map_err(Error::HttpError)?;
+            continue;
+        };
+
+        let raw_response = match BASE64_STANDARD.decode(serialized_response.as_ref()) {
+            Ok(v) => v,
+            Err(e) => {
+                p.println(format!("{e}"));
+                req.respond(
+                    tiny_http::Response::from_string("failed to deserialize response")
+                        .with_status_code(400)
+                        .cors(),
+                )
+                .map_err(Error::HttpError)?;
+                continue;
+            }
+        };
+        let response: AuthenticationResponse = match serde_json::from_slice(&raw_response) {
+            Ok(v) => v,
+            Err(_) => {
+                req.respond(
+                    tiny_http::Response::from_string("failed to deserialize response")
+                        .with_status_code(400)
+                        .cors(),
+                )
+                .map_err(Error::HttpError)?;
+                continue;
+            }
+        };
+
+        req.respond(tiny_http::Response::empty(200).cors())
+            .map_err(Error::HttpError)?;
+        break response;
+    };
+
+    p.set_message("Verifying login...");
+    let start = Instant::now();
+    let timeout = Duration::from_secs(10);
+    let jwks = loop {
+        p.inc(1);
+        if start.elapsed() >= timeout {
+            return Err(Error::JwksFetchTimeout);
+        }
+
+        match rx.try_recv() {
+            Ok(v) => break v?,
+            Err(mpsc::TryRecvError::Empty) => {
+                std::thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            Err(mpsc::TryRecvError::Disconnected) => {
+                // this shouldn't really happen
+                unreachable!("JWKS fetch thread disconnected early");
+            }
+        }
+    };
+
+    let jwt = match Jwt::try_from(auth.access_token.clone()) {
+        Ok(jwt) => jwt,
+        Err(err) => {
+            return Err(Error::InvalidJwt(err));
+        }
+    };
+
+    match workos::verify_token(jwt, &jwks)? {
+        workos::Status::NeedsRefresh => {
+            // TODO: can this actually happen?
+            unreachable!("Token needs to be refreshed immediately after generation");
+        }
+        workos::Status::Valid => {} // OK!
+    };
+
+    // TODO: store tokens and exit
+    p.println(format!("{auth:?}"));
+
+    p.finish_and_clear();
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthenticationResponse {
+    user: User,
+    organization_id: Option<String>,
+    access_token: String,
+    refresh_token: String,
+    impersonator: Option<Impersonator>,
+    authentication_method: Option<AuthenticationMethod>,
+    sealed_session: Option<String>,
+    oauth_tokens: Option<OauthTokens>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct User {
+    id: String,
+    email: String,
+    email_verified: bool,
+    profile_picture_url: Option<String>,
+    first_name: Option<String>,
+    last_name: Option<String>,
+    last_sign_in_at: Option<String>,
+    created_at: String,
+    updated_at: String,
+    external_id: Option<String>,
+    metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct Impersonator {
+    email: String,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+enum AuthenticationMethod {
+    SSO,
+    Password,
+    Passkey,
+    AppleOAuth,
+    GitHubOAuth,
+    GoogleOAuth,
+    MicrosoftOAuth,
+    MagicAuth,
+    Impersonation,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct OauthTokens {
+    access_token: String,
+    refresh_token: String,
+    expires_at: u64,
+    scopes: Vec<String>,
+}

--- a/crates/utils/re_auth/src/lib.rs
+++ b/crates/utils/re_auth/src/lib.rs
@@ -15,6 +15,11 @@ mod provider;
 mod service;
 mod token;
 
+#[cfg(feature = "cli")]
+pub mod cli;
+
+mod workos;
+
 pub use service::client;
 pub use token::{Jwt, TokenError};
 

--- a/crates/utils/re_auth/src/token.rs
+++ b/crates/utils/re_auth/src/token.rs
@@ -11,6 +11,12 @@ pub enum TokenError {
 #[repr(transparent)]
 pub struct Jwt(pub(crate) String);
 
+impl Jwt {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 impl TryFrom<String> for Jwt {
     type Error = TokenError;
 

--- a/crates/utils/re_auth/src/workos.rs
+++ b/crates/utils/re_auth/src/workos.rs
@@ -1,0 +1,145 @@
+use std::collections::HashMap;
+
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use serde::Deserialize;
+
+use crate::Jwt;
+
+const ISSUER_URL_BASE: &str = "https://api.workos.com/user_management";
+const JWKS_URL_BASE: &str = "https://api.workos.com/sso/jwks";
+
+// TODO: This is the client ID for the WorkOS public staging environment
+//       should be replaced by our actual client ID at some point.
+//       When doing so, don't forget to replace it everywhere. :)
+const WORKOS_CLIENT_ID: &str = match option_env!("WORKOS_CLIENT_ID") {
+    Some(v) => v,
+    None => "client_01JZ3JVQW6JNVXME6HV9G4VR0H",
+};
+
+fn issuer(client_id: &str) -> String {
+    format!("{ISSUER_URL_BASE}/{client_id}")
+}
+
+#[derive(Deserialize)]
+pub struct Claims {
+    iss: String,
+    sub: String,
+    act: Option<Act>,
+    org_id: Option<String>,
+    role: Option<String>,
+    permissions: Option<Vec<String>>,
+    entitlements: Option<Vec<String>>,
+    sid: String,
+    jti: String,
+    exp: usize,
+    iat: usize,
+}
+
+#[derive(Deserialize)]
+pub struct Act {
+    sub: String,
+}
+
+/// Json web key
+#[derive(Deserialize)]
+struct Jwk {
+    kid: String,
+    kty: String,
+    n: String,
+    e: String,
+    alg: String,
+}
+
+/// Json web key set
+#[derive(Deserialize)]
+pub struct JwksResponse {
+    keys: Vec<Jwk>,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum JwksDecodeError {
+    #[error("failed to decode JWKS: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+}
+
+impl JwksResponse {
+    pub fn decode(self) -> Result<Jwks, JwksDecodeError> {
+        let mut keys = HashMap::new();
+        for j in self.keys {
+            if j.kty != "RSA" {
+                continue;
+            }
+
+            let key = DecodingKey::from_rsa_components(&j.n, &j.e)?;
+            keys.insert(j.kid.clone(), key);
+        }
+
+        Ok(Jwks { keys })
+    }
+}
+
+/// Json web key set.
+///
+/// To produce this:
+/// 1. Fetch [`jwks_url`]
+/// 2. Decode JSON response into [`JwksResponse`]
+/// 3. Call [`JwksResponse::decode`]
+pub struct Jwks {
+    keys: HashMap<String, DecodingKey>,
+}
+
+impl Jwks {
+    pub fn get(&self, kid: &str) -> Option<&DecodingKey> {
+        self.keys.get(kid)
+    }
+}
+
+pub fn jwks_url() -> String {
+    format!("{JWKS_URL_BASE}/{WORKOS_CLIENT_ID}")
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum VerifyError {
+    #[error("invalid jwt: {0}")]
+    InvalidJwt(#[from] jsonwebtoken::errors::Error),
+
+    #[error("missing `kid` in JWT")]
+    MissingKeyId,
+
+    #[error("key with id {id:?} was not found in JWKS")]
+    KeyNotFound { id: String },
+}
+
+pub enum Status {
+    Valid,
+    NeedsRefresh,
+}
+
+pub fn verify_token(jwt: Jwt, jwks: &Jwks) -> Result<Status, VerifyError> {
+    // 1. Decode header to get `kid`
+    let header = decode_header(jwt.as_str())?;
+    let kid = header
+        .kid
+        .as_ref()
+        .ok_or_else(|| VerifyError::MissingKeyId)?;
+    let key = jwks
+        .get(kid)
+        .ok_or_else(|| VerifyError::KeyNotFound { id: kid.clone() })?;
+
+    // 2. Verify token
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.set_issuer(&[issuer(WORKOS_CLIENT_ID)]);
+    validation.validate_exp = true;
+    let _token_data = match decode::<Claims>(&jwt.as_str(), key, &validation) {
+        Ok(v) => v,
+        Err(err) => match err.kind() {
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature => return Ok(Status::NeedsRefresh),
+            _ => return Err(err.into()),
+        },
+    };
+
+    Ok(Status::Valid)
+}
+
+// TODO: refresh
+// https://workos.com/docs/reference/user-management/session-tokens/refresh-token

--- a/pixi.toml
+++ b/pixi.toml
@@ -165,28 +165,28 @@ man = "cargo --quiet run --package rerun-cli --all-features -- man > docs/conten
 # Compile and run the rerun viewer.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer --"
+rerun = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,auth --"
 
 # Compile and run the rerun viewer, with performance telemetry.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-perf-debug = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,perf_telemetry --"
+rerun-perf-debug = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,auth,perf_telemetry --"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build = "cargo build --package rerun-cli --no-default-features --features map_view,nasm,native_viewer"
+rerun-build = "cargo build --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,auth"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features map_view,nasm,native_viewer"
+rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features map_view,nasm,native_viewer,auth"
 
 # Compile and run the rerun viewer with --release.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-release = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer --release --"
+rerun-release = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,auth --release --"
 
 # Compile and run the rerun viewer in release, with performance telemetry.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-perf = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,perf_telemetry --release --"
+rerun-perf = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,auth,perf_telemetry --release --"
 
 # Compile `rerun-cli` with the same feature set as we build for releases.
 rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features release --", depends-on = [


### PR DESCRIPTION
Adds the ability to authenticate via WorkOS to the Rerun CLI.

* Sibling PR for landing: https://github.com/rerun-io/landing/pull/1067

## TODO

- [x] Add `rerun auth login`
  - [ ] Store tokens locally somewhere
- [ ] Add `rerun auth revoke` (logout?)
- [ ] Add `rerun auth check`
- [ ] Add `rerun auth details`

## Open questions

- Q: How should we store these tokens? (Is plaintext in `.config/rerun` OK?)