### PR TITLE
[pure refactor] Picking configuration is now part of view builder setup

### DIFF
--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -80,7 +80,7 @@ pub use rect::{RectF32, RectInt};
 pub use size::Size;
 pub use texture_info::Texture2DBufferInfo;
 pub use transform::RectTransform;
-pub use view_builder::ViewBuilder;
+pub use view_builder::{ViewBuilder, ViewPickingConfiguration};
 pub use wgpu_resources::{
     BindGroupDesc, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
     GpuPipelineLayoutPool, GpuRenderPipelineHandle, GpuRenderPipelinePool,

--- a/crates/viewer/re_renderer/src/renderer/lines.rs
+++ b/crates/viewer/re_renderer/src/renderer/lines.rs
@@ -770,7 +770,7 @@ mod tests {
         re_log::PanicOnWarnScope::new();
 
         RenderContext::new_test().execute_test_frame(|ctx| {
-            let mut view = ViewBuilder::new(ctx, TargetConfiguration::default());
+            let mut view = ViewBuilder::new(ctx, TargetConfiguration::default()).unwrap();
 
             let empty = LineDrawableBuilder::new(ctx);
             view.queue_draw(empty.into_draw_data().unwrap());

--- a/crates/viewer/re_renderer_examples/2d.rs
+++ b/crates/viewer/re_renderer_examples/2d.rs
@@ -306,7 +306,7 @@ impl framework::Example for Render2D {
                         pixels_per_point,
                         ..Default::default()
                     },
-                );
+                )?;
                 view_builder.queue_draw(line_strip_draw_data.clone());
                 view_builder.queue_draw(point_draw_data.clone());
                 view_builder.queue_draw(rectangle_draw_data.clone());
@@ -346,7 +346,7 @@ impl framework::Example for Render2D {
                         pixels_per_point,
                         ..Default::default()
                     },
-                );
+                )?;
                 let command_buffer = view_builder
                     .queue_draw(line_strip_draw_data)
                     .queue_draw(point_draw_data)

--- a/crates/viewer/re_renderer_examples/depth_cloud.rs
+++ b/crates/viewer/re_renderer_examples/depth_cloud.rs
@@ -127,7 +127,7 @@ impl RenderDepthClouds {
                 pixels_per_point,
                 ..Default::default()
             },
-        );
+        )?;
 
         let command_buffer = view_builder
             .queue_draw(GenericSkyboxDrawData::new(re_ctx, Default::default()))
@@ -205,7 +205,7 @@ impl RenderDepthClouds {
                 pixels_per_point,
                 ..Default::default()
             },
-        );
+        )?;
 
         let command_buffer = view_builder
             .queue_draw(GenericSkyboxDrawData::new(re_ctx, Default::default()))

--- a/crates/viewer/re_renderer_examples/depth_offset.rs
+++ b/crates/viewer/re_renderer_examples/depth_offset.rs
@@ -113,7 +113,7 @@ impl framework::Example for Render2D {
                 pixels_per_point,
                 ..Default::default()
             },
-        );
+        )?;
         let command_buffer = view_builder
             .queue_draw(RectangleDrawData::new(re_ctx, &rectangles)?)
             .draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;

--- a/crates/viewer/re_renderer_examples/multiview.rs
+++ b/crates/viewer/re_renderer_examples/multiview.rs
@@ -219,7 +219,7 @@ impl Multiview {
         draw_data: D,
         index: u32,
     ) -> anyhow::Result<(ViewBuilder, wgpu::CommandBuffer)> {
-        let mut view_builder = ViewBuilder::new(re_ctx, target_cfg);
+        let mut view_builder = ViewBuilder::new(re_ctx, target_cfg)?;
 
         if self
             .take_screenshot_next_frame_for_view

--- a/crates/viewer/re_renderer_examples/outlines.rs
+++ b/crates/viewer/re_renderer_examples/outlines.rs
@@ -75,7 +75,7 @@ impl framework::Example for Outlines {
                 }),
                 ..Default::default()
             },
-        );
+        )?;
 
         let outline_mask_large_mesh = match ((secs_since_startup * 0.5) as u64) % 5 {
             0 => OutlineMaskPreference::NONE,

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -85,7 +85,7 @@ impl framework::Example for Outlines {
                 outline_config: None,
                 ..Default::default()
             },
-        );
+        )?;
 
         view_builder.queue_draw(re_renderer::renderer::GenericSkyboxDrawData::new(
             re_ctx,

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
@@ -149,11 +149,10 @@ pub fn render_image(
         },
         viewport_transformation: re_renderer::RectTransform::IDENTITY,
         pixels_per_point,
-        outline_config: None,
-        blend_with_background: false,
+        ..Default::default()
     };
 
-    let mut view_builder = ViewBuilder::new(render_ctx, target_config);
+    let mut view_builder = ViewBuilder::new(render_ctx, target_config)?;
 
     view_builder.queue_draw(re_renderer::renderer::RectangleDrawData::new(
         render_ctx,


### PR DESCRIPTION
Previously, to set up picking on a `ViewBuilder`, you'd call `schedule_picking_rect`. With this refactor, it's instead part of the views initial configuration. Surprisingly, that's practically no issue at all for our existing Viewer & example code 🤷 

Why the hassle though, what's wrong with the old way?

This is a small piece of prep work I split out of another renderer refactor/enhancement pet-project of mine. At the core the issue addressed here is that it's very useful to know what draw phases are active when enqueuing `DrawData`. With the `schedule_picking_rect` approach this information wasn't guaranteed to be available ahead of time.
(With this, the only draw phase we don't know about whether it's active is the "screenshot phase" which is a bit of a strange copy-shim, rather dubious that it's a full phase in the first place.)