### PR TITLE
Use `ViewerImportUrl` for updating history, adds more unit tests

### DIFF
--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -15,7 +15,7 @@ pub enum LogDataSource {
     /// Could be either an `.rrd` recording or a `.rbl` blueprint.
     RrdHttpUrl {
         /// This is a canonicalized URL path without any parameters or fragments.
-        url: String,
+        url: url::Url,
 
         /// If `follow` is `true`, the viewer will open the stream in `Following` mode rather than `Playing` mode.
         follow: bool,
@@ -125,14 +125,12 @@ impl LogDataSource {
         } else if let Ok(uri) = url.parse::<re_uri::ProxyUri>() {
             Some(Self::RedapProxy(uri))
         } else {
-            let mut parsed_url = url::Url::parse(url)
+            let url = url::Url::parse(url)
                 .or_else(|_| url::Url::parse(&format!("http://{url}")))
                 .ok()?;
+            let path = url.path();
 
-            // Ignore any parameters, we don't support them for http urls.
-            parsed_url.set_query(None);
-            let url = parsed_url.to_string();
-            (url.ends_with(".rrd") || url.ends_with(".rbl"))
+            (path.ends_with(".rrd") || path.ends_with(".rbl"))
                 .then_some(Self::RrdHttpUrl { url, follow: false })
         }
     }
@@ -156,7 +154,9 @@ impl LogDataSource {
         match self {
             Self::RrdHttpUrl { url, follow } => Ok(
                 re_log_encoding::stream_rrd_from_http::stream_rrd_from_http_to_channel(
-                    url, follow, on_msg,
+                    url.to_string(),
+                    follow,
+                    on_msg,
                 ),
             ),
 

--- a/crates/store/re_log_types/src/path/data_path.rs
+++ b/crates/store/re_log_types/src/path/data_path.rs
@@ -23,7 +23,9 @@ pub struct DataPath {
 impl std::fmt::Display for DataPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.entity_path.fmt(f)?;
-        if let Some(instance) = &self.instance {
+        if let Some(instance) = &self.instance
+            && instance != &Instance::ALL
+        {
             write!(f, "[#{instance}]")?;
         }
         if let Some(component_descriptor) = &self.component_descriptor {

--- a/crates/viewer/re_global_context/src/item.rs
+++ b/crates/viewer/re_global_context/src/item.rs
@@ -63,6 +63,34 @@ impl Item {
             }
         }
     }
+
+    /// Converts this item to a data path if possible.
+    pub fn to_data_path(&self) -> Option<DataPath> {
+        match self {
+            Self::AppId(_)
+            | Self::TableId(_)
+            | Self::DataSource(_)
+            | Self::View(_)
+            | Self::Container(_)
+            | Self::StoreId(_)
+            | Self::RedapServer(_)
+            | Self::RedapEntry(_) => None,
+
+            Self::ComponentPath(component_path) => Some(DataPath {
+                entity_path: component_path.entity_path.clone(),
+                instance: None,
+                component_descriptor: Some(component_path.component_descriptor.clone()),
+            }),
+
+            Self::InstancePath(instance_path) | Self::DataResult(_, instance_path) => {
+                Some(DataPath {
+                    entity_path: instance_path.entity_path.clone(),
+                    instance: Some(instance_path.instance),
+                    component_descriptor: None,
+                })
+            }
+        }
+    }
 }
 
 impl From<ViewId> for Item {

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -3156,7 +3156,7 @@ fn update_web_address_bar(
     let Ok(url) =
         crate::open_url::ViewerImportUrl::from_display_mode(Some(store_hub), display_mode)
             // History entries expect the url parameter, not the full url, therefore don't pass a base url.
-            .and_then(|url| url.to_sharable_url(&None))
+            .and_then(|url| url.sharable_url(&None))
     else {
         return None;
     };

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -3154,9 +3154,9 @@ fn update_web_address_bar(
         return None;
     }
     let Ok(url) =
-        crate::open_url::ViewerImportUrl::from_display_mode(Some(store_hub), display_mode)
+        crate::open_url::ViewerImportUrl::from_display_mode(store_hub, display_mode.clone())
             // History entries expect the url parameter, not the full url, therefore don't pass a base url.
-            .and_then(|url| url.sharable_url(&None))
+            .and_then(|url| url.sharable_url(None))
     else {
         return None;
     };

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -648,6 +648,9 @@ impl App {
             }
 
             SystemCommand::AddRedapServer(origin) => {
+                if origin == *re_redap_browser::EXAMPLES_ORIGIN {
+                    return;
+                }
                 if self.state.redap_servers.has_server(&origin) {
                     return;
                 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -3150,7 +3150,13 @@ fn update_web_address_bar(
     if !enable_history {
         return None;
     }
-    let url = crate::open_url::display_mode_to_content_url(store_hub, display_mode)?;
+    let Ok(url) =
+        crate::open_url::ViewerImportUrl::from_display_mode(Some(store_hub), display_mode)
+            // History entries expect the url parameter, not the full url, therefore don't pass a base url.
+            .and_then(|url| url.to_sharable_url(&None))
+    else {
+        return None;
+    };
 
     re_log::debug!("Updating navigation bar");
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -865,7 +865,7 @@ impl App {
         match data_source {
             LogDataSource::RrdHttpUrl { url, follow } => {
                 let new_source = SmartChannelSource::RrdHttpStream {
-                    url: url.clone(),
+                    url: url.to_string(),
                     follow: *follow,
                 };
                 if all_sources.any(|source| source.is_same_ignoring_uri_fragments(&new_source)) {

--- a/crates/viewer/re_viewer/src/open_url.rs
+++ b/crates/viewer/re_viewer/src/open_url.rs
@@ -278,7 +278,7 @@ impl ViewerImportUrl {
     /// Whenever possible you should provide a web viewer base URL so that the URL can be opened
     /// in the browser (this does *not* exclude native, web viewer URLs can still be opened there as well!)
     ///
-    /// This is roughly the inverse of [`Self::from_str`].
+    /// This is roughly the inverse of `Self::from_str`.
     #[allow(unused)] // TODO(rerun/dataplatform#1336): Only used on the web. About to change!
     pub fn sharable_url(&self, web_viewer_base_url: Option<&url::Url>) -> anyhow::Result<String> {
         let urls: Vec1<String> = match self {

--- a/crates/viewer/re_viewer/src/open_url.rs
+++ b/crates/viewer/re_viewer/src/open_url.rs
@@ -1,6 +1,7 @@
 use vec1::{Vec1, vec1};
 
 use re_data_source::LogDataSource;
+use re_redap_browser::EXAMPLES_ORIGIN;
 use re_smart_channel::SmartChannelSource;
 use re_ui::CommandPaletteUrl;
 use re_viewer_context::{
@@ -276,21 +277,40 @@ impl ViewerImportUrl {
                 })?;
                 vec1![format!("{INTRA_RECORDING_URL_SCHEME}{data_path}")]
             }
+
             Self::RrdHttpUrl(url) => {
                 vec1![url.to_string()]
             }
+
+            #[cfg(not(target_arch = "wasm32"))]
             Self::FilePath(path_buf) => {
                 vec1![(*path_buf.to_string_lossy()).to_owned()]
             }
+
             Self::RedapDatasetPartition(dataset_partition_uri) => {
                 vec1![dataset_partition_uri.to_string()]
             }
+
             Self::RedapProxy(proxy_uri) => {
                 vec1![proxy_uri.to_string()]
             }
-            Self::RedapCatalog(catalog_uri) => vec1![catalog_uri.to_string()],
+
+            Self::RedapCatalog(catalog_uri) => {
+                // The welcome page is a fake catalog right now.
+                // If we dont'have a base url we'll just roll with it. It looks ugly but it's sharable.
+                if catalog_uri.origin == *EXAMPLES_ORIGIN
+                    && let Some(base_url) = web_viewer_base_url
+                {
+                    return Ok(base_url.to_string());
+                }
+
+                vec1![catalog_uri.to_string()]
+            }
+
             Self::RedapEntry(entry_uri) => vec1![entry_uri.to_string()],
+
             Self::WebEventListener => vec1![WEB_EVENT_LISTENER_SCHEME.to_owned()],
+
             Self::WebViewerUrl {
                 base_url: _,
                 url_parameters,

--- a/crates/viewer/re_viewer/src/open_url.rs
+++ b/crates/viewer/re_viewer/src/open_url.rs
@@ -189,6 +189,7 @@ impl ViewerImportUrl {
                 // Not much point in updating address for the settings screen.
                 Err(anyhow::anyhow!("Can't share links to the settings screen."))
             }
+
             DisplayMode::LocalRecordings => {
                 // Local recordings includes those downloaded from rrd urls
                 // (as of writing this includes the sample recordings!)

--- a/crates/viewer/re_viewer/src/open_url.rs
+++ b/crates/viewer/re_viewer/src/open_url.rs
@@ -178,6 +178,7 @@ impl ViewerImportUrl {
     /// Returns Err(reason) if the current state can't be shared with a url.
     // TODO(#10866): Should have anchors for selection etc. when supported. Need to figure out how this works together with the "share editor".
     // Does this method merely provide the starting point?
+    #[allow(unused)] // TODO(rerun/dataplatform#1336): Only used on the web. About to change!
     pub fn from_display_mode(
         store_hub: &StoreHub,
         display_mode: DisplayMode,
@@ -266,6 +267,7 @@ impl ViewerImportUrl {
     /// in the browser (this does *not* exclude native, web viewer URLs can still be opened there as well!)
     ///
     /// This is roughly the inverse of [`Self::from_str`].
+    #[allow(unused)] // TODO(rerun/dataplatform#1336): Only used on the web. About to change!
     pub fn to_sharable_url(
         &self,
         web_viewer_base_url: Option<&url::Url>,


### PR DESCRIPTION
_Mostly_ a refactor that got split out of other ongoing work

* integrate valid values of `LogDataSource` into `ViewerImportUrl` to avoid handling the same weird corner cases all the time
* `display_mode_to_content_url` is now integrated/split into `ViewerImportUrl` via `ViewerImportUrl::from_display_mode` and `ViewerImportUrl::sharable_url`
	* `sharable_url` already handles appending the a web viewer base to it which will be relevant in the next PR

But also:
* tons of new tests for these
* fix some corner cases with the example/welcome page where it was possible to get into a state where we add an invalid server & show the welcome page
* fix some formatting issue on intra recording urls