### PR TITLE
Parse `PointCloud2` into raw Arrow and `Points3D`

### DIFF
--- a/crates/store/re_data_loader/src/mcap/schema/mod.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/mod.rs
@@ -2,3 +2,10 @@ pub mod sensor_msgs;
 mod unsupported;
 
 pub use unsupported::UnsupportedSchemaMessageParser;
+
+pub(crate) fn fixed_size_list_builder<T: arrow::array::ArrayBuilder + Default>(
+    value_length: i32,
+    capacity: usize,
+) -> arrow::array::FixedSizeListBuilder<T> {
+    arrow::array::FixedSizeListBuilder::with_capacity(Default::default(), value_length, capacity)
+}

--- a/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/mod.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/mod.rs
@@ -1,7 +1,9 @@
 mod compressed_image;
 mod image;
 mod imu;
+mod point_cloud_2;
 
 pub use compressed_image::*;
 pub use image::*;
 pub use imu::*;
+pub use point_cloud_2::*;

--- a/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/point_cloud_2.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/point_cloud_2.rs
@@ -1,0 +1,394 @@
+use std::io::Cursor;
+
+use arrow::{
+    array::{
+        ArrayBuilder, BooleanBuilder, FixedSizeListBuilder, ListBuilder, StringBuilder,
+        StructBuilder, UInt8Builder, UInt32Builder,
+    },
+    datatypes::{DataType, Field, Fields},
+};
+use byteorder::{BigEndian, LittleEndian, ReadBytesExt as _};
+use re_chunk::{Chunk, ChunkComponents, ChunkId, TimePoint};
+use re_log_types::TimeCell;
+use re_mcap_ros2::sensor_msgs::{self, PointField, PointFieldDatatype};
+use re_types::{
+    AsComponents as _, Component as _, ComponentDescriptor, SerializedComponentColumn, archetypes,
+    components,
+};
+use std::collections::HashMap;
+
+use crate::mcap::{
+    cdr,
+    decode::{McapMessageParser, ParserContext, PluginError, SchemaPlugin},
+};
+
+/// Plugin that parses `sensor_msgs/msg/PointCloud2` messages.
+#[derive(Default)]
+pub struct PointCloud2SchemaPlugin;
+
+impl SchemaPlugin for PointCloud2SchemaPlugin {
+    fn name(&self) -> crate::mcap::decode::SchemaName {
+        "sensor_msgs/msg/PointCloud2".into()
+    }
+
+    fn parse_schema(
+        &self,
+        _channel: &mcap::Channel<'_>,
+    ) -> Result<re_sorbet::SorbetSchema, PluginError> {
+        Err(PluginError::Other(anyhow::anyhow!("todo")))
+    }
+
+    fn create_message_parser(
+        &self,
+        _channel: &mcap::Channel<'_>,
+        num_rows: usize,
+    ) -> Box<dyn crate::mcap::decode::McapMessageParser> {
+        Box::new(PointCloud2MessageParser::new(num_rows)) as Box<dyn McapMessageParser>
+    }
+}
+
+fn fixed_size_list_builder<T: ArrayBuilder + Default>(
+    value_length: i32,
+    capacity: usize,
+) -> FixedSizeListBuilder<T> {
+    FixedSizeListBuilder::with_capacity(Default::default(), value_length, capacity)
+}
+
+pub struct PointCloud2MessageParser {
+    num_rows: usize,
+
+    height: FixedSizeListBuilder<UInt32Builder>,
+    width: FixedSizeListBuilder<UInt32Builder>,
+    fields: FixedSizeListBuilder<ListBuilder<StructBuilder>>,
+    is_bigendian: FixedSizeListBuilder<BooleanBuilder>,
+    point_step: FixedSizeListBuilder<UInt32Builder>,
+    row_step: FixedSizeListBuilder<UInt32Builder>,
+    data: FixedSizeListBuilder<ListBuilder<UInt8Builder>>,
+
+    // We lazily create this, only if we can interpret the point cloud semantically.
+    points_3ds: Option<Vec<archetypes::Points3D>>,
+}
+
+impl PointCloud2MessageParser {
+    const ARCHETYPE_NAME: &str = "sensor_msgs.msg.PointCloud2";
+
+    fn new(num_rows: usize) -> Self {
+        let fields = FixedSizeListBuilder::with_capacity(
+            ListBuilder::new(StructBuilder::new(
+                Fields::from(vec![
+                    Field::new("name", DataType::Utf8, false),
+                    Field::new("offset", DataType::UInt32, false),
+                    Field::new("dataype", DataType::UInt8, false),
+                    Field::new("count", DataType::UInt32, false),
+                ]),
+                vec![
+                    Box::new(StringBuilder::new()),
+                    Box::new(UInt32Builder::new()),
+                    Box::new(UInt8Builder::new()),
+                    Box::new(UInt32Builder::new()),
+                ],
+            )),
+            1,
+            num_rows,
+        );
+
+        Self {
+            num_rows,
+
+            height: fixed_size_list_builder(1, num_rows),
+            width: fixed_size_list_builder(1, num_rows),
+            fields,
+            is_bigendian: fixed_size_list_builder(1, num_rows),
+            point_step: fixed_size_list_builder(1, num_rows),
+            row_step: fixed_size_list_builder(1, num_rows),
+            data: fixed_size_list_builder(1, num_rows),
+
+            points_3ds: None,
+        }
+    }
+}
+
+fn access(data: &[u8], datatype: PointFieldDatatype, is_big_endian: bool) -> std::io::Result<f32> {
+    let mut rdr = Cursor::new(data);
+    match (is_big_endian, datatype) {
+        (_, PointFieldDatatype::Unknown) => Ok(0f32), // Not in the original spec.
+        (_, PointFieldDatatype::UInt8) => rdr.read_u8().map(|x| x as f32),
+        (_, PointFieldDatatype::Int8) => rdr.read_i8().map(|x| x as f32),
+        (true, PointFieldDatatype::Int16) => rdr.read_i16::<BigEndian>().map(|x| x as f32),
+        (true, PointFieldDatatype::UInt16) => rdr.read_u16::<BigEndian>().map(|x| x as f32),
+        (true, PointFieldDatatype::Int32) => rdr.read_i32::<BigEndian>().map(|x| x as f32),
+        (true, PointFieldDatatype::UInt32) => rdr.read_u32::<BigEndian>().map(|x| x as f32),
+        (true, PointFieldDatatype::Float32) => rdr.read_f32::<BigEndian>(),
+        (true, PointFieldDatatype::Float64) => rdr.read_f64::<BigEndian>().map(|x| x as f32),
+        (false, PointFieldDatatype::Int16) => rdr.read_i16::<LittleEndian>().map(|x| x as f32),
+        (false, PointFieldDatatype::UInt16) => rdr.read_u16::<LittleEndian>().map(|x| x as f32),
+        (false, PointFieldDatatype::Int32) => rdr.read_i32::<LittleEndian>().map(|x| x as f32),
+        (false, PointFieldDatatype::UInt32) => rdr.read_u32::<LittleEndian>().map(|x| x as f32),
+        (false, PointFieldDatatype::Float32) => rdr.read_f32::<LittleEndian>(),
+        (false, PointFieldDatatype::Float64) => rdr.read_f64::<LittleEndian>().map(|x| x as f32),
+    }
+}
+
+pub struct Position3DIter<'a> {
+    point_iter: std::slice::ChunksExact<'a, u8>,
+    is_big_endian: bool,
+    x_accessor: (usize, PointFieldDatatype),
+    y_accessor: (usize, PointFieldDatatype),
+    z_accessor: (usize, PointFieldDatatype),
+}
+
+impl<'a> Position3DIter<'a> {
+    fn try_new(
+        data: &'a [u8],
+        step: usize,
+        is_big_endian: bool,
+        fields: &[PointField],
+    ) -> Option<Self> {
+        let mut x_accessor: Option<(usize, PointFieldDatatype)> = None;
+        let mut y_accessor: Option<(usize, PointFieldDatatype)> = None;
+        let mut z_accessor: Option<(usize, PointFieldDatatype)> = None;
+
+        for field in fields {
+            match field.name.as_str() {
+                "x" => x_accessor = Some((field.offset as usize, field.datatype)),
+                "y" => y_accessor = Some((field.offset as usize, field.datatype)),
+                "z" => z_accessor = Some((field.offset as usize, field.datatype)),
+                _ => {}
+            }
+        }
+
+        Some(Self {
+            point_iter: data.chunks_exact(step),
+            is_big_endian,
+            x_accessor: x_accessor?,
+            y_accessor: y_accessor?,
+            z_accessor: z_accessor?,
+        })
+    }
+}
+
+fn unwrap(res: std::io::Result<f32>, component: &str) -> f32 {
+    match res {
+        Ok(x) => x,
+        Err(err) => {
+            debug_assert!(false, "failed to read `{component}`: {err}");
+            f32::NAN
+        }
+    }
+}
+
+impl Iterator for Position3DIter<'_> {
+    type Item = [f32; 3];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let point = self.point_iter.next()?;
+
+        let x = self.x_accessor;
+        let y = self.y_accessor;
+        let z = self.z_accessor;
+
+        let x = unwrap(access(&point[x.0..], x.1, self.is_big_endian), "x");
+        let y = unwrap(access(&point[y.0..], y.1, self.is_big_endian), "y");
+        let z = unwrap(access(&point[z.0..], z.1, self.is_big_endian), "z");
+
+        Some([x, y, z])
+    }
+}
+
+impl McapMessageParser for PointCloud2MessageParser {
+    fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        let point_cloud = cdr::try_decode_message::<sensor_msgs::PointCloud2>(msg.data.as_ref())
+            .map_err(|err| PluginError::Other(anyhow::anyhow!(err)))?;
+
+        let cell = TimeCell::from_timestamp_nanos_since_epoch(point_cloud.header.stamp.as_nanos());
+        ctx.add_time_cell("timestamp", cell);
+
+        let Self {
+            num_rows,
+
+            height,
+            width,
+            fields,
+            is_bigendian,
+            point_step,
+            row_step,
+            data,
+
+            points_3ds,
+        } = self;
+
+        let mut timepoint = TimePoint::default();
+        timepoint.insert_cell("timestamp", cell);
+
+        height.values().append_slice(&[point_cloud.height]);
+        width.values().append_slice(&[point_cloud.width]);
+
+        let position_iter = Position3DIter::try_new(
+            &point_cloud.data,
+            point_cloud.point_step as usize,
+            point_cloud.is_bigendian,
+            &point_cloud.fields,
+        );
+
+        if let Some(position_iter) = position_iter {
+            points_3ds
+                .get_or_insert_with(|| Vec::with_capacity(*num_rows))
+                .push(archetypes::Points3D::new(position_iter));
+        }
+
+        {
+            let struct_builder = fields.values();
+
+            for point_field in point_cloud.fields {
+                {
+                    let name_builder = struct_builder
+                        .values()
+                        .field_builder::<StringBuilder>(0)
+                        .expect("has to exist");
+                    name_builder.append_value(point_field.name);
+                }
+                {
+                    let offset_builder = struct_builder
+                        .values()
+                        .field_builder::<UInt32Builder>(1)
+                        .expect("has to exist");
+                    offset_builder.append_value(point_field.offset);
+                }
+                {
+                    let datatype_builder = struct_builder
+                        .values()
+                        .field_builder::<UInt8Builder>(2)
+                        .expect("has to exist");
+                    datatype_builder.append_value(point_field.datatype as u8);
+                }
+                {
+                    let count_builder = struct_builder
+                        .values()
+                        .field_builder::<UInt32Builder>(3)
+                        .expect("has to exist");
+                    count_builder.append_value(point_field.count);
+                }
+                struct_builder.values().append(true);
+            }
+
+            struct_builder.append(true);
+            fields.append(true);
+        }
+
+        is_bigendian
+            .values()
+            .append_slice(&[point_cloud.is_bigendian]);
+        point_step.values().append_slice(&[point_cloud.point_step]);
+        row_step.values().append_slice(&[point_cloud.row_step]);
+
+        data.values().values().append_slice(&point_cloud.data);
+
+        height.append(true);
+        width.append(true);
+        is_bigendian.append(true);
+        point_step.append(true);
+        row_step.append(true);
+
+        data.values().append(true);
+        data.append(true);
+
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<re_chunk::Chunk>> {
+        let entity_path = ctx.entity_path().clone();
+        let timelines = ctx.build_timelines();
+
+        let Self {
+            num_rows: _,
+
+            mut width,
+            mut height,
+            mut fields,
+            mut is_bigendian,
+            mut point_step,
+            mut row_step,
+            mut data,
+
+            points_3ds,
+        } = *self;
+
+        let mut chunks = Vec::new();
+
+        for (i, points_3d) in points_3ds.into_iter().enumerate() {
+            let timelines = timelines
+                .iter()
+                .map(|(timeline, time_col)| (*timeline, time_col.row_sliced(i, 1).clone()))
+                .collect::<HashMap<_, _, _>>();
+
+            let components = points_3d
+                .as_serialized_batches()
+                .into_iter()
+                .map(SerializedComponentColumn::from)
+                .collect::<ChunkComponents>();
+
+            let c = Chunk::from_auto_row_ids(
+                ChunkId::new(),
+                entity_path.clone(),
+                timelines,
+                components,
+            )
+            .map_err(|err| PluginError::Other(anyhow::anyhow!(err)))?;
+
+            chunks.push(c);
+        }
+
+        let data_chunk = Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            entity_path.clone(),
+            timelines,
+            [
+                (
+                    ComponentDescriptor::partial("height")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    height.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("width")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    width.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("fields")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    fields.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("is_bigendian")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    is_bigendian.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("point_step")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    point_step.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("row_step")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    row_step.finish().into(),
+                ),
+                (
+                    ComponentDescriptor {
+                        archetype: Some(Self::ARCHETYPE_NAME.into()),
+                        component: "data".into(),
+                        component_type: Some(components::Blob::name()),
+                    },
+                    data.finish().into(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )
+        .map_err(|err| PluginError::Other(anyhow::anyhow!(err)))?;
+
+        chunks.push(data_chunk);
+
+        Ok(chunks)
+    }
+}

--- a/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/point_cloud_2.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/point_cloud_2.rs
@@ -1,9 +1,10 @@
 use std::io::Cursor;
 
+use super::super::fixed_size_list_builder;
 use arrow::{
     array::{
-        ArrayBuilder, BooleanBuilder, FixedSizeListBuilder, ListBuilder, StringBuilder,
-        StructBuilder, UInt8Builder, UInt32Builder,
+        BooleanBuilder, FixedSizeListBuilder, ListBuilder, StringBuilder, StructBuilder,
+        UInt8Builder, UInt32Builder,
     },
     datatypes::{DataType, Field, Fields},
 };
@@ -47,13 +48,6 @@ impl SchemaPlugin for PointCloud2SchemaPlugin {
     }
 }
 
-fn fixed_size_list_builder<T: ArrayBuilder + Default>(
-    value_length: i32,
-    capacity: usize,
-) -> FixedSizeListBuilder<T> {
-    FixedSizeListBuilder::with_capacity(Default::default(), value_length, capacity)
-}
-
 pub struct PointCloud2MessageParser {
     num_rows: usize,
 
@@ -66,6 +60,7 @@ pub struct PointCloud2MessageParser {
     data: FixedSizeListBuilder<ListBuilder<UInt8Builder>>,
 
     // We lazily create this, only if we can interpret the point cloud semantically.
+    // For now, this is the case if there are fields with names `x`,`y`, and `z` present.
     points_3ds: Option<Vec<archetypes::Points3D>>,
 }
 

--- a/crates/utils/re_mcap_ros2/src/geometry_msgs.rs
+++ b/crates/utils/re_mcap_ros2/src/geometry_msgs.rs
@@ -24,3 +24,18 @@ pub struct Quaternion {
     pub z: f64,
     pub w: f64,
 }
+
+/// This contains the position of a point in free space
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+/// A representation of pose in free space, composed of position and orientation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Pose {
+    pub position: Point,
+    pub orientation: Quaternion,
+}

--- a/crates/utils/re_mcap_ros2/src/sensor_msgs.rs
+++ b/crates/utils/re_mcap_ros2/src/sensor_msgs.rs
@@ -141,12 +141,12 @@ pub struct PointField {
 /// point data is stored as a binary blob, its layout described by the
 /// contents of the "fields" array.
 ///
-/// The point cloud data may be organized 2d (image-like) or 1d (unordered).
-/// Point clouds organized as 2d images may be produced by camera depth sensors
+/// The point cloud data may be organized 2D (image-like) or 1D (unordered).
+/// Point clouds organized as 2D images may be produced by camera depth sensors
 /// such as stereo or time-of-flight.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PointCloud2 {
-    /// Time of sensor data acquisition, and the coordinate frame ID (for 3d points).
+    /// Time of sensor data acquisition, and the coordinate frame ID (for 3D points).
     pub header: Header,
 
     /// 2D structure of the point cloud. If the cloud is unordered, height is
@@ -159,8 +159,10 @@ pub struct PointCloud2 {
 
     /// Is this data bigendian?
     pub is_bigendian: bool,
+
     /// Length of a point in bytes
     pub point_step: u32,
+
     /// Length of a row in bytes
     pub row_step: u32,
 

--- a/crates/utils/re_mcap_ros2/src/sensor_msgs.rs
+++ b/crates/utils/re_mcap_ros2/src/sensor_msgs.rs
@@ -108,3 +108,62 @@ pub struct Imu {
     pub linear_acceleration: geometry_msgs::Vector3,
     pub linear_acceleration_covariance: [f64; 9],
 }
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum PointFieldDatatype {
+    /// Does not exist in original spec.
+    Unknown = 0,
+    Int8 = 1,
+    UInt8 = 2,
+    Int16 = 3,
+    UInt16 = 4,
+    Int32 = 5,
+    UInt32 = 6,
+    Float32 = 7,
+    Float64 = 8,
+}
+
+/// This message holds the description of one point entry in the
+/// [`PointCloud2`] message format.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PointField {
+    /// Common [`PointField`] names are x, y, z, intensity, rgb, rgba
+    pub name: String,
+    pub offset: u32,
+    pub datatype: PointFieldDatatype,
+    pub count: u32,
+}
+
+/// This message holds a collection of N-dimensional points.
+///
+/// It may contain additional information such as normals, intensity, etc. The
+/// point data is stored as a binary blob, its layout described by the
+/// contents of the "fields" array.
+///
+/// The point cloud data may be organized 2d (image-like) or 1d (unordered).
+/// Point clouds organized as 2d images may be produced by camera depth sensors
+/// such as stereo or time-of-flight.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PointCloud2 {
+    /// Time of sensor data acquisition, and the coordinate frame ID (for 3d points).
+    pub header: Header,
+
+    /// 2D structure of the point cloud. If the cloud is unordered, height is
+    /// 1 and width is the length of the point cloud.
+    pub height: u32,
+    pub width: u32,
+
+    /// Describes the channels and their layout in the binary data blob.
+    pub fields: Vec<PointField>,
+
+    /// Is this data bigendian?
+    pub is_bigendian: bool,
+    /// Length of a point in bytes
+    pub point_step: u32,
+    /// Length of a row in bytes
+    pub row_step: u32,
+
+    /// Actual point data, size is (`row_step`*`height`)
+    pub data: Vec<u8>,
+}


### PR DESCRIPTION
### Related

* [x] ~Merge after #10748.~ Independent after rebase.

### What

Adds raw support for `PointCloud2` messages (and some other type definition that I stumbled upon). The next step I will be working on is mapping these to `Points2D`/`Points3D`.

<img width="432" height="340" alt="image" src="https://github.com/user-attachments/assets/3f8ae1b8-f381-4b5a-b403-456db241e021" />

