### PR TITLE
Enable OSS server feature when building wheels and release artifacts

### DIFF
--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -174,7 +174,7 @@ jobs:
             --locked \
             -p rerun-cli \
             --no-default-features \
-            --features full_release \
+            --features release_full \
             --release \
             --target ${{ needs.set-config.outputs.TARGET }}
 

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -174,7 +174,7 @@ jobs:
             --locked \
             -p rerun-cli \
             --no-default-features \
-            --features release \
+            --features full_release \
             --release \
             --target ${{ needs.set-config.outputs.TARGET }}
 

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -66,7 +66,7 @@ release_no_web_viewer = ["base", "nasm"]
 ## The features we enable when we build the pre-built binaries during our releases.
 ## These are the binaries we put in our release artifacts, and bundle in our Python wheel.
 ## This may enable features that require extra build tools that not everyone has.
-full_release = ["release_no_web_viewer", "web_viewer"]
+release_full = ["release_no_web_viewer", "web_viewer"]
 
 
 ## Support the map view.

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -35,12 +35,14 @@ doc = false
 ## so we have all the bells and wistles here, except those that may require extra tools
 ## (like "nasm").
 ## That is: `cargo install rerun-cli --locked` should work for _everyone_.
-default = ["native_viewer", "web_viewer", "map_view"]
+default = ["web_viewer", "base"]
 
+## Our base feature set, included in `default` and in `release`, but excludes the web viewer.
+base = ["native_viewer", "map_view", "oss_server"]
 
 # !!!IMPORTANT!!!
 #
-# Do you _really_ want to add features in `release` that are not in `default`?
+# Do you _really_ want to add features in `release_no_web_viewer` that are not in `base`?
 #
 # Here are some reasons not to:
 # - These features will be missing from the `cargo install rerun-cli --locked` command our users will inevitably use.
@@ -56,9 +58,15 @@ default = ["native_viewer", "web_viewer", "map_view"]
 # warning with instructions is printed when building `rerun-cli` in release mode without the `nasm` feature (see
 # `build.rs`).
 
-## The features we enable when we build the pre-built binaries during our releases.
+## The features we enable when we build the pre-built binaries during our releases,
+## but excluding the web viewer.
 ## This may enable features that require extra build tools that not everyone has.
-release = ["default", "nasm"]
+release_no_web_viewer = ["base", "nasm"]
+
+## The features we enable when we build the pre-built binaries during our releases.
+## These are the binaries we put in our release artifacts, and bundle in our Python wheel.
+## This may enable features that require extra build tools that not everyone has.
+full_release = ["release_no_web_viewer", "web_viewer"]
 
 
 ## Support the map view.

--- a/pixi.toml
+++ b/pixi.toml
@@ -175,36 +175,36 @@ man = "cargo --quiet run --package rerun-cli --all-features -- man > docs/conten
 # Compile and run the rerun viewer.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,oss_server --"
+rerun = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer --"
 
 # Compile and run the rerun viewer, with performance telemetry.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-perf-debug = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,perf_telemetry --"
+rerun-perf-debug = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer,perf_telemetry --"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build = "cargo build --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,oss_server"
+rerun-build = "cargo build --package rerun-cli --no-default-features --features release_no_web_viewer"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features map_view,nasm,native_viewer"
+rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features release_no_web_viewer"
 
 # Compile and run the rerun viewer with --release.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-release = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer --release --"
+rerun-release = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer --release --"
 
 # Compile and run the rerun viewer in release, with performance telemetry.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-perf = "cargo run --package rerun-cli --no-default-features --features map_view,nasm,native_viewer,perf_telemetry --release --"
+rerun-perf = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer,perf_telemetry --release --"
 
 # Compile `rerun-cli` with the same feature set as we build for releases.
-rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features release --", depends-on = [
+rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features full_release --", depends-on = [
   "rerun-build-web",
 ] }
 
 # Compile `rerun-cli` with the same feature set as we build for releases.
-rerun-build-native-and-web-release = { cmd = "cargo build --package rerun-cli --no-default-features --features release --release --", depends-on = [
+rerun-build-native-and-web-release = { cmd = "cargo build --package rerun-cli --no-default-features --features full_release --release --", depends-on = [
   "rerun-build-web-release",
 ] }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -199,12 +199,12 @@ rerun-release = "cargo run --package rerun-cli --no-default-features --features 
 rerun-perf = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer,perf_telemetry --release --"
 
 # Compile `rerun-cli` with the same feature set as we build for releases.
-rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features full_release --", depends-on = [
+rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features release_full --", depends-on = [
   "rerun-build-web",
 ] }
 
 # Compile `rerun-cli` with the same feature set as we build for releases.
-rerun-build-native-and-web-release = { cmd = "cargo build --package rerun-cli --no-default-features --features full_release --release --", depends-on = [
+rerun-build-native-and-web-release = { cmd = "cargo build --package rerun-cli --no-default-features --features release_full --release --", depends-on = [
   "rerun-build-web-release",
 ] }
 


### PR DESCRIPTION
This always enabled the `oss_server` feature flag, unless we explicitly opt-out of it.

I also refactored how we specify the release feature set, moving a bunch of complexity from `pixi.toml` into `rerun-cli/Cargo.toml`