### PR TITLE
Remove '-o' shorthand for stdout from script_add_args

### DIFF
--- a/docs/content/reference/migration/migration-0-25.md
+++ b/docs/content/reference/migration/migration-0-25.md
@@ -15,6 +15,11 @@ Use `--web-viewer` instead.
 This feature has been defunct for a while. A better replacement can be tracked [in this issue](https://github.com/rerun-io/rerun/issues/11024).
 
 
+## Removed the `-o` CLI argument shorthand for `--stdout` in `script_add_args`
+
+Use `--stdout` directly instead.
+
+
 ## Flush takes an optional timeout, and returns errors
 When flushing a recording stream you can now give it a maximum time for how long it should block.
 The flush will block until either it completes, fails (e.g. because of connection loss), or the timeout is reached.

--- a/rerun_py/rerun_sdk/rerun/script_helpers.py
+++ b/rerun_py/rerun_sdk/rerun/script_helpers.py
@@ -58,7 +58,6 @@ def script_add_args(parser: ArgumentParser) -> None:
     parser.add_argument("--url", type=str, default=None, help="Connect to this Rerun URL")
     parser.add_argument("--save", type=str, default=None, help="Save data to a .rrd file at this path")
     parser.add_argument(
-        "-o",
         "--stdout",
         dest="stdout",
         action="store_true",


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

The -o shorthand tends to clash with people's CLI args. Single-letter flags feel a bit overkill here.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
