### PR TITLE
Get rid of `CreatePartitionManifests` dev API

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -102,12 +102,6 @@ service ManifestRegistryService {
   // --- Developer/Debug APIs ---
   // Unstable APIs that are not exposed by the Frontend.
 
-  // Create manifests for all partitions in the Dataset. Partition manifest contains information about
-  // the chunks in the partitions.
-  //
-  // This is normally automatically done as part of the registration process.
-  rpc CreatePartitionManifests(CreatePartitionManifestsRequest) returns (CreatePartitionManifestsResponse) {}
-
   // Fetch the internal state of a Partition Manifest.
   rpc FetchPartitionManifest(FetchPartitionManifestRequest) returns (stream FetchPartitionManifestResponse) {}
 
@@ -493,27 +487,6 @@ message GetChunksResponse {
 
 // --- Developer/Debug APIs ---
 // Unstable APIs that are not exposed by the Frontend.
-
-message CreatePartitionManifestsRequest {
-  // Dataset for which we want to create manifests
-  rerun.common.v1alpha1.DatasetHandle entry = 1;
-
-  // Create manifest for specific partitions. All will be
-  // created if left unspecified (empty list)
-  repeated rerun.common.v1alpha1.PartitionId partition_ids = 2;
-
-  // types of partitions and their storage location (same order
-  // as partition ids above)
-  repeated DataSource data_sources = 3;
-
-  // Define what happens if create is called multiple times for the same
-  // Dataset / partitions
-  rerun.common.v1alpha1.IfDuplicateBehavior on_duplicate = 4;
-}
-
-message CreatePartitionManifestsResponse {
-  rerun.common.v1alpha1.DataframePart data = 1;
-}
 
 message FetchPartitionManifestRequest {
   rerun.common.v1alpha1.DatasetHandle entry = 1;

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -13,8 +13,8 @@ use re_sorbet::ComponentColumnDescriptor;
 
 use crate::common::v1alpha1::{ComponentDescriptor, DataframePart, TaskId};
 use crate::manifest_registry::v1alpha1::{
-    CreatePartitionManifestsResponse, DataSourceKind, GetDatasetSchemaResponse,
-    RegisterWithDatasetResponse, ScanPartitionTableResponse, VectorDistanceMetric,
+    DataSourceKind, GetDatasetSchemaResponse, RegisterWithDatasetResponse,
+    ScanPartitionTableResponse, VectorDistanceMetric,
 };
 use crate::v1alpha1::rerun_common_v1alpha1_ext::PartitionId;
 use crate::{TypeConversionError, invalid_field, missing_field};
@@ -287,73 +287,6 @@ pub struct QueryRange {
     pub index: String,
     pub index_range: re_log_types::ResolvedTimeRange,
 }
-
-// --- CreatePartitionManifestsResponse ---
-
-impl CreatePartitionManifestsResponse {
-    pub const FIELD_ID: &str = "id";
-    pub const FIELD_UPDATED_AT: &str = "updated_at";
-    pub const FIELD_ERROR: &str = "error";
-
-    /// The Arrow schema of the dataframe in [`Self::data`].
-    pub fn schema() -> Schema {
-        Schema::new(vec![
-            Field::new(Self::FIELD_ID, DataType::Utf8, false),
-            Field::new(
-                Self::FIELD_UPDATED_AT,
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-                true,
-            ),
-            Field::new(Self::FIELD_ERROR, DataType::Utf8, true),
-        ])
-    }
-
-    /// Helper to simplify instantiation of the dataframe in [`Self::data`].
-    pub fn create_dataframe(
-        partition_ids: Vec<String>,
-        updated_ats: Vec<Option<jiff::Timestamp>>,
-        errors: Vec<Option<String>>,
-    ) -> arrow::error::Result<RecordBatch> {
-        let updated_ats = updated_ats
-            .into_iter()
-            .map(|ts| ts.map(|ts| ts.as_nanosecond() as i64)) // ~300 years should be fine
-            .collect::<Vec<_>>();
-
-        let schema = Arc::new(Self::schema());
-        let columns: Vec<ArrayRef> = vec![
-            Arc::new(StringArray::from(partition_ids)),
-            Arc::new(TimestampNanosecondArray::from(updated_ats)),
-            Arc::new(StringArray::from(errors)),
-        ];
-
-        RecordBatch::try_new(schema, columns)
-    }
-}
-
-// TODO(#9430): I'd love if I could do this, but this creates a nasty circular dep with `re_log_encoding`.
-#[cfg(all(unix, windows))] // always statically false
-impl TryFrom<RecordBatch> for CreatePartitionManifestsResponse {
-    type Error = tonic::Status;
-
-    fn try_from(batch: RecordBatch) -> Result<Self, Self::Error> {
-        if !Self::schema().contains(batch.schema()) {
-            let typ = std::any::type_name::<Self>();
-            return Err(tonic::Status::internal(format!(
-                "invalid schema for {typ}: expected {:?} but got {:?}",
-                Self::schema(),
-                batch.schema(),
-            )));
-        }
-
-        use re_log_encoding::codec::wire::encoder::Encode as _;
-        batch
-            .encode()
-            .map(|data| Self { data: Some(data) })
-            .map_err(|err| tonic::Status::internal(format!("failed to encode chunk: {err}")))?;
-    }
-}
-
-// TODO(#9430): the other way around would be nice too, but same problem.
 
 // --- GetDatasetSchemaResponse ---
 

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -742,52 +742,6 @@ impl ::prost::Name for GetChunksResponse {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreatePartitionManifestsRequest {
-    /// Dataset for which we want to create manifests
-    #[prost(message, optional, tag = "1")]
-    pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
-    /// Create manifest for specific partitions. All will be
-    /// created if left unspecified (empty list)
-    #[prost(message, repeated, tag = "2")]
-    pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::PartitionId>,
-    /// types of partitions and their storage location (same order
-    /// as partition ids above)
-    #[prost(message, repeated, tag = "3")]
-    pub data_sources: ::prost::alloc::vec::Vec<DataSource>,
-    /// Define what happens if create is called multiple times for the same
-    /// Dataset / partitions
-    #[prost(
-        enumeration = "super::super::common::v1alpha1::IfDuplicateBehavior",
-        tag = "4"
-    )]
-    pub on_duplicate: i32,
-}
-impl ::prost::Name for CreatePartitionManifestsRequest {
-    const NAME: &'static str = "CreatePartitionManifestsRequest";
-    const PACKAGE: &'static str = "rerun.manifest_registry.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        "rerun.manifest_registry.v1alpha1.CreatePartitionManifestsRequest".into()
-    }
-    fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.manifest_registry.v1alpha1.CreatePartitionManifestsRequest".into()
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CreatePartitionManifestsResponse {
-    #[prost(message, optional, tag = "1")]
-    pub data: ::core::option::Option<super::super::common::v1alpha1::DataframePart>,
-}
-impl ::prost::Name for CreatePartitionManifestsResponse {
-    const NAME: &'static str = "CreatePartitionManifestsResponse";
-    const PACKAGE: &'static str = "rerun.manifest_registry.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        "rerun.manifest_registry.v1alpha1.CreatePartitionManifestsResponse".into()
-    }
-    fn type_url() -> ::prost::alloc::string::String {
-        "/rerun.manifest_registry.v1alpha1.CreatePartitionManifestsResponse".into()
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchPartitionManifestRequest {
     #[prost(message, optional, tag = "1")]
     pub entry: ::core::option::Option<super::super::common::v1alpha1::DatasetHandle>,
@@ -1418,31 +1372,6 @@ pub mod manifest_registry_service_client {
             ));
             self.inner.server_streaming(req, path, codec).await
         }
-        /// Create manifests for all partitions in the Dataset. Partition manifest contains information about
-        /// the chunks in the partitions.
-        ///
-        /// This is normally automatically done as part of the registration process.
-        pub async fn create_partition_manifests(
-            &mut self,
-            request: impl tonic::IntoRequest<super::CreatePartitionManifestsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreatePartitionManifestsResponse>,
-            tonic::Status,
-        > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/rerun.manifest_registry.v1alpha1.ManifestRegistryService/CreatePartitionManifests",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "rerun.manifest_registry.v1alpha1.ManifestRegistryService",
-                "CreatePartitionManifests",
-            ));
-            self.inner.unary(req, path, codec).await
-        }
         /// Fetch the internal state of a Partition Manifest.
         pub async fn fetch_partition_manifest(
             &mut self,
@@ -1653,17 +1582,6 @@ pub mod manifest_registry_service_server {
             &self,
             request: tonic::Request<super::GetChunksRequest>,
         ) -> std::result::Result<tonic::Response<Self::GetChunksStream>, tonic::Status>;
-        /// Create manifests for all partitions in the Dataset. Partition manifest contains information about
-        /// the chunks in the partitions.
-        ///
-        /// This is normally automatically done as part of the registration process.
-        async fn create_partition_manifests(
-            &self,
-            request: tonic::Request<super::CreatePartitionManifestsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreatePartitionManifestsResponse>,
-            tonic::Status,
-        >;
         /// Server streaming response type for the FetchPartitionManifest method.
         type FetchPartitionManifestStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::FetchPartitionManifestResponse, tonic::Status>,
@@ -2246,52 +2164,6 @@ pub mod manifest_registry_service_server {
                                 max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                "/rerun.manifest_registry.v1alpha1.ManifestRegistryService/CreatePartitionManifests" =>
-                {
-                    #[allow(non_camel_case_types)]
-                    struct CreatePartitionManifestsSvc<T: ManifestRegistryService>(pub Arc<T>);
-                    impl<T: ManifestRegistryService>
-                        tonic::server::UnaryService<super::CreatePartitionManifestsRequest>
-                        for CreatePartitionManifestsSvc<T>
-                    {
-                        type Response = super::CreatePartitionManifestsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::CreatePartitionManifestsRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as ManifestRegistryService>::create_partition_manifests(
-                                    &inner, request,
-                                )
-                                .await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let method = CreatePartitionManifestsSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)


### PR DESCRIPTION
This hasn't been used in ages: PM creation was automated and asynchronized a millions years ago. And now that I want to make changes to `DataSource`, this will annoy me for no reason.