### PR TITLE
Add some analytics events

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -169,4 +169,6 @@ extend-ignore-re = [
   "thrEEone", # Used in a test
 
   "notify_seeked", # Used in the `mcap` crate.
+
+  "muh_scalars", # Weird name introduced in `crates/viewer/re_view_time_series/tests/basic.rs` introduced in https://github.com/rerun-io/rerun/pull/10713
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8463,6 +8463,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "rand 0.8.5",
+ "re_analytics",
  "re_arrow_util",
  "re_build_tools",
  "re_entity_db",

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -35,7 +35,7 @@ default = [
   "server",
 ]
 
-## Enable telemetry using our analytics SDK.
+## Enable anonymized telemetry using our analytics SDK.
 analytics = [
   "dep:re_analytics",
   "re_crash_handler?/analytics",

--- a/crates/utils/re_analytics/src/event.rs
+++ b/crates/utils/re_analytics/src/event.rs
@@ -348,6 +348,25 @@ impl Properties for CrashSignal {
     }
 }
 
+// -----------------------------------------------
+
+/// Sent the first time a `?` help button is clicked.
+///
+/// Is used to track how many users find the help button.
+pub struct HelpButtonFirstClicked {}
+
+impl Event for HelpButtonFirstClicked {
+    const NAME: &'static str = "crash-signal";
+}
+
+impl Properties for HelpButtonFirstClicked {
+    fn serialize(self, _event: &mut AnalyticsEvent) {
+        let Self {} = self;
+    }
+}
+
+// -----------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/utils/re_analytics/src/event.rs
+++ b/crates/utils/re_analytics/src/event.rs
@@ -356,7 +356,7 @@ impl Properties for CrashSignal {
 pub struct HelpButtonFirstClicked {}
 
 impl Event for HelpButtonFirstClicked {
-    const NAME: &'static str = "crash-signal";
+    const NAME: &'static str = "help-button-clicked";
 }
 
 impl Properties for HelpButtonFirstClicked {

--- a/crates/utils/re_analytics/src/event.rs
+++ b/crates/utils/re_analytics/src/event.rs
@@ -80,6 +80,8 @@ pub struct ViewerRuntimeInformation {
     /// it's too detailed (could be used for fingerprinting which we don't want) and not as useful
     /// anyways since it's hard to learn about the typically identified capabilities.
     pub re_renderer_device_tier: String,
+
+    pub screen_info: ScreenInfo,
 }
 
 impl Properties for ViewerRuntimeInformation {
@@ -89,14 +91,50 @@ impl Properties for ViewerRuntimeInformation {
             is_wsl,
             graphics_adapter_backend,
             re_renderer_device_tier,
+            screen_info,
         } = self;
 
         event.insert("is_docker", is_docker);
         event.insert("is_wsl", is_wsl);
         event.insert("graphics_adapter_backend", graphics_adapter_backend);
         event.insert("re_renderer_device_tier", re_renderer_device_tier);
+        screen_info.serialize(event);
     }
 }
+
+// -----------------------------------------------
+
+/// Information about the user's monitor.
+pub struct ScreenInfo {
+    //// zoom_factor * native_pixels_per_point
+    ///
+    /// Is it usually 1.0 or 2.0, but could be anything.
+    pub pixels_per_point: f32,
+
+    /// OS pixel density
+    pub native_pixels_per_point: Option<f32>,
+
+    /// Chosen zoom, with cmd +/-.
+    ///
+    /// Default is 1.0, but the user can change it.
+    pub zoom_factor: f32,
+}
+
+impl Properties for ScreenInfo {
+    fn serialize(self, event: &mut AnalyticsEvent) {
+        let Self {
+            pixels_per_point,
+            native_pixels_per_point,
+            zoom_factor,
+        } = self;
+
+        event.insert("pixels_per_point", pixels_per_point);
+        event.insert_opt("native_pixels_per_point", native_pixels_per_point);
+        event.insert("zoom_factor", zoom_factor);
+    }
+}
+
+// -----------------------------------------------
 
 /// Sent when a new recording is opened.
 ///

--- a/crates/utils/re_analytics/src/event.rs
+++ b/crates/utils/re_analytics/src/event.rs
@@ -367,6 +367,21 @@ impl Properties for HelpButtonFirstClicked {
 
 // -----------------------------------------------
 
+/// The user opened the settings screen.
+pub struct SettingsOpened {}
+
+impl Event for SettingsOpened {
+    const NAME: &'static str = "settings-opened";
+}
+
+impl Properties for SettingsOpened {
+    fn serialize(self, _event: &mut AnalyticsEvent) {
+        let Self {} = self;
+    }
+}
+
+// -----------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/utils/re_analytics/src/lib.rs
+++ b/crates/utils/re_analytics/src/lib.rs
@@ -149,6 +149,13 @@ impl From<i64> for Property {
     }
 }
 
+impl From<f32> for Property {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self::Float(value as _)
+    }
+}
+
 impl From<f64> for Property {
     #[inline]
     fn from(value: f64) -> Self {

--- a/crates/viewer/re_ui/Cargo.toml
+++ b/crates/viewer/re_ui/Cargo.toml
@@ -39,10 +39,10 @@ arrow = ["dep:arrow"]
 [dependencies]
 re_analytics = { workspace = true, optional = true }
 re_arrow_util.workspace = true
-re_entity_db.workspace = true  # syntax-highlighting for InstancePath. TODO(emilk): move InstancePath
+re_entity_db.workspace = true                        # syntax-highlighting for InstancePath. TODO(emilk): move InstancePath
 re_format.workspace = true
 re_log.workspace = true
-re_log_types.workspace = true  # syntax-highlighting for EntityPath
+re_log_types.workspace = true                        # syntax-highlighting for EntityPath
 re_tracing.workspace = true
 
 ahash.workspace = true

--- a/crates/viewer/re_ui/Cargo.toml
+++ b/crates/viewer/re_ui/Cargo.toml
@@ -29,11 +29,15 @@ all-features = true
 [features]
 default = []
 
+## Enable anonymized telemetry using our analytics SDK.
+analytics = ["dep:re_analytics"]
+
 ## UI for arrow data
 arrow = ["dep:arrow"]
 
 
 [dependencies]
+re_analytics = { workspace = true, optional = true }
 re_arrow_util.workspace = true
 re_entity_db.workspace = true  # syntax-highlighting for InstancePath. TODO(emilk): move InstancePath
 re_format.workspace = true

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -1040,6 +1040,11 @@ pub trait UiExt {
                             ui.data_mut(|d| {
                                 d.insert_persisted(has_shown_help_id, true);
                             });
+
+                            #[cfg(feature = "analytics")]
+                            if let Some(analytics) = re_analytics::Analytics::global_or_init() {
+                                analytics.record(re_analytics::event::HelpButtonFirstClicked {});
+                            }
                         }
                     }
                 })

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -36,8 +36,8 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["analytics", "map_view"]
 
-## Enable telemetry using our analytics SDK.
-analytics = ["dep:re_analytics"]
+## Enable anonymized telemetry using our analytics SDK.
+analytics = ["dep:re_analytics", "re_ui/analytics"]
 
 ## Enable the map view
 map_view = ["dep:re_view_map"]

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1087,6 +1087,11 @@ impl App {
 
             UICommand::Settings => {
                 self.state.navigation.push(DisplayMode::Settings);
+
+                #[cfg(feature = "analytics")]
+                if let Some(analytics) = re_analytics::Analytics::global_or_init() {
+                    analytics.record(re_analytics::event::SettingsOpened {});
+                }
             }
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -296,7 +296,12 @@ impl App {
                 )
             },
         );
-        analytics.on_viewer_started(build_info.clone(), adapter_backend, device_tier);
+        analytics.on_viewer_started(
+            build_info.clone(),
+            &creation_context.egui_ctx,
+            adapter_backend,
+            device_tier,
+        );
 
         let panel_state_overrides = startup_options.panel_state_overrides;
 

--- a/crates/viewer/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/event.rs
@@ -34,9 +34,20 @@ pub fn identify(
 
 pub fn viewer_started(
     app_env: &AppEnvironment,
+    egui_ctx: &egui::Context,
     adapter_backend: wgpu::Backend,
     device_tier: re_renderer::device_caps::DeviceCapabilityTier,
 ) -> ViewerStarted {
+    // Note that some of these things can change at runtime,
+    // but we send them only once at startup.
+    // This means if the user changes the zoom factor we won't send it
+    // until the next restart.
+    let screen_info = re_analytics::event::ScreenInfo {
+        pixels_per_point: egui_ctx.pixels_per_point(),
+        native_pixels_per_point: egui_ctx.native_pixels_per_point(),
+        zoom_factor: egui_ctx.zoom_factor(),
+    };
+
     ViewerStarted {
         url: app_env.url().cloned(),
         app_env: app_env.name(),
@@ -45,6 +56,7 @@ pub fn viewer_started(
             is_wsl: super::wsl::is_wsl(),
             graphics_adapter_backend: adapter_backend.to_string(),
             re_renderer_device_tier: device_tier.to_string(),
+            screen_info,
         },
     }
 }

--- a/crates/viewer/re_viewer/src/viewer_analytics/mod.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/mod.rs
@@ -51,6 +51,7 @@ impl ViewerAnalytics {
     pub fn on_viewer_started(
         &self,
         build_info: re_build_info::BuildInfo,
+        egui_ctx: &egui::Context,
         adapter_backend: wgpu::Backend,
         device_tier: re_renderer::device_caps::DeviceCapabilityTier,
     ) {
@@ -69,6 +70,7 @@ impl ViewerAnalytics {
             ));
             analytics.record(event::viewer_started(
                 &self.app_env,
+                egui_ctx,
                 adapter_backend,
                 device_tier,
             ));

--- a/crates/viewer/re_web_viewer_server/Cargo.toml
+++ b/crates/viewer/re_web_viewer_server/Cargo.toml
@@ -46,7 +46,7 @@ all-features = true
 ## CI without propagating the `__ci` feature throughout the entire set of crates that depend on it.
 __ci = []
 
-## Enable telemetry using our analytics SDK.
+## Enable anonymized telemetry using our analytics SDK.
 analytics = ["dep:re_analytics"]
 
 [dependencies]


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/10597

### What

### Send an analytics event the first time the user clicks an help button.

Why? Because we've discovered in user interviews that a lot of people don't know how to use the viewer, because they never clicked the `?` question marks that we've scattered around. We've made them a bit more obvious now, but we still don't know if everyone finds them.

### Send analytics when the user enters settings
How many users know we have a settings screen?

### Send analytics about screen scaling
Collect the native pixel ratio and zoom level to figure out if it is worth designing Rerun for low-DPI screens