### PR TITLE
Fix empty server UI

### DIFF
--- a/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
+++ b/crates/viewer/re_dataframe_ui/src/datafusion_table_widget.rs
@@ -298,7 +298,16 @@ impl<'a> DataFusionTableWidget<'a> {
 
         let (sorbet_schema, migrated_fields) = {
             let Some(sorbet_batch) = sorbet_batches.first() else {
-                ui.label(egui::RichText::new("This dataset is empty").italics());
+                if let Some(title) = title {
+                    title_ui(ui, None, &title, url.as_ref());
+                }
+
+                Frame::new()
+                    .inner_margin(egui::vec2(16.0, 0.0))
+                    .show(ui, |ui| {
+                        ui.label(egui::RichText::new("Empty table").italics());
+                    });
+
                 return;
             };
 
@@ -348,7 +357,7 @@ impl<'a> DataFusionTableWidget<'a> {
         );
 
         if let Some(title) = title {
-            title_ui(ui, &mut table_config, &title, url.as_ref());
+            title_ui(ui, Some(&mut table_config), &title, url.as_ref());
         }
 
         apply_table_style_fixes(ui.style_mut());
@@ -520,7 +529,12 @@ fn id_from_session_context_and_table(
     egui::Id::new((session_ctx.session_id(), table_ref))
 }
 
-fn title_ui(ui: &mut egui::Ui, table_config: &mut TableConfig, title: &str, url: Option<&String>) {
+fn title_ui(
+    ui: &mut egui::Ui,
+    table_config: Option<&mut TableConfig>,
+    title: &str,
+    url: Option<&String>,
+) {
     Frame::new()
         .inner_margin(Margin {
             top: 16,
@@ -543,7 +557,9 @@ fn title_ui(ui: &mut egui::Ui, table_config: &mut TableConfig, title: &str, url:
                     }
                 },
                 |ui| {
-                    table_config.button_ui(ui);
+                    if let Some(table_config) = table_config {
+                        table_config.button_ui(ui);
+                    }
                 },
             );
         });


### PR DESCRIPTION
### What

Fix the redap browser UI for empty servers.

Note: the copy is a bit generic, but it happens in the datafusion table widget.

### Before/after

<img width="989" height="677" alt="image" src="https://github.com/user-attachments/assets/c1e59e80-81ae-4a3a-93a8-931d7a5bf8b5" />

<img width="989" height="677" alt="image" src="https://github.com/user-attachments/assets/869bd134-5dcb-4adc-9f74-d2fe26cf2ec0" />
