### PR TITLE
SDK: add do-global-maintenance operation 

### DIFF
--- a/crates/store/re_redap_client/src/connection_client.rs
+++ b/crates/store/re_redap_client/src/connection_client.rs
@@ -377,4 +377,14 @@ where
 
         Ok(())
     }
+
+    pub async fn do_global_maintenance(&mut self) -> Result<(), StreamError> {
+        self.inner()
+            .do_global_maintenance(tonic::Request::new(
+                re_protos::cloud::v1alpha1::DoGlobalMaintenanceRequest {},
+            ))
+            .await?;
+
+        Ok(())
+    }
 }

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1741,6 +1741,10 @@ class CatalogClientInternal:
 
     # ---
 
+    def do_global_maintenance(self) -> None: ...
+
+    # ---
+
     def _entry_id_from_entry_name(self, name: str) -> EntryId: ...
 
 class DataFusionTable:

--- a/rerun_py/rerun_sdk/rerun/catalog.py
+++ b/rerun_py/rerun_sdk/rerun/catalog.py
@@ -179,6 +179,10 @@ class CatalogClient:
         """
         return self._raw_client.register_table(name, url)
 
+    def do_global_maintenance(self) -> None:
+        """Perform maintenance tasks on the whole system."""
+        return self._raw_client.do_global_maintenance()
+
     @property
     def ctx(self) -> datafusion.SessionContext:
         """Returns a DataFusion session context for querying the catalog."""

--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -303,6 +303,17 @@ impl PyCatalogClientInternal {
         Py::new(py, (table, entry))
     }
 
+    // ---
+
+    /// Perform global maintenance tasks on the server.
+    fn do_global_maintenance(self_: Py<Self>, py: Python<'_>) -> PyResult<()> {
+        let connection = self_.borrow_mut(py).connection.clone();
+
+        connection.do_global_maintenance(py)
+    }
+
+    // ---
+
     /// The DataFusion context (if available).
     pub fn ctx(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         if let Some(datafusion_ctx) = &self.datafusion_ctx {

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -329,6 +329,21 @@ impl ConnectionHandle {
         )
     }
 
+    #[tracing::instrument(level = "info", skip_all)]
+    pub fn do_global_maintenance(&self, py: Python<'_>) -> PyResult<()> {
+        wait_for_future(
+            py,
+            async {
+                self.client()
+                    .await?
+                    .do_global_maintenance()
+                    .await
+                    .map_err(to_py_err)
+            }
+            .in_current_span(),
+        )
+    }
+
     // TODO(ab): migrate this to the `ConnectionClient` API.
     #[tracing::instrument(level = "info", skip_all)]
     pub fn query_tasks(&self, py: Python<'_>, task_ids: &[TaskId]) -> PyResult<RecordBatch> {


### PR DESCRIPTION
### Related
* Follow up to #11176 
* Related to rr-1930


### What
Add SDK suppoort for issuing global maintenance operations on the redap server.

### Testing

tested manually on my local rerun cloud server with:

```py
client = rr.catalog.CatalogClient(address="rerun+http://localhost:51234")
client.do_global_maintenance()
```
