### PR TITLE
Add flag that allows cleanup of more recent Lance files in the maintenance

### DIFF
--- a/crates/store/re_grpc_client/src/connection_client.rs
+++ b/crates/store/re_grpc_client/src/connection_client.rs
@@ -365,7 +365,7 @@ where
         build_scalar_indexes: bool,
         compact_fragments: bool,
         cleanup_before: Option<jiff::Timestamp>,
-        allow_recent_cleanup: bool,
+        unsafe_allow_recent_cleanup: bool,
     ) -> Result<(), StreamError> {
         self.inner()
             .do_maintenance(tonic::Request::new(
@@ -374,7 +374,7 @@ where
                     build_scalar_indexes,
                     compact_fragments,
                     cleanup_before,
-                    allow_recent_cleanup,
+                    unsafe_allow_recent_cleanup,
                 }
                 .into(),
             ))

--- a/crates/store/re_grpc_client/src/connection_client.rs
+++ b/crates/store/re_grpc_client/src/connection_client.rs
@@ -364,6 +364,7 @@ where
         build_scalar_indexes: bool,
         compact_fragments: bool,
         cleanup_before: Option<jiff::Timestamp>,
+        allow_recent_cleanup: bool,
     ) -> Result<(), StreamError> {
         self.inner()
             .do_maintenance(tonic::Request::new(
@@ -372,6 +373,7 @@ where
                     build_scalar_indexes,
                     compact_fragments,
                     cleanup_before,
+                    allow_recent_cleanup,
                 }
                 .into(),
             ))

--- a/crates/store/re_grpc_client/src/connection_client.rs
+++ b/crates/store/re_grpc_client/src/connection_client.rs
@@ -358,6 +358,7 @@ where
         Ok(response.table_entry)
     }
 
+    #[allow(clippy::fn_params_excessive_bools)]
     pub async fn do_maintenance(
         &mut self,
         dataset_id: EntryId,

--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -352,6 +352,6 @@ message DoMaintenanceRequest {
 
   // Override default platform behavior and allow cleanup of recent files. This will respect
   // the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
-  // Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
-  bool allow_recent_cleanup = 5;
+  // ⚠️ Do not ever use this unless you know exactly what you're doing. Improper use will lead to data loss.
+  bool unsafe_allow_recent_cleanup = 5;
 }

--- a/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/frontend.proto
@@ -343,5 +343,15 @@ message DoMaintenanceRequest {
   bool compact_fragments = 3;
 
   // If set, all Lance fragments older than this date will be removed, for all Rerun Manifests.
+  // In case requested date is more recent than 1 hour, it will be ignored and 1 hour ago
+  // timestamp will be used. This is to prevent still used files (like recent transaction files)
+  // to be removed and cause Lance Dataset update issues.
+  // See https://docs.rs/lance/latest/lance/dataset/cleanup/index.html
+  // and https://docs.rs/lance/latest/lance/dataset/cleanup/fn.cleanup_old_versions.html
   google.protobuf.Timestamp cleanup_before = 4;
+
+  // Override default platform behavior and allow cleanup of recent files. This will respect
+  // the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
+  // Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
+  bool allow_recent_cleanup = 5;
 }

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -560,8 +560,8 @@ message DoMaintenanceRequest {
 
   // Override default platform behavior and allow cleanup of recent files. This will respect
   // the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
-  // Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
-  bool allow_recent_cleanup = 5;
+  // ⚠️ Do not ever use this unless you know exactly what you're doing. Improper use will lead to data loss.
+  bool unsafe_allow_recent_cleanup = 5;
 }
 
 message DoMaintenanceResponse {

--- a/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/manifest_registry.proto
@@ -551,7 +551,17 @@ message DoMaintenanceRequest {
   bool compact_fragments = 3;
 
   // If set, all Lance fragments older than this date will be removed, for all Rerun Manifests.
+  // In case requested date is more recent than 1 hour, it will be ignored and 1 hour ago
+  // timestamp will be used. This is to prevent still used files (like recent transaction files)
+  // to be removed and cause Lance Dataset update issues.
+  // See https://docs.rs/lance/latest/lance/dataset/cleanup/index.html
+  // and https://docs.rs/lance/latest/lance/dataset/cleanup/fn.cleanup_old_versions.html
   google.protobuf.Timestamp cleanup_before = 4;
+
+  // Override default platform behavior and allow cleanup of recent files. This will respect
+  // the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
+  // Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
+  bool allow_recent_cleanup = 5;
 }
 
 message DoMaintenanceResponse {

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.ext.rs
@@ -180,6 +180,7 @@ pub struct DoMaintenanceRequest {
     pub build_scalar_indexes: bool,
     pub compact_fragments: bool,
     pub cleanup_before: Option<jiff::Timestamp>,
+    pub allow_recent_cleanup: bool,
 }
 
 impl From<DoMaintenanceRequest> for crate::frontend::v1alpha1::DoMaintenanceRequest {
@@ -192,6 +193,7 @@ impl From<DoMaintenanceRequest> for crate::frontend::v1alpha1::DoMaintenanceRequ
                 seconds: ts.as_second(),
                 nanos: ts.subsec_nanosecond(),
             }),
+            allow_recent_cleanup: value.allow_recent_cleanup,
         }
     }
 }

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.ext.rs
@@ -180,7 +180,7 @@ pub struct DoMaintenanceRequest {
     pub build_scalar_indexes: bool,
     pub compact_fragments: bool,
     pub cleanup_before: Option<jiff::Timestamp>,
-    pub allow_recent_cleanup: bool,
+    pub unsafe_allow_recent_cleanup: bool,
 }
 
 impl From<DoMaintenanceRequest> for crate::frontend::v1alpha1::DoMaintenanceRequest {
@@ -193,7 +193,7 @@ impl From<DoMaintenanceRequest> for crate::frontend::v1alpha1::DoMaintenanceRequ
                 seconds: ts.as_second(),
                 nanos: ts.subsec_nanosecond(),
             }),
-            allow_recent_cleanup: value.allow_recent_cleanup,
+            unsafe_allow_recent_cleanup: value.unsafe_allow_recent_cleanup,
         }
     }
 }

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -377,8 +377,18 @@ pub struct DoMaintenanceRequest {
     #[prost(bool, tag = "3")]
     pub compact_fragments: bool,
     /// If set, all Lance fragments older than this date will be removed, for all Rerun Manifests.
+    /// In case requested date is more recent than 1 hour, it will be ignored and 1 hour ago
+    /// timestamp will be used. This is to prevent still used files (like recent transaction files)
+    /// to be removed and cause Lance Dataset update issues.
+    /// See <https://docs.rs/lance/latest/lance/dataset/cleanup/index.html>
+    /// and <https://docs.rs/lance/latest/lance/dataset/cleanup/fn.cleanup_old_versions.html>
     #[prost(message, optional, tag = "4")]
     pub cleanup_before: ::core::option::Option<::prost_types::Timestamp>,
+    /// Override default platform behavior and allow cleanup of recent files. This will respect
+    /// the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
+    /// Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
+    #[prost(bool, tag = "5")]
+    pub allow_recent_cleanup: bool,
 }
 impl ::prost::Name for DoMaintenanceRequest {
     const NAME: &'static str = "DoMaintenanceRequest";

--- a/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.frontend.v1alpha1.rs
@@ -386,9 +386,9 @@ pub struct DoMaintenanceRequest {
     pub cleanup_before: ::core::option::Option<::prost_types::Timestamp>,
     /// Override default platform behavior and allow cleanup of recent files. This will respect
     /// the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
-    /// Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
+    /// ⚠️ Do not ever use this unless you know exactly what you're doing. Improper use will lead to data loss.
     #[prost(bool, tag = "5")]
-    pub allow_recent_cleanup: bool,
+    pub unsafe_allow_recent_cleanup: bool,
 }
 impl ::prost::Name for DoMaintenanceRequest {
     const NAME: &'static str = "DoMaintenanceRequest";

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -712,6 +712,7 @@ pub struct DoMaintenanceRequest {
     pub build_scalar_indexes: bool,
     pub compact_fragments: bool,
     pub cleanup_before: Option<jiff::Timestamp>,
+    pub allow_recent_cleanup: bool,
 }
 
 impl TryFrom<crate::manifest_registry::v1alpha1::DoMaintenanceRequest> for DoMaintenanceRequest {
@@ -737,6 +738,7 @@ impl TryFrom<crate::manifest_registry::v1alpha1::DoMaintenanceRequest> for DoMai
             build_scalar_indexes: value.build_scalar_indexes,
             compact_fragments: value.compact_fragments,
             cleanup_before,
+            allow_recent_cleanup: value.allow_recent_cleanup,
         })
     }
 }
@@ -751,6 +753,7 @@ impl From<DoMaintenanceRequest> for crate::manifest_registry::v1alpha1::DoMainte
                 seconds: ts.as_second(),
                 nanos: ts.subsec_nanosecond(),
             }),
+            allow_recent_cleanup: value.allow_recent_cleanup,
         }
     }
 }

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.ext.rs
@@ -712,7 +712,7 @@ pub struct DoMaintenanceRequest {
     pub build_scalar_indexes: bool,
     pub compact_fragments: bool,
     pub cleanup_before: Option<jiff::Timestamp>,
-    pub allow_recent_cleanup: bool,
+    pub unsafe_allow_recent_cleanup: bool,
 }
 
 impl TryFrom<crate::manifest_registry::v1alpha1::DoMaintenanceRequest> for DoMaintenanceRequest {
@@ -738,7 +738,7 @@ impl TryFrom<crate::manifest_registry::v1alpha1::DoMaintenanceRequest> for DoMai
             build_scalar_indexes: value.build_scalar_indexes,
             compact_fragments: value.compact_fragments,
             cleanup_before,
-            allow_recent_cleanup: value.allow_recent_cleanup,
+            unsafe_allow_recent_cleanup: value.unsafe_allow_recent_cleanup,
         })
     }
 }
@@ -753,7 +753,7 @@ impl From<DoMaintenanceRequest> for crate::manifest_registry::v1alpha1::DoMainte
                 seconds: ts.as_second(),
                 nanos: ts.subsec_nanosecond(),
             }),
-            allow_recent_cleanup: value.allow_recent_cleanup,
+            unsafe_allow_recent_cleanup: value.unsafe_allow_recent_cleanup,
         }
     }
 }

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -883,9 +883,9 @@ pub struct DoMaintenanceRequest {
     pub cleanup_before: ::core::option::Option<::prost_types::Timestamp>,
     /// Override default platform behavior and allow cleanup of recent files. This will respect
     /// the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
-    /// Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
+    /// ⚠️ Do not ever use this unless you know exactly what you're doing. Improper use will lead to data loss.
     #[prost(bool, tag = "5")]
-    pub allow_recent_cleanup: bool,
+    pub unsafe_allow_recent_cleanup: bool,
 }
 impl ::prost::Name for DoMaintenanceRequest {
     const NAME: &'static str = "DoMaintenanceRequest";

--- a/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.manifest_registry.v1alpha1.rs
@@ -874,8 +874,18 @@ pub struct DoMaintenanceRequest {
     #[prost(bool, tag = "3")]
     pub compact_fragments: bool,
     /// If set, all Lance fragments older than this date will be removed, for all Rerun Manifests.
+    /// In case requested date is more recent than 1 hour, it will be ignored and 1 hour ago
+    /// timestamp will be used. This is to prevent still used files (like recent transaction files)
+    /// to be removed and cause Lance Dataset update issues.
+    /// See <https://docs.rs/lance/latest/lance/dataset/cleanup/index.html>
+    /// and <https://docs.rs/lance/latest/lance/dataset/cleanup/fn.cleanup_old_versions.html>
     #[prost(message, optional, tag = "4")]
     pub cleanup_before: ::core::option::Option<::prost_types::Timestamp>,
+    /// Override default platform behavior and allow cleanup of recent files. This will respect
+    /// the value of `cleanup_before` timestamp even if it's more recent than 1 hour.
+    /// Warning - trying to cleanup more recent Lance artifacts may cause Dataset update issues.
+    #[prost(bool, tag = "5")]
+    pub allow_recent_cleanup: bool,
 }
 impl ::prost::Name for DoMaintenanceRequest {
     const NAME: &'static str = "DoMaintenanceRequest";

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1500,7 +1500,7 @@ class DatasetEntry(Entry):
         build_scalar_index: bool = False,
         compact_fragments: bool = False,
         cleanup_before: Optional[datetime] = None,
-        allow_recent_cleanup: bool = False,
+        unsafe_allow_recent_cleanup: bool = False,
     ) -> None:
         """Perform maintenance tasks on the datasets."""
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1500,6 +1500,7 @@ class DatasetEntry(Entry):
         build_scalar_index: bool = False,
         compact_fragments: bool = False,
         cleanup_before: Optional[datetime] = None,
+        allow_recent_cleanup: bool = False,
     ) -> None:
         """Perform maintenance tasks on the datasets."""
 

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -303,6 +303,7 @@ impl ConnectionHandle {
         build_scalar_indexes: bool,
         compact_fragments: bool,
         cleanup_before: Option<jiff::Timestamp>,
+        allow_recent_cleanup: bool,
     ) -> PyResult<()> {
         wait_for_future(
             py,
@@ -314,6 +315,7 @@ impl ConnectionHandle {
                         build_scalar_indexes,
                         compact_fragments,
                         cleanup_before,
+                        allow_recent_cleanup,
                     )
                     .await
                     .map_err(to_py_err)

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -296,6 +296,7 @@ impl ConnectionHandle {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
+    #[allow(clippy::fn_params_excessive_bools)]
     pub fn do_maintenance(
         &self,
         py: Python<'_>,

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -304,7 +304,7 @@ impl ConnectionHandle {
         build_scalar_indexes: bool,
         compact_fragments: bool,
         cleanup_before: Option<jiff::Timestamp>,
-        allow_recent_cleanup: bool,
+        unsafe_allow_recent_cleanup: bool,
     ) -> PyResult<()> {
         wait_for_future(
             py,
@@ -316,7 +316,7 @@ impl ConnectionHandle {
                         build_scalar_indexes,
                         compact_fragments,
                         cleanup_before,
-                        allow_recent_cleanup,
+                        unsafe_allow_recent_cleanup,
                     )
                     .await
                     .map_err(to_py_err)

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -728,7 +728,7 @@ impl PyDatasetEntry {
             build_scalar_index = false,
             compact_fragments = false,
             cleanup_before = None,
-            allow_recent_cleanup = false,
+            unsafe_allow_recent_cleanup = false,
     ))]
     #[instrument(skip_all, err)]
     #[allow(clippy::fn_params_excessive_bools)]
@@ -738,7 +738,7 @@ impl PyDatasetEntry {
         build_scalar_index: bool,
         compact_fragments: bool,
         cleanup_before: Option<Bound<'_, PyAny>>,
-        allow_recent_cleanup: bool,
+        unsafe_allow_recent_cleanup: bool,
     ) -> PyResult<()> {
         let super_ = self_.as_super();
         let connection = super_.client.borrow(self_.py()).connection().clone();
@@ -765,7 +765,7 @@ impl PyDatasetEntry {
             build_scalar_index,
             compact_fragments,
             cleanup_before,
-            allow_recent_cleanup,
+            unsafe_allow_recent_cleanup,
         )
     }
 }

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -728,6 +728,7 @@ impl PyDatasetEntry {
             build_scalar_index = false,
             compact_fragments = false,
             cleanup_before = None,
+            allow_recent_cleanup = false,
     ))]
     #[instrument(skip_all, err)]
     fn do_maintenance(
@@ -736,6 +737,7 @@ impl PyDatasetEntry {
         build_scalar_index: bool,
         compact_fragments: bool,
         cleanup_before: Option<Bound<'_, PyAny>>,
+        allow_recent_cleanup: bool,
     ) -> PyResult<()> {
         let super_ = self_.as_super();
         let connection = super_.client.borrow(self_.py()).connection().clone();
@@ -762,6 +764,7 @@ impl PyDatasetEntry {
             build_scalar_index,
             compact_fragments,
             cleanup_before,
+            allow_recent_cleanup,
         )
     }
 }

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -731,6 +731,7 @@ impl PyDatasetEntry {
             allow_recent_cleanup = false,
     ))]
     #[instrument(skip_all, err)]
+    #[allow(clippy::fn_params_excessive_bools)]
     fn do_maintenance(
         self_: PyRef<'_, Self>,
         py: Python<'_>,


### PR DESCRIPTION
### What

Introduce a flag in the ``DoMaintenance`` API call that allows overriding default platform behaviour that prevents cleanup of Lance dataset artifacts older than 1 hour. If ``allow_recent_cleanup`` is set, ``cleanup_before`` will be respected, regardless of its value. 
