### PR TITLE
Add test for empty batch creation related to calling count()

### DIFF
--- a/rerun_py/tests/unit/test_datafusion_tables.py
+++ b/rerun_py/tests/unit/test_datafusion_tables.py
@@ -113,6 +113,19 @@ def server_instance() -> Generator[tuple[subprocess.Popen[str], DatasetEntry], N
     shutdown_process(server_process)
 
 
+def test_df_count(server_instance: tuple[subprocess.Popen[str], DatasetEntry]) -> None:
+    """
+    Tests count() on a dataframe which ensures we collect empty batches properly.
+
+    See issue https://github.com/rerun-io/rerun/issues/10894 for additional context.
+    """
+    (_process, dataset) = server_instance
+
+    count = dataset.dataframe_query_view(index="time_1", contents="/**").df().count()
+
+    assert count == 64
+
+
 def test_df_aggregation(server_instance: tuple[subprocess.Popen[str], DatasetEntry]) -> None:
     (_process, dataset) = server_instance
 


### PR DESCRIPTION
### Related

Closes https://github.com/rerun-io/rerun/issues/10894

### What

This adds a unit test to verify that we have coverage for cases where we return empty record batches and need to initialize them with options to avoid a panic.

I reverted the correction in https://github.com/rerun-io/rerun/pull/10895 and ran the pytest. It generates the following error:

```
    def count(self) -> int:
        """Return the total number of rows in this :py:class:`DataFrame`.

        Note that this method will actually run a plan to calculate the
        count, which may be slow for large or complicated DataFrames.

        Returns:
            Number of rows in the DataFrame.
        """
>       return self.df.count()
               ^^^^^^^^^^^^^^^
E       Exception: DataFusion error: Execution("Arrow error: Invalid argument error: must either specify a row count or at least one column")
```

With the correction in place, this test passes.