### PR TITLE
Add the ability to sort `Drawables` (new subdivision of `DrawData`) to `re_renderer`

### DIFF
--- a/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -597,6 +597,8 @@ impl CpuWriteGpuReadBelt {
         re_tracing::profile_function!();
         self.receive_chunks();
 
+        // TODO(andreas): Use `map_buffer_on_submit` https://github.com/gfx-rs/wgpu/pull/8125 once available.
+
         let sender = &self.sender;
         for chunk in self.closed_chunks.drain(..) {
             let sender = sender.clone();

--- a/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
@@ -313,6 +313,9 @@ impl GpuReadbackBelt {
     /// This should be called after the command encoder(s) used in [`GpuReadbackBuffer`] copy operations are submitted.
     pub fn after_queue_submit(&mut self) {
         re_tracing::profile_function!();
+
+        // TODO(andreas): Use `map_buffer_on_submit` https://github.com/gfx-rs/wgpu/pull/8125 once available.
+
         for chunk in self.active_chunks.drain(..) {
             let sender = self.sender.clone();
             chunk.buffer.clone().slice(..chunk.unused_offset).map_async(

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -136,7 +136,7 @@ pub struct RenderContext {
 
 /// Struct owning *all* [`Renderer`].
 /// [`Renderer`] are created lazily and stay around indefinitely.
-pub(crate) struct Renderers {
+pub struct Renderers {
     renderers: concurrent::TypeMap,
 }
 

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -199,7 +199,7 @@ impl Renderers {
     /// For this to succeed, the renderer must have been initialized prior.
     /// (there would be no key otherwise anyways!)
     /// The returned type is the type erased [`RendererExt`] rather than a concrete renderer type.
-    pub fn get_by_key(&self, key: RendererTypeId) -> Option<&dyn RendererExt> {
+    pub(crate) fn get_by_key(&self, key: RendererTypeId) -> Option<&dyn RendererExt> {
         self.renderers_by_key.get(key as usize).map(|r| r.as_ref())
     }
 }

--- a/crates/viewer/re_renderer/src/draw_phase_manager.rs
+++ b/crates/viewer/re_renderer/src/draw_phase_manager.rs
@@ -64,7 +64,11 @@ impl std::fmt::Debug for PackedRenderingKeyAndDrawDataIndex {
 /// This is an expanded version used for processing/sorting.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Drawable {
-    /// Distance sort key from near (0.0) to far (float max).
+    /// Distance sort key from near (low values) to far (high values).
+    ///
+    /// For draw phases that use camera distances, 0 is regarded as being at the camera
+    /// with values increasing towards infinity with squared (!!) distance.
+    /// However, all values from -INF to INF are valid.
     ///
     /// See also [`DrawDataDrawable::distance_sort_key`].
     pub distance_sort_key: f32,

--- a/crates/viewer/re_renderer/src/draw_phase_manager.rs
+++ b/crates/viewer/re_renderer/src/draw_phase_manager.rs
@@ -94,7 +94,7 @@ impl Drawable {
     /// Within a single draw data, it puts near objects first so that the GPU can use early-z
     /// to discard objects that are further away.
     #[inline]
-    fn sort_for_opaque_phase(drawables: &mut Vec<Self>) {
+    fn sort_for_opaque_phase(drawables: &mut [Self]) {
         // Unstable sort is faster, but there's a chance we avoid flickering this way.
         drawables.sort_by_key(|drawable| {
             ((drawable.draw_data_plus_rendering_key.0 as u64) << 32)
@@ -109,7 +109,7 @@ impl Drawable {
     /// sorting by draw data index or renderer type at all since two [`Drawable::distance_sort_key`]
     /// are almost certainly going to be different.
     #[inline]
-    fn sort_for_transparent_phase(drawables: &mut Vec<Self>) {
+    fn sort_for_transparent_phase(drawables: &mut [Self]) {
         // Unstable sort is faster, but there's a chance we avoid flickering this way.
         drawables.sort_by_key(|drawable| !drawable.distance_sort_key.to_bits());
     }

--- a/crates/viewer/re_renderer/src/draw_phase_manager.rs
+++ b/crates/viewer/re_renderer/src/draw_phase_manager.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-/// Darw data id within the [`DrawPhaseManager`].
+/// Draw data id within the [`DrawPhaseManager`].
 type DrawDataIndex = u32;
 
 /// Combined draw data index and rendering key.
@@ -26,7 +26,7 @@ type DrawDataIndex = u32;
 /// [`DrawDataIndex`] are already grouped by renderer.
 /// However, using just the higher 8 bits for [`RendererTypeId`] makes the process a lot simpler.
 /// We may reconsider this if we change the design such that variations of renderers are
-/// expressed in the [`RendererTypeId`] such that 8bit are no longer sufficient.
+/// expressed in the [`RendererTypeId`] such that 8 bit are no longer sufficient.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct PackedRenderingKeyAndDrawDataIndex(u32);
 

--- a/crates/viewer/re_renderer/src/draw_phase_manager.rs
+++ b/crates/viewer/re_renderer/src/draw_phase_manager.rs
@@ -1,0 +1,202 @@
+use super::DrawPhase;
+
+use enumset::__internal::EnumSetTypePrivate as _; // TODO: sounds fishy
+use enumset::EnumSet;
+
+use crate::{
+    GpuRenderPipelinePoolAccessor, QueueableDrawData, RenderContext,
+    context::Renderers,
+    renderer::{
+        DrawDataDrawable, DrawDataPayload, DrawInstruction, DrawableCollectionViewInfo,
+        RendererTypeId,
+    },
+};
+
+/// Darw data id within the [`DrawPhaseManager`].
+type DrawDataIndex = u32;
+
+#[derive(Debug, Clone, Copy)]
+
+pub struct Drawable {
+    pub distance_sort_key: f32,
+
+    pub draw_data_payload: DrawDataPayload,
+
+    draw_data_index: DrawDataIndex,
+
+    /// Key for identifying the renderer type.
+    renderer_key: RendererTypeId,
+}
+
+/// Manages the drawables for all active phases.
+///
+/// This is where collection & sorting of drawables and their underlying draw data happens.
+/// Once all drawables are in place, we can render phase by phase.
+pub struct DrawPhaseManager {
+    active_phases: EnumSet<DrawPhase>,
+
+    /// Drawables for all active phases.
+    ///
+    /// Since there's only a small, fixed number of phases,
+    /// we can use a fixed size array, avoiding the need for a `HashMap`.
+    drawables: [Vec<Drawable>; DrawPhase::VARIANT_COUNT as usize],
+
+    draw_data: Vec<QueueableDrawData>,
+}
+
+impl DrawPhaseManager {
+    // TODO: docs
+
+    pub fn new(active_phases: EnumSet<DrawPhase>) -> Self {
+        Self {
+            active_phases,
+            drawables: [const { Vec::new() }; DrawPhase::VARIANT_COUNT as usize],
+            draw_data: Vec::new(),
+        }
+    }
+
+    pub fn add_draw_data(
+        &mut self,
+        ctx: &RenderContext,
+        draw_data: QueueableDrawData,
+        view_info: &DrawableCollectionViewInfo,
+    ) {
+        re_tracing::profile_function!();
+
+        let draw_data_index = self.draw_data.len() as _;
+        let renderer_key = draw_data.renderer_key(ctx);
+
+        {
+            let mut collector = DrawableCollector::new(self, draw_data_index, renderer_key);
+            re_tracing::profile_scope!("collect_drawables");
+            draw_data.collect_drawables(view_info, &mut collector);
+        }
+
+        self.draw_data.push(draw_data);
+    }
+
+    pub fn draw(
+        &self,
+        renderers: &Renderers,
+        gpu_resources: &GpuRenderPipelinePoolAccessor<'_>,
+        phase: DrawPhase,
+        pass: &mut wgpu::RenderPass<'_>,
+    ) {
+        re_tracing::profile_function!(format!("draw({phase:?})"));
+
+        debug_assert!(
+            self.active_phases.contains(phase),
+            "Phase {phase:?} not active",
+        );
+
+        // TODO: sort drawables according to the phases's requirements.
+
+        let renderer_chunked_drawables =
+            self.drawables[phase as usize].chunk_by(|a, b| a.renderer_key == b.renderer_key);
+
+        // Re-use draw instruction array so we don't have to allocate all the time.
+        let mut draw_instructions = Vec::with_capacity(64.min(self.draw_data.len()));
+
+        for drawable_run_with_same_renderer in renderer_chunked_drawables {
+            let first = &drawable_run_with_same_renderer[0]; // `std::slice::chunk_by` should always have at least one element per chunk.
+            let renderer_key = first.renderer_key;
+
+            // One instruction per draw data.
+            draw_instructions.clear();
+            draw_instructions.extend(
+                drawable_run_with_same_renderer
+                    .chunk_by(|a, b| a.draw_data_index == b.draw_data_index)
+                    .map(|drawables| DrawInstruction {
+                        draw_data: &self.draw_data[drawables[0].draw_data_index as usize],
+                        drawables,
+                    }),
+            );
+
+            let Some(renderer) = renderers.get_by_key(renderer_key) else {
+                // TODO: better error message.
+                re_log::error!("Renderer not found: {renderer_key}");
+                continue;
+            };
+
+            let draw_result =
+                renderer.run_draw_instructions(gpu_resources, phase, pass, &draw_instructions);
+
+            if let Err(err) = draw_result {
+                // TODO: better error message
+                re_log::error!("Failed to draw: {err}");
+            }
+        }
+    }
+}
+
+// TODO: docs
+pub struct DrawableCollector<'a> {
+    per_phase_drawables: &'a mut DrawPhaseManager,
+    draw_data_index: DrawDataIndex,
+    renderer_key: RendererTypeId,
+}
+
+impl<'a> DrawableCollector<'a> {
+    fn new(
+        per_phase_drawables: &'a mut DrawPhaseManager,
+        draw_data_index: DrawDataIndex,
+        renderer_key: RendererTypeId,
+    ) -> Self {
+        Self {
+            per_phase_drawables,
+            draw_data_index,
+            renderer_key,
+        }
+    }
+
+    /// Add multiple drawables to the collector for the given phases.
+    ///
+    /// Ignores any phase that isn't active.
+    #[inline]
+    pub fn add_drawables(
+        &mut self,
+        phases: impl Into<EnumSet<DrawPhase>>,
+        drawables: &[DrawDataDrawable],
+    ) {
+        let Self {
+            per_phase_drawables,
+            draw_data_index,
+            renderer_key,
+        } = self;
+
+        let phases = per_phase_drawables
+            .active_phases
+            .intersection(phases.into());
+
+        for phase in phases {
+            per_phase_drawables.drawables[phase.enum_into_u32() as usize].extend(
+                drawables.iter().map(|info| Drawable {
+                    distance_sort_key: info.distance_sort_key,
+                    draw_data_payload: info.draw_data_payload,
+                    draw_data_index: *draw_data_index,
+                    renderer_key: *renderer_key,
+                }),
+            );
+        }
+    }
+
+    /// Add a single drawable to the collector for the given phases.
+    ///
+    /// Ignores any phase that isn't active.
+    #[inline]
+    pub fn add_drawable(
+        &mut self,
+        phases: impl Into<EnumSet<DrawPhase>>,
+        drawable: DrawDataDrawable,
+    ) {
+        self.add_drawables(phases, &[drawable]);
+    }
+
+    /// Returns the phases that are currently active.
+    ///
+    /// This can be used as a performance optimization to avoid collecting drawables for phases that are not active.
+    #[inline]
+    pub fn active_phases(&self) -> EnumSet<DrawPhase> {
+        self.per_phase_drawables.active_phases
+    }
+}

--- a/crates/viewer/re_renderer/src/draw_phase_manager.rs
+++ b/crates/viewer/re_renderer/src/draw_phase_manager.rs
@@ -1,13 +1,13 @@
 use super::DrawPhase;
 
-use enumset::__internal::EnumSetTypePrivate as _; // TODO: sounds fishy
+use enumset::__internal::EnumSetTypePrivate as _;
 use enumset::EnumSet;
 
 use crate::{
     GpuRenderPipelinePoolAccessor, QueueableDrawData, RenderContext,
     context::Renderers,
     renderer::{
-        DrawDataDrawable, DrawDataPayload, DrawInstruction, DrawableCollectionViewInfo,
+        DrawDataDrawable, DrawDataDrawablePayload, DrawInstruction, DrawableCollectionViewInfo,
         RendererTypeId,
     },
 };
@@ -59,7 +59,7 @@ impl std::fmt::Debug for PackedRenderingKeyAndDrawDataIndex {
     }
 }
 
-/// A single drawable item within a given [`DrawData`].
+/// A single drawable item within a given [`crate::renderer::DrawData`].
 ///
 /// For more details see [`DrawDataDrawable`].
 /// This is an expanded version used for processing/sorting.
@@ -74,7 +74,7 @@ pub struct Drawable {
     draw_data_plus_rendering_key: PackedRenderingKeyAndDrawDataIndex,
 
     /// See [`DrawDataDrawable::draw_data_payload`].
-    pub draw_data_payload: DrawDataPayload,
+    pub draw_data_payload: DrawDataDrawablePayload,
 }
 
 impl Drawable {
@@ -233,7 +233,7 @@ impl DrawPhaseManager {
     }
 }
 
-/// Collector injected into [`DrawData::collect_drawables`] in order to build up drawable list.
+/// Collector injected into [`crate::renderer::DrawData::collect_drawables`] in order to build up drawable list.
 pub struct DrawableCollector<'a> {
     per_phase_drawables: &'a mut DrawPhaseManager,
     draw_data_index: DrawDataIndex,

--- a/crates/viewer/re_renderer/src/draw_phases/mod.rs
+++ b/crates/viewer/re_renderer/src/draw_phases/mod.rs
@@ -2,16 +2,17 @@
 // Need to start to formalize this further and create implementers for all DrawPhases to build up our render graph.
 
 mod outlines;
-pub use outlines::{OutlineConfig, OutlineMaskPreference, OutlineMaskProcessor};
-
 mod picking_layer;
+mod screenshot;
+
+pub use outlines::{OutlineConfig, OutlineMaskPreference, OutlineMaskProcessor};
 pub use picking_layer::{
     PickingLayerError, PickingLayerId, PickingLayerInstanceId, PickingLayerObjectId,
     PickingLayerProcessor,
 };
-
-mod screenshot;
 pub use screenshot::ScreenshotProcessor;
+
+// ------------
 
 /// Determines a (very rough) order of rendering and describes the active [`wgpu::RenderPass`].
 ///
@@ -22,12 +23,15 @@ pub use screenshot::ScreenshotProcessor;
 /// TODO(andreas): Should every phase/processor be associated with a single `wgpu::RenderPass`?
 ///     Note that this implies sub-phases (e.g. Opaque & background render to the same target).
 ///     Also we should then the higher level one to `RenderPass` or similar!
+///
+// TODO(#1025, #4787): Add a 2D phase after Background and before Transparent which we can use
+// to draw 2D objects that use a 2D layer key as sorting key
 #[derive(Debug, enumset::EnumSetType)]
 pub enum DrawPhase {
     /// Opaque objects, performing reads/writes to the depth buffer.
     ///
     /// Typically they are order independent, so everything uses this same index.
-    Opaque,
+    Opaque = 0,
 
     /// Background, rendering where depth wasn't written.
     Background,
@@ -37,7 +41,7 @@ pub enum DrawPhase {
 
     /// Everything that can be picked with GPU based picking.
     ///
-    /// This should be everything in the `Opaque` phase.
+    /// This typically contains everything in the `Opaque` phase.
     PickingLayer,
 
     /// Render mask for things that should get outlines.

--- a/crates/viewer/re_renderer/src/draw_phases/mod.rs
+++ b/crates/viewer/re_renderer/src/draw_phases/mod.rs
@@ -41,7 +41,7 @@ pub enum DrawPhase {
 
     /// Everything that can be picked with GPU based picking.
     ///
-    /// This typically contains everything in the `Opaque` phase.
+    /// Typically this contains everything from both the `Opaque` and `Transparent` phases drawn with z-test enabled.
     PickingLayer,
 
     /// Render mask for things that should get outlines.

--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -26,6 +26,7 @@ mod colormap;
 mod context;
 mod debug_label;
 mod depth_offset;
+mod draw_phase_manager;
 mod draw_phases;
 mod error_handling;
 mod file_resolver;
@@ -67,6 +68,7 @@ pub use context::{
 };
 pub use debug_label::DebugLabel;
 pub use depth_offset::DepthOffset;
+pub use draw_phase_manager::{DrawPhaseManager, Drawable, DrawableCollector};
 pub use draw_phases::{
     DrawPhase, OutlineConfig, OutlineMaskPreference, OutlineMaskProcessor, PickingLayerId,
     PickingLayerInstanceId, PickingLayerObjectId, PickingLayerProcessor, ScreenshotProcessor,

--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -6,6 +6,25 @@
 //! ## Feature flags
 #![doc = document_features::document_features!()]
 //!
+//! ## Draw recording overview
+//!
+//! [`ViewBuilder`] are the main entry point for all draw operations.
+//! Each [`ViewBuilder`] represents a rectangular screen area that is composited into the target surface
+//! via [`ViewBuilder::composite`].
+//!
+//! A user supplies [`renderer::DrawData`]s to the [`ViewBuilder`].
+//! Upon submission, the [`ViewBuilder`] collects the [`Drawable`]s from the [`QueueableDrawData`] and
+//! adds them to the appropriate work queues of each draw phase.
+//! [`Drawable`]s map roughly 1:1 to wgpu draw calls and have a [`renderer::DrawData`] type specific payload
+//! that identifies them within their [`renderer::DrawData`].
+//!
+//! Depending on the [`DrawPhase`] sorting of drawables may occur:
+//! for instance [`DrawPhase::Transparent`] sorts far to near to facilitate blending, whereas other phases aggressively
+//! bundle by [`renderer::DrawData`] types to minimize state changes.
+//!
+//! Each [`renderer::DrawData`] is associated with a single [`renderer::Renderer`].
+//! These encapsulate the knowledge (i.e. renderpipelines etc.) of how to render a certain kind of primitive.
+//! Unlike [`renderer::DrawData`]s, [`renderer::Renderer`]s are immutable and long-lived.
 
 // TODO(#6330): remove unwrap()
 #![allow(clippy::unwrap_used)]

--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -83,7 +83,7 @@ pub use colormap::{
     grayscale_srgb,
 };
 pub use context::{
-    MsaaMode, RenderConfig, RenderContext, RenderContextError, adapter_info_summary,
+    MsaaMode, RenderConfig, RenderContext, RenderContextError, RendererTypeId, adapter_info_summary,
 };
 pub use debug_label::DebugLabel;
 pub use depth_offset::DepthOffset;

--- a/crates/viewer/re_renderer/src/queueable_draw_data.rs
+++ b/crates/viewer/re_renderer/src/queueable_draw_data.rs
@@ -1,8 +1,8 @@
 use std::any::Any;
 
 use crate::{
-    DrawableCollector, RenderContext,
-    renderer::{DrawData, DrawableCollectionViewInfo, RendererTypeId},
+    DrawableCollector, RenderContext, RendererTypeId,
+    renderer::{DrawData, DrawableCollectionViewInfo},
 };
 
 /// Utility trait for implementing dynamic dispatch within [`QueueableDrawData`].

--- a/crates/viewer/re_renderer/src/queueable_draw_data.rs
+++ b/crates/viewer/re_renderer/src/queueable_draw_data.rs
@@ -66,7 +66,7 @@ impl std::ops::Deref for QueueableDrawData {
 }
 
 impl QueueableDrawData {
-    /// Panics if the type `T` is not the underlying type of this draw data.
+    /// Panics if the type `D` is not the underlying type of this draw data.
     #[inline]
     pub(crate) fn expect_downcast<D: DrawData + Any + 'static>(&self) -> &D {
         self.0

--- a/crates/viewer/re_renderer/src/queueable_draw_data.rs
+++ b/crates/viewer/re_renderer/src/queueable_draw_data.rs
@@ -1,56 +1,49 @@
+use std::any::Any;
+
 use crate::{
-    context::Renderers,
-    draw_phases::DrawPhase,
-    renderer::{DrawData, DrawError, Renderer as _},
-    wgpu_resources::GpuRenderPipelinePoolAccessor,
+    DrawableCollector, RenderContext,
+    renderer::{DrawData, DrawableCollectionViewInfo, RendererTypeId},
 };
 
-#[derive(thiserror::Error, Debug)]
-pub enum QueueableDrawDataError {
-    #[error("Failed to retrieve renderer of type {0}")]
-    FailedToRetrieveRenderer(&'static str),
-
-    #[error(transparent)]
-    DrawError(#[from] DrawError),
-}
-
+/// Utility trait for implementing dynamic dispatch within [`QueueableDrawData`].
 pub trait TypeErasedDrawData {
-    fn draw(
+    /// See [`DrawData::collect_drawables`].
+    fn collect_drawables(
         &self,
-        renderers: &Renderers,
-        gpu_resources: &GpuRenderPipelinePoolAccessor<'_>,
-        phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> Result<(), QueueableDrawDataError>;
+        view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    );
 
+    /// Returns the name of the renderer that this draw data is associated with.
     fn renderer_name(&self) -> &'static str;
 
-    fn participated_phases(&self) -> &'static [DrawPhase];
+    /// Returns the key of the renderer that this draw data is associated with.
+    ///
+    /// This also makes sure that the renderer has been initialized already.
+    fn renderer_key(&self, ctx: &RenderContext) -> RendererTypeId;
+
+    fn as_any(&self) -> &dyn Any;
 }
 
 impl<D: DrawData + 'static> TypeErasedDrawData for D {
-    fn draw(
+    fn collect_drawables(
         &self,
-        renderers: &Renderers,
-        gpu_resources: &GpuRenderPipelinePoolAccessor<'_>,
-        phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) -> Result<(), QueueableDrawDataError> {
-        let renderer = renderers.get::<D::Renderer>().ok_or(
-            QueueableDrawDataError::FailedToRetrieveRenderer(std::any::type_name::<D::Renderer>()),
-        )?;
-
-        renderer
-            .draw(gpu_resources, phase, pass, self)
-            .map_err(QueueableDrawDataError::from)
+        view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        <D as DrawData>::collect_drawables(self, view_info, collector);
     }
 
     fn renderer_name(&self) -> &'static str {
         std::any::type_name::<D::Renderer>()
     }
 
-    fn participated_phases(&self) -> &'static [DrawPhase] {
-        D::Renderer::participated_phases()
+    fn renderer_key(&self, ctx: &RenderContext) -> RendererTypeId {
+        ctx.renderer::<D::Renderer>().key()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -64,10 +57,21 @@ impl<D: TypeErasedDrawData + DrawData + Sync + Send + 'static> From<D> for Queue
 }
 
 impl std::ops::Deref for QueueableDrawData {
-    type Target = dyn TypeErasedDrawData;
+    type Target = dyn TypeErasedDrawData + Send + Sync;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()
+    }
+}
+
+impl QueueableDrawData {
+    /// Panics if the type `T` is not the underlying type of this draw data.
+    #[inline]
+    pub(crate) fn expect_downcast<D: DrawData + Any + 'static>(&self) -> &D {
+        self.0
+            .as_any()
+            .downcast_ref::<D>()
+            .expect("Draw data doesn't have the expected type")
     }
 }

--- a/crates/viewer/re_renderer/src/renderer/compositor.rs
+++ b/crates/viewer/re_renderer/src/renderer/compositor.rs
@@ -1,8 +1,11 @@
 use crate::{
-    OutlineConfig, Rgba,
+    DrawableCollector, OutlineConfig, Rgba,
     allocator::create_and_fill_uniform_buffer,
     include_shader_module,
-    renderer::{DrawData, DrawError, Renderer, screen_triangle_vertex_shader},
+    renderer::{
+        DrawData, DrawDataDrawable, DrawError, DrawInstruction, DrawableCollectionViewInfo,
+        Renderer, screen_triangle_vertex_shader,
+    },
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
@@ -50,6 +53,20 @@ pub struct CompositorDrawData {
 
 impl DrawData for CompositorDrawData {
     type Renderer = Compositor;
+
+    fn collect_drawables(
+        &self,
+        _view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        collector.add_drawable(
+            DrawPhase::Compositing | DrawPhase::CompositingScreenshot,
+            DrawDataDrawable {
+                distance_sort_key: 0.0,
+                draw_data_payload: 0,
+            },
+        );
+    }
 }
 
 impl CompositorDrawData {
@@ -216,29 +233,27 @@ impl Renderer for Compositor {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &CompositorDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
-        let pipeline_handle = match phase {
-            DrawPhase::Compositing => {
-                if draw_data.enable_blending {
-                    self.render_pipeline_blended
-                } else {
-                    self.render_pipeline_opaque
+        for DrawInstruction { draw_data, .. } in draw_instructions {
+            let pipeline_handle = match phase {
+                DrawPhase::Compositing => {
+                    if draw_data.enable_blending {
+                        self.render_pipeline_blended
+                    } else {
+                        self.render_pipeline_opaque
+                    }
                 }
-            }
-            DrawPhase::CompositingScreenshot => self.render_pipeline_screenshot,
-            _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
-        };
-        let pipeline = render_pipelines.get(pipeline_handle)?;
+                DrawPhase::CompositingScreenshot => self.render_pipeline_screenshot,
+                _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
+            };
+            let pipeline = render_pipelines.get(pipeline_handle)?;
 
-        pass.set_pipeline(pipeline);
-        pass.set_bind_group(1, &draw_data.bind_group, &[]);
-        pass.draw(0..3, 0..1);
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(1, &draw_data.bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
 
         Ok(())
-    }
-
-    fn participated_phases() -> &'static [DrawPhase] {
-        &[DrawPhase::Compositing, DrawPhase::CompositingScreenshot]
     }
 }

--- a/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
@@ -15,10 +15,12 @@ use itertools::Itertools as _;
 use smallvec::smallvec;
 
 use crate::{
-    Colormap, OutlineMaskPreference, PickingLayerObjectId, PickingLayerProcessor,
+    Colormap, DrawableCollector, OutlineMaskPreference, PickingLayerObjectId,
+    PickingLayerProcessor,
     allocator::create_and_fill_uniform_buffer_batch,
     draw_phases::{DrawPhase, OutlineMaskProcessor},
     include_shader_module,
+    renderer::{DrawDataDrawable, DrawInstruction, DrawableCollectionViewInfo},
     resource_managers::GpuTexture2D,
     view_builder::ViewBuilder,
     wgpu_resources::{
@@ -207,6 +209,8 @@ pub struct DepthClouds {
 
 #[derive(Clone)]
 struct DepthCloudDrawInstance {
+    sorting_world_position: glam::Vec3A,
+
     bind_group_opaque: GpuBindGroup,
     bind_group_outline: GpuBindGroup,
     num_points: u32,
@@ -220,6 +224,25 @@ pub struct DepthCloudDrawData {
 
 impl DrawData for DepthCloudDrawData {
     type Renderer = DepthCloudRenderer;
+
+    fn collect_drawables(
+        &self,
+        view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        for (index, instance) in self.instances.iter().enumerate() {
+            let drawable = DrawDataDrawable::from_world_position(
+                view_info,
+                instance.sorting_world_position,
+                index as u32,
+            );
+
+            collector.add_drawable(DrawPhase::Opaque | DrawPhase::PickingLayer, drawable);
+            if instance.render_outline_mask {
+                collector.add_drawable(DrawPhase::OutlineMask, drawable);
+            }
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -316,6 +339,7 @@ impl DepthCloudDrawData {
             let bind_group_opaque = mk_bind_group("depth_cloud_opaque".into(), ubo_opaque);
 
             instances.push(DepthCloudDrawInstance {
+                sorting_world_position: depth_cloud.world_from_rdf.translation,
                 num_points: depth_cloud.depth_dimensions.x * depth_cloud.depth_dimensions.y,
                 bind_group_opaque,
                 bind_group_outline,
@@ -336,14 +360,6 @@ pub struct DepthCloudRenderer {
 
 impl Renderer for DepthCloudRenderer {
     type RendererDrawData = DepthCloudDrawData;
-
-    fn participated_phases() -> &'static [DrawPhase] {
-        &[
-            DrawPhase::Opaque,
-            DrawPhase::PickingLayer,
-            DrawPhase::OutlineMask,
-        ]
-    }
 
     fn create_renderer(ctx: &RenderContext) -> Self {
         re_tracing::profile_function!();
@@ -473,12 +489,9 @@ impl Renderer for DepthCloudRenderer {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &Self::RendererDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
-        if draw_data.instances.is_empty() {
-            return Ok(());
-        }
 
         let pipeline_handle = match phase {
             DrawPhase::Opaque => self.render_pipeline_color,
@@ -490,19 +503,23 @@ impl Renderer for DepthCloudRenderer {
 
         pass.set_pipeline(pipeline);
 
-        for instance in &draw_data.instances {
-            if phase == DrawPhase::OutlineMask && !instance.render_outline_mask {
-                continue;
+        for DrawInstruction {
+            draw_data,
+            drawables,
+        } in draw_instructions
+        {
+            for drawable in *drawables {
+                let instance = &draw_data.instances[drawable.draw_data_payload as usize];
+
+                let bind_group = match phase {
+                    DrawPhase::OutlineMask => &instance.bind_group_outline,
+                    DrawPhase::PickingLayer | DrawPhase::Opaque => &instance.bind_group_opaque,
+                    _ => unreachable!(),
+                };
+
+                pass.set_bind_group(1, bind_group, &[]);
+                pass.draw(0..instance.num_points * 6, 0..1);
             }
-
-            let bind_group = match phase {
-                DrawPhase::OutlineMask => &instance.bind_group_outline,
-                DrawPhase::PickingLayer | DrawPhase::Opaque => &instance.bind_group_opaque,
-                _ => unreachable!(),
-            };
-
-            pass.set_bind_group(1, bind_group, &[]);
-            pass.draw(0..instance.num_points * 6, 0..1);
         }
 
         Ok(())

--- a/crates/viewer/re_renderer/src/renderer/generic_skybox.rs
+++ b/crates/viewer/re_renderer/src/renderer/generic_skybox.rs
@@ -1,10 +1,14 @@
 use smallvec::smallvec;
 
 use crate::{
+    DrawableCollector,
     allocator::create_and_fill_uniform_buffer,
     draw_phases::DrawPhase,
     include_shader_module,
-    renderer::screen_triangle_vertex_shader,
+    renderer::{
+        DrawDataDrawable, DrawInstruction, DrawableCollectionViewInfo,
+        screen_triangle_vertex_shader,
+    },
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
@@ -52,6 +56,20 @@ pub struct GenericSkyboxDrawData {
 
 impl DrawData for GenericSkyboxDrawData {
     type Renderer = GenericSkybox;
+
+    fn collect_drawables(
+        &self,
+        _view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        collector.add_drawable(
+            DrawPhase::Background,
+            DrawDataDrawable {
+                distance_sort_key: 0.0,
+                draw_data_payload: 0,
+            },
+        );
+    }
 }
 
 impl GenericSkyboxDrawData {
@@ -154,20 +172,18 @@ impl Renderer for GenericSkybox {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         _phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &Self::RendererDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
 
         let pipeline = render_pipelines.get(self.render_pipeline)?;
-
         pass.set_pipeline(pipeline);
-        pass.set_bind_group(1, &draw_data.bind_group, &[]);
-        pass.draw(0..3, 0..1);
+
+        for DrawInstruction { draw_data, .. } in draw_instructions {
+            pass.set_bind_group(1, &draw_data.bind_group, &[]);
+            pass.draw(0..3, 0..1);
+        }
 
         Ok(())
-    }
-
-    fn participated_phases() -> &'static [DrawPhase] {
-        &[DrawPhase::Background]
     }
 }

--- a/crates/viewer/re_renderer/src/renderer/lines.rs
+++ b/crates/viewer/re_renderer/src/renderer/lines.rs
@@ -83,11 +83,12 @@ use re_tracing::profile_function;
 use smallvec::smallvec;
 
 use crate::{
-    DebugLabel, DepthOffset, LineDrawableBuilder, OutlineMaskPreference, PickingLayerObjectId,
-    PickingLayerProcessor,
+    DebugLabel, DepthOffset, DrawableCollector, LineDrawableBuilder, OutlineMaskPreference,
+    PickingLayerObjectId, PickingLayerProcessor,
     allocator::create_and_fill_uniform_buffer_batch,
     draw_phases::{DrawPhase, OutlineMaskProcessor},
     include_shader_module,
+    renderer::{DrawDataDrawable, DrawInstruction, DrawableCollectionViewInfo},
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
@@ -192,6 +193,26 @@ pub struct LineDrawData {
 
 impl DrawData for LineDrawData {
     type Renderer = LineRenderer;
+
+    fn collect_drawables(
+        &self,
+        _view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        // TODO(#1611): transparency, split drawables for some semblence of transparency ordering.
+        // TODO(#1025, #4787): Better handling of 2D objects.
+
+        for (batch_idx, batch) in self.batches.iter().enumerate() {
+            collector.add_drawable(
+                batch.active_phases,
+                DrawDataDrawable {
+                    // TODO(andreas): Don't have distance information yet. For now just always draw lines last since they're quite expensive.
+                    distance_sort_key: f32::MAX,
+                    draw_data_payload: batch_idx as _,
+                },
+            );
+        }
+    }
 }
 
 bitflags! {
@@ -559,14 +580,6 @@ impl LineRenderer {
 impl Renderer for LineRenderer {
     type RendererDrawData = LineDrawData;
 
-    fn participated_phases() -> &'static [DrawPhase] {
-        &[
-            DrawPhase::Opaque,
-            DrawPhase::OutlineMask,
-            DrawPhase::PickingLayer,
-        ]
-    }
-
     fn create_renderer(ctx: &RenderContext) -> Self {
         profile_function!();
 
@@ -723,31 +736,39 @@ impl Renderer for LineRenderer {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &Self::RendererDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
-        let (pipeline_handle, bind_group_all_lines) = match phase {
-            DrawPhase::OutlineMask => (
-                self.render_pipeline_outline_mask,
-                &draw_data.bind_group_all_lines_outline_mask,
-            ),
-            DrawPhase::Opaque => (self.render_pipeline_color, &draw_data.bind_group_all_lines),
-            DrawPhase::PickingLayer => (
-                self.render_pipeline_picking_layer,
-                &draw_data.bind_group_all_lines,
-            ),
+        let pipeline_handle = match phase {
+            DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
+            DrawPhase::Opaque => self.render_pipeline_color,
+            DrawPhase::PickingLayer => self.render_pipeline_picking_layer,
             _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
-        };
-        let Some(bind_group_all_lines) = bind_group_all_lines else {
-            return Ok(()); // No lines submitted.
         };
 
         let pipeline = render_pipelines.get(pipeline_handle)?;
-
         pass.set_pipeline(pipeline);
-        pass.set_bind_group(1, bind_group_all_lines, &[]);
 
-        for batch in &draw_data.batches {
-            if batch.active_phases.contains(phase) {
+        for DrawInstruction {
+            draw_data,
+            drawables,
+        } in draw_instructions
+        {
+            let bind_group_draw_data = match phase {
+                DrawPhase::OutlineMask => &draw_data.bind_group_all_lines_outline_mask,
+                DrawPhase::Opaque | DrawPhase::PickingLayer => &draw_data.bind_group_all_lines,
+                _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
+            };
+            let Some(bind_group_draw_data) = bind_group_draw_data else {
+                debug_assert!(
+                    false,
+                    "Line data bind group for draw phase {phase:?} was not set despite being submitted for drawing."
+                );
+                continue;
+            };
+            pass.set_bind_group(1, bind_group_draw_data, &[]);
+
+            for drawable in *drawables {
+                let batch = &draw_data.batches[drawable.draw_data_payload as usize];
                 pass.set_bind_group(2, &batch.bind_group, &[]);
                 pass.draw(batch.vertex_range.clone(), 0..1);
             }
@@ -773,7 +794,7 @@ mod tests {
             let mut view = ViewBuilder::new(ctx, TargetConfiguration::default()).unwrap();
 
             let empty = LineDrawableBuilder::new(ctx);
-            view.queue_draw(empty.into_draw_data().unwrap());
+            view.queue_draw(ctx, empty.into_draw_data().unwrap());
 
             // This is the case that triggered
             // https://github.com/rerun-io/rerun/issues/8639
@@ -782,7 +803,7 @@ mod tests {
             empty_batch
                 .batch("empty batch")
                 .add_strip(std::iter::empty());
-            view.queue_draw(empty_batch.into_draw_data().unwrap());
+            view.queue_draw(ctx, empty_batch.into_draw_data().unwrap());
 
             let mut empty_batch_between_non_empty = LineDrawableBuilder::new(ctx);
             empty_batch_between_non_empty
@@ -794,7 +815,7 @@ mod tests {
             empty_batch_between_non_empty
                 .batch("non-empty batch")
                 .add_strip([glam::Vec3::ZERO, glam::Vec3::ZERO].into_iter());
-            view.queue_draw(empty_batch_between_non_empty.into_draw_data().unwrap());
+            view.queue_draw(ctx, empty_batch_between_non_empty.into_draw_data().unwrap());
 
             [view.draw(ctx, Rgba::BLACK).unwrap()]
         });

--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -94,7 +94,7 @@ struct MeshBatch {
     instance_start_index: u32,
     instance_end_index: u32,
 
-    /// Last index for meshes with with outlines
+    /// Last index for meshes with outlines
     ///
     /// We put all instances with outlines at the start of the instance buffer range, so this is always
     /// smaller or equal to `instance_end_index`.

--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -8,10 +8,12 @@ use std::{collections::BTreeMap, sync::Arc};
 use smallvec::smallvec;
 
 use crate::{
-    Color32, CpuWriteGpuReadError, OutlineMaskPreference, PickingLayerId, PickingLayerProcessor,
+    Color32, CpuWriteGpuReadError, DrawableCollector, OutlineMaskPreference, PickingLayerId,
+    PickingLayerProcessor,
     draw_phases::{DrawPhase, OutlineMaskProcessor},
     include_shader_module,
     mesh::{GpuMesh, gpu_data::MaterialUniformBuffer, mesh_vertices},
+    renderer::{DrawDataDrawable, DrawInstruction, DrawableCollectionViewInfo},
     view_builder::ViewBuilder,
     wgpu_resources::{
         BindGroupLayoutDesc, BufferDesc, GpuBindGroupLayoutHandle, GpuBuffer,
@@ -107,6 +109,25 @@ pub struct MeshDrawData {
 
 impl DrawData for MeshDrawData {
     type Renderer = MeshRenderer;
+
+    fn collect_drawables(
+        &self,
+        _view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        // TODO(andreas): transparency, distance sorting etc.
+        let phases = DrawPhase::Opaque | DrawPhase::PickingLayer | DrawPhase::OutlineMask;
+
+        for (batch_idx, _batch) in self.batches.iter().enumerate() {
+            collector.add_drawable(
+                phases, // TODO(andreas): even if count with outlines is 0, we have to submit the drawable right now.
+                DrawDataDrawable {
+                    distance_sort_key: f32::MAX,
+                    draw_data_payload: batch_idx as _,
+                },
+            );
+        }
+    }
 }
 
 pub struct GpuMeshInstance {
@@ -151,8 +172,6 @@ impl MeshDrawData {
         instances: &[GpuMeshInstance],
     ) -> Result<Self, CpuWriteGpuReadError> {
         re_tracing::profile_function!();
-
-        let _mesh_renderer = ctx.renderer::<MeshRenderer>();
 
         if instances.is_empty() {
             return Ok(Self {
@@ -292,14 +311,6 @@ pub struct MeshRenderer {
 impl Renderer for MeshRenderer {
     type RendererDrawData = MeshDrawData;
 
-    fn participated_phases() -> &'static [DrawPhase] {
-        &[
-            DrawPhase::Opaque,
-            DrawPhase::OutlineMask,
-            DrawPhase::PickingLayer,
-        ]
-    }
-
     fn create_renderer(ctx: &RenderContext) -> Self {
         re_tracing::profile_function!();
 
@@ -410,13 +421,9 @@ impl Renderer for MeshRenderer {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &Self::RendererDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
-
-        let Some(instance_buffer) = &draw_data.instance_buffer else {
-            return Ok(()); // Instance buffer was empty.
-        };
 
         let pipeline_handle = match phase {
             DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
@@ -428,55 +435,72 @@ impl Renderer for MeshRenderer {
 
         pass.set_pipeline(pipeline);
 
-        pass.set_vertex_buffer(0, instance_buffer.slice(..));
-        let mut instance_start_index = 0;
-
-        for mesh_batch in &draw_data.batches {
-            if phase == DrawPhase::OutlineMask && mesh_batch.count_with_outlines == 0 {
-                instance_start_index += mesh_batch.count;
-                continue;
-            }
-
-            let vertex_buffer_combined = &mesh_batch.mesh.vertex_buffer_combined;
-            let index_buffer = &mesh_batch.mesh.index_buffer;
-
-            pass.set_vertex_buffer(
-                1,
-                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_positions_range.clone()),
-            );
-            pass.set_vertex_buffer(
-                2,
-                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_colors_range.clone()),
-            );
-            pass.set_vertex_buffer(
-                3,
-                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_normals_range.clone()),
-            );
-            pass.set_vertex_buffer(
-                4,
-                vertex_buffer_combined.slice(mesh_batch.mesh.vertex_buffer_texcoord_range.clone()),
-            );
-            pass.set_index_buffer(
-                index_buffer.slice(mesh_batch.mesh.index_buffer_range.clone()),
-                wgpu::IndexFormat::Uint32,
-            );
-
-            let num_meshes_to_draw = if phase == DrawPhase::OutlineMask {
-                mesh_batch.count_with_outlines
-            } else {
-                mesh_batch.count
+        // TODO(andreas): use drawables to orchestrate drawing.
+        for DrawInstruction {
+            draw_data,
+            drawables,
+        } in draw_instructions
+        {
+            let Some(instance_buffer) = &draw_data.instance_buffer else {
+                continue; // Instance buffer was empty.
             };
-            let instance_range = instance_start_index..(instance_start_index + num_meshes_to_draw);
+            pass.set_vertex_buffer(0, instance_buffer.slice(..));
+            let mut instance_start_index = 0;
 
-            for material in &mesh_batch.mesh.materials {
-                debug_assert!(num_meshes_to_draw > 0);
+            for drawable in *drawables {
+                let mesh_batch = &draw_data.batches[drawable.draw_data_payload as usize];
 
-                pass.set_bind_group(1, &material.bind_group, &[]);
-                pass.draw_indexed(material.index_range.clone(), 0, instance_range.clone());
+                if phase == DrawPhase::OutlineMask && mesh_batch.count_with_outlines == 0 {
+                    instance_start_index += mesh_batch.count;
+                    continue;
+                }
+
+                let vertex_buffer_combined = &mesh_batch.mesh.vertex_buffer_combined;
+                let index_buffer = &mesh_batch.mesh.index_buffer;
+
+                pass.set_vertex_buffer(
+                    1,
+                    vertex_buffer_combined
+                        .slice(mesh_batch.mesh.vertex_buffer_positions_range.clone()),
+                );
+                pass.set_vertex_buffer(
+                    2,
+                    vertex_buffer_combined
+                        .slice(mesh_batch.mesh.vertex_buffer_colors_range.clone()),
+                );
+                pass.set_vertex_buffer(
+                    3,
+                    vertex_buffer_combined
+                        .slice(mesh_batch.mesh.vertex_buffer_normals_range.clone()),
+                );
+                pass.set_vertex_buffer(
+                    4,
+                    vertex_buffer_combined
+                        .slice(mesh_batch.mesh.vertex_buffer_texcoord_range.clone()),
+                );
+                pass.set_index_buffer(
+                    index_buffer.slice(mesh_batch.mesh.index_buffer_range.clone()),
+                    wgpu::IndexFormat::Uint32,
+                );
+
+                let num_meshes_to_draw = if phase == DrawPhase::OutlineMask {
+                    mesh_batch.count_with_outlines
+                } else {
+                    mesh_batch.count
+                };
+                let instance_range =
+                    instance_start_index..(instance_start_index + num_meshes_to_draw);
+
+                for material in &mesh_batch.mesh.materials {
+                    debug_assert!(num_meshes_to_draw > 0);
+
+                    pass.set_bind_group(1, &material.bind_group, &[]);
+                    pass.draw_indexed(material.index_range.clone(), 0, instance_range.clone());
+                }
+
+                // Advance instance start index with *total* number of instances in this batch.
+                instance_start_index += mesh_batch.count;
             }
-
-            // Advance instance start index with *total* number of instances in this batch.
-            instance_start_index += mesh_batch.count;
         }
 
         Ok(())

--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -98,7 +98,7 @@ struct MeshBatch {
     ///
     /// We put all instances with outlines at the start of the instance buffer range, so this is always
     /// smaller or equal to `instance_end_index`.
-    /// If it is equal to `instance_end_index`, there are no meshes with outlines in this batch.
+    /// If it is equal to `instance_start_index`, there are no meshes with outlines in this batch.
     instance_end_index_with_outlines: u32,
 }
 
@@ -447,7 +447,6 @@ impl Renderer for MeshRenderer {
 
         pass.set_pipeline(pipeline);
 
-        // TODO(andreas): use drawables to orchestrate drawing.
         for DrawInstruction {
             draw_data,
             drawables,

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -172,6 +172,9 @@ pub trait RendererExt: Send + Sync {
         pass: &mut wgpu::RenderPass<'_>,
         type_erased_draw_instructions: &[DrawInstruction<'_, QueueableDrawData>],
     ) -> Result<(), DrawError>;
+
+    /// Name of the renderer, used for debugging & error reporting.
+    fn name(&self) -> &'static str;
 }
 
 impl<R: Renderer + Send + Sync> RendererExt for R {
@@ -192,6 +195,10 @@ impl<R: Renderer + Send + Sync> RendererExt for R {
                 .collect();
 
         self.draw(gpu_resources, phase, pass, &draw_instructions)
+    }
+
+    fn name(&self) -> &'static str {
+        std::any::type_name::<R>()
     }
 }
 

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -59,7 +59,8 @@ pub type RendererTypeId = u8;
 pub struct DrawDataDrawable {
     /// Used for sorting drawables within a [`DrawPhase`].
     ///
-    /// Low values mean closer, high values mean further away from the camera.
+    /// Low values mean closer, high values mean further away from the camera, with 0.0 being at the camera.
+    /// (negative values are allowed but reserved for special cases)
     /// This is typically simply the squared scene space distance to the observer,
     /// but may also be a 2D layer index or similar.
     ///

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -35,17 +35,98 @@ pub(crate) use mesh_renderer::MeshRenderer;
 // ------------
 
 use crate::{
+    Drawable, DrawableCollector, QueueableDrawData,
     context::RenderContext,
     draw_phases::DrawPhase,
     include_shader_module,
     wgpu_resources::{GpuRenderPipelinePoolAccessor, PoolError},
 };
 
+pub type DrawDataPayload = u32;
+
+/// Unique identifier for a [`Renderer`] type.
+///
+/// The way the system is set up we don't expect many different distinct types of renderers,
+/// therefore 255 should be more than enough.
+/// Keeping this down makes drawable sorting more efficient.
+pub type RendererTypeId = u8;
+
+/// A single drawable item within a given [`DrawData`].
+///
+/// The general expectation is that there's a rough one to one relationship between
+/// drawables and drawcalls within a single [`DrawPhase`].
+#[derive(Debug, Clone, Copy)]
+pub struct DrawDataDrawable {
+    /// Used for sorting drawables within a [`DrawPhase`].
+    ///
+    /// Low values mean closer, high values mean further away from the camera.
+    /// This is typically simply the squared scene space distance to the observer,
+    /// but may also be a 2D layer index or similar.
+    ///
+    /// Sorting for NaN is considered undefined.
+    pub distance_sort_key: f32,
+
+    /// Key for identifying the drawable within a given draw data.
+    ///
+    /// This is effectively an arbitrary payload whose meaning is dependent on the drawable type
+    /// but typically refers to instances or instance ranges within the draw data.
+    pub draw_data_payload: DrawDataPayload,
+}
+
+impl DrawDataDrawable {
+    #[inline]
+    pub fn from_affine(
+        view_info: &DrawableCollectionViewInfo,
+        world_from_rdf: &glam::Affine3A,
+        draw_data_payload: DrawDataPayload,
+    ) -> Self {
+        Self::from_world_position(view_info, world_from_rdf.translation, draw_data_payload)
+    }
+
+    #[inline]
+    pub fn from_world_position(
+        view_info: &DrawableCollectionViewInfo,
+        world_position: glam::Vec3A,
+        draw_data_payload: DrawDataPayload,
+    ) -> Self {
+        Self {
+            distance_sort_key: world_position.distance_squared(view_info.camera_world_position),
+            draw_data_payload,
+        }
+    }
+}
+
+/// Information about the view for which can be taken into account when collecting drawables.
+pub struct DrawableCollectionViewInfo {
+    /// The position of the camera in world space.
+    pub camera_world_position: glam::Vec3A,
+}
+
 /// GPU sided data used by a [`Renderer`] to draw things to the screen.
 ///
-/// Valid only for the frame in which it was created (typically uses temp allocations!).
+/// Each [`DrawData`] produces one or more [`DrawDataDrawable`]s for each view & phase.
+///
+/// Valid only for the frame in which it was created (may use temp allocations!).
+//
+// TODO(andreas): As of writing we don't actually use temp allocations. We should either drop
+//               the single-frame validity assumption or enforce it!
+// TODO(andreas): Architecturally we're not far from re-using draw across several views.
+//                Only `QueueableDrawData` consuming draw data right now is preventing this.
 pub trait DrawData {
     type Renderer: Renderer<RendererDrawData = Self> + Send + Sync;
+
+    /// Collects all drawables for all phases of a specific view.
+    ///
+    /// Draw data implementations targeting several draw phases at once may choose to batch differently for each of them.
+    ///
+    /// Note that depending on the draw phase, drawables may be sorted differently or not at all.
+    // TODO(andreas): This might also be the right place to introduce frustum culling by extending the view info.
+    // on the flip side, we already put quite a bit of work into building up the draw data, not all of which is view-independent today (but it should be).
+    fn collect_drawables(
+        &self,
+        view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    );
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
@@ -54,29 +135,64 @@ pub enum DrawError {
     Pool(#[from] PoolError),
 }
 
+/// A draw instruction specifies which drawables of a given [`DrawData`] should be rendered.
+pub struct DrawInstruction<'a, D> {
+    pub draw_data: &'a D,
+    pub drawables: &'a [Drawable],
+}
+
 /// A Renderer encapsulate the knowledge of how to render a certain kind of primitives.
 ///
 /// It is an immutable, long-lived datastructure that only holds onto resources that will be needed
 /// for each of its [`Renderer::draw`] invocations.
-/// Any data that might be different per specific [`Renderer::draw`] invocation is stored in [`DrawData`].
+/// Any data that might be different over multiple [`Renderer::draw`] invocations is stored in [`DrawData`].
 pub trait Renderer {
-    type RendererDrawData: DrawData;
+    type RendererDrawData: DrawData + 'static;
 
     fn create_renderer(ctx: &RenderContext) -> Self;
 
-    // TODO(andreas): Some Renderers need to create their own passes, need something like this for that.
-
     /// Called once per phase given by [`Renderer::participated_phases`].
+    ///
+    /// For each draw data reference, there's at most one [`DrawInstruction`].
     fn draw(
         &self,
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &Self::RendererDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError>;
+}
 
-    /// Combination of flags indicating in which phases [`Renderer::draw`] should be called.
-    fn participated_phases() -> &'static [DrawPhase];
+/// Extension trait for [`Renderer`] that allows running draw instructions with type erased draw data.
+pub trait RendererExt: Send + Sync {
+    fn run_draw_instructions(
+        &self,
+        gpu_resources: &GpuRenderPipelinePoolAccessor<'_>,
+        phase: DrawPhase,
+        pass: &mut wgpu::RenderPass<'_>,
+        type_erased_draw_instructions: &[DrawInstruction<'_, QueueableDrawData>],
+    ) -> Result<(), DrawError>;
+}
+
+impl<R: Renderer + Send + Sync> RendererExt for R {
+    fn run_draw_instructions(
+        &self,
+        gpu_resources: &GpuRenderPipelinePoolAccessor<'_>,
+        phase: DrawPhase,
+        pass: &mut wgpu::RenderPass<'_>,
+        type_erased_draw_instructions: &[DrawInstruction<'_, QueueableDrawData>],
+    ) -> Result<(), DrawError> {
+        let draw_instructions: Vec<DrawInstruction<'_, R::RendererDrawData>> =
+            type_erased_draw_instructions
+                .iter()
+                .map(|type_erased_draw_instruction| DrawInstruction {
+                    draw_data: type_erased_draw_instruction.draw_data.expect_downcast(),
+                    drawables: type_erased_draw_instruction.drawables,
+                })
+                .collect();
+
+        self.draw(gpu_resources, phase, pass, &draw_instructions)
+    }
 }
 
 /// Gets or creates a vertex shader module for drawing a screen filling triangle.

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -45,13 +45,6 @@ use crate::{
 /// [`DrawData`] specific payload that is injected into the otherwise type agnostic [`crate::Drawable`].
 pub type DrawDataDrawablePayload = u32;
 
-/// Unique identifier for a [`Renderer`] type.
-///
-/// We generally don't expect many different distinct types of renderers,
-/// therefore 255 should be more than enough.
-/// This limitation simplifies sorting of drawables a bit.
-pub type RendererTypeId = u8;
-
 /// A single drawable item within a given [`DrawData`].
 ///
 /// The general expectation is that there's a rough one to one relationship between

--- a/crates/viewer/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/point_cloud.rs
@@ -120,7 +120,7 @@ impl DrawData for PointCloudDrawData {
         collector: &mut DrawableCollector<'_>,
     ) {
         // TODO(#1611): transparency, split drawables for some semblence of transparency ordering.
-        // TODO(#1025, #4787): Better handling of 2D objects, use per-2d layer sorting instead of depth offsets.
+        // TODO(#1025, #4787): Better handling of 2D objects, use per-2D layer sorting instead of depth offsets.
 
         for (batch_idx, batch) in self.batches.iter().enumerate() {
             collector.add_drawable(

--- a/crates/viewer/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/point_cloud.rs
@@ -16,10 +16,11 @@
 use std::{num::NonZeroU64, ops::Range};
 
 use crate::{
-    DebugLabel, DepthOffset, OutlineMaskPreference, PointCloudBuilder,
+    DebugLabel, DepthOffset, DrawableCollector, OutlineMaskPreference, PointCloudBuilder,
     allocator::create_and_fill_uniform_buffer_batch,
     draw_phases::{DrawPhase, OutlineMaskProcessor, PickingLayerObjectId, PickingLayerProcessor},
     include_shader_module,
+    renderer::{DrawDataDrawable, DrawInstruction, DrawableCollectionViewInfo},
     wgpu_resources::GpuRenderPipelinePoolAccessor,
 };
 use bitflags::bitflags;
@@ -112,6 +113,26 @@ pub struct PointCloudDrawData {
 
 impl DrawData for PointCloudDrawData {
     type Renderer = PointCloudRenderer;
+
+    fn collect_drawables(
+        &self,
+        _view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        // TODO(#1611): transparency, split drawables for some semblence of transparency ordering.
+        // TODO(#1025, #4787): Better handling of 2D objects, use per-2d layer sorting instead of depth offsets.
+
+        for (batch_idx, batch) in self.batches.iter().enumerate() {
+            collector.add_drawable(
+                batch.active_phases,
+                DrawDataDrawable {
+                    // TODO(andreas): Don't have distance information yet. For now just always draw points last since they're quite expensive.
+                    distance_sort_key: f32::MAX,
+                    draw_data_payload: batch_idx as _,
+                },
+            );
+        }
+    }
 }
 
 /// Data that is valid for a batch of point cloud points.
@@ -421,14 +442,6 @@ impl PointCloudRenderer {
 impl Renderer for PointCloudRenderer {
     type RendererDrawData = PointCloudDrawData;
 
-    fn participated_phases() -> &'static [DrawPhase] {
-        &[
-            DrawPhase::OutlineMask,
-            DrawPhase::Opaque,
-            DrawPhase::PickingLayer,
-        ]
-    }
-
     fn create_renderer(ctx: &RenderContext) -> Self {
         re_tracing::profile_function!();
 
@@ -588,30 +601,39 @@ impl Renderer for PointCloudRenderer {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &Self::RendererDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
-        let (pipeline_handle, bind_group_all_points) = match phase {
-            DrawPhase::OutlineMask => (
-                self.render_pipeline_outline_mask,
-                &draw_data.bind_group_all_points_outline_mask,
-            ),
-            DrawPhase::Opaque => (self.render_pipeline_color, &draw_data.bind_group_all_points),
-            DrawPhase::PickingLayer => (
-                self.render_pipeline_picking_layer,
-                &draw_data.bind_group_all_points,
-            ),
+        let pipeline_handle = match phase {
+            DrawPhase::OutlineMask => self.render_pipeline_outline_mask,
+            DrawPhase::Opaque => self.render_pipeline_color,
+            DrawPhase::PickingLayer => self.render_pipeline_picking_layer,
             _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
-        };
-        let Some(bind_group_all_points) = bind_group_all_points else {
-            return Ok(()); // No points submitted.
         };
         let pipeline = render_pipelines.get(pipeline_handle)?;
 
         pass.set_pipeline(pipeline);
-        pass.set_bind_group(1, bind_group_all_points, &[]);
 
-        for batch in &draw_data.batches {
-            if batch.active_phases.contains(phase) {
+        for DrawInstruction {
+            draw_data,
+            drawables,
+        } in draw_instructions
+        {
+            let bind_group_all_points = match phase {
+                DrawPhase::OutlineMask => &draw_data.bind_group_all_points_outline_mask,
+                DrawPhase::Opaque | DrawPhase::PickingLayer => &draw_data.bind_group_all_points,
+                _ => unreachable!("We were called on a phase we weren't subscribed to: {phase:?}"),
+            };
+            let Some(bind_group_all_points) = bind_group_all_points else {
+                debug_assert!(
+                    false,
+                    "Point data bind group for draw phase {phase:?} was not set despite being submitted for drawing."
+                );
+                continue;
+            };
+            pass.set_bind_group(1, bind_group_all_points, &[]);
+
+            for drawable in *drawables {
+                let batch = &draw_data.batches[drawable.draw_data_payload as usize];
                 pass.set_bind_group(2, &batch.bind_group, &[]);
                 pass.draw(batch.vertex_range.clone(), 0..1);
             }

--- a/crates/viewer/re_renderer/src/renderer/rectangles.rs
+++ b/crates/viewer/re_renderer/src/renderer/rectangles.rs
@@ -409,7 +409,7 @@ impl DrawData for RectangleDrawData {
         view_info: &DrawableCollectionViewInfo,
         collector: &mut DrawableCollector<'_>,
     ) {
-        // TODO(#1025, #4787): Better handling of 2D objects, use per-2d layer sorting instead of depth offsets.
+        // TODO(#1025, #4787): Better handling of 2D objects, use per-2D layer sorting instead of depth offsets.
         // This is extra hacky here since we actually have transparent objects, but putting them on that layer messes with the
         // 2D setup we have so far.
 

--- a/crates/viewer/re_renderer/src/renderer/rectangles.rs
+++ b/crates/viewer/re_renderer/src/renderer/rectangles.rs
@@ -14,11 +14,12 @@ use itertools::{Itertools as _, izip};
 use smallvec::smallvec;
 
 use crate::{
-    Colormap, OutlineMaskPreference, PickingLayerProcessor, Rgba,
+    Colormap, DrawableCollector, OutlineMaskPreference, PickingLayerProcessor, Rgba,
     allocator::create_and_fill_uniform_buffer_batch,
     depth_offset::DepthOffset,
     draw_phases::{DrawPhase, OutlineMaskProcessor},
     include_shader_module,
+    renderer::{DrawDataDrawable, DrawInstruction, DrawableCollectionViewInfo},
     resource_managers::GpuTexture2D,
     view_builder::ViewBuilder,
     wgpu_resources::{
@@ -390,6 +391,7 @@ mod gpu_data {
 
 #[derive(Clone)]
 struct RectangleInstance {
+    center_position: glam::Vec3A,
     bind_group: GpuBindGroup,
     draw_outline_mask: bool,
 }
@@ -401,6 +403,32 @@ pub struct RectangleDrawData {
 
 impl DrawData for RectangleDrawData {
     type Renderer = RectangleRenderer;
+
+    fn collect_drawables(
+        &self,
+        view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        // TODO(#1025, #4787): Better handling of 2D objects, use per-2d layer sorting instead of depth offsets.
+        // This is extra hacky here since we actually have transparent objects, but putting them on that layer messes with the
+        // 2D setup we have so far.
+
+        for (index, instance) in self.instances.iter().enumerate() {
+            let mut phases = DrawPhase::Opaque | DrawPhase::PickingLayer;
+            if instance.draw_outline_mask {
+                phases.insert(DrawPhase::OutlineMask);
+            }
+
+            collector.add_drawable(
+                phases,
+                DrawDataDrawable::from_world_position(
+                    view_info,
+                    instance.center_position,
+                    index as u32,
+                ),
+            );
+        }
+    }
 }
 
 impl RectangleDrawData {
@@ -470,6 +498,10 @@ impl RectangleDrawData {
                 };
 
             instances.push(RectangleInstance {
+                center_position: (rectangle.top_left_corner_position
+                    + rectangle.extent_u * 0.5
+                    + rectangle.extent_v * 0.5)
+                    .into(),
                 bind_group: ctx.gpu_resources.bind_groups.alloc(
                     &ctx.device,
                     &ctx.gpu_resources,
@@ -653,12 +685,9 @@ impl Renderer for RectangleRenderer {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &Self::RendererDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
-        if draw_data.instances.is_empty() {
-            return Ok(());
-        }
 
         let pipeline_handle = match phase {
             DrawPhase::Opaque => self.render_pipeline_color,
@@ -670,23 +699,18 @@ impl Renderer for RectangleRenderer {
 
         pass.set_pipeline(pipeline);
 
-        for rectangles in &draw_data.instances {
-            if phase == DrawPhase::OutlineMask && !rectangles.draw_outline_mask {
-                continue;
+        for DrawInstruction {
+            draw_data,
+            drawables,
+        } in draw_instructions
+        {
+            for drawable in *drawables {
+                let rectangles = &draw_data.instances[drawable.draw_data_payload as usize];
+                pass.set_bind_group(1, &rectangles.bind_group, &[]);
+                pass.draw(0..4, 0..1);
             }
-            pass.set_bind_group(1, &rectangles.bind_group, &[]);
-            pass.draw(0..4, 0..1);
         }
 
         Ok(())
-    }
-
-    fn participated_phases() -> &'static [DrawPhase] {
-        // TODO(andreas): This a hack. We have both opaque and transparent.
-        &[
-            DrawPhase::OutlineMask,
-            DrawPhase::Opaque,
-            DrawPhase::PickingLayer,
-        ]
     }
 }

--- a/crates/viewer/re_renderer/src/renderer/rectangles.rs
+++ b/crates/viewer/re_renderer/src/renderer/rectangles.rs
@@ -410,7 +410,7 @@ impl DrawData for RectangleDrawData {
         collector: &mut DrawableCollector<'_>,
     ) {
         // TODO(#1025, #4787): Better handling of 2D objects, use per-2D layer sorting instead of depth offsets.
-        // This is extra hacky here since we actually have transparent objects, but putting them on that layer messes with the
+        // This is extra hacky here since we actually have transparent objects, but putting them on the transparency layer messes with the
         // 2D setup we have so far.
 
         for (index, instance) in self.instances.iter().enumerate() {

--- a/crates/viewer/re_renderer/src/renderer/world_grid.rs
+++ b/crates/viewer/re_renderer/src/renderer/world_grid.rs
@@ -1,8 +1,9 @@
 use crate::{
-    ViewBuilder,
+    DrawableCollector, ViewBuilder,
     allocator::create_and_fill_uniform_buffer,
     draw_phases::DrawPhase,
     include_shader_module,
+    renderer::{DrawDataDrawable, DrawInstruction, DrawableCollectionViewInfo},
     wgpu_resources::{
         BindGroupDesc, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
         GpuRenderPipelineHandle, GpuRenderPipelinePoolAccessor, PipelineLayoutDesc,
@@ -66,6 +67,23 @@ pub struct WorldGridDrawData {
 
 impl DrawData for WorldGridDrawData {
     type Renderer = WorldGridRenderer;
+
+    fn collect_drawables(
+        &self,
+        _view_info: &DrawableCollectionViewInfo,
+        collector: &mut DrawableCollector<'_>,
+    ) {
+        collector.add_drawable(
+            DrawPhase::Transparent,
+            DrawDataDrawable {
+                // The grid is everywhere, making it a bit hard to sort against other transparent objects.
+                // We could use distance from the plane, but we rather use a stable sorting here to avoid flickering,
+                // therefore we want to draw it before any other "real" transparentobjects.
+                distance_sort_key: -1.0,
+                draw_data_payload: 0,
+            },
+        );
+    }
 }
 
 impl WorldGridDrawData {
@@ -180,18 +198,16 @@ impl Renderer for WorldGridRenderer {
         render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         _phase: DrawPhase,
         pass: &mut wgpu::RenderPass<'_>,
-        draw_data: &WorldGridDrawData,
+        draw_instructions: &[DrawInstruction<'_, Self::RendererDrawData>],
     ) -> Result<(), DrawError> {
         let pipeline = render_pipelines.get(self.render_pipeline)?;
 
         pass.set_pipeline(pipeline);
-        pass.set_bind_group(1, &draw_data.bind_group, &[]);
-        pass.draw(0..4, 0..1);
+        for DrawInstruction { draw_data, .. } in draw_instructions {
+            pass.set_bind_group(1, &draw_data.bind_group, &[]);
+            pass.draw(0..4, 0..1);
+        }
 
         Ok(())
-    }
-
-    fn participated_phases() -> &'static [DrawPhase] {
-        &[DrawPhase::Transparent]
     }
 }

--- a/crates/viewer/re_renderer/src/resource_managers/yuv_converter.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/yuv_converter.rs
@@ -358,7 +358,8 @@ impl DrawData for YuvFormatConversionTask {
         _view_info: &DrawableCollectionViewInfo,
         _collector: &mut DrawableCollector<'_>,
     ) {
-        // Doesn't participate in regular rendering.
+        // Doesn't participate in regular rendering.\
+        // TODO(andreas): Maybe this shouldn't miss-use the `DrawData`/`Renderer` interface?
     }
 }
 

--- a/crates/viewer/re_renderer/src/view_builder.rs
+++ b/crates/viewer/re_renderer/src/view_builder.rs
@@ -631,16 +631,10 @@ impl ViewBuilder {
         re_tracing::profile_function!();
 
         for queued_draw in &self.queued_draws {
-            if queued_draw.participated_phases.contains(&phase) {
-                let res = (queued_draw.draw_func)(
-                    renderers,
-                    render_pipelines,
-                    phase,
-                    pass,
-                    queued_draw.draw_data.as_ref(),
-                );
+            if queued_draw.participated_phases().contains(&phase) {
+                let res = queued_draw.draw(renderers, render_pipelines, phase, pass);
                 if let Err(err) = res {
-                    re_log::error!(renderer=%queued_draw.renderer_name, %err,
+                    re_log::error!(renderer=%queued_draw.renderer_name(), %err,
                         "renderer failed to draw");
                 }
             }

--- a/crates/viewer/re_renderer/src/view_builder.rs
+++ b/crates/viewer/re_renderer/src/view_builder.rs
@@ -2,20 +2,18 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 use crate::{
-    DebugLabel, MsaaMode, RectInt, RenderConfig, Rgba,
+    DebugLabel, DrawPhaseManager, MsaaMode, RectInt, RenderConfig, Rgba,
     allocator::{GpuReadbackIdentifier, create_and_fill_uniform_buffer},
-    context::{RenderContext, Renderers},
+    context::RenderContext,
     draw_phases::{
         DrawPhase, OutlineConfig, OutlineMaskProcessor, PickingLayerError, PickingLayerProcessor,
         ScreenshotProcessor,
     },
     global_bindings::FrameUniformBuffer,
     queueable_draw_data::QueueableDrawData,
-    renderer::{CompositorDrawData, DebugOverlayDrawData},
+    renderer::{CompositorDrawData, DebugOverlayDrawData, DrawableCollectionViewInfo},
     transform::RectTransform,
-    wgpu_resources::{
-        GpuBindGroup, GpuRenderPipelinePoolAccessor, GpuTexture, PoolError, TextureDesc,
-    },
+    wgpu_resources::{GpuBindGroup, GpuTexture, PoolError, TextureDesc},
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -31,7 +29,7 @@ pub enum ViewBuilderError {
 /// Used to build up/collect various resources and then send them off for rendering of a single view.
 pub struct ViewBuilder {
     setup: ViewTargetSetup,
-    queued_draws: Vec<QueueableDrawData>,
+    draw_phase_manager: DrawPhaseManager,
 
     // TODO(andreas): Consider making "render processors" a "thing" by establishing a form of hardcoded/limited-flexibility render-graph
     outline_mask_processor: Option<OutlineMaskProcessor>,
@@ -41,6 +39,8 @@ pub struct ViewBuilder {
 
 struct ViewTargetSetup {
     name: DebugLabel,
+
+    camera_position: glam::Vec3A,
 
     bind_group_0: GpuBindGroup,
     main_target_msaa: GpuTexture,
@@ -577,8 +577,31 @@ impl ViewBuilder {
             None
         };
 
+        let active_draw_phases = {
+            let mut active_draw_phases = DrawPhase::Opaque
+                | DrawPhase::Background
+                | DrawPhase::Transparent
+                | DrawPhase::Compositing;
+            if config.outline_config.is_some() {
+                active_draw_phases |= DrawPhase::OutlineMask;
+            }
+            if picking_processor.is_some() {
+                active_draw_phases |= DrawPhase::PickingLayer;
+            }
+            // TODO(andreas): should not always be active.
+            // TODO(andreas): The fact that this is a draw phase is actually a bit dubious.
+            //if screenshot_processor.is_some() {
+            active_draw_phases |= DrawPhase::CompositingScreenshot;
+            //}
+
+            active_draw_phases
+        };
+
+        let draw_phase_manager = DrawPhaseManager::new(active_draw_phases);
+
         let setup = ViewTargetSetup {
             name: config.name,
+            camera_position: camera_position.into(),
             bind_group_0,
             main_target_msaa,
             main_target_resolved,
@@ -592,25 +615,28 @@ impl ViewBuilder {
 
         let mut view_builder = Self {
             setup,
-            queued_draws: Default::default(),
+            draw_phase_manager,
             outline_mask_processor,
             screenshot_processor: Default::default(),
             picking_processor,
         };
 
-        view_builder.queue_draw(CompositorDrawData::new(
+        view_builder.queue_draw(
             ctx,
-            &view_builder.setup.main_target_resolved,
-            view_builder
-                .outline_mask_processor
-                .as_ref()
-                .map(|p| p.final_voronoi_texture()),
-            &config.outline_config,
-            config.blend_with_background,
-        ));
+            CompositorDrawData::new(
+                ctx,
+                &view_builder.setup.main_target_resolved,
+                view_builder
+                    .outline_mask_processor
+                    .as_ref()
+                    .map(|p| p.final_voronoi_texture()),
+                &config.outline_config,
+                config.blend_with_background,
+            ),
+        );
 
         for debug_overlay in debug_overlays {
-            view_builder.queue_draw(debug_overlay);
+            view_builder.queue_draw(ctx, debug_overlay);
         }
 
         Ok(view_builder)
@@ -621,28 +647,16 @@ impl ViewBuilder {
         self.setup.resolution_in_pixel
     }
 
-    fn draw_phase(
-        &self,
-        renderers: &Renderers,
-        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
-        phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'_>,
-    ) {
-        re_tracing::profile_function!();
-
-        for queued_draw in &self.queued_draws {
-            if queued_draw.participated_phases().contains(&phase) {
-                let res = queued_draw.draw(renderers, render_pipelines, phase, pass);
-                if let Err(err) = res {
-                    re_log::error!(renderer=%queued_draw.renderer_name(), %err,
-                        "renderer failed to draw");
-                }
-            }
-        }
-    }
-
-    pub fn queue_draw(&mut self, draw_data: impl Into<QueueableDrawData>) -> &mut Self {
-        self.queued_draws.push(draw_data.into());
+    pub fn queue_draw(
+        &mut self,
+        ctx: &RenderContext,
+        draw_data: impl Into<QueueableDrawData>,
+    ) -> &mut Self {
+        let view_info = DrawableCollectionViewInfo {
+            camera_world_position: self.setup.camera_position,
+        };
+        self.draw_phase_manager
+            .add_draw_data(ctx, draw_data.into(), &view_info);
         self
     }
 
@@ -730,7 +744,8 @@ impl ViewBuilder {
                 DrawPhase::Background,
                 DrawPhase::Transparent,
             ] {
-                self.draw_phase(&renderers, &pipelines, phase, &mut pass);
+                self.draw_phase_manager
+                    .draw(&renderers, &pipelines, phase, &mut pass);
             }
         }
 
@@ -748,7 +763,12 @@ impl ViewBuilder {
                 // 3: Draw call in renderer.
                 //
                 //pass.set_bind_group(0, &setup.bind_group_0, &[]);
-                self.draw_phase(&renderers, &pipelines, DrawPhase::PickingLayer, &mut pass);
+                self.draw_phase_manager.draw(
+                    &renderers,
+                    &pipelines,
+                    DrawPhase::PickingLayer,
+                    &mut pass,
+                );
             }
             match picking_processor.end_render_pass(&mut encoder, &pipelines) {
                 Err(PickingLayerError::ResourcePoolError(err)) => {
@@ -767,7 +787,12 @@ impl ViewBuilder {
                 re_tracing::profile_scope!("outline mask pass");
                 let mut pass = outline_mask_processor.start_mask_render_pass(&mut encoder);
                 pass.set_bind_group(0, &setup.bind_group_0, &[]);
-                self.draw_phase(&renderers, &pipelines, DrawPhase::OutlineMask, &mut pass);
+                self.draw_phase_manager.draw(
+                    &renderers,
+                    &pipelines,
+                    DrawPhase::OutlineMask,
+                    &mut pass,
+                );
             }
             outline_mask_processor.compute_outlines(&pipelines, &mut encoder)?;
         }
@@ -776,7 +801,7 @@ impl ViewBuilder {
             {
                 let mut pass = screenshot_processor.begin_render_pass(&setup.name, &mut encoder);
                 pass.set_bind_group(0, &setup.bind_group_0, &[]);
-                self.draw_phase(
+                self.draw_phase_manager.draw(
                     &renderers,
                     &pipelines,
                     DrawPhase::CompositingScreenshot,
@@ -846,7 +871,7 @@ impl ViewBuilder {
 
         pass.set_bind_group(0, &self.setup.bind_group_0, &[]);
 
-        self.draw_phase(
+        self.draw_phase_manager.draw(
             &ctx.read_lock_renderers(),
             &ctx.gpu_resources.render_pipelines.resources(),
             DrawPhase::Compositing,

--- a/crates/viewer/re_renderer/src/view_builder.rs
+++ b/crates/viewer/re_renderer/src/view_builder.rs
@@ -662,7 +662,7 @@ impl ViewBuilder {
 
     /// Draws the frame as instructed to a temporary HDR target.
     pub fn draw(
-        &self,
+        &mut self,
         ctx: &RenderContext,
         clear_color: Rgba,
     ) -> Result<wgpu::CommandBuffer, PoolError> {
@@ -686,10 +686,16 @@ impl ViewBuilder {
         // However, having our locking concentrated for the duration of a view draw
         // is also beneficial since it enforces the model of prepare->draw which avoids a lot of repeated
         // locking and unlocking.
+        //
+        // TODO(andreas): Above limitation has been lifted by now. We can lift some of the restrictions now!
+
         let renderers = ctx.read_lock_renderers();
         let pipelines = ctx.gpu_resources.render_pipelines.resources();
 
         let setup = &self.setup;
+
+        // Prepare the drawables for drawing!
+        self.draw_phase_manager.sort_drawables();
 
         let mut encoder = ctx
             .device

--- a/crates/viewer/re_renderer_examples/2d.rs
+++ b/crates/viewer/re_renderer_examples/2d.rs
@@ -307,9 +307,9 @@ impl framework::Example for Render2D {
                         ..Default::default()
                     },
                 )?;
-                view_builder.queue_draw(line_strip_draw_data.clone());
-                view_builder.queue_draw(point_draw_data.clone());
-                view_builder.queue_draw(rectangle_draw_data.clone());
+                view_builder.queue_draw(re_ctx, line_strip_draw_data.clone());
+                view_builder.queue_draw(re_ctx, point_draw_data.clone());
+                view_builder.queue_draw(re_ctx, rectangle_draw_data.clone());
                 let command_buffer = view_builder
                     .draw(re_ctx, re_renderer::Rgba::TRANSPARENT)
                     .unwrap();
@@ -348,9 +348,9 @@ impl framework::Example for Render2D {
                     },
                 )?;
                 let command_buffer = view_builder
-                    .queue_draw(line_strip_draw_data)
-                    .queue_draw(point_draw_data)
-                    .queue_draw(rectangle_draw_data)
+                    .queue_draw(re_ctx, line_strip_draw_data)
+                    .queue_draw(re_ctx, point_draw_data)
+                    .queue_draw(re_ctx, rectangle_draw_data)
                     .draw(re_ctx, re_renderer::Rgba::TRANSPARENT)
                     .unwrap();
                 framework::ViewDrawResult {

--- a/crates/viewer/re_renderer_examples/depth_cloud.rs
+++ b/crates/viewer/re_renderer_examples/depth_cloud.rs
@@ -130,10 +130,13 @@ impl RenderDepthClouds {
         )?;
 
         let command_buffer = view_builder
-            .queue_draw(GenericSkyboxDrawData::new(re_ctx, Default::default()))
-            .queue_draw(point_cloud_draw_data)
-            .queue_draw(frame_draw_data)
-            .queue_draw(image_draw_data)
+            .queue_draw(
+                re_ctx,
+                GenericSkyboxDrawData::new(re_ctx, Default::default()),
+            )
+            .queue_draw(re_ctx, point_cloud_draw_data)
+            .queue_draw(re_ctx, frame_draw_data)
+            .queue_draw(re_ctx, image_draw_data)
             .draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
 
         Ok(framework::ViewDrawResult {
@@ -208,10 +211,13 @@ impl RenderDepthClouds {
         )?;
 
         let command_buffer = view_builder
-            .queue_draw(GenericSkyboxDrawData::new(re_ctx, Default::default()))
-            .queue_draw(depth_cloud_draw_data)
-            .queue_draw(frame_draw_data)
-            .queue_draw(image_draw_data)
+            .queue_draw(
+                re_ctx,
+                GenericSkyboxDrawData::new(re_ctx, Default::default()),
+            )
+            .queue_draw(re_ctx, depth_cloud_draw_data)
+            .queue_draw(re_ctx, frame_draw_data)
+            .queue_draw(re_ctx, image_draw_data)
             .draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
 
         Ok(framework::ViewDrawResult {

--- a/crates/viewer/re_renderer_examples/depth_offset.rs
+++ b/crates/viewer/re_renderer_examples/depth_offset.rs
@@ -115,7 +115,7 @@ impl framework::Example for Render2D {
             },
         )?;
         let command_buffer = view_builder
-            .queue_draw(RectangleDrawData::new(re_ctx, &rectangles)?)
+            .queue_draw(re_ctx, RectangleDrawData::new(re_ctx, &rectangles)?)
             .draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
 
         Ok(vec![{

--- a/crates/viewer/re_renderer_examples/multiview.rs
+++ b/crates/viewer/re_renderer_examples/multiview.rs
@@ -230,8 +230,8 @@ impl Multiview {
         }
 
         let command_buffer = view_builder
-            .queue_draw(skybox)
-            .queue_draw(draw_data)
+            .queue_draw(re_ctx, skybox)
+            .queue_draw(re_ctx, draw_data)
             .draw(re_ctx, Rgba::TRANSPARENT)?;
 
         Ok((view_builder, command_buffer))

--- a/crates/viewer/re_renderer_examples/outlines.rs
+++ b/crates/viewer/re_renderer_examples/outlines.rs
@@ -122,13 +122,14 @@ impl framework::Example for Outlines {
             })
             .collect_vec();
 
-        view_builder.queue_draw(re_renderer::renderer::GenericSkyboxDrawData::new(
+        view_builder.queue_draw(
             re_ctx,
-            Default::default(),
-        ));
-        view_builder.queue_draw(re_renderer::renderer::MeshDrawData::new(
-            re_ctx, &instances,
-        )?);
+            re_renderer::renderer::GenericSkyboxDrawData::new(re_ctx, Default::default()),
+        );
+        view_builder.queue_draw(
+            re_ctx,
+            re_renderer::renderer::MeshDrawData::new(re_ctx, &instances)?,
+        );
 
         let command_buffer = view_builder.draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
 

--- a/crates/viewer/re_renderer_examples/picking.rs
+++ b/crates/viewer/re_renderer_examples/picking.rs
@@ -167,7 +167,7 @@ impl framework::Example for Picking {
                     &point_set.picking_ids,
                 );
         }
-        view_builder.queue_draw(point_builder.into_draw_data()?);
+        view_builder.queue_draw(re_ctx, point_builder.into_draw_data()?);
 
         let instances = self
             .model_mesh_instances
@@ -185,13 +185,14 @@ impl framework::Example for Picking {
             })
             .collect_vec();
 
-        view_builder.queue_draw(re_renderer::renderer::GenericSkyboxDrawData::new(
+        view_builder.queue_draw(
             re_ctx,
-            Default::default(),
-        ));
-        view_builder.queue_draw(re_renderer::renderer::MeshDrawData::new(
-            re_ctx, &instances,
-        )?);
+            re_renderer::renderer::GenericSkyboxDrawData::new(re_ctx, Default::default()),
+        );
+        view_builder.queue_draw(
+            re_ctx,
+            re_renderer::renderer::MeshDrawData::new(re_ctx, &instances)?,
+        );
 
         let command_buffer = view_builder.draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
 

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -87,24 +87,27 @@ impl framework::Example for Outlines {
             },
         )?;
 
-        view_builder.queue_draw(re_renderer::renderer::GenericSkyboxDrawData::new(
+        view_builder.queue_draw(
             re_ctx,
-            Default::default(),
-        ));
-        view_builder.queue_draw(re_renderer::renderer::WorldGridDrawData::new(
+            re_renderer::renderer::GenericSkyboxDrawData::new(re_ctx, Default::default()),
+        );
+        view_builder.queue_draw(
             re_ctx,
-            &re_renderer::renderer::WorldGridConfiguration {
-                #[expect(clippy::disallowed_methods)]
-                color: re_renderer::Rgba::from_rgb(0.5, 0.5, 0.5),
-                spacing: 0.1,
-                thickness_ui: 1.0,
-                plane: macaw::Plane3::ZX,
-            },
-        ));
-        view_builder.queue_draw(re_renderer::renderer::MeshDrawData::new(
+            re_renderer::renderer::WorldGridDrawData::new(
+                re_ctx,
+                &re_renderer::renderer::WorldGridConfiguration {
+                    #[expect(clippy::disallowed_methods)]
+                    color: re_renderer::Rgba::from_rgb(0.5, 0.5, 0.5),
+                    spacing: 0.1,
+                    thickness_ui: 1.0,
+                    plane: macaw::Plane3::ZX,
+                },
+            ),
+        );
+        view_builder.queue_draw(
             re_ctx,
-            &self.model_mesh_instances,
-        )?);
+            re_renderer::renderer::MeshDrawData::new(re_ctx, &self.model_mesh_instances)?,
+        );
 
         let command_buffer = view_builder.draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
 

--- a/crates/viewer/re_view_map/src/visualizers/geo_line_strings.rs
+++ b/crates/viewer/re_view_map/src/visualizers/geo_line_strings.rs
@@ -178,7 +178,7 @@ impl GeoLineStringsVisualizer {
             }
         }
 
-        view_builder.queue_draw(lines.into_draw_data()?);
+        view_builder.queue_draw(render_ctx, lines.into_draw_data()?);
 
         Ok(())
     }

--- a/crates/viewer/re_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_view_map/src/visualizers/geo_points.rs
@@ -193,7 +193,7 @@ impl GeoPointsVisualizer {
             point_batch.add_points_2d(&positions, &radii, &batch.colors, &batch.instance_id);
         }
 
-        view_builder.queue_draw(points.into_draw_data()?);
+        view_builder.queue_draw(render_ctx, points.into_draw_data()?);
 
         Ok(())
     }

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -262,7 +262,7 @@ impl SpatialView2D {
         let view_ctx = self.view_context(ctx, query.view_id, state); // Recreate view state to handle context editing during picking.
 
         for draw_data in system_output.draw_data {
-            view_builder.queue_draw(draw_data);
+            view_builder.queue_draw(ctx.render_ctx(), draw_data);
         }
 
         let background = ViewProperty::from_archetype::<Background>(
@@ -273,7 +273,7 @@ impl SpatialView2D {
         let (background_drawable, clear_color) =
             crate::configure_background(&view_ctx, &background, self)?;
         if let Some(background_drawable) = background_drawable {
-            view_builder.queue_draw(background_drawable);
+            view_builder.queue_draw(ctx.render_ctx(), background_drawable);
         }
 
         // ------------------------------------------------------------------------

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -677,7 +677,7 @@ impl SpatialView3D {
         );
 
         for draw_data in system_output.draw_data {
-            view_builder.queue_draw(draw_data);
+            view_builder.queue_draw(ctx.render_ctx(), draw_data);
         }
 
         let view_ctx = self.view_context(ctx, query.view_id, state);
@@ -689,11 +689,11 @@ impl SpatialView3D {
             query.view_id,
         );
         if let Some(draw_data) = self.setup_grid_3d(&view_ctx, &grid_config)? {
-            view_builder.queue_draw(draw_data);
+            view_builder.queue_draw(ctx.render_ctx(), draw_data);
         }
 
         // Commit ui induced lines.
-        view_builder.queue_draw(line_builder.into_draw_data()?);
+        view_builder.queue_draw(ctx.render_ctx(), line_builder.into_draw_data()?);
 
         let background = ViewProperty::from_archetype::<Background>(
             ctx.blueprint_db(),
@@ -703,7 +703,7 @@ impl SpatialView3D {
         let (background_drawable, clear_color) =
             crate::configure_background(&view_ctx, &background, self)?;
         if let Some(background_drawable) = background_drawable {
-            view_builder.queue_draw(background_drawable);
+            view_builder.queue_draw(ctx.render_ctx(), background_drawable);
         }
 
         ui.painter().add(gpu_bridge::new_renderer_callback(

--- a/crates/viewer/re_view_spatial/src/visualizers/encoded_image.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/encoded_image.rs
@@ -70,7 +70,7 @@ impl VisualizerSystem for EncodedImageVisualizer {
             },
         )?;
 
-        // TODO(#702): draw order is translated to depth offset, which works fine for opaque images,
+        // TODO(#1025): draw order is translated to depth offset, which works fine for opaque images,
         // but for everything with transparency, actual drawing order is still important.
         // We mitigate this a bit by at least sorting the images within each other.
         // Sorting of Images vs DepthImage vs SegmentationImage uses the fact that

--- a/crates/viewer/re_view_spatial/src/visualizers/images.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/images.rs
@@ -75,7 +75,7 @@ impl VisualizerSystem for ImageVisualizer {
             },
         )?;
 
-        // TODO(#702): draw order is translated to depth offset, which works fine for opaque images,
+        // TODO(#1025): draw order is translated to depth offset, which works fine for opaque images,
         // but for everything with transparency, actual drawing order is still important.
         // We mitigate this a bit by at least sorting the images within each other.
         // Sorting of Images vs DepthImage vs SegmentationImage uses the fact that

--- a/crates/viewer/re_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/segmentation_images.rs
@@ -146,7 +146,7 @@ impl VisualizerSystem for SegmentationImageVisualizer {
             },
         )?;
 
-        // TODO(#702): draw order is translated to depth offset, which works fine for opaque images,
+        // TODO(#1025): draw order is translated to depth offset, which works fine for opaque images,
         // but for everything with transparency, actual drawing order is still important.
         // We mitigate this a bit by at least sorting the segmentation images within each other.
         // Sorting of Images vs DepthImage vs SegmentationImage uses the fact that

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
@@ -154,10 +154,10 @@ pub fn render_image(
 
     let mut view_builder = ViewBuilder::new(render_ctx, target_config)?;
 
-    view_builder.queue_draw(re_renderer::renderer::RectangleDrawData::new(
+    view_builder.queue_draw(
         render_ctx,
-        &[textured_rectangle],
-    )?);
+        re_renderer::renderer::RectangleDrawData::new(render_ctx, &[textured_rectangle])?,
+    );
 
     egui_painter.add(new_renderer_callback(
         view_builder,

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/re_renderer_callback.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/re_renderer_callback.rs
@@ -1,3 +1,5 @@
+use parking_lot::Mutex;
+
 slotmap::new_key_type! { pub struct ViewBuilderHandle; }
 
 pub fn new_renderer_callback(
@@ -8,14 +10,14 @@ pub fn new_renderer_callback(
     egui_wgpu::Callback::new_paint_callback(
         viewport,
         ReRendererCallback {
-            view_builder,
+            view_builder: Mutex::new(view_builder),
             clear_color,
         },
     )
 }
 
 struct ReRendererCallback {
-    view_builder: re_renderer::ViewBuilder,
+    view_builder: Mutex<re_renderer::ViewBuilder>,
     clear_color: re_renderer::Rgba,
 }
 
@@ -38,7 +40,7 @@ impl egui_wgpu::CallbackTrait for ReRendererCallback {
             return Vec::new();
         };
 
-        match self.view_builder.draw(ctx, self.clear_color) {
+        match self.view_builder.lock().draw(ctx, self.clear_color) {
             Ok(command_buffer) => vec![command_buffer],
             Err(err) => {
                 re_log::error_once!("Failed to fill view builder: {err}");
@@ -61,6 +63,6 @@ impl egui_wgpu::CallbackTrait for ReRendererCallback {
             );
             return;
         };
-        self.view_builder.composite(ctx, render_pass);
+        self.view_builder.lock().composite(ctx, render_pass);
     }
 }


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/702
* Unblocks https://github.com/rerun-io/rerun/issues/1025
* Unblocks https://github.com/rerun-io/rerun/issues/4787
* Unblocks https://github.com/rerun-io/rerun/issues/8226
* Unblocks https://github.com/rerun-io/rerun/issues/1611
* Unblocks https://github.com/rerun-io/rerun/issues/7193
* Unblocks https://github.com/rerun-io/rerun/issues/8066
* Unblocks https://github.com/rerun-io/rerun/issues/6009 (some more challenges here though)
* Unblocks https://github.com/rerun-io/rerun/issues/4106
* Somewhat related to https://github.com/rerun-io/rerun/issues/4529
* Based on https://github.com/rerun-io/rerun/pull/11082

### What

Bit of an architectural shift on how we schedule drawing in re_renderer. Previously, we'd only supplied `DrawData` and drew them for every draw phase that made sense.
Now we additionally collect `Drawables` which refer into `DrawData` but unlike `DrawData` they are fixed size & super lightweight, allowing us to sort them depending on a phase's need i.e. far to near for transparent and aggressively batching for everything else.
This also means that `Renderer::draw` is now only called once in opaque draw phases with all collected draw data & drawables.
(it would be great to collect statistics about this, but that hasn't been implemented yet)

An updated overview of the drawing life cycle can be found in re_renderer's lib.rs

* [x] pass full ci