### PR TITLE
Add "🧢 MCAP" section to future `CHANGELOG.md`s

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log & send APIs, 📉 performance, sdk-python, sdk-cpp, sdk-rust, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log & send APIs, 📉 performance, sdk-python, sdk-cpp, sdk-rust, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🔨 testing, ui, 🕸️ web, 🧢 MCAP"
 
   wasm-bindgen-check:
     name: Check wasm-bindgen version

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -210,6 +210,7 @@ def main() -> None:
     enhancement = []
     examples = []
     log_api = []
+    mcap = []
     misc = []
     performance = []
     python = []
@@ -301,6 +302,8 @@ def main() -> None:
                     renderer.append(summary)
                 elif "🕸️ web" in labels:
                     web.append(summary)
+                elif "🧢 MCAP" in labels:
+                    mcap.append(summary)
                 elif "enhancement" in labels:
                     enhancement.append(summary)
                 elif "🚜 refactor" in labels:
@@ -346,6 +349,7 @@ def main() -> None:
     print_section("🖼 UI improvements", ui)
     print_section("🕸️ Web", web)
     print_section("🎨 Renderer improvements", renderer)
+    print_section("🧢 MCAP", mcap)
     print_section("✨ Other enhancement", enhancement)
     print_section("📈 Analytics", analytics)
     print_section("🗣 Merged RFCs", rfc)


### PR DESCRIPTION
### What

Title.

Also allows PRs to pass the label CI check, if they contain the "🧢 MCAP" label.

### TODO

* [x] ~Run `generate_changelog.py` locally~ I'm quite confident that both scripts (CI and changeling generation should work once this is merged).