### PR TITLE
Log all `sensor_msgs/msg/Image` metadata

### DIFF
--- a/crates/utils/re_mcap/src/parsers/ros2msg/sensor_msgs/image.rs
+++ b/crates/utils/re_mcap/src/parsers/ros2msg/sensor_msgs/image.rs
@@ -1,7 +1,8 @@
-use super::super::definitions::sensor_msgs;
+use super::definitions::sensor_msgs;
 use re_chunk::{Chunk, ChunkId};
 use re_log_types::TimeCell;
 use re_types::{
+    ComponentDescriptor,
     archetypes::{DepthImage, Image},
     datatypes::{ChannelDatatype, ColorModel, ImageFormat, PixelFormat},
 };
@@ -21,14 +22,26 @@ pub struct ImageMessageParser {
     /// Note: These blobs are directly moved into a `Blob`, without copying.
     blobs: Vec<Vec<u8>>,
     image_formats: Vec<ImageFormat>,
+    height: FixedSizeListBuilder<UInt32Builder>,
+    width: FixedSizeListBuilder<UInt32Builder>,
+    encoding: FixedSizeListBuilder<StringBuilder>,
+    is_bigendian: FixedSizeListBuilder<UInt32Builder>,
+    step: FixedSizeListBuilder<UInt32Builder>,
     is_depth_image: bool,
 }
 
 impl ImageMessageParser {
+    const ARCHETYPE_NAME: &str = "sensor_msgs.msg.Image";
+
     pub fn new(num_rows: usize) -> Self {
         Self {
             blobs: Vec::with_capacity(num_rows),
             image_formats: Vec::with_capacity(num_rows),
+            height: fixed_size_list_builder(1, num_rows),
+            width: fixed_size_list_builder(1, num_rows),
+            encoding: fixed_size_list_builder(1, num_rows),
+            is_bigendian: fixed_size_list_builder(1, num_rows),
+            step: fixed_size_list_builder(1, num_rows),
             is_depth_image: false,
         }
     }
@@ -65,6 +78,23 @@ impl MessageParser for ImageMessageParser {
         self.blobs.push(data.into_owned());
         self.image_formats.push(img_format);
 
+        self.height.values().append_slice(&[height]);
+        self.height.append(true);
+
+        self.width.values().append_slice(&[width]);
+        self.width.append(true);
+
+        self.encoding.values().append_value(encoding);
+        self.encoding.append(true);
+
+        self.is_bigendian
+            .values()
+            .append_slice(&[is_bigendian as u32]);
+        self.is_bigendian.append(true);
+
+        self.step.values().append_slice(&[step]);
+        self.step.append(true);
+
         Ok(())
     }
 
@@ -73,6 +103,11 @@ impl MessageParser for ImageMessageParser {
         let Self {
             blobs,
             image_formats,
+            mut height,
+            mut width,
+            mut encoding,
+            mut is_bigendian,
+            mut step,
             is_depth_image,
         } = *self;
 
@@ -95,7 +130,43 @@ impl MessageParser for ImageMessageParser {
 
         let chunk = Chunk::from_auto_row_ids(ChunkId::new(), entity_path, timelines, images)?;
 
-        Ok(vec![chunk])
+        let metadata_chunk = Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            entity_path.clone(),
+            timelines.clone(),
+            [
+                (
+                    ComponentDescriptor::partial("height")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    height.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("width")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    width.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("encoding")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    encoding.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("is_bigendian")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    is_bigendian.finish().into(),
+                ),
+                (
+                    ComponentDescriptor::partial("step")
+                        .with_archetype(Self::ARCHETYPE_NAME.into()),
+                    step.finish().into(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )
+        .map_err(|err| PluginError::Other(anyhow::anyhow!(err)))?;
+
+        Ok(vec![image_chunk, metadata_chunk])
     }
 }
 


### PR DESCRIPTION
### What

We now log all data from the `sensor_msgs/msg/Image` as arrow data.