### PR TITLE
Add a flag to `TimestampFormat` to control if today dates are omitted

### DIFF
--- a/crates/store/re_log_types/src/index/mod.rs
+++ b/crates/store/re_log_types/src/index/mod.rs
@@ -23,5 +23,5 @@ pub use self::{
     time_type::TimeType,
     timeline::{Timeline, TimelineName},
     timestamp::Timestamp,
-    timestamp_format::TimestampFormat,
+    timestamp_format::{TimestampFormat, TimestampFormatKind},
 };

--- a/crates/store/re_log_types/src/index/time_type.rs
+++ b/crates/store/re_log_types/src/index/time_type.rs
@@ -41,7 +41,7 @@ impl TimeType {
     }
 
     pub fn format_sequence(time_int: TimeInt) -> String {
-        Self::Sequence.format(time_int, TimestampFormat::Utc)
+        Self::Sequence.format(time_int, TimestampFormat::utc())
     }
 
     pub fn parse_sequence(s: &str) -> Option<TimeInt> {
@@ -116,7 +116,7 @@ impl TimeType {
 
     #[inline]
     pub fn format_utc(&self, time_int: TimeInt) -> String {
-        self.format(time_int, TimestampFormat::Utc)
+        self.format(time_int, TimestampFormat::utc())
     }
 
     #[inline]
@@ -134,7 +134,7 @@ impl TimeType {
 
     #[inline]
     pub fn format_range_utc(&self, time_range: AbsoluteTimeRange) -> String {
-        self.format_range(time_range, TimestampFormat::Utc)
+        self.format_range(time_range, TimestampFormat::utc())
     }
 
     /// Returns the appropriate arrow datatype to represent this timeline.

--- a/crates/store/re_log_types/src/index/timeline.rs
+++ b/crates/store/re_log_types/src/index/timeline.rs
@@ -132,7 +132,7 @@ impl Timeline {
     /// Returns a formatted string of `time_range` on this `Timeline`.
     #[inline]
     pub fn format_time_range_utc(&self, time_range: &AbsoluteTimeRange) -> String {
-        self.format_time_range(time_range, TimestampFormat::Utc)
+        self.format_time_range(time_range, TimestampFormat::utc())
     }
 
     /// Returns the appropriate arrow datatype to represent this timeline.

--- a/crates/store/re_log_types/src/index/timestamp.rs
+++ b/crates/store/re_log_types/src/index/timestamp.rs
@@ -1,7 +1,7 @@
+use super::{Duration, TimestampFormat};
+use crate::TimestampFormatKind;
 use crate::external::re_types_core;
 use std::str::FromStr as _;
-
-use super::{Duration, TimestampFormat};
 
 /// Encodes a timestamp in nanoseconds since unix epoch.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -164,8 +164,8 @@ impl Timestamp {
 
         let timestamp = jiff::Timestamp::from(self);
 
-        match timestamp_format {
-            TimestampFormat::UnixEpoch => {
+        match timestamp_format.kind() {
+            TimestampFormatKind::UnixEpoch => {
                 format!(
                     "{}{}",
                     timestamp.as_second(),
@@ -173,24 +173,24 @@ impl Timestamp {
                 )
             }
 
-            TimestampFormat::LocalTimezone
-            | TimestampFormat::LocalTimezoneImplicit
-            | TimestampFormat::Utc => {
+            TimestampFormatKind::LocalTimezone
+            | TimestampFormatKind::LocalTimezoneImplicit
+            | TimestampFormatKind::Utc => {
                 let tz = timestamp_format.to_jiff_time_zone();
                 let zoned = timestamp.to_zoned(tz.clone());
 
                 let is_today = zoned.date() == jiff::Timestamp::now().to_zoned(tz.clone()).date();
 
-                let formatted = if is_today {
+                let formatted = if timestamp_format.hide_today_date() && is_today {
                     zoned.strftime("%H:%M:%S").to_string()
                 } else {
                     zoned.strftime("%Y-%m-%d %H:%M:%S").to_string()
                 };
 
-                let suffix = match timestamp_format {
-                    TimestampFormat::LocalTimezone => tz.to_offset(timestamp).to_string(),
-                    TimestampFormat::LocalTimezoneImplicit => String::new(),
-                    TimestampFormat::Utc | TimestampFormat::UnixEpoch => "Z".to_owned(),
+                let suffix = match timestamp_format.kind() {
+                    TimestampFormatKind::LocalTimezone => tz.to_offset(timestamp).to_string(),
+                    TimestampFormatKind::LocalTimezoneImplicit => String::new(),
+                    TimestampFormatKind::Utc | TimestampFormatKind::UnixEpoch => "Z".to_owned(),
                 };
 
                 format!(
@@ -206,8 +206,8 @@ impl Timestamp {
     /// Shows dates when zoomed out, shows times when zoomed in,
     /// shows relative millisecond when really zoomed in.
     pub fn format_time_compact(self, timestamp_format: TimestampFormat) -> String {
-        match timestamp_format {
-            TimestampFormat::UnixEpoch => {
+        match timestamp_format.kind() {
+            TimestampFormatKind::UnixEpoch => {
                 let ns = self.nanos_since_epoch();
                 let fractional_nanos = ns % 1_000_000_000;
                 let is_whole_second = fractional_nanos == 0;
@@ -219,9 +219,9 @@ impl Timestamp {
                 }
             }
 
-            TimestampFormat::LocalTimezone
-            | TimestampFormat::LocalTimezoneImplicit
-            | TimestampFormat::Utc => {
+            TimestampFormatKind::LocalTimezone
+            | TimestampFormatKind::LocalTimezoneImplicit
+            | TimestampFormatKind::Utc => {
                 let zoned = self.to_jiff_zoned(timestamp_format);
                 if zoned.time() == jiff::civil::Time::MIN {
                     // Exactly midnight - show only the date:
@@ -239,7 +239,7 @@ impl Timestamp {
         }
     }
 
-    /// Parse a timestamp,
+    /// Parse a timestamp.
     ///
     /// If it is missing a timezone specifier, the given timezone is assumed.
     pub fn parse_with_format(s: &str, timestamp_format: TimestampFormat) -> Option<Self> {
@@ -254,7 +254,7 @@ impl Timestamp {
                 .to_zoned(timestamp_format.to_jiff_time_zone())
                 .ok()
                 .map(|zoned| zoned.into())
-        } else if timestamp_format == TimestampFormat::UnixEpoch {
+        } else if timestamp_format.kind() == TimestampFormatKind::UnixEpoch {
             let ns = re_format::parse_i64(s)?;
             Some(Self::from_nanos_since_epoch(ns))
         } else {
@@ -336,7 +336,7 @@ mod tests {
     fn test_formatting_whole_second_for_datetime() {
         let datetime = Timestamp::from_str("2022-02-28 22:35:42Z").unwrap();
         assert_eq!(
-            &datetime.format(TimestampFormat::Utc),
+            &datetime.format(TimestampFormat::utc()),
             "2022-02-28 22:35:42Z"
         );
     }
@@ -345,7 +345,7 @@ mod tests {
     fn test_formatting_whole_millisecond_for_datetime() {
         let datetime = Timestamp::from_str("2022-02-28 22:35:42.069Z").unwrap();
         assert_eq!(
-            &datetime.format(TimestampFormat::Utc),
+            &datetime.format(TimestampFormat::utc()),
             "2022-02-28 22:35:42.069Z"
         );
     }
@@ -354,7 +354,7 @@ mod tests {
     fn test_formatting_many_digits_for_datetime() {
         let datetime = Timestamp::from_str("2022-02-28 22:35:42.0690427Z").unwrap();
         assert_eq!(
-            &datetime.format(TimestampFormat::Utc),
+            &datetime.format(TimestampFormat::utc()),
             "2022-02-28 22:35:42.069042Z"
         ); // format function is not rounding
     }
@@ -371,7 +371,23 @@ mod tests {
             .build()
             .unwrap();
         let datetime = Timestamp::from(today);
-        assert_eq!(&datetime.format(TimestampFormat::Utc), "22:35:42Z");
+        assert_eq!(&datetime.format(TimestampFormat::utc()), "22:35:42Z");
+    }
+
+    #[test]
+    fn test_formatting_today_omit_date_disabled() {
+        let tz = jiff::tz::TimeZone::UTC;
+        let today = jiff::Timestamp::now()
+            .to_zoned(tz)
+            .with()
+            .time(jiff::civil::Time::new(22, 35, 42, 0).unwrap())
+            .build()
+            .unwrap();
+        let datetime = Timestamp::from(today.clone());
+        assert_eq!(
+            datetime.format(TimestampFormat::utc().with_hide_today_date(false)),
+            format!("{} 22:35:42Z", today.strftime("%Y-%m-%d"))
+        );
     }
 
     #[test]
@@ -384,7 +400,7 @@ mod tests {
             ("2022-01-01T00:00:00Z", "2022-01-01"),
         ] {
             let timestamp: Timestamp = input.parse().unwrap();
-            let formatted = timestamp.format_time_compact(TimestampFormat::Utc);
+            let formatted = timestamp.format_time_compact(TimestampFormat::utc());
             assert_eq!(formatted, expected);
         }
     }
@@ -396,21 +412,22 @@ mod tests {
         }
 
         let all_formats = [
-            TimestampFormat::Utc,
-            TimestampFormat::LocalTimezone,
-            TimestampFormat::UnixEpoch,
+            TimestampFormat::utc(),
+            TimestampFormat::local_timezone(),
+            TimestampFormat::local_timezone_implicit(),
+            TimestampFormat::unix_epoch(),
         ];
 
         // Full dates.
         // Fun fact: 1954-04-11 is by some considered the least eventful day in history!
         // Full date and time
         assert_eq!(
-            parse("1954-04-11 22:35:42", TimestampFormat::Utc),
+            parse("1954-04-11 22:35:42", TimestampFormat::utc()),
             Some(Timestamp::from_str("1954-04-11 22:35:42Z").unwrap())
         );
         // Full date and time with milliseconds
         assert_eq!(
-            parse("1954-04-11 22:35:42.069", TimestampFormat::Utc),
+            parse("1954-04-11 22:35:42.069", TimestampFormat::utc()),
             Some(Timestamp::from_str("1954-04-11 22:35:42.069Z").unwrap())
         );
 
@@ -434,7 +451,7 @@ mod tests {
         // Full date and time.
         if let Ok(tz) = jiff::tz::TimeZone::try_system() {
             assert_eq!(
-                parse("1954-04-11 22:35:42", TimestampFormat::LocalTimezone),
+                parse("1954-04-11 22:35:42", TimestampFormat::local_timezone()),
                 Some(Timestamp::from(
                     jiff::civil::DateTime::from_str("1954-04-11 22:35:42")
                         .unwrap()
@@ -444,7 +461,7 @@ mod tests {
             );
             // Full date and time with milliseconds
             assert_eq!(
-                parse("1954-04-11 22:35:42.069", TimestampFormat::LocalTimezone),
+                parse("1954-04-11 22:35:42.069", TimestampFormat::local_timezone()),
                 Some(Timestamp::from(
                     jiff::civil::DateTime::from_str("1954-04-11 22:35:42.069")
                         .unwrap()
@@ -455,8 +472,8 @@ mod tests {
         }
 
         // Test invalid formats
-        assert_eq!(parse("invalid", TimestampFormat::Utc), None);
-        assert_eq!(parse("2022-13-28", TimestampFormat::Utc), None); // Invalid month
-        assert_eq!(parse("2022-02-29", TimestampFormat::Utc), None); // Invalid day (not leap year)
+        assert_eq!(parse("invalid", TimestampFormat::utc()), None);
+        assert_eq!(parse("2022-13-28", TimestampFormat::utc()), None); // Invalid month
+        assert_eq!(parse("2022-02-29", TimestampFormat::utc()), None); // Invalid day (not leap year)
     }
 }

--- a/crates/store/re_log_types/src/index/timestamp_format.rs
+++ b/crates/store/re_log_types/src/index/timestamp_format.rs
@@ -1,7 +1,7 @@
 /// How to display a [`crate::Timestamp`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-pub enum TimestampFormat {
+pub enum TimestampFormatKind {
     /// Convert to the local timezone and display as such explicitly (e.g. with "+01" for CET).
     LocalTimezone,
 
@@ -18,18 +18,80 @@ pub enum TimestampFormat {
     UnixEpoch,
 }
 
+/// How to display a [`crate::Timestamp`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct TimestampFormat {
+    /// What kind of format to use.
+    format_kind: TimestampFormatKind,
+
+    /// For date-time format kinds, should we omit the date part when it's today?
+    ///
+    /// By default, we do, but having this toggle is convenient for the uses-cases where omitting
+    /// the date part is not desirable.
+    hide_today_date: bool,
+}
+
+impl Default for TimestampFormat {
+    fn default() -> Self {
+        Self {
+            format_kind: Default::default(),
+            hide_today_date: true,
+        }
+    }
+}
+
+impl From<TimestampFormatKind> for TimestampFormat {
+    fn from(value: TimestampFormatKind) -> Self {
+        Self {
+            format_kind: value,
+            ..Default::default()
+        }
+    }
+}
+
 impl TimestampFormat {
+    pub fn utc() -> Self {
+        Self::from(TimestampFormatKind::Utc)
+    }
+
+    pub fn local_timezone() -> Self {
+        Self::from(TimestampFormatKind::LocalTimezone)
+    }
+
+    pub fn local_timezone_implicit() -> Self {
+        Self::from(TimestampFormatKind::LocalTimezoneImplicit)
+    }
+
+    pub fn unix_epoch() -> Self {
+        Self::from(TimestampFormatKind::UnixEpoch)
+    }
+
+    pub fn kind(&self) -> TimestampFormatKind {
+        self.format_kind
+    }
+
+    pub fn with_hide_today_date(mut self, show_date_when_today: bool) -> Self {
+        self.hide_today_date = show_date_when_today;
+        self
+    }
+
+    pub fn hide_today_date(&self) -> bool {
+        self.hide_today_date
+    }
+
     pub fn to_jiff_time_zone(self) -> jiff::tz::TimeZone {
         use jiff::tz::TimeZone;
 
-        match self {
-            Self::UnixEpoch | Self::Utc => TimeZone::UTC,
+        match self.format_kind {
+            TimestampFormatKind::UnixEpoch | TimestampFormatKind::Utc => TimeZone::UTC,
 
-            Self::LocalTimezone | Self::LocalTimezoneImplicit => TimeZone::try_system()
-                .unwrap_or_else(|err| {
+            TimestampFormatKind::LocalTimezone | TimestampFormatKind::LocalTimezoneImplicit => {
+                TimeZone::try_system().unwrap_or_else(|err| {
                     re_log::warn_once!("Failed to detect system/local time zone: {err}");
                     TimeZone::UTC
-                }),
+                })
+            }
         }
     }
 }

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -42,7 +42,8 @@ pub use self::{
     entry_id::{EntryId, EntryIdOrName},
     index::{
         AbsoluteTimeRange, AbsoluteTimeRangeF, Duration, NonMinI64, TimeCell, TimeInt, TimePoint,
-        TimeReal, TimeType, Timeline, TimelineName, Timestamp, TimestampFormat, TryFromIntError,
+        TimeReal, TimeType, Timeline, TimelineName, Timestamp, TimestampFormat,
+        TimestampFormatKind, TryFromIntError,
     },
     instance::Instance,
     path::*,

--- a/crates/viewer/re_global_context/src/app_options.rs
+++ b/crates/viewer/re_global_context/src/app_options.rs
@@ -80,7 +80,7 @@ impl Default for AppOptions {
 
             blueprint_gc: true,
 
-            timestamp_format: TimestampFormat::Utc,
+            timestamp_format: TimestampFormat::default(),
 
             video_decoder_hw_acceleration: DecodeHardwareAcceleration::default(),
             video_decoder_override_ffmpeg_path: false,

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -117,33 +117,33 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
 
     ui.re_radio_value(
         &mut app_options.timestamp_format,
-        TimestampFormat::Utc,
+        TimestampFormat::utc(),
         "UTC",
     );
-    timestamp_example_ui(ui, timestamp, TimestampFormat::Utc);
+    timestamp_example_ui(ui, timestamp, TimestampFormat::utc());
     ui.re_radio_value(
         &mut app_options.timestamp_format,
-        TimestampFormat::LocalTimezone,
+        TimestampFormat::local_timezone(),
         "Local (show time zone)",
     );
-    timestamp_example_ui(ui, timestamp, TimestampFormat::LocalTimezone);
+    timestamp_example_ui(ui, timestamp, TimestampFormat::local_timezone());
     ui.re_radio_value(
         &mut app_options.timestamp_format,
-        TimestampFormat::LocalTimezoneImplicit,
+        TimestampFormat::local_timezone_implicit(),
         "Local (hide time zone)",
     );
     ui.horizontal(|ui| {
         ui.add_space(ui.spacing().icon_width + ui.spacing().icon_spacing);
         ui.label("Note: timestamps without time zone are ambiguous when copied elsewhere.");
     });
-    timestamp_example_ui(ui, timestamp, TimestampFormat::LocalTimezoneImplicit);
+    timestamp_example_ui(ui, timestamp, TimestampFormat::local_timezone_implicit());
 
     ui.re_radio_value(
         &mut app_options.timestamp_format,
-        TimestampFormat::UnixEpoch,
+        TimestampFormat::unix_epoch(),
         "Seconds since Unix epoch",
     );
-    timestamp_example_ui(ui, timestamp, TimestampFormat::UnixEpoch);
+    timestamp_example_ui(ui, timestamp, TimestampFormat::unix_epoch());
 
     //
     // Map view


### PR DESCRIPTION
### Related

* part of https://linear.app/rerun/project/ability-to-filter-tables-in-the-viewer-8dcb9ff4e6bc/overview
* part of https://github.com/rerun-io/rerun/issues/10560
* part of https://linear.app/rerun/issue/RR-2215/tracking-issue-ability-to-filter-tables-in-the-viewer

### What

This PR adds a flag to  `TimestampFormat` which controls whether or not the date is omitted when it is today. Consistent with what we did so far, this flag is enabled by default. Also, it is not exposed in the UI. So this PR is user-facing noop.

### Why

In some circumstances, omitting the date when its today is confusing. It is the case for the WIP timestamp filtering in tables (https://github.com/rerun-io/rerun/pull/11227). This PR makes it easy for part of the UI codebase to disable the "omit today" behaviour when required. 

### Possible future work

- Expose this flag in the settings.
- Disable "omit today" is some places, for example in table were it might be common to have a mix of today and non-today dates in a given column.
- Add more formatting options.