### PR TITLE
Better component UI for Arrow `StructArray`

### DIFF
--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/custom_struct_array_any_value_struct_array.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/custom_struct_array_any_value_struct_array.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61ad9f98de9e348f3b9e35b0dd7cd512726fd1cfbf6f1f89f140a49a466abdab
+size 4222

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/custom_struct_array_single_element_any_value_struct_array_single_element.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/custom_struct_array_single_element_any_value_struct_array_single_element.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ecddb648590d760ad2f1424f301ad7d3a83f713f1230c74680e8dc552fe85acb
+size 3927

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/custom_struct_array_any_value_struct_array.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/custom_struct_array_any_value_struct_array.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cfc5679981abf0dbaba5f3ba9d25b4ee201d0519e8f669f4cc97436989c16d3
+size 9384

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/custom_struct_array_single_element_any_value_struct_array_single_element.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/custom_struct_array_single_element_any_value_struct_array_single_element.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:512c0b115f06ece3979d9db0522bf662d4f8a6029ff6975458fa0b4edf7f5f37
+size 5819

--- a/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
+++ b/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashSet, fmt::Formatter, fs, sync::Arc};
 
-use arrow::array::ArrayRef;
+use arrow::{array::ArrayRef, datatypes::DataType};
 use egui::Vec2;
 use egui_kittest::{SnapshotError, SnapshotOptions};
 use itertools::Itertools as _;
@@ -106,6 +106,42 @@ fn test_cases(reflection: &Reflection) -> Vec<TestCase> {
             ComponentType::from("custom_large_blob"),
             arrow::array::UInt8Array::from(vec![42; 3001]),
             "any_value_large_blob",
+        ),
+        TestCase::from_arrow(
+            ComponentType::from("custom_struct_array"),
+            arrow::array::StructArray::from(vec![
+                (
+                    Arc::new(arrow::datatypes::Field::new("a", DataType::Utf8, false)),
+                    Arc::new(arrow::array::StringArray::from(vec!["foo", "bar"])) as ArrayRef,
+                ),
+                (
+                    Arc::new(arrow::datatypes::Field::new("b", DataType::Boolean, false)),
+                    Arc::new(arrow::array::BooleanArray::from(vec![true, false])) as ArrayRef,
+                ),
+                (
+                    Arc::new(arrow::datatypes::Field::new("c", DataType::Int32, false)),
+                    Arc::new(arrow::array::Int32Array::from(vec![42, 17])) as ArrayRef,
+                ),
+            ]),
+            "any_value_struct_array",
+        ),
+        TestCase::from_arrow(
+            ComponentType::from("custom_struct_array_single_element"),
+            arrow::array::StructArray::from(vec![
+                (
+                    Arc::new(arrow::datatypes::Field::new("a", DataType::Utf8, false)),
+                    Arc::new(arrow::array::StringArray::from(vec!["foo"])) as ArrayRef,
+                ),
+                (
+                    Arc::new(arrow::datatypes::Field::new("b", DataType::Boolean, false)),
+                    Arc::new(arrow::array::BooleanArray::from(vec![true])) as ArrayRef,
+                ),
+                (
+                    Arc::new(arrow::datatypes::Field::new("c", DataType::Int32, false)),
+                    Arc::new(arrow::array::Int32Array::from(vec![42])) as ArrayRef,
+                ),
+            ]),
+            "any_value_struct_array_single_element",
         ),
     ];
 

--- a/crates/viewer/re_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_ui/src/arrow_ui.rs
@@ -82,6 +82,15 @@ pub fn arrow_ui(ui: &mut egui::Ui, ui_layout: UiLayout, array: &dyn arrow::array
                 re_format::format_bytes(instance_count as _)
             } else if let Some(dtype) = simple_datatype_string(array.data_type()) {
                 format!("{instance_count_str} items of {dtype}")
+            } else if let DataType::Struct(fields) = array.data_type() {
+                format!(
+                    "{instance_count_str} structs with {} fields: {}",
+                    fields.len(),
+                    fields
+                        .iter()
+                        .map(|f| format!("{}:{}", f.name(), f.data_type()))
+                        .join(", ")
+                )
             } else {
                 format!("{instance_count_str} items")
             };


### PR DESCRIPTION
### Related

* #9949 

### What

Some MCAP messages have structs as fields, which we map to Arrow `StructArray`s in our 1:1 mappings. This PR improves the rendering of `StructArray`s in `re_component_ui`.

Selection panel and dataframes benefit from this.

### Screenshot

See image comparison tests.

