### PR TITLE
New .proto definitions for updating a Catalog Entry -- starting with name

### DIFF
--- a/crates/store/re_protos/Cargo.toml
+++ b/crates/store/re_protos/Cargo.toml
@@ -37,7 +37,7 @@ prost.workspace = true
 pyo3 = { workspace = true, optional = true }
 serde.workspace = true
 thiserror.workspace = true
-url.workspace = true
+url = { workspace = true, features = ["serde"] }
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
@@ -179,8 +179,8 @@ message EntryDetails {
 
 // Updatable fields of an Entry
 message EntryDetailsUpdate {
-  // The new name for this entry (optional - if not provided, name will remain unchanged).
-  optional string name = 1;
+  // The name of this entry.
+  optional string name = 2;
 }
 
 message DatasetDetails {

--- a/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/catalog.proto
@@ -13,6 +13,8 @@ service CatalogService {
   rpc FindEntries(FindEntriesRequest) returns (FindEntriesResponse) {}
   rpc DeleteEntry(DeleteEntryRequest) returns (DeleteEntryResponse) {}
 
+  rpc UpdateEntry(UpdateEntryRequest) returns (UpdateEntryResponse) {}
+
   rpc CreateDatasetEntry(CreateDatasetEntryRequest) returns (CreateDatasetEntryResponse) {}
   rpc ReadDatasetEntry(ReadDatasetEntryRequest) returns (ReadDatasetEntryResponse) {}
   rpc UpdateDatasetEntry(UpdateDatasetEntryRequest) returns (UpdateDatasetEntryResponse) {}
@@ -42,6 +44,21 @@ message DeleteEntryRequest {
 }
 
 message DeleteEntryResponse {}
+
+// UpdateEntry
+
+message UpdateEntryRequest {
+  // The entry to modify.
+  rerun.common.v1alpha1.EntryId id = 1;
+
+  // The new values for updatable fields.
+  EntryDetailsUpdate entry_details_update = 2;
+}
+
+message UpdateEntryResponse {
+  // The updated entry details
+  EntryDetails entry_details = 1;
+}
 
 // CreateDatasetEntry
 
@@ -158,6 +175,12 @@ message EntryDetails {
 
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp updated_at = 5;
+}
+
+// Updatable fields of an Entry
+message EntryDetailsUpdate {
+  // The new name for this entry (optional - if not provided, name will remain unchanged).
+  optional string name = 1;
 }
 
 message DatasetDetails {

--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -27,6 +27,8 @@ service FrontendService {
 
   rpc DeleteEntry(rerun.catalog.v1alpha1.DeleteEntryRequest) returns (rerun.catalog.v1alpha1.DeleteEntryResponse) {}
 
+  rpc UpdateEntry(rerun.catalog.v1alpha1.UpdateEntryRequest) returns (rerun.catalog.v1alpha1.UpdateEntryResponse) {}
+
   rpc CreateDatasetEntry(rerun.catalog.v1alpha1.CreateDatasetEntryRequest) returns (rerun.catalog.v1alpha1.CreateDatasetEntryResponse) {}
   rpc ReadDatasetEntry(rerun.catalog.v1alpha1.ReadDatasetEntryRequest) returns (rerun.catalog.v1alpha1.ReadDatasetEntryResponse) {}
   rpc UpdateDatasetEntry(rerun.catalog.v1alpha1.UpdateDatasetEntryRequest) returns (rerun.catalog.v1alpha1.UpdateDatasetEntryResponse) {}

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.ext.rs
@@ -375,6 +375,98 @@ impl TryFrom<crate::catalog::v1alpha1::DeleteEntryRequest> for re_log_types::Ent
     }
 }
 
+// --- EntryDetailsUpdate ---
+
+#[derive(Debug, Clone, Default)]
+pub struct EntryDetailsUpdate {
+    pub name: Option<String>,
+}
+
+impl TryFrom<crate::catalog::v1alpha1::EntryDetailsUpdate> for EntryDetailsUpdate {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::catalog::v1alpha1::EntryDetailsUpdate) -> Result<Self, Self::Error> {
+        Ok(Self { name: value.name })
+    }
+}
+
+impl From<EntryDetailsUpdate> for crate::catalog::v1alpha1::EntryDetailsUpdate {
+    fn from(value: EntryDetailsUpdate) -> Self {
+        Self { name: value.name }
+    }
+}
+
+// --- UpdateEntryRequest ---
+
+#[derive(Debug, Clone)]
+pub struct UpdateEntryRequest {
+    pub id: re_log_types::EntryId,
+    pub entry_details_update: EntryDetailsUpdate,
+}
+
+impl TryFrom<crate::catalog::v1alpha1::UpdateEntryRequest> for UpdateEntryRequest {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::catalog::v1alpha1::UpdateEntryRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: value
+                .id
+                .ok_or(missing_field!(
+                    crate::catalog::v1alpha1::UpdateEntryRequest,
+                    "id"
+                ))?
+                .try_into()?,
+            entry_details_update: value
+                .entry_details_update
+                .ok_or(missing_field!(
+                    crate::catalog::v1alpha1::UpdateEntryRequest,
+                    "entry_details_update"
+                ))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<UpdateEntryRequest> for crate::catalog::v1alpha1::UpdateEntryRequest {
+    fn from(value: UpdateEntryRequest) -> Self {
+        Self {
+            id: Some(value.id.into()),
+            entry_details_update: Some(value.entry_details_update.into()),
+        }
+    }
+}
+
+// --- UpdateEntryResponse ---
+
+#[derive(Debug, Clone)]
+pub struct UpdateEntryResponse {
+    pub entry_details: EntryDetails,
+}
+
+impl TryFrom<crate::catalog::v1alpha1::UpdateEntryResponse> for UpdateEntryResponse {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::catalog::v1alpha1::UpdateEntryResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            entry_details: value
+                .entry_details
+                .ok_or(missing_field!(
+                    crate::catalog::v1alpha1::UpdateEntryResponse,
+                    "entry_details"
+                ))?
+                .try_into()?,
+        })
+    }
+}
+
+impl From<UpdateEntryResponse> for crate::catalog::v1alpha1::UpdateEntryResponse {
+    fn from(value: UpdateEntryResponse) -> Self {
+        Self {
+            entry_details: Some(value.entry_details.into()),
+        }
+    }
+}
+
 // --- ReadTableEntryRequest ---
 
 impl TryFrom<crate::catalog::v1alpha1::ReadTableEntryRequest> for re_log_types::EntryId {

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
@@ -313,8 +313,8 @@ impl ::prost::Name for EntryDetails {
 /// Updatable fields of an Entry
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EntryDetailsUpdate {
-    /// The new name for this entry (optional - if not provided, name will remain unchanged).
-    #[prost(string, optional, tag = "1")]
+    /// The name of this entry.
+    #[prost(string, optional, tag = "2")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
 }
 impl ::prost::Name for EntryDetailsUpdate {

--- a/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.catalog.v1alpha1.rs
@@ -57,6 +57,41 @@ impl ::prost::Name for DeleteEntryResponse {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateEntryRequest {
+    /// The entry to modify.
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
+    /// The new values for updatable fields.
+    #[prost(message, optional, tag = "2")]
+    pub entry_details_update: ::core::option::Option<EntryDetailsUpdate>,
+}
+impl ::prost::Name for UpdateEntryRequest {
+    const NAME: &'static str = "UpdateEntryRequest";
+    const PACKAGE: &'static str = "rerun.catalog.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.catalog.v1alpha1.UpdateEntryRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.catalog.v1alpha1.UpdateEntryRequest".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateEntryResponse {
+    /// The updated entry details
+    #[prost(message, optional, tag = "1")]
+    pub entry_details: ::core::option::Option<EntryDetails>,
+}
+impl ::prost::Name for UpdateEntryResponse {
+    const NAME: &'static str = "UpdateEntryResponse";
+    const PACKAGE: &'static str = "rerun.catalog.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.catalog.v1alpha1.UpdateEntryResponse".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.catalog.v1alpha1.UpdateEntryResponse".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateDatasetEntryRequest {
     /// Name of the dataset entry to create.
     ///
@@ -273,6 +308,23 @@ impl ::prost::Name for EntryDetails {
     }
     fn type_url() -> ::prost::alloc::string::String {
         "/rerun.catalog.v1alpha1.EntryDetails".into()
+    }
+}
+/// Updatable fields of an Entry
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EntryDetailsUpdate {
+    /// The new name for this entry (optional - if not provided, name will remain unchanged).
+    #[prost(string, optional, tag = "1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+}
+impl ::prost::Name for EntryDetailsUpdate {
+    const NAME: &'static str = "EntryDetailsUpdate";
+    const PACKAGE: &'static str = "rerun.catalog.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.catalog.v1alpha1.EntryDetailsUpdate".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.catalog.v1alpha1.EntryDetailsUpdate".into()
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -555,6 +607,25 @@ pub mod catalog_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_entry(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateEntryRequest>,
+        ) -> std::result::Result<tonic::Response<super::UpdateEntryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.catalog.v1alpha1.CatalogService/UpdateEntry",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.catalog.v1alpha1.CatalogService",
+                "UpdateEntry",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn create_dataset_entry(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateDatasetEntryRequest>,
@@ -674,6 +745,10 @@ pub mod catalog_service_server {
             &self,
             request: tonic::Request<super::DeleteEntryRequest>,
         ) -> std::result::Result<tonic::Response<super::DeleteEntryResponse>, tonic::Status>;
+        async fn update_entry(
+            &self,
+            request: tonic::Request<super::UpdateEntryRequest>,
+        ) -> std::result::Result<tonic::Response<super::UpdateEntryResponse>, tonic::Status>;
         async fn create_dataset_entry(
             &self,
             request: tonic::Request<super::CreateDatasetEntryRequest>,
@@ -836,6 +911,47 @@ pub mod catalog_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = DeleteEntrySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.catalog.v1alpha1.CatalogService/UpdateEntry" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateEntrySvc<T: CatalogService>(pub Arc<T>);
+                    impl<T: CatalogService> tonic::server::UnaryService<super::UpdateEntryRequest>
+                        for UpdateEntrySvc<T>
+                    {
+                        type Response = super::UpdateEntryResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpdateEntryRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CatalogService>::update_entry(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = UpdateEntrySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -530,6 +530,27 @@ pub mod frontend_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        pub async fn update_entry(
+            &mut self,
+            request: impl tonic::IntoRequest<super::super::super::catalog::v1alpha1::UpdateEntryRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::catalog::v1alpha1::UpdateEntryResponse>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.frontend.v1alpha1.FrontendService/UpdateEntry",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.frontend.v1alpha1.FrontendService",
+                "UpdateEntry",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn create_dataset_entry(
             &mut self,
             request: impl tonic::IntoRequest<
@@ -1092,6 +1113,13 @@ pub mod frontend_service_server {
             tonic::Response<super::super::super::catalog::v1alpha1::DeleteEntryResponse>,
             tonic::Status,
         >;
+        async fn update_entry(
+            &self,
+            request: tonic::Request<super::super::super::catalog::v1alpha1::UpdateEntryRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::super::super::catalog::v1alpha1::UpdateEntryResponse>,
+            tonic::Status,
+        >;
         async fn create_dataset_entry(
             &self,
             request: tonic::Request<
@@ -1518,6 +1546,51 @@ pub mod frontend_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = DeleteEntrySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.frontend.v1alpha1.FrontendService/UpdateEntry" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateEntrySvc<T: FrontendService>(pub Arc<T>);
+                    impl<T: FrontendService>
+                        tonic::server::UnaryService<
+                            super::super::super::catalog::v1alpha1::UpdateEntryRequest,
+                        > for UpdateEntrySvc<T>
+                    {
+                        type Response = super::super::super::catalog::v1alpha1::UpdateEntryResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::super::super::catalog::v1alpha1::UpdateEntryRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as FrontendService>::update_entry(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = UpdateEntrySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(


### PR DESCRIPTION
### Related
- https://github.com/rerun-io/dataplatform/issues/1102

### What

Just basic grpc scaffolding.
Also noticed a missing serde dep on `url` that was causing `cargo check -p re_protos` to fail.
