### PR TITLE
Use partition id in the recording panel

### DIFF
--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -2,6 +2,7 @@
 //!
 //! TODO(andreas): This is not a `data_ui`, can this go somewhere else, shouldn't be in `re_data_ui`.
 
+use re_entity_db::entity_db::EntityDbClass;
 use re_entity_db::{EntityTree, InstancePath};
 use re_format::format_uint;
 use re_log_types::{ApplicationId, EntityPath, TableId, TimeInt, TimeType, Timeline, TimelineName};
@@ -696,6 +697,8 @@ pub fn entity_db_button_ui(
         entity_db.recording_info_property::<Name>(&RecordingInfo::descriptor_name())
     {
         Some(recording_name.to_string())
+    } else if let EntityDbClass::DatasetPartition(url) = entity_db.store_class() {
+        Some(url.partition_id.clone())
     } else {
         entity_db
             .recording_info_property::<Timestamp>(&RecordingInfo::descriptor_start_time())


### PR DESCRIPTION
### What

With this PR, the recording panel (and everywhere we use `entity_db_button_ui`), we now use:

- the recording's name (from the properties) if any
- the partition id if any (obviously remote stuff only)
- the recording starting time if any
- `<unknown>` otherwise

Previously, we didn't have the partition id step.

Here is what i currently looks like with droid dataset:

<img width="1705" height="937" alt="image" src="https://github.com/user-attachments/assets/9ce7835a-d79a-47ae-94b2-448c69e178b7" />
