### PR TITLE
CI: Fix retry on windows runners

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -182,6 +182,7 @@ jobs:
           max_attempts: 2
           retry_wait_seconds: 30
           timeout_minutes: 60
+          shell: bash
           command: cd rerun_py/tests && pixi run -e wheel-test-min pytest -c ../pyproject.toml
 
       - name: Run e2e test


### PR DESCRIPTION
Powershell is apparently not powerfull enough to support `&&`