### PR TITLE
Revert "gitignore `target_pixi_wasm`"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ _deps
 **/target_pixi_wasm
 **/target_ra
 **/target_wasm
-**/target_pixi_wasm
 
 # Python virtual environment:
 **/venv*


### PR DESCRIPTION
Reverts rerun-io/rerun#10975

This was a mistake, it's already there (added in https://github.com/rerun-io/rerun/pull/10952/files) ...maybe a bad checkout on my side at some point? For some reason my git diff contained the files even though i saw it in gitignore. fixed on my side