### PR TITLE
Fixes broken link to re_server docs

### DIFF
--- a/crates/store/re_server/README.md
+++ b/crates/store/re_server/README.md
@@ -2,8 +2,8 @@
 
 Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
 
-[![Latest version](https://img.shields.io/crates/v/redap_server.svg)](https://crates.io/crates/redap_server)
-[![Documentation](https://docs.rs/redap_server/badge.svg)](https://docs.rs/redap_server)
+[![Latest version](https://img.shields.io/crates/v/re_server.svg)](https://crates.io/crates/re_server)
+[![Documentation](https://docs.rs/re_server/badge.svg)](https://docs.rs/re_server)
 ![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
 


### PR DESCRIPTION
Fixes this CI error:
https://github.com/rerun-io/rerun/actions/runs/17785726206/job/50552997353