### PR TITLE
Add `__len__` to codegened Python datatypes

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -1450,26 +1450,22 @@ fn quote_len_method_from_obj(ext_class: &ExtensionClass, obj: &Object) -> String
     }
 
     let field_name = &obj.fields[0].name;
-    if obj.fields[0].is_nullable {
+
+    let null_string = if obj.fields[0].is_nullable {
         // If the field is optional, we return 0 if it is None.
-        return unindent(&format!(
-            "
-            def __len__(self) -> int:
-                # You can define your own __len__ function as a member of {} in {}
-                return len(self.{field_name}) if self.{field_name} is not None else 0
-            ",
-            ext_class.name, ext_class.file_name
-        ));
+        format!(" if self.{field_name} is not None else 0")
     } else {
-        unindent(&format!(
-            "
-            def __len__(self) -> int:
-                # You can define your own __len__ function as a member of {} in {}
-                return len(self.{field_name})
-            ",
-            ext_class.name, ext_class.file_name
-        ))
-    }
+        String::new()
+    };
+
+    unindent(&format!(
+        "
+        def __len__(self) -> int:
+            # You can define your own __len__ function as a member of {} in {}
+            return len(self.{field_name}){null_string}
+        ",
+        ext_class.name, ext_class.file_name
+    ))
 }
 
 /// Automatically implement `__str__`, `__int__`, or `__float__` as well as `__hash__` methods if the object has a single

--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -31,6 +31,9 @@ const INIT_METHOD: &str = "__init__";
 /// The standard numpy interface for converting to an array type
 const ARRAY_METHOD: &str = "__array__";
 
+/// The standard python len method
+const LEN_METHOD: &str = "__len__";
+
 /// The method used to convert a native type into a pyarrow array
 const NATIVE_TO_PA_ARRAY_METHOD: &str = "native_to_pa_array_override";
 
@@ -200,6 +203,12 @@ struct ExtensionClass {
 
     /// Whether the `ObjectExt` contains a `deferred_patch_class()` method
     has_deferred_patch_class: bool,
+
+    /// Whether the `ObjectExt` contains __len__()
+    ///
+    /// If the `ExtensionClass` contains its own `__len__` then we avoid generating
+    /// a default implementation.
+    has_len: bool,
 }
 
 impl ExtensionClass {
@@ -248,6 +257,7 @@ impl ExtensionClass {
 
             let has_init = methods.contains(&INIT_METHOD);
             let has_array = methods.contains(&ARRAY_METHOD);
+            let has_len = methods.contains(&LEN_METHOD);
             let has_native_to_pa_array = methods.contains(&NATIVE_TO_PA_ARRAY_METHOD);
             let has_deferred_patch_class = methods.contains(&DEFERRED_PATCH_CLASS_METHOD);
             let field_converter_overrides: Vec<String> = methods
@@ -286,6 +296,7 @@ impl ExtensionClass {
                 has_array,
                 has_native_to_pa_array,
                 has_deferred_patch_class,
+                has_len,
             }
         } else {
             Self {
@@ -298,6 +309,7 @@ impl ExtensionClass {
                 has_array: false,
                 has_native_to_pa_array: false,
                 has_deferred_patch_class: false,
+                has_len: false,
             }
         }
     }
@@ -805,6 +817,7 @@ fn code_for_struct(
 
         code.push_indented(1, quote_array_method_from_obj(ext_class, objects, obj), 1);
         code.push_indented(1, quote_native_types_method_from_obj(objects, obj), 1);
+        code.push_indented(1, quote_len_method_from_obj(ext_class, obj), 1);
 
         if *kind != ObjectKind::Archetype {
             code.push_indented(0, quote_aliases_from_object(obj), 1);
@@ -1422,6 +1435,41 @@ fn quote_array_method_from_obj(
         ",
         ext_class.name, ext_class.file_name
     ))
+}
+
+fn quote_len_method_from_obj(ext_class: &ExtensionClass, obj: &Object) -> String {
+    // allow overriding the __len__ function
+    if ext_class.has_len {
+        return format!("# __len__ can be found in {}", ext_class.file_name);
+    }
+
+    // exclude archetypes, objects which don't have a single field, and anything that isn't plural
+    if obj.kind == ObjectKind::Archetype || obj.fields.len() != 1 || !obj.fields[0].typ.is_plural()
+    {
+        return String::new();
+    }
+
+    let field_name = &obj.fields[0].name;
+    if obj.fields[0].is_nullable {
+        // If the field is optional, we return 0 if it is None.
+        return unindent(&format!(
+            "
+            def __len__(self) -> int:
+                # You can define your own __len__ function as a member of {} in {}
+                return len(self.{field_name}) if self.{field_name} is not None else 0
+            ",
+            ext_class.name, ext_class.file_name
+        ));
+    } else {
+        unindent(&format!(
+            "
+            def __len__(self) -> int:
+                # You can define your own __len__ function as a member of {} in {}
+                return len(self.{field_name})
+            ",
+            ext_class.name, ext_class.file_name
+        ))
+    }
 }
 
 /// Automatically implement `__str__`, `__int__`, or `__float__` as well as `__hash__` methods if the object has a single

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -59,6 +59,10 @@ class AnnotationContext(AnnotationContextExt, ComponentMixin):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AnnotationContextExt in annotation_context_ext.py
+        return len(self.class_map)
+
 
 if TYPE_CHECKING:
     AnnotationContextLike = Union[

--- a/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
+++ b/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
@@ -33,6 +33,10 @@ class GeoLineString(GeoLineStringExt, ComponentMixin):
 
     lat_lon: list[datatypes.DVec2D] = field()
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of GeoLineStringExt in geo_line_string_ext.py
+        return len(self.lat_lon)
+
 
 if TYPE_CHECKING:
     GeoLineStringLike = Union[GeoLineString, datatypes.DVec2DArrayLike, npt.NDArray[np.float64]]

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -51,6 +51,10 @@ class LineStrip2D(LineStrip2DExt, ComponentMixin):
 
     points: list[datatypes.Vec2D] = field()
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of LineStrip2DExt in line_strip2d_ext.py
+        return len(self.points)
+
 
 if TYPE_CHECKING:
     LineStrip2DLike = Union[LineStrip2D, datatypes.Vec2DArrayLike, npt.NDArray[np.float32]]

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -51,6 +51,10 @@ class LineStrip3D(LineStrip3DExt, ComponentMixin):
 
     points: list[datatypes.Vec3D] = field()
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of LineStrip3DExt in line_strip3d_ext.py
+        return len(self.points)
+
 
 if TYPE_CHECKING:
     LineStrip3DLike = Union[LineStrip3D, datatypes.Vec3DArrayLike, npt.NDArray[np.float32]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/blob.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/blob.py
@@ -40,6 +40,10 @@ class Blob(BlobExt):
         # You can define your own __array__ function as a member of BlobExt in blob_ext.py
         return np.asarray(self.data, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of BlobExt in blob_ext.py
+        return len(self.data)
+
 
 if TYPE_CHECKING:
     BlobLike = Union[Blob, bytes, npt.NDArray[np.uint8]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/dvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/dvec2d.py
@@ -40,6 +40,10 @@ class DVec2D(DVec2DExt):
         # You can define your own __array__ function as a member of DVec2DExt in dvec2d_ext.py
         return np.asarray(self.xy, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of DVec2DExt in dvec2d_ext.py
+        return len(self.xy)
+
 
 if TYPE_CHECKING:
     DVec2DLike = Union[DVec2D, npt.NDArray[Any], npt.ArrayLike, Sequence[float]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -72,6 +72,10 @@ class Mat3x3(Mat3x3Ext):
         # You can define your own __array__ function as a member of Mat3x3Ext in mat3x3_ext.py
         return np.asarray(self.flat_columns, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of Mat3x3Ext in mat3x3_ext.py
+        return len(self.flat_columns)
+
 
 if TYPE_CHECKING:
     Mat3x3Like = Union[Mat3x3, npt.ArrayLike]

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -74,6 +74,10 @@ class Mat4x4(Mat4x4Ext):
         # You can define your own __array__ function as a member of Mat4x4Ext in mat4x4_ext.py
         return np.asarray(self.flat_columns, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of Mat4x4Ext in mat4x4_ext.py
+        return len(self.flat_columns)
+
 
 if TYPE_CHECKING:
     Mat4x4Like = Union[Mat4x4, npt.ArrayLike]

--- a/rerun_py/rerun_sdk/rerun/datatypes/plane3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/plane3d.py
@@ -46,6 +46,10 @@ class Plane3D(Plane3DExt):
         # You can define your own __array__ function as a member of Plane3DExt in plane3d_ext.py
         return np.asarray(self.xyzd, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of Plane3DExt in plane3d_ext.py
+        return len(self.xyzd)
+
 
 Plane3DLike = Plane3D
 Plane3DArrayLike = Union[Plane3D, Sequence[Plane3DLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -41,6 +41,10 @@ class Quaternion(QuaternionExt):
         # You can define your own __array__ function as a member of QuaternionExt in quaternion_ext.py
         return np.asarray(self.xyzw, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of QuaternionExt in quaternion_ext.py
+        return len(self.xyzw)
+
 
 QuaternionLike = Quaternion
 QuaternionArrayLike = Union[

--- a/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
@@ -40,6 +40,10 @@ class Range1D(Range1DExt):
         # You can define your own __array__ function as a member of Range1DExt in range1d_ext.py
         return np.asarray(self.range, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of Range1DExt in range1d_ext.py
+        return len(self.range)
+
 
 if TYPE_CHECKING:
     Range1DLike = Union[Range1D, npt.NDArray[Any], npt.ArrayLike, Sequence[float], slice]

--- a/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
@@ -51,6 +51,10 @@ class Uuid(UuidExt):
         # You can define your own __array__ function as a member of UuidExt in uuid_ext.py
         return np.asarray(self.bytes, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of UuidExt in uuid_ext.py
+        return len(self.bytes)
+
 
 if TYPE_CHECKING:
     UuidLike = Union[Uuid, npt.NDArray[Any], npt.ArrayLike, Sequence[int], bytes]

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
@@ -40,6 +40,10 @@ class UVec2D(UVec2DExt):
         # You can define your own __array__ function as a member of UVec2DExt in uvec2d_ext.py
         return np.asarray(self.xy, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of UVec2DExt in uvec2d_ext.py
+        return len(self.xy)
+
 
 if TYPE_CHECKING:
     UVec2DLike = Union[UVec2D, npt.NDArray[Any], npt.ArrayLike, Sequence[int]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
@@ -40,6 +40,10 @@ class UVec3D(UVec3DExt):
         # You can define your own __array__ function as a member of UVec3DExt in uvec3d_ext.py
         return np.asarray(self.xyz, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of UVec3DExt in uvec3d_ext.py
+        return len(self.xyz)
+
 
 if TYPE_CHECKING:
     UVec3DLike = Union[UVec3D, npt.NDArray[Any], npt.ArrayLike, Sequence[int]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
@@ -39,6 +39,10 @@ class UVec4D:
         # You can define your own __array__ function as a member of UVec4DExt in uvec4d_ext.py
         return np.asarray(self.xyzw, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of UVec4DExt in uvec4d_ext.py
+        return len(self.xyzw)
+
 
 if TYPE_CHECKING:
     UVec4DLike = Union[UVec4D, npt.NDArray[Any], npt.ArrayLike, Sequence[int]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
@@ -40,6 +40,10 @@ class Vec2D(Vec2DExt):
         # You can define your own __array__ function as a member of Vec2DExt in vec2d_ext.py
         return np.asarray(self.xy, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of Vec2DExt in vec2d_ext.py
+        return len(self.xy)
+
 
 if TYPE_CHECKING:
     Vec2DLike = Union[Vec2D, npt.NDArray[Any], npt.ArrayLike, Sequence[float]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
@@ -40,6 +40,10 @@ class Vec3D(Vec3DExt):
         # You can define your own __array__ function as a member of Vec3DExt in vec3d_ext.py
         return np.asarray(self.xyz, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of Vec3DExt in vec3d_ext.py
+        return len(self.xyz)
+
 
 if TYPE_CHECKING:
     Vec3DLike = Union[Vec3D, npt.NDArray[Any], npt.ArrayLike, Sequence[float]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
@@ -40,6 +40,10 @@ class Vec4D(Vec4DExt):
         # You can define your own __array__ function as a member of Vec4DExt in vec4d_ext.py
         return np.asarray(self.xyzw, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of Vec4DExt in vec4d_ext.py
+        return len(self.xyzw)
+
 
 if TYPE_CHECKING:
     Vec4DLike = Union[Vec4D, npt.NDArray[Any], npt.ArrayLike, Sequence[float]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/view_coordinates.py
@@ -72,6 +72,10 @@ class ViewCoordinates(ViewCoordinatesExt):
         # You can define your own __array__ function as a member of ViewCoordinatesExt in view_coordinates_ext.py
         return np.asarray(self.coordinates, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of ViewCoordinatesExt in view_coordinates_ext.py
+        return len(self.coordinates)
+
 
 if TYPE_CHECKING:
     ViewCoordinatesLike = Union[ViewCoordinates, npt.ArrayLike]

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -40,6 +40,10 @@ class AffixFuzzer11(ComponentMixin):
         # You can define your own __array__ function as a member of AffixFuzzer11Ext in affix_fuzzer11_ext.py
         return np.asarray(self.many_floats_optional, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer11Ext in affix_fuzzer11_ext.py
+        return len(self.many_floats_optional) if self.many_floats_optional is not None else 0
+
 
 AffixFuzzer11Like = AffixFuzzer11
 AffixFuzzer11ArrayLike = Union[

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -31,6 +31,10 @@ class AffixFuzzer12(ComponentMixin):
 
     many_strings_required: list[str] = field()
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer12Ext in affix_fuzzer12_ext.py
+        return len(self.many_strings_required)
+
 
 AffixFuzzer12Like = AffixFuzzer12
 AffixFuzzer12ArrayLike = Union[

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -31,6 +31,10 @@ class AffixFuzzer13(ComponentMixin):
 
     many_strings_optional: list[str] | None = field(default=None)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer13Ext in affix_fuzzer13_ext.py
+        return len(self.many_strings_optional) if self.many_strings_optional is not None else 0
+
 
 AffixFuzzer13Like = AffixFuzzer13
 AffixFuzzer13ArrayLike = Union[

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -33,6 +33,10 @@ class AffixFuzzer16(ComponentMixin):
 
     many_required_unions: list[datatypes.AffixFuzzer3] = field()
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer16Ext in affix_fuzzer16_ext.py
+        return len(self.many_required_unions)
+
 
 AffixFuzzer16Like = AffixFuzzer16
 AffixFuzzer16ArrayLike = Union[

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -33,6 +33,10 @@ class AffixFuzzer17(ComponentMixin):
 
     many_optional_unions: list[datatypes.AffixFuzzer3] | None = field(default=None)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer17Ext in affix_fuzzer17_ext.py
+        return len(self.many_optional_unions) if self.many_optional_unions is not None else 0
+
 
 AffixFuzzer17Like = AffixFuzzer17
 AffixFuzzer17ArrayLike = Union[

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -33,6 +33,10 @@ class AffixFuzzer18(ComponentMixin):
 
     many_optional_unions: list[datatypes.AffixFuzzer4] | None = field(default=None)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer18Ext in affix_fuzzer18_ext.py
+        return len(self.many_optional_unions) if self.many_optional_unions is not None else 0
+
 
 AffixFuzzer18Like = AffixFuzzer18
 AffixFuzzer18ArrayLike = Union[

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -33,6 +33,10 @@ class AffixFuzzer7(ComponentMixin):
 
     many_optional: list[datatypes.AffixFuzzer1] | None = field(default=None)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer7Ext in affix_fuzzer7_ext.py
+        return len(self.many_optional) if self.many_optional is not None else 0
+
 
 AffixFuzzer7Like = AffixFuzzer7
 AffixFuzzer7ArrayLike = Union[

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer22.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer22.py
@@ -36,6 +36,10 @@ class AffixFuzzer22:
         # You can define your own __array__ function as a member of AffixFuzzer22Ext in affix_fuzzer22_ext.py
         return np.asarray(self.fixed_sized_native, dtype=dtype, copy=copy)
 
+    def __len__(self) -> int:
+        # You can define your own __len__ function as a member of AffixFuzzer22Ext in affix_fuzzer22_ext.py
+        return len(self.fixed_sized_native)
+
 
 AffixFuzzer22Like = AffixFuzzer22
 AffixFuzzer22ArrayLike = Union[

--- a/rerun_py/tests/unit/test_transform3d.py
+++ b/rerun_py/tests/unit/test_transform3d.py
@@ -68,7 +68,7 @@ def test_angle() -> None:
 def test_transform3d() -> None:
     rotation_axis_angle = [None, RotationAxisAngle([1, 2, 3], rr.Angle(deg=10))]
     quaternion_arrays = [None, Quaternion(xyzw=[1, 2, 3, 4])]
-    scale_arrays = [None, 1.0, 1, [1.0, 2.0, 3.0]]
+    scale_arrays = [None, 1.0, 1, [1.0, 2.0, 3.0], rr.Scale3D([1.0, 2.0, 3.0])]
     axis_lengths = [None, 1, 1.0]
     relations = [
         None,

--- a/rerun_py/tests/unit/test_utilities_datafusion.py
+++ b/rerun_py/tests/unit/test_utilities_datafusion.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import importlib
 from unittest.mock import Mock, patch
 
 import pytest
+import rerun.utilities.datafusion.functions.url_generation
 from rerun.error_utils import RerunOptionalDependencyError
 
 
@@ -21,6 +23,7 @@ def test_partition_url_without_datafusion() -> None:
     """Check that calling partition_url raises RerunOptionalDependencyError when datafusion is unavailable."""
     # Mock the import to make datafusion unavailable
     with patch.dict("sys.modules", {"datafusion": None}):
+        importlib.reload(rerun.utilities.datafusion.functions.url_generation)
         # Import the module - this should work
         from rerun.utilities.datafusion.functions.url_generation import partition_url
 


### PR DESCRIPTION
### Related

* closes https://github.com/rerun-io/rerun/issues/10761

### What
Right now flatbuffers doesn't expose `__len__` and our codegen doesn't expose it either. A variety of our extensions check for the `__len__` attr in order to determine if something is a scalar or sized. Follow the `__array__` pattern in order to determine when we can generate a `__len__` automatically.
