### PR TITLE
pixi: Use llvm-ar from PATH on macOS, avoid unexpanded ${PIXI_PROJECT…

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -55,7 +55,7 @@ EXECUTABLE_EXTENSION = ".exe"
 
 # TODO(rust-lang/stacker#127): Work around until wasm build on mac is resolved
 [target.osx-arm64.activation.env]
-AR = "${PIXI_PROJECT_ROOT}/.pixi/envs/default/bin/llvm-ar"
+AR = "llvm-ar"
 
 # python-dev
 


### PR DESCRIPTION
**Problem**
Builds on macOS arm64 (Apple Silicon) fail consistently, and it is not possible to run the project.
The build log shows these lines:
```
    `AR = Some(${PIXI_PROJECT_ROOT}/.pixi/envs/default/bin/llvm-ar)
    ...
    error: failed to find tool "${PIXI_PROJECT_ROOT}/.pixi/envs/default/bin/llvm-ar":
    No such file or directory`
```

It seems that the env var is not expanded, and that TOML treats it as a literal string. Normal shell expansion does not kick in.

**Solution**
A simple fix is to refer to llvm-ar from PATH directly. This affects only osx-arm64.
Tested on macOS arm64 (Apple Silicon) inside pixi shell.
Cargo build succeeds and the project can be run with `pixi run rerun`.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
