### PR TITLE
Fix closing recordings/tables that are still being loaded showing up again

### DIFF
--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -558,7 +558,18 @@ impl App {
 
             SystemCommand::CloseRecordingOrTable(entry) => {
                 // TODO(#9464): Find a better successor here.
+
+                let data_source = match &entry {
+                    RecordingOrTable::Recording { store_id } => {
+                        store_hub.entity_db_mut(store_id).data_source.clone()
+                    }
+                    RecordingOrTable::Table { .. } => None,
+                };
+                self.rx_log
+                    .retain(|r| Some(r.source()) != data_source.as_ref());
+
                 store_hub.remove(&entry);
+
                 update_web_address_bar(
                     self.startup_options.web_history_enabled(),
                     store_hub,


### PR DESCRIPTION
* Fixes https://github.com/rerun-io/rerun/issues/10965
* Fixes https://github.com/rerun-io/rerun/issues/9848

To reproduce the issue, open a large partition or throttle your network speed. As it's loading, close it in the recording panel. It actually stays there and continues downloading.

The fix is to drop the receiver as well.

I also noticed that dropping the receiver doesn't immediately cancel the download, the `GetChunks` continues in the background according to the console network tab. We should probably look into making those requests fully cancel safe