### PR TITLE
Default to webGL on firefox web-viewer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -805,6 +805,7 @@ unnecessary_debug_formatting = "allow"
 # egui_kittest = { path = "../../egui/crates/egui_kittest" }
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
+# wgpu = { path = "../../wgpu/wgpu" }
 
 # egui_plot = { git = "https://github.com/emilk/egui_plot.git", branch = "main" }
 # egui_plot = { path = "../../egui_plot/egui_plot" }

--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -477,6 +477,8 @@ pub fn default_backends() -> wgpu::Backends {
             .unwrap_or(wgpu::Backends::VULKAN | wgpu::Backends::METAL | wgpu::Backends::GL)
     } else if is_safari_browser() {
         wgpu::Backends::GL // TODO(#8559): Fix WebGPU on Safari
+    } else if is_firefox_browser() {
+        wgpu::Backends::GL // TODO(#11009): Fix videos on WebGPU firefox
     } else {
         wgpu::Backends::GL | wgpu::Backends::BROWSER_WEBGPU
     }
@@ -566,4 +568,19 @@ pub fn is_safari_browser() -> bool {
     }
 
     is_safari_browser_inner().unwrap_or(false)
+}
+
+/// Are we running inside the Firefox browser?
+pub fn is_firefox_browser() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        web_sys::window()
+            .and_then(|w| w.navigator().user_agent().ok())
+            .is_some_and(|ua| ua.to_lowercase().contains("firefox"))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        false
+    }
 }

--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -475,10 +475,10 @@ pub fn default_backends() -> wgpu::Backends {
         // For changing the backend we use standard wgpu env var, i.e. WGPU_BACKEND.
         wgpu::Backends::from_env()
             .unwrap_or(wgpu::Backends::VULKAN | wgpu::Backends::METAL | wgpu::Backends::GL)
-    } else if is_safari_browser() {
-        wgpu::Backends::GL // TODO(#8559): Fix WebGPU on Safari
-    } else if is_firefox_browser() {
-        wgpu::Backends::GL // TODO(#11009): Fix videos on WebGPU firefox
+    } else if is_safari_browser() || is_firefox_browser() {
+        // TODO(#8559): Fix WebGPU on Safari
+        // TODO(#11009): Fix videos on WebGPU firefox
+        wgpu::Backends::GL
     } else {
         wgpu::Backends::GL | wgpu::Backends::BROWSER_WEBGPU
     }


### PR DESCRIPTION
### Related

Related to #11009 and https://github.com/gfx-rs/wgpu/issues/8186

### What

Because videos crash on webgpu & Firefox we shouldn't default to using webgpu there. You can still restart the web-viewer with webgpu on Firefox after this. And when this has been fixed in Firefox we can revert this change.