### PR TITLE
Make the min size of text edits in filter popup narrower

### DIFF
--- a/crates/viewer/re_dataframe_ui/src/filters/filter_ui.rs
+++ b/crates/viewer/re_dataframe_ui/src/filters/filter_ui.rs
@@ -436,6 +436,10 @@ impl FilterOperation {
 
         let operator_text = self.operator_text();
 
+        // Reduce the default width unnecessarily expands the popup width (queries as usually vers
+        // small).
+        ui.spacing_mut().text_edit_width = 150.0;
+
         // TODO(ab): this is getting unwieldy. All arms should have an independent inner struct,
         // which all handle their own UI.
         match self {

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_float_compares.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_float_compares.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2699faa00f1cb6f4cdd0a21e0b5f897dc81fc952fb51346d348fe2709179c92e
+oid sha256:3e43ff81436f2695c0b0d31a1f92e6c9d01578e0fced681dbf7c8209549688ae
 size 10947

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_float_compares_none.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_float_compares_none.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2490d89b16fc2ffb12daca8f8633d656f6be528f2449120fb5e9718f7cb55e44
+oid sha256:9b9457808e7ae212422f2dd50bba44479c743bccfa269981b5813aeefcea2c79
 size 10292

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_int_compare.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_int_compare.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cbf9a1e697191bcdae5f75a405c6648f264809d93eac1b836f35bdb8250ebd97
-size 10812
+oid sha256:1c8ca09259ed04dfeb14a80da05829a1747b3195b74b18a130e7bfebdbbbd183
+size 10814

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_int_compare_none.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_int_compare_none.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9e3469ee17d111327b879230e56015f5951c66011a26c1ac0fd7396fcc4187b
+oid sha256:79b7036a3bd936aff4b9e9ffa0af016ca2a831984e526986087ae8d7ed2c58b0
 size 10230

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_string_contains.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_string_contains.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c56b21bbca15ddef223fe15ca91300c708491052ba23a6d0b1d521dba9008234
+oid sha256:11e014ed8d77d2aa10cacec21ae53cdc7e153ce77d1e65d2c9ffe883a512309f
 size 11857

--- a/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_string_contains_empty.png
+++ b/crates/viewer/re_dataframe_ui/tests/snapshots/popup_ui_string_contains_empty.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8967923ea3f58a517f11adff936c482d32bd816567bd924b47ef865c4606530
+oid sha256:463ea1359770db59f494af262df3b54fa62e214fb9b9ac29d41b3c237d6cacb4
 size 10980


### PR DESCRIPTION
### Related

* part of https://linear.app/rerun/project/ability-to-filter-tables-in-the-viewer-8dcb9ff4e6bc/overview
* part of https://github.com/rerun-io/rerun/issues/10560
* part of https://linear.app/rerun/issue/RR-2215/tracking-issue-ability-to-filter-tables-in-the-viewer
* closes of https://linear.app/rerun/issue/RR-2271/table-filter-ui-refinements

### What

Make the min size of text edits in filter popup narrower.

DNM: chained