### PR TITLE
Use `opened_store_id_or_recommended()` in MCAP loader

### DIFF
--- a/crates/store/re_data_loader/src/loader_mcap.rs
+++ b/crates/store/re_data_loader/src/loader_mcap.rs
@@ -162,7 +162,7 @@ fn load_mcap(
 ) -> Result<(), DataLoaderError> {
     re_tracing::profile_function!();
 
-    let store_id = settings.recommended_store_id();
+    let store_id = settings.opened_store_id_or_recommended();
 
     if tx
         .send(LoadedData::LogMsg(

--- a/crates/store/re_data_loader/src/loader_mcap.rs
+++ b/crates/store/re_data_loader/src/loader_mcap.rs
@@ -162,6 +162,7 @@ fn load_mcap(
 ) -> Result<(), DataLoaderError> {
     re_tracing::profile_function!();
 
+    // If there's an open store, use it. If there's no store yet, use the recommended id.
     let store_id = settings.opened_store_id_or_recommended();
 
     if tx


### PR DESCRIPTION
### What

Update MCAP loader to prefer the opened store when available, falling back to the recommended store ID if none is opened.

This was causing the recording to split in two when loading an MCAP file using the SDK.