### PR TITLE
[CI] Fix not caching Rust artifacts on Mac & Windows & use bigger runners

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -81,7 +81,7 @@ runs:
         done
 
     - name: Set up sccache
-      uses: rerun-io/sccache-action@andreas/fix-config-path
+      uses: rerun-io/sccache-action@v0.8.0
       with:
         version: "v0.10.0"
         use_gcs: true

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -88,11 +88,6 @@ runs:
         gcs_bucket: rerun-sccache
         gcs_read_only: false
 
-    - name: Display sccache config
-      shell: bash
-      run: |
-        cat $HOME/.config/sccache/config
-
     - name: Verify sccache
       shell: bash
       run: |

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -83,7 +83,7 @@ runs:
     - name: Set up sccache
       uses: rerun-io/sccache-action@andreas/fix-config-path
       with:
-        version: "v0.7.7"
+        version: "v0.10.0"
         use_gcs: true
         gcs_bucket: rerun-sccache
         gcs_read_only: false

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -81,7 +81,7 @@ runs:
         done
 
     - name: Set up sccache
-      uses: rerun-io/sccache-action@v0.7.1
+      uses: rerun-io/sccache-action@andreas/fix-config-path
       with:
         version: "v0.7.7"
         use_gcs: true

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -97,19 +97,19 @@ jobs:
               bin_name="rerun"
               ;;
             windows-x64)
-              runner="windows-latest-8-cores"
+              runner="windows-latest-16-cores"
               target="x86_64-pc-windows-msvc"
               container="null"
               bin_name="rerun.exe"
               ;;
             macos-arm64)
-              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               bin_name="rerun"
               ;;
             macos-x64)
-              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="x86_64-apple-darwin"
               container="null"
               bin_name="rerun"

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -116,19 +116,19 @@ jobs:
               container="'rerunio/ci_docker:0.16.0'" # Required to be manylinux compatible
               ;;
             windows-x64)
-              runner="windows-latest-8-cores"
+              runner="windows-latest-16-cores"
               target="x86_64-pc-windows-msvc"
               container="null"
               compat="manylinux_2_28"
               ;;
             macos-arm64)
-              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               compat="manylinux_2_28"
               ;;
             macos-x64)
-              runner="macos-15-large" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-15-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="x86_64-apple-darwin"
               container="null"
               compat="manylinux_2_28"

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -150,9 +150,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs_on: "macos-15-large"
+          - runs_on: "macos-15-xlarge"
             name: "macos"
-          - runs_on: "windows-latest-8-cores"
+          - runs_on: "windows-latest-16-cores"
             name: "windows"
 
     # Note: we can't use `matrix.runs_on` here because its evaluated before the matrix stuff.

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -94,7 +94,7 @@ jobs:
         run: pixi run rerun-build-web && pixi run ./scripts/ci/check_cli_docs.py
 
   rs-tests:
-    name: Rust tests
+    name: Test on Linux
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so
     runs-on: ubuntu-22.04-large
     env:
@@ -133,7 +133,7 @@ jobs:
       - name: Rust tests
         run: pixi run rs-check --only tests
 
-      - name: Rust tests without --all-features
+      - name: Rust tests without --all-features (`main`/`nightly` channel)
         if: ${{ inputs.CHANNEL != 'pr' }}
         run: pixi run rs-check --only tests_without_all_features
 
@@ -190,11 +190,11 @@ jobs:
       - name: Setup software rasterizer
         run: pixi run python ./scripts/ci/setup_software_rasterizer.py
 
-      - name: Rust tests
+      - name: Rust tests (`main` channel)
         if: ${{ inputs.CHANNEL == 'main' }}
         run: pixi run rs-check --only tests
 
-      - name: Rust all checks & tests
+      - name: Rust all checks & tests (`nightly` channel)
         if: ${{ inputs.CHANNEL == 'nightly' }}
         run: pixi run rs-check
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -2200,7 +2200,7 @@ impl App {
         storage_ctx: &StorageContext<'_>,
         command_sender: &CommandSender,
     ) {
-        #![allow(clippy::needless_continue)] // false positive, depending on target_arche
+        #![allow(clippy::needless_continue)] // false positive, depending on target_arch
 
         preview_files_being_dropped(egui_ctx);
 


### PR DESCRIPTION
Turns out the culprit for ultra slow Windows & Mac test runs (recently enabled for PRs) is that sccache config wasn't hit.
This is fixed in https://github.com/rerun-io/sccache-action/tree/andreas/fix-config-path

Some cosmetics on the way.

Draft:
* [x] Just testing this whole thing
* [x] test again with newer sccache version
* [x] use tagged version
* [x] test large mac runner
* [x] 16 core windows runner
* [x] rename our 16 windows runner to `windows-latest-16-cores` and ensure this works

---
Measurement overview. Uses updated sccache unless noted otherwise. Cache hit numbers are from `Post Set up Rust` step. More details & links in comments:

Mac:

* large: no cache 43min
* large: build cache (sccache7.7) 35min
* large: cache hit rate 14%: 31min
* large: cache hit rate 96%: 17.5min
* Xlarge: cache hit rate 17%: 15min
* Xlarge: cache hit rate 96%: 9min
* Xlarge: cache hit rate 96%: 8min

Windows:

* 8-core: no cache 34min
* 8-core: build cache (sccache7.7) 38min 
* 8-core: cache hit rate 0%: 35min
* 8-core: cache hit rate 82%: 24min
* 16-core: cache hit rate 82%: 17min


Linux times stayed the whole time constant around 7min