### PR TITLE
Fix link checker (again)

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -283,7 +283,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.6.1
         with:
           fail: true
-          lycheeVersion: "0.20.1"
+          lycheeVersion: "v0.20.1"
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
           # Pass --verbose, so that all considered links are printed, making it easier to debug.
           args: |

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -263,22 +263,22 @@ jobs:
           restore-keys: cache-lychee-
 
       # For PRs: Check only links in added lines
-      - name: PR Link Checker (added lines only)
-        if: ${{ inputs.CHANNEL == 'pr' }}
-        run: |
-          # Install lychee
-          curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.20.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar -xz
-          sudo mv lychee /usr/local/bin/
+      # - name: PR Link Checker (added lines only)
+      #   if: ${{ inputs.CHANNEL == 'pr' }}
+      #   run: |
+      #     # Install lychee
+      #     curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.20.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+      #     sudo mv lychee /usr/local/bin/
 
-          # Fetch the base branch
-          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+      #     # Fetch the base branch
+      #     git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
-          # Run our custom PR link checker
-          python3 scripts/ci/pr_link_checker.py --base-ref origin/${{ github.base_ref }}
+      #     # Run our custom PR link checker
+      #     python3 scripts/ci/pr_link_checker.py --base-ref origin/${{ github.base_ref }}
 
       # For nightly: Check all links in the entire codebase
       - name: Full Link Checker
-        if: ${{ inputs.CHANNEL == 'nightly' }}
+        #if: ${{ inputs.CHANNEL == 'nightly' }}
         id: lychee
         uses: lycheeverse/lychee-action@v1.10.0
         with:

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Full Link Checker
         #if: ${{ inputs.CHANNEL == 'nightly' }}
         id: lychee
-        uses: lycheeverse/lychee-action@v1.10.0
+        uses: lycheeverse/lychee-action@v2.6.1
         with:
           fail: true
           lycheeVersion: "0.20.1"

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -263,22 +263,22 @@ jobs:
           restore-keys: cache-lychee-
 
       # For PRs: Check only links in added lines
-      # - name: PR Link Checker (added lines only)
-      #   if: ${{ inputs.CHANNEL == 'pr' }}
-      #   run: |
-      #     # Install lychee
-      #     curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.20.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar -xz
-      #     sudo mv lychee /usr/local/bin/
+      - name: PR Link Checker (added lines only)
+        if: ${{ inputs.CHANNEL == 'pr' }}
+        run: |
+          # Install lychee
+          curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.20.1/lychee-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          sudo mv lychee /usr/local/bin/
 
-      #     # Fetch the base branch
-      #     git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+          # Fetch the base branch
+          git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
 
-      #     # Run our custom PR link checker
-      #     python3 scripts/ci/pr_link_checker.py --base-ref origin/${{ github.base_ref }}
+          # Run our custom PR link checker
+          python3 scripts/ci/pr_link_checker.py --base-ref origin/${{ github.base_ref }}
 
       # For nightly: Check all links in the entire codebase
       - name: Full Link Checker
-        #if: ${{ inputs.CHANNEL == 'nightly' }}
+        if: ${{ inputs.CHANNEL == 'nightly' }}
         id: lychee
         uses: lycheeverse/lychee-action@v2.6.1
         with:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -48,7 +48,7 @@ If we are doing a patch release, we do a branch off of the latest release tag (e
 
 # Release process
 
-### 1. Check the root [`Cargo.toml`](/Cargo.toml) to see what version we are currently on.
+### 1. Check the root [`Cargo.toml`](./Cargo.toml) to see what version we are currently on.
 
 ### 2. Create a release branch.
 
@@ -85,7 +85,7 @@ Where `z` is the previous patch number.
 Note that the `cherry-pick` will fail if there are no additional `docs-latest` commits to include,
 which is fine.
 
-### 4. Update [`CHANGELOG.md`](/CHANGELOG.md) and clean ups.
+### 4. Update [`CHANGELOG.md`](./CHANGELOG.md) and clean ups.
 
 Update the change log. It should include:
   - A one-line summary of the release

--- a/crates/viewer/re_ui/data/Inter-README.txt
+++ b/crates/viewer/re_ui/data/Inter-README.txt
@@ -31,35 +31,6 @@ Get started
 2. Use your app's font picker to view the font family and all the
 available styles
 
-Learn more about variable fonts
--------------------------------
-
-  https://developers.google.com/web/fundamentals/design-and-ux/typography/variable-fonts
-  https://variablefonts.typenetwork.com
-  https://medium.com/variable-fonts
-
-In desktop apps
-
-  https://theblog.adobe.com/can-variable-fonts-illustrator-cc
-  https://helpx.adobe.com/nz/photoshop/using/fonts.html#variable_fonts
-
-Online
-
-  https://developers.google.com/fonts/docs/getting_started
-  https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide
-  https://developer.microsoft.com/en-us/microsoft-edge/testdrive/demos/variable-fonts
-
-Installing fonts
-
-  MacOS: https://support.apple.com/en-us/HT201749
-  Linux: https://www.google.com/search?q=how+to+install+a+font+on+gnu%2Blinux
-  Windows: https://support.microsoft.com/en-us/help/314960/how-to-install-or-remove-a-font-in-windows
-
-Android Apps
-
-  https://developers.google.com/fonts/docs/android
-  https://developer.android.com/guide/topics/ui/look-and-feel/downloadable-fonts
-
 License
 -------
 Please read the full license text (OFL.txt) to understand the permissions,

--- a/lychee.toml
+++ b/lychee.toml
@@ -46,9 +46,9 @@ accept = [
 exclude_path = [
   # Unfortunately lychee doesn't yet read .gitignore https://github.com/lycheeverse/lychee/issues/1331
   # The following entries are there because of that:
-  ".git",
   "__pycache__",
   "_deps/",
+  ".git",
   ".pixi",
   "build",
   "docs/python/",
@@ -59,8 +59,8 @@ exclude_path = [
   "rerun_js/node_modules/",
   "rerun_notebook/node_modules/",
   "rerun_py/site/",
-  "target_pixi",
   "target_pixi_wasm",
+  "target_pixi",
   "target_ra",
   "target_wasm",
   "target",
@@ -93,12 +93,13 @@ exclude = [
   'rerun:/.*',
 
   # Local links that require further setup.
+  '/examples',            # Relative link to our examples gallery.
+  'http://0.0.0.0:51234',
   'http://127.0.0.1',
   'http://localhost',
+  're_viewer.js',         # Build artifact that html is linking to.
   'recording:/',          # rrd recording link.
   'ws:/',
-  're_viewer.js',         # Build artifact that html is linking to.
-  'http://0.0.0.0:51234',
 
   # Api endpoints.
   'https://fonts.googleapis.com/',                                               # Font API entrypoint, not a link.
@@ -139,14 +140,15 @@ exclude = [
   # Not accessible from CI.
   '.github/workflows/.*.yml',                                          # GitHub action workflows cause issues on CI.
   'https://9p.io/sys/doc/lexnames.html',                               # Works locally but on CI we get: `Failed: Network error: error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:ssl/statem/extensions.c:946:`
+  'https://claude.site/artifacts/',                                    # Giving a 500, but only from CI
+  'https://fifteen-thirtyeight.rerun.io/script.js',                    # Gives 403 forbidden on CI.
+  'https://lib.rs/*',                                                  # Gives 403 forbidden on CI.
+  'https://math.stackexchange.com/',                                   # Gives 403 forbidden on CI.
   'https://pixabay.com/photos/brother-sister-girl-family-boy-977170/', # Gives 403 forbidden on CI.
   'https://stackoverflow.com/',                                        # Stackoverflow links are no longer accessible from CI.
-  'https://math.stackexchange.com/',                                   # Gives 403 forbidden on CI.
   'https://vimeo.com/',                                                # Gives 403 forbidden on CI.
   'https://www.reddit.com/',                                           # Gives 403 forbidden on CI.
   'https://www.tensorflow.org/',                                       # tensorflow.org apparently blocks CI.
-  'https://claude.site/artifacts/',                                    # Giving a 500, but only from CI
-  'https://fifteen-thirtyeight.rerun.io/script.js',                    # Gives 403 forbidden on CI.
 
   # Need GitHub login.
   'https://github.com/rerun-io/landing',


### PR DESCRIPTION
The full nightly version of our link checker no longer ran. Not sure when that broke - did it when I merged pr-diff-based link checking?

Working run with full link checker:
https://github.com/rerun-io/rerun/actions/runs/17429284992/job/49483646496?pr=11087

and it actually passing:
https://github.com/rerun-io/rerun/actions/runs/17429912661/job/49485729321?pr=11087

