### PR TITLE
Add arrow data inspector in seleciton panel

### DIFF
--- a/crates/viewer/re_ui/data/dark_theme.ron
+++ b/crates/viewer/re_ui/data/dark_theme.ron
@@ -269,6 +269,16 @@
     "list_item_collapse_default": {
       "color": "{Gray.700}"
     },
+
+    "code_index": {
+      "color": "#D176BF"
+    },
+    "code_number": {
+      "color": "#4ACB94"
+    },
+    "code_string": {
+      "color": "#818EF8"
+    },
   },
 
   "alert_success": {

--- a/crates/viewer/re_ui/data/light_theme.ron
+++ b/crates/viewer/re_ui/data/light_theme.ron
@@ -268,6 +268,16 @@
     "list_item_collapse_default": {
       "color": "{Gray.250}"
     },
+
+    "code_index": {
+      "color": "#BF68AF"
+    },
+    "code_number": {
+      "color": "#32AA79"
+    },
+    "code_string": {
+      "color": "#7782EA"
+    },
   },
 
   "alert_success": {

--- a/crates/viewer/re_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_ui/src/arrow_ui.rs
@@ -523,12 +523,7 @@ impl<'a> ArrowNode<'a> {
     }
 }
 
-fn list_item_ranges(
-    ui: &mut Ui,
-    range: Range<usize>,
-    range_detail_fn: &mut dyn FnMut(&Ui, Range<usize>) -> LayoutJob,
-    item_fn: &mut dyn FnMut(&mut Ui, usize),
-) {
+fn list_item_ranges(ui: &mut Ui, range: Range<usize>, item_fn: &mut dyn FnMut(&mut Ui, usize)) {
     let range_len = range.len();
 
     const RANGE_SIZE: usize = 100;

--- a/crates/viewer/re_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_ui/src/arrow_ui.rs
@@ -1,3 +1,5 @@
+use crate::list_item::{LabelContent, PropertyContent, list_item_scope};
+use crate::{UiExt, UiLayout};
 use arrow::array::AsArray;
 use arrow::{
     array::{Array, StructArray},
@@ -5,14 +7,12 @@ use arrow::{
     error::ArrowError,
     util::display::{ArrayFormatter, FormatOptions},
 };
-use egui::{Id, Response, Ui, Widget, WidgetText};
+use eframe::epaint::StrokeKind;
+use egui::{Frame, Id, Response, RichText, Stroke, Ui, Widget, WidgetText};
 use itertools::Itertools as _;
 use re_arrow_util::ArrowArrayDowncastRef as _;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-
-use crate::list_item::{LabelContent, PropertyContent, list_item_scope};
-use crate::{UiExt, UiLayout};
 
 pub fn arrow_ui(ui: &mut egui::Ui, ui_layout: UiLayout, array: &dyn arrow::array::Array) {
     re_tracing::profile_function!();
@@ -378,8 +378,15 @@ impl<'a> ArrowNode<'a> {
                             ui.monospace(value);
                         },
                         |ui| {
+                            let visuals = visuals;
                             if visuals.hovered {
-                                ui.weak(data_type_name);
+                                let response = ui.small(RichText::new(data_type_name).strong());
+                                ui.painter().rect_stroke(
+                                    response.rect.expand(2.0),
+                                    4.0,
+                                    Stroke::new(1.0, visuals.text_color()),
+                                    StrokeKind::Middle,
+                                );
                             }
                         },
                     );

--- a/crates/viewer/re_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_ui/src/arrow_ui.rs
@@ -264,8 +264,8 @@ fn array_item_ui<'a>(array: &'a dyn Array, index: usize) -> ArrowNode<'a> {
 
     let mut node = ArrowNode::new(value, array.data_type());
 
-    if let Some(struct_array) = array.as_struct_opt() {
-        node = node.with_children(move |ui| {
+    node = if let Some(struct_array) = array.as_struct_opt() {
+        node.with_children(move |ui| {
             for column_name in struct_array.column_names() {
                 let column = struct_array
                     .column_by_name(column_name)
@@ -274,24 +274,24 @@ fn array_item_ui<'a>(array: &'a dyn Array, index: usize) -> ArrowNode<'a> {
                 let node = array_item_ui(column.as_ref(), index);
                 node.ui(ui, column_name);
             }
-        });
+        })
     } else if let Some(list) = array.as_list_opt::<i32>() {
-        node = node.with_children(move |ui| {
+        node.with_children(move |ui| {
             let value = list.value(index);
             array_items_ui(ui, &value);
-        });
+        })
     } else if let Some(list) = array.as_list_opt::<i64>() {
-        node = node.with_children(move |ui| {
+        node.with_children(move |ui| {
             let value = list.value(index);
             array_items_ui(ui, &value);
-        });
+        })
     } else if let Some(list_array) = array.as_fixed_size_list_opt() {
-        node = node.with_children(move |ui| {
+        node.with_children(move |ui| {
             let value = list_array.value(index);
             array_items_ui(ui, &value);
-        });
+        })
     } else if let Some(dict_array) = array.as_any_dictionary_opt() {
-        node = node.with_children(move |ui| {
+        node.with_children(move |ui| {
             if !dict_array.keys().data_type().is_nested() {
                 let formatter = make_formatter(dict_array.keys())
                     .expect("Formatter should be created for dictionary keys");
@@ -304,9 +304,9 @@ fn array_item_ui<'a>(array: &'a dyn Array, index: usize) -> ArrowNode<'a> {
                 key_node.ui(ui, "key");
                 value_node.ui(ui, "value");
             }
-        });
+        })
     } else if let Some(map_array) = array.as_map_opt() {
-        node = node.with_children(move |ui| {
+        node.with_children(move |ui| {
             if !map_array.keys().data_type().is_nested() {
                 let formatter = make_formatter(map_array.keys())
                     .expect("Formatter should be created for map keys");
@@ -319,13 +319,15 @@ fn array_item_ui<'a>(array: &'a dyn Array, index: usize) -> ArrowNode<'a> {
                 key_node.ui(ui, "key");
                 value_node.ui(ui, "value");
             }
-        });
+        })
     } else if let Some(union_array) = array.as_union_opt() {
         let variant_index = union_array.type_id(index);
         let child = union_array.child(variant_index);
         let node = array_item_ui(child, index);
-        return node;
-    }
+        node
+    } else {
+        node
+    };
 
     node
 }

--- a/crates/viewer/re_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_ui/src/arrow_ui.rs
@@ -412,17 +412,15 @@ impl<'a> ArrowNode<'a> {
             };
 
             let data_type: &DataType = self.array.as_ref().data_type();
-            let format = if data_type.is_primitive() {
-                Self::text_format_number(ui)
-            } else {
-                Self::text_format_string(ui)
-            };
-            if matches!(
+            let format = if matches!(
                 data_type,
                 DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
             ) {
                 value = format!("\"{value}\"");
-            }
+                Self::text_format_string(ui)
+            } else {
+                Self::text_format_number(ui)
+            };
             job.append(&value, 0.0, format);
         }
     }

--- a/crates/viewer/re_ui/src/arrow_ui/child_nodes.rs
+++ b/crates/viewer/re_ui/src/arrow_ui/child_nodes.rs
@@ -1,0 +1,148 @@
+use arrow::array::{Array, StructArray, UnionArray};
+use arrow::datatypes::DataType;
+use egui::Ui;
+use std::sync::Arc;
+
+/// Iterator over child nodes of an Arrow array.
+///
+/// For some kinds, this will hold a reference to the parent array and an index.
+/// For others (lists), it will hold a reference to the child array.
+pub enum ChildNodes<'a> {
+    List(Arc<dyn Array>),
+    Struct {
+        parent_index: usize,
+        array: &'a StructArray,
+    },
+    /// Map where the key is shown as the node name
+    InlineKeyMap {
+        keys: MaybeArc<'a>,
+        values: MaybeArc<'a>,
+        parent_index: usize,
+    },
+    /// Map where key and value are shown as separate nodes
+    Map {
+        keys: MaybeArc<'a>,
+        values: MaybeArc<'a>,
+        parent_index: usize,
+    },
+    Union {
+        array: &'a UnionArray,
+        parent_index: usize,
+    },
+}
+
+impl<'a> ChildNodes<'a> {
+    pub fn len(&self) -> usize {
+        match self {
+            ChildNodes::List(array) => array.len(),
+            ChildNodes::Struct {
+                parent_index: _,
+                array,
+            } => array.num_columns(),
+            ChildNodes::InlineKeyMap { .. } => 2, // TODO: Implement inline thingy
+            ChildNodes::Map { .. } => 2,
+            ChildNodes::Union {
+                array: union_array,
+                parent_index: _,
+            } => 1,
+        }
+    }
+
+    /// Ui is needed to style the name of InlineKeyMap nodes
+    fn get_child(&self, index: usize) -> crate::arrow_ui::ArrowNode<'a> {
+        assert!(index < self.len(), "Index out of bounds: {}", index);
+        match self {
+            ChildNodes::List(list) => crate::arrow_ui::ArrowNode::new(list.clone(), index),
+            ChildNodes::Struct {
+                parent_index: struct_index,
+                array,
+            } => {
+                let column = array.column(index);
+                let name = array.column_names()[index];
+                crate::arrow_ui::ArrowNode::new(&**column, *struct_index).with_field_name(name)
+            }
+            ChildNodes::InlineKeyMap {
+                keys,
+                values,
+                parent_index,
+            } => {
+                // TODO: Implement inline node
+                // let key_node = crate::arrow_ui::ArrowNode::new(keys.clone(), *parent_index);
+                // let key_job = key_node.layout_job(ui);
+                // crate::arrow_ui::ArrowNode::new(values.clone(), *parent_index)
+                //     .with_field_name(key_job)
+
+                if index == 0 {
+                    crate::arrow_ui::ArrowNode::new(keys.clone(), *parent_index)
+                } else {
+                    crate::arrow_ui::ArrowNode::new(values.clone(), *parent_index)
+                }
+            }
+            ChildNodes::Map {
+                keys,
+                values,
+                parent_index,
+            } => {
+                if index == 0 {
+                    crate::arrow_ui::ArrowNode::new(keys.clone(), *parent_index)
+                } else {
+                    crate::arrow_ui::ArrowNode::new(values.clone(), *parent_index)
+                }
+            }
+            ChildNodes::Union {
+                array: union_array,
+                parent_index,
+            } => {
+                let variant_index = union_array.type_id(*parent_index);
+                let child = union_array.child(variant_index);
+                let names = union_array.type_names();
+                let variant_name = names
+                    .get(variant_index as usize)
+                    .expect("Variant index should be valid");
+                crate::arrow_ui::ArrowNode::new(child.clone(), *parent_index)
+                    .with_field_name(variant_name.clone())
+            }
+        }
+    }
+
+    pub fn iter<'b>(&'b self) -> impl NodeIterator<'b> {
+        (0..self.len()).map(move |index| self.get_child(index))
+    }
+}
+
+pub trait NodeIterator<'a>:
+    Iterator<Item = crate::arrow_ui::ArrowNode<'a>> + ExactSizeIterator
+{
+}
+
+impl<'a, I: Iterator<Item = crate::arrow_ui::ArrowNode<'a>> + ExactSizeIterator> NodeIterator<'a>
+    for I
+{
+}
+
+#[derive(Debug, Clone)]
+pub enum MaybeArc<'a> {
+    Array(&'a dyn Array),
+    Arc(arrow::array::ArrayRef),
+}
+
+impl MaybeArc<'_> {
+    pub fn as_ref(&self) -> &dyn Array {
+        match self {
+            MaybeArc::Array(array) => *array,
+            MaybeArc::Arc(arc) => arc.as_ref(),
+        }
+    }
+}
+
+impl<'a> From<&'a dyn Array> for MaybeArc<'a> {
+    fn from(array: &'a dyn Array) -> Self {
+        MaybeArc::Array(array)
+    }
+}
+
+impl<'a> From<arrow::array::ArrayRef> for MaybeArc<'a> {
+    fn from(array: arrow::array::ArrayRef) -> Self {
+        MaybeArc::Arc(array)
+    }
+}

--- a/crates/viewer/re_ui/src/arrow_ui/child_nodes.rs
+++ b/crates/viewer/re_ui/src/arrow_ui/child_nodes.rs
@@ -74,8 +74,10 @@ impl<'a> ChildNodes<'a> {
 
                 if index == 0 {
                     crate::arrow_ui::ArrowNode::new(keys.clone(), *parent_index)
+                        .with_field_name("key")
                 } else {
                     crate::arrow_ui::ArrowNode::new(values.clone(), *parent_index)
+                        .with_field_name("value")
                 }
             }
             ChildNodes::Map {
@@ -85,8 +87,10 @@ impl<'a> ChildNodes<'a> {
             } => {
                 if index == 0 {
                     crate::arrow_ui::ArrowNode::new(keys.clone(), *parent_index)
+                        .with_field_name("key")
                 } else {
                     crate::arrow_ui::ArrowNode::new(values.clone(), *parent_index)
+                        .with_field_name("value")
                 }
             }
             ChildNodes::Union {

--- a/crates/viewer/re_ui/src/arrow_ui/child_nodes.rs
+++ b/crates/viewer/re_ui/src/arrow_ui/child_nodes.rs
@@ -49,7 +49,7 @@ impl<'a> ChildNodes<'a> {
     }
 
     /// Ui is needed to style the name of InlineKeyMap nodes
-    fn get_child(&self, index: usize) -> crate::arrow_ui::ArrowNode<'a> {
+    pub fn get_child(&self, index: usize) -> crate::arrow_ui::ArrowNode<'a> {
         assert!(index < self.len(), "Index out of bounds: {}", index);
         match self {
             ChildNodes::List(list) => crate::arrow_ui::ArrowNode::new(list.clone(), index),

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -208,6 +208,10 @@ pub struct DesignTokens {
     pub list_item_hovered_bg: Color32,
     pub list_item_active_bg: Color32,
     pub list_item_collapse_default: Color32,
+
+    pub code_index: Color32,
+    pub code_string: Color32,
+    pub code_number: Color32,
 }
 
 impl DesignTokens {
@@ -341,6 +345,10 @@ impl DesignTokens {
             list_item_hovered_bg: get_color("list_item_hovered_bg"),
             list_item_active_bg: get_color("list_item_active_bg"),
             list_item_collapse_default: get_color("list_item_collapse_default"),
+
+            code_index: get_color("code_index"),
+            code_string: get_color("code_string"),
+            code_number: get_color("code_number"),
         })
     }
 

--- a/crates/viewer/re_ui/src/list_item/list_item.rs
+++ b/crates/viewer/re_ui/src/list_item/list_item.rs
@@ -82,6 +82,7 @@ pub struct ListVisuals {
     pub active: bool,
     pub interactive: bool,
     pub strong: bool,
+    pub openness: Option<f32>,
 }
 
 impl ListVisuals {
@@ -157,6 +158,32 @@ impl ListVisuals {
         } else {
             self.interactive_icon_tint(icon_hovered)
         }
+    }
+
+    /// Is the item collapsible?
+    pub fn is_collapsible(&self) -> bool {
+        self.openness.is_some()
+    }
+
+    /// Is the item fully collapsed?
+    ///
+    /// Returns true if the item is not collapsible.
+    pub fn collapsed(&self) -> bool {
+        self.openness.is_none_or(|openness| openness <= 0.0)
+    }
+
+    /// Is the item fully opened?
+    ///
+    /// Returns false if the item is not collapsible.
+    pub fn opened(&self) -> bool {
+        !self.collapsed()
+    }
+
+    /// Openness of the item.
+    ///
+    /// 0.0 if the item is not collapsible.
+    pub fn openness(&self) -> f32 {
+        self.openness.unwrap_or(0.0)
     }
 }
 
@@ -500,6 +527,7 @@ impl ListItem {
             active,
             interactive,
             strong: false,
+            openness: collapse_openness,
         };
 
         let mut collapse_response = None;


### PR DESCRIPTION
### Related

* closes https://github.com/rerun-io/rerun/issues/10750

### What

Instead of formatting arrow data as a String and displaying that, this adds an interactive arrow data explorer:

https://github.com/user-attachments/assets/84265daf-e829-4cb3-96cc-bf24bf581a0c

It's still usable if data is rapidly changing:
https://github.com/user-attachments/assets/4b604967-c7f5-472f-8262-a1ca7fbfd121

And it even handles large arrays:
https://github.com/user-attachments/assets/3487d7b6-4077-415f-9ab0-c5863c2c93e8


