### PR TITLE
Run more Rust checks on each PR

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -122,7 +122,7 @@ jobs:
     uses: ./.github/workflows/reusable_checks_rust.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
-      CHANNEL: pr
+      CHANNEL: main # We run the full test suite here, because we've had so many breakages
     secrets: inherit
 
   python-checks:


### PR DESCRIPTION
We've had a red CI way too often lately. Time to require more checks to pass before merging.