### PR TITLE
Fix building Web Viewer on macOS

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -55,10 +55,10 @@ EXECUTABLE_EXTENSION = ".exe"
 
 # TODO(rust-lang/stacker#127): Work around until wasm build on mac is resolved
 [target.osx-64.activation.env]
-AR = "${PIXI_HOME}/.pixi/envs/cpp/bin/llvm-ar"
+AR = "${PIXI_PROJECT_ROOT}/.pixi/envs/cpp/bin/llvm-ar"
 
 [target.osx-arm64.activation.env]
-AR = "${PIXI_HOME}/.pixi/envs/cpp/bin/llvm-ar"
+AR = "${PIXI_PROJECT_ROOT}/.pixi/envs/cpp/bin/llvm-ar"
 
 # python-dev
 


### PR DESCRIPTION
### Related
Closes #9849

### What
Basically mac has a fun combination where you can have `clang`/`llvm` components but not `llvm-ar`. Mac's `ar` pads bytes in way that make llvm barf. Our pixi env for c++ has the `cxx-compiler` package which has a more full fledged llvm install. On mac on activation set `AR` to point to `llvm-ar`. It works on my machine! I'm not sure if we should have a second person try or if we should setup a test for the web build on mac just for this weird edge case.