### PR TITLE
Refactor setting selection to always use system commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9078,7 +9078,6 @@ dependencies = [
  "half",
  "home",
  "image",
- "indexmap 2.10.0",
  "itertools 0.14.0",
  "linked-hash-map",
  "macaw",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7757,6 +7757,8 @@ dependencies = [
  "egui",
  "egui_tiles",
  "home",
+ "indexmap 2.10.0",
+ "itertools 0.14.0",
  "re_capabilities",
  "re_chunk",
  "re_chunk_store",

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -13,8 +13,8 @@ use re_ui::{
 };
 use re_viewer_context::{
     CollapseScope, ContainerId, Contents, DragAndDropFeedback, DragAndDropPayload, HoverHighlight,
-    Item, ItemCollection, ItemContext, SystemCommandSender as _, ViewId, ViewerContext,
-    VisitorControlFlow, contents_name_style, icon_for_container_kind,
+    Item, ItemCollection, ItemContext, SystemCommand, SystemCommandSender as _, ViewId,
+    ViewerContext, VisitorControlFlow, contents_name_style, icon_for_container_kind,
 };
 use re_viewport_blueprint::{ViewportBlueprint, ui::show_add_view_or_container_modal};
 
@@ -165,7 +165,8 @@ impl BlueprintTree {
 
                     // clear selection upon clicking on empty space
                     if empty_space_response.clicked() {
-                        ctx.selection_state().clear_selection();
+                        ctx.command_sender()
+                            .send_system(SystemCommand::clear_selection());
                     }
 
                     // handle drag and drop interaction on empty space
@@ -554,7 +555,8 @@ impl BlueprintTree {
                     )
                     .clicked()
                 {
-                    ctx.selection_state().set_selection(item);
+                    ctx.command_sender()
+                        .send_system(SystemCommand::SetSelection(item.into()));
                 }
 
                 return;
@@ -724,7 +726,8 @@ impl BlueprintTree {
             });
 
             if let ControlFlow::Break(Some(item)) = result {
-                ctx.selection_state().set_selection(item.clone());
+                ctx.command_sender()
+                    .send_system(SystemCommand::SetSelection(item.clone().into()));
                 self.scroll_to_me_item = Some(item.clone());
                 self.range_selection_anchor_item = Some(item);
             }
@@ -753,7 +756,8 @@ impl BlueprintTree {
             });
 
             if let ControlFlow::Break(Some(item)) = result {
-                ctx.selection_state().set_selection(item.clone());
+                ctx.command_sender()
+                    .send_system(SystemCommand::SetSelection(item.clone().into()));
                 self.scroll_to_me_item = Some(item.clone());
                 self.range_selection_anchor_item = Some(item);
             }
@@ -802,9 +806,11 @@ impl BlueprintTree {
                     );
 
                     if modifiers.command {
-                        ctx.selection_state.extend_selection(items);
+                        ctx.selection_state
+                            .extend_selection(items, ctx.command_sender());
                     } else {
-                        ctx.selection_state.set_selection(items);
+                        ctx.command_sender()
+                            .send_system(SystemCommand::SetSelection(items));
                     }
                 }
             }

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -806,8 +806,11 @@ impl BlueprintTree {
                     );
 
                     if modifiers.command {
-                        ctx.selection_state
-                            .extend_selection(items, ctx.command_sender());
+                        // We extend into the current selection to append new items at the end.
+                        let mut selection = ctx.selection().clone();
+                        selection.extend(items);
+                        ctx.command_sender()
+                            .send_system(SystemCommand::SetSelection(selection));
                     } else {
                         ctx.command_sender()
                             .send_system(SystemCommand::SetSelection(items));

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -75,7 +75,7 @@ pub fn redap_uri_button(
             // Show it:
             ctx.command_sender()
                 .send_system(SystemCommand::SetSelection(
-                    re_viewer_context::Item::StoreId(loaded_recording_id),
+                    re_viewer_context::Item::StoreId(loaded_recording_id).into(),
                 ));
         }
     } else if is_loading {

--- a/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
+++ b/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
@@ -5,7 +5,7 @@ use nohash_hasher::IntSet;
 use re_log_types::{EntityPath, EntityPathFilter, EntityPathRule, RuleEffect};
 use re_types::ViewClassIdentifier;
 use re_ui::UiExt as _;
-use re_viewer_context::{Item, RecommendedView};
+use re_viewer_context::{Item, RecommendedView, SystemCommand, SystemCommandSender as _};
 use re_viewport_blueprint::ViewBlueprint;
 
 use crate::{ContextMenuAction, ContextMenuContext};
@@ -174,8 +174,8 @@ fn create_view_for_selected_entities(
     ctx.viewport_blueprint
         .add_views(std::iter::once(view), target_container_id, None);
     ctx.viewer_context
-        .selection_state()
-        .set_selection(Item::View(view_id));
+        .command_sender()
+        .send_system(SystemCommand::SetSelection(Item::View(view_id).into()));
     ctx.viewport_blueprint
         .mark_user_interaction(ctx.viewer_context);
 }

--- a/crates/viewer/re_context_menu/src/actions/clone_view.rs
+++ b/crates/viewer/re_context_menu/src/actions/clone_view.rs
@@ -1,4 +1,4 @@
-use re_viewer_context::{Item, ViewId};
+use re_viewer_context::{Item, SystemCommand, SystemCommandSender as _, ViewId};
 
 use crate::{ContextMenuAction, ContextMenuContext};
 
@@ -20,8 +20,8 @@ impl ContextMenuAction for CloneViewAction {
             .duplicate_view(view_id, ctx.viewer_context)
         {
             ctx.viewer_context
-                .selection_state()
-                .set_selection(Item::View(new_view_id));
+                .command_sender()
+                .send_system(SystemCommand::SetSelection(Item::View(new_view_id).into()));
             ctx.viewport_blueprint
                 .mark_user_interaction(ctx.viewer_context);
         }

--- a/crates/viewer/re_context_menu/src/lib.rs
+++ b/crates/viewer/re_context_menu/src/lib.rs
@@ -10,7 +10,8 @@ use re_entity_db::InstancePath;
 use re_log_types::TableId;
 use re_ui::UiExt as _;
 use re_viewer_context::{
-    ContainerId, Contents, Item, ItemCollection, ItemContext, ViewId, ViewerContext,
+    ContainerId, Contents, Item, ItemCollection, ItemContext, SystemCommand,
+    SystemCommandSender as _, ViewId, ViewerContext,
 };
 use re_viewport_blueprint::{ContainerBlueprint, ViewportBlueprint};
 
@@ -121,7 +122,8 @@ fn context_menu_ui_for_item_with_context_impl(
                         // and, if not, we update the selection to include only the item that was clicked.
                         if item_response.hovered() && item_response.secondary_clicked() {
                             show_context_menu(&item_collection);
-                            ctx.selection_state().set_selection(item_collection);
+                            ctx.command_sender()
+                                .send_system(SystemCommand::SetSelection(item_collection));
                         } else {
                             show_context_menu(ctx.selection());
                         }
@@ -134,7 +136,8 @@ fn context_menu_ui_for_item_with_context_impl(
                     show_context_menu(&item_collection);
 
                     if item_response.secondary_clicked() {
-                        ctx.selection_state().set_selection(item_collection);
+                        ctx.command_sender()
+                            .send_system(SystemCommand::SetSelection(item_collection));
                     }
                 }
 

--- a/crates/viewer/re_global_context/Cargo.toml
+++ b/crates/viewer/re_global_context/Cargo.toml
@@ -50,6 +50,8 @@ rfd.workspace = true
 serde.workspace = true
 strum_macros.workspace = true
 uuid = { workspace = true, features = ["serde", "v4", "js"] }
+indexmap = { workspace = true, features = ["std", "serde"] }
+itertools.workspace = true
 
 
 # Native dependencies:

--- a/crates/viewer/re_global_context/src/command_sender.rs
+++ b/crates/viewer/re_global_context/src/command_sender.rs
@@ -91,7 +91,7 @@ pub enum SystemCommand {
     EnableInspectBlueprintTimeline(bool),
 
     /// Set the item selection.
-    SetSelection(crate::Item),
+    SetSelection(crate::ItemCollection),
 
     /// Set the active timeline and time for the given recording.
     SetActiveTime {
@@ -129,6 +129,12 @@ pub enum SystemCommand {
     /// Add a task, run on a background thread, that saves something to disk.
     #[cfg(not(target_arch = "wasm32"))]
     FileSaver(Box<dyn FnOnce() -> anyhow::Result<std::path::PathBuf> + Send + 'static>),
+}
+
+impl SystemCommand {
+    pub fn clear_selection() -> Self {
+        Self::SetSelection(crate::ItemCollection::default())
+    }
 }
 
 impl std::fmt::Debug for SystemCommand {

--- a/crates/viewer/re_global_context/src/item_collection.rs
+++ b/crates/viewer/re_global_context/src/item_collection.rs
@@ -1,0 +1,299 @@
+use indexmap::IndexMap;
+use itertools::Itertools as _;
+use re_chunk::EntityPath;
+use re_entity_db::EntityDb;
+use re_log_types::StoreKind;
+use re_types::external::glam;
+
+use crate::{Item, ViewId, resolve_mono_instance_path_item};
+
+/// Context information that a view might attach to an item from [`ItemCollection`] and useful
+/// for how a selection might be displayed and interacted with.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+pub enum ItemContext {
+    /// Hovering/Selecting in a 2D space.
+    TwoD {
+        space_2d: EntityPath,
+
+        /// Where in this 2D space (+ depth)?
+        pos: glam::Vec3,
+    },
+
+    /// Hovering/Selecting in a 3D space.
+    ThreeD {
+        /// The 3D space with the camera(s)
+        space_3d: EntityPath,
+
+        /// The point in 3D space that is hovered, if any.
+        pos: Option<glam::Vec3>,
+
+        /// Path to an entity that is currently tracked by the eye-camera.
+        /// (None for a free floating Eye)
+        tracked_entity: Option<EntityPath>,
+
+        /// Corresponding 2D spaces and pixel coordinates (with Z=depth)
+        point_in_space_cameras: Vec<(EntityPath, Option<glam::Vec3>)>,
+    },
+
+    /// Hovering/selecting in one of the streams trees.
+    StreamsTree {
+        /// Which store does this streams tree correspond to?
+        store_kind: StoreKind,
+
+        /// The current entity filter session id, if any.
+        filter_session_id: Option<egui::Id>,
+    },
+
+    /// Hovering/selecting in the blueprint tree.
+    BlueprintTree {
+        /// The current entity filter session id, if any.
+        filter_session_id: Option<egui::Id>,
+    },
+}
+/// An ordered collection of [`Item`] and optional associated context objects.
+///
+/// Used to store what is currently selected and/or hovered.
+#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+pub struct ItemCollection(IndexMap<Item, Option<ItemContext>>);
+
+impl From<Item> for ItemCollection {
+    #[inline]
+    fn from(val: Item) -> Self {
+        Self([(val, None)].into())
+    }
+}
+
+impl ItemCollection {
+    pub fn from_items_and_context(
+        items: impl IntoIterator<Item = (Item, Option<ItemContext>)>,
+    ) -> Self {
+        Self(items.into_iter().collect())
+    }
+
+    /// Is this view the selected one (and no other)?
+    pub fn is_view_the_only_selected(&self, needle: &ViewId) -> bool {
+        let mut is_selected = false;
+        for item in self.iter_items() {
+            let item_is_view = match item {
+                Item::View(id) | Item::DataResult(id, _) => id == needle,
+                _ => false,
+            };
+
+            if item_is_view {
+                is_selected = true;
+            } else {
+                return false; // More than one view selected
+            }
+        }
+        is_selected
+    }
+}
+
+impl IntoIterator for ItemCollection {
+    type Item = (Item, Option<ItemContext>);
+    type IntoIter = indexmap::map::IntoIter<Item, Option<ItemContext>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl ItemCollection {
+    /// For each item in this selection, if it refers to the first element of an instance with a
+    /// single element, resolve it to a unindexed entity path.
+    pub fn into_mono_instance_path_items(
+        self,
+        entity_db: &EntityDb,
+        query: &re_chunk_store::LatestAtQuery,
+    ) -> Self {
+        Self(
+            self.0
+                .into_iter()
+                .map(|(item, item_context)| {
+                    (
+                        resolve_mono_instance_path_item(entity_db, query, &item),
+                        item_context,
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    /// The first selected object if any.
+    pub fn first_item(&self) -> Option<&Item> {
+        self.0.keys().next()
+    }
+
+    /// Check if the selection contains a single item and returns it if so.
+    pub fn single_item(&self) -> Option<&Item> {
+        if self.len() == 1 {
+            self.first_item()
+        } else {
+            None
+        }
+    }
+
+    pub fn iter_items(&self) -> impl Iterator<Item = &Item> {
+        self.0.keys()
+    }
+
+    pub fn iter_item_context(&self) -> impl Iterator<Item = &ItemContext> {
+        self.0
+            .iter()
+            .filter_map(|(_, item_context)| item_context.as_ref())
+    }
+
+    pub fn context_for_item(&self, item: &Item) -> Option<&ItemContext> {
+        self.0.get(item).and_then(Option::as_ref)
+    }
+
+    /// Returns true if the exact selection is part of the current selection.
+    pub fn contains_item(&self, needle: &Item) -> bool {
+        self.0.iter().any(|(item, _)| item == needle)
+    }
+
+    pub fn are_all_items_same_kind(&self) -> Option<&'static str> {
+        if let Some(first_item) = self.first_item()
+            && self
+                .iter_items()
+                .skip(1)
+                .all(|item| std::mem::discriminant(first_item) == std::mem::discriminant(item))
+        {
+            return Some(first_item.kind());
+        }
+        None
+    }
+
+    /// Retains elements that fulfill a certain condition.
+    pub fn retain(&mut self, f: impl FnMut(&Item, &mut Option<ItemContext>) -> bool) {
+        self.0.retain(f);
+    }
+
+    /// Returns the number of items in the selection.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Check if the selection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the items and their selected context.
+    pub fn iter(&self) -> impl Iterator<Item = (&Item, &Option<ItemContext>)> {
+        self.0.iter()
+    }
+
+    /// Returns a mutable iterator over the items and their selected context.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Item, &mut Option<ItemContext>)> {
+        self.0.iter_mut()
+    }
+
+    /// Extend the selection with more items.
+    pub fn extend(&mut self, other: impl IntoIterator<Item = (Item, Option<ItemContext>)>) {
+        self.0.extend(other);
+    }
+
+    /// Tries to copy a description of the selection to the clipboard.
+    ///
+    /// Only certain elements are copyable right now.
+    pub fn copy_to_clipboard(&self, egui_ctx: &egui::Context) {
+        if self.is_empty() {
+            return;
+        }
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        enum ClipboardTextDesc {
+            FilePath,
+            Url,
+            AppId,
+            StoreId,
+            EntityPath,
+        }
+
+        #[allow(clippy::match_same_arms)]
+        let clipboard_texts_per_type = self
+            .iter()
+            .filter_map(|(item, _)| match item {
+                Item::Container(_) => None,
+                Item::View(_) => None,
+                // TODO(lucasmerlin): Should these be copyable as URLs?
+                Item::RedapServer(_) => None,
+                Item::RedapEntry(_) => None,
+                Item::TableId(_) => None, // TODO(grtlr): Make `TableId`s copyable too
+
+                Item::DataSource(source) => match source {
+                    re_smart_channel::SmartChannelSource::File(path) => {
+                        Some((ClipboardTextDesc::FilePath, path.to_string_lossy().into()))
+                    }
+                    re_smart_channel::SmartChannelSource::RrdHttpStream { url, follow: _ } => {
+                        Some((ClipboardTextDesc::Url, url.clone()))
+                    }
+                    re_smart_channel::SmartChannelSource::RrdWebEventListener => None,
+                    re_smart_channel::SmartChannelSource::JsChannel { .. } => None,
+                    re_smart_channel::SmartChannelSource::Sdk => None,
+                    re_smart_channel::SmartChannelSource::Stdin => None,
+                    re_smart_channel::SmartChannelSource::RedapGrpcStream { uri, .. } => {
+                        Some((ClipboardTextDesc::Url, uri.to_string()))
+                    }
+                    re_smart_channel::SmartChannelSource::MessageProxy(uri) => {
+                        Some((ClipboardTextDesc::Url, uri.to_string()))
+                    }
+                },
+
+                Item::AppId(id) => Some((ClipboardTextDesc::AppId, id.to_string())),
+
+                // TODO(ab): it is not very meaningful to copy the `StoreId` representation, but
+                // that's the best we can do for now. In the future, we should have URIs for
+                // in-memory recordings, and that's what we should copy here.
+                Item::StoreId(id) => Some((ClipboardTextDesc::StoreId, format!("{id:?}"))),
+
+                Item::DataResult(_, instance_path) | Item::InstancePath(instance_path) => Some((
+                    ClipboardTextDesc::EntityPath,
+                    instance_path.entity_path.to_string(),
+                )),
+                Item::ComponentPath(component_path) => Some((
+                    ClipboardTextDesc::EntityPath,
+                    component_path.entity_path.to_string(),
+                )),
+            })
+            .chunk_by(|(desc, _)| *desc);
+
+        let mut clipboard_text = String::new();
+        let mut content_description = String::new();
+
+        for (desc, entries) in &clipboard_texts_per_type {
+            let entries = entries.map(|(_, text)| text).collect_vec();
+
+            let desc = match desc {
+                ClipboardTextDesc::FilePath => "file path",
+                ClipboardTextDesc::Url => "URL",
+                ClipboardTextDesc::AppId => "app id",
+                ClipboardTextDesc::StoreId => "store id",
+                ClipboardTextDesc::EntityPath => "entity path",
+            };
+            if !content_description.is_empty() {
+                content_description.push_str(", ");
+            }
+            if entries.len() == 1 {
+                content_description.push_str(desc);
+            } else {
+                content_description.push_str(&format!("{desc}s"));
+            }
+
+            let texts = entries.into_iter().join("\n");
+            if !clipboard_text.is_empty() {
+                clipboard_text.push('\n');
+            }
+            clipboard_text.push_str(&texts);
+        }
+
+        if !clipboard_text.is_empty() {
+            re_log::info!(
+                "Copied {content_description} to clipboard:\n{}",
+                &clipboard_text
+            );
+            egui_ctx.copy_text(clipboard_text);
+        }
+    }
+}

--- a/crates/viewer/re_global_context/src/item_collection.rs
+++ b/crates/viewer/re_global_context/src/item_collection.rs
@@ -50,6 +50,7 @@ pub enum ItemContext {
         filter_session_id: Option<egui::Id>,
     },
 }
+
 /// An ordered collection of [`Item`] and optional associated context objects.
 ///
 /// Used to store what is currently selected and/or hovered.

--- a/crates/viewer/re_global_context/src/lib.rs
+++ b/crates/viewer/re_global_context/src/lib.rs
@@ -8,6 +8,7 @@ mod command_sender;
 mod contents;
 mod file_dialog;
 mod item;
+mod item_collection;
 mod recording_or_table;
 
 pub use self::{
@@ -19,6 +20,7 @@ pub use self::{
     contents::{Contents, ContentsName, blueprint_id_to_tile_id},
     file_dialog::santitize_file_name,
     item::{Item, resolve_mono_instance_path, resolve_mono_instance_path_item},
+    item_collection::{ItemCollection, ItemContext},
     recording_or_table::RecordingOrTable,
 };
 

--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -390,7 +390,7 @@ fn dataset_entry_ui(
 
     if item_response.clicked() {
         ctx.command_sender()
-            .send_system(SystemCommand::SetSelection(item));
+            .send_system(SystemCommand::SetSelection(item.into()));
         ctx.command_sender()
             .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
                 re_uri::EntryUri::new(origin.clone(), *entry_id),
@@ -424,7 +424,7 @@ fn remote_table_entry_ui(
 
     if item_response.clicked() {
         ctx.command_sender()
-            .send_system(SystemCommand::SetSelection(item));
+            .send_system(SystemCommand::SetSelection(item.into()));
         ctx.command_sender()
             .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
                 re_uri::EntryUri::new(origin.clone(), *entry_id),
@@ -459,7 +459,7 @@ fn failed_entry_ui(
 
     if item_response.clicked() {
         ctx.command_sender()
-            .send_system(SystemCommand::SetSelection(item));
+            .send_system(SystemCommand::SetSelection(item.into()));
         ctx.command_sender()
             .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
                 re_uri::EntryUri::new(origin.clone(), *entry_id),

--- a/crates/viewer/re_redap_browser/src/lib.rs
+++ b/crates/viewer/re_redap_browser/src/lib.rs
@@ -43,6 +43,6 @@ pub fn switch_to_welcome_screen(command_sender: &re_viewer_context::CommandSende
         re_viewer_context::DisplayMode::RedapServer(EXAMPLES_ORIGIN.clone()),
     ));
     command_sender.send_system(SystemCommand::SetSelection(
-        re_viewer_context::Item::RedapServer(EXAMPLES_ORIGIN.clone()),
+        re_viewer_context::Item::RedapServer(EXAMPLES_ORIGIN.clone()).into(),
     ));
 }

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -14,8 +14,9 @@ use re_ui::{
     list_item::{self, PropertyContent},
 };
 use re_viewer_context::{
-    ContainerId, Contents, DataQueryResult, DataResult, HoverHighlight, Item, UiLayout,
-    ViewContext, ViewId, ViewStates, ViewerContext, contents_name_style, icon_for_container_kind,
+    ContainerId, Contents, DataQueryResult, DataResult, HoverHighlight, Item, SystemCommand,
+    SystemCommandSender as _, UiLayout, ViewContext, ViewId, ViewStates, ViewerContext,
+    contents_name_style, icon_for_container_kind,
 };
 use re_viewport_blueprint::{ViewportBlueprint, ui::show_add_view_or_container_modal};
 
@@ -571,7 +572,8 @@ fn clone_view_button_ui(
         list_item::ButtonContent::new("Clone this view")
             .on_click(|| {
                 if let Some(new_view_id) = viewport.duplicate_view(&view_id, ctx) {
-                    ctx.selection_state().set_selection(Item::View(new_view_id));
+                    ctx.command_sender()
+                        .send_system(SystemCommand::SetSelection(Item::View(new_view_id).into()));
                     viewport.mark_user_interaction(ctx);
                 }
             })

--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -1180,8 +1180,11 @@ impl TimePanel {
                     );
 
                     if modifiers.command {
-                        ctx.selection_state
-                            .extend_selection(items, ctx.command_sender());
+                        // We extend into the current selection to append new items at the end.
+                        let mut selection = ctx.selection().clone();
+                        selection.extend(items);
+                        ctx.command_sender()
+                            .send_system(SystemCommand::SetSelection(selection));
                     } else {
                         ctx.command_sender()
                             .send_system(SystemCommand::SetSelection(items));

--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -19,8 +19,9 @@ use re_types_core::ComponentDescriptor;
 use re_ui::{ContextExt as _, DesignTokens, Help, UiExt as _, filter_widget, icons, list_item};
 use re_ui::{IconText, filter_widget::format_matching_text};
 use re_viewer_context::{
-    CollapseScope, HoverHighlight, Item, ItemCollection, ItemContext, RecordingConfig, TimeControl,
-    TimeView, UiLayout, ViewerContext, VisitorControlFlow,
+    CollapseScope, HoverHighlight, Item, ItemCollection, ItemContext, RecordingConfig,
+    SystemCommand, SystemCommandSender as _, TimeControl, TimeView, UiLayout, ViewerContext,
+    VisitorControlFlow,
 };
 use re_viewport_blueprint::ViewportBlueprint;
 
@@ -1095,7 +1096,8 @@ impl TimePanel {
             });
 
             if let ControlFlow::Break(Some(item)) = result {
-                ctx.selection_state().set_selection(item.clone());
+                ctx.command_sender()
+                    .send_system(SystemCommand::SetSelection(item.clone().into()));
                 self.scroll_to_me_item = Some(item.clone());
                 self.range_selection_anchor_item = Some(item);
             }
@@ -1126,7 +1128,8 @@ impl TimePanel {
             });
 
             if let ControlFlow::Break(Some(item)) = result {
-                ctx.selection_state().set_selection(item.clone());
+                ctx.command_sender()
+                    .send_system(SystemCommand::SetSelection(item.clone().into()));
                 self.scroll_to_me_item = Some(item.clone());
                 self.range_selection_anchor_item = Some(item);
             }
@@ -1177,9 +1180,11 @@ impl TimePanel {
                     );
 
                     if modifiers.command {
-                        ctx.selection_state.extend_selection(items);
+                        ctx.selection_state
+                            .extend_selection(items, ctx.command_sender());
                     } else {
-                        ctx.selection_state.set_selection(items);
+                        ctx.command_sender()
+                            .send_system(SystemCommand::SetSelection(items));
                     }
                 }
             }

--- a/crates/viewer/re_view_dataframe/src/view_class.rs
+++ b/crates/viewer/re_view_dataframe/src/view_class.rs
@@ -6,8 +6,9 @@ use re_log_types::EntityPath;
 use re_types_core::ViewClassIdentifier;
 use re_ui::{Help, UiExt as _};
 use re_viewer_context::{
-    Item, SystemExecutionOutput, ViewClass, ViewClassRegistryError, ViewId, ViewQuery,
-    ViewSpawnHeuristics, ViewState, ViewStateExt as _, ViewSystemExecutionError, ViewerContext,
+    Item, SystemCommand, SystemCommandSender as _, SystemExecutionOutput, ViewClass,
+    ViewClassRegistryError, ViewId, ViewQuery, ViewSpawnHeuristics, ViewState, ViewStateExt as _,
+    ViewSystemExecutionError, ViewerContext,
 };
 
 use crate::{
@@ -204,7 +205,8 @@ fn timeline_not_found_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, view_id: Vi
         )
         .clicked()
     {
-        ctx.selection_state.set_selection(Item::View(view_id));
+        ctx.command_sender()
+            .send_system(SystemCommand::SetSelection(Item::View(view_id).into()));
     }
 }
 

--- a/crates/viewer/re_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_view_graph/src/ui/draw.rs
@@ -10,8 +10,8 @@ use re_entity_db::InstancePath;
 use re_types::ArrowString;
 use re_ui::list_item;
 use re_viewer_context::{
-    HoverHighlight, InteractionHighlight, Item, SelectionHighlight, UiLayout, ViewHighlights,
-    ViewQuery, ViewerContext,
+    HoverHighlight, InteractionHighlight, Item, SelectionHighlight, SystemCommand,
+    SystemCommandSender as _, UiLayout, ViewHighlights, ViewQuery, ViewerContext,
 };
 
 use crate::{
@@ -375,10 +375,14 @@ pub fn draw_graph(
                 // Warning! The order is very important here.
                 if response.double_clicked() {
                     // Select the entire entity
-                    ctx.selection_state().set_selection(Item::DataResult(
-                        query.view_id,
-                        instance_path.entity_path.clone().into(),
-                    ));
+                    ctx.command_sender()
+                        .send_system(SystemCommand::SetSelection(
+                            Item::DataResult(
+                                query.view_id,
+                                instance_path.entity_path.clone().into(),
+                            )
+                            .into(),
+                        ));
                 } else if response.hovered() || response.clicked() {
                     *hover_click_item = Some((
                         Item::DataResult(query.view_id, instance_path.clone()),

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -12,10 +12,10 @@ use re_types::{
 use re_ui::{self, Help, IconText, MouseButtonText, UiExt as _, icons};
 use re_view::{controls::DRAG_PAN2D_BUTTON, view_property_ui};
 use re_viewer_context::{
-    IdentifiedViewSystem as _, Item, RecommendedView, SystemExecutionOutput, ViewClass,
-    ViewClassExt as _, ViewClassLayoutPriority, ViewClassRegistryError, ViewId, ViewQuery,
-    ViewSpawnHeuristics, ViewState, ViewStateExt as _, ViewSystemExecutionError,
-    ViewSystemRegistrator, ViewerContext,
+    IdentifiedViewSystem as _, Item, RecommendedView, SystemCommand, SystemCommandSender as _,
+    SystemExecutionOutput, ViewClass, ViewClassExt as _, ViewClassLayoutPriority,
+    ViewClassRegistryError, ViewId, ViewQuery, ViewSpawnHeuristics, ViewState, ViewStateExt as _,
+    ViewSystemExecutionError, ViewSystemRegistrator, ViewerContext,
 };
 use re_viewport_blueprint::ViewProperty;
 
@@ -217,8 +217,10 @@ impl ViewClass for GraphView {
 
         if resp.clicked() {
             // clicked elsewhere, select the view
-            ctx.selection_state()
-                .set_selection(Item::View(query.view_id));
+            ctx.command_sender()
+                .send_system(SystemCommand::SetSelection(
+                    Item::View(query.view_id).into(),
+                ));
         }
 
         // Update blueprint if changed

--- a/crates/viewer/re_view_map/src/map_view.rs
+++ b/crates/viewer/re_view_map/src/map_view.rs
@@ -15,10 +15,10 @@ use re_types::{
 };
 use re_ui::{Help, IconText, icons, list_item};
 use re_viewer_context::{
-    IdentifiedViewSystem as _, Item, SystemExecutionOutput, UiLayout, ViewClass, ViewClassExt as _,
-    ViewClassLayoutPriority, ViewClassRegistryError, ViewHighlights, ViewId, ViewQuery,
-    ViewSpawnHeuristics, ViewState, ViewStateExt as _, ViewSystemExecutionError,
-    ViewSystemRegistrator, ViewerContext, gpu_bridge,
+    IdentifiedViewSystem as _, Item, SystemCommand, SystemCommandSender as _,
+    SystemExecutionOutput, UiLayout, ViewClass, ViewClassExt as _, ViewClassLayoutPriority,
+    ViewClassRegistryError, ViewHighlights, ViewId, ViewQuery, ViewSpawnHeuristics, ViewState,
+    ViewStateExt as _, ViewSystemExecutionError, ViewSystemRegistrator, ViewerContext, gpu_bridge,
 };
 use re_viewport_blueprint::ViewProperty;
 
@@ -492,15 +492,18 @@ fn handle_ui_interactions(
         // double click selects the entire entity
         if map_response.double_clicked() {
             // Select the entire entity
-            ctx.selection_state().set_selection(Item::DataResult(
-                query.view_id,
-                instance_path.entity_path.clone().into(),
-            ));
+            ctx.command_sender()
+                .send_system(SystemCommand::SetSelection(
+                    Item::DataResult(query.view_id, instance_path.entity_path.clone().into())
+                        .into(),
+                ));
         }
     } else if map_response.clicked() {
         // clicked elsewhere, select the view
-        ctx.selection_state()
-            .set_selection(Item::View(query.view_id));
+        ctx.command_sender()
+            .send_system(SystemCommand::SetSelection(
+                Item::View(query.view_id).into(),
+            ));
     } else if map_response.hovered() {
         ctx.selection_state().set_hovered(Item::View(query.view_id));
     }

--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -17,10 +17,11 @@ use re_ui::{Help, UiExt as _, list_item};
 use re_view::view_property_ui;
 use re_viewer_context::{
     ColormapWithRange, IdentifiedViewSystem as _, IndicatedEntities, Item,
-    MaybeVisualizableEntities, PerVisualizer, TensorStatsCache, TypedComponentFallbackProvider,
-    ViewClass, ViewClassExt as _, ViewClassRegistryError, ViewContext, ViewId, ViewQuery,
-    ViewState, ViewStateExt as _, ViewSystemExecutionError, ViewerContext, VisualizableEntities,
-    gpu_bridge, suggest_view_for_each_entity,
+    MaybeVisualizableEntities, PerVisualizer, SystemCommand, SystemCommandSender as _,
+    TensorStatsCache, TypedComponentFallbackProvider, ViewClass, ViewClassExt as _,
+    ViewClassRegistryError, ViewContext, ViewId, ViewQuery, ViewState, ViewStateExt as _,
+    ViewSystemExecutionError, ViewerContext, VisualizableEntities, gpu_bridge,
+    suggest_view_for_each_entity,
 };
 use re_viewport_blueprint::ViewProperty;
 
@@ -251,8 +252,10 @@ Set the displayed dimensions in a selection panel.",
         }
 
         if response.clicked() {
-            ctx.selection_state()
-                .set_selection(Item::View(query.view_id));
+            ctx.command_sender()
+                .send_system(SystemCommand::SetSelection(
+                    Item::View(query.view_id).into(),
+                ));
         }
 
         Ok(())

--- a/crates/viewer/re_view_text_document/src/view_class.rs
+++ b/crates/viewer/re_view_text_document/src/view_class.rs
@@ -3,9 +3,9 @@ use egui::{Label, Sense};
 use re_types::{View as _, ViewClassIdentifier};
 use re_ui::{Help, UiExt as _};
 use re_viewer_context::{
-    Item, ViewClass, ViewClassRegistryError, ViewId, ViewQuery, ViewState, ViewStateExt as _,
-    ViewSystemExecutionError, ViewerContext, external::re_log_types::EntityPath,
-    suggest_view_for_each_entity,
+    Item, SystemCommand, SystemCommandSender as _, ViewClass, ViewClassRegistryError, ViewId,
+    ViewQuery, ViewState, ViewStateExt as _, ViewSystemExecutionError, ViewerContext,
+    external::re_log_types::EntityPath, suggest_view_for_each_entity,
 };
 
 use crate::visualizer_system::{TextDocumentEntry, TextDocumentSystem};
@@ -151,8 +151,10 @@ impl ViewClass for TextDocumentView {
         }
 
         if clicked {
-            ctx.selection_state()
-                .set_selection(Item::View(query.view_id));
+            ctx.command_sender()
+                .send_system(SystemCommand::SetSelection(
+                    Item::View(query.view_id).into(),
+                ));
         }
 
         Ok(())

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -3214,6 +3214,7 @@ fn update_web_address_bar(
     enable_history: bool,
     store_hub: &StoreHub,
     display_mode: &DisplayMode,
+    // TODO(#10866): Use this to add the current selection to the url.
     _selection: &ApplicationSelectionState,
 ) -> Option<()> {
     if !enable_history {

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -13,10 +13,11 @@ use re_renderer::WgpuResourcePoolStatistics;
 use re_smart_channel::{ReceiveSet, SmartChannelSource};
 use re_ui::{ContextExt as _, UICommand, UICommandSender as _, UiExt as _, notifications};
 use re_viewer_context::{
-    AppOptions, AsyncRuntimeHandle, BlueprintUndoState, CommandReceiver, CommandSender,
-    ComponentUiRegistry, DisplayMode, Item, PlayState, RecordingConfig, RecordingOrTable,
-    StorageContext, StoreContext, SystemCommand, SystemCommandSender as _, TableStore, ViewClass,
-    ViewClassRegistry, ViewClassRegistryError, command_channel, santitize_file_name,
+    AppOptions, ApplicationSelectionState, AsyncRuntimeHandle, BlueprintUndoState, CommandReceiver,
+    CommandSender, ComponentUiRegistry, DisplayMode, Item, PlayState, RecordingConfig,
+    RecordingOrTable, StorageContext, StoreContext, SystemCommand, SystemCommandSender as _,
+    TableStore, ViewClass, ViewClassRegistry, ViewClassRegistryError, command_channel,
+    santitize_file_name,
     store_hub::{BlueprintPersistence, StoreHub, StoreHubStats},
 };
 
@@ -536,6 +537,7 @@ impl App {
                     self.startup_options.web_history_enabled(),
                     store_hub,
                     self.state.navigation.peek(),
+                    &self.state.selection_state,
                 );
             }
 
@@ -545,6 +547,7 @@ impl App {
                     self.startup_options.web_history_enabled(),
                     store_hub,
                     self.state.navigation.peek(),
+                    &self.state.selection_state,
                 );
             }
 
@@ -564,6 +567,7 @@ impl App {
                     self.startup_options.web_history_enabled(),
                     store_hub,
                     self.state.navigation.peek(),
+                    &self.state.selection_state,
                 );
             }
 
@@ -609,6 +613,7 @@ impl App {
                     self.startup_options.web_history_enabled(),
                     store_hub,
                     self.state.navigation.peek(),
+                    &self.state.selection_state,
                 );
             }
 
@@ -653,6 +658,7 @@ impl App {
                         self.startup_options.web_history_enabled(),
                         store_hub,
                         &display_mode,
+                        &self.state.selection_state,
                     );
                 }
 
@@ -756,47 +762,50 @@ impl App {
                 self.app_options_mut().inspect_blueprint_timeline = show;
             }
 
-            SystemCommand::SetSelection(item) => {
-                match &item {
-                    Item::RedapEntry(entry) => {
-                        self.state
-                            .navigation
-                            .replace(DisplayMode::RedapEntry(entry.clone()));
-                    }
+            SystemCommand::SetSelection(items) => {
+                if let Some(item) = items.single_item() {
+                    match item {
+                        Item::RedapEntry(entry) => {
+                            self.state
+                                .navigation
+                                .replace(DisplayMode::RedapEntry(entry.clone()));
+                        }
 
-                    Item::RedapServer(origin) => {
-                        self.state
-                            .navigation
-                            .replace(DisplayMode::RedapServer(origin.clone()));
-                    }
+                        Item::RedapServer(origin) => {
+                            self.state
+                                .navigation
+                                .replace(DisplayMode::RedapServer(origin.clone()));
+                        }
 
-                    Item::TableId(table_id) => {
-                        self.state
-                            .navigation
-                            .replace(DisplayMode::LocalTable(table_id.clone()));
-                    }
+                        Item::TableId(table_id) => {
+                            self.state
+                                .navigation
+                                .replace(DisplayMode::LocalTable(table_id.clone()));
+                        }
 
-                    Item::StoreId(store_id) => {
-                        self.state.navigation.replace(DisplayMode::LocalRecordings);
-                        store_hub.set_active_recording_id(store_id.clone());
-                    }
+                        Item::StoreId(store_id) => {
+                            self.state.navigation.replace(DisplayMode::LocalRecordings);
+                            store_hub.set_active_recording_id(store_id.clone());
+                        }
 
-                    Item::AppId(_)
-                    | Item::DataSource(_)
-                    | Item::InstancePath(_)
-                    | Item::ComponentPath(_)
-                    | Item::Container(_)
-                    | Item::View(_)
-                    | Item::DataResult(_, _) => {
-                        self.state.navigation.replace(DisplayMode::LocalRecordings);
+                        Item::AppId(_)
+                        | Item::DataSource(_)
+                        | Item::InstancePath(_)
+                        | Item::ComponentPath(_)
+                        | Item::Container(_)
+                        | Item::View(_)
+                        | Item::DataResult(_, _) => {
+                            self.state.navigation.replace(DisplayMode::LocalRecordings);
+                        }
                     }
                 }
 
-                self.state.selection_state.set_selection(item);
+                self.state.selection_state.set_selection(items);
                 update_web_address_bar(
                     self.startup_options.web_history_enabled(),
                     store_hub,
                     self.state.navigation.peek(),
+                    &self.state.selection_state,
                 );
                 egui_ctx.request_repaint(); // Make sure we actually see the new selection.
             }
@@ -1882,7 +1891,7 @@ impl App {
                         re_log::debug!("Inserted table store with id: `{}`", table.id);
                     }
                     self.command_sender.send_system(SystemCommand::SetSelection(
-                        re_viewer_context::Item::TableId(table.id.clone()),
+                        re_viewer_context::Item::TableId(table.id.clone()).into(),
                     ));
 
                     // If the viewer is in the background, tell the user that it has received something new.
@@ -2118,7 +2127,7 @@ impl App {
 
         // Also select the new recording:
         self.command_sender.send_system(SystemCommand::SetSelection(
-            re_viewer_context::Item::StoreId(store_id.clone()),
+            re_viewer_context::Item::StoreId(store_id.clone()).into(),
         ));
 
         // If the viewer is in the background, tell the user that it has received something new.
@@ -3195,6 +3204,7 @@ fn update_web_address_bar(
     _enable_history: bool,
     _store_hub: &StoreHub,
     _display_mode: &DisplayMode,
+    _selection: &ApplicationSelectionState,
 ) {
     // No-op on native.
 }
@@ -3204,6 +3214,7 @@ fn update_web_address_bar(
     enable_history: bool,
     store_hub: &StoreHub,
     display_mode: &DisplayMode,
+    _selection: &ApplicationSelectionState,
 ) -> Option<()> {
     if !enable_history {
         return None;

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -670,7 +670,7 @@ impl AppState {
 
         // Deselect on ESC. Must happen after all other UI code to let them capture ESC if needed.
         if ui.input(|i| i.key_pressed(egui::Key::Escape)) && !is_any_popup_open {
-            self.selection_state.clear_selection();
+            command_sender.send_system(SystemCommand::clear_selection());
         }
 
         // If there's no text edit or label selected, and the user triggers a copy command, copy a description of the current selection.

--- a/crates/viewer/re_viewer/src/open_url.rs
+++ b/crates/viewer/re_viewer/src/open_url.rs
@@ -412,7 +412,7 @@ impl ViewerOpenUrl {
 
         match self {
             Self::IntraRecordingSelection(item) => {
-                command_sender.send_system(SystemCommand::SetSelection(item));
+                command_sender.send_system(SystemCommand::SetSelection(item.into()));
             }
             Self::RrdHttpUrl(url) => {
                 command_sender.send_system(SystemCommand::LoadDataSource(
@@ -446,12 +446,14 @@ impl ViewerOpenUrl {
             }
             Self::RedapCatalog(uri) => {
                 command_sender.send_system(SystemCommand::AddRedapServer(uri.origin.clone()));
-                command_sender
-                    .send_system(SystemCommand::SetSelection(Item::RedapServer(uri.origin)));
+                command_sender.send_system(SystemCommand::SetSelection(
+                    Item::RedapServer(uri.origin).into(),
+                ));
             }
             Self::RedapEntry(uri) => {
                 command_sender.send_system(SystemCommand::AddRedapServer(uri.origin.clone()));
-                command_sender.send_system(SystemCommand::SetSelection(Item::RedapEntry(uri)));
+                command_sender
+                    .send_system(SystemCommand::SetSelection(Item::RedapEntry(uri).into()));
             }
             Self::WebEventListener => {
                 handle_web_event_listener(egui_ctx, command_sender);

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -55,7 +55,6 @@ emath.workspace = true
 glam = { workspace = true, features = ["serde"] }
 half.workspace = true
 image = { workspace = true, features = ["jpeg", "png"] }
-indexmap = { workspace = true, features = ["std", "serde"] }
 itertools.workspace = true
 linked-hash-map.workspace = true
 macaw.workspace = true

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -62,8 +62,8 @@ pub use self::{
     },
     query_range::QueryRange,
     selection_state::{
-        ApplicationSelectionState, HoverHighlight, InteractionHighlight, ItemCollection,
-        ItemContext, SelectionChange, SelectionHighlight,
+        ApplicationSelectionState, HoverHighlight, InteractionHighlight, SelectionChange,
+        SelectionHighlight,
     },
     storage_context::StorageContext,
     store_context::StoreContext,

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -59,7 +59,7 @@ impl InteractionHighlight {
 #[derive(Default, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct ApplicationSelectionState {
-    /// The selected items. Write to this with [`SystemCommand::SetSelection`].
+    /// The selected items. Write to this with [`re_global_context::SystemCommand::SetSelection`].
     selection: ItemCollection,
 
     /// Has selection changed since the previous frame?

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -56,22 +56,18 @@ impl InteractionHighlight {
 ///
 /// Both hover and selection are double buffered:
 /// Changes from one frame are only visible in the next frame.
-#[derive(Default, serde::Deserialize, serde::Serialize)]
-#[serde(default)]
+#[derive(Default)]
 pub struct ApplicationSelectionState {
     /// The selected items. Write to this with [`re_global_context::SystemCommand::SetSelection`].
     selection: ItemCollection,
 
     /// Has selection changed since the previous frame?
-    #[serde(skip)]
     selection_changed: bool,
 
     /// What objects are hovered? Read from this.
-    #[serde(skip)]
     hovered_previous_frame: ItemCollection,
 
     /// What objects are hovered? Write to this.
-    #[serde(skip)]
     hovered_this_frame: Mutex<ItemCollection>,
 }
 

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -86,12 +86,16 @@ impl ApplicationSelectionState {
         // Use a different name so we don't get a collision in puffin.
         re_tracing::profile_scope!("SelectionState::on_frame_start");
 
+        let start_len = self.selection.len();
         // Purge selection of invalid items.
         self.selection.retain(|item, _| item_retain_condition(item));
+
+        self.selection_changed |= start_len != self.selection.len();
+
+        // Set to fallback if empty.
         if self.selection.is_empty()
             && let Some(fallback_selection) = fallback_selection
         {
-            self.selection_changed = true;
             self.selection = ItemCollection::from(fallback_selection);
         }
 

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -127,7 +127,7 @@ impl ApplicationSelectionState {
         self.selection_this_frame = items.into();
     }
 
-    /// Extend the selection with the provided items.
+    /// Sends a command to select the current selection + `items`.
     pub fn extend_selection(
         &self,
         items: impl Into<ItemCollection>,
@@ -153,7 +153,7 @@ impl ApplicationSelectionState {
         *self.hovered_this_frame.lock() = hovered.into();
     }
 
-    /// Select passed objects unless already selected in which case they get unselected.
+    /// Sends a command to select passed objects unless already selected in which case they get unselected.
     /// If however an object is already selected but now gets passed a *different* item context, it stays selected after all
     /// but with an updated context!
     pub fn toggle_selection(&self, toggle_items: ItemCollection, command_sender: &CommandSender) {

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -1,59 +1,10 @@
 use ahash::HashMap;
-use indexmap::IndexMap;
-use itertools::Itertools as _;
 use parking_lot::Mutex;
-
-use re_entity_db::EntityPath;
-use re_global_context::{ViewId, resolve_mono_instance_path_item};
-use re_log_types::StoreKind;
-
-use crate::ViewerContext;
+use re_global_context::{
+    CommandSender, ItemCollection, ItemContext, SystemCommand, SystemCommandSender as _,
+};
 
 use super::Item;
-
-/// Context information that a view might attach to an item from [`ItemCollection`] and useful
-/// for how a selection might be displayed and interacted with.
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub enum ItemContext {
-    /// Hovering/Selecting in a 2D space.
-    TwoD {
-        space_2d: EntityPath,
-
-        /// Where in this 2D space (+ depth)?
-        pos: glam::Vec3,
-    },
-
-    /// Hovering/Selecting in a 3D space.
-    ThreeD {
-        /// The 3D space with the camera(s)
-        space_3d: EntityPath,
-
-        /// The point in 3D space that is hovered, if any.
-        pos: Option<glam::Vec3>,
-
-        /// Path to an entity that is currently tracked by the eye-camera.
-        /// (None for a free floating Eye)
-        tracked_entity: Option<EntityPath>,
-
-        /// Corresponding 2D spaces and pixel coordinates (with Z=depth)
-        point_in_space_cameras: Vec<(EntityPath, Option<glam::Vec3>)>,
-    },
-
-    /// Hovering/selecting in one of the streams trees.
-    StreamsTree {
-        /// Which store does this streams tree correspond to?
-        store_kind: StoreKind,
-
-        /// The current entity filter session id, if any.
-        filter_session_id: Option<egui::Id>,
-    },
-
-    /// Hovering/selecting in the blueprint tree.
-    BlueprintTree {
-        /// The current entity filter session id, if any.
-        filter_session_id: Option<egui::Id>,
-    },
-}
 
 /// Selection highlight, sorted from weakest to strongest.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -104,254 +55,6 @@ impl InteractionHighlight {
     }
 }
 
-/// An ordered collection of [`Item`] and optional associated context objects.
-///
-/// Used to store what is currently selected and/or hovered.
-#[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ItemCollection(IndexMap<Item, Option<ItemContext>>);
-
-impl From<Item> for ItemCollection {
-    #[inline]
-    fn from(val: Item) -> Self {
-        Self([(val, None)].into())
-    }
-}
-
-impl ItemCollection {
-    pub fn from_items_and_context(
-        items: impl IntoIterator<Item = (Item, Option<ItemContext>)>,
-    ) -> Self {
-        Self(items.into_iter().collect())
-    }
-
-    /// Is this view the selected one (and no other)?
-    pub fn is_view_the_only_selected(&self, needle: &ViewId) -> bool {
-        let mut is_selected = false;
-        for item in self.iter_items() {
-            let item_is_view = match item {
-                Item::View(id) | Item::DataResult(id, _) => id == needle,
-                _ => false,
-            };
-
-            if item_is_view {
-                is_selected = true;
-            } else {
-                return false; // More than one view selected
-            }
-        }
-        is_selected
-    }
-}
-
-impl IntoIterator for ItemCollection {
-    type Item = (Item, Option<ItemContext>);
-    type IntoIter = indexmap::map::IntoIter<Item, Option<ItemContext>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl ItemCollection {
-    /// For each item in this selection, if it refers to the first element of an instance with a
-    /// single element, resolve it to a unindexed entity path.
-    pub fn into_mono_instance_path_items(self, ctx: &ViewerContext<'_>) -> Self {
-        Self(
-            self.0
-                .into_iter()
-                .map(|(item, item_context)| {
-                    (
-                        resolve_mono_instance_path_item(
-                            ctx.recording(),
-                            &ctx.current_query(),
-                            &item,
-                        ),
-                        item_context,
-                    )
-                })
-                .collect(),
-        )
-    }
-
-    /// The first selected object if any.
-    pub fn first_item(&self) -> Option<&Item> {
-        self.0.keys().next()
-    }
-
-    /// Check if the selection contains a single item and returns it if so.
-    pub fn single_item(&self) -> Option<&Item> {
-        if self.len() == 1 {
-            self.first_item()
-        } else {
-            None
-        }
-    }
-
-    pub fn iter_items(&self) -> impl Iterator<Item = &Item> {
-        self.0.keys()
-    }
-
-    pub fn iter_item_context(&self) -> impl Iterator<Item = &ItemContext> {
-        self.0
-            .iter()
-            .filter_map(|(_, item_context)| item_context.as_ref())
-    }
-
-    pub fn context_for_item(&self, item: &Item) -> Option<&ItemContext> {
-        self.0.get(item).and_then(Option::as_ref)
-    }
-
-    /// Returns true if the exact selection is part of the current selection.
-    pub fn contains_item(&self, needle: &Item) -> bool {
-        self.0.iter().any(|(item, _)| item == needle)
-    }
-
-    pub fn are_all_items_same_kind(&self) -> Option<&'static str> {
-        if let Some(first_item) = self.first_item()
-            && self
-                .iter_items()
-                .skip(1)
-                .all(|item| std::mem::discriminant(first_item) == std::mem::discriminant(item))
-        {
-            return Some(first_item.kind());
-        }
-        None
-    }
-
-    /// Retains elements that fulfill a certain condition.
-    pub fn retain(&mut self, f: impl FnMut(&Item, &mut Option<ItemContext>) -> bool) {
-        self.0.retain(f);
-    }
-
-    /// Returns the number of items in the selection.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Check if the selection is empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Returns an iterator over the items and their selected context.
-    pub fn iter(&self) -> impl Iterator<Item = (&Item, &Option<ItemContext>)> {
-        self.0.iter()
-    }
-
-    /// Returns a mutable iterator over the items and their selected context.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Item, &mut Option<ItemContext>)> {
-        self.0.iter_mut()
-    }
-
-    /// Extend the selection with more items.
-    pub fn extend(&mut self, other: impl IntoIterator<Item = (Item, Option<ItemContext>)>) {
-        self.0.extend(other);
-    }
-
-    /// Tries to copy a description of the selection to the clipboard.
-    ///
-    /// Only certain elements are copyable right now.
-    pub fn copy_to_clipboard(&self, egui_ctx: &egui::Context) {
-        if self.is_empty() {
-            return;
-        }
-
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-        enum ClipboardTextDesc {
-            FilePath,
-            Url,
-            AppId,
-            StoreId,
-            EntityPath,
-        }
-
-        #[allow(clippy::match_same_arms)]
-        let clipboard_texts_per_type = self
-            .iter()
-            .filter_map(|(item, _)| match item {
-                Item::Container(_) => None,
-                Item::View(_) => None,
-                // TODO(lucasmerlin): Should these be copyable as URLs?
-                Item::RedapServer(_) => None,
-                Item::RedapEntry(_) => None,
-                Item::TableId(_) => None, // TODO(grtlr): Make `TableId`s copyable too
-
-                Item::DataSource(source) => match source {
-                    re_smart_channel::SmartChannelSource::File(path) => {
-                        Some((ClipboardTextDesc::FilePath, path.to_string_lossy().into()))
-                    }
-                    re_smart_channel::SmartChannelSource::RrdHttpStream { url, follow: _ } => {
-                        Some((ClipboardTextDesc::Url, url.clone()))
-                    }
-                    re_smart_channel::SmartChannelSource::RrdWebEventListener => None,
-                    re_smart_channel::SmartChannelSource::JsChannel { .. } => None,
-                    re_smart_channel::SmartChannelSource::Sdk => None,
-                    re_smart_channel::SmartChannelSource::Stdin => None,
-                    re_smart_channel::SmartChannelSource::RedapGrpcStream { uri, .. } => {
-                        Some((ClipboardTextDesc::Url, uri.to_string()))
-                    }
-                    re_smart_channel::SmartChannelSource::MessageProxy(uri) => {
-                        Some((ClipboardTextDesc::Url, uri.to_string()))
-                    }
-                },
-
-                Item::AppId(id) => Some((ClipboardTextDesc::AppId, id.to_string())),
-
-                // TODO(ab): it is not very meaningful to copy the `StoreId` representation, but
-                // that's the best we can do for now. In the future, we should have URIs for
-                // in-memory recordings, and that's what we should copy here.
-                Item::StoreId(id) => Some((ClipboardTextDesc::StoreId, format!("{id:?}"))),
-
-                Item::DataResult(_, instance_path) | Item::InstancePath(instance_path) => Some((
-                    ClipboardTextDesc::EntityPath,
-                    instance_path.entity_path.to_string(),
-                )),
-                Item::ComponentPath(component_path) => Some((
-                    ClipboardTextDesc::EntityPath,
-                    component_path.entity_path.to_string(),
-                )),
-            })
-            .chunk_by(|(desc, _)| *desc);
-
-        let mut clipboard_text = String::new();
-        let mut content_description = String::new();
-
-        for (desc, entries) in &clipboard_texts_per_type {
-            let entries = entries.map(|(_, text)| text).collect_vec();
-
-            let desc = match desc {
-                ClipboardTextDesc::FilePath => "file path",
-                ClipboardTextDesc::Url => "URL",
-                ClipboardTextDesc::AppId => "app id",
-                ClipboardTextDesc::StoreId => "store id",
-                ClipboardTextDesc::EntityPath => "entity path",
-            };
-            if !content_description.is_empty() {
-                content_description.push_str(", ");
-            }
-            if entries.len() == 1 {
-                content_description.push_str(desc);
-            } else {
-                content_description.push_str(&format!("{desc}s"));
-            }
-
-            let texts = entries.into_iter().join("\n");
-            if !clipboard_text.is_empty() {
-                clipboard_text.push('\n');
-            }
-            clipboard_text.push_str(&texts);
-        }
-
-        if !clipboard_text.is_empty() {
-            re_log::info!(
-                "Copied {content_description} to clipboard:\n{}",
-                &clipboard_text
-            );
-            egui_ctx.copy_text(clipboard_text);
-        }
-    }
-}
-
 /// Selection and hover state.
 ///
 /// Both hover and selection are double buffered:
@@ -362,9 +65,9 @@ pub struct ApplicationSelectionState {
     /// Selection of the previous frame. Read from this.
     selection_previous_frame: ItemCollection,
 
-    /// Selection of the current frame. Write to this.
+    /// Selection of the current frame. Write to this with [`SystemCommand::SetSelection`].
     #[serde(skip)]
-    selection_this_frame: Mutex<ItemCollection>,
+    selection_this_frame: ItemCollection,
 
     /// What objects are hovered? Read from this.
     #[serde(skip)]
@@ -391,7 +94,7 @@ impl ApplicationSelectionState {
         re_tracing::profile_scope!("SelectionState::on_frame_start");
 
         // Purge selection of invalid items.
-        let selection_this_frame = self.selection_this_frame.get_mut();
+        let selection_this_frame = &mut self.selection_this_frame;
         selection_this_frame.retain(|item, _| item_retain_condition(item));
         if selection_this_frame.is_empty()
             && let Some(fallback_selection) = fallback_selection
@@ -413,20 +116,26 @@ impl ApplicationSelectionState {
     }
 
     /// Clears the current selection out.
-    pub fn clear_selection(&self) {
+    pub fn clear_selection(&mut self) {
         self.set_selection(ItemCollection::default());
     }
 
     /// Sets several objects to be selected, updating history as needed.
     ///
     /// Clears the selected item context if none was specified.
-    pub fn set_selection(&self, items: impl Into<ItemCollection>) {
-        *self.selection_this_frame.lock() = items.into();
+    pub fn set_selection(&mut self, items: impl Into<ItemCollection>) {
+        self.selection_this_frame = items.into();
     }
 
     /// Extend the selection with the provided items.
-    pub fn extend_selection(&self, items: impl Into<ItemCollection>) {
-        self.selection_this_frame.lock().extend(items.into());
+    pub fn extend_selection(
+        &self,
+        items: impl Into<ItemCollection>,
+        command_sender: &CommandSender,
+    ) {
+        let mut selections = self.selection_this_frame.clone();
+        selections.extend(items.into());
+        command_sender.send_system(SystemCommand::SetSelection(selections));
     }
 
     /// Returns the current selection.
@@ -447,7 +156,7 @@ impl ApplicationSelectionState {
     /// Select passed objects unless already selected in which case they get unselected.
     /// If however an object is already selected but now gets passed a *different* item context, it stays selected after all
     /// but with an updated context!
-    pub fn toggle_selection(&self, toggle_items: ItemCollection) {
+    pub fn toggle_selection(&self, toggle_items: ItemCollection, command_sender: &CommandSender) {
         re_tracing::profile_function!();
 
         let mut toggle_items_set: HashMap<Item, Option<ItemContext>> = toggle_items
@@ -484,12 +193,11 @@ impl ApplicationSelectionState {
         // Add the new items, unless they were toggling out existing items:
         new_selection.extend(
             toggle_items
-                .0
                 .into_iter()
                 .filter(|(item, _)| toggle_items_set.contains_key(item)),
         );
 
-        *self.selection_this_frame.lock() = new_selection;
+        command_sender.send_system(SystemCommand::SetSelection(new_selection));
     }
 
     pub fn selection_item_contexts(&self) -> impl Iterator<Item = &ItemContext> {

--- a/crates/viewer/re_viewport/src/viewport_ui.rs
+++ b/crates/viewer/re_viewport/src/viewport_ui.rs
@@ -11,8 +11,9 @@ use re_log_types::{EntityPath, ResolvedEntityPathRule, RuleEffect};
 use re_ui::{ContextExt as _, Help, Icon, IconText, UiExt as _, design_tokens_of_visuals};
 use re_view::controls::TOGGLE_MAXIMIZE_VIEW;
 use re_viewer_context::{
-    Contents, DragAndDropFeedback, DragAndDropPayload, Item, PublishedViewInfo,
-    SystemExecutionOutput, ViewId, ViewQuery, ViewStates, ViewerContext, icon_for_container_kind,
+    Contents, DragAndDropFeedback, DragAndDropPayload, Item, PublishedViewInfo, SystemCommand,
+    SystemCommandSender as _, SystemExecutionOutput, ViewId, ViewQuery, ViewStates, ViewerContext,
+    icon_for_container_kind,
 };
 use re_viewport_blueprint::{
     ViewBlueprint, ViewportBlueprint, ViewportCommand, create_entity_add_info,
@@ -288,8 +289,10 @@ impl ViewportUi {
                     }
                 });
 
-            ctx.selection_state()
-                .set_selection(Item::View(view_blueprint.id));
+            ctx.command_sender()
+                .send_system(SystemCommand::SetSelection(
+                    Item::View(view_blueprint.id).into(),
+                ));
 
             // drop is completed, no need for highlighting anymore
             false


### PR DESCRIPTION
### Related

Part of #10866.

### What

To be able to handle selection updates in one place to update the viewer url I made all instances of setting the selection to instead send a `SystemCommand::SetSelection`. This also means we can make selection not be in a mutex.

Part of this is also moving `ItemCollection` to `re_global_context` to be able to send it in the `SetSelection` command.

### TODO
 - [x] implement the web url updating using these changes