### PR TITLE
[ci] Re-use built CLI for man page check

### DIFF
--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -178,6 +178,13 @@ jobs:
             --release \
             --target ${{ needs.set-config.outputs.TARGET }}
 
+      # Now that we already have a CLI binary, we can use it to check whether our man page is up to date.
+      - name: Compare man page to CLI docs
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          pixi run ./scripts/ci/check_cli_docs.py --rerun-exe ./target_pixi/release/rerun
+
       - name: Get sha
         id: get-sha
         run: |

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -90,9 +90,6 @@ jobs:
         # See tests/assets/rrd/README.md for more
         run: pixi run check-backwards-compatibility
 
-      - name: Compare man page to CLI docs
-        run: pixi run rerun-build-web && pixi run ./scripts/ci/check_cli_docs.py
-
   rs-tests:
     name: Test on Linux
     # TODO(andreas): setup-vulkan doesn't work on 24.4 right now due to missing .so

--- a/scripts/ci/check_cli_docs.py
+++ b/scripts/ci/check_cli_docs.py
@@ -10,8 +10,23 @@ from pathlib import Path
 
 
 def main() -> None:
-    command = ["cargo", "run", "--package", "rerun-cli", "--all-features", "--", "man"]
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check if CLI documentation is up-to-date.")
+    parser.add_argument(
+        "--rerun-exe",
+        type=str,
+        default=None,
+        help="Path to rerun executable to use instead of building with cargo.",
+    )
+    args = parser.parse_args()
+
     expected_file: Path = Path("docs/content/reference/cli.md")
+
+    if args.rerun_exe:
+        command = [args.rerun_exe, "man"]
+    else:
+        command = ["cargo", "run", "--package", "rerun-cli", "--all-features", "--", "man"]
 
     # Generate current output
     try:


### PR DESCRIPTION
We recently introduced a check for the cli's doc page. But we built the cli from scratch for that (plus some sccache caching which doesn't work _that_ well) taking around 7min 😱 . We already build the CLI on *every* CI run, so let's re-use that!