### PR TITLE
Fix table UI not saying switch to when opening a certain links

### DIFF
--- a/crates/utils/re_smart_channel/src/lib.rs
+++ b/crates/utils/re_smart_channel/src/lib.rs
@@ -130,6 +130,14 @@ impl SmartChannelSource {
         }
     }
 
+    /// Same as [`Self::redap_uri`], but strips any extra query or fragment from the uri.
+    pub fn stripped_redap_uri(&self) -> Option<RedapUri> {
+        self.redap_uri().map(|uri| match uri {
+            RedapUri::Catalog(_) | RedapUri::Entry(_) | RedapUri::Proxy(_) => uri,
+            RedapUri::DatasetData(uri) => RedapUri::DatasetData(uri.without_query_and_fragment()),
+        })
+    }
+
     /// Loading text for sources that load data from a specific source (e.g. a file or a URL).
     ///
     /// Returns `None` for any source that receives data dynamically through SDK calls or similar.

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -38,7 +38,7 @@ pub fn redap_uri_button(
         if db
             .data_source
             .as_ref()
-            .is_some_and(|source| source.redap_uri().as_ref() == Some(&uri))
+            .is_some_and(|source| source.stripped_redap_uri().as_ref() == Some(&uri))
         {
             Some(db.store_id().clone())
         } else {
@@ -50,7 +50,7 @@ pub fn redap_uri_button(
             .connected_receivers
             .sources()
             .iter()
-            .any(|source| source.redap_uri().as_ref() == Some(&uri));
+            .any(|source| source.stripped_redap_uri().as_ref() == Some(&uri));
 
     // Show the link left aligned and justified, so the whole cell is clickable.
     let put_justified_left_aligned = |ui: &mut Ui, link| {


### PR DESCRIPTION
### Related

Closes #11196

### What

Fixes a bug where recordings opened with links that had time selection or fragments didn't show as "Switch To" or loading in the table.