### PR TITLE
Fix rerun-cpp cmake export for OSX

### DIFF
--- a/rerun_cpp/Config.cmake.in
+++ b/rerun_cpp/Config.cmake.in
@@ -11,7 +11,7 @@ if(@RERUN_INSTALL_RERUN_C@)
         get_filename_component(RERUN_C_LIB_NAME "@RERUN_C_LIB_LOCATION@" NAME)
         set_target_properties(rerun_c PROPERTIES IMPORTED_LOCATION "${RERUN_LIB_DIR}/${RERUN_C_LIB_NAME}")
         if(APPLE)
-            target_link_libraries(rerun_c INTERFACE "-framework CoreFoundation" "-framework IOKit")
+            target_link_libraries(rerun_c INTERFACE "-framework CoreFoundation" "-framework IOKit" "-framework Security")
         elseif(UNIX) # if(LINUX) # CMake 3.25
             target_link_libraries(rerun_c INTERFACE "-lm -ldl -pthread")
         elseif(WIN32)


### PR DESCRIPTION
### Related

No related issues.

### What

Follow-up on PR #8991. In-tree cmake target was fixed, but corresponding cmake export config wasn't, this leads to link errors if rerun is imported through cmake config.
