### PR TITLE
Fix spawn CARGO_TARGET_DIR redirect not properly working on windows

### DIFF
--- a/crates/top/re_sdk/src/spawn.rs
+++ b/crates/top/re_sdk/src/spawn.rs
@@ -110,10 +110,19 @@ impl SpawnOptions {
         {
             let cargo_target_dir =
                 std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_owned());
-            let local_build_path = format!("{cargo_target_dir}/debug/{RERUN_BINARY}");
+            let local_build_path = format!(
+                "{cargo_target_dir}/debug/{}{}",
+                self.executable_name,
+                std::env::consts::EXE_SUFFIX
+            );
             if std::fs::metadata(&local_build_path).is_ok() {
                 re_log::info!("Spawning the locally built rerun at {local_build_path}");
                 return local_build_path;
+            } else {
+                re_log::info!(
+                    "No locally built rerun found at {local_build_path:?}, using executable named {:?} from PATH.",
+                    self.executable_name
+                );
             }
         }
 


### PR DESCRIPTION
### Related

* Follow-up to https://github.com/rerun-io/rerun/pull/10935


### What

Fixes issues with spawning development version of Rerun viewer on Windows