### PR TITLE
always allow blueprint panel resizing

### DIFF
--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -543,9 +543,7 @@ impl AppState {
                             | DisplayMode::RedapEntry(..)
                             | DisplayMode::RedapServer(..) => {
                                 let show_blueprints = *display_mode == DisplayMode::LocalRecordings;
-                                let resizable = ctx.storage_context.bundle.recordings().count() > 3
-                                    && show_blueprints;
-
+                                let resizable = show_blueprints;
                                 if resizable {
                                     // Don't shrink either recordings panel or blueprint panel below this height
                                     let min_height_each =


### PR DESCRIPTION
now one needs to have 4 recordings open to be able to resize the blueprint panel. 
especially with a long list for catalog this rule doesnt work anymore as it's quickly too long and annoying. 
Hence the change! 
