### PR TITLE
Pass on all URLs  to the viewer indiscriminantly

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -1424,11 +1424,9 @@ impl ReceiversFromUrlParams {
                         data_sources.push(data_source);
                     }
                 }
-            } else if url.parse::<re_uri::RedapUri>().is_ok() {
-                // Readp URLs always have to be passed on.
-                urls_to_pass_on_to_viewer.push(url);
             } else {
-                re_log::warn!("{url:?} is not a valid data source or redap uri.");
+                // We don't have the full url parsing logic here. Just pass it on to the viewer!
+                urls_to_pass_on_to_viewer.push(url);
             }
         }
 


### PR DESCRIPTION
I found myself wanting to paste viewer URLs for the native viewer so I could run for instance
`rerun "https://rerun.io/viewer/pr/11034?url=rerun%2Bhttps%3A%2F%2Fsandbox.redap.rerun.io%3A443%2Fdataset%2F1859BD0CCDE7CBB548618cd40dcbdc32%3Fpartition_id%3DTRI_52ca9b6a_2024_02_08_10h_55m_36s"`

This tiny fix makes this possible since the viewer will just do the right thing with URLs, no need to guess what's good for it!


The crazy thing is that this "just works" with the web viewer from command line as well:
 `pixi run rerun-web "https://rerun.io/viewer/pr/11034?url=rerun%2Bhttps%3A%2F%2Fsandbox.redap.rerun.io%3A443%2Fdataset%2F1859BD0CCDE7CBB548618cd40dcbdc32%3Fpartition_id%3DAUTOLab_cf2a60c6_2023_12_17_15h_15m_18s"`

Opens 
`http://localhost:9090/?url=https%3A%2F%2Frerun%2Eio%2Fviewer%2Fpr%2F11034%3Furl%3Drerun%252Bhttps%253A%252F%252Fsandbox%2Eredap%2Ererun%2Eio%253A443%252Fdataset%252F1859BD0CCDE7CBB548618cd40dcbdc32%253Fpartition%5Fid%253DAUTOLab%5Fcf2a60c6%5F2023%5F12%5F17%5F15h%5F15m%5F18s`

which correctly opens the underlying recording but gives you warning that the viewer url is mismatching. 🪄 