### PR TITLE
Fix windows integration tests

### DIFF
--- a/crates/store/re_server/src/frontend.rs
+++ b/crates/store/re_server/src/frontend.rs
@@ -5,11 +5,8 @@ use arrow::array::{
 };
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use nohash_hasher::IntSet;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
-use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
-    path::PathBuf,
-};
 use tokio_stream::StreamExt as _;
 
 use crate::store::{Dataset, InMemoryStore};
@@ -401,8 +398,8 @@ impl FrontendService for FrontendHandler {
                 ));
             }
 
-            if let Some(rrd_path) = storage_url.as_str().strip_prefix("file://") {
-                let new_partition_ids = dataset.load_rrd(&PathBuf::from(rrd_path), on_duplicate)?;
+            if let Ok(rrd_path) = storage_url.to_file_path() {
+                let new_partition_ids = dataset.load_rrd(&rrd_path, on_duplicate)?;
 
                 for partition_id in new_partition_ids {
                     partition_ids.push(partition_id.to_string());

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -112,7 +112,11 @@ pub struct App {
 
     egui_debug_panel_open: bool,
 
-    pub(crate) latest_latency_interest: web_time::Instant,
+    /// Last time the latency was deemed interesting.
+    ///
+    /// Note that initializing with an "old" `Instant` won't work reliably cross platform
+    /// since `Instant`'s counter may start at program start.
+    pub(crate) latest_latency_interest: Option<web_time::Instant>,
 
     /// Measures how long a frame takes to paint
     pub(crate) frame_time_history: egui::util::History<f32>,
@@ -268,11 +272,6 @@ impl App {
         let mut component_ui_registry = re_component_ui::create_component_ui_registry();
         re_data_ui::register_component_uis(&mut component_ui_registry);
 
-        // TODO(emilk): `Instant::MIN` when we have our own `Instant` that supports it.;
-        let long_time_ago = web_time::Instant::now()
-            .checked_sub(web_time::Duration::from_secs(1_000_000_000))
-            .unwrap_or(web_time::Instant::now());
-
         let (_adapter_backend, _device_tier) = creation_context.wgpu_render_state.as_ref().map_or(
             (
                 wgpu::Backend::Noop,
@@ -364,7 +363,7 @@ impl App {
 
             egui_debug_panel_open: false,
 
-            latest_latency_interest: long_time_ago,
+            latest_latency_interest: None,
 
             frame_time_history: egui::util::History::new(1..100, 0.5),
 

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -107,18 +107,20 @@ fn top_bar_ui(
             if let Some(latency_snapshot) = latency_snapshot {
                 // Should we show the e2e latency?
 
-                // High enough to be consering; low enough to be believable (and almost realtime).
+                // High enough to be concerning; low enough to be believable (and almost realtime).
                 let is_latency_interesting = latency_snapshot
                     .e2e
                     .is_some_and(|e2e| app.app_options().warn_e2e_latency < e2e && e2e < 60.0);
 
-                // Avoid flicker by showing the latency for 1 seconds ince it was last deemned interesting:
-
+                // Avoid flicker by showing the latency for 1 second since it was last deemed interesting:
                 if is_latency_interesting {
-                    app.latest_latency_interest = web_time::Instant::now();
+                    app.latest_latency_interest = Some(web_time::Instant::now());
                 }
 
-                if app.latest_latency_interest.elapsed().as_secs_f32() < 1.0 {
+                if app
+                    .latest_latency_interest
+                    .is_some_and(|instant| instant.elapsed().as_secs_f32() < 1.0)
+                {
                     ui.separator();
                     latency_snapshot_button_ui(ui, latency_snapshot);
                 }

--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -5,7 +5,6 @@ use egui_kittest::kittest::Queryable as _;
 use re_viewer::viewer_test_utils;
 
 /// Navigates from welcome to settings screen and snapshots it.
-#[cfg(not(windows))] // TODO(#10971): Fix it
 #[tokio::test]
 async fn settings_screen() {
     let mut harness = viewer_test_utils::viewer_harness();

--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -13,6 +13,7 @@ async fn settings_screen() {
     harness.get_by_label_contains("Settings…").click();
     // Wait for the FFmpeg-check loading spinner to disappear.
     viewer_test_utils::step_until(
+        "Settings screen shows up with FFMpeg binary not found error",
         &mut harness,
         |harness| {
             harness

--- a/tests/rust/re_integration_test/src/lib.rs
+++ b/tests/rust/re_integration_test/src/lib.rs
@@ -24,8 +24,11 @@ impl TestServer {
             .expect("Failed to start pixi")
             .wait_for_success();
 
-        let mut server = Command::new("../../../target_pixi/debug/rerun");
+        let cargo_target =
+            std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_owned());
+        let mut server = Command::new(format!("../../../{cargo_target}/debug/rerun"));
         server.args(["server", "--port", &port.to_string()]);
+        eprintln!("Starting rerun server at {server:?}");
         let server = server.spawn().expect("Failed to start rerun server");
 
         let mut success = false;

--- a/tests/rust/re_integration_test/src/lib.rs
+++ b/tests/rust/re_integration_test/src/lib.rs
@@ -74,25 +74,35 @@ fn get_free_port() -> u16 {
 }
 
 /// Run `re_integration.py` to load some test data.
-pub fn load_test_data(port: u16) -> String {
+pub fn load_test_data(port: u16) -> Result<String, String> {
     let url = format!("rerun+http://localhost:{port}");
     let mut script = Command::new("pixi");
-    script.args([
-        "run",
-        "-e",
-        "py",
-        "python",
-        "tests/re_integration.py",
-        "--url",
-        &url,
-    ]);
+    script
+        .args([
+            "run",
+            "-e",
+            "py",
+            "python",
+            "tests/re_integration.py",
+            "--url",
+            &url,
+        ])
+        // Fix very silly encoding issues when printing UTF-8 on Windows while being in a commandline with different encoding.
+        .env("PYTHONIOENCODING", "utf-8");
+
     let output = script
         .output()
         .expect("Failed to run re_integration.py script");
-    let stderr = String::from_utf8(output.stderr).expect("Failed to convert stderr to string");
-    let stdout = String::from_utf8(output.stdout).expect("Failed to convert output to string");
 
-    format!("{}\n\n{}", stdout.trim(), stderr.trim())
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let output_text = format!("{}\n\n{}", stdout.trim(), stderr.trim());
+
+    if output.status.success() {
+        Ok(output_text)
+    } else {
+        Err(output_text)
+    }
 }
 
 trait ChildExt {

--- a/tests/rust/re_integration_test/tests/re_integration.py
+++ b/tests/rust/re_integration_test/tests/re_integration.py
@@ -8,6 +8,8 @@ Connect to the OSS Server (or Rerun Cloud Server) and test it.
 
 from __future__ import annotations
 
+import os
+import tempfile
 from argparse import ArgumentParser
 
 import rerun as rr
@@ -25,7 +27,9 @@ def main() -> None:
     dataset_name = "my_dataset"
 
     # Create a simple recording:
-    filepath = "/tmp/rerun_example_test.rrd"
+    filepath = os.path.join(tempfile.gettempdir(), "rerun_example_test.rrd")
+    print(f"Saving recording to {filepath}")
+
     rec = rr.RecordingStream("rerun_example_test", recording_id="new_recording_id")
     rec.save(filepath)
     for x in range(20):

--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -7,7 +7,7 @@ use re_viewer::viewer_test_utils;
 // #[test] // TODO(emilk): re-enable when they actually work
 pub fn integration_test() {
     let server = TestServer::spawn();
-    let test_output = load_test_data(server.port());
+    let test_output = load_test_data(server.port()).expect("Failed to load test data");
 
     with_settings!({
         filters => vec![
@@ -18,11 +18,10 @@ pub fn integration_test() {
     });
 }
 
-#[cfg(not(windows))] // TODO(#10971): Fix it
 #[tokio::test]
 pub async fn dataset_ui_test() {
     let server = TestServer::spawn();
-    load_test_data(server.port());
+    load_test_data(server.port()).expect("Failed to load test data");
 
     let mut harness = viewer_test_utils::viewer_harness();
     let mut snapshot_results = SnapshotResults::new();

--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -49,6 +49,7 @@ pub async fn dataset_ui_test() {
     harness.run_ok();
 
     viewer_test_utils::step_until(
+        "Redap server dataset appears",
         &mut harness,
         |harness| harness.query_by_label_contains("my_dataset").is_some(),
         tokio::time::Duration::from_millis(100),
@@ -58,6 +59,7 @@ pub async fn dataset_ui_test() {
 
     harness.get_by_label("my_dataset").click();
     viewer_test_utils::step_until(
+        "Redap recording id appears",
         &mut harness,
         |harness| {
             harness


### PR DESCRIPTION
### Related

* Fix https://github.com/rerun-io/rerun/issues/10971

### What

Commit by commit.

Functional fixes:
* Windows very briefly showed latency report on startup because the timer init didn't work out
* Registering files on the OSS server was broken on Windows

Rest concerns test harness things


* [ ] pass main-ci