### PR TITLE
Make pb-breaking run against `latest` branch rather than `main`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -300,7 +300,7 @@ pb-lint = "buf lint --error-format=json"
 #   "pb-snapshot-main",
 # ]}
 
-pb-breaking = "buf breaking --error-format=json --against '.git#branch=origin/main'"
+pb-breaking = "buf breaking --error-format=json --against '.git#branch=origin/latest'"
 
 pb-check = { depends-on = ["pb-fmt-check", "pb-lint", "pb-breaking"] }
 


### PR DESCRIPTION
Fix needed for patch releases