### PR TITLE
Fix debug-crash in undo.rs because of state restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8952,6 +8952,7 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
+ "static_assertions",
  "thiserror 1.0.69",
  "tokio",
  "wasm-bindgen-futures",

--- a/crates/store/re_sorbet/src/sorbet_schema.rs
+++ b/crates/store/re_sorbet/src/sorbet_schema.rs
@@ -164,7 +164,7 @@ impl SorbetSchema {
             && batch_version != &Self::METADATA_VERSION.to_string()
         {
             re_log::warn_once!(
-                "Sorbet batch version mismatch. Expected {:?}, got {batch_version:?}",
+                "Sorbet batch version mismatch. Expected {}, got {batch_version:?}",
                 Self::METADATA_VERSION
             );
         }

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -40,6 +40,7 @@ pub struct AppState {
     pub blueprint_cfg: RecordingConfig,
 
     /// Maps blueprint id to the current undo state for it.
+    #[serde(skip)]
     pub blueprint_undo_state: HashMap<StoreId, BlueprintUndoState>,
 
     selection_panel: re_selection_panel::SelectionPanel,

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -64,6 +64,7 @@ parking_lot = { workspace = true, features = ["serde"] }
 serde.workspace = true
 slotmap.workspace = true
 smallvec.workspace = true
+static_assertions.workspace = true
 thiserror.workspace = true
 web-time.workspace = true
 wgpu.workspace = true


### PR DESCRIPTION
* Bug introduced in https://github.com/rerun-io/rerun/pull/10853

This disables restoring the undo-stack when restarting the application. This has likely never been tested anyways.
