### PR TITLE
Remove `debug_assert` for `field.name()` in Arrow formatting

### DIFF
--- a/crates/utils/re_arrow_util/src/format_data_type.rs
+++ b/crates/utils/re_arrow_util/src/format_data_type.rs
@@ -127,7 +127,6 @@ impl std::fmt::Display for DisplayDatatype<'_> {
 }
 
 fn format_inner_field(field: &Field) -> String {
-    debug_assert_eq!(field.name(), "item");
     let datatype_display = DisplayDatatype(field.data_type());
     if field.is_nullable() {
         format!("nullable {datatype_display}")


### PR DESCRIPTION
### What

This `debug_assert_eq` would trigger when encountering `MapArray`s (which are totally fine in this context):

```sh
# (Triggered by hovering over a Map field).
thread 'main' panicked at 'assertion `left == right` failed
  left: "entries"
 right: "item"'
re_arrow_util/src/format_data_type.rs:130
```

