### PR TITLE
Enable serde in global context crate to fix CI

### DIFF
--- a/crates/store/re_types/Cargo.toml
+++ b/crates/store/re_types/Cargo.toml
@@ -43,7 +43,7 @@ image = ["dep:ecolor", "dep:image", "dep:tiff"]
 video = ["dep:re_video"]
 
 ## Enable (de)serialization using serde.
-serde = ["dep:serde"]
+serde = ["dep:serde", "glam/serde"]
 
 ## Include testing archetypes/components/datatypes into the crate.
 ## Only useful for testing purposes.

--- a/crates/viewer/re_global_context/Cargo.toml
+++ b/crates/viewer/re_global_context/Cargo.toml
@@ -35,7 +35,7 @@ re_log.workspace = true
 re_renderer = { workspace = true, features = ["serde"] }
 re_smart_channel.workspace = true
 re_tracing.workspace = true
-re_types = { workspace = true, features = ["ecolor", "glam", "image"] }
+re_types = { workspace = true, features = ["ecolor", "glam", "image", "serde"] }
 re_types_core.workspace = true
 re_ui.workspace = true
 re_uri.workspace = true


### PR DESCRIPTION
### Related

https://github.com/rerun-io/rerun/actions/runs/17612222863/job/50036598707

### What

Enables `re_types` serde feature in `re_global_context` and pass serde feature to glam from `re_types`