### PR TITLE
rerun_cpp: Fix useless semicolon warnings

### DIFF
--- a/rerun_cpp/src/rerun/log_sink.hpp
+++ b/rerun_cpp/src/rerun/log_sink.hpp
@@ -70,5 +70,5 @@ namespace rerun {
 
     namespace detail {
         rr_log_sink to_rr_log_sink(LogSink sink);
-    };
-}; // namespace rerun
+    }
+} // namespace rerun


### PR DESCRIPTION
This shows up when user code is compiled with `-Wpedantic`.
