### PR TITLE
Allow opening web viewer links directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8958,6 +8958,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
+ "vec1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8958,6 +8958,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
+ "url",
  "vec1",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -8,7 +8,7 @@ use crate::FileContents;
 use anyhow::Context as _;
 
 /// Somewhere we can get Rerun logging data from.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LogDataSource {
     /// A remote RRD file, served over http.
     ///

--- a/crates/store/re_data_source/src/lib.rs
+++ b/crates/store/re_data_source/src/lib.rs
@@ -20,7 +20,7 @@ pub use self::data_source::LogDataSource;
 /// This is what you get when loading a file on Web, or when using drag-n-drop.
 //
 // TODO(#4554): drag-n-drop streaming support
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct FileContents {
     pub name: String,
     pub bytes: std::sync::Arc<[u8]>,

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -139,6 +139,7 @@ serde_json.workspace = true
 serde-wasm-bindgen.workspace = true
 tap.workspace = true
 thiserror.workspace = true
+vec1.workspace = true
 web-time.workspace = true
 wgpu.workspace = true
 

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -139,6 +139,7 @@ serde_json.workspace = true
 serde-wasm-bindgen.workspace = true
 tap.workspace = true
 thiserror.workspace = true
+url.workspace = true
 vec1.workspace = true
 web-time.workspace = true
 wgpu.workspace = true

--- a/crates/viewer/re_viewer/src/open_url.rs
+++ b/crates/viewer/re_viewer/src/open_url.rs
@@ -201,13 +201,16 @@ impl ViewerImportUrl {
                     if let Some(window) = web_sys::window()
                         && let Ok(location) = window.location().href()
                         && let Ok(location) = url::Url::parse(&location)
-                        && _base_url != base_url(&location)
                     {
-                        re_log::warn!(
-                            "The base URL of the web viewer ({:?}) does not match the URL being opened ({:?}). This URL may be intended for a different Rerun version.",
-                            location.origin().unicode_serialization(),
-                            _base_url.unicode_serialization(),
-                        );
+                        let current_webpage_base_url = base_url(&location);
+
+                        if _base_url != current_webpage_base_url {
+                            re_log::warn!(
+                                "The base URL of the web viewer ({:?}) does not match the URL being opened ({:?}). This URL may be intended for a different Rerun version.",
+                                current_webpage_base_url.as_str(),
+                                _base_url.as_str(),
+                            );
+                        }
                     }
                 }
 

--- a/crates/viewer/re_viewer/src/open_url.rs
+++ b/crates/viewer/re_viewer/src/open_url.rs
@@ -38,6 +38,15 @@ pub enum ViewerImportUrl {
     ///
     /// This is used only for legacy notebooks.
     WebEventListener(String),
+
+    /// A web viewer URL with one or more url parameters which all individually can be imported.
+    WebViewerUrl {
+        /// The base URL of the web viewer (this no longer includes any queries and fragments).
+        base_url: url::Origin,
+
+        /// The url parameter(s) that can be imported individually.
+        url_parameters: vec1::Vec1<ViewerImportUrl>,
+    },
 }
 
 impl std::str::FromStr for ViewerImportUrl {
@@ -52,6 +61,23 @@ impl std::str::FromStr for ViewerImportUrl {
     /// * intra-recording links (typically links to an entity)
     /// * web event listeners
     fn from_str(url: &str) -> Result<Self, Self::Err> {
+        // This might be a web-viewer URL with `url` parameters.
+        // Extract the `url` parameter and call this function again.
+        if let Ok(url) = url::Url::parse(url) {
+            // It's rare, but there might be *several* `url` parameters.
+            let url_params = url
+                .query_pairs()
+                .filter_map(|(key, value)| (key == "url").then(|| Self::from_str(&value)))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+
+            if let Ok(url_parameters) = vec1::Vec1::try_from_vec(url_params) {
+                return Ok(Self::WebViewerUrl {
+                    base_url: url.origin(),
+                    url_parameters,
+                });
+            }
+        }
+
         if let Ok(uri) = url.parse::<re_uri::CatalogUri>() {
             Ok(Self::RedapCatalog(uri))
         } else if let Ok(uri) = url.parse::<re_uri::EntryUri>() {
@@ -135,6 +161,38 @@ impl ViewerImportUrl {
             Self::WebEventListener(url) => {
                 handle_web_event_listener(egui_ctx, &url, command_sender);
             }
+
+            Self::WebViewerUrl {
+                base_url: _base_url,
+                url_parameters,
+            } => {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    // We _are_ a web viewer.
+                    // If the base URL doesn't match our own then that's reason for concern (==warn),
+                    // because this URL was probably meant to be opened in a different Rerun version.
+                    if let Some(window) = web_sys::window()
+                        && let Ok(location) = window.location().href()
+                        && let Ok(location) = url::Url::parse(&location)
+                        && _base_url != location.origin()
+                    {
+                        re_log::warn!(
+                            "The base URL of the web viewer ({:?}) does not match the URL being opened ({:?}). This URL may be intended for a different Rerun version.",
+                            location.origin().unicode_serialization(),
+                            _base_url.unicode_serialization(),
+                        );
+                    }
+                }
+
+                for url in url_parameters {
+                    url.open(
+                        egui_ctx,
+                        follow_if_http,
+                        select_redap_source_when_loaded,
+                        command_sender,
+                    );
+                }
+            }
         }
     }
 
@@ -189,6 +247,14 @@ impl ViewerImportUrl {
             }
 
             Self::WebEventListener(_) => "Connect to web event listener".to_owned(),
+
+            Self::WebViewerUrl { url_parameters, .. } => {
+                if url_parameters.len() == 1 {
+                    url_parameters.first().open_description()
+                } else {
+                    format!("Open {} URLs", url_parameters.len())
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Related

* based on https://github.com/rerun-io/rerun/pull/10927

### What

Allows you to open the content parts of links like `https://rerun.io/viewer?url=https%3A%2F%2Fapp.rerun.io%2Fversion%2F0.24.1%2Fexamples%2Fgraphs.rrd` directly into native/web viewer.

Opening a mismatching webviewer link on the web will warn. Here's what happens when you put `https://rerun.io/viewer?url=https%3A%2F%2Fapp.rerun.io%2Fversion%2F0.24.1%2Fexamples%2Fgraphs.rrd` into e.g. `http://localhost:9090/?url=rerun%2Bhttp%3A%2F%2Flocalhost%3A9876%2Fproxy`. It still loads fine though!

<img width="455" height="216" alt="image" src="https://github.com/user-attachments/assets/003afa2d-62b0-47e3-ad47-e64b244312cb" />

