### PR TITLE
[WHAT IF] Do not omit brackets for mono instances

### DIFF
--- a/crates/viewer/re_arrow_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_arrow_ui/src/arrow_ui.rs
@@ -20,19 +20,11 @@ pub fn arrow_ui(ui: &mut egui::Ui, ui_layout: UiLayout, array: &dyn Array) {
                         DataTypeUi::new(array.data_type()).list_item_ui(ui);
                     });
                     list_item_scope(ui, "arrow_ui", |ui| {
-                        if array.len() == 1 {
-                            array_formatter.show_value(0, ui);
-                        } else {
-                            array_formatter.show(ui);
-                        }
+                        array_formatter.show(ui);
                     });
                 }
                 UiLayout::Tooltip | UiLayout::List => {
-                    let highlighted = if array.len() == 1 {
-                        array_formatter.value_highlighted(0)
-                    } else {
-                        array_formatter.highlighted()
-                    };
+                    let highlighted = array_formatter.highlighted();
                     match highlighted {
                         Ok(job) => {
                             ui_layout.data_label(ui, job);

--- a/crates/viewer/re_arrow_ui/src/show_index.rs
+++ b/crates/viewer/re_arrow_ui/src/show_index.rs
@@ -49,14 +49,6 @@ impl<'a> ArrayUi<'a> {
         })
     }
 
-    /// Show a single value at `idx`.
-    ///
-    /// This will create a list item that might have some nested children.
-    /// The list item will _not_ display the index.
-    pub fn show_value(&self, idx: usize, ui: &mut Ui) {
-        self.format.show(idx, ui);
-    }
-
     /// Show a `list_item` based tree view of the data.
     pub fn show(&self, ui: &mut Ui) {
         list_ui(ui, 0..self.array.len(), &*self.format);
@@ -68,15 +60,6 @@ impl<'a> ArrayUi<'a> {
     pub fn highlighted(&self) -> Result<SyntaxHighlightedBuilder, ArrowError> {
         let mut highlighted = SyntaxHighlightedBuilder::new();
         write_list(&mut highlighted, 0..self.array.len(), &*self.format)?;
-        Ok(highlighted)
-    }
-
-    /// Returns a [`SyntaxHighlightedBuilder`] that displays a single value at `idx`.
-    ///
-    /// Nested arrays will be limited to a sane number of items ([`MAX_ARROW_LIST_ITEMS`]).
-    pub fn value_highlighted(&self, idx: usize) -> Result<SyntaxHighlightedBuilder, ArrowError> {
-        let mut highlighted = SyntaxHighlightedBuilder::new();
-        self.format.write(idx, &mut highlighted)?;
         Ok(highlighted)
     }
 }


### PR DESCRIPTION
### What

What if we didn't strip the `[ ]` for mono-instance componants?