### PR TITLE
Make archetype and URDF loaders honor `entity_path_prefix`

### DIFF
--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -60,7 +60,11 @@ impl DataLoader for ArchetypeLoader {
 
         re_tracing::profile_function!(filepath.display().to_string());
 
-        let entity_path = EntityPath::from_file_path(&filepath);
+        let entity_path = settings
+            .entity_path_prefix
+            .clone()
+            .map(|prefix| prefix / EntityPath::from_file_path(&filepath))
+            .unwrap_or_else(|| EntityPath::from_file_path(&filepath));
 
         let mut timepoint = TimePoint::default();
         // TODO(cmc): log these once heuristics (I think?) are fixed

--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -80,8 +80,14 @@ impl DataLoader for UrdfDataLoader {
         let robot = urdf_rs::read_file(&filepath)
             .with_context(|| format!("Path: {}", filepath.display()))?;
 
-        log_robot(robot, &filepath, &tx, &settings.recommended_store_id())
-            .with_context(|| "Failed to load URDF file!")?;
+        log_robot(
+            robot,
+            &filepath,
+            &tx,
+            &settings.recommended_store_id(),
+            &settings.entity_path_prefix,
+        )
+        .with_context(|| "Failed to load URDF file!")?;
 
         Ok(())
     }
@@ -102,8 +108,14 @@ impl DataLoader for UrdfDataLoader {
         let robot = urdf_rs::read_from_string(&String::from_utf8_lossy(&contents))
             .with_context(|| format!("Path: {}", filepath.display()))?;
 
-        log_robot(robot, &filepath, &tx, &settings.recommended_store_id())
-            .with_context(|| "Failed to load URDF file!")?;
+        log_robot(
+            robot,
+            &filepath,
+            &tx,
+            &settings.recommended_store_id(),
+            &settings.entity_path_prefix,
+        )
+        .with_context(|| "Failed to load URDF file!")?;
 
         Ok(())
     }
@@ -251,18 +263,17 @@ fn log_robot(
     filepath: &Path,
     tx: &Sender<LoadedData>,
     store_id: &StoreId,
+    entity_path_prefix: &Option<EntityPath>,
 ) -> anyhow::Result<()> {
     let urdf_dir = filepath.parent().map(|path| path.to_path_buf());
 
     let urdf_tree = UrdfTree::new(robot, urdf_dir).with_context(|| "Failed to build URDF tree!")?;
+    let entity_path = entity_path_prefix
+        .clone()
+        .map(|prefix| prefix / EntityPath::from_single_string(urdf_tree.name.clone()))
+        .unwrap_or_else(|| EntityPath::from_single_string(urdf_tree.name.clone()));
 
-    walk_tree(
-        &urdf_tree,
-        tx,
-        store_id,
-        &EntityPath::from_single_string(urdf_tree.name.clone()),
-        &urdf_tree.root.name,
-    )?;
+    walk_tree(&urdf_tree, tx, store_id, &entity_path, &urdf_tree.root.name)?;
 
     Ok(())
 }

--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -150,8 +150,13 @@ impl EntityPath {
         Self::new(
             file_path
                 .clean()
-                .iter()
-                .map(|p| EntityPathPart::from(p.to_string_lossy().to_string()))
+                .components()
+                .filter_map(|component| match component {
+                    std::path::Component::Normal(os_str) => {
+                        Some(EntityPathPart::from(os_str.to_string_lossy().to_string()))
+                    }
+                    _ => None, // Skip root, prefix, parent dir, current dir components
+                })
                 .collect(),
         )
     }
@@ -795,5 +800,70 @@ mod tests {
             &EntityPath::from("world") / EntityPathPart::new("robot/arm"),
             EntityPath::from("world/robot\\/arm")
         );
+    }
+
+    #[test]
+    fn from_file_path() {
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("foo/bar/baz.txt")),
+            EntityPath::from("foo/bar/baz.txt")
+        );
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("/absolute/path/file.log")),
+            EntityPath::from("absolute/path/file.log")
+        );
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("single_file.txt")),
+            EntityPath::from("single_file.txt")
+        );
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("foo/../bar/./baz.txt")),
+            EntityPath::from("bar/baz.txt")
+        );
+
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("bar/./../baz.txt")),
+            EntityPath::from("baz.txt")
+        );
+
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("folder/file with spaces.txt")),
+            EntityPath::from("folder/file with spaces.txt")
+        );
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("")),
+            EntityPath::root()
+        );
+        assert_eq!(
+            EntityPath::from_file_path(std::path::Path::new("/")),
+            EntityPath::root()
+        );
+
+        // Windows paths
+        #[cfg(target_os = "windows")]
+        {
+            assert_eq!(
+                EntityPath::from_file_path(std::path::Path::new(
+                    r"C:\Users\user\Documents\robot.txt"
+                )),
+                EntityPath::from("Users/user/Documents/robot.txt")
+            );
+            assert_eq!(
+                EntityPath::from_file_path(std::path::Path::new(
+                    r"folder\subfolder\camera_rgbd.mp4"
+                )),
+                EntityPath::from("folder/subfolder/camera_rgbd.mp4")
+            );
+            assert_eq!(
+                EntityPath::from_file_path(std::path::Path::new(
+                    r"D:\Program Files\App\config.ini"
+                )),
+                EntityPath::from("Program Files/App/config.ini")
+            );
+            assert_eq!(
+                EntityPath::from_file_path(std::path::Path::new(r"\\server\share\file.dat")),
+                EntityPath::from("server/share/file.dat")
+            );
+        }
     }
 }


### PR DESCRIPTION
### Related

* Closes #8344

### What

Both `loader_archetype` and `loader_urdf` now honor `entity_path_prefix` when it is set. The LeRobot and MCAP loaders do not, since their entity paths directly reflect the structure of the data being loaded.
