### PR TITLE
Add module definition to all `pyclasses`

### DIFF
--- a/crates/utils/re_video/src/decode/mod.rs
+++ b/crates/utils/re_video/src/decode/mod.rs
@@ -207,7 +207,7 @@ pub fn new_decoder(
     debug_name: &str,
     video: &crate::VideoDataDescription,
     decode_settings: &DecodeSettings,
-    output_sender: crossbeam::channel::Sender<FrameResult>,
+    output_sender: &crossbeam::channel::Sender<FrameResult>,
 ) -> Result<Box<dyn AsyncDecoder>> {
     #![allow(unused_variables, clippy::needless_return)] // With some feature flags
 

--- a/rerun_py/src/dataframe/component_columns.rs
+++ b/rerun_py/src/dataframe/component_columns.rs
@@ -9,7 +9,11 @@ use re_sorbet::{ComponentColumnDescriptor, ComponentColumnSelector};
 /// Column descriptors are used to describe the columns in a
 /// [`Schema`][rerun.dataframe.Schema]. They are read-only. To select a component
 /// column, use [`ComponentColumnSelector`][rerun.dataframe.ComponentColumnSelector].
-#[pyclass(frozen, name = "ComponentColumnDescriptor")]
+#[pyclass(
+    frozen,
+    name = "ComponentColumnDescriptor",
+    module = "rerun_bindings.rerun_bindings"
+)]
 #[derive(Clone)]
 pub struct PyComponentColumnDescriptor(pub ComponentColumnDescriptor);
 
@@ -97,7 +101,11 @@ impl From<PyComponentColumnDescriptor> for ComponentColumnDescriptor {
 ///     The entity path to select.
 /// component : str
 ///     The component to select
-#[pyclass(frozen, name = "ComponentColumnSelector")]
+#[pyclass(
+    frozen,
+    name = "ComponentColumnSelector",
+    module = "rerun_bindings.rerun_bindings"
+)]
 #[derive(Clone)]
 pub struct PyComponentColumnSelector(pub ComponentColumnSelector);
 

--- a/rerun_py/src/dataframe/index_columns.rs
+++ b/rerun_py/src/dataframe/index_columns.rs
@@ -9,7 +9,11 @@ use re_sorbet::{IndexColumnDescriptor, TimeColumnSelector};
 /// Column descriptors are used to describe the columns in a
 /// [`Schema`][rerun.dataframe.Schema]. They are read-only. To select an index
 /// column, use [`IndexColumnSelector`][rerun.dataframe.IndexColumnSelector].
-#[pyclass(frozen, name = "IndexColumnDescriptor")]
+#[pyclass(
+    frozen,
+    name = "IndexColumnDescriptor",
+    module = "rerun_bindings.rerun_bindings"
+)]
 #[derive(Clone)]
 pub struct PyIndexColumnDescriptor(pub IndexColumnDescriptor);
 
@@ -50,7 +54,11 @@ impl From<IndexColumnDescriptor> for PyIndexColumnDescriptor {
 /// ----------
 /// index : str
 ///     The name of the index to select. Usually the name of a timeline.
-#[pyclass(frozen, name = "IndexColumnSelector")]
+#[pyclass(
+    frozen,
+    name = "IndexColumnSelector",
+    module = "rerun_bindings.rerun_bindings"
+)]
 #[derive(Clone)]
 pub struct PyIndexColumnSelector(pub TimeColumnSelector);
 

--- a/rerun_py/src/dataframe/recording.rs
+++ b/rerun_py/src/dataframe/recording.rs
@@ -25,7 +25,7 @@ use super::{PyRecordingView, PySchema};
 /// You can examine the [`.schema()`][rerun.dataframe.Recording.schema] of the recording to see
 /// what data is available, or create a [`RecordingView`][rerun.dataframe.RecordingView] to
 /// to retrieve the data.
-#[pyclass(name = "Recording")]
+#[pyclass(name = "Recording", module = "rerun_bindings.rerun_bindings")]
 pub struct PyRecording {
     pub(crate) store: ChunkStoreHandle,
     pub(crate) cache: re_dataframe::QueryCacheHandle,

--- a/rerun_py/src/dataframe/recording_view.rs
+++ b/rerun_py/src/dataframe/recording_view.rs
@@ -31,7 +31,7 @@ use crate::utils::py_rerun_warn_cstr;
 /// included in the view, as determined by the `row_id` column. This will
 /// generally be the last value logged, as row_ids are guaranteed to be
 /// monotonically increasing when data is sent from a single process.
-#[pyclass(name = "RecordingView")]
+#[pyclass(name = "RecordingView", module = "rerun_bindings.rerun_bindings")]
 #[derive(Clone)]
 pub struct PyRecordingView {
     pub(crate) recording: PyRecordingHandle,

--- a/rerun_py/src/dataframe/rrd.rs
+++ b/rerun_py/src/dataframe/rrd.rs
@@ -11,7 +11,7 @@ use super::PyRecording;
 /// An archive loaded from an RRD.
 ///
 /// RRD archives may include 1 or more recordings or blueprints.
-#[pyclass(frozen, name = "RRDArchive")]
+#[pyclass(frozen, name = "RRDArchive", module = "rerun_bindings.rerun_bindings")]
 #[derive(Clone)]
 pub struct PyRRDArchive {
     pub datasets: BTreeMap<StoreId, ChunkStoreHandle>,

--- a/rerun_py/src/dataframe/schema.rs
+++ b/rerun_py/src/dataframe/schema.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::catalog::to_py_err;
 
-#[pyclass]
+#[pyclass(module = "rerun_bindings.rerun_bindings")]
 pub struct SchemaIterator {
     iter: std::vec::IntoIter<PyObject>,
 }
@@ -29,7 +29,7 @@ impl SchemaIterator {
     }
 }
 
-#[pyclass(frozen, name = "Schema")]
+#[pyclass(frozen, name = "Schema", module = "rerun_bindings.rerun_bindings")]
 #[derive(Clone)]
 //TODO(#9457): improve this object and use it for `Dataset.schema()`.
 pub struct PySchema {

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -144,6 +144,7 @@ fn init_perf_telemetry() -> parking_lot::MutexGuard<'static, re_perf_telemetry::
 
 /// The python module is called "rerun_bindings".
 #[pymodule]
+#[pyo3(name = "rerun_bindings")]
 fn rerun_bindings(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     if cfg!(feature = "perf_telemetry") && std::env::var("TELEMETRY_ENABLED").is_ok() {
         // TODO(tracing/issues#2499): allow installing multiple tracing sinks (https://github.com/tokio-rs/tracing/issues/2499)
@@ -1633,7 +1634,7 @@ fn flush(py: Python<'_>, blocking: bool, recording: Option<&PyRecordingStream>) 
 /// Every component at a given entity path is uniquely identified by the
 /// `component` field of the descriptor. The `archetype` and `component_type`
 /// fields provide additional information about the semantics of the data.
-#[pyclass(name = "ComponentDescriptor")]
+#[pyclass(name = "ComponentDescriptor", module = "rerun_bindings.rerun_bindings")]
 #[derive(Clone)]
 struct PyComponentDescriptor(pub ComponentDescriptor);
 

--- a/rerun_py/src/viewer.rs
+++ b/rerun_py/src/viewer.rs
@@ -17,7 +17,7 @@ pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()>
 }
 
 /// A connection to an instance of a Rerun viewer.
-#[pyclass(name = "ViewerClient")]
+#[pyclass(name = "ViewerClient", module = "rerun_bindings.rerun_bindings")]
 pub struct PyViewerClient {
     conn: ViewerConnectionHandle,
 }


### PR DESCRIPTION
### What
Without specifically listing module all of our classes show as if they are from `builtins`

Before
```python
from rerun import ComponentDescriptor
type(ComponentDescriptor("foo"))
<class 'rerun_bindings.rerun_bindings.ComponentDescriptor'>
```

After
```python
from rerun import ComponentDescriptor
type(ComponentDescriptor("foo"))
<class 'builtins.ComponentDescriptor'>
```

This also seems to resolve the issue with `pixi run py-docs-serve` not sure if pyo3 or griffe or some other thing in the toolchain updated which broke things since this worked on main 2 weeks ago.