### PR TITLE
Update video documentation to clarify MP4 export process (remuxing)

### DIFF
--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -59,7 +59,7 @@ TODO(#10090): fix above if ticket is outdated.
 TODO(#10422): fix above if ticket is outdated.
 -->
 
-### Remuxing video streams
+### Export MP4 from RRD (remuxing)
 
 Sample data from [`VideoStream`](../reference/types/archetypes/video_stream.md) can be queried
 and remuxed to mp4 without re-encoding the video as demonstrated in [this sample](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/archetypes/video_stream_query_and_mux.py#speculative-link).


### PR DESCRIPTION
Based on the original discussion on Slack https://rerunio.slack.com/archives/C04UBTMMGJK/p1756500919499429

Users searching for “rrd to mp4” may not recognize the term “remuxing.” This PR adds a beginner‑friendly heading (“Convert RRD to MP4 (remuxing)”) to the video docs, improving search/discoverability without changing content.