### PR TITLE
Clean up `re_perf_telemetry` related code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -253,8 +253,8 @@ In order to get a dependency graph for our in-house crates and their docs, we re
 
 ```
 cargo install cargo-depgraph
-cargo depgraph --all-deps --workspace-only --all-features --dedup-transitive-deps | dot -Tpng > deps.png
-open deps.png
+cargo depgraph --all-deps --workspace-only --all-features --dedup-transitive-deps | dot -Tpng > /tmp/rerun-deps.png
+open /tmp/rerun-deps.png
 ```
 
 and:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ argh = "0.1.12"
 array-init = "2.1"
 arrow = { version = "55.2", default-features = false }
 async-stream = "0.3"
+axum = "0.8.4"
 backtrace = "0.3"
 base64 = "0.22"
 bincode = "1.3"
@@ -292,6 +293,7 @@ pollster = "0.4"
 prettyplease = "0.2"
 proc-macro2 = { version = "1.0", default-features = false }
 profiling = { version = "1.0.12", default-features = false }
+prometheus-client = "0.24"
 prost = "0.13.3"
 prost-build = "0.13.3"
 prost-types = "0.13.3"

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -114,7 +114,7 @@ rerun = { workspace = true, default-features = false, features = [
 ] }
 
 document-features.workspace = true
-mimalloc = "0.1.43"
+mimalloc.workspace = true
 
 
 [build-dependencies]

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -86,7 +86,7 @@ oss_server = ["rerun/oss_server"]
 
 ## Enables integration with `re_perf_telemetry` (Tracy, Jaeger).
 ##
-## This only works on native.
+## This only works on native, and only with `TELEMETRY_ENABLED` set.
 perf_telemetry = ["rerun/perf_telemetry"]
 
 ## Support serving a web viewer over HTTP.

--- a/crates/top/rerun-cli/src/bin/rerun.rs
+++ b/crates/top/rerun-cli/src/bin/rerun.rs
@@ -19,8 +19,14 @@ static GLOBAL: AccountingAllocator<mimalloc::MiMalloc> =
 fn main() -> std::process::ExitCode {
     let main_thread_token = rerun::MainThreadToken::i_promise_i_am_on_the_main_thread();
 
-    #[cfg(not(feature = "perf_telemetry"))]
-    re_log::setup_logging();
+    if cfg!(feature = "perf_telemetry") && std::env::var("TELEMETRY_ENABLED").is_ok() {
+        // TODO(tracing/issues#2499): allow installing multiple tracing sinks (https://github.com/tokio-rs/tracing/issues/2499)
+        eprintln!(
+            "Turning off stderr logging because of perf_telemetry needs exclusive access to the global tracing subscriber"
+        );
+    } else {
+        re_log::setup_logging();
+    }
 
     let build_info = re_build_info::build_info!();
 

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -95,7 +95,7 @@ oss_server = ["dep:re_server"]
 
 ## Enables integration with `re_perf_telemetry` (Tracy, Jaeger).
 ##
-## This only works on native.
+## This only works on native, and only with `TELEMETRY_ENABLED` set.
 perf_telemetry = [
   "dep:re_perf_telemetry",
   "re_redap_client/perf_telemetry",

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -585,8 +585,11 @@ where
     );
 
     #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(not(feature = "perf_telemetry"))]
-    re_crash_handler::install_crash_handlers(build_info.clone());
+    if cfg!(feature = "perf_telemetry") && std::env::var("TELEMETRY_ENABLED").is_ok() {
+        eprintln!("Disabling crash handler because of perf_telemetry/TELEMETRY_ENABLED"); // Ask Clement why
+    } else {
+        re_crash_handler::install_crash_handlers(build_info.clone());
+    }
 
     use clap::Parser as _;
     let mut args = Args::parse_from(args);

--- a/crates/utils/re_perf_telemetry/Cargo.toml
+++ b/crates/utils/re_perf_telemetry/Cargo.toml
@@ -48,6 +48,7 @@ tracy = ["dep:tracing-tracy"]
 # External
 ahash.workspace = true
 anyhow.workspace = true
+axum.workspace = true
 base64.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 http.workspace = true
@@ -73,9 +74,8 @@ tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "json",
 ] }
-axum = "0.8.4"
-prometheus-client = "0.24"
-tokio = { workspace = true }
+prometheus-client.workspace = true
+tokio.workspace = true
 
 # External (optional)
 tracing-tracy = { workspace = true, optional = true }

--- a/crates/utils/re_perf_telemetry/README.md
+++ b/crates/utils/re_perf_telemetry/README.md
@@ -7,13 +7,14 @@ Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
 ![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
 
-In and out of process performance profiling utilities for Rerun & Redap.
+In and out of process telemetry and profiling utilities for Rerun & Redap.
 
 Performance telemetry is always disabled by default. It is gated both by a feature flag (`perf_telemetry`) and runtime configuration in the form of environment variables:
 * `TELEMETRY_ENABLED`: is performance telemetry enabled at all (default: `false`)?
 * `TRACY_ENABLED`: is the tracy integration enabled (default: `false`)? works even if `TELEMETRY_ENABLED=false`, to reduce noise in measurements.
 * `OTEL_SDK_ENABLED`: is the OpenTelemetry enabled (default: `false`)? does nothing if `TELEMETRY_ENABLED=false`.
 
+Note that despite the name, this crate also hands all log output to the telemetry backend.
 
 ## What
 

--- a/crates/utils/re_perf_telemetry/src/lib.rs
+++ b/crates/utils/re_perf_telemetry/src/lib.rs
@@ -1,5 +1,12 @@
 //! Everything needed to set up telemetry (logs, traces, metrics) for both clients and servers.
 //!
+//! Despite the name `re_perf_telemetry`, this actually handles _all_ forms of telemetry,
+//! including all log output.
+//!
+//! This sort of telemetry is always disabled on our OSS binaries, and is only used for
+//! * The Rerun Cloud infrastructure
+//! * Profiling by Rerun developer
+//!
 //! Logging strategy
 //! ================
 //!

--- a/crates/utils/re_perf_telemetry/src/metrics_server.rs
+++ b/crates/utils/re_perf_telemetry/src/metrics_server.rs
@@ -18,6 +18,7 @@ use tracing::error;
 use crate::prometheus::{MetricContainer, convert_to_prometheus, encode_registry};
 
 /// Start a metrics server that binds synchronously and serves asynchronously.
+///
 /// Returns the bound socket address after successful binding.
 /// The server continues running in the spawned task.
 pub(crate) async fn start_metrics_server(
@@ -55,8 +56,12 @@ pub(crate) async fn start_metrics_server(
     Ok(bound_addr)
 }
 
-/// Handler for the ManualReader-based /metrics endpoint
-/// This collects metrics on-demand from `OpenTelemetry's` `ManualReader`
+/// Handler for the ManualReader-based /metrics endpoint.
+///
+/// This collects metrics on-demand from `OpenTelemetry's` `ManualReader`.
+///
+/// Exposing metrics is meant to be cheap in every moment.
+/// As long as determining the data to be exposed is not cheap it has to be somewhat cached and made available cheaply.
 async fn manual_metrics_handler(State(reader): State<Arc<ManualReader>>) -> impl IntoResponse {
     // This handler is picking up data from telemetry SDK's ManualReader,
     // this is a temporary solution to expose metrics in different ways

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -143,11 +143,14 @@ fn init_perf_telemetry() -> parking_lot::MutexGuard<'static, re_perf_telemetry::
 /// The python module is called "rerun_bindings".
 #[pymodule]
 fn rerun_bindings(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // NOTE: We do this here because some the inner init methods don't respond too kindly to being
-    // called more than once.
-    // The SDK should not be as noisy as the CLI, so we set log filter to warning if not specified otherwise.
-    #[cfg(not(feature = "perf_telemetry"))]
-    re_log::setup_logging_with_filter(&re_log::log_filter_from_env_or_default("warn"));
+    if cfg!(feature = "perf_telemetry") && std::env::var("TELEMETRY_ENABLED").is_ok() {
+        // TODO(tracing/issues#2499): allow installing multiple tracing sinks (https://github.com/tokio-rs/tracing/issues/2499)
+    } else {
+        // NOTE: We set up the logging this here because some the inner init methods don't respond too kindly to being
+        // called more than once.
+        // The SDK should not be as noisy as the CLI, so we set log filter to warning if not specified otherwise.
+        re_log::setup_logging_with_filter(&re_log::log_filter_from_env_or_default("warn"));
+    }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "perf_telemetry"))]
     let _telemetry = init_perf_telemetry();


### PR DESCRIPTION
It was extremely surprising and frustrating that `cargo run --all-features` would have no log output, for no apparent reason.