### PR TITLE
Crate publishing: after publishing a crate, wait for it to be available

### DIFF
--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -444,7 +444,21 @@ def publish_crate(crate: Crate, token: str, version: str, env: dict[str, Any]) -
                 dry_run=False,
                 capture=True,
             )
+
+            if not is_already_published(version, crate):
+                # Theoretically this shouldn't be needed… but sometimes it is.
+                print(f"{R}Waiting for {name} to become available…")
+                time.sleep(2)  # give crates.io some time to index the new crate
+                num_retries = 0
+                while not is_already_published(version, crate):
+                    time.sleep(3)
+                    num_retries += 1
+                    if num_retries > 10:
+                        print(f"{R}We published{X} {B}{name}{X} but it was never made available. Continuing anyway.")
+                        return
+
             print(f"{G}Published{X} {B}{name}{X}@{B}{version}{X}")
+
             break
         except subprocess.CalledProcessError as e:
             error_message = e.stdout.decode("utf-8").strip()


### PR DESCRIPTION
I had this problem:
<img width="865" height="804" alt="image" src="https://github.com/user-attachments/assets/f4e635d8-eaf6-4fdc-b21f-ea90747a60f0" />

So `re_build_info` was successfully published, but when trying to publish something that was using it, we still failed.
I had a similar problem earlier, but with `re_log`

So I added a loop to wait for the crate to become "visible". I hope that will help.