### PR TITLE
Add `tzdata` dependency to fix Windows CI

### DIFF
--- a/rerun_py/tests/unit/test_datafusion_tables.py
+++ b/rerun_py/tests/unit/test_datafusion_tables.py
@@ -28,6 +28,14 @@ DATASET_FILEPATH = pathlib.Path(__file__).parent.parent.parent.parent / "tests" 
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_windows_tzdata() -> None:
+    """
+    Adds timezone data on Windows machines.
+
+    Pyarrow requires timezone data to handle timestamps properly.
+    Arrow can use the OS-provided timezone database on Mac and Linux
+    but it requires this command to install tzdata for Windows.
+    https://arrow.apache.org/docs/python/install.html#tzdata-on-windows
+    """
     if platform.system() == "Windows":
         pa.util.download_tzdata_on_windows()
 

--- a/rerun_py/tests/unit/test_datafusion_tables.py
+++ b/rerun_py/tests/unit/test_datafusion_tables.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import platform
 import subprocess
 import time
 from typing import TYPE_CHECKING
@@ -23,6 +24,12 @@ CATALOG_URL = f"rerun+http://{HOST}:{PORT}"
 DATASET_NAME = "dataset"
 
 DATASET_FILEPATH = pathlib.Path(__file__).parent.parent.parent.parent / "tests" / "assets" / "rrd" / "dataset"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_windows_tzdata() -> None:
+    if platform.system() == "Windows":
+        pa.util.download_tzdata_on_windows()
 
 
 def shutdown_process(process: subprocess.Popen[str]) -> None:


### PR DESCRIPTION
This is related to the following CI failure: https://github.com/rerun-io/rerun/actions/runs/17284887058/job/49062341297

This adds tzdata, a 120kb dependency. With this users will have time zones support that is needed by pyarrow. There are other ways to get the time zone support, which is why it is not a required dependency. 