### PR TITLE
Lower default max tooltip width from 720 to 600

### DIFF
--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -481,7 +481,7 @@ impl DesignTokens {
         egui_style.spacing.scroll.bar_width = 6.0;
         egui_style.spacing.scroll.bar_outer_margin = 2.0;
 
-        egui_style.spacing.tooltip_width = 720.0;
+        egui_style.spacing.tooltip_width = 600.0;
 
         egui_style.visuals.image_loading_spinners = false;
     }


### PR DESCRIPTION
Slightly less annoying

## Related
* Follows https://github.com/rerun-io/rerun/pull/11190