### PR TITLE
Deprecate AnyValues With Archetype

### DIFF
--- a/crates/store/re_types/src/any_values.rs
+++ b/crates/store/re_types/src/any_values.rs
@@ -15,7 +15,12 @@ pub struct AnyValues {
 }
 
 impl AnyValues {
+    //TODO(#10879): Prune this method in 0.26.0
     /// Assigns an (archetype) name to this set of any values.
+    #[deprecated(
+        since = "0.24.0",
+        note = "Use of archetype leads to subtle errors. Use default instead."
+    )]
     #[inline]
     pub fn new(archetype_name: impl Into<ArchetypeName>) -> Self {
         Self {

--- a/docs/content/howto/logging/custom-data.md
+++ b/docs/content/howto/logging/custom-data.md
@@ -9,8 +9,8 @@ Rerun comes with many pre-built [Types](../../reference/types.md) that you can u
 For Python and Rust we have helpers for this, called `AnyValues`, allowing you to easily attach custom values to any entity instance.
 You find the documentation for these helpers here:
 
-* [`AnyValues` in Python](https://ref.rerun.io/docs/python/main/common/custom_data/)
-* [`AnyValues` in Rust](https://docs.rs/rerun/latest/rerun/struct.AnyValues.html)
+-   [`AnyValues` in Python](https://ref.rerun.io/docs/python/main/common/custom_data/)
+-   [`AnyValues` in Rust](https://docs.rs/rerun/latest/rerun/struct.AnyValues.html)
 
 ```python
 rr.log(
@@ -20,13 +20,6 @@ rr.log(
         homepage="https://www.rerun.io",
         repository="https://github.com/rerun-io/rerun",
     )
-    # Using Rerun's builtin components.
-    .with_field(
-        rr.ComponentDescriptor("confidence", component_type=rr.components.ScalarBatch._COMPONENT_TYPE), [1.2, 3.4, 5.6]
-    )
-    .with_field(
-        rr.ComponentDescriptor("description", component_type=rr.components.TextBatch._COMPONENT_TYPE), "Bla bla bla…"
-    ),
 )
 ```
 

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -5,6 +5,7 @@ from typing import Any
 import numpy as np
 import pyarrow as pa
 from pyarrow import ArrowInvalid
+from typing_extensions import deprecated
 
 from rerun._baseclasses import ComponentDescriptor
 
@@ -299,10 +300,19 @@ class AnyValues(AsComponents):
                 if batch.is_valid():
                     self.component_batches.append(DescribedComponentBatch(batch, batch.descriptor))
 
+    # TODO(#10908): Prune this method in 0.26.0
+    @deprecated(
+        "`rr.AnyValues.with_field` is deprecated, use constructor directly.",
+    )
     def with_field(
         self, descriptor: str | ComponentDescriptor, value: Any, drop_untyped_nones: bool = True
     ) -> AnyValues:
-        """Adds an `AnyValueBatch` to this `AnyValues` bundle."""
+        """
+        DEPRECATED: Adds an `AnyValueBatch` to this `AnyValues` bundle.
+
+        This method has been deprecated because it is difficult to use correctly.
+        The archetype argument via the descriptor isn't used in constructing a uuid for data entries.
+        """
         batch = AnyBatchValue(descriptor, value, drop_untyped_nones=drop_untyped_nones)
         if batch.is_valid():
             self.component_batches.append(DescribedComponentBatch(batch, batch.descriptor))


### PR DESCRIPTION
### Related
Closes #https://github.com/rerun-io/rerun/issues/10879

### What
This actually takes two different approaches here we might want to wait to resolve this until we discuss what we want from anyvalues/dynamic archetype builder
* For python deprecates `with_field` since that is the only way to include the archetype
* For rust deprecates new since that is how we include the archetype

[This](https://github.com/rerun-io/rerun/pull/10900) changes the formatting which again sort of resolves the issue. 
