### PR TITLE
Add support for layers to the python registration APIs

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1367,7 +1367,7 @@ class DatasetEntry(Entry):
         Parameters
         ----------
         recording_uri: str
-            The URI of the RRD to register
+            The URI of the RRD to register.
 
         recording_layer: str
             The layer to which the recording will be registered to.
@@ -1392,7 +1392,7 @@ class DatasetEntry(Entry):
         Parameters
         ----------
         recording_uris: list[str]
-            The URIs of the RRDs to register
+            The URIs of the RRDs to register.
 
         recording_layers: list[str]
             The layers to which the recordings will be registered to:

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1357,7 +1357,7 @@ class DatasetEntry(Entry):
 
         """
 
-    def register(self, recording_uri: str, recording_layer: str = "base", timeout_secs: int = 60) -> str:
+    def register(self, recording_uri: str, *, recording_layer: str = "base", timeout_secs: int = 60) -> str:
         """
         Register a RRD URI to the dataset and wait for completion.
 
@@ -1382,7 +1382,7 @@ class DatasetEntry(Entry):
 
         """
 
-    def register_batch(self, recording_uris: list[str], recording_layers: list[str] = []) -> Tasks:
+    def register_batch(self, recording_uris: list[str], *, recording_layers: list[str] = []) -> Tasks:
         """
         Register a batch of RRD URIs to the dataset and return a handle to the tasks.
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1357,7 +1357,7 @@ class DatasetEntry(Entry):
 
         """
 
-    def register(self, recording_uri: str, timeout_secs: int = 60) -> str:
+    def register(self, recording_uri: str, recording_layer: str = "base", timeout_secs: int = 60) -> str:
         """
         Register a RRD URI to the dataset and wait for completion.
 
@@ -1369,6 +1369,9 @@ class DatasetEntry(Entry):
         recording_uri: str
             The URI of the RRD to register
 
+        recording_layer: str
+            The layer to which the recording will be registered to.
+
         timeout_secs: int
             The timeout after which this method raises a `TimeoutError` if the task is not completed.
 
@@ -1379,7 +1382,7 @@ class DatasetEntry(Entry):
 
         """
 
-    def register_batch(self, recording_uris: list[str]) -> Tasks:
+    def register_batch(self, recording_uris: list[str], recording_layers: list[str] = []) -> Tasks:
         """
         Register a batch of RRD URIs to the dataset and return a handle to the tasks.
 
@@ -1390,6 +1393,13 @@ class DatasetEntry(Entry):
         ----------
         recording_uris: list[str]
             The URIs of the RRDs to register
+
+        recording_layers: list[str]
+            The layers to which the recordings will be registered to:
+            * When empty, this defaults to `["base"]`.
+            * If longer than `recording_uris`, `recording_layers` will be truncated.
+            * If shorter than `recording_uris`, `recording_layers` will be extended by repeating its last value.
+              I.e. an empty `recording_layers` will result in `"base"` begin repeated `len(recording_layers)` times.
 
         """
 

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -252,7 +252,7 @@ impl PyDatasetEntry {
     /// Parameters
     /// ----------
     /// recording_uri: str
-    ///     The URI of the RRD to register
+    ///     The URI of the RRD to register.
     ///
     /// timeout_secs: int
     ///     The timeout after which this method raises a `TimeoutError` if the task is not completed.
@@ -263,6 +263,9 @@ impl PyDatasetEntry {
     ///     The partition ID of the registered RRD.
     ///
     #[pyo3(signature = (recording_uri, recording_layer = "base".to_owned(), timeout_secs = 60))]
+    #[pyo3(
+        text_signature = "(self, recording_uri: str, recording_layer: str = 'base', timeout_secs: int = 60)"
+    )]
     fn register(
         self_: PyRef<'_, Self>,
         recording_uri: String,
@@ -309,6 +312,11 @@ impl PyDatasetEntry {
     ///     * If shorter than `recording_uris`, `recording_layers` will be extended by repeating its last value.
     ///       I.e. an empty `recording_layers` will result in `"base"` begin repeated `len(recording_layers)` times.
     #[allow(rustdoc::broken_intra_doc_links)]
+    #[pyo3(signature = (
+        recording_uris,
+        recording_layers = vec![],
+    ))]
+    #[pyo3(text_signature = "(self, recording_uris: list[str], recording_layers: list[str] = [])")]
     // TODO(ab): it might be useful to return partition ids directly since we have them
     fn register_batch(
         self_: PyRef<'_, Self>,

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -254,6 +254,9 @@ impl PyDatasetEntry {
     /// recording_uri: str
     ///     The URI of the RRD to register.
     ///
+    /// recording_layer: str
+    ///     The layer to which the recording will be registered to.
+    ///
     /// timeout_secs: int
     ///     The timeout after which this method raises a `TimeoutError` if the task is not completed.
     ///
@@ -261,7 +264,6 @@ impl PyDatasetEntry {
     /// -------
     /// partition_id: str
     ///     The partition ID of the registered RRD.
-    ///
     #[pyo3(signature = (recording_uri, *, recording_layer = "base".to_owned(), timeout_secs = 60))]
     #[pyo3(
         text_signature = "(self, recording_uri: str, *, recording_layer: str = 'base', timeout_secs: int = 60)"

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -262,10 +262,11 @@ impl PyDatasetEntry {
     /// partition_id: str
     ///     The partition ID of the registered RRD.
     ///
-    #[pyo3(signature = (recording_uri, timeout_secs = 60))]
+    #[pyo3(signature = (recording_uri, recording_layer = "base".to_owned(), timeout_secs = 60))]
     fn register(
         self_: PyRef<'_, Self>,
         recording_uri: String,
+        recording_layer: String,
         timeout_secs: u64,
     ) -> PyResult<String> {
         let register_timeout = std::time::Duration::from_secs(timeout_secs);
@@ -273,8 +274,12 @@ impl PyDatasetEntry {
         let connection = super_.client.borrow(self_.py()).connection().clone();
         let dataset_id = super_.details.id;
 
-        let mut results =
-            connection.register_with_dataset(self_.py(), dataset_id, vec![recording_uri])?;
+        let mut results = connection.register_with_dataset(
+            self_.py(),
+            dataset_id,
+            vec![recording_uri],
+            vec![recording_layer],
+        )?;
 
         let Some(task_descriptor) = results.pop() else {
             return Err(PyRuntimeError::new_err(
@@ -295,15 +300,31 @@ impl PyDatasetEntry {
     /// Parameters
     /// ----------
     /// recording_uris: list[str]
-    ///     The URIs of the RRDs to register
+    ///     The URIs of the RRDs to register.
+    ///
+    /// recording_layers: list[str]
+    ///     The layers to which the recordings will be registered to:
+    ///     * When empty, this defaults to `["base"]`.
+    ///     * If longer than `recording_uris`, `recording_layers` will be truncated.
+    ///     * If shorter than `recording_uris`, `recording_layers` will be extended by repeating its last value.
+    ///       I.e. an empty `recording_layers` will result in `"base"` begin repeated `len(recording_layers)` times.
     #[allow(rustdoc::broken_intra_doc_links)]
     // TODO(ab): it might be useful to return partition ids directly since we have them
-    fn register_batch(self_: PyRef<'_, Self>, recording_uris: Vec<String>) -> PyResult<PyTasks> {
+    fn register_batch(
+        self_: PyRef<'_, Self>,
+        recording_uris: Vec<String>,
+        recording_layers: Vec<String>,
+    ) -> PyResult<PyTasks> {
         let super_ = self_.as_super();
         let connection = super_.client.borrow(self_.py()).connection().clone();
         let dataset_id = super_.details.id;
 
-        let results = connection.register_with_dataset(self_.py(), dataset_id, recording_uris)?;
+        let results = connection.register_with_dataset(
+            self_.py(),
+            dataset_id,
+            recording_uris,
+            recording_layers,
+        )?;
 
         Ok(PyTasks::new(
             super_.client.clone_ref(self_.py()),

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -262,9 +262,9 @@ impl PyDatasetEntry {
     /// partition_id: str
     ///     The partition ID of the registered RRD.
     ///
-    #[pyo3(signature = (recording_uri, recording_layer = "base".to_owned(), timeout_secs = 60))]
+    #[pyo3(signature = (recording_uri, *, recording_layer = "base".to_owned(), timeout_secs = 60))]
     #[pyo3(
-        text_signature = "(self, recording_uri: str, recording_layer: str = 'base', timeout_secs: int = 60)"
+        text_signature = "(self, recording_uri: str, *, recording_layer: str = 'base', timeout_secs: int = 60)"
     )]
     fn register(
         self_: PyRef<'_, Self>,
@@ -314,9 +314,12 @@ impl PyDatasetEntry {
     #[allow(rustdoc::broken_intra_doc_links)]
     #[pyo3(signature = (
         recording_uris,
+        *,
         recording_layers = vec![],
     ))]
-    #[pyo3(text_signature = "(self, recording_uris: list[str], recording_layers: list[str] = [])")]
+    #[pyo3(
+        text_signature = "(self, recording_uris: list[str], *, recording_layers: list[str] = [])"
+    )]
     // TODO(ab): it might be useful to return partition ids directly since we have them
     fn register_batch(
         self_: PyRef<'_, Self>,

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -266,7 +266,7 @@ impl PyDatasetEntry {
     ///     The partition ID of the registered RRD.
     #[pyo3(signature = (recording_uri, *, recording_layer = "base".to_owned(), timeout_secs = 60))]
     #[pyo3(
-        text_signature = "(self, recording_uri: str, *, recording_layer: str = 'base', timeout_secs: int = 60)"
+        text_signature = "(self, /, recording_uri, *, recording_layer = 'base', timeout_secs = 60)"
     )]
     fn register(
         self_: PyRef<'_, Self>,
@@ -319,9 +319,7 @@ impl PyDatasetEntry {
         *,
         recording_layers = vec![],
     ))]
-    #[pyo3(
-        text_signature = "(self, recording_uris: list[str], *, recording_layers: list[str] = [])"
-    )]
+    #[pyo3(text_signature = "(self, /, recording_uris, *, recording_layers = [])")]
     // TODO(ab): it might be useful to return partition ids directly since we have them
     fn register_batch(
         self_: PyRef<'_, Self>,


### PR DESCRIPTION
The gRPC API was already exposed, so this is fairly light.

I went with a clamping-semantics-like approach for the batched registration API, i.e. we will either truncate or extend the list of layers automatically as needed. As I implemented a layer-aware `dataset-util`, this really felt like the most pleasant API to work with.

* Said `dataset-util` implementation: https://github.com/rerun-io/dataplatform/pull/1411