### PR TITLE
Fix 3D eye camera reset not resuming tracking scene bounding box

### DIFF
--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -102,9 +102,7 @@ impl View3DState {
         scene_bbox: &SceneBoundingBoxes,
         scene_view_coordinates: Option<ViewCoordinates>,
     ) {
-        // Mark as interaction since we want to stop doing any automatic interpolations,
-        // even if this is caused by a full reset.
-        self.last_eye_interaction = Some(Instant::now());
+        self.last_eye_interaction = None;
         self.interpolate_to_view_eye(default_eye(&scene_bbox.current, scene_view_coordinates));
         self.tracked_entity = None;
         self.camera_before_tracked_entity = None;


### PR DESCRIPTION
Previously, when resetting the camera it wouldn't _fully_ reset: in its initial state the camera tracks the scene bounding box, but we explicitly made it so that it never goes back to that state. In hindsight that's rather confusing and got brought up [on Discord](https://discord.com/channels/1062300748202921994/1075873257124810852/1410370680758992997)



https://github.com/user-attachments/assets/f5cdaf8c-5853-4de0-a76b-561898152d00

