### PR TITLE
Fix typo: "elsapsed" -> "elapsed"

### DIFF
--- a/crates/store/re_log_types/src/index/timestamp.rs
+++ b/crates/store/re_log_types/src/index/timestamp.rs
@@ -38,7 +38,7 @@ impl Timestamp {
     }
 
     #[inline]
-    pub fn elsapsed(self) -> Duration {
+    pub fn elapsed(self) -> Duration {
         Self::now() - self
     }
 }

--- a/crates/viewer/re_ui/src/time.rs
+++ b/crates/viewer/re_ui/src/time.rs
@@ -50,7 +50,7 @@ pub fn short_duration_ui(
     show: impl FnOnce(&mut egui::Ui, String) -> egui::Response,
 ) -> egui::Response {
     // Remember to update the ui so it doesn't say "just now" forever:
-    let age = timestamp.elsapsed().as_secs_f64();
+    let age = timestamp.elapsed().as_secs_f64();
     let repaint_in_sec = if age < 60.0 {
         1
     } else if age < 3600.0 {


### PR DESCRIPTION
### Related
* Introduced in https://github.com/rerun-io/rerun/pull/11114
