### PR TITLE
Add kitdiff comment to PRs

### DIFF
--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -71,6 +71,8 @@ jobs:
             | ------ | ------- | ----- | -------- |
             | ⏳ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
 
+            View image diff on [https://rerun-io.github.io/kitdiff/?url=${{github.event.pull_request.html_url}}](kitdiff).
+
             <sup>Note: This comment is updated whenever you push a commit.</sup>
 
       - name: Set up Rust
@@ -124,5 +126,7 @@ jobs:
             | Result | Commit  | Link  | Manifest |
             | ------ | ------- | ----- | -------- |
             | ❌ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
+
+            View image diff on [https://rerun-io.github.io/kitdiff/?url=${{github.event.pull_request.html_url}}](kitdiff).
 
             <sup>Note: This comment is updated whenever you push a commit.</sup>

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -153,6 +153,8 @@ jobs:
             | ------ | ------- | ---- | -------- |
             | ✅ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
 
+            View image diff on [https://rerun-io.github.io/kitdiff/?url=${{github.event.pull_request.html_url}}](kitdiff).
+
             <sup>Note: This comment is updated whenever you push a commit.</sup>
 
       - name: Status comment
@@ -168,5 +170,7 @@ jobs:
             | Result | Commit  | Link | Manifest |
             | ------ | ------- | ----- |
             | ❌ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
+
+            View image diff on [https://rerun-io.github.io/kitdiff/?url=${{github.event.pull_request.html_url}}](kitdiff).
 
             <sup>Note: This comment is updated whenever you push a commit.</sup>

--- a/crates/viewer/re_ui/data/dark_theme.ron
+++ b/crates/viewer/re_ui/data/dark_theme.ron
@@ -95,7 +95,7 @@
     },
 
     "panel_bg_color": {
-      "color": "{Gray.100}"
+      "color": "{Red.100}"
     },
     "text_edit_bg_color": {
       "color": "{Gray.200}"
@@ -203,10 +203,10 @@
       "color": "{Gray.550}"
     },
     "text_default": {
-      "color": "{Gray.775}"
+      "color": "{Gray.355}"
     },
     "text_strong": {
-      "color": "{Gray.1000}"
+      "color": "{Green.1000}"
     },
     "error_fg_color": {
       "color": "#AB0116"


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
