### PR TITLE
Resolve CPP Arrow Build

### DIFF
--- a/rerun_cpp/download_and_build_arrow.cmake
+++ b/rerun_cpp/download_and_build_arrow.cmake
@@ -69,6 +69,8 @@ function(download_and_build_arrow)
 
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
         # TODO(#10798): Arrow can't support CMake 4.0 yet
+        # See arrow issue linked from our internal issue above for more details.
+        # See here for what this does https://cmake.org/cmake/help/latest/variable/CMAKE_POLICY_VERSION_MINIMUM.html
         set(VERSION_PATCH -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
     else()
         set(VERSION_PATCH "")

--- a/rerun_cpp/download_and_build_arrow.cmake
+++ b/rerun_cpp/download_and_build_arrow.cmake
@@ -68,7 +68,7 @@ function(download_and_build_arrow)
     endif()
 
     if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
-        # TODO(nick): Remove when resolved  # See https://github.com/apache/arrow/issues/45985
+        # TODO(#10798): Arrow can't support CMake 4.0 yet
         set(VERSION_PATCH -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
     else()
         set(VERSION_PATCH "")

--- a/rerun_cpp/download_and_build_arrow.cmake
+++ b/rerun_cpp/download_and_build_arrow.cmake
@@ -74,6 +74,11 @@ function(download_and_build_arrow)
         set(VERSION_PATCH "")
     endif()
 
+    # Allow for CMAKE_POLICY Override
+    if(CMAKE_POLICY_VERSION_MINIMUM)
+        set(VERSION_PATCH "-DCMAKE_POLICY_VERSION_MINIMUM=${CMAKE_POLICY_VERSION_MINIMUM}")
+    endif()
+
     ExternalProject_Add(
         arrow_cpp
         PREFIX ${ARROW_DOWNLOAD_PATH}

--- a/rerun_cpp/download_and_build_arrow.cmake
+++ b/rerun_cpp/download_and_build_arrow.cmake
@@ -67,6 +67,13 @@ function(download_and_build_arrow)
         set(ARROW_CMAKE_PRESET ninja-release-minimal)
     endif()
 
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
+        # TODO(nick): Remove when resolved  # See https://github.com/apache/arrow/issues/45985
+        set(VERSION_PATCH -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
+    else()
+        set(VERSION_PATCH "")
+    endif()
+
     ExternalProject_Add(
         arrow_cpp
         PREFIX ${ARROW_DOWNLOAD_PATH}
@@ -101,6 +108,7 @@ function(download_and_build_arrow)
         -DBOOST_SOURCE=BUNDLED
         -DARROW_BOOST_USE_SHARED=OFF
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} # Specify the toolchain file for cross-compilation (see https://github.com/rerun-io/rerun/issues/7445)
+        ${VERSION_PATCH}
         SOURCE_SUBDIR cpp
         BUILD_BYPRODUCTS ${ARROW_LIBRARY_FILE} ${ARROW_BUNDLED_DEPENDENCIES_FILE}
     )

--- a/scripts/zombie_todos.py
+++ b/scripts/zombie_todos.py
@@ -210,7 +210,24 @@ def main() -> None:
     root_dirpath = os.path.abspath(f"{script_dirpath}/..")
     os.chdir(root_dirpath)
 
-    extensions = ["c", "cpp", "fbs", "h", "hpp", "html", "js", "md", "py", "rs", "sh", "toml", "txt", "wgsl", "yml"]
+    extensions = [
+        "c",
+        "cpp",
+        "fbs",
+        "h",
+        "hpp",
+        "html",
+        "js",
+        "md",
+        "py",
+        "rs",
+        "sh",
+        "toml",
+        "txt",
+        "wgsl",
+        "yml",
+        "cmake",
+    ]
 
     exclude_paths = {
         "./CODE_STYLE.md",


### PR DESCRIPTION
### Related
* closes #10796 

### What
This checks for newer CMake and automatically applies an automatic workaround.
If a user explicitly provides a `CMAKE_POLICY_VERSION_MINIMUM` we defer to that.

Verified by running the cmake commands from `cpp-compile-all`
```console
cmake -G 'Ninja' -B build/debug -S . -DCMAKE_BUILD_TYPE=Debug
cmake --build build/debug --config Debug --target ALL
```
This works

```console
cmake -G 'Ninja' -B build/debug -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_POLICY_VERSION_MINIMUM=4.0
cmake --build build/debug --config Debug --target ALL
```
This intentionall fails