### PR TITLE
Fix: fourcc unused in some build configurations

### DIFF
--- a/crates/store/re_log_encoding/src/lib.rs
+++ b/crates/store/re_log_encoding/src/lib.rs
@@ -130,6 +130,7 @@ pub enum OptionsError {
 #[cfg(any(feature = "encoder", feature = "decoder"))]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FileHeader {
+    #[allow(dead_code)] // only used with the "encoder" feature
     pub fourcc: [u8; 4],
     pub version: [u8; 4],
     pub options: EncodingOptions,


### PR DESCRIPTION
* Introduced in https://github.com/rerun-io/rerun/pull/11265