### PR TITLE
Fix GUI hickup when starting native video player

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -169,4 +169,6 @@ extend-ignore-re = [
   "thrEEone", # Used in a test
 
   "notify_seeked", # Used in the `mcap` crate.
+
+  "muh_scalars", # Weird name introduced in `crates/viewer/re_view_time_series/tests/basic.rs` introduced in https://github.com/rerun-io/rerun/pull/10713
 ]

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -304,15 +304,18 @@ impl FFmpegProcessAndListener {
         // no longer receive any new frames or errors from this process.
         let on_output = Arc::new(Mutex::new(Some(on_output)));
 
+        // Reads the output from the ffmpeg process:
         let listen_thread = std::thread::Builder::new()
             .name(format!("ffmpeg-reader for {debug_name}"))
             .spawn({
                 let on_output = on_output.clone();
                 let debug_name = debug_name.to_owned();
+                let ffmpeg_path = ffmpeg_path.map(|p| p.to_owned());
                 let outstanding_frames = num_outstanding_frames.clone();
                 move || {
                     read_ffmpeg_output(
                         &debug_name,
+                        ffmpeg_path.as_deref(),
                         ffmpeg_iterator,
                         &frame_info_rx,
                         &pixel_format,
@@ -324,6 +327,8 @@ impl FFmpegProcessAndListener {
             .expect("Failed to spawn ffmpeg listener thread");
 
         let avcc = encoding_details.as_ref().and_then(|e| e.avcc()).cloned();
+
+        // Writes video data to the ffmpeg process:
         let write_thread = std::thread::Builder::new()
             .name(format!("ffmpeg-writer for {debug_name}"))
             .spawn({
@@ -618,12 +623,21 @@ impl FrameBuffer {
 
 fn read_ffmpeg_output(
     debug_name: &str,
+    ffmpeg_path: Option<&std::path::Path>,
     ffmpeg_iterator: ffmpeg_sidecar::iter::FfmpegIterator,
     frame_info_rx: &Receiver<FFmpegFrameInfo>,
     pixel_format: &PixelFormat,
     outstanding_frames: &AtomicI32,
     on_output: &Mutex<Option<Arc<OutputCallback>>>,
 ) -> Option<()> {
+    // Before we do anything else - make sure the ffmpeg version is compatible:
+    // Ok to block here - we're in a background thread.
+    let ffmpeg_version_result = FFmpegVersion::for_executable_blocking(ffmpeg_path);
+    if let Err(err) = check_ffmpeg_version(ffmpeg_version_result) {
+        (on_output.lock().as_ref()?)(Err(err.into()));
+        return None;
+    }
+
     let mut buffer = FrameBuffer::new();
 
     for event in ffmpeg_iterator {
@@ -832,10 +846,14 @@ impl FFmpegCliH264Decoder {
     ) -> Result<Self, Error> {
         re_tracing::profile_function!();
 
-        // Check the version once ahead of running FFmpeg.
-        // The error is still handled if it happens while running FFmpeg, but it's a bit unclear if we can get it to start in the first place then.
-        let ffmpeg_version_result = FFmpegVersion::for_executable_blocking(ffmpeg_path.as_deref());
-        check_ffmpeg_version(ffmpeg_version_result)?;
+        // Check the version once ahead of running FFmpeg, if we can get it without blocking.
+        // We also check it in a background thread, but getting the error
+        // early is preferable:
+        if let std::task::Poll::Ready(ffmpeg_version_result) =
+            FFmpegVersion::for_executable_poll(ffmpeg_path.as_deref())
+        {
+            check_ffmpeg_version(ffmpeg_version_result)?;
+        }
 
         let on_output = Arc::new(on_output);
         let ffmpeg = FFmpegProcessAndListener::new(

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
@@ -98,7 +98,8 @@ impl FFmpegVersion {
 
     /// Like [`Self::for_executable_poll`], but blocks until the version is ready.
     ///
-    /// WARNING: this blocks for half a second on Mac the first time this is called with a given path, maybe more on other platforms.
+    /// WARNING: this can block for SEVEN SECONDS on Mac, but usually only the first time
+    /// after a reboot. NEVER call this on the GUI thread!
     pub fn for_executable_blocking(path: Option<&std::path::Path>) -> FfmpegVersionResult {
         re_tracing::profile_function!();
 

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
@@ -178,9 +178,10 @@ fn ffmpeg_version(
     // Don't use sidecar's ffmpeg_version_with_path/ffmpeg_version directly since the error message for
     // file not found isn't great and we want this for display in the UI.
 
-    let path = path
-        .cloned()
-        .unwrap_or(ffmpeg_sidecar::paths::ffmpeg_path());
+    let path = path.cloned().unwrap_or_else(|| {
+        re_tracing::profile_scope!("ffmpeg_path");
+        ffmpeg_sidecar::paths::ffmpeg_path()
+    });
     let mut cmd = match std::process::Command::new(&path)
         .arg("-version")
         .stdout(std::process::Stdio::piped()) // not stderr when calling `-version`


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/10789

### What
Starting the ffmpeg executable on a cold boot can take SEVEN SECONDS on Mac. Not sure how - maybe it is dynamically loading a bunch of dynamic libraries, and looking for plugins or something. Anyways - we _really_ don't want to lock up the UI thread for this :)