### PR TITLE
Prevent 100% CPU Usage when running gRPC server by sleeping instead of yielding

### DIFF
--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -196,6 +196,7 @@ pub async fn serve_from_channel(
                     break;
                 }
                 Err(re_smart_channel::TryRecvError::Empty) => {
+                    // Sleep briefly to avoid busy loop when no data is available
                     tokio::time::sleep(Duration::from_millis(10)).await;
                     continue;
                 }
@@ -254,9 +255,10 @@ pub fn spawn_from_rx_set(
                     // We won't ever receive more data:
                     break;
                 }
-                // Because `try_recv` is blocking, we should give other tasks
+                // Because `try_recv` is non-blocking, we should give other tasks
                 // a chance to run before we continue
-                tokio::task::yield_now().await;
+                // Sleep briefly to avoid busy loop when no data is available
+                tokio::time::sleep(Duration::from_millis(10)).await;
                 continue;
             };
 

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -5,7 +5,7 @@ pub mod shutdown;
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::pin::Pin;
-
+use std::time::Duration;
 use re_byte_size::SizeBytes;
 use re_log_encoding::codec::wire::decoder::Decode as _;
 use re_log_types::TableMsg;
@@ -196,8 +196,7 @@ pub async fn serve_from_channel(
                     break;
                 }
                 Err(re_smart_channel::TryRecvError::Empty) => {
-                    // Let other tokio tasks run:
-                    tokio::task::yield_now().await;
+                    tokio::time::sleep(Duration::from_millis(10)).await;
                     continue;
                 }
             };


### PR DESCRIPTION
### Related

I couldn't find anything via search.

### What

When using `server_grpc[_opts]`, the idling gRPC server uses 100% CPU. I tested both on Ubuntu(Host OS) and Debian(Container OS) on AMD64 architecture and had the high usage every time.

```rust
let rec = RecordingStreamBuilder::new("test")
    .recording_id("test")
    .serve_grpc().unwrap();  // <-- process should take up on full CPU core/thread just by starting it
```

The culprit seemed to be the `tokio::task::yield_now()`. If there no other tokio tasks to yield to, then we immediately continue, resulting in a super fast `loop` execution, consuming all of the CPU.


By introducing a proper sleep, we can reduce the idling load to a minimum. I went with 10ms as a trade-off between latency and CPU usage, but I'm happy to adjust it based on reviewer feedback.

I looked at `.recv()` and `.recv_timeout()` but those are not supported in wasm32 which sounded like a no-go (I have to admit I don't know very much about rerun's architecture, so maybe it would be okay?).