### PR TITLE
Remove `impl Display for StoreId` as it no longer makes sense

### DIFF
--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -535,7 +535,7 @@ impl std::fmt::Display for ChunkStore {
 
         f.write_str("ChunkStore {\n")?;
 
-        f.write_str(&indent::indent_all_by(4, format!("id: {id}\n")))?;
+        f.write_str(&indent::indent_all_by(4, format!("id: {id:?}\n")))?;
         f.write_str(&indent::indent_all_by(4, format!("config: {config:?}\n")))?;
 
         f.write_str(&indent::indent_all_by(4, "stats: {\n"))?;
@@ -742,7 +742,7 @@ impl ChunkStore {
 
                 re_log_types::LogMsg::ArrowMsg(store_id, msg) => {
                     let Some(store) = stores.get_mut(&store_id) else {
-                        anyhow::bail!("unknown store ID: {store_id}");
+                        anyhow::bail!("unknown store ID: {store_id:?}");
                     };
 
                     let chunk = Chunk::from_arrow_msg(&msg)
@@ -790,7 +790,7 @@ impl ChunkStore {
 
                 re_log_types::LogMsg::ArrowMsg(store_id, msg) => {
                     let Some(store) = stores.get_mut(&store_id) else {
-                        anyhow::bail!("unknown store ID: {store_id}");
+                        anyhow::bail!("unknown store ID: {store_id:?}");
                     };
 
                     let chunk = Chunk::from_arrow_msg(&msg)

--- a/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/store/re_chunk_store/tests/formatting.rs
 expression: "format!(\"{:240}\", store)"
-snapshot_kind: text
 ---
 ChunkStore {
-    id: test_id
+    id: StoreId(Recording, "test_app", "test_id")
     config: ChunkStoreConfig { enable_changelog: true, chunk_max_bytes: 393216, chunk_max_rows: 4096, chunk_max_rows_if_unsorted: 1024 }
     stats: {
         num_chunks: 1

--- a/crates/store/re_entity_db/src/store_bundle.rs
+++ b/crates/store/re_entity_db/src/store_bundle.rs
@@ -133,7 +133,7 @@ impl StoreBundle {
     /// One is created if it doesn't already exist.
     pub fn entry(&mut self, id: &StoreId) -> &mut EntityDb {
         self.recording_store.entry(id.clone()).or_insert_with(|| {
-            re_log::trace!("Creating new store: '{id}'");
+            re_log::trace!("Creating new store: '{id:?}'");
             EntityDb::new(id.clone())
         })
     }
@@ -151,7 +151,7 @@ impl StoreBundle {
 
             let mut blueprint_db = EntityDb::new(id.clone());
 
-            re_log::trace!("Creating a new blueprint '{id}'");
+            re_log::trace!("Creating a new blueprint '{id:?}'");
 
             blueprint_db.set_store_info(re_log_types::SetStoreInfo {
                 row_id: *re_chunk::RowId::new(),

--- a/crates/store/re_entity_db/src/times_per_timeline.rs
+++ b/crates/store/re_entity_db/src/times_per_timeline.rs
@@ -91,7 +91,7 @@ impl ChunkStoreSubscriber for TimesPerTimeline {
                     if delta < 0 {
                         *count = count.checked_sub(delta.unsigned_abs()).unwrap_or_else(|| {
                             re_log::debug!(
-                                store_id = %event.store_id,
+                                store_id = ?event.store_id,
                                 entity_path = %event.chunk.entity_path(),
                                 current = count,
                                 removed = delta.unsigned_abs(),
@@ -102,7 +102,7 @@ impl ChunkStoreSubscriber for TimesPerTimeline {
                     } else {
                         *count = count.checked_add(delta.unsigned_abs()).unwrap_or_else(|| {
                             re_log::debug!(
-                                store_id = %event.store_id,
+                                store_id = ?event.store_id,
                                 entity_path = %event.chunk.entity_path(),
                                 current = count,
                                 removed = delta.unsigned_abs(),

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -119,12 +119,24 @@ impl std::fmt::Display for StoreKind {
 /// dataset entry id, and the recording id is the partition id. The former is a UUID, and the latter
 /// is, by definition, unique within the dataset entry. As a result, the uniqueness of the `StoreId`
 /// is always guaranteed in this case.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct StoreId {
     kind: StoreKind,
-    recording_id: RecordingId,
     application_id: ApplicationId,
+    recording_id: RecordingId,
+}
+
+/// More compact debug representation of a [`StoreId`].
+impl std::fmt::Debug for StoreId {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("StoreId")
+            .field(&self.kind)
+            .field(&self.application_id.as_str())
+            .field(&self.recording_id.as_str())
+            .finish()
+    }
 }
 
 impl StoreId {
@@ -231,17 +243,6 @@ impl StoreId {
     #[inline]
     pub fn application_id(&self) -> &ApplicationId {
         &self.application_id
-    }
-}
-
-//TODO(#10746): this is outdated and should be removed
-impl std::fmt::Display for StoreId {
-    #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // `StoreKind` is not part of how we display the id,
-        // because that can easily lead to confusion and bugs
-        // when roundtripping to a string (e.g. via Python SDK).
-        self.recording_id.fmt(f)
     }
 }
 

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -174,7 +174,7 @@ impl std::fmt::Debug for QueryCache {
         let mut strings = Vec::new();
 
         strings.push(format!(
-            "[Entities that must be checked for clears @ {store_id}]\n"
+            "[Entities that must be checked for clears @ {store_id:?}]\n"
         ));
         {
             let sorted: BTreeSet<EntityPath> =
@@ -185,7 +185,7 @@ impl std::fmt::Debug for QueryCache {
             strings.push("\n".to_owned());
         }
 
-        strings.push(format!("[LatestAt @ {store_id}]"));
+        strings.push(format!("[LatestAt @ {store_id:?}]"));
         {
             let latest_at_per_cache_key = latest_at_per_cache_key.read();
             let latest_at_per_cache_key: BTreeMap<_, _> = latest_at_per_cache_key.iter().collect();
@@ -209,7 +209,7 @@ impl std::fmt::Debug for QueryCache {
             }
         }
 
-        strings.push(format!("[Range @ {store_id}]"));
+        strings.push(format!("[Range @ {store_id:?}]"));
         {
             let range_per_cache_key = range_per_cache_key.read();
             let range_per_cache_key: BTreeMap<_, _> = range_per_cache_key.iter().collect();
@@ -300,7 +300,7 @@ impl ChunkStoreSubscriber for QueryCache {
 
             assert!(
                 self.store_id == *store_id,
-                "attempted to use a query cache {} with the wrong datastore ({})",
+                "attempted to use a query cache {:?} with the wrong datastore ({:?})",
                 self.store_id,
                 store_id,
             );

--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -63,7 +63,7 @@ pub trait LogSink: Send + Sync + 'static {
                 self.send(activation_cmd.into());
             } else {
                 re_log::warn!(
-                    "Blueprint ID mismatch when sending blueprint: {} != {}. Ignoring activation.",
+                    "Blueprint ID mismatch when sending blueprint: {:?} != {:?}. Ignoring activation.",
                     blueprint_id,
                     activation_cmd.blueprint_id
                 );

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -969,7 +969,7 @@ impl RecordingStreamInner {
 
         {
             re_log::debug!(
-                store_id = %store_info.store_id,
+                store_id = ?store_info.store_id,
                 "Setting StoreInfo",
             );
             sink.send(
@@ -1538,7 +1538,7 @@ fn forwarding_thread(
                 // Send the recording info to the new sink. This is idempotent.
                 {
                     re_log::debug!(
-                        store_id = %store_info.store_id,
+                        store_id = ?store_info.store_id,
                         "Setting StoreInfo",
                     );
                     new_sink.send(
@@ -2266,7 +2266,7 @@ impl RecordingStream {
                 self.record_msg(activation_cmd.into());
             } else {
                 re_log::warn!(
-                    "Blueprint ID mismatch when sending blueprint: {} != {}. Ignoring activation.",
+                    "Blueprint ID mismatch when sending blueprint: {:?} != {:?}. Ignoring activation.",
                     blueprint_id,
                     activation_cmd.blueprint_id
                 );

--- a/crates/top/rerun/src/commands/rrd/print.rs
+++ b/crates/top/rerun/src/commands/rrd/print.rs
@@ -77,7 +77,7 @@ fn print_msg(verbose: u8, msg: LogMsg) -> anyhow::Result<()> {
             println!("{info:#?}");
         }
 
-        LogMsg::ArrowMsg(_row_id, arrow_msg) => {
+        LogMsg::ArrowMsg(_store_id, arrow_msg) => {
             let mut chunk =
                 re_sorbet::ChunkBatch::try_from(&arrow_msg.batch).context("corrupt chunk")?;
 
@@ -131,7 +131,7 @@ fn print_msg(verbose: u8, msg: LogMsg) -> anyhow::Result<()> {
             make_default,
         }) => {
             println!(
-                "BlueprintActivationCommand({blueprint_id}, make_active: {make_active}, make_default: {make_default})"
+                "BlueprintActivationCommand({blueprint_id:?}, make_active: {make_active}, make_default: {make_default})"
             );
         }
     }

--- a/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
@@ -398,9 +398,15 @@ impl DatastoreUi {
         list_item::list_item_scope(ui, "chunk store info", |ui| {
             let stats = chunk_store.stats().total();
             ui.list_item_collapsible_noninteractive_label("Info", false, |ui| {
+                // Note: no need to print the store kind, because it's selected by the top-level toggle.
                 ui.list_item_flat_noninteractive(
-                    list_item::PropertyContent::new("Store ID")
-                        .value_text(chunk_store.id().to_string()),
+                    list_item::PropertyContent::new("Application ID")
+                        .value_text(chunk_store.id().application_id().to_string()),
+                );
+
+                ui.list_item_flat_noninteractive(
+                    list_item::PropertyContent::new("Recording ID")
+                        .value_text(chunk_store.id().recording_id().to_string()),
                 );
 
                 ui.list_item_flat_noninteractive(

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -22,13 +22,12 @@ impl crate::DataUi for EntityDb {
     ) {
         if ui_layout.is_single_line() {
             // TODO(emilk): standardize this formatting with that in `entity_db_button_ui`
-            let mut string = self.store_id().to_string();
+            let mut string = self.store_id().recording_id().to_string(); //TODO: correct? where can I see that?
             if let Some(data_source) = &self.data_source {
                 string += &format!(", {data_source}");
             }
-            if let Some(store_info) = self.store_info() {
-                string += &format!(", {}", store_info.application_id());
-            }
+            string += &format!(", {}", self.store_id().application_id());
+
             ui.label(string);
             return;
         }

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -21,8 +21,10 @@ impl crate::DataUi for EntityDb {
         _db: &re_entity_db::EntityDb,
     ) {
         if ui_layout.is_single_line() {
-            // TODO(emilk): standardize this formatting with that in `entity_db_button_ui`
-            let mut string = self.store_id().recording_id().to_string(); //TODO: correct? where can I see that?
+            // TODO(emilk): standardize this formatting with that in `entity_db_button_ui` (this is
+            // probably dead code, as `entity_db_button_ui` is actually used in all single line
+            // contexts).
+            let mut string = self.store_id().recording_id().to_string();
             if let Some(data_source) = &self.data_source {
                 string += &format!(", {data_source}");
             }

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -664,7 +664,9 @@ pub fn store_id_button_ui(
     if let Some(entity_db) = ctx.storage_context.bundle.get(store_id) {
         entity_db_button_ui(ctx, ui, entity_db, ui_layout, true);
     } else {
-        ui_layout.label(ui, format!("{store_id:?}")); //TODO BAAAD, when does that happen?
+        ui_layout.label(ui, "<unknown store>").on_hover_ui(|ui| {
+            ui.label(format!("{store_id:?}"));
+        });
     }
 }
 

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -664,7 +664,7 @@ pub fn store_id_button_ui(
     if let Some(entity_db) = ctx.storage_context.bundle.get(store_id) {
         entity_db_button_ui(ctx, ui, entity_db, ui_layout, true);
     } else {
-        ui_layout.label(ui, store_id.to_string());
+        ui_layout.label(ui, format!("{store_id:?}")); //TODO BAAAD, when does that happen?
     }
 }
 

--- a/crates/viewer/re_data_ui/src/store_id.rs
+++ b/crates/viewer/re_data_ui/src/store_id.rs
@@ -6,18 +6,9 @@ impl crate::DataUi for re_log_types::StoreId {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
-        query: &re_chunk_store::LatestAtQuery,
-        db: &re_entity_db::EntityDb,
+        _query: &re_chunk_store::LatestAtQuery,
+        _db: &re_entity_db::EntityDb,
     ) {
-        if let Some(entity_db) = ctx.storage_context.bundle.get(self) {
-            entity_db.data_ui(ctx, ui, ui_layout, query, db);
-        } else {
-            //TODO: improve this to take into account the app id
-            ui.label(format!(
-                "{} ID {} (not found)",
-                self.kind(),
-                self.recording_id()
-            ));
-        }
+        crate::item_ui::store_id_button_ui(ctx, ui, self, ui_layout);
     }
 }

--- a/crates/viewer/re_data_ui/src/store_id.rs
+++ b/crates/viewer/re_data_ui/src/store_id.rs
@@ -12,7 +12,7 @@ impl crate::DataUi for re_log_types::StoreId {
         if let Some(entity_db) = ctx.storage_context.bundle.get(self) {
             entity_db.data_ui(ctx, ui, ui_layout, query, db);
         } else {
-            //TODO(#10746): improve this to take into account the app id
+            //TODO: improve this to take into account the app id
             ui.label(format!(
                 "{} ID {} (not found)",
                 self.kind(),

--- a/crates/viewer/re_data_ui/src/store_id.rs
+++ b/crates/viewer/re_data_ui/src/store_id.rs
@@ -6,9 +6,15 @@ impl crate::DataUi for re_log_types::StoreId {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
-        _query: &re_chunk_store::LatestAtQuery,
-        _db: &re_entity_db::EntityDb,
+        query: &re_chunk_store::LatestAtQuery,
+        db: &re_entity_db::EntityDb,
     ) {
-        crate::item_ui::store_id_button_ui(ctx, ui, self, ui_layout);
+        if let Some(entity_db) = ctx.storage_context.bundle.get(self) {
+            entity_db.data_ui(ctx, ui, ui_layout, query, db);
+        } else {
+            ui_layout.label(ui, "<unknown store>").on_hover_ui(|ui| {
+                ui.label(format!("{self:?}"));
+            });
+        }
     }
 }

--- a/crates/viewer/re_selection_panel/src/item_title.rs
+++ b/crates/viewer/re_selection_panel/src/item_title.rs
@@ -84,11 +84,7 @@ impl ItemTitle {
     }
 
     pub fn from_store_id(ctx: &ViewerContext<'_>, store_id: &re_log_types::StoreId) -> Self {
-        //TODO: improve this to take into account the app id
-        let id_str = format!("{} ID: {}", store_id.kind(), store_id.recording_id());
-
         let title = if let Some(entity_db) = ctx.storage_context.bundle.get(store_id) {
-            let application_id = entity_db.application_id().to_string();
             if let Some(started) = entity_db
                 .recording_info_property::<Timestamp>(&RecordingInfo::descriptor_start_time())
             {
@@ -96,12 +92,12 @@ impl ItemTitle {
                     .to_jiff_zoned(ctx.app_options().timestamp_format)
                     .strftime("%H:%M:%S")
                     .to_string();
-                format!("{application_id} - {time}")
+                format!("{} - {time}", store_id.application_id())
             } else {
-                application_id
+                store_id.application_id().to_string()
             }
         } else {
-            id_str.clone()
+            store_id.application_id().to_string()
         };
 
         let icon = match store_id.kind() {
@@ -109,7 +105,12 @@ impl ItemTitle {
             re_log_types::StoreKind::Blueprint => &icons::BLUEPRINT,
         };
 
-        Self::new(title, icon).with_tooltip(id_str)
+        Self::new(title, icon).with_tooltip(format!(
+            "Store kind: {}\nApplication ID: {}\nRecording ID: {}",
+            store_id.kind(),
+            store_id.application_id(),
+            store_id.recording_id(),
+        ))
     }
 
     pub fn from_instance_path(

--- a/crates/viewer/re_selection_panel/src/item_title.rs
+++ b/crates/viewer/re_selection_panel/src/item_title.rs
@@ -84,7 +84,7 @@ impl ItemTitle {
     }
 
     pub fn from_store_id(ctx: &ViewerContext<'_>, store_id: &re_log_types::StoreId) -> Self {
-        //TODO(#10746): improve this to take into account the app id
+        //TODO: improve this to take into account the app id
         let id_str = format!("{} ID: {}", store_id.kind(), store_id.recording_id());
 
         let title = if let Some(entity_db) = ctx.storage_context.bundle.get(store_id) {

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1643,7 +1643,6 @@ impl App {
 
             if store_hub.is_active_blueprint(store_id) {
                 // TODO(#5514): handle loading of active blueprints.
-                //TODO: user facing
                 re_log::warn_once!(
                     "Loading a blueprint {store_id:?} that is active. See https://github.com/rerun-io/rerun/issues/5514 for details."
                 );

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -721,11 +721,11 @@ impl App {
             }
 
             SystemCommand::SetActiveTime {
-                store_id: rec_id,
+                store_id,
                 timeline,
                 time,
             } => {
-                if let Some(rec_cfg) = self.recording_config_mut(store_hub, &rec_id) {
+                if let Some(rec_cfg) = self.recording_config_mut(store_hub, &store_id) {
                     let mut time_ctrl = rec_cfg.time_ctrl.write();
 
                     time_ctrl.set_timeline(timeline);
@@ -737,24 +737,24 @@ impl App {
                     time_ctrl.pause();
                 } else {
                     re_log::debug!(
-                        "SystemCommand::SetActiveTime ignored: unknown recording ID '{rec_id}'"
+                        "SystemCommand::SetActiveTime ignored: unknown store ID '{store_id:?}'"
                     );
                 }
             }
 
             SystemCommand::SetLoopSelection {
-                store_id: rec_id,
+                store_id,
                 timeline,
                 time_range,
             } => {
-                if let Some(rec_cfg) = self.recording_config_mut(store_hub, &rec_id) {
+                if let Some(rec_cfg) = self.recording_config_mut(store_hub, &store_id) {
                     let mut guard = rec_cfg.time_ctrl.write();
                     guard.set_timeline(timeline);
                     guard.set_loop_selection(time_range);
                     guard.set_looping(re_viewer_context::Looping::Selection);
                 } else {
                     re_log::debug!(
-                        "SystemCommand::SetLoopSelection ignored: unknown recording ID '{rec_id}'"
+                        "SystemCommand::SetLoopSelection ignored: unknown recording ID '{store_id:?}'"
                     );
                 }
             }
@@ -1224,7 +1224,7 @@ impl App {
                 ) {
                 rec_name.to_string()
             } else {
-                store.store_id().to_string()
+                format!("{}-{}", store.application_id(), store.recording_id())
             }
             .pipe(|name| santitize_file_name(&name))
             .pipe(|stem| format!("{stem}.rrd"));
@@ -1643,8 +1643,9 @@ impl App {
 
             if store_hub.is_active_blueprint(store_id) {
                 // TODO(#5514): handle loading of active blueprints.
+                //TODO: user facing
                 re_log::warn_once!(
-                    "Loading a blueprint {store_id} that is active. See https://github.com/rerun-io/rerun/issues/5514 for details."
+                    "Loading a blueprint {store_id:?} that is active. See https://github.com/rerun-io/rerun/issues/5514 for details."
                 );
             }
 
@@ -1695,7 +1696,7 @@ impl App {
                         // updates the app-id when changing the recording.
                         match store_id.kind() {
                             StoreKind::Recording => {
-                                re_log::trace!("Opening a new recording: '{store_id}'");
+                                re_log::trace!("Opening a new recording: '{store_id:?}'");
                                 store_hub.set_active_recording_id(store_id.clone());
 
                                 // Also select the new recording:
@@ -1727,7 +1728,7 @@ impl App {
                 LogMsg::BlueprintActivationCommand(cmd) => match store_id.kind() {
                     StoreKind::Recording => {
                         re_log::debug!(
-                            "Unexpected `BlueprintActivationCommand` message for {store_id}"
+                            "Unexpected `BlueprintActivationCommand` message for {store_id:?}"
                         );
                     }
                     StoreKind::Blueprint => {
@@ -1901,12 +1902,12 @@ impl App {
     pub fn recording_config_mut(
         &mut self,
         store_hub: &StoreHub,
-        rec_id: &StoreId,
+        store_id: &StoreId,
     ) -> Option<&mut RecordingConfig> {
-        if let Some(entity_db) = store_hub.store_bundle().get(rec_id) {
+        if let Some(entity_db) = store_hub.store_bundle().get(store_id) {
             Some(self.state.recording_config_mut(entity_db))
         } else {
-            re_log::debug!("Failed to find recording '{rec_id}' in store hub");
+            re_log::debug!("Failed to find recording '{store_id:?}' in store hub");
             None
         }
     }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -754,7 +754,7 @@ impl App {
                     guard.set_looping(re_viewer_context::Looping::Selection);
                 } else {
                     re_log::debug!(
-                        "SystemCommand::SetLoopSelection ignored: unknown recording ID '{store_id:?}'"
+                        "SystemCommand::SetLoopSelection ignored: unknown store ID '{store_id:?}'"
                     );
                 }
             }

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -384,7 +384,7 @@ impl WebHandle {
         let hub = app.store_hub.as_ref()?;
         let recording = hub.active_recording()?;
 
-        Some(recording.store_id().to_string())
+        Some(recording.store_id().recording_id().to_string())
     }
 
     //TODO(#10737): we should refer to logical recordings using store id (recording id is ambibuous)
@@ -454,7 +454,7 @@ impl WebHandle {
         let rec_cfg = recording_config_entry(&mut state.recording_configs, recording);
 
         let Some(timeline) = recording.timelines().get(&timeline_name.into()).copied() else {
-            re_log::warn!("Failed to find timeline '{timeline_name}' in {store_id}");
+            re_log::warn!("Failed to find timeline '{timeline_name}' in {store_id:?}");
             return;
         };
 
@@ -501,7 +501,7 @@ impl WebHandle {
         };
         let rec_cfg = recording_config_entry(&mut state.recording_configs, recording);
         let Some(timeline) = recording.timelines().get(&timeline_name.into()).copied() else {
-            re_log::warn!("Failed to find timeline '{timeline_name}' in {store_id}");
+            re_log::warn!("Failed to find timeline '{timeline_name}' in {store_id:?}");
             return;
         };
 

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -300,7 +300,7 @@ impl ItemCollection {
 
                 // TODO(ab): it is not very meaningful to copy the `StoreId` representation, but
                 // that's the best we can do for now. In the future, we should have URIs for
-                // in-memery recordings, and that's what we should copy here.
+                // in-memory recordings, and that's what we should copy here.
                 Item::StoreId(id) => Some((ClipboardTextDesc::StoreId, format!("{id:?}"))),
 
                 Item::DataResult(_, instance_path) | Item::InstancePath(instance_path) => Some((

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -297,7 +297,7 @@ impl ItemCollection {
                 },
 
                 Item::AppId(id) => Some((ClipboardTextDesc::AppId, id.to_string())),
-                Item::StoreId(id) => Some((ClipboardTextDesc::StoreId, id.to_string())),
+                Item::StoreId(id) => Some((ClipboardTextDesc::StoreId, format!("{id:?}"))), //TODO
 
                 Item::DataResult(_, instance_path) | Item::InstancePath(instance_path) => Some((
                     ClipboardTextDesc::EntityPath,

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -297,7 +297,11 @@ impl ItemCollection {
                 },
 
                 Item::AppId(id) => Some((ClipboardTextDesc::AppId, id.to_string())),
-                Item::StoreId(id) => Some((ClipboardTextDesc::StoreId, format!("{id:?}"))), //TODO
+
+                // TODO(ab): it is not very meaningful to copy the `StoreId` representation, but
+                // that's the best we can do for now. In the future, we should have URIs for
+                // in-memery recordings, and that's what we should copy here.
+                Item::StoreId(id) => Some((ClipboardTextDesc::StoreId, format!("{id:?}"))),
 
                 Item::DataResult(_, instance_path) | Item::InstancePath(instance_path) => Some((
                     ClipboardTextDesc::EntityPath,

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -540,7 +540,7 @@ impl StoreHub {
         match store_id.kind() {
             StoreKind::Recording => self.set_active_recording_id(store_id),
             StoreKind::Blueprint => {
-                re_log::debug!("Tried to activate the blueprint {store_id} as a recording.");
+                re_log::debug!("Tried to activate the blueprint {store_id:?} as a recording.");
             }
         }
     }
@@ -573,7 +573,7 @@ impl StoreHub {
         }
 
         re_log::trace!(
-            "Switching default blueprint for '{}' to '{}'",
+            "Switching default blueprint for '{:?}' to '{:?}'",
             blueprint_id.application_id(),
             blueprint_id
         );
@@ -619,7 +619,7 @@ impl StoreHub {
         let new_id = StoreId::random(StoreKind::Blueprint, app_id.clone());
 
         re_log::trace!(
-            "Cloning '{blueprint_id}' as '{new_id}' the active blueprint for '{app_id}'"
+            "Cloning '{blueprint_id:?}' as '{new_id:?}' the active blueprint for '{app_id}'"
         );
 
         let blueprint = self
@@ -654,7 +654,7 @@ impl StoreHub {
     pub fn clear_active_blueprint(&mut self) {
         if let Some(app_id) = &self.active_application_id {
             if let Some(blueprint_id) = self.active_blueprint_by_app_id.remove(app_id) {
-                re_log::debug!("Clearing blueprint for {app_id}: {blueprint_id}");
+                re_log::debug!("Clearing blueprint for {app_id}: {blueprint_id:?}");
                 self.remove_store(&blueprint_id);
             }
         }
@@ -861,7 +861,7 @@ impl StoreHub {
             }
 
             let Some(blueprint) = self.store_bundle.get_mut(blueprint_id) else {
-                re_log::debug!("Failed to find blueprint {blueprint_id}.");
+                re_log::debug!("Failed to find blueprint {blueprint_id:?}.");
                 continue;
             };
             if self.blueprint_last_save.get(blueprint_id) == Some(&blueprint.generation()) {
@@ -905,7 +905,7 @@ impl StoreHub {
                 // We found the blueprint we were looking for; make it active.
                 // borrow-checker won't let us just call `self.set_blueprint_for_app_id`
                 re_log::debug!(
-                    "Activating new blueprint {} for {app_id}; loaded from disk",
+                    "Activating new blueprint {:?} for {app_id}; loaded from disk",
                     store.store_id(),
                 );
                 self.active_blueprint_by_app_id

--- a/examples/rust/custom_store_subscriber/src/main.rs
+++ b/examples/rust/custom_store_subscriber/src/main.rs
@@ -110,14 +110,14 @@ impl ChunkStoreSubscriber for ComponentsPerRecording {
                 // if first occurrence, speak!
                 if event.delta() > 0 && *count == 0 {
                     println!(
-                        "New component introduced in recording {}: {}!",
+                        "New component introduced in recording {:?}: {}!",
                         event.store_id, component_descr,
                     );
                 }
                 // if last occurrence, speak!
                 else if event.delta() < 0 && *count <= event.delta().unsigned_abs() {
                     println!(
-                        "Component retired from recording {}: {}!",
+                        "Component retired from recording {:?}: {}!",
                         event.store_id, component_descr,
                     );
                 }
@@ -133,8 +133,8 @@ impl ChunkStoreSubscriber for ComponentsPerRecording {
         println!("Component stats");
         println!("---------------");
 
-        for (recording, per_component) in &self.counters {
-            println!("  Recording '{recording}':"); // NOLINT
+        for (store_id, per_component) in &self.counters {
+            println!("  Recording '{store_id:?}':"); // NOLINT
             for (component, counter) in per_component {
                 println!("    {component}: {counter} occurrences");
             }

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -638,7 +638,7 @@ fn get_application_id(recording: Option<&PyRecordingStream>) -> Option<String> {
 fn get_recording_id(recording: Option<&PyRecordingStream>) -> Option<String> {
     get_data_recording(recording)?
         .store_info()
-        .map(|info| info.store_id.to_string())
+        .map(|info| info.store_id.recording_id().to_string())
 }
 
 /// Returns the currently active data recording in the global scope, if any; fallbacks to the specified recording otherwise, if any.


### PR DESCRIPTION
### Related

- follow up to: #10742
- fixes: https://github.com/rerun-io/rerun/issues/10746
- sibling: https://github.com/rerun-io/dataplatform/pull/1368

### What

See https://github.com/rerun-io/rerun/issues/10746 for what this does. Mostly boilerplate but quite a few UX micro decisions. Some may be debatable, but I think this is a strict improvement given what `StoreId` are now.