### PR TITLE
Add profile scopes to mcap loader

### DIFF
--- a/crates/store/re_data_loader/src/mcap/decode.rs
+++ b/crates/store/re_data_loader/src/mcap/decode.rs
@@ -234,6 +234,8 @@ impl<'a> McapChunkDecoder<'a> {
 
     /// Decode the next message in the chunk
     pub fn decode_next(&mut self, msg: &::mcap::Message<'_>) -> Result<(), PluginError> {
+        re_tracing::profile_function!();
+
         let channel = msg.channel.as_ref();
         let channel_id = ChannelId(channel.id);
         let entity_path = EntityPath::from(channel.topic.as_str());

--- a/crates/store/re_data_loader/src/mcap/schema/protobuf.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/protobuf.rs
@@ -103,6 +103,7 @@ impl McapMessageParser for ProtobufMessageParser {
         _ctx: &mut crate::mcap::decode::ParserContext,
         msg: &mcap::Message<'_>,
     ) -> anyhow::Result<()> {
+        re_tracing::profile_function!();
         let dynamic_message =
             DynamicMessage::decode(self.message_descriptor.clone(), msg.data.as_ref()).map_err(
                 |err| Error::InvalidMessage {
@@ -131,6 +132,7 @@ impl McapMessageParser for ProtobufMessageParser {
         self: Box<Self>,
         ctx: crate::mcap::decode::ParserContext,
     ) -> anyhow::Result<Vec<re_chunk::Chunk>> {
+        re_tracing::profile_function!();
         let entity_path = ctx.entity_path().clone();
         let timelines = ctx.build_timelines();
 

--- a/crates/store/re_data_loader/src/mcap/schema/raw.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/raw.rs
@@ -22,6 +22,7 @@ impl RawMcapMessageParser {
 
 impl McapMessageParser for RawMcapMessageParser {
     fn append(&mut self, _ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        re_tracing::profile_function!();
         self.data.values().values().append_slice(&msg.data);
         self.data.values().append(true);
         self.data.append(true);
@@ -29,6 +30,7 @@ impl McapMessageParser for RawMcapMessageParser {
     }
 
     fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<re_chunk::Chunk>> {
+        re_tracing::profile_function!();
         let Self { mut data } = *self;
 
         let entity_path = ctx.entity_path().clone();

--- a/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/compressed_image.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/compressed_image.rs
@@ -56,6 +56,7 @@ impl CompressedImageMessageParser {
 
 impl McapMessageParser for CompressedImageMessageParser {
     fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        re_tracing::profile_function!();
         let sensor_msgs::CompressedImage {
             header,
             data,
@@ -82,6 +83,7 @@ impl McapMessageParser for CompressedImageMessageParser {
     }
 
     fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<re_chunk::Chunk>> {
+        re_tracing::profile_function!();
         let Self {
             blobs,
             mut formats,

--- a/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/image.rs
+++ b/crates/store/re_data_loader/src/mcap/schema/sensor_msgs/image.rs
@@ -50,6 +50,7 @@ impl ImageMessageParser {
 
 impl McapMessageParser for ImageMessageParser {
     fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        re_tracing::profile_function!();
         // TODO(#10725): Do we want to log the unused fields?
         #[allow(unused)]
         let sensor_msgs::Image {
@@ -82,6 +83,7 @@ impl McapMessageParser for ImageMessageParser {
     }
 
     fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<re_chunk::Chunk>> {
+        re_tracing::profile_function!();
         let Self {
             blobs,
             image_formats,


### PR DESCRIPTION
### What
Example: `pixi run rerun-release --profile uva_var_2024.mcap`

Result:
![mcap-profile-scopes](https://github.com/user-attachments/assets/5483dfb0-2cb6-4a91-b49e-52a0fb7deb3a)
