### PR TITLE
Typo in `name` of CI task

### DIFF
--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -90,7 +90,7 @@ jobs:
         # See tests/assets/rrd/README.md for more
         run: pixi run check-backwards-compatibility
 
-      - name: Compare man page to CLI dcs
+      - name: Compare man page to CLI docs
         run: pixi run rerun-build-web && pixi run ./scripts/ci/check_cli_docs.py
 
   rs-tests:


### PR DESCRIPTION
Title.
