### PR TITLE
Fix: Patch blueprint id when forced_application_id is set

### DIFF
--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -204,7 +204,20 @@ fn decode_and_stream<R: std::io::Read>(
                 }
 
                 re_log_types::LogMsg::BlueprintActivationCommand(blueprint_activation_command) => {
-                    re_log_types::LogMsg::BlueprintActivationCommand(blueprint_activation_command)
+                    let mut blueprint_id = blueprint_activation_command.blueprint_id.clone();
+                    if let Some(forced_application_id) = forced_application_id {
+                        blueprint_id =
+                            blueprint_id.with_application_id(forced_application_id.clone());
+                    }
+                    if let Some(forced_recording_id) = forced_recording_id {
+                        blueprint_id = blueprint_id.with_recording_id(forced_recording_id.clone());
+                    }
+                    re_log_types::LogMsg::BlueprintActivationCommand(
+                        re_log_types::BlueprintActivationCommand {
+                            blueprint_id,
+                            ..blueprint_activation_command
+                        },
+                    )
                 }
             }
         } else {

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -209,9 +209,6 @@ fn decode_and_stream<R: std::io::Read>(
                         blueprint_id =
                             blueprint_id.with_application_id(forced_application_id.clone());
                     }
-                    if let Some(forced_recording_id) = forced_recording_id {
-                        blueprint_id = blueprint_id.with_recording_id(forced_recording_id.clone());
-                    }
                     re_log_types::LogMsg::BlueprintActivationCommand(
                         re_log_types::BlueprintActivationCommand {
                             blueprint_id,


### PR DESCRIPTION
### What

Patch the blueprint id in outgoing `LogMsg`s, if a `forced_application_id` is set. This was implemented for `LogMsg::ArrowMsg` and `LogMsg::SetStoreInfo` in #10742 but not for `LogMsg::BlueprintActivationCommand`.