### PR TITLE
Add compatibility to both numpy1 and numpy2.

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -603,7 +603,7 @@ jinja2 = ">=3.1.3,<3.2"           # For `build_screenshot_compare.py` and other 
 mypy = "1.14.1.*"
 nasm = ">=2.16"                   # Required by https://github.com/memorysafety/rav1d for native video support
 ninja = "1.11.1.*"
-numpy = ">=2"                     # Whenever upgrading here, also make sure to upgrade in `rerun_py/pyproject.toml`
+numpy = ">=1.24"                  # Whenever upgrading here, also make sure to upgrade in `rerun_py/pyproject.toml`
 prettier = ">=3.6"
 pyarrow = "18.0.0.*"              # Whenever upgrading here, also make sure to upgrade in `rerun_py/pyproject.toml`
 pytest = ">=8.4.1"
@@ -693,7 +693,7 @@ platforms = ["linux-64", "linux-aarch64", "osx-arm64", "osx-64", "win-64"]
 #
 # This is also redundantly defined in `python-pypi`
 opencv = ">4.6"
-numpy = ">=2"   # Rerun still needs numpy <2. Enforce this outside of the pypi dep tree so we pick up the conda version.
+numpy = ">=1.24" # Rerun still needs numpy <2. Enforce this outside of the pypi dep tree so we pick up the conda version.
 
 [feature.python-dev.pypi-dependencies]
 # Install the `rerun_py` as a package in editable mode.
@@ -748,7 +748,7 @@ platforms = ["linux-64", "linux-aarch64", "osx-arm64", "osx-64", "win-64"]
 [feature.python-pypi.dependencies]
 # Note these are the same as in `python-dev` but we need to repeat them here because the two are mutually exclusive.
 opencv = ">4.6"
-numpy = ">=2"   # Rerun still needs numpy <2. Enforce this outside of the pypi dep tree so we pick up the conda version.
+numpy = ">=1.24" # Rerun still needs numpy <2. Enforce this outside of the pypi dep tree so we pick up the conda version.
 
 
 [feature.python-pypi.pypi-dependencies]

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
   # Must match list in `.github/workflows/reusable_test_wheels.yml`
   "attrs>=23.1.0",
-  "numpy>=2",
+  "numpy>=1.24",
   "pillow>=8.0.0",          # Used for JPEG encoding. 8.0.0 added the `format` arguments to `Image.open`
   "pyarrow>=18.0.0",
   "typing_extensions>=4.5",

--- a/rerun_py/rerun_sdk/rerun/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/angle.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -34,7 +36,13 @@ class Angle(AngleExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of AngleExt in angle_ext.py
-        return np.asarray(self.radians, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.radians, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.radians, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.radians, dtype=dtype)
 
     def __float__(self) -> float:
         return float(self.radians)

--- a/rerun_py/rerun_sdk/rerun/datatypes/blob.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/blob.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,13 @@ class Blob(BlobExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of BlobExt in blob_ext.py
-        return np.asarray(self.data, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.data, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.data, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.data, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of BlobExt in blob_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -34,7 +36,13 @@ class ClassId:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of ClassIdExt in class_id_ext.py
-        return np.asarray(self.id, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.id, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.id, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.id, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.id)

--- a/rerun_py/rerun_sdk/rerun/datatypes/dvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/dvec2d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,13 @@ class DVec2D(DVec2DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of DVec2DExt in dvec2d_ext.py
-        return np.asarray(self.xy, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xy, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xy, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xy, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of DVec2DExt in dvec2d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/float32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float32.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -34,7 +36,13 @@ class Float32:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Float32Ext in float32_ext.py
-        return np.asarray(self.value, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.value, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.value, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.value, dtype=dtype)
 
     def __float__(self) -> float:
         return float(self.value)

--- a/rerun_py/rerun_sdk/rerun/datatypes/float64.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float64.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -34,7 +36,13 @@ class Float64:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Float64Ext in float64_ext.py
-        return np.asarray(self.value, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.value, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.value, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.value, dtype=dtype)
 
     def __float__(self) -> float:
         return float(self.value)

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -41,7 +43,13 @@ class KeypointId:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of KeypointIdExt in keypoint_id_ext.py
-        return np.asarray(self.id, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.id, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.id, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.id, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.id)

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -70,7 +72,13 @@ class Mat3x3(Mat3x3Ext):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Mat3x3Ext in mat3x3_ext.py
-        return np.asarray(self.flat_columns, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.flat_columns, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.flat_columns, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.flat_columns, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of Mat3x3Ext in mat3x3_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -72,7 +74,13 @@ class Mat4x4(Mat4x4Ext):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Mat4x4Ext in mat4x4_ext.py
-        return np.asarray(self.flat_columns, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.flat_columns, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.flat_columns, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.flat_columns, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of Mat4x4Ext in mat4x4_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/plane3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/plane3d.py
@@ -44,7 +44,13 @@ class Plane3D(Plane3DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Plane3DExt in plane3d_ext.py
-        return np.asarray(self.xyzd, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xyzd, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xyzd, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xyzd, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of Plane3DExt in plane3d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -39,7 +41,13 @@ class Quaternion(QuaternionExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of QuaternionExt in quaternion_ext.py
-        return np.asarray(self.xyzw, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xyzw, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xyzw, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xyzw, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of QuaternionExt in quaternion_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,13 @@ class Range1D(Range1DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Range1DExt in range1d_ext.py
-        return np.asarray(self.range, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.range, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.range, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.range, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of Range1DExt in range1d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -46,7 +48,13 @@ class Rgba32(Rgba32Ext):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Rgba32Ext in rgba32_ext.py
-        return np.asarray(self.rgba, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.rgba, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.rgba, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.rgba, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.rgba)

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -31,7 +33,13 @@ class TimeInt(TimeIntExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of TimeIntExt in time_int_ext.py
-        return np.asarray(self.value, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.value, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.value, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.value, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.value)

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint16.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint16.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -34,7 +36,13 @@ class UInt16:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of UInt16Ext in uint16_ext.py
-        return np.asarray(self.value, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.value, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.value, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.value, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.value)

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -34,7 +36,13 @@ class UInt32:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of UInt32Ext in uint32_ext.py
-        return np.asarray(self.value, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.value, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.value, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.value, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.value)

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -34,7 +36,13 @@ class UInt64:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of UInt64Ext in uint64_ext.py
-        return np.asarray(self.value, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.value, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.value, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.value, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.value)

--- a/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -49,7 +51,13 @@ class Uuid(UuidExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of UuidExt in uuid_ext.py
-        return np.asarray(self.bytes, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.bytes, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.bytes, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.bytes, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of UuidExt in uuid_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,13 @@ class UVec2D(UVec2DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of UVec2DExt in uvec2d_ext.py
-        return np.asarray(self.xy, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xy, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xy, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xy, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of UVec2DExt in uvec2d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,13 @@ class UVec3D(UVec3DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of UVec3DExt in uvec3d_ext.py
-        return np.asarray(self.xyz, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xyz, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xyz, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xyz, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of UVec3DExt in uvec3d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -37,7 +39,13 @@ class UVec4D:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of UVec4DExt in uvec4d_ext.py
-        return np.asarray(self.xyzw, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xyzw, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xyzw, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xyzw, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of UVec4DExt in uvec4d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,14 @@ class Vec2D(Vec2DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Vec2DExt in vec2d_ext.py
-        return np.asarray(self.xy, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xy, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xy, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xy, dtype=dtype)
+
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of Vec2DExt in vec2d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,13 @@ class Vec3D(Vec3DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Vec3DExt in vec3d_ext.py
-        return np.asarray(self.xyz, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xyz, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xyz, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xyz, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of Vec3DExt in vec3d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -38,7 +40,13 @@ class Vec4D(Vec4DExt):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of Vec4DExt in vec4d_ext.py
-        return np.asarray(self.xyzw, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.xyzw, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.xyzw, dtype=dtype, copy=copy)
+            else:
+                return np.asarray(self.xyzw, dtype=dtype)
 
     def __len__(self) -> int:
         # You can define your own __len__ function as a member of Vec4DExt in vec4d_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/video_timestamp.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/video_timestamp.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
+from packaging import version
+IS_NUMPY_2 = True if version.parse(np.__version__) >= version.parse("2.0.0") else False
 
 from .._baseclasses import (
     BaseBatch,
@@ -50,7 +52,13 @@ class VideoTimestamp:
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> npt.NDArray[Any]:
         # You can define your own __array__ function as a member of VideoTimestampExt in video_timestamp_ext.py
-        return np.asarray(self.timestamp_ns, dtype=dtype, copy=copy)
+        if IS_NUMPY_2:
+            return np.asarray(self.timestamp_ns, dtype=dtype, copy=copy)
+        else:
+            if copy:
+                return np.array(self.timestamp_ns, dtype=dtype, copy=True)
+            else:
+                return np.asarray(self.timestamp_ns, dtype=dtype)
 
     def __int__(self) -> int:
         return int(self.timestamp_ns)


### PR DESCRIPTION
### Related

https://github.com/rerun-io/rerun/pull/9109#issuecomment-3245297266

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What
Add compatibility to numpy1, to relax the requirement of numpy2 as the minimum version.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
