### PR TITLE
Add data inline viewer validity test

### DIFF
--- a/docs/content/howto/logging/send-columns.md
+++ b/docs/content/howto/logging/send-columns.md
@@ -36,7 +36,7 @@ which can be translated to the column-oriented `send_columns` API as such:
 
 snippet: archetypes/scalars_column_updates
 
-<picture data-inline-viewer="snippets/scalar_column_updates">
+<picture data-inline-viewer="snippets/scalars_column_updates">
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/transform3d_column_updates/2b7ccfd29349b2b107fcf7eb8a1291a92cf1cafc/480w.png">
   <source media="(max-width: 768px)" srcset="https://static.rerun.io/transform3d_column_updates/2b7ccfd29349b2b107fcf7eb8a1291a92cf1cafc/768w.png">
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/transform3d_column_updates/2b7ccfd29349b2b107fcf7eb8a1291a92cf1cafc/1024w.png">

--- a/scripts/ci/mdlint.py
+++ b/scripts/ci/mdlint.py
@@ -228,6 +228,7 @@ class BacktickLinkError(Error):
             """,
         )
 
+
 class BadDataReferenceError(Error):
     CODE = "E005"
 
@@ -269,8 +270,8 @@ def get_non_void_element_spans(content: str, search_start: int, tagname: str) ->
     if element_start == -1:
         return None
 
-    opening_tag_content_start = element_start + len(tagname) + 1;
-    opening_tag_content_end = content.find(">", opening_tag_content_start);
+    opening_tag_content_start = element_start + len(tagname) + 1
+    opening_tag_content_end = content.find(">", opening_tag_content_start)
 
     line_start = content.rfind("\n", 0, element_start)
     if line_start == -1:
@@ -322,6 +323,7 @@ PICTURE_BAD_SOURCE_INDENT = re.compile("(\\n\\s*)(\\n\\s+)<source")
 
 DATA_INLINE_VIEWER = "data-inline-viewer"
 
+
 def check_picture_elements(content: str, errors: list[Error]) -> None:
     search_start = 0
     while True:
@@ -338,25 +340,23 @@ def check_picture_elements(content: str, errors: list[Error]) -> None:
 
         check_preceding_newline("picture", content, spans, errors)
 
-        tag_content = spans.opening_tag_content.slice(content);
-        data_inline_viewer = tag_content.find(DATA_INLINE_VIEWER);
+        tag_content = spans.opening_tag_content.slice(content)
+        data_inline_viewer = tag_content.find(DATA_INLINE_VIEWER)
 
         if data_inline_viewer >= 0:
-            data_reference_start = tag_content.find('"', data_inline_viewer + len(DATA_INLINE_VIEWER)) + 1;
-            data_reference_end = tag_content.find('"', data_reference_start);
+            data_reference_start = tag_content.find('"', data_inline_viewer + len(DATA_INLINE_VIEWER)) + 1
+            data_reference_end = tag_content.find('"', data_reference_start)
 
-            data_reference_span = Span(data_reference_start, data_reference_end);
-            data_reference_name = data_reference_span.slice(tag_content);
-            (kind, name) = data_reference_name.split("/");
+            data_reference_span = Span(data_reference_start, data_reference_end)
+            data_reference_name = data_reference_span.slice(tag_content)
+            (kind, name) = data_reference_name.split("/")
 
-            valid_reference = ((kind == "snippets" and glob(f"docs/snippets/all/**/{name}.py")) or
-                (kind == "examples" and glob(f"examples/python/{name}")))
-                
-
+            valid_reference = (kind == "snippets" and glob(f"docs/snippets/all/**/{name}.py")) or (
+                kind == "examples" and glob(f"examples/python/{name}")
+            )
 
             if not valid_reference:
                 errors.append(BadDataReferenceError(data_reference_name, data_reference_span))
-
 
         search_start = spans.element.end + 1
 

--- a/scripts/ci/mdlint.py
+++ b/scripts/ci/mdlint.py
@@ -228,17 +228,35 @@ class BacktickLinkError(Error):
             """,
         )
 
+class BadDataReferenceError(Error):
+    CODE = "E005"
+
+    def __init__(self, data_reference_name: str, span: Span) -> None:
+        super().__init__(type(self).CODE, f"`{data_reference_name}` is not a valid data reference", span)
+
+    @staticmethod
+    def explain() -> str:
+        return textwrap.dedent(
+            """
+            A `data_inline_viewer` should be a valid reference.
+            """,
+        )
+
 
 EXPLAIN = {
     NoClosingTagError.CODE: NoClosingTagError.explain,
     NoPrecedingBlankLineError.CODE: NoPrecedingBlankLineError.explain,
     BlankLinesError.CODE: BlankLinesError.explain,
     BacktickLinkError.CODE: BacktickLinkError.explain,
+    BadDataReferenceError.CODE: BacktickLinkError.explain,
 }
 
 
 @dataclass
 class ElementSpans:
+    opening_tag_content: Span
+    """Span for the opening tag content"""
+
     element: Span
     """Span from the opening tag to the closing tag"""
 
@@ -250,6 +268,9 @@ def get_non_void_element_spans(content: str, search_start: int, tagname: str) ->
     element_start = content.find(f"<{tagname}", search_start)
     if element_start == -1:
         return None
+
+    opening_tag_content_start = element_start + len(tagname) + 1;
+    opening_tag_content_end = content.find(">", opening_tag_content_start);
 
     line_start = content.rfind("\n", 0, element_start)
     if line_start == -1:
@@ -265,6 +286,7 @@ def get_non_void_element_spans(content: str, search_start: int, tagname: str) ->
         return NoClosingTagError(tagname, Span(line_start, line_end))
 
     return ElementSpans(
+        opening_tag_content=Span(opening_tag_content_start, opening_tag_content_end),
         element=Span(element_start, element_end),
         line=Span(line_start, line_end),
     )
@@ -298,6 +320,7 @@ def check_preceding_newline(tagname: str, content: str, spans: ElementSpans, err
 #   </picture>
 PICTURE_BAD_SOURCE_INDENT = re.compile("(\\n\\s*)(\\n\\s+)<source")
 
+DATA_INLINE_VIEWER = "data-inline-viewer"
 
 def check_picture_elements(content: str, errors: list[Error]) -> None:
     search_start = 0
@@ -314,6 +337,26 @@ def check_picture_elements(content: str, errors: list[Error]) -> None:
             errors.append(BlankLinesError("picture", Span(match.start(), match.end()).offset(spans.element.start)))
 
         check_preceding_newline("picture", content, spans, errors)
+
+        tag_content = spans.opening_tag_content.slice(content);
+        data_inline_viewer = tag_content.find(DATA_INLINE_VIEWER);
+
+        if data_inline_viewer >= 0:
+            data_reference_start = tag_content.find('"', data_inline_viewer + len(DATA_INLINE_VIEWER)) + 1;
+            data_reference_end = tag_content.find('"', data_reference_start);
+
+            data_reference_span = Span(data_reference_start, data_reference_end);
+            data_reference_name = data_reference_span.slice(tag_content);
+            (kind, name) = data_reference_name.split("/");
+
+            valid_reference = ((kind == "snippets" and glob(f"docs/snippets/all/**/{name}.py")) or
+                (kind == "examples" and glob(f"examples/python/{name}")))
+                
+
+
+            if not valid_reference:
+                errors.append(BadDataReferenceError(data_reference_name, data_reference_span))
+
 
         search_start = spans.element.end + 1
 

--- a/scripts/ci/mdlint.py
+++ b/scripts/ci/mdlint.py
@@ -249,7 +249,7 @@ EXPLAIN = {
     NoPrecedingBlankLineError.CODE: NoPrecedingBlankLineError.explain,
     BlankLinesError.CODE: BlankLinesError.explain,
     BacktickLinkError.CODE: BacktickLinkError.explain,
-    BadDataReferenceError.CODE: BacktickLinkError.explain,
+    BadDataReferenceError.CODE: BadDataReferenceError.explain,
 }
 
 


### PR DESCRIPTION
### Related

* Closes #10831

### What

Fixes an invalid snippet reference and adds a test for checking that `data-inline-viewer` tags actually point to a valid reference.