### PR TITLE
Prevent arow_cpp from configuring/building/installing all the time

### DIFF
--- a/rerun_cpp/download_and_build_arrow.cmake
+++ b/rerun_cpp/download_and_build_arrow.cmake
@@ -88,6 +88,7 @@ function(download_and_build_arrow)
         GIT_TAG apache-arrow-18.0.0
         GIT_SHALLOW ON
         GIT_PROGRESS OFF # Git progress sounds like a nice idea but is in practice very spammy.
+        UPDATE_COMMAND "" # Prevent unnecessary rebuilds on every cmake --build
 
         # LOG_X ON means that the output of the command will
         # be logged to a file _instead_ of printed to the console.


### PR DESCRIPTION
This addresses the following issue: whenever I build my cmake project based on [Rerun C++ hello world](https://rerun.io/docs/getting-started/quick-start/cpp), the arrow_cpp target gets re-configured, re-built and re-installed even though it did not change (and I did not even try to install my build):

```
>cmake --build build
MSBuild version 17.8.5+b5265ef37 for .NET Framework

  Checking File Globs
  1>Performing update step for 'arrow_cpp'
  -- Already at requested tag: apache-arrow-18.0.0
  No patch step for 'arrow_cpp'
  Performing configure step for 'arrow_cpp'
  -- arrow_cpp configure command succeeded.  See also C:/Users/emichel/SourceCode/SparkleOptimizer3/build/_deps/rerun_sdk-build/arrow/src/arrow_cpp-stamp/a
  rrow_cpp-configure-*.log
  Performing build step for 'arrow_cpp'
  -- arrow_cpp build command succeeded.  See also C:/Users/emichel/SourceCode/SparkleOptimizer3/build/_deps/rerun_sdk-build/arrow/src/arrow_cpp-stamp/arrow
  _cpp-build-*.log
  Performing install step for 'arrow_cpp'
  -- arrow_cpp install command succeeded.  See also C:/Users/emichel/SourceCode/SparkleOptimizer3/build/_deps/rerun_sdk-build/arrow/src/arrow_cpp-stamp/arr
  ow_cpp-install-*.log
  Completed 'arrow_cpp'
  rerun_sdk.vcxproj -> C:\Users\emichel\SourceCode\SparkleOptimizer3\build\_deps\rerun_sdk-build\Debug\rerun_sdk.lib
```

This is addressed by adding an empty `UPDATE_COMMAND` to the external project definition.

PS: Is there any reason why this is an `ExternalProject` and not a `FetchContent`?

