### PR TITLE
Quote string literals properly in `entity-queries.md` python snippets

### DIFF
--- a/docs/content/reference/entity-queries.md
+++ b/docs/content/reference/entity-queries.md
@@ -67,7 +67,7 @@ be written as:
 ```python
 rrb.Spatial3DView(
     contents=[
-        "+ helix/**,
+        "+ helix/**",
         "- helix/structure/scaffolding",
     ],
 ),
@@ -84,7 +84,7 @@ For example, the above query could be rewritten as:
 rrb.Spatial3DView(
     origin="helix",
     contents=[
-        "+ $origin/**,
+        "+ $origin/**",
         "- $origin/structure/scaffolding",
     ],
 ),


### PR DESCRIPTION


### What

Noticed, while skimming the docs, that some strings in the python code fence were not quoted properly.

<img width="1296" height="1255" alt="image" src="https://github.com/user-attachments/assets/2d4b4ebd-3de3-4bb0-a6c9-e772976e69b4" />


<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
