### PR TITLE
Fix loading MCAP on wasm

### DIFF
--- a/crates/store/re_data_loader/src/lib.rs
+++ b/crates/store/re_data_loader/src/lib.rs
@@ -481,10 +481,8 @@ pub const SUPPORTED_POINT_CLOUD_EXTENSIONS: &[&str] = &["ply"];
 
 pub const SUPPORTED_RERUN_EXTENSIONS: &[&str] = &["rbl", "rrd"];
 
-#[cfg(not(target_arch = "wasm32"))]
+/// 3rd party formats with built-in support.
 pub const SUPPORTED_THIRD_PARTY_FORMATS: &[&str] = &["mcap"];
-#[cfg(target_arch = "wasm32")]
-pub const SUPPORTED_THIRD_PARTY_FORMATS: &[&str] = &[];
 
 // TODO(#4555): Add catch-all builtin `DataLoader` for text files
 pub const SUPPORTED_TEXT_EXTENSIONS: &[&str] = &["txt", "md"];

--- a/crates/store/re_data_loader/src/lib.rs
+++ b/crates/store/re_data_loader/src/lib.rs
@@ -502,10 +502,17 @@ pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
 
 /// Is this a supported file extension by any of our builtin [`DataLoader`]s?
 pub fn is_supported_file_extension(extension: &str) -> bool {
-    SUPPORTED_IMAGE_EXTENSIONS.contains(&extension)
-        || SUPPORTED_VIDEO_EXTENSIONS.contains(&extension)
-        || SUPPORTED_MESH_EXTENSIONS.contains(&extension)
-        || SUPPORTED_POINT_CLOUD_EXTENSIONS.contains(&extension)
-        || SUPPORTED_RERUN_EXTENSIONS.contains(&extension)
-        || SUPPORTED_TEXT_EXTENSIONS.contains(&extension)
+    debug_assert!(
+        !extension.starts_with('.'),
+        "Expected extion without period, but got {extension:?}"
+    );
+    let extension = extension.to_lowercase();
+    supported_extensions().any(|ext| ext == extension)
+}
+
+#[test]
+fn test_supported_extensions() {
+    assert!(is_supported_file_extension("rrd"));
+    assert!(is_supported_file_extension("mcap"));
+    assert!(is_supported_file_extension("png"));
 }

--- a/crates/store/re_data_loader/src/lib.rs
+++ b/crates/store/re_data_loader/src/lib.rs
@@ -504,7 +504,7 @@ pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
 pub fn is_supported_file_extension(extension: &str) -> bool {
     debug_assert!(
         !extension.starts_with('.'),
-        "Expected extion without period, but got {extension:?}"
+        "Expected extension without period, but got {extension:?}"
     );
     let extension = extension.to_lowercase();
     supported_extensions().any(|ext| ext == extension)


### PR DESCRIPTION
Also avoid running external data loaders when loading an .mcap, or a .png, or any other file type that Rerun natively supports.