### PR TITLE
Use Display for DataTypes, not Debug formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7421,6 +7421,7 @@ dependencies = [
  "egui_extras",
  "itertools 0.14.0",
  "re_arrow_ui",
+ "re_arrow_util",
  "re_byte_size",
  "re_chunk_store",
  "re_format",

--- a/crates/store/re_data_loader/src/loader_lerobot.rs
+++ b/crates/store/re_data_loader/src/loader_lerobot.rs
@@ -600,7 +600,7 @@ fn make_scalar_entity_chunk(
 fn extract_scalar_slices_as_f64(data: &ArrayRef) -> anyhow::Result<Vec<ArrayRef>> {
     // cast the slice to f64 first, as scalars need an f64
     let scalar_values = cast(&data, &DataType::Float64)
-        .with_context(|| format!("Failed to cast {:?} to Float64", data.data_type()))?;
+        .with_context(|| format!("Failed to cast {} to Float64", data.data_type()))?;
 
     Ok((0..data.len())
         .map(|idx| scalar_values.slice(idx, 1))
@@ -613,7 +613,7 @@ fn extract_fixed_size_list_array_elements_as_f64(
     (0..data.len())
         .map(|idx| {
             cast(&data.value(idx), &DataType::Float64)
-                .with_context(|| format!("Failed to cast {:?} to Float64", data.data_type()))
+                .with_context(|| format!("Failed to cast {} to Float64", data.data_type()))
         })
         .collect::<Result<Vec<_>, _>>()
 }
@@ -624,7 +624,7 @@ fn extract_list_array_elements_as_f64(
     (0..data.len())
         .map(|idx| {
             cast(&data.value(idx), &DataType::Float64)
-                .with_context(|| format!("Failed to cast {:?} to Float64", data.data_type()))
+                .with_context(|| format!("Failed to cast {} to Float64", data.data_type()))
         })
         .collect::<Result<Vec<_>, _>>()
 }

--- a/crates/store/re_sorbet/src/index_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/index_column_descriptor.rs
@@ -5,7 +5,7 @@ use re_log_types::{Timeline, TimelineName};
 use crate::MetadataExt as _;
 
 #[derive(thiserror::Error, Debug)]
-#[error("Unsupported time type: {datatype:?}")]
+#[error("Unsupported time type: {datatype}")]
 pub struct UnsupportedTimeType {
     pub datatype: ArrowDatatype,
 }

--- a/crates/store/re_sorbet/src/row_id_column_descriptor.rs
+++ b/crates/store/re_sorbet/src/row_id_column_descriptor.rs
@@ -86,7 +86,7 @@ impl TryFrom<&ArrowField> for RowIdColumnDescriptor {
             })
         } else {
             Err(WrongDatatypeError(format!(
-                "Expected a RowId column with datatype {expected_datatype:?}, but column {:?} has datatype {actual_datatype:?}",
+                "Expected a RowId column with datatype {expected_datatype}, but column {:?} has datatype {actual_datatype}",
                 field.name()
             )))
         }

--- a/crates/store/re_types/src/archetypes/depth_image_ext.rs
+++ b/crates/store/re_types/src/archetypes/depth_image_ext.rs
@@ -50,7 +50,7 @@ impl DepthImage {
         let num_expected_bytes = image_format.num_bytes();
         if buffer.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {} {datatype:?} image to be {num_expected_bytes} B, but got {} B",
+                "Expected {width}x{height} {} {datatype} image to be {num_expected_bytes} B, but got {} B",
                 ColorModel::L,
                 buffer.len()
             );

--- a/crates/store/re_types/src/archetypes/image_ext.rs
+++ b/crates/store/re_types/src/archetypes/image_ext.rs
@@ -99,7 +99,7 @@ impl Image {
         let num_expected_bytes = image_format.num_bytes();
         if buffer.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B",
+                "Expected {width}x{height} {color_model:?} {datatype} image to be {num_expected_bytes} B, but got {} B",
                 buffer.len()
             );
         }

--- a/crates/store/re_types/src/components/image_buffer_ext.rs
+++ b/crates/store/re_types/src/components/image_buffer_ext.rs
@@ -20,7 +20,7 @@ impl ImageBuffer {
         let num_expected_bytes = image_format.num_bytes();
         if bytes.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B",
+                "Expected {width}x{height} {color_model:?} {datatype} image to be {num_expected_bytes} B, but got {} B",
                 bytes.len()
             );
         }

--- a/crates/store/re_types_core/src/reflection.rs
+++ b/crates/store/re_types_core/src/reflection.rs
@@ -95,7 +95,7 @@ pub fn generic_placeholder_for_datatype(
 
             TimeUnit::Microsecond | TimeUnit::Nanosecond => {
                 re_log::debug_once!(
-                    "Attempted to create a placeholder for out-of-spec datatype: {datatype:?}"
+                    "Attempted to create a placeholder for out-of-spec datatype: {datatype}"
                 );
                 array::new_empty_array(datatype)
             }
@@ -112,7 +112,7 @@ pub fn generic_placeholder_for_datatype(
 
             TimeUnit::Second | TimeUnit::Millisecond => {
                 re_log::debug_once!(
-                    "Attempted to create a placeholder for out-of-spec datatype: {datatype:?}"
+                    "Attempted to create a placeholder for out-of-spec datatype: {datatype}"
                 );
                 array::new_empty_array(datatype)
             }
@@ -198,7 +198,7 @@ pub fn generic_placeholder_for_datatype(
             {
                 Arc::new(array::FixedSizeListArray::from(list_data))
             } else {
-                re_log::warn_once!("Bug in FixedSizeListArray of {:?}", field.data_type());
+                re_log::warn_once!("Bug in FixedSizeListArray of {}", field.data_type());
                 array::new_empty_array(datatype)
             }
         }
@@ -245,7 +245,7 @@ pub fn generic_placeholder_for_datatype(
         | DataType::LargeListView { .. }
         | DataType::RunEndEncoded { .. } => {
             // TODO(emilk)
-            re_log::debug_once!("Unimplemented: placeholder value for: {datatype:?}");
+            re_log::debug_once!("Unimplemented: placeholder value for: {datatype}");
             array::new_empty_array(datatype) // TODO(emilk)
         }
     }

--- a/crates/store/re_types_core/src/result.rs
+++ b/crates/store/re_types_core/src/result.rs
@@ -142,7 +142,7 @@ pub enum DeserializationError {
     #[error("Expected non-nullable data but didn't find any")]
     MissingData { backtrace: Box<_Backtrace> },
 
-    #[error("Expected field {field_name:?} to be present in {datatype:#?}")]
+    #[error("Expected field {field_name:?} to be present in {datatype}")]
     MissingStructField {
         datatype: arrow::datatypes::DataType,
         field_name: String,
@@ -160,7 +160,7 @@ pub enum DeserializationError {
         backtrace: Box<_Backtrace>,
     },
 
-    #[error("Expected union arm {arm_name:?} (#{arm_index}) to be present in {datatype:#?}")]
+    #[error("Expected union arm {arm_name:?} (#{arm_index}) to be present in {datatype}")]
     MissingUnionArm {
         datatype: arrow::datatypes::DataType,
         arm_name: String,
@@ -168,7 +168,7 @@ pub enum DeserializationError {
         backtrace: Box<_Backtrace>,
     },
 
-    #[error("Expected {expected:#?} but found {got:#?} instead")]
+    #[error("Expected {expected} but found {got} instead")]
     DatatypeMismatch {
         expected: arrow::datatypes::DataType,
         got: arrow::datatypes::DataType,

--- a/crates/top/rerun/src/commands/rrd/verify.rs
+++ b/crates/top/rerun/src/commands/rrd/verify.rs
@@ -140,7 +140,7 @@ impl Verifier {
             }
 
             let list_array = column.as_list_opt::<i32>().ok_or_else(|| {
-                anyhow::anyhow!("Expected list array, found {:?}", column.data_type())
+                anyhow::anyhow!("Expected list array, found {}", column.data_type())
             })?;
 
             assert_eq!(column.len() + 1, list_array.offsets().len());

--- a/crates/utils/re_arrow_util/src/format_data_type.rs
+++ b/crates/utils/re_arrow_util/src/format_data_type.rs
@@ -5,6 +5,8 @@ use std::fmt::Formatter;
 use arrow::datatypes::{DataType, Field, IntervalUnit, TimeUnit};
 
 /// Compact format of an arrow data type.
+///
+/// TODO(emilk): upstream this to `arrow` instead.
 pub fn format_data_type(data_type: &DataType) -> String {
     DisplayDatatype(data_type).to_string()
 }

--- a/crates/viewer/re_chunk_store_ui/Cargo.toml
+++ b/crates/viewer/re_chunk_store_ui/Cargo.toml
@@ -20,6 +20,7 @@ all-features = true
 
 [dependencies]
 re_arrow_ui.workspace = true
+re_arrow_util.workspace = true
 re_byte_size.workspace = true
 re_chunk_store.workspace = true
 re_format.workspace = true

--- a/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
@@ -85,7 +85,7 @@ impl ChunkUi {
             .map(|(component_desc, list_array)| {
                 (
                     component_desc.clone(),
-                    format!("{:#?}", list_array.data_type()),
+                    re_arrow_util::format_data_type(list_array.data_type()),
                 )
             })
             .collect::<BTreeMap<_, _>>();
@@ -208,7 +208,7 @@ impl ChunkUi {
                 ui.push_id(field.name().clone(), |ui| {
                     ui.list_item_collapsible_noninteractive_label(field.name(), false, |ui| {
                         ui.list_item_collapsible_noninteractive_label("Data type", false, |ui| {
-                            ui.label(format!("{:#?}", field.data_type()));
+                            ui.label(re_arrow_util::format_data_type(field.data_type()));
                         });
 
                         ui.list_item_collapsible_noninteractive_label("Metadata", false, |ui| {


### PR DESCRIPTION
### Related
* https://github.com/apache/arrow-rs/pull/8290
* https://github.com/apache/datafusion/pull/17565
* https://github.com/rerun-io/dataplatform/pull/1719

### What
In general, use `Display` formatting for anything user facing, which includes all UI and all debug messages, and all log messages.