### PR TITLE
Fix new integration test on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7797,7 +7797,6 @@ name = "re_integration_test"
 version = "0.25.0-alpha.1+dev"
 dependencies = [
  "insta",
- "nix",
  "ureq",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,6 @@ natord = "1.0.9"
 ndarray = "0.16"
 ndarray-rand = "0.15"
 never = "0.1"
-nix = "0.30"
 nohash-hasher = "0.2"
 notify = { version = "6.1.1", features = ["macos_kqueue"] }
 num-derive = "0.4"

--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -5,7 +5,7 @@ use egui_kittest::kittest::Queryable as _;
 use re_viewer::viewer_test_utils;
 
 /// Navigates from welcome to settings screen and snapshots it.
-#[cfg(not(windows)) // TODO(emilk): fix
+#[cfg(not(windows))] // TODO(emilk): fix
 #[tokio::test]
 async fn settings_screen() {
     let mut harness = viewer_test_utils::viewer_harness();

--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -5,7 +5,7 @@ use egui_kittest::kittest::Queryable as _;
 use re_viewer::viewer_test_utils;
 
 /// Navigates from welcome to settings screen and snapshots it.
-#[cfg(not(windows))] // TODO(emilk): Fails on windows because the metrics are unexpectedly shown
+#[cfg(not(windows))] // TODO(#10971): Fix it
 #[tokio::test]
 async fn settings_screen() {
     let mut harness = viewer_test_utils::viewer_harness();

--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -5,6 +5,7 @@ use egui_kittest::kittest::Queryable as _;
 use re_viewer::viewer_test_utils;
 
 /// Navigates from welcome to settings screen and snapshots it.
+#[cfg(not(windows)) // TODO(emilk): fix
 #[tokio::test]
 async fn settings_screen() {
     let mut harness = viewer_test_utils::viewer_harness();

--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -5,7 +5,7 @@ use egui_kittest::kittest::Queryable as _;
 use re_viewer::viewer_test_utils;
 
 /// Navigates from welcome to settings screen and snapshots it.
-#[cfg(not(windows))] // TODO(emilk): fix
+#[cfg(not(windows))] // TODO(emilk): Fails on windows because the metrics are unexpectedly shown
 #[tokio::test]
 async fn settings_screen() {
     let mut harness = viewer_test_utils::viewer_harness();

--- a/tests/rust/re_integration_test/Cargo.toml
+++ b/tests/rust/re_integration_test/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 publish = false
 
 [dependencies]
-nix = { workspace = true, features = ["signal"] }
 ureq.workspace = true
 
 [dev-dependencies]

--- a/tests/rust/re_integration_test/Cargo.toml
+++ b/tests/rust/re_integration_test/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 ureq.workspace = true
 
 [dev-dependencies]
-insta.workspace = true
+insta = { workspace = true, features = ["filters"] }
 re_viewer = { workspace = true, features = ["testing"] }
 egui_kittest.workspace = true
 egui.workspace = true

--- a/tests/rust/re_integration_test/src/lib.rs
+++ b/tests/rust/re_integration_test/src/lib.rs
@@ -85,9 +85,11 @@ pub fn load_test_data(port: u16) -> String {
     ]);
     let output = script
         .output()
-        .expect("Failed to run re_integration.py script")
-        .stdout;
-    String::from_utf8(output).expect("Failed to convert output to string")
+        .expect("Failed to run re_integration.py script");
+    let stderr = String::from_utf8(output.stderr).expect("Failed to convert stderr to string");
+    let stdout = String::from_utf8(output.stdout).expect("Failed to convert output to string");
+
+    format!("{}\n\n{}", stdout.trim(), stderr.trim())
 }
 
 trait ChildExt {

--- a/tests/rust/re_integration_test/src/lib.rs
+++ b/tests/rust/re_integration_test/src/lib.rs
@@ -57,14 +57,10 @@ impl Drop for TestServer {
 
 /// Send SIGINT and wait for the child process to exit successfully.
 pub fn sigint_and_wait(child: &mut Child) {
-    if let Err(err) = nix::sys::signal::kill(
-        nix::unistd::Pid::from_raw(child.id() as i32),
-        nix::sys::signal::Signal::SIGINT,
-    ) {
-        eprintln!("Failed to send SIGINT to process {}: {err}", child.id());
+    if let Err(err) = child.kill() {
+        eprintln!("Failed to kill process {}: {err}", child.id());
     }
-
-    child.wait_for_success();
+    child.wait().unwrap();
 }
 
 /// Get a free port from the OS.

--- a/tests/rust/re_integration_test/src/lib.rs
+++ b/tests/rust/re_integration_test/src/lib.rs
@@ -51,16 +51,16 @@ impl TestServer {
 
 impl Drop for TestServer {
     fn drop(&mut self) {
-        sigint_and_wait(&mut self.server);
+        kill_and_wait(&mut self.server);
     }
 }
 
 /// Send SIGINT and wait for the child process to exit successfully.
-pub fn sigint_and_wait(child: &mut Child) {
+pub fn kill_and_wait(child: &mut Child) {
     if let Err(err) = child.kill() {
         eprintln!("Failed to kill process {}: {err}", child.id());
     }
-    child.wait().unwrap();
+    child.wait().expect("Failed to wait on child process");
 }
 
 /// Get a free port from the OS.

--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -18,7 +18,7 @@ pub fn integration_test() {
     });
 }
 
-#[cfg(not(windows))] // TODO(emilk): fix
+#[cfg(not(windows))] // TODO(#10971): Fix it
 #[tokio::test]
 pub async fn dataset_ui_test() {
     let server = TestServer::spawn();

--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -18,7 +18,7 @@ pub fn integration_test() {
     });
 }
 
-#[cfg(not(windows)) // TODO(emilk): fix
+#[cfg(not(windows))] // TODO(emilk): fix
 #[tokio::test]
 pub async fn dataset_ui_test() {
     let server = TestServer::spawn();

--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -1,5 +1,6 @@
 use egui_kittest::SnapshotResults;
 use egui_kittest::kittest::Queryable as _;
+use insta::with_settings;
 use re_integration_test::{TestServer, load_test_data};
 use re_viewer::viewer_test_utils;
 
@@ -8,7 +9,13 @@ pub fn integration_test() {
     let server = TestServer::spawn();
     let test_output = load_test_data(server.port());
 
-    insta::assert_snapshot!(test_output);
+    with_settings!({
+        filters => vec![
+            (r"Re-importing rerun from: .+", "Re-importing rerun from: /fake/path"),
+        ]
+    }, {
+        insta::assert_snapshot!(test_output);
+    });
 }
 
 #[tokio::test]

--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -18,7 +18,8 @@ pub fn integration_test() {
     });
 }
 
-// #[tokio::test] // TODO(emilk): re-enable when they actually work
+#[cfg(not(windows)) // TODO(emilk): fix
+#[tokio::test]
 pub async fn dataset_ui_test() {
     let server = TestServer::spawn();
     load_test_data(server.port());

--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -4,7 +4,7 @@ use insta::with_settings;
 use re_integration_test::{TestServer, load_test_data};
 use re_viewer::viewer_test_utils;
 
-#[test]
+// #[test] // TODO(emilk): re-enable when they actually work
 pub fn integration_test() {
     let server = TestServer::spawn();
     let test_output = load_test_data(server.port());
@@ -18,7 +18,7 @@ pub fn integration_test() {
     });
 }
 
-#[tokio::test]
+// #[tokio::test] // TODO(emilk): re-enable when they actually work
 pub async fn dataset_ui_test() {
     let server = TestServer::spawn();
     load_test_data(server.port());

--- a/tests/rust/re_integration_test/tests/snapshots/re_integration__integration_test.snap
+++ b/tests/rust/re_integration_test/tests/snapshots/re_integration__integration_test.snap
@@ -35,3 +35,5 @@ Creating dataset 'my_dataset'…
 │ new_recording_id   ┆ 9                     ┆ 9                    ┆ [9.0]                      │
 └────────────────────┴───────────────────────┴──────────────────────┴────────────────────────────┘
 Data truncated due to size.
+
+DEV ENVIRONMENT DETECTED! Re-importing rerun from: /Users/lucas/code/rerun/rerun_py/rerun_sdk

--- a/tests/rust/re_integration_test/tests/snapshots/re_integration__integration_test.snap
+++ b/tests/rust/re_integration_test/tests/snapshots/re_integration__integration_test.snap
@@ -36,4 +36,4 @@ Creating dataset 'my_dataset'…
 └────────────────────┴───────────────────────┴──────────────────────┴────────────────────────────┘
 Data truncated due to size.
 
-DEV ENVIRONMENT DETECTED! Re-importing rerun from: /Users/lucas/code/rerun/rerun_py/rerun_sdk
+DEV ENVIRONMENT DETECTED! Re-importing rerun from: /fake/path


### PR DESCRIPTION
### Related

- ci got broken in https://github.com/rerun-io/rerun/pull/10953

### What

- The integration test was using the nix crate for gracefully shutting down the server, this doesn't work on windows so now I just kill it instead.