### PR TITLE
Use release version as JS docs version name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
       CONCURRENCY: ${{ github.ref_name }}
       PY_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && needs.version.outputs.final || 'dev' }}
       CPP_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
-      JS_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && 'stable' || 'dev' }}
+      JS_DOCS_VERSION_NAME: ${{ inputs.release-type == 'final' && needs.version.outputs.final || 'dev' }}
       RELEASE_COMMIT: ${{ needs.version.outputs.release-commit }}
       RELEASE_VERSION: ${{ needs.version.outputs.final }}
       UPDATE_LATEST: ${{ inputs.release-type == 'final' }}


### PR DESCRIPTION
`stable` is just a redirect, the actual docs are stored under `docs/js/{version}`. Previously it would both redirect to `docs/js/stable` and also upload docs to `docs/js/stable`