### PR TITLE
Fix some menu buttons closing unexpectedly

### DIFF
--- a/crates/viewer/re_ui/src/list_item/item_buttons.rs
+++ b/crates/viewer/re_ui/src/list_item/item_buttons.rs
@@ -196,6 +196,8 @@ where
     /// The `alt_text` will also be used for the tooltip.
     ///
     /// See [`Self::with_button`] for more information.
+    ///
+    /// Sets [`Self::with_always_show_buttons`] to `true` (TODO(emilk/egui#7531)).
     #[inline]
     fn with_menu_button(
         self,
@@ -204,12 +206,14 @@ where
         add_contents: impl FnOnce(&mut egui::Ui) + 'a,
     ) -> Self {
         let hover_text = alt_text.into();
-        self.with_button(
+        self.with_always_show_buttons(true).with_button(
             super::ItemMenuButton::new(icon, &hover_text, add_contents).hover_text(hover_text),
         )
     }
 
     /// Set the help text tooltip to be shown in the header.
+    ///
+    /// Sets [`Self::with_always_show_buttons`] to `true` (TODO(emilk/egui#7531)).
     #[inline]
     fn with_help_text(self, help: impl Into<egui::WidgetText> + 'a) -> Self {
         self.with_help_ui(|ui| {
@@ -218,6 +222,8 @@ where
     }
 
     /// Set the help markdown tooltip to be shown in the header.
+    ///
+    /// Sets [`Self::with_always_show_buttons`] to `true` (TODO(emilk/egui#7531)).
     #[inline]
     fn with_help_markdown(self, help: &'a str) -> Self {
         self.with_help_ui(|ui| {
@@ -226,8 +232,21 @@ where
     }
 
     /// Set the help UI closure to be shown in the header.
+    ///
+    /// Sets [`Self::with_always_show_buttons`] to `true` (TODO(emilk/egui#7531)).
     #[inline]
     fn with_help_ui(self, help: impl FnOnce(&mut egui::Ui) + 'a) -> Self {
-        self.with_button(|ui: &mut egui::Ui| ui.help_button(help))
+        self.with_always_show_buttons(true)
+            .with_button(|ui: &mut egui::Ui| ui.help_button(help))
+    }
+}
+
+impl<'a> ListItemContentButtonsExt<'a> for ItemButtons<'a> {
+    fn buttons(&self) -> &ItemButtons<'a> {
+        self
+    }
+
+    fn buttons_mut(&mut self) -> &mut ItemButtons<'a> {
+        self
     }
 }

--- a/crates/viewer/re_ui/src/list_item/item_buttons.rs
+++ b/crates/viewer/re_ui/src/list_item/item_buttons.rs
@@ -242,11 +242,11 @@ where
 }
 
 impl<'a> ListItemContentButtonsExt<'a> for ItemButtons<'a> {
-    fn buttons(&self) -> &ItemButtons<'a> {
+    fn buttons(&self) -> &Self {
         self
     }
 
-    fn buttons_mut(&mut self) -> &mut ItemButtons<'a> {
+    fn buttons_mut(&mut self) -> &mut Self {
         self
     }
 }

--- a/crates/viewer/re_ui/src/section_collapsing_header.rs
+++ b/crates/viewer/re_ui/src/section_collapsing_header.rs
@@ -19,7 +19,9 @@ impl SectionCollapsingHeader<'_> {
         Self {
             label: label.into(),
             default_open: true,
-            buttons: ItemButtons::default(),
+            buttons: ItemButtons::default()
+                // Section headers should always show buttons
+                .with_always_show_buttons(true),
         }
     }
 


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/11245

### What

Changes the default for `should_always_show_buttons` to true when adding a menu button. 
Maybe we should change the default to be always true though?
I feel like usually you want to always show buttons, unless every list item has it (e.g. visibility in the blueprint tree) where it would add too much noise / use too much space.

When I worked on the new ItemButtons, I defaulted to false since that was the default in LabelContent.
