### PR TITLE
impl AsRef<str> for PartitionId

### DIFF
--- a/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.common.v1alpha1.ext.rs
@@ -139,6 +139,12 @@ impl From<PartitionId> for crate::common::v1alpha1::PartitionId {
     }
 }
 
+impl AsRef<str> for PartitionId {
+    fn as_ref(&self) -> &str {
+        self.id.as_str()
+    }
+}
+
 // shortcuts
 
 impl From<String> for crate::common::v1alpha1::PartitionId {


### PR DESCRIPTION
This makes it orders of magnitude easier to pass slices and vecs of `PartitionId`s around in different typing contexts.