### PR TITLE
Cherry-pick version bump for alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "animated_urdf"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "clock"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2136,7 +2136,7 @@ checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "custom_callback"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "bincode",
  "mimalloc",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "custom_data_loader"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "re_build_tools",
  "rerun",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "custom_store_subscriber"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "re_build_tools",
  "rerun",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "custom_view"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "mimalloc",
  "rerun",
@@ -2226,7 +2226,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "dataframe_query"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "itertools 0.14.0",
  "rerun",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "dna"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "extend_viewer_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "mimalloc",
  "rerun",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "graph_lattice"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4567,7 +4567,7 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "incremental_logging"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "log_benchmark"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "log_file"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5375,14 +5375,14 @@ dependencies = [
 
 [[package]]
 name = "minimal"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "rerun",
 ]
 
 [[package]]
 name = "minimal_options"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5392,7 +5392,7 @@ dependencies = [
 
 [[package]]
 name = "minimal_serve"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "rerun",
 ]
@@ -6086,7 +6086,7 @@ dependencies = [
 
 [[package]]
 name = "objectron"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -6566,7 +6566,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plot_dashboard_stress"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -7156,7 +7156,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "raw_mesh"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7193,7 +7193,7 @@ dependencies = [
 
 [[package]]
 name = "re_analytics"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "crossbeam",
  "directories",
@@ -7214,7 +7214,7 @@ dependencies = [
 
 [[package]]
 name = "re_arrow_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "egui",
@@ -7228,7 +7228,7 @@ dependencies = [
 
 [[package]]
 name = "re_arrow_util"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7241,7 +7241,7 @@ dependencies = [
 
 [[package]]
 name = "re_auth"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "base64 0.22.1",
  "const_format",
@@ -7262,7 +7262,7 @@ dependencies = [
 
 [[package]]
 name = "re_blueprint_tree"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "egui",
  "egui_kittest",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "re_build_info"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "re_byte_size",
  "serde",
@@ -7297,7 +7297,7 @@ dependencies = [
 
 [[package]]
 name = "re_build_tools"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -7311,7 +7311,7 @@ dependencies = [
 
 [[package]]
 name = "re_byte_size"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "half",
@@ -7320,7 +7320,7 @@ dependencies = [
 
 [[package]]
 name = "re_capabilities"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "document-features",
  "egui",
@@ -7329,14 +7329,14 @@ dependencies = [
 
 [[package]]
 name = "re_case"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "convert_case",
 ]
 
 [[package]]
 name = "re_chunk"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7367,7 +7367,7 @@ dependencies = [
 
 [[package]]
 name = "re_chunk_store"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7398,7 +7398,7 @@ dependencies = [
 
 [[package]]
 name = "re_chunk_store_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "egui",
@@ -7416,7 +7416,7 @@ dependencies = [
 
 [[package]]
 name = "re_component_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "egui",
@@ -7441,7 +7441,7 @@ dependencies = [
 
 [[package]]
 name = "re_context_menu"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "egui",
  "egui_tiles",
@@ -7462,7 +7462,7 @@ dependencies = [
 
 [[package]]
 name = "re_crash_handler"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "backtrace",
  "econtext",
@@ -7475,7 +7475,7 @@ dependencies = [
 
 [[package]]
 name = "re_data_loader"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7511,7 +7511,7 @@ dependencies = [
 
 [[package]]
 name = "re_data_source"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -7534,7 +7534,7 @@ dependencies = [
 
 [[package]]
 name = "re_data_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7568,7 +7568,7 @@ dependencies = [
 
 [[package]]
 name = "re_dataframe"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7595,7 +7595,7 @@ dependencies = [
 
 [[package]]
 name = "re_dataframe_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "arrow",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "re_datafusion"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7659,7 +7659,7 @@ dependencies = [
 
 [[package]]
 name = "re_dev_tools"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "argh",
@@ -7686,7 +7686,7 @@ dependencies = [
 
 [[package]]
 name = "re_entity_db"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7719,14 +7719,14 @@ dependencies = [
 
 [[package]]
 name = "re_error"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "re_format"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "half",
  "num-traits",
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "re_format_arrow"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "comfy-table",
@@ -7747,7 +7747,7 @@ dependencies = [
 
 [[package]]
 name = "re_global_context"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7780,7 +7780,7 @@ dependencies = [
 
 [[package]]
 name = "re_grpc_client"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "async-stream",
  "crossbeam",
@@ -7804,7 +7804,7 @@ dependencies = [
 
 [[package]]
 name = "re_grpc_server"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "crossbeam",
@@ -7834,7 +7834,7 @@ dependencies = [
 
 [[package]]
 name = "re_int_histogram"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "criterion",
  "insta",
@@ -7845,7 +7845,7 @@ dependencies = [
 
 [[package]]
 name = "re_integration_test"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "egui",
  "egui_kittest",
@@ -7861,7 +7861,7 @@ dependencies = [
 
 [[package]]
 name = "re_log"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "env_filter",
  "env_logger",
@@ -7875,7 +7875,7 @@ dependencies = [
 
 [[package]]
 name = "re_log_encoding"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "bytes",
@@ -7907,7 +7907,7 @@ dependencies = [
 
 [[package]]
 name = "re_log_types"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "arrow",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "re_mcap"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7965,7 +7965,7 @@ dependencies = [
 
 [[package]]
 name = "re_memory"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "backtrace",
@@ -7998,7 +7998,7 @@ dependencies = [
 
 [[package]]
 name = "re_perf_telemetry"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8026,7 +8026,7 @@ dependencies = [
 
 [[package]]
 name = "re_protos"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "jiff",
@@ -8048,7 +8048,7 @@ dependencies = [
 
 [[package]]
 name = "re_protos_builder"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "camino",
  "prost-build",
@@ -8058,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "re_query"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8113,7 +8113,7 @@ dependencies = [
 
 [[package]]
 name = "re_recording_panel"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "egui",
@@ -8135,7 +8135,7 @@ dependencies = [
 
 [[package]]
 name = "re_redap_browser"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "datafusion",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "re_redap_client"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "itertools 0.14.0",
@@ -8192,7 +8192,7 @@ dependencies = [
 
 [[package]]
 name = "re_renderer"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8243,7 +8243,7 @@ dependencies = [
 
 [[package]]
 name = "re_renderer_examples"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8266,7 +8266,7 @@ dependencies = [
 
 [[package]]
 name = "re_sdk"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "const_format",
@@ -8302,7 +8302,7 @@ dependencies = [
 
 [[package]]
 name = "re_selection_panel"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "egui",
@@ -8335,7 +8335,7 @@ dependencies = [
 
 [[package]]
 name = "re_server"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8368,7 +8368,7 @@ dependencies = [
 
 [[package]]
 name = "re_smart_channel"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "crossbeam",
  "parking_lot",
@@ -8381,7 +8381,7 @@ dependencies = [
 
 [[package]]
 name = "re_sorbet"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "itertools 0.14.0",
@@ -8401,14 +8401,14 @@ dependencies = [
 
 [[package]]
 name = "re_span"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "re_string_interner"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "nohash-hasher",
@@ -8419,7 +8419,7 @@ dependencies = [
 
 [[package]]
 name = "re_test_context"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "re_test_viewport"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "egui",
@@ -8465,7 +8465,7 @@ dependencies = [
 
 [[package]]
 name = "re_time_panel"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "re_tracing"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "puffin",
  "puffin_http",
@@ -8507,7 +8507,7 @@ dependencies = [
 
 [[package]]
 name = "re_tuid"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "bytemuck",
  "criterion",
@@ -8521,7 +8521,7 @@ dependencies = [
 
 [[package]]
 name = "re_types"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "array-init",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "re_types_builder"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "camino",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "re_types_core"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8620,7 +8620,7 @@ dependencies = [
 
 [[package]]
 name = "re_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8655,7 +8655,7 @@ dependencies = [
 
 [[package]]
 name = "re_uri"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "re_log",
  "re_log_types",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "re_video"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "bit-vec",
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "re_view"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "egui",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_bar_chart"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "egui",
@@ -8746,7 +8746,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_dataframe"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8775,7 +8775,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_graph"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "egui",
@@ -8803,7 +8803,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_map"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "bytemuck",
  "egui",
@@ -8828,7 +8828,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_spatial"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8875,7 +8875,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_tensor"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_text_document"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "egui",
  "egui_commonmark",
@@ -8917,7 +8917,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_text_log"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "egui",
  "egui_extras",
@@ -8938,7 +8938,7 @@ dependencies = [
 
 [[package]]
 name = "re_view_time_series"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "egui",
  "egui_plot",
@@ -8964,7 +8964,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewer"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -9056,7 +9056,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewer_context"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewport"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "egui",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "re_viewport_blueprint"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "arrow",
@@ -9163,7 +9163,7 @@ dependencies = [
 
 [[package]]
 name = "re_web_viewer_server"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "document-features",
  "re_analytics",
@@ -9341,7 +9341,7 @@ dependencies = [
 
 [[package]]
 name = "rerun"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -9399,7 +9399,7 @@ dependencies = [
 
 [[package]]
 name = "rerun-cli"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "document-features",
  "mimalloc",
@@ -9413,7 +9413,7 @@ dependencies = [
 
 [[package]]
 name = "rerun-loader-rust-file"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "argh",
@@ -9422,7 +9422,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_c"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "ahash",
  "arrow",
@@ -9439,7 +9439,7 @@ dependencies = [
 
 [[package]]
 name = "rerun_py"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "arrow",
  "chrono",
@@ -9599,7 +9599,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "run_wasm"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "cargo-run-wasm",
  "pico-args",
@@ -9985,7 +9985,7 @@ dependencies = [
 
 [[package]]
 name = "shared_recording"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "rerun",
 ]
@@ -10151,7 +10151,7 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "snippets"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "itertools 0.14.0",
  "ndarray",
@@ -10175,7 +10175,7 @@ dependencies = [
 
 [[package]]
 name = "spawn_viewer"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "rerun",
 ]
@@ -10255,7 +10255,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdio"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "rerun",
 ]
@@ -10412,7 +10412,7 @@ dependencies = [
 
 [[package]]
 name = "template"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "rerun",
 ]
@@ -10428,7 +10428,7 @@ dependencies = [
 
 [[package]]
 name = "test_api"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -10443,7 +10443,7 @@ dependencies = [
 
 [[package]]
 name = "test_data_density_graph"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -10453,7 +10453,7 @@ dependencies = [
 
 [[package]]
 name = "test_image_memory"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "mimalloc",
  "re_format",
@@ -10463,7 +10463,7 @@ dependencies = [
 
 [[package]]
 name = "test_pinhole_projection"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -10474,7 +10474,7 @@ dependencies = [
 
 [[package]]
 name = "test_send_columns"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "re_chunk",
  "rerun",
@@ -10482,7 +10482,7 @@ dependencies = [
 
 [[package]]
 name = "test_ui_wakeup"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -11313,7 +11313,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "viewer_callbacks"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = [
  "mimalloc",
  "rerun",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ include = [
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rerun-io/rerun"
 rust-version = "1.88"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 
 [workspace.metadata.cargo-shear]
 ignored = [
@@ -56,95 +56,95 @@ ignored = [
 # re_log_types 0.3.0-alpha.0, NOT 0.3.0-alpha.4 even though it is newer and semver-compatible.
 
 # crates/build:
-re_build_info = { path = "crates/build/re_build_info", version = "=0.25.0-alpha.1", default-features = false }
-re_build_tools = { path = "crates/build/re_build_tools", version = "=0.25.0-alpha.1", default-features = false }
-re_dev_tools = { path = "crates/build/re_dev_tools", version = "=0.25.0-alpha.1", default-features = false }
-re_protos_builder = { path = "crates/build/re_protos_builder", version = "=0.25.0-alpha.1", default-features = false }
-re_types_builder = { path = "crates/build/re_types_builder", version = "=0.25.0-alpha.1", default-features = false }
+re_build_info = { path = "crates/build/re_build_info", version = "=0.25.0-alpha.2", default-features = false }
+re_build_tools = { path = "crates/build/re_build_tools", version = "=0.25.0-alpha.2", default-features = false }
+re_dev_tools = { path = "crates/build/re_dev_tools", version = "=0.25.0-alpha.2", default-features = false }
+re_protos_builder = { path = "crates/build/re_protos_builder", version = "=0.25.0-alpha.2", default-features = false }
+re_types_builder = { path = "crates/build/re_types_builder", version = "=0.25.0-alpha.2", default-features = false }
 
 # crates/store:
-re_chunk = { path = "crates/store/re_chunk", version = "=0.25.0-alpha.1", default-features = false }
-re_chunk_store = { path = "crates/store/re_chunk_store", version = "=0.25.0-alpha.1", default-features = false }
-re_data_loader = { path = "crates/store/re_data_loader", version = "=0.25.0-alpha.1", default-features = false }
-re_data_source = { path = "crates/store/re_data_source", version = "=0.25.0-alpha.1", default-features = false }
-re_dataframe = { path = "crates/store/re_dataframe", version = "=0.25.0-alpha.1", default-features = false }
-re_datafusion = { path = "crates/store/re_datafusion", version = "=0.25.0-alpha.1", default-features = false }
-re_entity_db = { path = "crates/store/re_entity_db", version = "=0.25.0-alpha.1", default-features = false }
-re_format_arrow = { path = "crates/store/re_format_arrow", version = "=0.25.0-alpha.1", default-features = false }
-re_redap_client = { path = "crates/store/re_redap_client", version = "=0.25.0-alpha.1", default-features = false }
-re_grpc_client = { path = "crates/store/re_grpc_client", version = "=0.25.0-alpha.1", default-features = false }
-re_grpc_server = { path = "crates/store/re_grpc_server", version = "=0.25.0-alpha.1", default-features = false }
-re_protos = { path = "crates/store/re_protos", version = "=0.25.0-alpha.1", default-features = false }
-re_log_encoding = { path = "crates/store/re_log_encoding", version = "=0.25.0-alpha.1", default-features = false }
-re_log_types = { path = "crates/store/re_log_types", version = "=0.25.0-alpha.1", default-features = false }
-re_query = { path = "crates/store/re_query", version = "=0.25.0-alpha.1", default-features = false }
-re_server = { path = "crates/store/re_server", version = "=0.25.0-alpha.1", default-features = false }
-re_sorbet = { path = "crates/store/re_sorbet", version = "=0.25.0-alpha.1", default-features = false }
-re_types = { path = "crates/store/re_types", version = "=0.25.0-alpha.1", default-features = false }
-re_types_core = { path = "crates/store/re_types_core", version = "=0.25.0-alpha.1", default-features = false }
+re_chunk = { path = "crates/store/re_chunk", version = "=0.25.0-alpha.2", default-features = false }
+re_chunk_store = { path = "crates/store/re_chunk_store", version = "=0.25.0-alpha.2", default-features = false }
+re_data_loader = { path = "crates/store/re_data_loader", version = "=0.25.0-alpha.2", default-features = false }
+re_data_source = { path = "crates/store/re_data_source", version = "=0.25.0-alpha.2", default-features = false }
+re_dataframe = { path = "crates/store/re_dataframe", version = "=0.25.0-alpha.2", default-features = false }
+re_datafusion = { path = "crates/store/re_datafusion", version = "=0.25.0-alpha.2", default-features = false }
+re_entity_db = { path = "crates/store/re_entity_db", version = "=0.25.0-alpha.2", default-features = false }
+re_format_arrow = { path = "crates/store/re_format_arrow", version = "=0.25.0-alpha.2", default-features = false }
+re_redap_client = { path = "crates/store/re_redap_client", version = "=0.25.0-alpha.2", default-features = false }
+re_grpc_client = { path = "crates/store/re_grpc_client", version = "=0.25.0-alpha.2", default-features = false }
+re_grpc_server = { path = "crates/store/re_grpc_server", version = "=0.25.0-alpha.2", default-features = false }
+re_protos = { path = "crates/store/re_protos", version = "=0.25.0-alpha.2", default-features = false }
+re_log_encoding = { path = "crates/store/re_log_encoding", version = "=0.25.0-alpha.2", default-features = false }
+re_log_types = { path = "crates/store/re_log_types", version = "=0.25.0-alpha.2", default-features = false }
+re_query = { path = "crates/store/re_query", version = "=0.25.0-alpha.2", default-features = false }
+re_server = { path = "crates/store/re_server", version = "=0.25.0-alpha.2", default-features = false }
+re_sorbet = { path = "crates/store/re_sorbet", version = "=0.25.0-alpha.2", default-features = false }
+re_types = { path = "crates/store/re_types", version = "=0.25.0-alpha.2", default-features = false }
+re_types_core = { path = "crates/store/re_types_core", version = "=0.25.0-alpha.2", default-features = false }
 
 # crates/top:
-re_sdk = { path = "crates/top/re_sdk", version = "=0.25.0-alpha.1", default-features = false }
-rerun = { path = "crates/top/rerun", version = "=0.25.0-alpha.1", default-features = false }
-rerun_c = { path = "crates/top/rerun_c", version = "=0.25.0-alpha.1", default-features = false }
-rerun-cli = { path = "crates/top/rerun-cli", version = "=0.25.0-alpha.1", default-features = false }
+re_sdk = { path = "crates/top/re_sdk", version = "=0.25.0-alpha.2", default-features = false }
+rerun = { path = "crates/top/rerun", version = "=0.25.0-alpha.2", default-features = false }
+rerun_c = { path = "crates/top/rerun_c", version = "=0.25.0-alpha.2", default-features = false }
+rerun-cli = { path = "crates/top/rerun-cli", version = "=0.25.0-alpha.2", default-features = false }
 
 # crates/utils:
-re_analytics = { path = "crates/utils/re_analytics", version = "=0.25.0-alpha.1", default-features = false }
-re_arrow_util = { path = "crates/utils/re_arrow_util", version = "=0.25.0-alpha.1", default-features = false }
-re_auth = { path = "crates/utils/re_auth", version = "=0.25.0-alpha.1", default-features = false }
-re_byte_size = { path = "crates/utils/re_byte_size", version = "=0.25.0-alpha.1", default-features = false }
-re_capabilities = { path = "crates/utils/re_capabilities", version = "=0.25.0-alpha.1", default-features = false }
-re_case = { path = "crates/utils/re_case", version = "=0.25.0-alpha.1", default-features = false }
-re_crash_handler = { path = "crates/utils/re_crash_handler", version = "=0.25.0-alpha.1", default-features = false }
-re_error = { path = "crates/utils/re_error", version = "=0.25.0-alpha.1", default-features = false }
-re_format = { path = "crates/utils/re_format", version = "=0.25.0-alpha.1", default-features = false }
-re_int_histogram = { path = "crates/utils/re_int_histogram", version = "=0.25.0-alpha.1", default-features = false }
-re_log = { path = "crates/utils/re_log", version = "=0.25.0-alpha.1", default-features = false }
-re_mcap = { path = "crates/utils/re_mcap", version = "=0.25.0-alpha.1", default-features = false }
-re_memory = { path = "crates/utils/re_memory", version = "=0.25.0-alpha.1", default-features = false }
-re_perf_telemetry = { path = "crates/utils/re_perf_telemetry", version = "=0.25.0-alpha.1", default-features = false }
-re_smart_channel = { path = "crates/utils/re_smart_channel", version = "=0.25.0-alpha.1", default-features = false }
-re_span = { path = "crates/utils/re_span", version = "=0.25.0-alpha.1", default-features = false }
-re_string_interner = { path = "crates/utils/re_string_interner", version = "=0.25.0-alpha.1", default-features = false }
-re_tracing = { path = "crates/utils/re_tracing", version = "=0.25.0-alpha.1", default-features = false }
-re_tuid = { path = "crates/utils/re_tuid", version = "=0.25.0-alpha.1", default-features = false }
-re_uri = { path = "crates/utils/re_uri", version = "=0.25.0-alpha.1", default-features = false }
-re_video = { path = "crates/utils/re_video", version = "=0.25.0-alpha.1", default-features = false }
+re_analytics = { path = "crates/utils/re_analytics", version = "=0.25.0-alpha.2", default-features = false }
+re_arrow_util = { path = "crates/utils/re_arrow_util", version = "=0.25.0-alpha.2", default-features = false }
+re_auth = { path = "crates/utils/re_auth", version = "=0.25.0-alpha.2", default-features = false }
+re_byte_size = { path = "crates/utils/re_byte_size", version = "=0.25.0-alpha.2", default-features = false }
+re_capabilities = { path = "crates/utils/re_capabilities", version = "=0.25.0-alpha.2", default-features = false }
+re_case = { path = "crates/utils/re_case", version = "=0.25.0-alpha.2", default-features = false }
+re_crash_handler = { path = "crates/utils/re_crash_handler", version = "=0.25.0-alpha.2", default-features = false }
+re_error = { path = "crates/utils/re_error", version = "=0.25.0-alpha.2", default-features = false }
+re_format = { path = "crates/utils/re_format", version = "=0.25.0-alpha.2", default-features = false }
+re_int_histogram = { path = "crates/utils/re_int_histogram", version = "=0.25.0-alpha.2", default-features = false }
+re_log = { path = "crates/utils/re_log", version = "=0.25.0-alpha.2", default-features = false }
+re_mcap = { path = "crates/utils/re_mcap", version = "=0.25.0-alpha.2", default-features = false }
+re_memory = { path = "crates/utils/re_memory", version = "=0.25.0-alpha.2", default-features = false }
+re_perf_telemetry = { path = "crates/utils/re_perf_telemetry", version = "=0.25.0-alpha.2", default-features = false }
+re_smart_channel = { path = "crates/utils/re_smart_channel", version = "=0.25.0-alpha.2", default-features = false }
+re_span = { path = "crates/utils/re_span", version = "=0.25.0-alpha.2", default-features = false }
+re_string_interner = { path = "crates/utils/re_string_interner", version = "=0.25.0-alpha.2", default-features = false }
+re_tracing = { path = "crates/utils/re_tracing", version = "=0.25.0-alpha.2", default-features = false }
+re_tuid = { path = "crates/utils/re_tuid", version = "=0.25.0-alpha.2", default-features = false }
+re_uri = { path = "crates/utils/re_uri", version = "=0.25.0-alpha.2", default-features = false }
+re_video = { path = "crates/utils/re_video", version = "=0.25.0-alpha.2", default-features = false }
 
 # crates/viewer:
-re_arrow_ui = { path = "crates/viewer/re_arrow_ui", version = "=0.25.0-alpha.1", default-features = false }
-re_blueprint_tree = { path = "crates/viewer/re_blueprint_tree", version = "=0.25.0-alpha.1", default-features = false }
-re_redap_browser = { path = "crates/viewer/re_redap_browser", version = "=0.25.0-alpha.1", default-features = false }
-re_component_ui = { path = "crates/viewer/re_component_ui", version = "=0.25.0-alpha.1", default-features = false }
-re_context_menu = { path = "crates/viewer/re_context_menu", version = "=0.25.0-alpha.1", default-features = false }
-re_chunk_store_ui = { path = "crates/viewer/re_chunk_store_ui", version = "=0.25.0-alpha.1", default-features = false }
-re_dataframe_ui = { path = "crates/viewer/re_dataframe_ui", version = "=0.25.0-alpha.1", default-features = false }
-re_data_ui = { path = "crates/viewer/re_data_ui", version = "=0.25.0-alpha.1", default-features = false }
-re_global_context = { path = "crates/viewer/re_global_context", version = "=0.25.0-alpha.1", default-features = false }
-re_recording_panel = { path = "crates/viewer/re_recording_panel", version = "=0.25.0-alpha.1", default-features = false }
-re_renderer = { path = "crates/viewer/re_renderer", version = "=0.25.0-alpha.1", default-features = false }
-re_renderer_examples = { path = "crates/viewer/re_renderer_examples", version = "=0.25.0-alpha.1", default-features = false }
-re_selection_panel = { path = "crates/viewer/re_selection_panel", version = "=0.25.0-alpha.1", default-features = false }
-re_test_context = { path = "crates/viewer/re_test_context", version = "=0.25.0-alpha.1", default-features = false }
-re_test_viewport = { path = "crates/viewer/re_test_viewport", version = "=0.25.0-alpha.1", default-features = false }
-re_time_panel = { path = "crates/viewer/re_time_panel", version = "=0.25.0-alpha.1", default-features = false }
-re_ui = { path = "crates/viewer/re_ui", version = "=0.25.0-alpha.1", default-features = false }
-re_view = { path = "crates/viewer/re_view", version = "=0.25.0-alpha.1", default-features = false }
-re_view_bar_chart = { path = "crates/viewer/re_view_bar_chart", version = "=0.25.0-alpha.1", default-features = false }
-re_view_spatial = { path = "crates/viewer/re_view_spatial", version = "=0.25.0-alpha.1", default-features = false }
-re_view_dataframe = { path = "crates/viewer/re_view_dataframe", version = "=0.25.0-alpha.1", default-features = false }
-re_view_graph = { path = "crates/viewer/re_view_graph", version = "=0.25.0-alpha.1", default-features = false }
-re_view_map = { path = "crates/viewer/re_view_map", version = "=0.25.0-alpha.1", default-features = false }
-re_view_tensor = { path = "crates/viewer/re_view_tensor", version = "=0.25.0-alpha.1", default-features = false }
-re_view_text_document = { path = "crates/viewer/re_view_text_document", version = "=0.25.0-alpha.1", default-features = false }
-re_view_text_log = { path = "crates/viewer/re_view_text_log", version = "=0.25.0-alpha.1", default-features = false }
-re_view_time_series = { path = "crates/viewer/re_view_time_series", version = "=0.25.0-alpha.1", default-features = false }
-re_viewer = { path = "crates/viewer/re_viewer", version = "=0.25.0-alpha.1", default-features = false }
-re_viewer_context = { path = "crates/viewer/re_viewer_context", version = "=0.25.0-alpha.1", default-features = false }
-re_viewport = { path = "crates/viewer/re_viewport", version = "=0.25.0-alpha.1", default-features = false }
-re_viewport_blueprint = { path = "crates/viewer/re_viewport_blueprint", version = "=0.25.0-alpha.1", default-features = false }
-re_web_viewer_server = { path = "crates/viewer/re_web_viewer_server", version = "=0.25.0-alpha.1", default-features = false }
+re_arrow_ui = { path = "crates/viewer/re_arrow_ui", version = "=0.25.0-alpha.2", default-features = false }
+re_blueprint_tree = { path = "crates/viewer/re_blueprint_tree", version = "=0.25.0-alpha.2", default-features = false }
+re_redap_browser = { path = "crates/viewer/re_redap_browser", version = "=0.25.0-alpha.2", default-features = false }
+re_component_ui = { path = "crates/viewer/re_component_ui", version = "=0.25.0-alpha.2", default-features = false }
+re_context_menu = { path = "crates/viewer/re_context_menu", version = "=0.25.0-alpha.2", default-features = false }
+re_chunk_store_ui = { path = "crates/viewer/re_chunk_store_ui", version = "=0.25.0-alpha.2", default-features = false }
+re_dataframe_ui = { path = "crates/viewer/re_dataframe_ui", version = "=0.25.0-alpha.2", default-features = false }
+re_data_ui = { path = "crates/viewer/re_data_ui", version = "=0.25.0-alpha.2", default-features = false }
+re_global_context = { path = "crates/viewer/re_global_context", version = "=0.25.0-alpha.2", default-features = false }
+re_recording_panel = { path = "crates/viewer/re_recording_panel", version = "=0.25.0-alpha.2", default-features = false }
+re_renderer = { path = "crates/viewer/re_renderer", version = "=0.25.0-alpha.2", default-features = false }
+re_renderer_examples = { path = "crates/viewer/re_renderer_examples", version = "=0.25.0-alpha.2", default-features = false }
+re_selection_panel = { path = "crates/viewer/re_selection_panel", version = "=0.25.0-alpha.2", default-features = false }
+re_test_context = { path = "crates/viewer/re_test_context", version = "=0.25.0-alpha.2", default-features = false }
+re_test_viewport = { path = "crates/viewer/re_test_viewport", version = "=0.25.0-alpha.2", default-features = false }
+re_time_panel = { path = "crates/viewer/re_time_panel", version = "=0.25.0-alpha.2", default-features = false }
+re_ui = { path = "crates/viewer/re_ui", version = "=0.25.0-alpha.2", default-features = false }
+re_view = { path = "crates/viewer/re_view", version = "=0.25.0-alpha.2", default-features = false }
+re_view_bar_chart = { path = "crates/viewer/re_view_bar_chart", version = "=0.25.0-alpha.2", default-features = false }
+re_view_spatial = { path = "crates/viewer/re_view_spatial", version = "=0.25.0-alpha.2", default-features = false }
+re_view_dataframe = { path = "crates/viewer/re_view_dataframe", version = "=0.25.0-alpha.2", default-features = false }
+re_view_graph = { path = "crates/viewer/re_view_graph", version = "=0.25.0-alpha.2", default-features = false }
+re_view_map = { path = "crates/viewer/re_view_map", version = "=0.25.0-alpha.2", default-features = false }
+re_view_tensor = { path = "crates/viewer/re_view_tensor", version = "=0.25.0-alpha.2", default-features = false }
+re_view_text_document = { path = "crates/viewer/re_view_text_document", version = "=0.25.0-alpha.2", default-features = false }
+re_view_text_log = { path = "crates/viewer/re_view_text_log", version = "=0.25.0-alpha.2", default-features = false }
+re_view_time_series = { path = "crates/viewer/re_view_time_series", version = "=0.25.0-alpha.2", default-features = false }
+re_viewer = { path = "crates/viewer/re_viewer", version = "=0.25.0-alpha.2", default-features = false }
+re_viewer_context = { path = "crates/viewer/re_viewer_context", version = "=0.25.0-alpha.2", default-features = false }
+re_viewport = { path = "crates/viewer/re_viewport", version = "=0.25.0-alpha.2", default-features = false }
+re_viewport_blueprint = { path = "crates/viewer/re_viewport_blueprint", version = "=0.25.0-alpha.2", default-features = false }
+re_web_viewer_server = { path = "crates/viewer/re_web_viewer_server", version = "=0.25.0-alpha.2", default-features = false }
 
 # Rerun crates in other repos:
 re_mp4 = "0.3.0"

--- a/examples/rust/animated_urdf/Cargo.toml
+++ b/examples/rust/animated_urdf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "animated_urdf"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_callback/Cargo.toml
+++ b/examples/rust/custom_callback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_callback"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_data_loader/Cargo.toml
+++ b/examples/rust/custom_data_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_data_loader"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_store_subscriber/Cargo.toml
+++ b/examples/rust/custom_store_subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_store_subscriber"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/custom_view/Cargo.toml
+++ b/examples/rust/custom_view/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_view"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/dataframe_query/Cargo.toml
+++ b/examples/rust/dataframe_query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dataframe_query"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/dna/Cargo.toml
+++ b/examples/rust/dna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dna"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/extend_viewer_ui/Cargo.toml
+++ b/examples/rust/extend_viewer_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extend_viewer_ui"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/external_data_loader/Cargo.toml
+++ b/examples/rust/external_data_loader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rerun-loader-rust-file"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/graph_lattice/Cargo.toml
+++ b/examples/rust/graph_lattice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph_lattice"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/incremental_logging/Cargo.toml
+++ b/examples/rust/incremental_logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incremental_logging"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/log_file/Cargo.toml
+++ b/examples/rust/log_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "log_file"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/minimal/Cargo.toml
+++ b/examples/rust/minimal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal_options"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/minimal_serve/Cargo.toml
+++ b/examples/rust/minimal_serve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimal_serve"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objectron"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raw_mesh"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/shared_recording/Cargo.toml
+++ b/examples/rust/shared_recording/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared_recording"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/spawn_viewer/Cargo.toml
+++ b/examples/rust/spawn_viewer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spawn_viewer"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/stdio/Cargo.toml
+++ b/examples/rust/stdio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stdio"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/template/Cargo.toml
+++ b/examples/rust/template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "template"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/examples/rust/viewer_callbacks/Cargo.toml
+++ b/examples/rust/viewer_callbacks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viewer_callbacks"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT OR Apache-2.0"

--- a/pixi.lock
+++ b/pixi.lock
@@ -4117,7 +4117,7 @@ environments:
       - pypi: ./examples/python/shared_recording
       - pypi: ./examples/python/stdio
       - pypi: ./examples/python/structure_from_motion
-      - pypi: ./rerun_py
+      - pypi: rerun_py
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.0-h9b725a8_10.conda
@@ -4505,7 +4505,7 @@ environments:
       - pypi: ./examples/python/shared_recording
       - pypi: ./examples/python/stdio
       - pypi: ./examples/python/structure_from_motion
-      - pypi: ./rerun_py
+      - pypi: rerun_py
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.8.0-h6c5491b_10.conda
@@ -4891,7 +4891,7 @@ environments:
       - pypi: ./examples/python/shared_recording
       - pypi: ./examples/python/stdio
       - pypi: ./examples/python/structure_from_motion
-      - pypi: ./rerun_py
+      - pypi: rerun_py
   examples-pypi:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -6534,7 +6534,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/55/8a/81671f05619edbacd49bd84ce6899a09fc8299be20c09ae92f6618ccb92d/zstandard-0.24.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: ./rerun_py
+      - pypi: rerun_py
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aiohttp-3.9.5-py311hcd402e7_0.conda
@@ -6918,7 +6918,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/4c/63523169fe84773a7462cd090b0989cb7c7a7f2a8b0a5fbf00009ba7d74d/zstandard-0.24.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-      - pypi: ./rerun_py
+      - pypi: rerun_py
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.5-py311h05b510d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
@@ -7280,7 +7280,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/ba/3059bd5cd834666a789251d14417621b5c61233bd46e7d9023ea8bc1043a/zstandard-0.24.0-cp311-cp311-macosx_11_0_arm64.whl
-      - pypi: ./rerun_py
+      - pypi: rerun_py
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/aiohttp-3.9.5-py311ha68e1ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
@@ -7641,7 +7641,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/8e/2c8e5c681ae4937c007938f954a060fa7c74f36273b289cabdb5ef0e9a7e/zstandard-0.24.0-cp311-cp311-win_amd64.whl
-      - pypi: ./rerun_py
+      - pypi: rerun_py
   py-docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -14525,6 +14525,19 @@ packages:
   - backports-datetime-fromisoformat ; python_full_version < '3.7'
   - grpclib
   - stringcase
+  - black ; extra == 'compiler'
+  - jinja2 ; extra == 'compiler'
+  - protobuf ; extra == 'compiler'
+  requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/ff/2e/abfed7a721928e14aeb900182ff695be474c4ee5f07ef0874cc5ecd5b0b1/betterproto-1.2.5.tar.gz
+  name: betterproto
+  version: 1.2.5
+  sha256: 74a3ab34646054f674d236d1229ba8182dc2eae86feb249b8590ef496ce9803d
+  requires_dist:
+  - grpclib
+  - stringcase
+  - dataclasses ; python_full_version < '3.7'
+  - backports-datetime-fromisoformat ; python_full_version < '3.7'
   - black ; extra == 'compiler'
   - jinja2 ; extra == 'compiler'
   - protobuf ; extra == 'compiler'
@@ -33547,10 +33560,10 @@ packages:
   - pytest==7.1.2 ; extra == 'tests'
   - rerun-notebook==0.24.0 ; extra == 'notebook'
   requires_python: '>=3.9'
-- pypi: ./rerun_py
+- pypi: rerun_py
   name: rerun-sdk
-  version: 0.25.0a1+dev
-  sha256: de26dd790e6a6cc8dfab7f1e0f5f8ff3e583cfdf5e7ca5139b4d6d31a5f477db
+  version: 0.25.0a2
+  sha256: 2c44d0955de085a46001e4e8c938717bcf105a16bba6f613010e897d28bcf1b3
   requires_dist:
   - attrs>=23.1.0
   - numpy>=2
@@ -33558,7 +33571,7 @@ packages:
   - pyarrow>=18.0.0
   - typing-extensions>=4.5
   - pytest==8.4.1 ; extra == 'tests'
-  - rerun-notebook==0.25.0a1+dev ; extra == 'notebook'
+  - rerun-notebook==0.25.0a2 ; extra == 'notebook'
   - datafusion==47.0.0 ; extra == 'datafusion'
   - notebook ; extra == 'all'
   - datafusion ; extra == 'all'

--- a/rerun_cpp/src/rerun/c/sdk_info.h
+++ b/rerun_cpp/src/rerun/c/sdk_info.h
@@ -2,7 +2,7 @@
 ///
 /// This should match the string returned by `rr_version_string` (C) or `rerun::version_string` (C++).
 /// If not, the SDK's binary and the C header are out of sync.
-#define RERUN_SDK_HEADER_VERSION "0.25.0-alpha.1+dev"
+#define RERUN_SDK_HEADER_VERSION "0.25.0-alpha.2"
 
 /// Major version of the Rerun C SDK.
 #define RERUN_SDK_HEADER_VERSION_MAJOR 0

--- a/rerun_js/web-viewer-react/README.md
+++ b/rerun_js/web-viewer-react/README.md
@@ -35,7 +35,7 @@ export default function App() {
 ```
 
 The `rrd` in the snippet above should be a URL pointing to either:
-- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.24.0/examples/dna.rrd>
+- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.25.0-alpha.2/examples/dna.rrd>
 - A gRPC connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk/operating-modes#serve) API
 
 If `rrd` is not set, the Viewer will display the same welcome screen as <https://app.rerun.io>.

--- a/rerun_js/web-viewer-react/package.json
+++ b/rerun_js/web-viewer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rerun-io/web-viewer-react",
-  "version": "0.25.0-alpha.1+dev",
+  "version": "0.25.0-alpha.2",
   "description": "Embed the Rerun web viewer in your React app",
   "licenses": [
     {
@@ -43,7 +43,7 @@
     "tsconfig.json"
   ],
   "dependencies": {
-    "@rerun-io/web-viewer": "0.25.0-alpha.1"
+    "@rerun-io/web-viewer": "0.25.0-alpha.2"
   },
   "peerDependencies": {
     "@types/react": "^18.2.33 || ^19.0.0",

--- a/rerun_js/web-viewer/README.md
+++ b/rerun_js/web-viewer/README.md
@@ -28,7 +28,7 @@ This means that:
 
 ## Usage
 
-The entrypoint for this packages is the [`WebViewer`](https://ref.rerun.io/docs/js/0.24.0/web-viewer/classes/WebViewer.html) class.
+The entrypoint for this packages is the [`WebViewer`](https://ref.rerun.io/docs/js/0.25.0-alpha.2/web-viewer/classes/WebViewer.html) class.
 The web viewer is an object which manages a canvas element:
 
 ```js
@@ -44,7 +44,7 @@ viewer.stop();
 ```
 
 The `rrd` in the snippet above should be a URL pointing to either:
-- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.24.0/examples/dna.rrd>
+- A hosted `.rrd` file, such as <https://app.rerun.io/version/0.25.0-alpha.2/examples/dna.rrd>
 - A gRPC connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk/operating-modes#serve) API
 
 If `rrd` is not set, the Viewer will display the same welcome screen as <https://app.rerun.io>.

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -305,7 +305,7 @@ function delay(ms: number) {
  * ```
  *
  * Data may be provided to the Viewer as:
- * - An HTTP file URL, e.g. `viewer.start("https://app.rerun.io/version/0.24.0/examples/dna.rrd")`
+ * - An HTTP file URL, e.g. `viewer.start("https://app.rerun.io/version/0.25.0-alpha.2/examples/dna.rrd")`
  * - A Rerun gRPC URL, e.g. `viewer.start("rerun+http://127.0.0.1:9876/proxy")`
  * - A stream of log messages, via {@link WebViewer.open_channel}.
  *

--- a/rerun_js/web-viewer/package.json
+++ b/rerun_js/web-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rerun-io/web-viewer",
-  "version": "0.25.0-alpha.1+dev",
+  "version": "0.25.0-alpha.2",
   "description": "Embed the Rerun web viewer in your app",
   "licenses": [
     {

--- a/rerun_notebook/pyproject.toml
+++ b/rerun_notebook/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rerun-notebook"
 description = "Implementation helper for running rerun-sdk in notebooks"
-version = "0.25.0-alpha.1+dev"
+version = "0.25.0-alpha.2"
 dependencies = ["anywidget", "jupyter-ui-poll"]
 readme = "README.md"
 keywords = ["rerun", "notebook"]

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -36,7 +36,7 @@ text = "MIT OR Apache-2.0"
 
 [project.optional-dependencies]
 tests = ["pytest==8.4.1"]
-notebook = ["rerun-notebook==0.25.0-alpha.1+dev"]
+notebook = ["rerun-notebook==0.25.0-alpha.2"]
 datafusion = ["datafusion==47.0.0"]
 all = ["notebook", "datafusion"]
 

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 import numpy as np
 
-__version__ = "0.25.0-alpha.1+dev"
-__version_info__ = (0, 25, 0, "alpha.1")
+__version__ = "0.25.0-alpha.2"
+__version_info__ = (0, 25, 0, "alpha.2")
 
 
 if sys.version_info < (3, 9):  # noqa: UP036


### PR DESCRIPTION
Because of git shenanigans, it's easier to not merge the 0.25.0-alpha.2 branch back to `main`. This is a cherry pick of its version bump commit, which we need.

Related:
- https://github.com/rerun-io/rerun/pull/11042