### PR TITLE
Persist fallback token

### DIFF
--- a/crates/store/re_grpc_client/src/connection_registry.rs
+++ b/crates/store/re_grpc_client/src/connection_registry.rs
@@ -93,16 +93,12 @@ impl ConnectionRegistryHandle {
     /// client instances for longer than the immediate needs. In the future, authentication may
     /// require periodic tokens refresh, so it is necessary to always get a "fresh" client.
     ///
-    /// If a token has already been registered for this origin, it will be used. It will attempt to
+    /// If a token has already been registered for this origin, it will be used. Otherwise, it will attempt to
     /// use the following token, in this order:
     /// - The fallback token, if set via [`Self::set_fallback_token`].
     /// - The `REDAP_TOKEN` environment variable is set.
     ///
     /// Failing that, no token will be used.
-    ///
-    /// Note that a token set via `REDAP_TOKEN` will not be persisted unless [`Self::set_token`] is
-    /// explicitly called. The rationale is to avoid sneakily saving in clear text potentially
-    /// sensitive information.
     pub async fn client(
         &self,
         origin: re_uri::Origin,

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -351,6 +351,7 @@
           enable_history: true,
           notebook: get_query_bool(query, "notebook", false),
           persist: get_query_bool(query, "persist", true),
+          fallback_token: query.get("token"),
         };
 
         let handle = new wasm_bindgen.WebHandle(options);


### PR DESCRIPTION
To reproduce the issue:

- Navigate to an instance with auth enabled, putting in instance URL and token in query params
  - `http://localhost:9090/?url=rerun%2Bhttp%3A%2F%2F127.0.0.1%3A51234%2Fcatalog&token=<TOKEN>`
- The server browser should activate and load up fine
- Reload the page
- The server browser no longer loads, with an error message like "missing credentials".

The token is removed from the URL by the Viewer, but it is also not persisted. That means it's just gone upon reload. Very annoying for the user, so we now persist the fallback token. If a new one is set via `?token=`, then it takes precedence over the stored one.