### PR TITLE
Add Example Of LeRobot Dataloader

### DIFF
--- a/docs/content/getting-started/data-in/open-any-file.md
+++ b/docs/content/getting-started/data-in/open-any-file.md
@@ -15,13 +15,14 @@ All these file loading methods support loading a single file, many files at once
 
 ⚠ Drag-and-drop of folders does [not yet work](https://github.com/rerun-io/rerun/issues/4528) on the web version of the Rerun Viewer ⚠
 
-The following file types have built-in support in the Rerun Viewer and SDK:
+The following data types have built-in support in the Rerun Viewer and SDK:
 
 -   Native Rerun files: `rrd`
 -   3D models: `gltf`, `glb`, `obj`, `stl`
--   Images: `avif`, `bmp`, `dds`, `exr`, `farbfeld`, `ff`, `gif`, `hdr`, `ico`, `jpeg`, `jpg`, `pam`, `pbm`, `pgm`, `png`, `ppm`, `tga`, `tif`, `tiff`, `webp`.
--   Point clouds: `ply`.
--   Text files: `md`, `txt`.
+-   Images: `avif`, `bmp`, `dds`, `exr`, `farbfeld`, `ff`, `gif`, `hdr`, `ico`, `jpeg`, `jpg`, `pam`, `pbm`, `pgm`, `png`, `ppm`, `tga`, `tif`, `tiff`, `webp`
+-   Point clouds: `ply`
+-   Text files: `md`, `txt`
+-   [LeRobot](https://huggingface.co/docs/lerobot/index) datasets: `directory`
 
 With the exception of `rrd` files that can be streamed from an HTTP URL (e.g. `rerun https://demo.rerun.io/version/latest/examples/dna/data.rrd`), we only support loading files from the local filesystem for now, with [plans to make this generic over any URI and protocol in the future](https://github.com/rerun-io/rerun/issues/4525).
 

--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -124,6 +124,7 @@ examples = [
   "ros_bridge",
   "notebook",
   "notebook_neural_field_2d",
+  "lerobot_loader",
   "urdf_loader",
   "vrs",
   "revy",

--- a/examples/python/lerobot/README.md
+++ b/examples/python/lerobot/README.md
@@ -16,7 +16,7 @@ LeRobot is a project by huggingface that aims to provide models, datasets and to
 
 This is an external example, check the [repository](https://github.com/rerun-io/lerobot/tree/alexander/train_viz) for more information.
 
-To train the model as shown in the video, install git-lfs and clone the [repository](https://github.com/rerun-io/lerobottree/alexander/train_viz) and then run the following code:
+To train the model as shown in the video, install git-lfs and clone the [repository](https://github.com/rerun-io/lerobot/tree/alexander/train_viz) and then run the following code:
 
 ```
 pip install -e '.[pusht]'

--- a/examples/python/lerobot/README.md
+++ b/examples/python/lerobot/README.md
@@ -14,9 +14,9 @@ LeRobot is a project by huggingface that aims to provide models, datasets and to
 
 ## Run the code
 
-This is an external example, check the [repository](https://github.com/rerun-io/lerobot) for more information.
+This is an external example, check the [repository](https://github.com/rerun-io/lerobot/tree/alexander/train_viz) for more information.
 
-To train the model as shown in the video, install git-lfs and clone the [repository](https://github.com/rerun-io/lerobot) and then run the following code:
+To train the model as shown in the video, install git-lfs and clone the [repository](https://github.com/rerun-io/lerobottree/alexander/train_viz) and then run the following code:
 
 ```
 pip install -e '.[pusht]'

--- a/examples/python/lerobot_loader/README.md
+++ b/examples/python/lerobot_loader/README.md
@@ -1,0 +1,37 @@
+<!--[metadata]
+title = "LeRobot loader"
+tags = ["2D", "Video", "Loader", "Hugging Face", "LeRobot"]
+thumbnail = "https://static.rerun.io/LeRobot/ec638243c38d01c0d9e27ef4e52e62c43c6e4ba4/480w.png"
+thumbnail_dimensions = [480, 480]
+-->
+
+<picture>
+  <img src="https://static.rerun.io/LeRobot/ec638243c38d01c0d9e27ef4e52e62c43c6e4ba4/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/LeRobot/ec638243c38d01c0d9e27ef4e52e62c43c6e4ba4/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/LeRobot/ec638243c38d01c0d9e27ef4e52e62c43c6e4ba4/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/LeRobot/ec638243c38d01c0d9e27ef4e52e62c43c6e4ba4/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/LeRobot/ec638243c38d01c0d9e27ef4e52e62c43c6e4ba4/1200w.png">
+</picture>
+
+## Overview
+
+Rerun has a built in data-loader to visualize [LeRobot](https://github.com/huggingface/lerobot) datasets.
+
+## Try it out
+
+Here is a sample dataset used in [SmolVLA](https://huggingface.co/blog/smolvla)
+
+```bash
+git lfs install # If not already installed
+git clone https://huggingface.co/datasets/satvikahuja/mixer_on_off_new_1
+```
+
+Then you can open the Viewer and select the directory to load the dataset, or you can open it directly from the terminal:
+
+```bash
+rerun mixer_on_off_new_1
+```
+
+### SDK support
+
+Since this dataloader is included other SDK functionalities should work similar to loading a rerun file but pointing at the directory instead.

--- a/examples/python/lerobot_loader/README.md
+++ b/examples/python/lerobot_loader/README.md
@@ -2,7 +2,7 @@
 title = "LeRobot loader"
 tags = ["2D", "Video", "Loader", "Hugging Face", "LeRobot"]
 thumbnail = "https://static.rerun.io/LeRobot/ec638243c38d01c0d9e27ef4e52e62c43c6e4ba4/480w.png"
-thumbnail_dimensions = [480, 480]
+thumbnail_dimensions = [480, 275]
 -->
 
 <picture>


### PR DESCRIPTION
Our docs currently aren't clear that we support LeRobot via a built in dataloader. This adds a simple example of it and highlights the integration. Hopefully it makes it more discoverable via search on our doc page as well.

I also updated the github link for our existing demo that points to our lerobot fork. It was previously pointing to main but I synced main to latest upstream.
