### PR TITLE
Unify button handling for CustomContent

### DIFF
--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -299,15 +299,12 @@ impl BlueprintTree {
             .label_style(contents_name_style(&container_data.name))
             .with_icon(icon_for_container_kind(&container_data.kind))
             .with_buttons(|ui| {
-                let vis_response = visibility_button_ui(ui, parent_visible, &mut visible);
+                visibility_button_ui(ui, parent_visible, &mut visible);
 
-                let remove_response = remove_button_ui(ui, "Remove container");
-                if remove_response.clicked() {
+                if remove_button_ui(ui, "Remove container").clicked() {
                     viewport_blueprint.mark_user_interaction(ctx);
                     viewport_blueprint.remove_contents(content);
                 }
-
-                remove_response | vis_response
             });
 
         // Globally unique id - should only be one of these in view at one time.
@@ -390,15 +387,12 @@ impl BlueprintTree {
             .with_icon(class.icon())
             .subdued(!view_visible)
             .with_buttons(|ui| {
-                let vis_response = visibility_button_ui(ui, container_visible, &mut visible);
+                visibility_button_ui(ui, container_visible, &mut visible);
 
-                let response = remove_button_ui(ui, "Remove view from the viewport");
-                if response.clicked() {
+                if remove_button_ui(ui, "Remove view from the viewport").clicked() {
                     viewport_blueprint.mark_user_interaction(ctx);
                     viewport_blueprint.remove_contents(Contents::View(view_data.id));
                 }
-
-                response | vis_response
             });
 
         // Globally unique id - should only be one of these in view at one time.
@@ -517,22 +511,20 @@ impl BlueprintTree {
                         .subdued(!view_visible || !data_result_data.visible)
                         .with_buttons(|ui: &mut egui::Ui| {
                             let mut visible_after = data_result_data.visible;
-                            let vis_response =
-                                visibility_button_ui(ui, view_visible, &mut visible_after);
+                            visibility_button_ui(ui, view_visible, &mut visible_after);
                             if visible_after != data_result_data.visible {
                                 data_result_data.update_visibility(ctx, visible_after);
                             }
 
-                            let response = remove_button_ui(
+                            if remove_button_ui(
                                 ui,
                                 "Remove this entity and all its children from the view",
-                            );
-                            if response.clicked() {
+                            )
+                            .clicked()
+                            {
                                 data_result_data
                                     .remove_data_result_from_view(ctx, viewport_blueprint);
                             }
-
-                            response | vis_response
                         })
                 }
             }

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -8,6 +8,7 @@ use re_data_ui::item_ui::guess_instance_path_icon;
 use re_entity_db::InstancePath;
 use re_log_types::{ApplicationId, EntityPath};
 use re_ui::filter_widget::format_matching_text;
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{
     ContextExt as _, DesignTokens, UiExt as _, drag_and_drop::DropTarget, filter_widget, list_item,
 };

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -8,7 +8,7 @@ use re_data_ui::item_ui::guess_instance_path_icon;
 use re_entity_db::InstancePath;
 use re_log_types::{ApplicationId, EntityPath};
 use re_ui::filter_widget::format_matching_text;
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{
     ContextExt as _, DesignTokens, UiExt as _, drag_and_drop::DropTarget, filter_widget, list_item,
 };

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -102,7 +102,7 @@ impl BlueprintTree {
                             );
                         }
                     })
-                    .menu_button(
+                    .with_menu_button(
                         &re_ui::icons::MORE,
                         "Open menu with more options",
                         |ui| {

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -102,15 +102,12 @@ impl BlueprintTree {
                             );
                         }
                     })
-                    .with_menu_button(
-                        &re_ui::icons::MORE,
-                        "Open menu with more options",
-                        |ui| {
-                            add_new_view_or_container_menu_button(ctx, viewport_blueprint, ui);
-                            set_blueprint_to_default_menu_buttons(ctx, ui);
-                            set_blueprint_to_auto_menu_button(ctx, ui);
-                        },
-                    ),
+                    .with_menu_button(&re_ui::icons::MORE, "Open menu with more options", |ui| {
+                        add_new_view_or_container_menu_button(ctx, viewport_blueprint, ui);
+                        set_blueprint_to_default_menu_buttons(ctx, ui);
+                        set_blueprint_to_auto_menu_button(ctx, ui);
+                    })
+                    .with_always_show_buttons(true),
                 );
             });
         });

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -9,7 +9,7 @@ use re_types::{
     archetypes::RecordingInfo,
     components::{Name, Timestamp},
 };
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{SyntaxHighlighting as _, UiExt as _, icons, list_item};
 use re_viewer_context::{
     HoverHighlight, Item, SystemCommand, SystemCommandSender as _, UiLayout, ViewId, ViewerContext,

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -740,7 +740,6 @@ pub fn entity_db_button_ui(
                         store_id.clone().into(),
                     ));
             }
-            resp
         });
     }
 
@@ -812,7 +811,6 @@ pub fn table_id_button_ui(
                         table_id.clone().into(),
                     ));
             }
-            resp
         });
     }
 

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -9,6 +9,7 @@ use re_types::{
     archetypes::RecordingInfo,
     components::{Name, Timestamp},
 };
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{SyntaxHighlighting as _, UiExt as _, icons, list_item};
 use re_viewer_context::{
     HoverHighlight, Item, SystemCommand, SystemCommandSender as _, UiLayout, ViewId, ViewerContext,

--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -7,7 +7,7 @@ use re_data_ui::item_ui::{entity_db_button_ui, table_id_button_ui};
 use re_log_types::TableId;
 use re_redap_browser::{Command, EXAMPLES_ORIGIN, LOCAL_ORIGIN, RedapServers};
 use re_smart_channel::SmartChannelSource;
-use re_ui::list_item::{ItemButton as _, ItemMenuButton, LabelContent, ListItemContentButtonsExt};
+use re_ui::list_item::{ItemMenuButton, LabelContent, ListItemContentButtonsExt as _};
 use re_ui::{UiExt as _, UiLayout, icons, list_item};
 use re_viewer_context::{
     DisplayMode, Item, RecordingOrTable, SystemCommand, SystemCommandSender as _, ViewerContext,

--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -7,7 +7,7 @@ use re_data_ui::item_ui::{entity_db_button_ui, table_id_button_ui};
 use re_log_types::TableId;
 use re_redap_browser::{Command, EXAMPLES_ORIGIN, LOCAL_ORIGIN, RedapServers};
 use re_smart_channel::SmartChannelSource;
-use re_ui::list_item::{ItemButton as _, ItemMenuButton, LabelContent};
+use re_ui::list_item::{ItemButton as _, ItemMenuButton, LabelContent, ListItemContentButtonsExt};
 use re_ui::{UiExt as _, UiLayout, icons, list_item};
 use re_viewer_context::{
     DisplayMode, Item, RecordingOrTable, SystemCommand, SystemCommandSender as _, ViewerContext,
@@ -219,7 +219,7 @@ fn server_section_ui(
     } = server_data;
 
     let content = list_item::LabelContent::header(origin.host.to_string())
-        .always_show_buttons(true)
+        .with_always_show_buttons(true)
         .with_buttons(|ui| {
             ItemMenuButton::new(&icons::MORE, "Actions", move |ui| {
                 if icons::RESET

--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -221,7 +221,7 @@ fn server_section_ui(
     let content = list_item::LabelContent::header(origin.host.to_string())
         .always_show_buttons(true)
         .with_buttons(|ui| {
-            Box::new(ItemMenuButton::new(&icons::MORE, "Actions", move |ui| {
+            ItemMenuButton::new(&icons::MORE, "Actions", move |ui| {
                 if icons::RESET
                     .as_button_with_label(ui.tokens(), "Refresh")
                     .ui(ui)
@@ -243,8 +243,8 @@ fn server_section_ui(
                 {
                     servers.send_command(Command::RemoveServer(origin.clone()));
                 }
-            }))
-            .ui(ui)
+            })
+            .ui(ui);
         });
 
     let item_response = ui
@@ -358,8 +358,6 @@ fn dataset_entry_ui(
                         ));
                 }
             }
-
-            resp
         });
     }
 
@@ -498,7 +496,6 @@ fn app_id_section_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, local_app_id: &
                 ctx.command_sender()
                     .send_system(SystemCommand::CloseApp(app_id.clone()));
             }
-            resp
         });
     }
 
@@ -565,8 +562,6 @@ fn receiver_ui(
         if resp.clicked() {
             ctx.connected_receivers.remove(receiver);
         }
-
-        resp
     });
 
     if show_hierarchal {

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -9,6 +9,7 @@ use re_data_ui::{DataUi as _, archetype_label_list_item_ui};
 use re_log_types::EntityPath;
 use re_types_core::ComponentDescriptor;
 use re_types_core::reflection::ComponentDescriptorExt as _;
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{SyntaxHighlighting as _, UiExt as _, list_item::LabelContent};
 use re_viewer_context::{
     ComponentUiTypes, QueryContext, SystemCommand, SystemCommandSender as _, UiLayout, ViewContext,
@@ -146,7 +147,7 @@ fn active_default_ui(
             let response = ui.list_item_flat_noninteractive(
                 re_ui::list_item::PropertyContent::new(component_descr.archetype_field_name())
                     .min_desired_width(150.0)
-                    .action_button(&re_ui::icons::CLOSE, "Clear blueprint component", || {
+                    .with_action_button(&re_ui::icons::CLOSE, "Clear blueprint component", || {
                         ctx.clear_blueprint_component(
                             view.defaults_path.clone(),
                             component_descr.clone(),

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -9,7 +9,7 @@ use re_data_ui::{DataUi as _, archetype_label_list_item_ui};
 use re_log_types::EntityPath;
 use re_types_core::ComponentDescriptor;
 use re_types_core::reflection::ComponentDescriptorExt as _;
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{SyntaxHighlighting as _, UiExt as _, list_item::LabelContent};
 use re_viewer_context::{
     ComponentUiTypes, QueryContext, SystemCommand, SystemCommandSender as _, UiLayout, ViewContext,
@@ -91,8 +91,8 @@ Click on the `+` button to add a new default value.";
         active_default_ui(ctx, ui, &active_defaults, view, query, db);
     };
     ui.section_collapsing_header("Component defaults")
-        .button(add_button)
-        .help_markdown(markdown)
+        .with_button(add_button)
+        .with_help_markdown(markdown)
         .show(ui, body);
 }
 

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -9,7 +9,7 @@ use re_data_ui::{
 use re_entity_db::{EntityPath, InstancePath};
 use re_log_types::{ComponentPath, EntityPathFilter, EntityPathSubs, ResolvedEntityPathFilter};
 use re_types::ComponentDescriptor;
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{
     SyntaxHighlighting as _, UiExt as _, icons,
     list_item::{self, PropertyContent},
@@ -428,7 +428,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
 
         if let Some(view) = viewport.view(view_id) {
             ui.section_collapsing_header("Entity path filter")
-                .button(
+                .with_button(
                     list_item::ItemActionButton::new(
                         &re_ui::icons::EDIT,
                         "Add new entity…",
@@ -438,7 +438,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
                     )
                     .hover_text("Modify the entity query using the editor"),
                 )
-                .help_markdown(markdown)
+                .with_help_markdown(markdown)
                 .show(ui, |ui| {
                     // TODO(#6075): Because `list_item_scope` changes it. Temporary until everything is `ListItem`.
                     ui.spacing_mut().item_spacing.y = ui.ctx().style().spacing.item_spacing.y;
@@ -709,7 +709,7 @@ fn container_children(
     };
 
     ui.section_collapsing_header("Contents")
-        .button(
+        .with_button(
             list_item::ItemActionButton::new(&re_ui::icons::ADD, "Add to container", || {
                 show_add_view_or_container_modal(*container_id);
             })

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -997,8 +997,6 @@ fn show_list_item_for_container_child(
                         if response.clicked() {
                             remove_contents = true;
                         }
-
-                        response
                     }),
             )
         }
@@ -1023,8 +1021,6 @@ fn show_list_item_for_container_child(
                         if response.clicked() {
                             remove_contents = true;
                         }
-
-                        response
                     }),
             )
         }

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -9,6 +9,7 @@ use re_data_ui::{
 use re_entity_db::{EntityPath, InstancePath};
 use re_log_types::{ComponentPath, EntityPathFilter, EntityPathSubs, ResolvedEntityPathFilter};
 use re_types::ComponentDescriptor;
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{
     SyntaxHighlighting as _, UiExt as _, icons,
     list_item::{self, PropertyContent},

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -7,6 +7,7 @@ use re_types::{
     blueprint::{archetypes as blueprint_archetypes, components::VisibleTimeRange},
     datatypes::{TimeInt, TimeRange, TimeRangeBoundary},
 };
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{TimeDragValue, UiExt as _};
 use re_viewer_context::{QueryRange, ViewClass, ViewState, ViewerContext};
 use re_viewport_blueprint::{ViewBlueprint, entity_path_for_view_property};
@@ -173,7 +174,7 @@ Notes:
     let collapsing_response = ui
         .section_collapsing_header("Visible time range")
         .default_open(true)
-        .help_markdown(markdown)
+        .with_help_markdown(markdown)
         .show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.re_radio_value(has_individual_time_range, false, "Default")

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -8,7 +8,7 @@ use re_log_types::{ComponentPath, EntityPath};
 use re_types::blueprint::archetypes::VisualizerOverrides;
 use re_types::{ComponentDescriptor, reflection::ComponentDescriptorExt as _};
 use re_types_core::external::arrow::array::ArrayRef;
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{UiExt as _, design_tokens_of_visuals, list_item};
 use re_view::latest_at_with_blueprint_resolved_data;
 use re_viewer_context::{
@@ -75,8 +75,8 @@ in the blueprint or in the UI by selecting the view.
 specific to the visualizer and the current view type.";
 
     ui.section_collapsing_header("Visualizers")
-        .button(button)
-        .help_markdown(markdown)
+        .with_button(button)
+        .with_help_markdown(markdown)
         .show(ui, |ui| {
             visualizer_ui_impl(ctx, ui, &data_result, &active_visualizers, &all_visualizers);
         });

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -129,7 +129,9 @@ pub fn visualizer_ui_impl(
                             ),
                         )
                         .min_desired_width(150.0)
-                        .with_buttons(|ui| remove_visualizer_button(ui, visualizer_id))
+                        .with_buttons(|ui| {
+                            remove_visualizer_button(ui, visualizer_id);
+                        })
                         .always_show_buttons(true),
                     );
                 visualizer_components(ctx, ui, data_result, visualizer);
@@ -138,7 +140,9 @@ pub fn visualizer_ui_impl(
                     list_item::LabelContent::new(format!("{visualizer_id} (unknown visualizer)"))
                         .weak(true)
                         .min_desired_width(150.0)
-                        .with_buttons(|ui| remove_visualizer_button(ui, visualizer_id))
+                        .with_buttons(|ui| {
+                            remove_visualizer_button(ui, visualizer_id);
+                        })
                         .always_show_buttons(true),
                 );
             }

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -8,6 +8,7 @@ use re_log_types::{ComponentPath, EntityPath};
 use re_types::blueprint::archetypes::VisualizerOverrides;
 use re_types::{ComponentDescriptor, reflection::ComponentDescriptorExt as _};
 use re_types_core::external::arrow::array::ArrayRef;
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{UiExt as _, design_tokens_of_visuals, list_item};
 use re_view::latest_at_with_blueprint_resolved_data;
 use re_viewer_context::{
@@ -132,7 +133,7 @@ pub fn visualizer_ui_impl(
                         .with_buttons(|ui| {
                             remove_visualizer_button(ui, visualizer_id);
                         })
-                        .always_show_buttons(true),
+                        .with_always_show_buttons(true),
                     );
                 visualizer_components(ctx, ui, data_result, visualizer);
             } else {
@@ -143,7 +144,7 @@ pub fn visualizer_ui_impl(
                         .with_buttons(|ui| {
                             remove_visualizer_button(ui, visualizer_id);
                         })
-                        .always_show_buttons(true),
+                        .with_always_show_buttons(true),
                 );
             }
         }
@@ -410,22 +411,21 @@ fn visualizer_components(
                 )
                 .value_fn(value_fn)
                 .show_only_when_collapsed(false)
-                .menu_button(
-                    &re_ui::icons::MORE,
-                    "More options",
-                    |ui: &mut egui::Ui| {
-                        menu_more(
-                            ctx,
-                            ui,
-                            component_descr.clone(),
-                            override_path,
-                            &raw_override.clone().map(|(_, raw_override)| raw_override),
-                            raw_default.clone().map(|(_, raw_override)| raw_override),
-                            raw_fallback.clone(),
-                            raw_current_value.clone(),
-                        );
-                    },
-                ),
+                .with_menu_button(&re_ui::icons::MORE, "More options", |ui: &mut egui::Ui| {
+                    menu_more(
+                        ctx,
+                        ui,
+                        component_descr.clone(),
+                        override_path,
+                        &raw_override.clone().map(|(_, raw_override)| raw_override),
+                        raw_default.clone().map(|(_, raw_override)| raw_override),
+                        raw_fallback.clone(),
+                        raw_current_value.clone(),
+                    );
+                })
+                // TODO(emilk/egui#7531): Ideally we would hide the button unless hovered, but this
+                // currently breaks the menu.
+                .with_always_show_buttons(true),
                 add_children,
             )
             .item_response;
@@ -464,7 +464,7 @@ fn editable_blueprint_component_list_item(
                     allow_multiline,
                 );
             })
-            .action_button(&re_ui::icons::CLOSE, "Clear blueprint component", || {
+            .with_action_button(&re_ui::icons::CLOSE, "Clear blueprint component", || {
                 query_ctx
                     .viewer_ctx()
                     .clear_blueprint_component(blueprint_path, component_descr.clone());

--- a/crates/viewer/re_ui/examples/re_ui_example/main.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/main.rs
@@ -3,6 +3,7 @@ mod hierarchical_drag_and_drop;
 mod right_panel;
 
 use egui::{Modifiers, os};
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{
     CommandPalette, CommandPaletteAction, CommandPaletteUrl, ContextExt as _, DesignTokens, Help,
     IconText, UICommand, UICommandSender, UiExt as _,
@@ -250,7 +251,7 @@ impl eframe::App for ExampleApp {
             // ---
 
             ui.section_collapsing_header("Data")
-                .button(list_item::ItemMenuButton::new(
+                .with_button(list_item::ItemMenuButton::new(
                     &re_ui::icons::ADD,
                     "Add",
                     |ui| {

--- a/crates/viewer/re_ui/examples/re_ui_example/right_panel.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/right_panel.rs
@@ -1,8 +1,8 @@
 use egui::Ui;
 
-use re_ui::{UiExt as _, list_item};
-
 use crate::{drag_and_drop, hierarchical_drag_and_drop};
+use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::{UiExt as _, list_item};
 
 pub struct RightPanel {
     show_hierarchical_demo: bool,
@@ -195,8 +195,8 @@ impl RightPanel {
                 ui.list_item().show_hierarchical(
                     ui,
                     list_item::LabelContent::new("LabelContent with buttons").with_buttons(|ui| {
-                        ui.small_icon_button(&re_ui::icons::ADD, "Add")
-                            | ui.small_icon_button(&re_ui::icons::REMOVE, "Remove")
+                        ui.small_icon_button(&re_ui::icons::ADD, "Add");
+                        ui.small_icon_button(&re_ui::icons::REMOVE, "Remove");
                     }),
                 );
 
@@ -204,10 +204,10 @@ impl RightPanel {
                     ui,
                     list_item::LabelContent::new("LabelContent with buttons (always shown)")
                         .with_buttons(|ui| {
-                            ui.small_icon_button(&re_ui::icons::ADD, "Add")
-                                | ui.small_icon_button(&re_ui::icons::REMOVE, "Remove")
+                            ui.small_icon_button(&re_ui::icons::ADD, "Add");
+                            ui.small_icon_button(&re_ui::icons::REMOVE, "Remove");
                         })
-                        .always_show_buttons(true),
+                        .with_always_show_buttons(true),
                 );
             },
         );
@@ -248,20 +248,22 @@ impl RightPanel {
                         ui,
                         list_item::PropertyContent::new("Color")
                             .with_icon(&re_ui::icons::VIEW_TEXT)
-                            .action_button(&re_ui::icons::ADD, "Add", || {
+                            .with_action_button(&re_ui::icons::ADD, "Add", || {
                                 re_log::warn!("Add button clicked");
                             })
-                            .value_color(&self.color),
+                            .value_color(&self.color)
+                            .with_always_show_buttons(true),
                     );
 
                     ui.list_item().show_hierarchical(
                         ui,
                         list_item::PropertyContent::new("Color (editable)")
                             .with_icon(&re_ui::icons::VIEW_TEXT)
-                            .action_button(&re_ui::icons::ADD, "Add", || {
+                            .with_action_button(&re_ui::icons::ADD, "Add", || {
                                 re_log::warn!("Add button clicked");
                             })
-                            .value_color_mut(&mut self.color),
+                            .value_color_mut(&mut self.color)
+                            .with_always_show_buttons(true),
                     );
                 });
             },
@@ -296,7 +298,7 @@ impl RightPanel {
 
                     let mut content = list_item::PropertyContent::new("Use action button");
                     if self.use_action_button {
-                        content = content.action_button(&re_ui::icons::ADD, "Add", || {
+                        content = content.with_action_button(&re_ui::icons::ADD, "Add", || {
                             re_log::warn!("Add button clicked");
                         });
                     }

--- a/crates/viewer/re_ui/examples/re_ui_example/right_panel.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/right_panel.rs
@@ -344,9 +344,10 @@ impl RightPanel {
                             "CustomContent with an action button",
                         );
                     })
-                    .action_button(&re_ui::icons::ADD, "Add", || {
+                    .with_action_button(&re_ui::icons::ADD, "Add", || {
                         re_log::warn!("Add button clicked");
-                    }),
+                    })
+                    .with_always_show_buttons(true),
                 );
             },
         );

--- a/crates/viewer/re_ui/examples/re_ui_example/right_panel.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/right_panel.rs
@@ -1,7 +1,7 @@
 use egui::Ui;
 
 use crate::{drag_and_drop, hierarchical_drag_and_drop};
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{UiExt as _, list_item};
 
 pub struct RightPanel {

--- a/crates/viewer/re_ui/src/filter_widget.rs
+++ b/crates/viewer/re_ui/src/filter_widget.rs
@@ -184,7 +184,8 @@ impl FilterState {
                         || {
                             toggle_search_clicked = true;
                         },
-                    ),
+                    )
+                    .with_always_show_buttons(true),
                 );
         });
 

--- a/crates/viewer/re_ui/src/filter_widget.rs
+++ b/crates/viewer/re_ui/src/filter_widget.rs
@@ -4,6 +4,7 @@ use egui::{Color32, NumExt as _, Widget as _};
 use itertools::Itertools as _;
 use smallvec::SmallVec;
 
+use crate::list_item::ListItemContentButtonsExt;
 use crate::{UiExt as _, icons, list_item};
 
 /// State for the filter widget when it is toggled on.
@@ -169,7 +170,7 @@ impl FilterState {
                         }
                     })
                     .with_content_width(text_width)
-                    .action_button(
+                    .with_action_button(
                         if is_searching {
                             &icons::CLOSE
                         } else {

--- a/crates/viewer/re_ui/src/list_item/custom_content.rs
+++ b/crates/viewer/re_ui/src/list_item/custom_content.rs
@@ -1,7 +1,9 @@
 use egui::{NumExt as _, Ui};
 
 use crate::UiExt as _;
-use crate::list_item::{ContentContext, DesiredWidth, ListItemContent};
+use crate::list_item::{
+    ContentContext, DesiredWidth, ItemButtons, ListItemContent, ListItemContentButtonsExt,
+};
 
 /// Control how the [`CustomContent`] advertises its width.
 #[derive(Debug, Clone, Copy)]
@@ -26,8 +28,7 @@ pub struct CustomContent<'a> {
     ui: Box<dyn FnOnce(&mut egui::Ui, &ContentContext<'_>) + 'a>,
     desired_width: CustomContentDesiredWidth,
 
-    //TODO(ab): in the future, that should be a `Vec`, with some auto expanding mini-toolbar
-    button: Option<Box<dyn super::ItemButton + 'a>>,
+    buttons: ItemButtons<'a>,
 }
 
 impl<'a> CustomContent<'a> {
@@ -40,7 +41,7 @@ impl<'a> CustomContent<'a> {
         Self {
             ui: Box::new(ui),
             desired_width: Default::default(),
-            button: None,
+            buttons: ItemButtons::default(),
         }
     }
 
@@ -58,71 +59,6 @@ impl<'a> CustomContent<'a> {
         self.desired_width = CustomContentDesiredWidth::ContentWidth(desired_content_width);
         self
     }
-
-    /// Add a right-aligned [`super::ItemButton`].
-    ///
-    /// Note: for aesthetics, space is always reserved for the action button.
-    // TODO(#6191): accept multiple calls for this function for multiple actions.
-    #[inline]
-    pub fn button(mut self, button: impl super::ItemButton + 'a) -> Self {
-        // TODO(#6191): support multiple action buttons
-        assert!(
-            self.button.is_none(),
-            "Only one action button is supported right now"
-        );
-
-        self.button = Some(Box::new(button));
-        self
-    }
-
-    /// Helper to add an [`super::ItemActionButton`] to the right of the item.
-    ///
-    /// The `alt_text` will be used for accessibility (e.g. read by screen readers),
-    /// and is also how we can query the button in tests.
-    ///
-    /// See [`Self::button`] for more information.
-    #[inline]
-    pub fn action_button(
-        self,
-        icon: &'static crate::icons::Icon,
-        alt_text: impl Into<String>,
-        on_click: impl FnOnce() + 'a,
-    ) -> Self {
-        self.action_button_with_enabled(icon, alt_text, true, on_click)
-    }
-
-    /// Helper to add an enabled/disabled [`super::ItemActionButton`] to the right of the item.
-    ///
-    /// The `alt_text` will be used for accessibility (e.g. read by screen readers),
-    /// and is also how we can query the button in tests.
-    ///
-    /// See [`Self::button`] for more information.
-    #[inline]
-    pub fn action_button_with_enabled(
-        self,
-        icon: &'static crate::icons::Icon,
-        alt_text: impl Into<String>,
-        enabled: bool,
-        on_click: impl FnOnce() + 'a,
-    ) -> Self {
-        self.button(super::ItemActionButton::new(icon, alt_text, on_click).enabled(enabled))
-    }
-
-    /// Helper to add a [`super::ItemMenuButton`] to the right of the item.
-    ///
-    /// The `alt_text` will be used for accessibility (e.g. read by screen readers),
-    /// and is also how we can query the button in tests.
-    ///
-    /// See [`Self::button`] for more information.
-    #[inline]
-    pub fn menu_button(
-        self,
-        icon: &'static crate::icons::Icon,
-        alt_text: impl Into<String>,
-        add_contents: impl FnOnce(&mut egui::Ui) + 'a,
-    ) -> Self {
-        self.button(super::ItemMenuButton::new(icon, alt_text, add_contents))
-    }
 }
 
 impl ListItemContent for CustomContent<'_> {
@@ -130,22 +66,11 @@ impl ListItemContent for CustomContent<'_> {
         let Self {
             ui: content_ui,
             desired_width: _,
-            button,
+            buttons,
         } = *self;
 
-        let tokens = ui.tokens();
-        let button_dimension = tokens.small_icon_size.x + 2.0 * ui.spacing().button_padding.x;
-
-        let content_width = if button.is_some() {
-            (context.rect.width() - button_dimension - tokens.text_to_icon_padding()).at_least(0.0)
-        } else {
-            context.rect.width()
-        };
-
-        let content_rect = egui::Rect::from_min_size(
-            context.rect.min,
-            egui::vec2(content_width, context.rect.height()),
-        );
+        let mut content_rect = context.rect;
+        buttons.show_and_shrink_rect(ui, context, &mut content_rect);
 
         ui.scope_builder(
             egui::UiBuilder::new()
@@ -160,37 +85,24 @@ impl ListItemContent for CustomContent<'_> {
                 content_ui(ui, context);
             },
         );
-
-        if let Some(button) = button {
-            let action_button_rect = egui::Rect::from_center_size(
-                context.rect.right_center() - egui::vec2(button_dimension / 2.0, 0.0),
-                egui::Vec2::splat(button_dimension),
-            );
-
-            // the right to left layout is used to mimic LabelContent's buttons behavior and get a
-            // better alignment
-            let mut child_ui = ui.new_child(
-                egui::UiBuilder::new()
-                    .max_rect(action_button_rect)
-                    .layout(egui::Layout::right_to_left(egui::Align::Center)),
-            );
-
-            button.ui(&mut child_ui);
-        }
     }
 
     fn desired_width(&self, ui: &Ui) -> DesiredWidth {
         match self.desired_width {
             CustomContentDesiredWidth::DesiredWidth(desired_width) => desired_width,
             CustomContentDesiredWidth::ContentWidth(mut content_width) => {
-                if self.button.is_some() {
-                    let tokens = ui.tokens();
-                    content_width += tokens.small_icon_size.x
-                        + 2.0 * ui.spacing().button_padding.x
-                        + tokens.text_to_icon_padding();
-                }
                 DesiredWidth::AtLeast(content_width)
             }
         }
+    }
+}
+
+impl<'a> ListItemContentButtonsExt<'a> for CustomContent<'a> {
+    fn buttons(&self) -> &ItemButtons<'a> {
+        &self.buttons
+    }
+
+    fn buttons_mut(&mut self) -> &mut ItemButtons<'a> {
+        &mut self.buttons
     }
 }

--- a/crates/viewer/re_ui/src/list_item/item_button.rs
+++ b/crates/viewer/re_ui/src/list_item/item_button.rs
@@ -95,6 +95,12 @@ impl super::ItemButton for ItemMenuButton<'_> {
     }
 }
 
+impl egui::Widget for ItemMenuButton<'_> {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        super::ItemButton::ui(Box::new(self), ui)
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 
 /// An [`super::ItemButton`] that acts as an action button.
@@ -176,5 +182,11 @@ impl super::ItemButton for ItemActionButton<'_> {
             response
         })
         .inner
+    }
+}
+
+impl egui::Widget for ItemActionButton<'_> {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        super::ItemButton::ui(Box::new(self), ui)
     }
 }

--- a/crates/viewer/re_ui/src/list_item/item_buttons.rs
+++ b/crates/viewer/re_ui/src/list_item/item_buttons.rs
@@ -1,0 +1,107 @@
+use crate::UiExt;
+use crate::list_item::ContentContext;
+use egui::Widget;
+
+#[derive(Default)]
+pub struct ItemButtons<'a>(Vec<Box<dyn FnOnce(&mut egui::Ui) + 'a>>);
+
+impl Clone for ItemButtons<'_> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl std::fmt::Debug for ItemButtons<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Buttons").field(&self.0.len()).finish()
+    }
+}
+
+impl<'a> ItemButtons<'a> {
+    pub fn add(&mut self, button: impl Widget + 'a) {
+        self.0.push(Box::new(move |ui: &mut egui::Ui| {
+            button.ui(ui);
+        }));
+    }
+
+    pub fn add_buttons(&mut self, buttons: impl FnOnce(&mut egui::Ui) + 'a) {
+        self.0.push(Box::new(buttons));
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn should_show_buttons(context: &ContentContext) -> bool {
+        // We can't use `.hovered()` or the buttons disappear just as the user clicks,
+        // so we use `contains_pointer` instead. That also means we need to check
+        // that we aren't dragging anything.
+        // By showing the buttons when selected, we allow users to find them on touch screens.
+        (context.list_item.interactive
+            && context
+                .response
+                .ctx
+                .rect_contains_pointer(context.response.layer_id, context.bg_rect)
+            && !egui::DragAndDrop::has_any_payload(&context.response.ctx))
+            || context.list_item.selected
+    }
+
+    pub fn show_and_shrink_rect(
+        self,
+        ui: &mut egui::Ui,
+        context: &ContentContext,
+        always_show: bool,
+        rect: &mut egui::Rect,
+    ) {
+        if self.0.is_empty() || !(Self::should_show_buttons(context) || always_show) {
+            return;
+        }
+
+        let mut ui = ui.new_child(
+            egui::UiBuilder::new()
+                .max_rect(*rect)
+                .layout(egui::Layout::right_to_left(egui::Align::Center)),
+        );
+
+        let tokens = ui.tokens();
+        if context.list_item.selected {
+            // Icons and text get different colors when they are on a selected background:
+            let visuals = ui.visuals_mut();
+
+            visuals.widgets.noninteractive.weak_bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.inactive.weak_bg_fill = egui::Color32::TRANSPARENT;
+            visuals.widgets.active.weak_bg_fill = tokens.surface_on_primary_hovered;
+            visuals.widgets.hovered.weak_bg_fill = tokens.surface_on_primary_hovered;
+
+            visuals.widgets.noninteractive.fg_stroke.color = tokens.icon_color_on_primary;
+            visuals.widgets.inactive.fg_stroke.color = tokens.icon_color_on_primary;
+            visuals.widgets.active.fg_stroke.color = tokens.icon_color_on_primary_hovered;
+            visuals.widgets.hovered.fg_stroke.color = tokens.icon_color_on_primary_hovered;
+        }
+
+        for button in self.0 {
+            button(&mut ui);
+        }
+
+        let used_rect = ui.min_rect();
+        rect.max.x -= used_rect.width() + tokens.text_to_icon_padding();
+    }
+}
+
+pub trait ListItemContentButtonsExt<'a>
+where
+    Self: Sized,
+{
+    fn buttons(&self) -> &ItemButtons<'a>;
+    fn buttons_mut(&mut self) -> &mut ItemButtons<'a>;
+
+    fn button(mut self, button: impl Widget + 'a) -> Self {
+        self.buttons_mut().add(button);
+        self
+    }
+
+    fn buttons_fn(mut self, buttons: impl FnOnce(&mut egui::Ui) + 'a) -> Self {
+        self.buttons_mut().add_buttons(buttons);
+        self
+    }
+}

--- a/crates/viewer/re_ui/src/list_item/label_content.rs
+++ b/crates/viewer/re_ui/src/list_item/label_content.rs
@@ -21,7 +21,6 @@ pub struct LabelContent<'a> {
     label_style: LabelStyle,
     icon_fn: Option<Box<dyn FnOnce(&mut egui::Ui, egui::Rect, ListVisuals) + 'a>>,
     buttons: ItemButtons<'a>,
-    always_show_buttons: bool,
 
     text_wrap_mode: Option<egui::TextWrapMode>,
     min_desired_width: Option<f32>,
@@ -40,7 +39,6 @@ impl<'a> LabelContent<'a> {
             label_style: Default::default(),
             icon_fn: None,
             buttons: ItemButtons::default(),
-            always_show_buttons: false,
 
             text_wrap_mode: None,
             min_desired_width: None,
@@ -141,36 +139,6 @@ impl<'a> LabelContent<'a> {
         self
     }
 
-    /// Provide a closure to display on-hover buttons on the right of the item.
-    ///
-    /// Buttons also show when the item is selected, in order to support clicking them on touch
-    /// screens. The buttons can be set to be always shown with [`Self::always_show_buttons`].
-    ///
-    /// If there are multiple buttons, the response returned should be the union of both buttons.
-    ///
-    /// Notes:
-    /// - If buttons are used, the item will allocate the full available width of the parent. If the
-    ///   enclosing UI adapts to the childrens width, it will unnecessarily grow. If buttons aren't
-    ///   used, the item will only allocate the width needed for the text and icons if any.
-    /// - A right to left layout is used, so the right-most button must be added first.
-    // TODO(#6191): This should reconciled this with the `ItemButton` abstraction by using something
-    //              like `Vec<Box<dyn ItemButton>>` instead of a generic closure.
-    #[inline]
-    pub fn with_buttons(mut self, buttons: impl FnOnce(&mut egui::Ui) + 'a) -> Self {
-        self.buttons.add_buttons(buttons);
-        self
-    }
-
-    /// Always show the buttons.
-    ///
-    /// By default, buttons are only shown when the item is hovered or selected. By setting this to
-    /// `true`, the buttons are always shown.
-    #[inline]
-    pub fn always_show_buttons(mut self, always_show_buttons: bool) -> Self {
-        self.always_show_buttons = always_show_buttons;
-        self
-    }
-
     fn get_text_wrap_mode(&self, ui: &egui::Ui) -> egui::TextWrapMode {
         if let Some(text_wrap_mode) = self.text_wrap_mode {
             text_wrap_mode
@@ -195,7 +163,6 @@ impl ListItemContent for LabelContent<'_> {
             label_style,
             icon_fn,
             buttons,
-            always_show_buttons,
             text_wrap_mode: _,
             min_desired_width: _,
         } = *self;
@@ -233,7 +200,7 @@ impl ListItemContent for LabelContent<'_> {
             icon_fn(ui, icon_rect, visuals);
         }
 
-        buttons.show_and_shrink_rect(ui, context, always_show_buttons, &mut text_rect);
+        buttons.show_and_shrink_rect(ui, context, &mut text_rect);
 
         // Draw text
         let mut layout_job = Arc::unwrap_or_clone(text.into_layout_job(

--- a/crates/viewer/re_ui/src/list_item/label_content.rs
+++ b/crates/viewer/re_ui/src/list_item/label_content.rs
@@ -1,4 +1,4 @@
-use egui::{Align, Align2, NumExt as _, RichText, Ui, text::TextWrapping};
+use egui::{Align, Align2, NumExt as _, RichText, Ui, Widget, text::TextWrapping};
 use std::sync::Arc;
 
 use super::{
@@ -200,33 +200,35 @@ impl ListItemContent for LabelContent<'_> {
             icon_fn(ui, icon_rect, visuals);
         }
 
-        buttons.show_and_shrink_rect(ui, context, &mut text_rect);
-
-        // Draw text
-        let mut layout_job = Arc::unwrap_or_clone(text.into_layout_job(
-            ui.style(),
-            egui::FontSelection::Default,
-            Align::LEFT,
-        ));
-        layout_job.wrap = TextWrapping::from_wrap_mode_and_width(text_wrap_mode, text_rect.width());
-
-        let galley = ui.fonts(|fonts| fonts.layout_job(layout_job));
-
-        // this happens here to avoid cloning the text
-        context.response.widget_info(|| {
-            egui::WidgetInfo::selected(
-                egui::WidgetType::SelectableLabel,
-                ui.is_enabled(),
-                context.list_item.selected,
-                galley.text(),
-            )
+        buttons.show(ui, context, text_rect, |ui| {
+            egui::Label::new(text).selectable(false).ui(ui);
         });
 
-        let text_pos = Align2::LEFT_CENTER
-            .align_size_within_rect(galley.size(), text_rect)
-            .min;
+        // // Draw text
+        // let mut layout_job = Arc::unwrap_or_clone(text.into_layout_job(
+        //     ui.style(),
+        //     egui::FontSelection::Default,
+        //     Align::LEFT,
+        // ));
+        // layout_job.wrap = TextWrapping::from_wrap_mode_and_width(text_wrap_mode, text_rect.width());
 
-        ui.painter().galley(text_pos, galley, text_color);
+        // let galley = ui.fonts(|fonts| fonts.layout_job(layout_job));
+
+        // this happens here to avoid cloning the text
+        // context.response.widget_info(|| {
+        //     egui::WidgetInfo::selected(
+        //         egui::WidgetType::SelectableLabel,
+        //         ui.is_enabled(),
+        //         context.list_item.selected,
+        //         galley.text(),
+        //     )
+        // });
+        //
+        // let text_pos = Align2::LEFT_CENTER
+        //     .align_size_within_rect(galley.size(), text_rect)
+        //     .min;
+        //
+        // ui.painter().galley(text_pos, galley, text_color);
     }
 
     fn desired_width(&self, ui: &Ui) -> DesiredWidth {

--- a/crates/viewer/re_ui/src/list_item/mod.rs
+++ b/crates/viewer/re_ui/src/list_item/mod.rs
@@ -6,6 +6,7 @@ mod button_content;
 mod custom_content;
 mod debug_content;
 mod item_button;
+mod item_buttons;
 mod label_content;
 #[allow(clippy::module_inception)]
 mod list_item;
@@ -16,6 +17,7 @@ pub use button_content::*;
 pub use custom_content::*;
 pub use debug_content::*;
 pub use item_button::*;
+pub use item_buttons::*;
 pub use label_content::*;
 pub use list_item::*;
 pub use property_content::*;

--- a/crates/viewer/re_ui/src/list_item/property_content.rs
+++ b/crates/viewer/re_ui/src/list_item/property_content.rs
@@ -4,7 +4,10 @@ use egui::{Align, Align2, NumExt as _, Ui, text::TextWrapping};
 
 use crate::{Icon, UiExt as _};
 
-use super::{ContentContext, DesiredWidth, LayoutInfoStack, ListItemContent, ListVisuals};
+use super::{
+    ContentContext, DesiredWidth, ItemButtons, LabelContent, LayoutInfoStack, ListItemContent,
+    ListItemContentButtonsExt, ListVisuals,
+};
 
 /// Closure to draw an icon left of the label.
 type IconFn<'a> = dyn FnOnce(&mut egui::Ui, egui::Rect, ListVisuals) + 'a;
@@ -24,7 +27,7 @@ pub struct PropertyContent<'a> {
     show_only_when_collapsed: bool,
     value_fn: Option<Box<PropertyValueFn<'a>>>,
     //TODO(ab): in the future, that should be a `Vec`, with some auto expanding mini-toolbar
-    button: Option<Box<dyn super::ItemButton + 'a>>,
+    buttons: ItemButtons<'a>,
     /**/
     //TODO(ab): icon styling? link icon right of label? clickable label?
 }
@@ -40,7 +43,7 @@ impl<'a> PropertyContent<'a> {
             icon_fn: None,
             show_only_when_collapsed: true,
             value_fn: None,
-            button: None,
+            buttons: ItemButtons::default(),
         }
     }
 
@@ -70,71 +73,6 @@ impl<'a> PropertyContent<'a> {
     {
         self.icon_fn = Some(Box::new(icon_fn));
         self
-    }
-
-    /// Add a right-aligned [`super::ItemButton`].
-    ///
-    /// Note: for aesthetics, space is always reserved for the action button.
-    // TODO(#6191): accept multiple calls for this function for multiple actions.
-    #[inline]
-    pub fn button(mut self, button: impl super::ItemButton + 'a) -> Self {
-        // TODO(#6191): support multiple action buttons
-        assert!(
-            self.button.is_none(),
-            "Only one action button is supported right now"
-        );
-
-        self.button = Some(Box::new(button));
-        self
-    }
-
-    /// Helper to add an [`super::ItemActionButton`] to the right of the item.
-    ///
-    /// The `alt_text` will be used for accessibility (e.g. read by screen readers),
-    /// and is also how we can query the button in tests.
-    ///
-    /// See [`Self::button`] for more information.
-    #[inline]
-    pub fn action_button(
-        self,
-        icon: &'static crate::icons::Icon,
-        alt_text: impl Into<String>,
-        on_click: impl FnOnce() + 'a,
-    ) -> Self {
-        self.action_button_with_enabled(icon, alt_text, true, on_click)
-    }
-
-    /// Helper to add an enabled/disabled [`super::ItemActionButton`] to the right of the item.
-    ///
-    /// The `alt_text` will be used for accessibility (e.g. read by screen readers),
-    /// and is also how we can query the button in tests.
-    ///
-    /// See [`Self::button`] for more information.
-    #[inline]
-    pub fn action_button_with_enabled(
-        self,
-        icon: &'static crate::icons::Icon,
-        alt_text: impl Into<String>,
-        enabled: bool,
-        on_click: impl FnOnce() + 'a,
-    ) -> Self {
-        self.button(super::ItemActionButton::new(icon, alt_text, on_click).enabled(enabled))
-    }
-
-    /// Helper to add a [`super::ItemMenuButton`] to the right of the item.
-    ///
-    /// The `alt_text` will be used for accessibility (e.g. read by screen readers),
-    /// and is also how we can query the button in tests.
-    ///
-    /// See [`Self::button`] for more information.
-    #[inline]
-    pub fn menu_button(
-        self,
-        icon: &'static crate::icons::Icon,
-        alt_text: impl Into<String>,
-        add_contents: impl FnOnce(&mut egui::Ui) + 'a,
-    ) -> Self {
-        self.button(super::ItemMenuButton::new(icon, alt_text, add_contents))
     }
 
     /// Display value only for leaf or collapsed items.
@@ -241,7 +179,7 @@ impl ListItemContent for PropertyContent<'_> {
             icon_fn,
             show_only_when_collapsed,
             value_fn,
-            button,
+            buttons,
         } = *self;
 
         let tokens = ui.tokens();
@@ -283,24 +221,18 @@ impl ListItemContent for PropertyContent<'_> {
         // Based on egui::ImageButton::ui()
         let action_button_dimension =
             tokens.small_icon_size.x + 2.0 * ui.spacing().button_padding.x;
-        let reserve_action_button_space =
-            button.is_some() || context.layout_info.reserve_action_button_space;
-        let action_button_extra = if reserve_action_button_space {
-            action_button_dimension + tokens.text_to_icon_padding()
-        } else {
-            0.0
-        };
 
         let label_rect = egui::Rect::from_x_y_ranges(
             (content_left_x + icon_extra)..=(mid_point_x - Self::COLUMN_SPACING / 2.0),
             context.rect.y_range(),
         );
 
-        let value_rect = egui::Rect::from_x_y_ranges(
-            (mid_point_x + Self::COLUMN_SPACING / 2.0)
-                ..=(context.rect.right() - action_button_extra),
+        let mut value_rect = egui::Rect::from_x_y_ranges(
+            (mid_point_x + Self::COLUMN_SPACING / 2.0)..=context.rect.right(),
             context.rect.y_range(),
         );
+
+        buttons.show_and_shrink_rect(ui, context, &mut value_rect);
 
         let visuals = context.visuals;
 
@@ -329,9 +261,6 @@ impl ListItemContent for PropertyContent<'_> {
         context
             .layout_info
             .register_desired_left_column_width(ui.ctx(), desired_width);
-        context
-            .layout_info
-            .reserve_action_button_space(ui.ctx(), button.is_some());
 
         let galley = if desired_galley.size().x <= label_rect.width() {
             desired_galley
@@ -398,24 +327,6 @@ impl ListItemContent for PropertyContent<'_> {
                 child_ui.min_rect().right() - context.layout_info.left_x,
             );
         }
-
-        // Draw action button
-        if let Some(button) = button {
-            let action_button_rect = egui::Rect::from_center_size(
-                context.rect.right_center() - egui::vec2(action_button_dimension / 2.0, 0.0),
-                egui::Vec2::splat(action_button_dimension),
-            );
-
-            // the right to left layout is used to mimic LabelContent's buttons behavior and get a
-            // better alignment
-            let mut child_ui = ui.new_child(
-                egui::UiBuilder::new()
-                    .max_rect(action_button_rect)
-                    .layout(egui::Layout::right_to_left(egui::Align::Center)),
-            );
-
-            button.ui(&mut child_ui);
-        }
     }
 
     fn desired_width(&self, ui: &Ui) -> DesiredWidth {
@@ -427,18 +338,19 @@ impl ListItemContent for PropertyContent<'_> {
         } else if let Some(max_width) = layout_info.property_content_max_width {
             let mut desired_width = max_width + layout_info.left_x - ui.max_rect().left();
 
-            // TODO(ab): ideally there wouldn't be as much code duplication with `Self::ui`
-            let action_button_dimension =
-                tokens.small_icon_size.x + 2.0 * ui.spacing().button_padding.x;
-            let reserve_action_button_space =
-                self.button.is_some() || layout_info.reserve_action_button_space;
-            if reserve_action_button_space {
-                desired_width += action_button_dimension + tokens.text_to_icon_padding();
-            }
-
             DesiredWidth::AtLeast(desired_width.ceil())
         } else {
             DesiredWidth::AtLeast(self.min_desired_width)
         }
+    }
+}
+
+impl<'a> ListItemContentButtonsExt<'a> for PropertyContent<'a> {
+    fn buttons(&self) -> &ItemButtons<'a> {
+        &self.buttons
+    }
+
+    fn buttons_mut(&mut self) -> &mut ItemButtons<'a> {
+        &mut self.buttons
     }
 }

--- a/crates/viewer/re_ui/src/list_item/property_content.rs
+++ b/crates/viewer/re_ui/src/list_item/property_content.rs
@@ -5,7 +5,7 @@ use egui::{Align, Align2, NumExt as _, Ui, text::TextWrapping};
 use crate::{Icon, UiExt as _};
 
 use super::{
-    ContentContext, DesiredWidth, ItemButtons, LabelContent, LayoutInfoStack, ListItemContent,
+    ContentContext, DesiredWidth, ItemButtons, LayoutInfoStack, ListItemContent,
     ListItemContentButtonsExt, ListVisuals,
 };
 
@@ -218,10 +218,6 @@ impl ListItemContent for PropertyContent<'_> {
             0.0
         };
 
-        // Based on egui::ImageButton::ui()
-        let action_button_dimension =
-            tokens.small_icon_size.x + 2.0 * ui.spacing().button_padding.x;
-
         let label_rect = egui::Rect::from_x_y_ranges(
             (content_left_x + icon_extra)..=(mid_point_x - Self::COLUMN_SPACING / 2.0),
             context.rect.y_range(),
@@ -331,12 +327,11 @@ impl ListItemContent for PropertyContent<'_> {
 
     fn desired_width(&self, ui: &Ui) -> DesiredWidth {
         let layout_info = LayoutInfoStack::top(ui.ctx());
-        let tokens = ui.tokens();
 
         if crate::is_in_resizable_panel(ui) {
             DesiredWidth::AtLeast(self.min_desired_width)
         } else if let Some(max_width) = layout_info.property_content_max_width {
-            let mut desired_width = max_width + layout_info.left_x - ui.max_rect().left();
+            let desired_width = max_width + layout_info.left_x - ui.max_rect().left();
 
             DesiredWidth::AtLeast(desired_width.ceil())
         } else {

--- a/crates/viewer/re_ui/src/list_item/scope.rs
+++ b/crates/viewer/re_ui/src/list_item/scope.rs
@@ -124,9 +124,6 @@ pub struct LayoutInfo {
     /// value.
     pub(crate) left_column_width: Option<f32>,
 
-    /// If true, right-aligned space should be reserved for the action button, even if not used.
-    pub(crate) reserve_action_button_space: bool,
-
     /// Scope id, used to retrieve the corresponding [`LayoutStatistics`].
     scope_id: egui::Id,
 
@@ -141,7 +138,6 @@ impl Default for LayoutInfo {
         Self {
             left_x: 0.0,
             left_column_width: None,
-            reserve_action_button_space: true,
             scope_id: egui::Id::NULL,
             property_content_max_width: None,
         }
@@ -284,7 +280,6 @@ pub fn list_item_scope<R>(
     let state = LayoutInfo {
         left_x: ui.max_rect().left(),
         left_column_width,
-        reserve_action_button_space: layout_stats.is_action_button_used,
         scope_id,
         property_content_max_width: layout_stats.property_content_max_width,
     };

--- a/crates/viewer/re_ui/src/section_collapsing_header.rs
+++ b/crates/viewer/re_ui/src/section_collapsing_header.rs
@@ -9,10 +9,9 @@ pub struct SectionCollapsingHeader<'a> {
     label: egui::WidgetText,
     default_open: bool,
     buttons: ItemButtons<'a>,
-    help: Option<Box<dyn FnOnce(&mut egui::Ui) + 'a>>,
 }
 
-impl<'a> SectionCollapsingHeader<'a> {
+impl SectionCollapsingHeader<'_> {
     /// Create a new [`Self`].
     ///
     /// See also [`crate::UiExt::section_collapsing_header`]
@@ -21,7 +20,6 @@ impl<'a> SectionCollapsingHeader<'a> {
             label: label.into(),
             default_open: true,
             buttons: ItemButtons::default(),
-            help: None,
         }
     }
 
@@ -31,42 +29,6 @@ impl<'a> SectionCollapsingHeader<'a> {
     #[inline]
     pub fn default_open(mut self, default_open: bool) -> Self {
         self.default_open = default_open;
-        self
-    }
-
-    /// Set the button to be shown in the header.
-    #[inline]
-    pub fn button(mut self, button: impl egui::Widget + 'a) -> Self {
-        self.buttons.add(button);
-        self
-    }
-
-    /// Set the help text tooltip to be shown in the header.
-    //TODO(#6191): the help button should be just another `impl ItemButton`.
-    #[inline]
-    pub fn help_text(mut self, help: impl Into<egui::WidgetText>) -> Self {
-        let help = help.into();
-        self.help = Some(Box::new(move |ui| {
-            ui.label(help);
-        }));
-        self
-    }
-
-    /// Set the help markdown tooltip to be shown in the header.
-    //TODO(#6191): the help button should be just another `impl ItemButton`.
-    #[inline]
-    pub fn help_markdown(mut self, help: &'a str) -> Self {
-        self.help = Some(Box::new(move |ui| {
-            ui.markdown_ui(help);
-        }));
-        self
-    }
-
-    /// Set the help UI closure to be shown in the header.
-    //TODO(#6191): the help button should be just another `impl ItemButton`.
-    #[inline]
-    pub fn help_ui(mut self, help: impl FnOnce(&mut egui::Ui) + 'a) -> Self {
-        self.help = Some(Box::new(help));
         self
     }
 
@@ -80,7 +42,6 @@ impl<'a> SectionCollapsingHeader<'a> {
             label,
             default_open,
             buttons,
-            help,
         } = self;
 
         let id = ui.make_persistent_id(label.text());
@@ -113,5 +74,15 @@ impl<'a> SectionCollapsingHeader<'a> {
             body_returned: None,
             openness: resp.openness,
         }
+    }
+}
+
+impl<'a> ListItemContentButtonsExt<'a> for SectionCollapsingHeader<'a> {
+    fn buttons(&self) -> &ItemButtons<'a> {
+        &self.buttons
+    }
+
+    fn buttons_mut(&mut self) -> &mut ItemButtons<'a> {
+        &mut self.buttons
     }
 }

--- a/crates/viewer/re_ui/tests/filter_widget_test.rs
+++ b/crates/viewer/re_ui/tests/filter_widget_test.rs
@@ -1,6 +1,7 @@
 use egui::Vec2;
 
 use re_ui::filter_widget::FilterState;
+use re_ui::list_item::list_item_scope;
 
 #[test]
 pub fn test_filter_widget() {
@@ -10,10 +11,12 @@ pub fn test_filter_widget() {
 
         FilterState::default().section_title_ui(ui, egui::RichText::new("Small").strong());
 
-        FilterState::default().section_title_ui(
-            ui,
-            egui::RichText::new("Expanding available width").strong(),
-        );
+        list_item_scope(ui, "expanding", |ui| {
+            FilterState::default().section_title_ui(
+                ui,
+                egui::RichText::new("Expanding available width").strong(),
+            );
+        });
 
         ui.set_width(600.0);
         ui.set_max_width(600.0);

--- a/crates/viewer/re_ui/tests/list_item_tests.rs
+++ b/crates/viewer/re_ui/tests/list_item_tests.rs
@@ -1,5 +1,6 @@
 use egui::Vec2;
 use egui_kittest::SnapshotOptions;
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{UiExt as _, icons, list_item};
 
 #[test]
@@ -112,8 +113,8 @@ pub fn test_list_items_should_match_snapshot() {
                 ui.list_item().show_hierarchical(
                     ui,
                     list_item::LabelContent::new("LabelContent with buttons").with_buttons(|ui| {
-                        ui.small_icon_button(&icons::ADD, "Add")
-                            | ui.small_icon_button(&icons::REMOVE, "Remove")
+                        ui.small_icon_button(&icons::ADD, "Add");
+                        ui.small_icon_button(&icons::REMOVE, "Remove");
                     }),
                 );
 
@@ -121,10 +122,10 @@ pub fn test_list_items_should_match_snapshot() {
                     ui,
                     list_item::LabelContent::new("LabelContent with buttons (always shown)")
                         .with_buttons(|ui| {
-                            ui.small_icon_button(&icons::ADD, "Add")
-                                | ui.small_icon_button(&icons::REMOVE, "Remove")
+                            ui.small_icon_button(&icons::ADD, "Add");
+                            ui.small_icon_button(&icons::REMOVE, "Remove");
                         })
-                        .always_show_buttons(true),
+                        .with_always_show_buttons(true),
                 );
             },
         );
@@ -165,16 +166,18 @@ pub fn test_list_items_should_match_snapshot() {
                         ui,
                         list_item::PropertyContent::new("Color")
                             .with_icon(&icons::VIEW_TEXT)
-                            .action_button(&icons::ADD, "Add", || {})
-                            .value_color(&color),
+                            .with_action_button(&icons::ADD, "Add", || {})
+                            .value_color(&color)
+                            .with_always_show_buttons(true),
                     );
 
                     ui.list_item().show_hierarchical(
                         ui,
                         list_item::PropertyContent::new("Color (editable)")
                             .with_icon(&icons::VIEW_TEXT)
-                            .action_button(&icons::ADD, "Add", || {})
-                            .value_color_mut(&mut color),
+                            .with_action_button(&icons::ADD, "Add", || {})
+                            .value_color_mut(&mut color)
+                            .with_always_show_buttons(true),
                     );
                 });
             },

--- a/crates/viewer/re_ui/tests/list_item_tests.rs
+++ b/crates/viewer/re_ui/tests/list_item_tests.rs
@@ -1,6 +1,6 @@
 use egui::Vec2;
 use egui_kittest::SnapshotOptions;
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{UiExt as _, icons, list_item};
 
 #[test]

--- a/crates/viewer/re_ui/tests/list_item_tests.rs
+++ b/crates/viewer/re_ui/tests/list_item_tests.rs
@@ -215,7 +215,8 @@ pub fn test_list_items_should_match_snapshot() {
                             "CustomContent with an action button",
                         );
                     })
-                    .action_button(&icons::ADD, "Add", || {}),
+                    .with_action_button(&icons::ADD, "Add", || {})
+                    .with_always_show_buttons(true),
                 );
             },
         );

--- a/crates/viewer/re_ui/tests/modal_tests.rs
+++ b/crates/viewer/re_ui/tests/modal_tests.rs
@@ -1,6 +1,6 @@
 use egui::Vec2;
 
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::modal::{ModalHandler, ModalWrapper};
 use re_ui::{UiExt as _, list_item};
 

--- a/crates/viewer/re_ui/tests/modal_tests.rs
+++ b/crates/viewer/re_ui/tests/modal_tests.rs
@@ -1,5 +1,6 @@
 use egui::Vec2;
 
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::modal::{ModalHandler, ModalWrapper};
 use re_ui::{UiExt as _, list_item};
 
@@ -36,7 +37,8 @@ pub fn test_modal_list_item_should_match_snapshot() {
                 ui.list_item_flat_noninteractive(
                     list_item::PropertyContent::new("Property content")
                         .value_color(&egui::Color32::RED.to_array())
-                        .action_button(&re_ui::icons::EDIT, "Edit", || {}),
+                        .with_action_button(&re_ui::icons::EDIT, "Edit", || {})
+                        .with_always_show_buttons(true),
                 );
             });
         },

--- a/crates/viewer/re_ui/tests/snapshots/filter_widget.png
+++ b/crates/viewer/re_ui/tests/snapshots/filter_widget.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d6ab8cf3bf12341821892f5a23235fdfc13d9f96a8e077bac8e6d1ef51b4aef
-size 9812
+oid sha256:ccaeb1194f7078aa1be271796d29dae3ee9490403e23b8c32cae3e9458d9bab1
+size 9656

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -1,6 +1,6 @@
 use re_types::ComponentDescriptor;
 use re_types_core::{Archetype, ArchetypeReflectionMarker, reflection::ArchetypeFieldReflection};
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{UiExt as _, list_item};
 use re_viewer_context::{
     ComponentFallbackProvider, ComponentUiTypes, QueryContext, ViewContext, ViewerContext,

--- a/crates/viewer/re_view/src/view_property_ui.rs
+++ b/crates/viewer/re_view/src/view_property_ui.rs
@@ -1,5 +1,6 @@
 use re_types::ComponentDescriptor;
 use re_types_core::{Archetype, ArchetypeReflectionMarker, reflection::ArchetypeFieldReflection};
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{UiExt as _, list_item};
 use re_viewer_context::{
     ComponentFallbackProvider, ComponentUiTypes, QueryContext, ViewContext, ViewerContext,
@@ -160,9 +161,10 @@ pub fn view_property_component_ui_custom(
     let component_descr = field.component_descriptor(property.archetype_name);
 
     let singleline_list_item_content = list_item::PropertyContent::new(display_name)
-        .menu_button(&re_ui::icons::MORE, "More options", |ui| {
+        .with_menu_button(&re_ui::icons::MORE, "More options", |ui| {
             menu_more(ctx.viewer_ctx(), ui, property, &component_descr);
         })
+        .with_always_show_buttons(true)
         .value_fn(move |ui, _| singleline_ui(ui));
 
     let list_item_response = if let Some(multiline_ui) = multiline_ui {

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -7,7 +7,7 @@ use re_log_types::{
 };
 use re_sorbet::ColumnSelector;
 use re_types::blueprint::components;
-use re_ui::list_item::ListItemContentButtonsExt;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{TimeDragValue, UiExt as _, list_item};
 use re_viewer_context::{ViewId, ViewSystemExecutionError, ViewerContext};
 use std::collections::{BTreeSet, HashSet};

--- a/crates/viewer/re_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_view_dataframe/src/view_query/ui.rs
@@ -7,6 +7,7 @@ use re_log_types::{
 };
 use re_sorbet::ColumnSelector;
 use re_types::blueprint::components;
+use re_ui::list_item::ListItemContentButtonsExt;
 use re_ui::{TimeDragValue, UiExt as _, list_item};
 use re_viewer_context::{ViewId, ViewSystemExecutionError, ViewerContext};
 use std::collections::{BTreeSet, HashSet};
@@ -66,7 +67,7 @@ impl Query {
 
             ui.list_item_flat_noninteractive(
                 list_item::PropertyContent::new("Start")
-                    .action_button_with_enabled(
+                    .with_action_button_enabled(
                         &re_ui::icons::RESET,
                         "Reset",
                         start != TimeInt::MIN,
@@ -74,6 +75,7 @@ impl Query {
                             reset_start = true;
                         },
                     )
+                    .with_always_show_buttons(true)
                     .value_fn(|ui, _| {
                         if let Some((time_drag_value, timeline_type)) = &time_drag_value_and_type {
                             let response = time_boundary_ui(
@@ -106,7 +108,7 @@ impl Query {
 
             ui.list_item_flat_noninteractive(
                 list_item::PropertyContent::new("End")
-                    .action_button_with_enabled(
+                    .with_action_button_enabled(
                         &re_ui::icons::RESET,
                         "Reset",
                         end != TimeInt::MAX,
@@ -114,6 +116,7 @@ impl Query {
                             reset_to = true;
                         },
                     )
+                    .with_always_show_buttons(true)
                     .value_fn(|ui, _| {
                         if let Some((time_drag_value, timeline_type)) = &time_drag_value_and_type {
                             let response = time_boundary_ui(


### PR DESCRIPTION
### Related

* follow-up to #11164 

### What

Implement the ItemButtons for CustomContent. This still has some problems around how overflow is handled (see the changed test image). I attempted to fix this using egui::Sides but this doesn't seem to fix anything yet. Maybe we could try to change the remember_property_content_max_width to work for all the content types.
