### PR TITLE
Adjust label checker & changelog gen to use `sdk-` prefixed labels

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, 🌊 C++ API, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log & send APIs, 📉 performance, 🐍 Python API, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log & send APIs, 📉 performance, sdk-python, sdk-cpp, sdk-rust, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🔨 testing, ui, 🕸️ web"
 
   wasm-bindgen-check:
     name: Check wasm-bindgen version

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -253,13 +253,13 @@ def main() -> None:
                 log_api.append(summary)
                 added = True
             else:
-                if "🌊 C++ API" in labels:
+                if "sdk-cpp" in labels:
                     cpp.append(summary)
                     added = True
-                if "🐍 Python API" in labels:
+                if "sdk-python" in labels:
                     python.append(summary)
                     added = True
-                if "🦀 Rust API" in labels:
+                if "sdk-rust" in labels:
                     rust.append(summary)
                     added = True
 


### PR DESCRIPTION
The icons were nice, but unified label categories are nicer. And frankly easier to parse.