### PR TITLE
Shrink many of our error types

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -62,6 +62,15 @@ pub enum ChunkError {
     InvalidSorbetSchema(#[from] re_sorbet::SorbetError),
 }
 
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<ChunkError>() <= 72,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<ChunkError>()
+    );
+}
+
 pub type ChunkResult<T> = Result<T, ChunkError>;
 
 // ---

--- a/crates/store/re_entity_db/src/instance_path.rs
+++ b/crates/store/re_entity_db/src/instance_path.rs
@@ -105,7 +105,7 @@ impl FromStr for InstancePath {
 
         if let Some(component_descriptor) = component_descriptor {
             return Err(PathParseError::UnexpectedComponentDescriptor(
-                component_descriptor,
+                component_descriptor.into(),
             ));
         }
 

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -19,7 +19,29 @@ const MAX_DECODING_MESSAGE_SIZE: usize = u32::MAX as usize;
 
 /// Wrapper with a nicer error message
 #[derive(Debug)]
-pub struct TonicStatusError(pub tonic::Status);
+pub struct TonicStatusError(Box<tonic::Status>);
+
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<TonicStatusError>() <= 32,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<TonicStatusError>()
+    );
+}
+
+impl AsRef<tonic::Status> for TonicStatusError {
+    fn as_ref(&self) -> &tonic::Status {
+        &self.0
+    }
+}
+
+impl TonicStatusError {
+    /// Returns the inner [`tonic::Status`].
+    pub fn into_inner(self) -> tonic::Status {
+        *self.0
+    }
+}
 
 impl std::fmt::Display for TonicStatusError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -47,7 +69,7 @@ impl std::fmt::Display for TonicStatusError {
 
 impl From<tonic::Status> for TonicStatusError {
     fn from(value: tonic::Status) -> Self {
-        Self(value)
+        Self(Box::new(value))
     }
 }
 
@@ -102,6 +124,15 @@ pub enum StreamError {
 
     #[error("arrow error: {0}")]
     ArrowError(#[from] arrow::error::ArrowError),
+}
+
+#[test]
+fn test_stream_error_size() {
+    assert!(
+        std::mem::size_of::<StreamError>() <= 80,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<StreamError>()
+    );
 }
 
 impl From<tonic::Status> for StreamError {

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -31,6 +31,7 @@ fn test_error_size() {
 }
 
 impl AsRef<tonic::Status> for TonicStatusError {
+    #[inline]
     fn as_ref(&self) -> &tonic::Status {
         &self.0
     }

--- a/crates/store/re_grpc_client/src/message_proxy/read.rs
+++ b/crates/store/re_grpc_client/src/message_proxy/read.rs
@@ -60,7 +60,7 @@ async fn stream_async(
     let mut stream = client
         .read_messages(ReadMessagesRequest {})
         .await
-        .map_err(TonicStatusError)?
+        .map_err(TonicStatusError::from)?
         .into_inner();
 
     let mut app_id_cache = re_log_encoding::CachingApplicationIdInjector::default();

--- a/crates/store/re_grpc_client/src/message_proxy/write.rs
+++ b/crates/store/re_grpc_client/src/message_proxy/write.rs
@@ -284,7 +284,7 @@ async fn message_proxy_client(
     let disconnect_result = if let Err(status) = client.write_messages(stream).await {
         re_log::error!(
             "Write messages call failed: {}",
-            TonicStatusError(status.clone())
+            TonicStatusError::from(status.clone())
         );
 
         // Ignore status code "Unknown" since this was observed to happen on regular Viewer shutdowns.

--- a/crates/store/re_grpc_client/src/redap/mod.rs
+++ b/crates/store/re_grpc_client/src/redap/mod.rs
@@ -91,6 +91,15 @@ pub enum ConnectionError {
     InvalidOrigin(String),
 }
 
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<ConnectionError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<ConnectionError>()
+    );
+}
+
 #[cfg(target_arch = "wasm32")]
 pub async fn channel(origin: Origin) -> Result<tonic_web_wasm_client::Client, ConnectionError> {
     let channel = tonic_web_wasm_client::Client::new_with_options(

--- a/crates/store/re_log_encoding/src/codec/file/decoder.rs
+++ b/crates/store/re_log_encoding/src/codec/file/decoder.rs
@@ -1,12 +1,13 @@
 use re_log_types::{BlueprintActivationCommand, LogMsg, SetStoreInfo};
 use re_protos::missing_field;
 
-use super::{MessageHeader, MessageKind};
+use crate::{
+    ApplicationIdInjector,
+    codec::{CodecError, arrow::decode_arrow},
+    decoder::DecodeError,
+};
 
-use crate::ApplicationIdInjector;
-use crate::codec::CodecError;
-use crate::codec::arrow::decode_arrow;
-use crate::decoder::DecodeError;
+use super::{MessageHeader, MessageKind};
 
 // ---
 

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -5,18 +5,17 @@ pub mod stream;
 #[cfg(feature = "decoder")]
 pub mod streaming;
 
-use std::io::BufRead as _;
-use std::io::Read as _;
+use std::io::{BufRead as _, Read as _};
 
 use re_build_info::CrateVersion;
 use re_log_types::LogMsg;
 
-use crate::FileHeader;
-use crate::OLD_RRD_HEADERS;
-use crate::app_id_injector::CachingApplicationIdInjector;
-use crate::codec;
-use crate::codec::file::decoder;
-use crate::{EncodingOptions, Serializer};
+use crate::{
+    EncodingOptions, FileHeader, OLD_RRD_HEADERS, Serializer,
+    app_id_injector::CachingApplicationIdInjector,
+    codec::{self, file::decoder},
+};
+
 // ----------------------------------------------------------------------------
 
 fn warn_on_version_mismatch(encoded_version: [u8; 4]) -> Result<(), DecodeError> {
@@ -30,8 +29,8 @@ fn warn_on_version_mismatch(encoded_version: [u8; 4]) -> Result<(), DecodeError>
     if encoded_version.major == 0 && encoded_version.minor < 23 {
         // We broke compatibility for 0.23 for (hopefully) the last time.
         Err(DecodeError::IncompatibleRerunVersion {
-            file: encoded_version,
-            local: CrateVersion::LOCAL,
+            file: Box::new(encoded_version),
+            local: Box::new(CrateVersion::LOCAL),
         })
     } else if encoded_version <= CrateVersion::LOCAL {
         // Loading old files should be fine, and if it is not, the chunk migration in re_sorbet should already log a warning.
@@ -60,8 +59,8 @@ pub enum DecodeError {
         "Data from Rerun version {file}, which is incompatible with the local Rerun version {local}"
     )]
     IncompatibleRerunVersion {
-        file: CrateVersion,
-        local: CrateVersion,
+        file: Box<CrateVersion>,
+        local: Box<CrateVersion>,
     },
 
     /// This is returned when `ArrowMsg` or `BlueprintActivationCommand` are received with a legacy
@@ -86,19 +85,40 @@ pub enum DecodeError {
     Protobuf(#[from] re_protos::external::prost::DecodeError),
 
     #[error("Could not convert type from protobuf: {0}")]
-    TypeConversion(#[from] re_protos::TypeConversionError),
+    TypeConversion(Box<re_protos::TypeConversionError>),
 
     #[error("Sorbet error: {0}")]
     SorbetError(#[from] re_sorbet::SorbetError),
 
     #[error("Failed to read chunk: {0}")]
-    Chunk(#[from] re_chunk::ChunkError),
+    Chunk(Box<re_chunk::ChunkError>),
 
     #[error("Arrow error: {0}")]
     Arrow(#[from] arrow::error::ArrowError),
 
     #[error("Codec error: {0}")]
     Codec(#[from] codec::CodecError),
+}
+
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<DecodeError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<DecodeError>()
+    );
+}
+
+impl From<re_protos::TypeConversionError> for DecodeError {
+    fn from(value: re_protos::TypeConversionError) -> Self {
+        Self::TypeConversion(Box::new(value))
+    }
+}
+
+impl From<re_chunk::ChunkError> for DecodeError {
+    fn from(value: re_chunk::ChunkError) -> Self {
+        Self::Chunk(Box::new(value))
+    }
 }
 
 impl From<re_protos::common::v1alpha1::ext::StoreIdMissingApplicationIdError> for DecodeError {

--- a/crates/store/re_log_encoding/src/encoder.rs
+++ b/crates/store/re_log_encoding/src/encoder.rs
@@ -31,13 +31,28 @@ pub enum EncodeError {
     Codec(#[from] codec::CodecError),
 
     #[error("Chunk error: {0}")]
-    Chunk(#[from] ChunkError),
+    Chunk(Box<ChunkError>),
 
     #[error("Called append on already finished encoder")]
     AlreadyFinished,
 
     #[error("Missing field: {0}")]
     MissingField(&'static str),
+}
+
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<EncodeError>() <= 48,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<EncodeError>()
+    );
+}
+
+impl From<ChunkError> for EncodeError {
+    fn from(err: ChunkError) -> Self {
+        Self::Chunk(Box::new(err))
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/store/re_log_types/src/path/parse_path.rs
+++ b/crates/store/re_log_types/src/path/parse_path.rs
@@ -31,7 +31,7 @@ pub enum PathParseError {
     UnexpectedInstance(Instance),
 
     #[error("Found an unexpected trailing component descriptor: {0:?}")]
-    UnexpectedComponentDescriptor(ComponentDescriptor),
+    UnexpectedComponentDescriptor(Box<ComponentDescriptor>),
 
     #[error("Missing component")]
     MissingComponentIdentifier,
@@ -54,6 +54,15 @@ pub enum PathParseError {
 
     #[error("Expected e.g. '\\u{{262E}}', found: '\\u{0}'")]
     InvalidUnicodeEscape(String),
+}
+
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<PathParseError>() <= 48,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<PathParseError>()
+    );
 }
 
 type Result<T, E = PathParseError> = std::result::Result<T, E>;
@@ -179,7 +188,7 @@ impl EntityPath {
         }
         if let Some(component_descriptor) = component_descriptor {
             return Err(PathParseError::UnexpectedComponentDescriptor(
-                component_descriptor,
+                component_descriptor.into(),
             ));
         }
 

--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -71,4 +71,13 @@ pub enum QueryError {
     Other(#[from] anyhow::Error),
 }
 
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<QueryError>() <= 80,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<QueryError>()
+    );
+}
+
 pub type Result<T> = std::result::Result<T, QueryError>;

--- a/crates/store/re_sorbet/src/error.rs
+++ b/crates/store/re_sorbet/src/error.rs
@@ -38,3 +38,12 @@ pub enum SorbetError {
     #[error("Failed to deserialize chunk ID: {0}")]
     ChunkIdDeserializationError(String),
 }
+
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<SorbetError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<SorbetError>()
+    );
+}

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -94,7 +94,7 @@ pub trait Archetype {
         _ = data; // NOTE: do this here to avoid breaking users' autocomplete snippets
         Err(crate::DeserializationError::NotImplemented {
             fqname: Self::name().to_string(),
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         })
     }
 }

--- a/crates/store/re_types_core/src/result.rs
+++ b/crates/store/re_types_core/src/result.rs
@@ -17,19 +17,28 @@ pub enum SerializationError {
     #[error("Trying to serialize a field lacking extension metadata: {fqname:?}")]
     MissingExtensionMetadata {
         fqname: String,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error("{fqname} doesn't support Serialization: {reason}")]
     NotImplemented {
         fqname: String,
         reason: String,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     /// E.g. too many values (overflows i32).
     #[error(transparent)]
     ArrowError(#[from] ArcArrowError),
+}
+
+#[test]
+fn test_serialization_error_size() {
+    assert!(
+        std::mem::size_of::<SerializationError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<SerializationError>()
+    );
 }
 
 impl std::fmt::Debug for SerializationError {
@@ -47,7 +56,7 @@ impl SerializationError {
     pub fn missing_extension_metadata(fqname: impl AsRef<str>) -> Self {
         Self::MissingExtensionMetadata {
             fqname: fqname.as_ref().into(),
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -56,7 +65,7 @@ impl SerializationError {
         Self::NotImplemented {
             fqname: fqname.as_ref().into(),
             reason: reason.as_ref().into(),
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -127,17 +136,17 @@ pub enum DeserializationError {
     #[error("{fqname} doesn't support deserialization")]
     NotImplemented {
         fqname: String,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error("Expected non-nullable data but didn't find any")]
-    MissingData { backtrace: _Backtrace },
+    MissingData { backtrace: Box<_Backtrace> },
 
     #[error("Expected field {field_name:?} to be present in {datatype:#?}")]
     MissingStructField {
         datatype: arrow::datatypes::DataType,
         field_name: String,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error(
@@ -148,7 +157,7 @@ pub enum DeserializationError {
         field1_length: usize,
         field2_name: String,
         field2_length: usize,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error("Expected union arm {arm_name:?} (#{arm_index}) to be present in {datatype:#?}")]
@@ -156,21 +165,21 @@ pub enum DeserializationError {
         datatype: arrow::datatypes::DataType,
         arm_name: String,
         arm_index: usize,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error("Expected {expected:#?} but found {got:#?} instead")]
     DatatypeMismatch {
         expected: arrow::datatypes::DataType,
         got: arrow::datatypes::DataType,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error("Offset ouf of bounds: trying to read at offset #{offset} in an array of size {len}")]
     OffsetOutOfBounds {
         offset: usize,
         len: usize,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error(
@@ -180,17 +189,29 @@ pub enum DeserializationError {
         from: usize,
         to: usize,
         len: usize,
-        backtrace: _Backtrace,
+        backtrace: Box<_Backtrace>,
     },
 
     #[error("Downcast to {to} failed")]
-    DowncastError { to: String, backtrace: _Backtrace },
+    DowncastError {
+        to: String,
+        backtrace: Box<_Backtrace>,
+    },
 
     #[error("Datacell deserialization Failed: {0}")]
     DataCellError(String),
 
     #[error("Validation Error: {0}")]
     ValidationError(String),
+}
+
+#[test]
+fn test_derserialization_error_size() {
+    assert!(
+        std::mem::size_of::<DeserializationError>() <= 72,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<DeserializationError>()
+    );
 }
 
 impl std::fmt::Debug for DeserializationError {
@@ -207,7 +228,7 @@ impl DeserializationError {
     #[inline]
     pub fn missing_data() -> Self {
         Self::MissingData {
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -219,7 +240,7 @@ impl DeserializationError {
         Self::MissingStructField {
             datatype: datatype.into(),
             field_name: field_name.as_ref().into(),
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -235,7 +256,7 @@ impl DeserializationError {
             field1_length,
             field2_name: field2_name.as_ref().into(),
             field2_length,
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -249,7 +270,7 @@ impl DeserializationError {
             datatype: datatype.into(),
             arm_name: arm_name.as_ref().into(),
             arm_index,
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -261,7 +282,7 @@ impl DeserializationError {
         Self::DatatypeMismatch {
             expected: expected.into(),
             got: got.into(),
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -270,7 +291,7 @@ impl DeserializationError {
         Self::OffsetOutOfBounds {
             offset,
             len,
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -280,7 +301,7 @@ impl DeserializationError {
             from,
             to,
             len,
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 
@@ -288,7 +309,7 @@ impl DeserializationError {
     pub fn downcast_error<ToType>() -> Self {
         Self::DowncastError {
             to: any::type_name::<ToType>().to_owned(),
-            backtrace: std::backtrace::Backtrace::capture(),
+            backtrace: Box::new(std::backtrace::Backtrace::capture()),
         }
     }
 

--- a/crates/viewer/re_dataframe_ui/src/display_record_batch.rs
+++ b/crates/viewer/re_dataframe_ui/src/display_record_batch.rs
@@ -12,7 +12,6 @@ use arrow::{
     buffer::ScalarBuffer as ArrowScalarBuffer,
     datatypes::DataType as ArrowDataType,
 };
-use thiserror::Error;
 
 use re_arrow_util::ArrowArrayDowncastRef as _;
 use re_chunk_store::LatestAtQuery;
@@ -29,7 +28,7 @@ use re_viewer_context::{UiLayout, VariantName, ViewerContext};
 
 use crate::table_blueprint::ColumnBlueprint;
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum DisplayRecordBatchError {
     #[error("Bad column for timeline '{timeline}': {error}")]
     BadTimeColumn {

--- a/crates/viewer/re_renderer/src/mesh.rs
+++ b/crates/viewer/re_renderer/src/mesh.rs
@@ -160,6 +160,15 @@ pub enum MeshError {
     CpuWriteGpuReadError(#[from] crate::allocator::CpuWriteGpuReadError),
 }
 
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<MeshError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<MeshError>()
+    );
+}
+
 #[derive(Clone)]
 pub struct Material {
     pub label: DebugLabel,

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -51,6 +51,15 @@ pub enum VideoPlayerError {
     ImageDataToTextureError(#[from] crate::resource_managers::ImageDataToTextureError),
 }
 
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<VideoPlayerError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<VideoPlayerError>()
+    );
+}
+
 impl VideoPlayerError {
     pub fn should_request_more_frames(&self) -> bool {
         // Decoders often (not always!) recover from errors and will succeed eventually.

--- a/crates/viewer/re_viewer_context/src/view/mod.rs
+++ b/crates/viewer/re_viewer_context/src/view/mod.rs
@@ -50,10 +50,10 @@ pub enum ViewSystemExecutionError {
     VisualizerSystemNotFound(&'static str),
 
     #[error(transparent)]
-    QueryError2(#[from] re_query::QueryError),
+    QueryError(Box<re_query::QueryError>),
 
     #[error(transparent)]
-    DeserializationError(#[from] re_types::DeserializationError),
+    DeserializationError(Box<re_types::DeserializationError>),
 
     #[error("Failed to create draw data: {0}")]
     DrawDataCreationError(Box<dyn std::error::Error>),
@@ -74,6 +74,15 @@ pub enum ViewSystemExecutionError {
     ViewBuilderError(#[from] re_renderer::view_builder::ViewBuilderError),
 }
 
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<ViewSystemExecutionError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<ViewSystemExecutionError>()
+    );
+}
+
 // Convenience conversions for some re_renderer error types since these are so frequent.
 
 impl From<re_renderer::renderer::LineDrawDataError> for ViewSystemExecutionError {
@@ -85,5 +94,11 @@ impl From<re_renderer::renderer::LineDrawDataError> for ViewSystemExecutionError
 impl From<re_renderer::renderer::PointCloudDrawDataError> for ViewSystemExecutionError {
     fn from(val: re_renderer::renderer::PointCloudDrawDataError) -> Self {
         Self::DrawDataCreationError(Box::new(val))
+    }
+}
+
+impl From<re_types::DeserializationError> for ViewSystemExecutionError {
+    fn from(val: re_types::DeserializationError) -> Self {
+        Self::DeserializationError(Box::new(val))
     }
 }

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -12,7 +12,7 @@ use re_viewer_context::{
 #[derive(thiserror::Error, Debug)]
 pub enum ViewPropertyQueryError {
     #[error(transparent)]
-    SerializationError(#[from] re_types::DeserializationError),
+    DeserializationError(#[from] re_types::DeserializationError),
 
     #[error(transparent)]
     ComponentFallbackError(#[from] ComponentFallbackError),
@@ -21,7 +21,7 @@ pub enum ViewPropertyQueryError {
 impl From<ViewPropertyQueryError> for ViewSystemExecutionError {
     fn from(val: ViewPropertyQueryError) -> Self {
         match val {
-            ViewPropertyQueryError::SerializationError(err) => err.into(),
+            ViewPropertyQueryError::DeserializationError(err) => err.into(),
             ViewPropertyQueryError::ComponentFallbackError(err) => err.into(),
         }
     }

--- a/rerun_py/src/catalog/errors.rs
+++ b/rerun_py/src/catalog/errors.rs
@@ -32,19 +32,19 @@ enum ExternalError {
     ConnectionError(#[from] ConnectionError),
 
     #[error("{0}")]
-    TonicStatusError(#[from] tonic::Status),
+    TonicStatusError(Box<tonic::Status>),
 
     #[error("{0}")]
     UriError(#[from] re_uri::Error),
 
     #[error("{0}")]
-    ChunkError(#[from] re_chunk::ChunkError),
+    ChunkError(Box<re_chunk::ChunkError>),
 
     #[error("{0}")]
-    ChunkStoreError(#[from] re_chunk_store::ChunkStoreError),
+    ChunkStoreError(Box<re_chunk_store::ChunkStoreError>),
 
     #[error("{0}")]
-    StreamError(#[from] re_grpc_client::StreamError),
+    StreamError(Box<re_grpc_client::StreamError>),
 
     #[error("{0}")]
     ArrowError(#[from] arrow::error::ArrowError),
@@ -53,7 +53,7 @@ enum ExternalError {
     UrlParseError(#[from] url::ParseError),
 
     #[error("{0}")]
-    DatafusionError(#[from] datafusion::error::DataFusionError),
+    DatafusionError(Box<datafusion::error::DataFusionError>),
 
     #[error(transparent)]
     CodecError(#[from] re_log_encoding::codec::CodecError),
@@ -68,11 +68,37 @@ enum ExternalError {
     ColumnSelectorResolveError(#[from] re_sorbet::ColumnSelectorResolveError),
 
     #[error(transparent)]
-    TypeConversionError(#[from] re_protos::TypeConversionError),
+    TypeConversionError(Box<re_protos::TypeConversionError>),
 
     #[error(transparent)]
     TokenError(#[from] re_auth::TokenError),
 }
+
+#[test]
+fn test_error_size() {
+    assert!(
+        std::mem::size_of::<ExternalError>() <= 64,
+        "Size of error is {} bytes. Let's try to keep errors small.",
+        std::mem::size_of::<ExternalError>()
+    );
+}
+
+macro_rules! impl_from_boxed {
+    ($external_type:ty, $variant:ident) => {
+        impl From<$external_type> for ExternalError {
+            fn from(value: $external_type) -> Self {
+                Self::$variant(Box::new(value))
+            }
+        }
+    };
+}
+
+impl_from_boxed!(re_chunk::ChunkError, ChunkError);
+impl_from_boxed!(re_chunk_store::ChunkStoreError, ChunkStoreError);
+impl_from_boxed!(re_grpc_client::StreamError, StreamError);
+impl_from_boxed!(tonic::Status, TonicStatusError);
+impl_from_boxed!(datafusion::error::DataFusionError, DatafusionError);
+impl_from_boxed!(re_protos::TypeConversionError, TypeConversionError);
 
 impl From<re_protos::manifest_registry::v1alpha1::ext::GetDatasetSchemaResponseError>
     for ExternalError


### PR DESCRIPTION
Large errors leads to large `Result`s, which may lead to a lot of `memcpy`:s when returning a `Result` (even an `Ok` one), which can hurt performance.

Some of our error types were over 100 bytes, even 200 bytes.

Many of our errors are still pretty huge (64+ bytes), but this is a start.