### PR TITLE
Fix partition_id filtering for queries

### DIFF
--- a/crates/store/re_datafusion/src/dataframe_query_common.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_common.rs
@@ -59,6 +59,7 @@ impl DataframeQueryTableProvider {
         connection: ConnectionRegistryHandle,
         dataset_id: EntryId,
         query_expression: &QueryExpression,
+        partition_ids: &[impl AsRef<str> + Sync],
     ) -> Result<Self, DataFusionError> {
         use futures::StreamExt as _;
 
@@ -133,7 +134,10 @@ impl DataframeQueryTableProvider {
 
         let dataset_query = QueryDatasetRequest {
             dataset_id: Some(dataset_id.into()),
-            partition_ids: vec![],
+            partition_ids: partition_ids
+                .iter()
+                .map(|id| id.as_ref().to_owned().into())
+                .collect(),
             chunk_ids: vec![],
             entity_paths: entity_paths
                 .into_iter()

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -487,6 +487,7 @@ impl PyDataframeQueryView {
                 connection.connection_registry().clone(),
                 dataset_id,
                 &self.query_expression,
+                &self.partition_ids,
             )
             .await
         })


### PR DESCRIPTION
This was causing queries like:
```
result = (
    dataset.dataframe_query_view(index="real_time", contents="/action/joint_positions")
    .filter_partition_id("TRI_52ca9b6a_2023_10_31_13h_31m_34s")
    .df()
    .select(
        col("rerun_partition_id"),
        col("real_time"),
    )
)
```
to still return all the partitions.