### PR TITLE
Fix UI glitch when connected twice to the same server

### DIFF
--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -483,9 +483,17 @@ impl RedapServers {
                 match entry.inner() {
                     Ok(crate::entries::EntryInner::Dataset(dataset)) => {
                         server.dataset_entry_ui(viewer_ctx, ui, dataset);
+
+                        // If we're connected twice to the same server, we will find this entry
+                        // multiple times. We avoid it by returning here.
+                        return;
                     }
                     Ok(crate::entries::EntryInner::Table(table)) => {
                         server.table_entry_ui(viewer_ctx, ui, table);
+
+                        // If we're connected twice to the same server, we will find this entry
+                        // multiple times. We avoid it by returning here.
+                        return;
                     }
                     Err(err) => {
                         Frame::new().inner_margin(16.0).show(ui, |ui| {


### PR DESCRIPTION
### What

Fixes a pretty bad UI glitch that would happen when:
- the viewer is connected to the same server more than once, using different dns addresses
- a dataset is selected

<img width="1638" height="824" alt="image" src="https://github.com/user-attachments/assets/8874d852-356f-4ff0-8b41-efa130b9b498" />


