### PR TITLE
Remove `--drop-at-latency`

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -97,16 +97,6 @@ struct Args {
     #[clap(long, default_value = "0.0.0.0")]
     bind: IpAddr,
 
-    /// Set a maximum input latency, e.g. "200ms" or "10s".
-    ///
-    /// If we go over this, we start dropping packets.
-    ///
-    /// The default is no limit, which means Rerun might eat more and more memory
-    /// and have longer and longer latency, if you are logging data faster
-    /// than Rerun can index it.
-    #[clap(long)]
-    drop_at_latency: Option<String>,
-
     #[clap(
         long,
         default_value = "75%",
@@ -487,13 +477,6 @@ impl Args {
             // > What bind address IP to use.
             // >
             // > [default: 0.0.0.0]
-            //
-            // `--drop-at-latency <DROP_AT_LATENCY>`
-            // > Set a maximum input latency, e.g. "200ms" or "10s".
-            // >
-            // > If we go over this, we start dropping packets.
-            // >
-            // > The default is no limit, which means Rerun might eat more and more memory and have longer and longer latency, if you are logging data faster than Rerun can index it.
             // """
             let floatings = any_floating_args.then(|| {
                 let options = cmd

--- a/docs/content/howto/visualization/limit-ram.md
+++ b/docs/content/howto/visualization/limit-ram.md
@@ -9,9 +9,3 @@ description: How to limit the memory used by the Rerun Viewer so that it doesn't
 The Rerun Viewer can not yet view more data than fits in RAM. The more data you log, the more RAM the Rerun Viewer will use. When it reaches a certain limit, the oldest data will be dropped. The default limit it to use up to 75% of the total system RAM.
 
 You can set the limit by with the `--memory-limit` command-lint argument, or the `memory_limit` argument of [`rr.spawn`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.spawn).
-
-### --drop-at-latency
-
-If you have multiple processes generating log data to Rerun it could happen that the Viewer builds up a backlog of unprocessed log messages. This can induce latency and also use up memory, which `--memory-limit` cannot fix. To handle this case, you can use `rerun --drop-at-latency 500ms` to start ignoring _new_ data if the input buffer exceeds 500ms of data.
-
-This is a rarely used feature, and is mostly documented here for completeness.

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -43,13 +43,6 @@ The Rerun command-line interface:
 >
 > [Default: `0.0.0.0`]
 
-* `--drop-at-latency <DROP_AT_LATENCY>`
-> Set a maximum input latency, e.g. "200ms" or "10s".
->
-> If we go over this, we start dropping packets.
->
-> The default is no limit, which means Rerun might eat more and more memory and have longer and longer latency, if you are logging data faster than Rerun can index it.
-
 * `--memory-limit <MEMORY_LIMIT>`
 > An upper limit on how much memory the Rerun Viewer should use.
 > When this limit is reached, Rerun will drop the oldest data.

--- a/docs/content/reference/migration/migration-0-25.md
+++ b/docs/content/reference/migration/migration-0-25.md
@@ -10,6 +10,11 @@ order: 985
 Use `--web-viewer` instead.
 
 
+## Removed the `--drop-at-latency` CLI argument
+
+This feature has been defunct for a while. A better replacement can be tracked [in this issue](https://github.com/rerun-io/rerun/issues/11024).
+
+
 ## Changed arrow encoding of blobs
 We used to encode blobs as `List<uint8>`, which was rather unidiomatic.
 Now they are instead encoded as `Binary`.


### PR DESCRIPTION
### Related
* https://github.com/rerun-io/rerun/issues/11024

### What
This option has been broken for a while (a no-op).

A better solution is
* https://github.com/rerun-io/rerun/issues/11024