### PR TITLE
Depricate python 3.9

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -46,7 +46,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -63,7 +63,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
 defaults:
   run:

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -39,7 +39,7 @@ permissions:
   id-token: "write"
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.10"
 
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings

--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -2283,10 +2283,10 @@ return pa.array(pa_data, type=data_type)
                 .into_iter()
                 .sorted() // Make order not dependent on hash shenanigans (also looks nicer often).
                 .filter(|typename| !typename.contains('[')) // If we keep these we unfortunately get: `TypeError: Subscripted generics cannot be used with class and instance checks`
-                .filter(|typename| !typename.ends_with("Like")) // `xLike` types are union types and checking those is not supported until Python 3.10.
+                .filter(|typename| !typename.ends_with("Like")) // TODO(#10959): `xLike` types are union types and checking those is not supported until Python 3.10.
                 .map(|typename| {
                     if typename == "None" {
-                        "type(None)".to_owned() // `NoneType` requires Python 3.10.
+                        "type(None)".to_owned() // TODO(#10959): `NoneType` requires Python 3.10.
                     } else {
                         typename
                     }

--- a/docs/content/getting-started/quick-start/python.md
+++ b/docs/content/getting-started/quick-start/python.md
@@ -5,7 +5,7 @@ order: 2
 
 ## Installing Rerun
 
-The Rerun SDK for Python requires a working installation of [Python-3.9+](https://www.python.org/).
+The Rerun SDK for Python requires a working installation of [Python-3.10+](https://www.python.org/).
 
 You can install the Rerun SDK using the [rerun-sdk](https://pypi.org/project/rerun-sdk/) pypi package via pip:
 

--- a/docs/content/reference/migration/migration-0-25.md
+++ b/docs/content/reference/migration/migration-0-25.md
@@ -29,3 +29,12 @@ Previously this could only be configured for gRPC sinks, and it was configured o
 In the C++ and Python APIs, negative timeouts used to have special meaning. Now they are no longer permitted.
 
 The Python flush calls now raises an error if the flushing did not complete successfully.
+
+## ❗ Deprecations
+
+### Python 3.9
+
+Support for Python 3.9 is being deprecated. Python 3.9 is past end-of-life. See: https://devguide.python.org/versions/
+In the next release, we will fully drop support and switch to Python 3.10 as the minimum supported version.
+
+See an overview for supported python versions [here](https://ref.rerun.io/docs/python/main/common#supported-python-versions).

--- a/examples/python/air_traffic_data/README.md
+++ b/examples/python/air_traffic_data/README.md
@@ -28,7 +28,7 @@ This example demonstrates multiple aspects of the Rerun viewer:
 
 ## Run the code
 
-To run this example, make sure you have Python version at least 3.9, the Rerun repository checked out and the latest SDK installed:
+To run this example, make sure you have the [required Python version](https://ref.rerun.io/docs/python/main/common#supported-python-versions), the Rerun repository checked out and the latest SDK installed:
 ```bash
 pip install --upgrade rerun-sdk  # install the latest Rerun SDK
 git clone git@github.com:rerun-io/rerun.git  # Clone the repository

--- a/examples/python/all_examples/pyproject.toml
+++ b/examples/python/all_examples/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "all_examples"
 version = "0.1.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["dependencies"]
 

--- a/examples/python/blueprint_stocks/pyproject.toml
+++ b/examples/python/blueprint_stocks/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "blueprint_stocks"
 version = "0.1.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 dependencies = ["humanize", "rerun-sdk", "yfinance"]
 

--- a/examples/python/nuscenes_dataset/README.md
+++ b/examples/python/nuscenes_dataset/README.md
@@ -172,7 +172,7 @@ We programmatically create one view per sensor and arrange them in a grid layout
 
 
 ## Run the code
-To run this example, make sure you have Python version at least 3.9, the Rerun repository checked out and the latest SDK installed:
+To run this example, make sure you have the [required Python version](https://ref.rerun.io/docs/python/main/common#supported-python-versions), the Rerun repository checked out and the latest SDK installed:
 ```bash
 pip install --upgrade rerun-sdk  # install the latest Rerun SDK
 git clone git@github.com:rerun-io/rerun.git  # Clone the repository

--- a/examples/python/objectron/README.md
+++ b/examples/python/objectron/README.md
@@ -107,7 +107,7 @@ In particular, we want to reproject the points and the 3D annotation box in the 
 
 
 ## Run the code
-To run this example, make sure you have Python version at least 3.9, the Rerun repository checked out and the latest SDK installed:
+To run this example, make sure you have the [required Python version](https://ref.rerun.io/docs/python/main/common#supported-python-versions), the Rerun repository checked out and the latest SDK installed:
 ```bash
 pip install --upgrade rerun-sdk  # install the latest Rerun SDK
 git clone git@github.com:rerun-io/rerun.git  # Clone the repository

--- a/examples/python/openstreetmap_data/README.md
+++ b/examples/python/openstreetmap_data/README.md
@@ -20,7 +20,7 @@ and display it on a [map view](https://www.rerun.io/docs/reference/types/views/m
 
 ## Run the code
 
-To run this example, make sure you have Python version at least 3.9, the Rerun repository checked out and the latest SDK installed:
+To run this example, make sure you have the [required Python version](https://ref.rerun.io/docs/python/main/common#supported-python-versions), the Rerun repository checked out and the latest SDK installed:
 ```bash
 pip install --upgrade rerun-sdk  # install the latest Rerun SDK
 git clone git@github.com:rerun-io/rerun.git  # Clone the repository

--- a/pixi.lock
+++ b/pixi.lock
@@ -14718,12 +14718,12 @@ packages:
 - pypi: ./examples/python/blueprint_stocks
   name: blueprint-stocks
   version: 0.1.0
-  sha256: 931c90b4c05a2f881a1c68dcb9a84887e1a185ff0fc9d366fd7e5e60e1738b50
+  sha256: cf1919bbc931b1dbcae9b042b3d6d1b3b224c5e6dbdeb7d9d8f3b548fad23a8b
   requires_dist:
   - humanize
   - rerun-sdk
   - yfinance
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/buf-1.56.0-ha8f183a_0.conda
   sha256: 54ef4312e1c81abd15105f8b9bab49f22699f060e6864e9351b016e5411e5d2e
@@ -33550,7 +33550,7 @@ packages:
 - pypi: ./rerun_py
   name: rerun-sdk
   version: 0.25.0a1+dev
-  sha256: de26dd790e6a6cc8dfab7f1e0f5f8ff3e583cfdf5e7ca5139b4d6d31a5f477db
+  sha256: 5221da5f22fa3bc1bb2556a4e82ee3dcb89cdd018653a00182009d8d7ec0b685
   requires_dist:
   - attrs>=23.1.0
   - numpy>=2
@@ -33562,7 +33562,7 @@ packages:
   - datafusion==47.0.0 ; extra == 'datafusion'
   - notebook ; extra == 'all'
   - datafusion ; extra == 'all'
-  requires_python: '>=3.9'
+  requires_python: '>=3.10'
   editable: true
 - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
   name: rfc3339-validator

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -91,7 +91,7 @@ mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
 numpy.workspace = true
 parking_lot.workspace = true
 pyo3 = { workspace = true, features = [
-  "abi3-py39", # Require at least Python 3.9
+  "abi3-py39", # Require at least Python 3.10
   "chrono",    #TODO(#9317): migrate to jiff
 ] }
 rand = { workspace = true, features = ["std", "std_rng"] }

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 description = "The Rerun Logging SDK"
 keywords = ["computer-vision", "logging", "rerun"]
 name = "rerun-sdk"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 
 [[project.authors]]

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -11,8 +11,8 @@ __version__ = "0.25.0-alpha.1+dev"
 __version_info__ = (0, 25, 0, "alpha.1")
 
 
-if sys.version_info < (3, 9):  # noqa: UP036
-    raise RuntimeError("Rerun SDK requires Python 3.9 or later.")
+if sys.version_info < (3, 10):  # noqa: UP036
+    raise RuntimeError("Rerun SDK requires Python 3.10 or later.")
 
 
 # =====================================


### PR DESCRIPTION
### Related

Related issue: #10958

### What

 - Updates our github workflows to use python 3.10.
 - Update mentions of 3.9 to either a link to https://ref.rerun.io/docs/python/main/common#supported-python-versions, or 3.10.
 - Update python packages to require 3.10.
 - Update python version warning print to check against 3.10.