### PR TITLE
Fix space origin editor resetting & closing immediately

### DIFF
--- a/crates/viewer/re_selection_panel/src/view_space_origin_ui.rs
+++ b/crates/viewer/re_selection_panel/src/view_space_origin_ui.rs
@@ -43,7 +43,10 @@ pub(crate) fn view_space_origin_widget_ui(
             let mut space_origin_string = view.space_origin.to_string();
             let output = egui::TextEdit::singleline(&mut space_origin_string).show(ui);
 
-            if output.response.gained_focus() {
+            // Delay opening the popup until the click is finished, otherwise the popup will close
+            // immediately because the popup thinks this is a clicked_elsewhere.
+            let click_finished = ui.ctx().input(|i| !i.pointer.any_down());
+            if output.response.has_focus() && click_finished {
                 state = SpaceOriginEditState::Editing(EditState {
                     origin_string: space_origin_string,
                     entered_editing: true,

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -1,7 +1,8 @@
 use std::hash::Hash;
 
 use egui::{
-    CollapsingResponse, Color32, NumExt as _, Rangef, Rect, Widget as _, WidgetText,
+    CollapsingResponse, Color32, NumExt as _, PopupCloseBehavior, Rangef, Rect, Widget as _,
+    WidgetText,
     emath::{GuiRounding as _, Rot2},
     pos2,
 };

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -1,8 +1,7 @@
 use std::hash::Hash;
 
 use egui::{
-    CollapsingResponse, Color32, NumExt as _, PopupCloseBehavior, Rangef, Rect, Widget as _,
-    WidgetText,
+    CollapsingResponse, Color32, NumExt as _, Rangef, Rect, Widget as _, WidgetText,
     emath::{GuiRounding as _, Rot2},
     pos2,
 };


### PR DESCRIPTION
### Related
* close https://github.com/rerun-io/rerun/issues/11244

### What

Fixes the space origin editor. It will now always switch to editing state if focused, before, even without breaking this would have been weird and buggy if clicking the text again. Still not ideal but good enough for now. Maybe eventually we could make a generic autocomplete widget with better focus handling.