### PR TITLE
Add time range query params when opening a time_range-based url

### DIFF
--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -1,3 +1,4 @@
+use re_protos::manifest_registry::v1alpha1::ext::{Query, QueryLatestAt, QueryRange};
 use tokio_stream::{Stream, StreamExt as _};
 
 use re_auth::client::AuthDecorator;
@@ -456,7 +457,26 @@ async fn stream_partition_from_server(
                 fuzzy_descriptors: vec![],
                 exclude_static_data: true,
                 exclude_temporal_data: false,
-                query: None,
+                query: time_range.clone().map(|time_range| {
+                    Query {
+                        range: Some(QueryRange {
+                            index: time_range.timeline.name().to_string(),
+                            index_range: time_range.clone().into(),
+                        }),
+                        latest_at: Some(QueryLatestAt {
+                            index: Some(time_range.timeline.name().to_string()),
+                            at: time_range.min.into(),
+                        }),
+                        columns_always_include_everything: false,
+                        columns_always_include_chunk_ids: false,
+                        columns_always_include_byte_offsets: false,
+                        columns_always_include_entity_paths: false,
+                        columns_always_include_static_indexes: false,
+                        columns_always_include_global_indexes: false,
+                        columns_always_include_component_indexes: false,
+                    }
+                    .into()
+                }),
             })
             .await?
             .into_inner()

--- a/crates/utils/re_uri/src/time_range.rs
+++ b/crates/utils/re_uri/src/time_range.rs
@@ -18,6 +18,12 @@ impl From<TimeRange> for ResolvedTimeRangeF {
     }
 }
 
+impl From<TimeRange> for re_log_types::ResolvedTimeRange {
+    fn from(range: TimeRange) -> Self {
+        Self::new(range.min, range.max)
+    }
+}
+
 impl std::fmt::Display for TimeRange {
     /// Used for formatting time ranges in URLs
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
### Related
- Improves: https://github.com/rerun-io/rerun/issues/10692

### What
When the URL includes a time_range, use that to construct the corresponding QueryRange

Tested with:
```
pixi run rerun 'rerun://sandbox.redap.rerun.io:443/dataset/1856E1DEE197671A2e7f16d393c3418d?partition_id=ILIAD_50aee79f_2023_08_19_11h_10m_51s&time_range=real_time@2023-08-19T18:11:00Z..2023-08-19T18:11:05Z'
```
