### PR TITLE
Fix mesh cache eviction issue

### DIFF
--- a/crates/viewer/re_view_spatial/src/mesh_cache.rs
+++ b/crates/viewer/re_view_spatial/src/mesh_cache.rs
@@ -117,9 +117,9 @@ impl MeshCache {
 
 impl Cache for MeshCache {
     fn begin_frame(&mut self) {
-        // We aggressivly clear caches that weren't used in the last frame because
+        // We aggressively clear caches that weren't used in the last frame because
         // `query_result_hash` in `MeshCacheKey` includes overrides in the hash. And
-        // we currenlty have no way of knowing which hash should be removed because
+        // we currently have no way of knowing which hash should be removed because
         // of overrides changing.
         self.cache.retain(|_, meshes| {
             meshes.retain(|_, mesh| mesh.last_used_generation == self.generation);


### PR DESCRIPTION
### Related

Fixes #11049.

### What

This adds cache-eviction similarly to how it's done in `crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs`. Store a `last_used_generation` for each cache entry, and if it wasn't used within the last frame we evict it.