### PR TITLE
dataplatform: make traceheaders struct serde friendly

### DIFF
--- a/crates/utils/re_perf_telemetry/src/lib.rs
+++ b/crates/utils/re_perf_telemetry/src/lib.rs
@@ -125,7 +125,7 @@ pub fn current_trace_headers() -> Option<TraceHeaders> {
     Some(carrier)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TraceHeaders {
     pub traceparent: String,
     pub tracestate: Option<String>,


### PR DESCRIPTION
### Related

* Part of RR-1891

### What

As part of ongoing changes to make dataplatform deploy seamlessly to Azure environments, we need to make the internal TraceHeaders structure serde-friendly.
