### PR TITLE
Fix `Ellipsoids3D` archetype not showing in 2D view projections

### DIFF
--- a/crates/viewer/re_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/mod.rs
@@ -76,6 +76,7 @@ pub fn register_2d_spatial_visualizers(
     system_registry.register_visualizer::<boxes2d::Boxes2DVisualizer>()?;
     system_registry.register_visualizer::<boxes3d::Boxes3DVisualizer>()?;
     system_registry.register_visualizer::<depth_images::DepthImageVisualizer>()?;
+    system_registry.register_visualizer::<ellipsoids::Ellipsoids3DVisualizer>()?;
     system_registry.register_visualizer::<encoded_image::EncodedImageVisualizer>()?;
     system_registry.register_visualizer::<images::ImageVisualizer>()?;
     system_registry.register_visualizer::<lines2d::Lines2DVisualizer>()?;


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/10919


### What

Would be great to have a regression test on this (an image comparison test that tests various projections might be great regardless!), but I'm a bit short on time and don't want to drop the fix in the name of perfection :/

Confirmed this works with the example script provided in https://github.com/rerun-io/rerun/issues/10919