### PR TITLE
Implement row filtering on client side

### DIFF
--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -392,7 +392,7 @@ impl PyDataframeQueryView {
         let capsule_name = cr"datafusion_table_provider".into();
 
         let runtime = get_tokio_runtime().handle().clone();
-        let provider = FFI_TableProvider::new(provider, false, Some(runtime));
+        let provider = FFI_TableProvider::new(provider, true, Some(runtime));
 
         PyCapsule::new(py, provider, Some(capsule_name))
     }


### PR DESCRIPTION
### Related

Closes https://github.com/rerun-io/dataplatform/issues/851

### What

This PR identifies when the push down filters provided to the table provider are checking for a component that is not null. If so it pushes this filter down into the chunk store query. This reduces the amount of data coming out of the cpu worker thread and passed into the rest of the datafusion engine.

These are equivalent

- column is not null
- not (column is null)
- column != lit(null)
