### PR TITLE
Fixed typos in docs

### DIFF
--- a/crates/utils/re_log/src/setup.rs
+++ b/crates/utils/re_log/src/setup.rs
@@ -96,7 +96,7 @@ thread_local! {
 /// Note that we can't enable this for all threads since threads run in parallel and may not want to set this.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct PanicOnWarnScope {
-    // The panic scope should decrease the same thread-local value, so it musn't be Send or Sync.
+    // The panic scope should decrease the same thread-local value, so it mustn't be Send or Sync.
     not_send_sync: std::marker::PhantomData<std::cell::Cell<()>>,
 }
 

--- a/rerun_cpp/src/rerun/collection.hpp
+++ b/rerun_cpp/src/rerun/collection.hpp
@@ -185,7 +185,7 @@ namespace rerun {
         /// Borrows binary compatible data into the collection from a vector.
         ///
         /// Borrowed data must outlive the collection!
-        /// The referenced vector must not be resized and musn't be temporary.
+        /// The referenced vector must not be resized and mustn't be temporary.
         ///
         /// Since `rerun::Collection` does not provide write access, data is guaranteed to be unchanged by
         /// any function or operation taking on a `rerun::Collection`.
@@ -466,7 +466,7 @@ namespace rerun {
     /// Borrows binary data into the collection from a vector.
     ///
     /// Borrowed data must outlive the collection!
-    /// The referenced vector must not be resized and musn't be temporary.
+    /// The referenced vector must not be resized and mustn't be temporary.
     ///
     /// Since `rerun::Collection` does not provide write access, data is guaranteed to be unchanged by
     /// any function or operation taking on a `rerun::Collection`.


### PR DESCRIPTION
### What

Fixes typos in `mustn't`.