### PR TITLE
Add copy button to the recording link table item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7445,6 +7445,7 @@ dependencies = [
  "re_arrow_util",
  "re_data_ui",
  "re_format",
+ "re_log",
  "re_log_types",
  "re_protos",
  "re_test_context",

--- a/crates/viewer/re_component_ui/Cargo.toml
+++ b/crates/viewer/re_component_ui/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 re_arrow_util.workspace = true
 re_data_ui.workspace = true # Needed for `item_ui`.
 re_format.workspace = true
+re_log.workspace = true
 re_log_types.workspace = true
 re_protos.workspace = true
 re_tracing.workspace = true

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -55,7 +55,9 @@ pub fn redap_uri_button(
             .any(|source| source.redap_uri().as_ref() == Some(&uri));
 
     let uri_clone = uri.clone();
-    // Show the link left aligned, and add a copy button.
+    // Show the link left aligned and justified so the whole cell is clickable.
+    //
+    // And add a button to copy the link.
     let link_with_copy = |ui: &mut Ui, link| {
         let rect = ui.max_rect();
         let contains_pointer = ui.rect_contains_pointer(rect);

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -63,21 +63,17 @@ pub fn redap_uri_button(
         let contains_pointer = ui.rect_contains_pointer(rect);
         egui::Sides::new()
             .shrink_left()
+            .height(ui.max_rect().height())
             .show(
                 ui,
                 |ui| {
                     ui.scope_builder(
-                        UiBuilder::new()
-                            .max_rect(egui::Rect::from_x_y_ranges(
-                                ui.max_rect().x_range(),
-                                rect.y_range(),
-                            ))
-                            .layout(
-                                Layout::left_to_right(Align::Center)
-                                    .with_main_justify(true)
-                                    .with_cross_justify(true)
-                                    .with_main_align(Align::Min),
-                            ),
+                        UiBuilder::new().max_rect(ui.max_rect()).layout(
+                            Layout::left_to_right(Align::Center)
+                                .with_main_justify(true)
+                                .with_cross_justify(true)
+                                .with_main_align(Align::Min),
+                        ),
                         |ui| ui.add(link),
                     )
                     .inner
@@ -85,19 +81,7 @@ pub fn redap_uri_button(
                 |ui| {
                     if contains_pointer
                         && ui
-                            .scope_builder(
-                                UiBuilder::new()
-                                    .max_rect(egui::Rect::from_x_y_ranges(
-                                        ui.max_rect().x_range(),
-                                        rect.y_range(),
-                                    ))
-                                    .layout(
-                                        Layout::right_to_left(Align::Center)
-                                            .with_cross_justify(true),
-                                    ),
-                                |ui| ui.small_icon_button(&re_ui::icons::COPY, "Copy link"),
-                            )
-                            .inner
+                            .small_icon_button(&re_ui::icons::COPY, "Copy link")
                             .clicked()
                     {
                         if let Ok(url) = ViewerOpenUrl::from(uri_clone).sharable_url(None) {

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -3,7 +3,7 @@ use std::str::FromStr as _;
 
 use egui::{Align, Layout, Link, Ui, UiBuilder};
 use re_types_core::{ComponentDescriptor, RowId};
-use re_ui::UiExt;
+use re_ui::UiExt as _;
 use re_uri::RedapUri;
 use re_viewer_context::{
     SystemCommand, SystemCommandSender as _, ViewerContext, open_url::ViewerOpenUrl,
@@ -55,18 +55,37 @@ pub fn redap_uri_button(
             .any(|source| source.redap_uri().as_ref() == Some(&uri));
 
     let uri_clone = uri.clone();
-    // Show the link left aligned and justified, so the whole cell is clickable.
-    let put_justified_left_aligned = |ui: &mut Ui, link| {
-        ui.scope_builder(
-            UiBuilder::new().max_rect(ui.max_rect()).layout(
-                Layout::right_to_left(Align::Center)
-                    .with_cross_justify(true)
-                    .with_main_align(Align::Min),
-            ),
-            |ui| {
-                let rect = if ui.rect_contains_pointer(ui.max_rect()) {
-                    let res = ui.small_icon_button(&re_ui::icons::COPY, "Copy link");
-                    if res.clicked() {
+    // Show the link left aligned, and add a copy button.
+    let link_with_copy = |ui: &mut Ui, link| {
+        let rect = ui.max_rect();
+        let contains_pointer = ui.rect_contains_pointer(rect);
+        egui::Sides::new()
+            .shrink_left()
+            .show(
+                ui,
+                |ui| {
+                    ui.scope_builder(
+                        UiBuilder::new()
+                            .max_rect(egui::Rect::from_x_y_ranges(
+                                ui.max_rect().x_range(),
+                                rect.y_range(),
+                            ))
+                            .layout(
+                                Layout::left_to_right(Align::Center)
+                                    .with_main_justify(true)
+                                    .with_cross_justify(true)
+                                    .with_main_align(Align::Min),
+                            ),
+                        |ui| ui.add(link),
+                    )
+                    .inner
+                },
+                |ui| {
+                    if contains_pointer
+                        && ui
+                            .small_icon_button(&re_ui::icons::COPY, "Copy link")
+                            .clicked()
+                    {
                         if let Ok(url) = ViewerOpenUrl::from(uri_clone).sharable_url(None) {
                             ctx.command_sender()
                                 .send_system(SystemCommand::CopyViewerUrl(url));
@@ -74,31 +93,13 @@ pub fn redap_uri_button(
                             re_log::error!("Failed to create a sharable url for recording");
                         }
                     }
-
-                    let mut rect = ui.max_rect();
-                    rect.max.x = res.rect.min.x;
-                    rect
-                } else {
-                    ui.max_rect()
-                };
-
-                ui.scope_builder(
-                    UiBuilder::new().max_rect(rect).layout(
-                        Layout::left_to_right(Align::Center)
-                            .with_main_justify(true)
-                            .with_cross_justify(true)
-                            .with_main_align(Align::Min),
-                    ),
-                    |ui| ui.add(link),
-                )
-                .inner
-            },
-        )
-        .inner
+                },
+            )
+            .0
     };
 
     if let Some(loaded_recording_id) = loaded_recording_id {
-        let response = put_justified_left_aligned(ui, Link::new("Switch to")).on_hover_ui(|ui| {
+        let response = link_with_copy(ui, Link::new("Switch to")).on_hover_ui(|ui| {
             ui.label("This recording is already loaded. Click to switch to it.");
         });
 
@@ -122,7 +123,7 @@ pub fn redap_uri_button(
             }
         });
     } else {
-        let response = put_justified_left_aligned(ui, Link::new("Open")).on_hover_ui(|ui| {
+        let response = link_with_copy(ui, Link::new("Open")).on_hover_ui(|ui| {
             ui.label(uri.to_string());
         });
 

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -85,7 +85,19 @@ pub fn redap_uri_button(
                 |ui| {
                     if contains_pointer
                         && ui
-                            .small_icon_button(&re_ui::icons::COPY, "Copy link")
+                            .scope_builder(
+                                UiBuilder::new()
+                                    .max_rect(egui::Rect::from_x_y_ranges(
+                                        ui.max_rect().x_range(),
+                                        rect.y_range(),
+                                    ))
+                                    .layout(
+                                        Layout::right_to_left(Align::Center)
+                                            .with_cross_justify(true),
+                                    ),
+                                |ui| ui.small_icon_button(&re_ui::icons::COPY, "Copy link"),
+                            )
+                            .inner
                             .clicked()
                     {
                         if let Ok(url) = ViewerOpenUrl::from(uri_clone).sharable_url(None) {

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -35,7 +35,6 @@ pub fn redap_uri_button(
         .value(0);
 
     let uri = RedapUri::from_str(url_str)?;
-    let uri_clone = uri.clone();
 
     let loaded_recording_id = ctx.storage_context.bundle.recordings().find_map(|db| {
         if db
@@ -55,6 +54,7 @@ pub fn redap_uri_button(
             .iter()
             .any(|source| source.redap_uri().as_ref() == Some(&uri));
 
+    let uri_clone = uri.clone();
     // Show the link left aligned and justified, so the whole cell is clickable.
     let put_justified_left_aligned = |ui: &mut Ui, link| {
         let res = ui

--- a/crates/viewer/re_viewer_context/src/open_url.rs
+++ b/crates/viewer/re_viewer_context/src/open_url.rs
@@ -86,6 +86,17 @@ pub enum ViewerOpenUrl {
     },
 }
 
+impl From<re_uri::RedapUri> for ViewerOpenUrl {
+    fn from(value: re_uri::RedapUri) -> Self {
+        match value {
+            re_uri::RedapUri::Catalog(uri) => Self::RedapCatalog(uri),
+            re_uri::RedapUri::Entry(uri) => Self::RedapEntry(uri),
+            re_uri::RedapUri::DatasetData(uri) => Self::RedapDatasetPartition(uri),
+            re_uri::RedapUri::Proxy(uri) => Self::RedapProxy(uri),
+        }
+    }
+}
+
 impl std::str::FromStr for ViewerOpenUrl {
     type Err = anyhow::Error;
 


### PR DESCRIPTION
### Related

Part of #10815

### What

Adds a copy button that's shown on hover in table url entries
<img width="322" height="394" alt="image" src="https://github.com/user-attachments/assets/63e0ce09-01ec-419b-b3e1-b4cfe3bf2fd6" />

- [x] look into if it's possible to not have to define the copy button rect