### PR TITLE
End-to-end out-of-band entry headers: kickoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8355,7 +8355,6 @@ dependencies = [
  "re_log_encoding",
  "re_log_types",
  "re_protos",
- "re_tuid",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/crates/store/re_datafusion/src/datafusion_connector.rs
+++ b/crates/store/re_datafusion/src/datafusion_connector.rs
@@ -3,10 +3,8 @@ use std::sync::Arc;
 use datafusion::{catalog::TableProvider, error::DataFusionError};
 use tracing::instrument;
 
-use re_log_types::{EntryId, external::re_tuid::Tuid};
-use re_protos::cloud::v1alpha1::{
-    DatasetEntry, EntryFilter, ReadDatasetEntryRequest, ext::EntryDetails,
-};
+use re_log_types::EntryId;
+use re_protos::cloud::v1alpha1::{EntryFilter, ext::EntryDetails};
 use re_redap_client::ConnectionClient;
 
 use crate::partition_table::PartitionTableProvider;
@@ -49,24 +47,6 @@ impl DataFusionConnector {
         TableEntryTableProvider::new(self.client.clone(), entry.id)
             .into_provider()
             .await
-    }
-
-    #[instrument(skip(self), err)]
-    pub async fn get_dataset_entry(
-        &mut self,
-        id: Tuid,
-    ) -> Result<Option<DatasetEntry>, tonic::Status> {
-        let entry = self
-            .client
-            .inner()
-            .read_dataset_entry(ReadDatasetEntryRequest {
-                id: Some(id.into()),
-            })
-            .await?
-            .into_inner()
-            .dataset;
-
-        Ok(entry)
     }
 
     #[instrument(skip(self), err)]

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -96,6 +96,31 @@ impl std::fmt::Display for StoreKind {
     }
 }
 
+impl std::str::FromStr for StoreKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "recording" => Ok(Self::Recording),
+            "blueprint" => Ok(Self::Blueprint),
+            unknown => Err(format!("{unknown:?} is not a valid StoreKind")),
+        }
+    }
+}
+
+#[test]
+fn store_kind_str_roundtrip() {
+    {
+        let kind = StoreKind::Recording;
+        assert_eq!(kind, kind.to_string().parse().unwrap());
+    }
+
+    {
+        let kind = StoreKind::Blueprint;
+        assert_eq!(kind, kind.to_string().parse().unwrap());
+    }
+}
+
 /// A unique id per store.
 ///
 /// The kind of store is part of the id, and can be either a [`StoreKind::Recording`] or a

--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -51,9 +51,9 @@ service RerunCloudService {
 
   // Write chunks to one or more partitions.
   //
-  // The partition ID for each individual chunk is extracted from their metadata (`rerun.partition_id`).
+  // The partition ID for each individual chunk is extracted from their metadata (`rerun:partition_id`).
   //
-  // The destination dataset must be provided in the `x-rerun-dataset-id` header.
+  // This endpoint requires the standard dataset headers.
   rpc WriteChunks(stream WriteChunksRequest) returns (WriteChunksResponse) {}
 
   /* Query schemas */

--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -9,6 +9,17 @@ import "rerun/v1alpha1/common.proto";
 import "rerun/v1alpha1/log_msg.proto";
 
 // The Rerun Cloud public API.
+//
+// ## Headers
+//
+// Most endpoints in the Rerun Cloud service require specific gRPC headers to be set.
+//
+// The so-called "standard dataset headers" correspond to at least one of the following headers:
+// * x-rerun-entry-id: ID of the entry of interest, e.g. `1860390B087BC65F602d68eb646c385c`.
+// * x-rerun-entry-name-bin: Name of the entry of interest, e.g. `droid:sample2k`.
+//
+// Headers with a -bin suffix must be base64-encoded (HTTP only supports ASCII values, UTF8 strings must
+// binary encoded).
 service RerunCloudService {
   rpc Version(VersionRequest) returns (VersionResponse) {}
 
@@ -22,6 +33,9 @@ service RerunCloudService {
 
   rpc CreateDatasetEntry(CreateDatasetEntryRequest) returns (CreateDatasetEntryResponse) {}
 
+  // Fetch metadata about a specific dataset.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc ReadDatasetEntry(ReadDatasetEntryRequest) returns (ReadDatasetEntryResponse) {}
 
   rpc UpdateDatasetEntry(UpdateDatasetEntryRequest) returns (UpdateDatasetEntryResponse) {}
@@ -48,6 +62,8 @@ service RerunCloudService {
   //
   // * To inspect the data of the partition table, use `ScanPartitionTable`.
   // * To retrieve the schema of the underlying dataset, use `GetDatasetSchema` instead.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc GetPartitionTableSchema(GetPartitionTableSchemaRequest) returns (GetPartitionTableSchemaResponse) {}
 
   // Inspect the contents of the partition table (i.e. the dataset manifest).
@@ -207,9 +223,7 @@ message WriteChunksResponse {}
 
 /* Query schemas */
 
-message GetPartitionTableSchemaRequest {
-  rerun.common.v1alpha1.EntryId dataset_id = 1;
-}
+message GetPartitionTableSchemaRequest {}
 
 message GetPartitionTableSchemaResponse {
   rerun.common.v1alpha1.Schema schema = 1;
@@ -732,9 +746,7 @@ message CreateDatasetEntryResponse {
 
 // ReadDatasetEntry
 
-message ReadDatasetEntryRequest {
-  rerun.common.v1alpha1.EntryId id = 1;
-}
+message ReadDatasetEntryRequest {}
 
 message ReadDatasetEntryResponse {
   DatasetEntry dataset = 1;

--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -223,7 +223,10 @@ message WriteChunksResponse {}
 
 /* Query schemas */
 
-message GetPartitionTableSchemaRequest {}
+message GetPartitionTableSchemaRequest {
+  reserved 1;
+  reserved "dataset_id";
+}
 
 message GetPartitionTableSchemaResponse {
   rerun.common.v1alpha1.Schema schema = 1;
@@ -746,7 +749,10 @@ message CreateDatasetEntryResponse {
 
 // ReadDatasetEntry
 
-message ReadDatasetEntryRequest {}
+message ReadDatasetEntryRequest {
+  reserved 1;
+  reserved "id";
+}
 
 message ReadDatasetEntryResponse {
   DatasetEntry dataset = 1;

--- a/crates/store/re_protos/src/headers.rs
+++ b/crates/store/re_protos/src/headers.rs
@@ -1,0 +1,115 @@
+#![allow(clippy::result_large_err)] // we're just returning tonic::Status
+
+/// The HTTP header key to pass an entry ID to the `RerunCloudService` APIs.
+pub const RERUN_HTTP_HEADER_ENTRY_ID: &str = "x-rerun-entry-id";
+
+/// The HTTP header key to pass an entry name to the `RerunCloudService` APIs.
+///
+/// This will automatically be resolved to an entry ID, as long as a dataset with the associated
+/// name can be found in the database.
+///
+/// This is serialized as base64-encoded data (hence `-bin`), since entry names can be any UTF8 strings,
+/// while HTTP2 headers only support ASCII.
+pub const RERUN_HTTP_HEADER_ENTRY_NAME: &str = "x-rerun-entry-name-bin";
+
+/// Helper struct to inject Rerun Data Protocol headers into gRPC requests.
+///
+/// Example:
+/// ```
+/// # use re_protos::headers::RerunHeadersInjector;
+/// let mut req = tonic::Request::new(());
+/// RerunHeadersInjector(&mut req).with_entry_name("droid:sample2k").unwrap();
+/// ```
+pub struct RerunHeadersInjector<'a, T>(pub &'a mut tonic::Request<T>);
+
+impl<T> RerunHeadersInjector<'_, T> {
+    pub fn with_entry_id(&mut self, entry_id: impl AsRef<str>) -> Result<(), tonic::Status> {
+        const HEADER: &str = RERUN_HTTP_HEADER_ENTRY_ID;
+
+        let entry_id = entry_id.as_ref();
+        let entry_id = entry_id.parse().map_err(|err| {
+            tonic::Status::invalid_argument(format!(
+                "'{entry_id}' is not a valid value for '{HEADER}': {err:#}"
+            ))
+        })?;
+
+        self.0.metadata_mut().insert(HEADER, entry_id);
+
+        Ok(())
+    }
+
+    #[expect(clippy::unnecessary_wraps)] // for consistency / future-proofing
+    pub fn with_entry_name(&mut self, entry_name: impl AsRef<str>) -> Result<(), tonic::Status> {
+        const HEADER: &str = RERUN_HTTP_HEADER_ENTRY_NAME;
+
+        let entry_name = entry_name.as_ref();
+        let entry_name = tonic::metadata::BinaryMetadataValue::from_bytes(entry_name.as_bytes());
+
+        self.0.metadata_mut().insert_bin(HEADER, entry_name);
+
+        Ok(())
+    }
+
+    pub fn with_metadata(&mut self, md: &tonic::metadata::MetadataMap) {
+        if let Some(entry_id) = md.get(RERUN_HTTP_HEADER_ENTRY_ID).cloned() {
+            self.0
+                .metadata_mut()
+                .insert(RERUN_HTTP_HEADER_ENTRY_ID, entry_id);
+        }
+
+        if let Some(entry_name) = md.get_bin(RERUN_HTTP_HEADER_ENTRY_NAME).cloned() {
+            self.0
+                .metadata_mut()
+                .insert_bin(RERUN_HTTP_HEADER_ENTRY_NAME, entry_name);
+        }
+    }
+}
+
+/// Helper struct to extract Rerun Data Protocol headers from gRPC requests.
+///
+/// Example:
+/// ```
+/// # use re_protos::headers::RerunHeadersExtractor;
+/// # let req = tonic::Request::new(());
+/// let entry_id = RerunHeadersExtractor(&req).entry_id().unwrap();
+/// ```
+pub struct RerunHeadersExtractor<'a, T>(pub &'a tonic::Request<T>);
+
+impl<'a, T> RerunHeadersExtractor<'a, T> {
+    pub fn entry_id(&self) -> Result<Option<&'a str>, tonic::Status> {
+        const HEADER: &str = RERUN_HTTP_HEADER_ENTRY_ID;
+
+        let Some(entry_id) = self.0.metadata().get(HEADER) else {
+            return Ok(None);
+        };
+
+        let entry_id = entry_id.to_str().map_err(|err| {
+            tonic::Status::invalid_argument(format!(
+                "'{entry_id:?}' is not a valid value for '{HEADER}': {err:#}"
+            ))
+        })?;
+
+        Ok(Some(entry_id))
+    }
+
+    pub fn entry_name(&self) -> Result<Option<String>, tonic::Status> {
+        const HEADER: &str = RERUN_HTTP_HEADER_ENTRY_NAME;
+
+        let Some(entry_name) = self.0.metadata().get_bin(HEADER) else {
+            return Ok(None);
+        };
+
+        let entry_name = entry_name.to_bytes().map_err(|err| {
+            tonic::Status::invalid_argument(format!(
+                "'{entry_name:?}' is not a valid value for '{HEADER}': {err:#}"
+            ))
+        })?;
+        let entry_name = String::from_utf8(entry_name.to_vec()).map_err(|err| {
+            tonic::Status::invalid_argument(format!(
+                "'{entry_name:?}' is not a valid value for '{HEADER}': {err:#}"
+            ))
+        })?;
+
+        Ok(Some(entry_name))
+    }
+}

--- a/crates/store/re_protos/src/lib.rs
+++ b/crates/store/re_protos/src/lib.rs
@@ -9,6 +9,8 @@ pub mod external {
     pub use prost;
 }
 
+pub mod headers;
+
 // This extra module is needed, because of how imports from different packages are resolved.
 // For example, `rerun.remote_store.v1alpha1.EncoderVersion` is resolved to `super::super::remote_store::v1alpha1::EncoderVersion`.
 // We need an extra module in the path to `common` to make that work.

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
@@ -22,24 +22,6 @@ use crate::common::v1alpha1::ext::{
 use crate::common::v1alpha1::{ComponentDescriptor, DataframePart, TaskId};
 use crate::{TypeConversionError, missing_field};
 
-// --- GetPartitionTableSchemaRequest ---
-
-impl TryFrom<crate::cloud::v1alpha1::GetPartitionTableSchemaRequest> for re_log_types::EntryId {
-    type Error = TypeConversionError;
-
-    fn try_from(
-        value: crate::cloud::v1alpha1::GetPartitionTableSchemaRequest,
-    ) -> Result<Self, Self::Error> {
-        Ok(value
-            .dataset_id
-            .ok_or(missing_field!(
-                crate::cloud::v1alpha1::GetPartitionTableSchemaRequest,
-                "dataset_id"
-            ))?
-            .try_into()?)
-    }
-}
-
 // --- ScanPartitionTableRequest ---
 
 pub struct ScanPartitionTableRequest {
@@ -491,24 +473,6 @@ impl TryFrom<crate::cloud::v1alpha1::CreateDatasetEntryResponse> for CreateDatas
                 ))?
                 .try_into()?,
         })
-    }
-}
-
-// --- ReadDatasetEntryRequest ---
-
-impl TryFrom<crate::cloud::v1alpha1::ReadDatasetEntryRequest> for re_log_types::EntryId {
-    type Error = TypeConversionError;
-
-    fn try_from(
-        value: crate::cloud::v1alpha1::ReadDatasetEntryRequest,
-    ) -> Result<Self, Self::Error> {
-        Ok(value
-            .id
-            .ok_or(missing_field!(
-                crate::cloud::v1alpha1::ReadDatasetEntryRequest,
-                "id"
-            ))?
-            .try_into()?)
     }
 }
 

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -138,10 +138,7 @@ impl ::prost::Name for WriteChunksResponse {
     }
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct GetPartitionTableSchemaRequest {
-    #[prost(message, optional, tag = "1")]
-    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
-}
+pub struct GetPartitionTableSchemaRequest {}
 impl ::prost::Name for GetPartitionTableSchemaRequest {
     const NAME: &'static str = "GetPartitionTableSchemaRequest";
     const PACKAGE: &'static str = "rerun.cloud.v1alpha1";
@@ -1241,10 +1238,7 @@ impl ::prost::Name for CreateDatasetEntryResponse {
     }
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
-pub struct ReadDatasetEntryRequest {
-    #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
-}
+pub struct ReadDatasetEntryRequest {}
 impl ::prost::Name for ReadDatasetEntryRequest {
     const NAME: &'static str = "ReadDatasetEntryRequest";
     const PACKAGE: &'static str = "rerun.cloud.v1alpha1";
@@ -1712,6 +1706,17 @@ pub mod rerun_cloud_service_client {
     use tonic::codegen::http::Uri;
     use tonic::codegen::*;
     /// The Rerun Cloud public API.
+    ///
+    /// ## Headers
+    ///
+    /// Most endpoints in the Rerun Cloud service require specific gRPC headers to be set.
+    ///
+    /// The so-called "standard dataset headers" correspond to at least one of the following headers:
+    /// * x-rerun-entry-id: ID of the entry of interest, e.g. `1860390B087BC65F602d68eb646c385c`.
+    /// * x-rerun-entry-name-bin: Name of the entry of interest, e.g. `droid:sample2k`.
+    ///
+    /// Headers with a -bin suffix must be base64-encoded (HTTP only supports ASCII values, UTF8 strings must
+    /// binary encoded).
     #[derive(Debug, Clone)]
     pub struct RerunCloudServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1874,6 +1879,9 @@ pub mod rerun_cloud_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
+        /// Fetch metadata about a specific dataset.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn read_dataset_entry(
             &mut self,
             request: impl tonic::IntoRequest<super::ReadDatasetEntryRequest>,
@@ -1979,6 +1987,8 @@ pub mod rerun_cloud_service_client {
         ///
         /// * To inspect the data of the partition table, use `ScanPartitionTable`.
         /// * To retrieve the schema of the underlying dataset, use `GetDatasetSchema` instead.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn get_partition_table_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::GetPartitionTableSchemaRequest>,
@@ -2375,6 +2385,9 @@ pub mod rerun_cloud_service_server {
             &self,
             request: tonic::Request<super::CreateDatasetEntryRequest>,
         ) -> std::result::Result<tonic::Response<super::CreateDatasetEntryResponse>, tonic::Status>;
+        /// Fetch metadata about a specific dataset.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn read_dataset_entry(
             &self,
             request: tonic::Request<super::ReadDatasetEntryRequest>,
@@ -2405,6 +2418,8 @@ pub mod rerun_cloud_service_server {
         ///
         /// * To inspect the data of the partition table, use `ScanPartitionTable`.
         /// * To retrieve the schema of the underlying dataset, use `GetDatasetSchema` instead.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn get_partition_table_schema(
             &self,
             request: tonic::Request<super::GetPartitionTableSchemaRequest>,
@@ -2551,6 +2566,17 @@ pub mod rerun_cloud_service_server {
         ) -> std::result::Result<tonic::Response<super::DoMaintenanceResponse>, tonic::Status>;
     }
     /// The Rerun Cloud public API.
+    ///
+    /// ## Headers
+    ///
+    /// Most endpoints in the Rerun Cloud service require specific gRPC headers to be set.
+    ///
+    /// The so-called "standard dataset headers" correspond to at least one of the following headers:
+    /// * x-rerun-entry-id: ID of the entry of interest, e.g. `1860390B087BC65F602d68eb646c385c`.
+    /// * x-rerun-entry-name-bin: Name of the entry of interest, e.g. `droid:sample2k`.
+    ///
+    /// Headers with a -bin suffix must be base64-encoded (HTTP only supports ASCII values, UTF8 strings must
+    /// binary encoded).
     #[derive(Debug)]
     pub struct RerunCloudServiceServer<T> {
         inner: Arc<T>,

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -1961,9 +1961,9 @@ pub mod rerun_cloud_service_client {
         }
         /// Write chunks to one or more partitions.
         ///
-        /// The partition ID for each individual chunk is extracted from their metadata (`rerun.partition_id`).
+        /// The partition ID for each individual chunk is extracted from their metadata (`rerun:partition_id`).
         ///
-        /// The destination dataset must be provided in the `x-rerun-dataset-id` header.
+        /// This endpoint requires the standard dataset headers.
         pub async fn write_chunks(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::WriteChunksRequest>,
@@ -2407,9 +2407,9 @@ pub mod rerun_cloud_service_server {
         ) -> std::result::Result<tonic::Response<super::RegisterWithDatasetResponse>, tonic::Status>;
         /// Write chunks to one or more partitions.
         ///
-        /// The partition ID for each individual chunk is extracted from their metadata (`rerun.partition_id`).
+        /// The partition ID for each individual chunk is extracted from their metadata (`rerun:partition_id`).
         ///
-        /// The destination dataset must be provided in the `x-rerun-dataset-id` header.
+        /// This endpoint requires the standard dataset headers.
         async fn write_chunks(
             &self,
             request: tonic::Request<tonic::Streaming<super::WriteChunksRequest>>,

--- a/crates/store/re_redap_client/src/connection_client.rs
+++ b/crates/store/re_redap_client/src/connection_client.rs
@@ -147,11 +147,12 @@ where
         &mut self,
         entry_id: EntryId,
     ) -> Result<DatasetEntry, StreamError> {
+        let mut req = tonic::Request::new(ReadDatasetEntryRequest {});
+        re_protos::headers::RerunHeadersInjector(&mut req).with_entry_id(entry_id.to_string())?;
+
         let response: ReadDatasetEntryResponse = self
             .inner()
-            .read_dataset_entry(ReadDatasetEntryRequest {
-                id: Some(entry_id.into()),
-            })
+            .read_dataset_entry(req)
             .await?
             .into_inner()
             .try_into()?;

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -4,13 +4,10 @@ use re_log_types::{
     BlueprintActivationCommand, EntryId, LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind,
     StoreSource,
 };
-use re_protos::cloud::v1alpha1::ReadDatasetEntryRequest;
+use re_protos::cloud::v1alpha1::GetChunksRequest;
 use re_protos::cloud::v1alpha1::ext::{Query, QueryLatestAt, QueryRange};
 use re_protos::cloud::v1alpha1::rerun_cloud_service_client::RerunCloudServiceClient;
 use re_protos::common::v1alpha1::ext::PartitionId;
-use re_protos::{
-    cloud::v1alpha1::GetChunksRequest, cloud::v1alpha1::ext::ReadDatasetEntryResponse,
-};
 use re_uri::{DatasetPartitionUri, Origin, TimeSelection};
 
 use tokio_stream::{Stream, StreamExt as _};
@@ -329,19 +326,12 @@ pub async fn stream_blueprint_and_partition_from_server(
 ) -> Result<(), StreamError> {
     re_log::debug!("Loading {uri}…");
 
-    let response: ReadDatasetEntryResponse = client
-        .inner()
-        .read_dataset_entry(ReadDatasetEntryRequest {
-            id: Some(uri.dataset_id.into()),
-        })
-        .await?
-        .into_inner()
-        .try_into()?;
+    let dataset_entry = client.read_dataset_entry(uri.dataset_id.into()).await?;
 
     let recording_store_id = uri.store_id();
 
     if let Some((blueprint_dataset, blueprint_partition)) =
-        response.dataset_entry.dataset_details.default_bluprint()
+        dataset_entry.dataset_details.default_bluprint()
     {
         re_log::debug!("Streaming blueprint dataset {blueprint_dataset}");
 

--- a/crates/store/re_server/Cargo.toml
+++ b/crates/store/re_server/Cargo.toml
@@ -35,7 +35,6 @@ re_log = { workspace = true, features = ["setup"] }
 re_log_encoding.workspace = true
 re_log_types.workspace = true
 re_protos.workspace = true
-re_tuid.workspace = true
 
 # External
 anyhow.workspace = true

--- a/crates/utils/re_perf_telemetry/src/grpc.rs
+++ b/crates/utils/re_perf_telemetry/src/grpc.rs
@@ -1,3 +1,6 @@
+// See `re_protos::headers`.
+const RERUN_HTTP_HEADER_ENTRY_ID: &str = "x-rerun-entry-id";
+
 // --- Telemetry middlewares ---
 
 /// Implements [`tower_http::trace::MakeSpan`] where the trace name is the gRPC method name.
@@ -50,7 +53,7 @@ impl<B> tower_http::trace::MakeSpan<B> for GrpcMakeSpan {
 
         let dataset_id = request
             .headers()
-            .get("x-rerun-dataset-id")
+            .get(RERUN_HTTP_HEADER_ENTRY_ID)
             .and_then(|v| v.to_str().ok().map(ToOwned::to_owned));
 
         // NOTE: Remember: the span we're creating here will propagate no matter what -- there is
@@ -506,7 +509,7 @@ pub type ServerTelemetryLayer = tower::layer::util::Stack<
 pub fn new_server_telemetry_layer() -> ServerTelemetryLayer {
     use tower_http::propagate_header::PropagateHeaderLayer;
     let dataset_id_propagation_layer =
-        PropagateHeaderLayer::new(http::HeaderName::from_static("x-rerun-dataset-id"));
+        PropagateHeaderLayer::new(http::HeaderName::from_static(RERUN_HTTP_HEADER_ENTRY_ID));
     let request_id_propagation_layer =
         PropagateHeaderLayer::new(http::HeaderName::from_static("x-request-id"));
 
@@ -549,7 +552,7 @@ pub type ClientTelemetryLayer = tower::layer::util::Stack<
 pub fn new_client_telemetry_layer() -> ClientTelemetryLayer {
     use tower_http::propagate_header::PropagateHeaderLayer;
     let dataset_id_propagation_layer =
-        PropagateHeaderLayer::new(http::HeaderName::from_static("x-rerun-dataset-id"));
+        PropagateHeaderLayer::new(http::HeaderName::from_static(RERUN_HTTP_HEADER_ENTRY_ID));
     let request_id_propagation_layer =
         PropagateHeaderLayer::new(http::HeaderName::from_static("x-request-id"));
 


### PR DESCRIPTION
This introduces gRPC headers as first class citizens of the Rerun Data Protocol.

To demonstrate it in action, two endpoints have been ported to use them:
* `rerun.cloud.v1alpha1.RerunCloudService/ReadDatasetEntry`
* `rerun.cloud.v1alpha1.RerunCloudService/GetPartitionTableSchema`

Update: actually, a third surprise endpoint joined the party: `/WriteChunks` was already header based.

There are a bunch of reasons why we'd want to leverage headers more. They are explained in:
* Sibling: https://github.com/rerun-io/dataplatform/pull/1650