### PR TITLE
Don't add env variable since we don't special case osx-86

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -54,9 +54,6 @@ EXECUTABLE_EXTENSION = ""
 EXECUTABLE_EXTENSION = ".exe"
 
 # TODO(rust-lang/stacker#127): Work around until wasm build on mac is resolved
-[target.osx-64.activation.env]
-AR = "${PIXI_PROJECT_ROOT}/.pixi/envs/default/bin/llvm-ar"
-
 [target.osx-arm64.activation.env]
 AR = "${PIXI_PROJECT_ROOT}/.pixi/envs/default/bin/llvm-ar"
 


### PR DESCRIPTION
### Related
Another bug fix related to https://github.com/rerun-io/rerun/issues/9849

### What
Don't use pixi `ar` on osx-86 because that platform _just works_ so doesn't have all our other custom stuff.
