### PR TITLE
Show welcome screen when all recordings are closed

### DIFF
--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -613,8 +613,8 @@ impl App {
             }
 
             SystemCommand::CloseAllEntries => {
+                self.state.navigation.push_default();
                 store_hub.clear_entries();
-                self.state.navigation.clear();
 
                 // Stop receiving into the old recordings.
                 // This is most important when going back to the example screen by using the "Back"
@@ -2722,7 +2722,6 @@ impl eframe::App for App {
         // Make sure some app is active
         // Must be called before `read_context` below.
         if store_hub.active_app().is_none() {
-            self.state.navigation.clear();
             let apps: std::collections::BTreeSet<&ApplicationId> = store_hub
                 .store_bundle()
                 .entity_dbs()
@@ -2748,6 +2747,7 @@ impl eframe::App for App {
                     None => {}
                 }
             } else {
+                self.state.navigation.push_default();
                 store_hub.set_active_app(StoreHub::welcome_screen_app_id());
             }
         }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -614,6 +614,7 @@ impl App {
 
             SystemCommand::CloseAllEntries => {
                 store_hub.clear_entries();
+                self.state.navigation.clear();
 
                 // Stop receiving into the old recordings.
                 // This is most important when going back to the example screen by using the "Back"
@@ -2721,6 +2722,7 @@ impl eframe::App for App {
         // Make sure some app is active
         // Must be called before `read_context` below.
         if store_hub.active_app().is_none() {
+            self.state.navigation.clear();
             let apps: std::collections::BTreeSet<&ApplicationId> = store_hub
                 .store_bundle()
                 .entity_dbs()

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -613,7 +613,7 @@ impl App {
             }
 
             SystemCommand::CloseAllEntries => {
-                self.state.navigation.push_default();
+                self.state.navigation.push_start_mode();
                 store_hub.clear_entries();
 
                 // Stop receiving into the old recordings.
@@ -2747,7 +2747,7 @@ impl eframe::App for App {
                     None => {}
                 }
             } else {
-                self.state.navigation.push_default();
+                self.state.navigation.push_start_mode();
                 store_hub.set_active_app(StoreHub::welcome_screen_app_id());
             }
         }

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -617,11 +617,9 @@ impl AppState {
 
                             DisplayMode::LocalRecordings => {
                                 // If we are here and the "default" app id is selected,
-                                // or the selection is empty we should instead switch to
-                                // the welcome screen.
-                                if ctx.store_context.recording_store_id().is_empty_recording()
-                                    || ctx.store_context.application_id()
-                                        == &StoreHub::welcome_screen_app_id()
+                                // we should instead switch to the welcome screen.
+                                if ctx.store_context.application_id()
+                                    == &StoreHub::welcome_screen_app_id()
                                 {
                                     ctx.command_sender().send_system(
                                         SystemCommand::ChangeDisplayMode(DisplayMode::RedapServer(

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -617,9 +617,11 @@ impl AppState {
 
                             DisplayMode::LocalRecordings => {
                                 // If we are here and the "default" app id is selected,
-                                // we should instead switch to the welcome screen.
-                                if ctx.store_context.application_id()
-                                    == &StoreHub::welcome_screen_app_id()
+                                // or the selection is empty we should instead switch to
+                                // the welcome screen.
+                                if ctx.store_context.recording_store_id().is_empty_recording()
+                                    || ctx.store_context.application_id()
+                                        == &StoreHub::welcome_screen_app_id()
                                 {
                                     ctx.command_sender().send_system(
                                         SystemCommand::ChangeDisplayMode(DisplayMode::RedapServer(

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -27,6 +27,10 @@ impl Navigation {
         self.history.push(display_mode);
     }
 
+    pub fn push_default(&mut self) {
+        self.push(self.default.clone());
+    }
+
     pub fn replace(&mut self, new_mode: DisplayMode) -> Option<DisplayMode> {
         let previous = self.history.pop();
 
@@ -46,9 +50,5 @@ impl Navigation {
 
     pub fn peek(&self) -> &DisplayMode {
         self.history.last().unwrap_or(&self.default)
-    }
-
-    pub fn clear(&mut self) {
-        *self = Self::default();
     }
 }

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -6,14 +6,14 @@ use re_viewer_context::DisplayMode;
 /// we retrieve the display mode and pass that around.
 pub(crate) struct Navigation {
     history: Vec<DisplayMode>,
-    default: DisplayMode,
+    start_mode: DisplayMode,
 }
 
 impl Default for Navigation {
     fn default() -> Self {
         Self {
             history: Default::default(),
-            default: DisplayMode::RedapServer(re_redap_browser::EXAMPLES_ORIGIN.clone()),
+            start_mode: DisplayMode::RedapServer(re_redap_browser::EXAMPLES_ORIGIN.clone()),
         }
     }
 }
@@ -27,8 +27,12 @@ impl Navigation {
         self.history.push(display_mode);
     }
 
-    pub fn push_default(&mut self) {
-        self.push(self.default.clone());
+    /// Pushes the start display mode to history which is also the fallback mode for
+    /// navigation.
+    ///
+    /// This is defined in the default implementation for [`Navigation`]
+    pub fn push_start_mode(&mut self) {
+        self.push(self.start_mode.clone());
     }
 
     pub fn replace(&mut self, new_mode: DisplayMode) -> Option<DisplayMode> {
@@ -49,6 +53,6 @@ impl Navigation {
     }
 
     pub fn peek(&self) -> &DisplayMode {
-        self.history.last().unwrap_or(&self.default)
+        self.history.last().unwrap_or(&self.start_mode)
     }
 }

--- a/crates/viewer/re_viewer/src/navigation.rs
+++ b/crates/viewer/re_viewer/src/navigation.rs
@@ -47,4 +47,8 @@ impl Navigation {
     pub fn peek(&self) -> &DisplayMode {
         self.history.last().unwrap_or(&self.default)
     }
+
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
 }

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -402,6 +402,7 @@ impl StoreHub {
 
         self.table_stores.clear();
         self.active_application_id = Some(Self::welcome_screen_app_id());
+        self.active_recording_or_table = None;
     }
 
     // ---------------------


### PR DESCRIPTION
### Related

Closes RR-1573

Closes #10872

### What

Fixes a regression where the viewer was put in an undefined state after all recordings were closed.