### PR TITLE
Add entry id to resolve api update

### DIFF
--- a/crates/store/re_datafusion/src/search_provider.rs
+++ b/crates/store/re_datafusion/src/search_provider.rs
@@ -113,7 +113,9 @@ impl GrpcStreamToTable for SearchResultsTableProvider {
     async fn send_streaming_request(
         &mut self,
     ) -> DataFusionResult<tonic::Response<tonic::Streaming<Self::GrpcStreamData>>> {
-        let request = self.request.clone();
+        let request = tonic::Request::new(self.request.clone())
+            .with_entry_id(self.dataset_id)
+            .map_err(|err| DataFusionError::External(Box::new(err)))?;
 
         let mut client = self.client.clone();
 


### PR DESCRIPTION
### Related
Our vector search on the cloud is broken because we aren't adding the entry id to the header.
https://rerunio.slack.com/archives/C07T0LFT5BQ/p1758117346508129?thread_ts=1758115910.966309&cid=C07T0LFT5BQ

### What
Adds an entry id to the header.

Repro to confirm the fix:
* Enable cloud credentials
```python
client = rr.catalog.CatalogClient(CATALOG_URL)
dataset = client.get_dataset_entry(name=DATASET)

import numpy as np
embedding_column = rr.dataframe.ComponentColumnSelector("/camera/wrist/embedding", "embeddings")
search_results = dataset.search_vector(np.zeros((768,)), embedding_column, top_k=1000).df()
print(f"Found {search_results.count()} with similar images")
search_results
```
