### PR TITLE
Fixed highlighting of Python code in docs

### DIFF
--- a/docs/content/concepts/spaces-and-transforms.md
+++ b/docs/content/concepts/spaces-and-transforms.md
@@ -84,7 +84,7 @@ In the future, Rerun will be adding support for additional types of transforms.
 
 Say you have a 3D world with two cameras with known extrinsics (pose) and intrinsics (pinhole model and resolution). You want to log some things in the shared 3D space, and also log each camera image and some detection in these images.
 
-```py
+```python
 # Log some data to the 3D world:
 rr.log("world/points", rr.Points3D(…))
 

--- a/docs/content/reference/migration/migration-0-15.md
+++ b/docs/content/reference/migration/migration-0-15.md
@@ -22,7 +22,7 @@ We still support _splatting_, where you log one single color for the whole point
 
 If you were relying on `InstanceKey` solely to identify your instances when inspecting them in the viewer, then you can replace it with a custom value using [custom data](../../howto/extend/custom-data.md):
 
-```py
+```python
 rr.log(
     "my/points",
     rr.AnyValues(point_id=[17, 42, 103]),

--- a/docs/content/reference/migration/migration-0-22.md
+++ b/docs/content/reference/migration/migration-0-22.md
@@ -20,7 +20,7 @@ The following snippets give a succinct before/after picture; for more informatio
 #### Python
 
 *Before*:
-```py
+```python
 positions = [[i, 0, 0] for i in range(0, 10)]
 
 rr.set_time_sequence("frame", 0)
@@ -41,7 +41,7 @@ rr.log("points", [rr.components.Position3DBatch(positions), rr.components.Radius
 ```
 
 *After*:
-```py
+```python
 positions = [[i, 0, 0] for i in range(0, 10)]
 
 rr.set_time_sequence("frame", 0)
@@ -215,7 +215,7 @@ See also the API reference:
 #### Python
 
 *Before*:
-```py
+```python
 # Prepare a point cloud that evolves over 5 timesteps, changing the number of points in the process.
 times = np.arange(10, 15, 1.0)
 positions = [
@@ -244,7 +244,7 @@ rr.send_columns(
 ```
 
 *After*:
-```py
+```python
 # Prepare a point cloud that evolves over 5 timesteps, changing the number of points in the process.
 times = np.arange(10, 15, 1.0)
 # fmt: off

--- a/docs/content/reference/migration/migration-0-23.md
+++ b/docs/content/reference/migration/migration-0-23.md
@@ -191,7 +191,7 @@ Just like with `send_columns` in the previous release, blueprint overrides and d
 Setting default & override for radius
 
 Before:
-```py
+```python
 rrb.Spatial2DView(
     name="Rect 1",
     origin="/",
@@ -201,7 +201,7 @@ rrb.Spatial2DView(
 )
 ```
 After:
-```py
+```python
 rrb.Spatial2DView(
     name="Rect 1",
     origin="/",
@@ -214,7 +214,7 @@ rrb.Spatial2DView(
 Setting up styles for a plot.
 
 Before:
-```py
+```python
 # …
 rrb.TimeSeriesView(
     name="Trig",
@@ -235,7 +235,7 @@ rrb.TimeSeriesView(
 # …
 ```
 After:
-```py
+```python
 # …
 rrb.TimeSeriesView(
     name="Trig",
@@ -271,7 +271,7 @@ Also, Viewer interaction [was hampered](https://github.com/rerun-io/rerun/issues
 Overrides for these two properties are now always recursive, and can be applied using the new `EntityBehavior` archetype.
 
 Before:
-```py
+```python
 rr.send_blueprint(
     rrb.Spatial2DView(
         overrides={"points": [rrb.components.Visible(False)]}
@@ -290,7 +290,7 @@ rr.send_blueprint(
 ```
 
 After:
-```py
+```python
 rr.send_blueprint(
     rrb.Spatial2DView(
         overrides={
@@ -307,7 +307,7 @@ rr.send_blueprint(
 (Note that this functionality broken in at least Rerun 0.21 and 0.22 but is fixed now. See [#8557](https://github.com/rerun-io/rerun/issues/8557))
 
 Before:
-```py
+```python
 # …
 overrides={
     "helix/structure/scaffolding/beads": [
@@ -322,7 +322,7 @@ overrides={
 ```
 
 After:
-```py
+```python
 # …
 overrides={
     "helix/structure/scaffolding/beads": rrb.VisibleTimeRanges(
@@ -334,7 +334,7 @@ overrides={
 # …
 ```
 … or respectively for multiple timelines:
-```py
+```python
 # …
 overrides={
     "helix/structure/scaffolding/beads": rrb.VisibleTimeRanges([
@@ -361,7 +361,7 @@ scatter plots or lines on the same archetype.
 
 
 Before:
-```py
+```python
 rr.log("trig/sin", rr.SeriesLines(color=[s0, 255, 0], name="cos(0.01t)", width=4), static=True)
 
 for t in range(int(tau * 2 * 100.0)):
@@ -370,7 +370,7 @@ for t in range(int(tau * 2 * 100.0)):
 ```
 
 After:
-```py
+```python
 rr.log("trig/sin", rr.SeriesLines(colors=[255, 0, 0], names="sin(0.01t)", widths=2), static=True)
 
 for t in range(int(tau * 2 * 100.0)):


### PR DESCRIPTION
### What

Unfortunately, I don't know how your site is compiled, so cannot change it to treat `py` as `python` as it happens on GitHub in markdown. Therefore, I changed all occurrences of `py` to be `python` for proper code rendering.