### PR TITLE
Use `opened_store_id_or_recommended()` in URDF loader

### DIFF
--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -84,7 +84,7 @@ impl DataLoader for UrdfDataLoader {
             robot,
             &filepath,
             &tx,
-            &settings.recommended_store_id(),
+            &settings.opened_store_id_or_recommended(),
             &settings.entity_path_prefix,
         )
         .with_context(|| "Failed to load URDF file!")?;
@@ -112,7 +112,7 @@ impl DataLoader for UrdfDataLoader {
             robot,
             &filepath,
             &tx,
-            &settings.recommended_store_id(),
+            &settings.opened_store_id_or_recommended(),
             &settings.entity_path_prefix,
         )
         .with_context(|| "Failed to load URDF file!")?;


### PR DESCRIPTION
### What

Update URDF loader to prefer the opened store when available, falling back to the recommended store ID if none is opened.

This was causing the recording to split in two when loading an URDF file using the SDK.