### PR TITLE
Update Our Schema To Make Query View Requirements Clearer

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1336,6 +1336,9 @@ class DatasetEntry(Entry):
         Pass `None` to clear the bluprint. This fails if the change cannot be made to the remote server.
         """
 
+    def schema(self) -> Schema:
+        """Return the schema of the data contained in the dataset."""
+
     def partition_ids(self) -> list[str]:
         """Returns a list of partitions IDs for the dataset."""
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -120,6 +120,14 @@ class ComponentColumnDescriptor:
         This property is read-only.
         """
 
+    @property
+    def name(self) -> str:
+        """
+        The name of this column.
+
+        This property is read-only.
+        """
+
 class ComponentColumnSelector:
     """
     A selector for a component column.

--- a/rerun_py/src/dataframe/component_columns.rs
+++ b/rerun_py/src/dataframe/component_columns.rs
@@ -9,8 +9,14 @@ use re_sorbet::{ComponentColumnDescriptor, ComponentColumnSelector};
 /// Column descriptors are used to describe the columns in a
 /// [`Schema`][rerun.dataframe.Schema]. They are read-only. To select a component
 /// column, use [`ComponentColumnSelector`][rerun.dataframe.ComponentColumnSelector].
-#[pyclass(frozen, name = "ComponentColumnDescriptor")]
-#[derive(Clone)]
+#[pyclass(
+    frozen,
+    hash,
+    eq,
+    name = "ComponentColumnDescriptor",
+    module = "rerun_bindings.rerun_bindings"
+)]
+#[derive(Clone, PartialEq, Hash)]
 pub struct PyComponentColumnDescriptor(pub ComponentColumnDescriptor);
 
 impl From<ComponentColumnDescriptor> for PyComponentColumnDescriptor {
@@ -37,7 +43,7 @@ impl PyComponentColumnDescriptor {
              \tArchetype: {arch}\n\
              \tComponent type: {ctype}\n\
              \tComponent: {comp}{static_info}",
-            col = self.0.column_name(re_sorbet::BatchType::Dataframe),
+            col = self.name(),
             path = self.entity_path(),
             arch = self.archetype().unwrap_or("None"),
             ctype = self.component_type().unwrap_or(""),
@@ -46,9 +52,9 @@ impl PyComponentColumnDescriptor {
         )
     }
 
-    fn __eq__(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
+    // fn __eq__(&self, other: &Self) -> bool {
+    //     self.0 == other.0
+    // }
 
     /// The entity path.
     ///
@@ -88,6 +94,14 @@ impl PyComponentColumnDescriptor {
     #[getter]
     fn is_static(&self) -> bool {
         self.0.is_static
+    }
+
+    /// The name of the column.
+    ///
+    /// This property is read-only.
+    #[getter]
+    fn name(&self) -> String {
+        self.0.column_name(re_sorbet::BatchType::Dataframe)
     }
 }
 

--- a/rerun_py/src/dataframe/component_columns.rs
+++ b/rerun_py/src/dataframe/component_columns.rs
@@ -22,17 +22,27 @@ impl From<ComponentColumnDescriptor> for PyComponentColumnDescriptor {
 #[pymethods]
 impl PyComponentColumnDescriptor {
     pub fn __repr__(&self) -> String {
+        // We could print static state all the time
+        // but in schema non-static print out with IndexColumnDescriptors
+        // so it looks a bit noisy.
+        let static_info = if self.is_static() {
+            "\n\tStatic: true"
+        } else {
+            ""
+        };
+
         format!(
             "Column name: {col}\n\
              \tEntity path: {path}\n\
              \tArchetype: {arch}\n\
              \tComponent type: {ctype}\n\
-             \tComponent: {comp}",
+             \tComponent: {comp}{static_info}",
             col = self.0.column_name(re_sorbet::BatchType::Dataframe),
             path = self.entity_path(),
             arch = self.archetype().unwrap_or("None"),
             ctype = self.component_type().unwrap_or(""),
             comp = self.component(),
+            static_info = static_info,
         )
     }
 

--- a/rerun_py/src/dataframe/component_columns.rs
+++ b/rerun_py/src/dataframe/component_columns.rs
@@ -52,10 +52,6 @@ impl PyComponentColumnDescriptor {
         )
     }
 
-    // fn __eq__(&self, other: &Self) -> bool {
-    //     self.0 == other.0
-    // }
-
     /// The entity path.
     ///
     /// This property is read-only.

--- a/rerun_py/src/dataframe/component_columns.rs
+++ b/rerun_py/src/dataframe/component_columns.rs
@@ -96,7 +96,7 @@ impl PyComponentColumnDescriptor {
         self.0.is_static
     }
 
-    /// The name of the column.
+    /// The name of this column.
     ///
     /// This property is read-only.
     #[getter]


### PR DESCRIPTION
### Related
https://github.com/rerun-io/rerun/issues/11204

### What
Mostly just exposes some more details from our ComponentColumnDescriptor then demonstrates a candidate use case as a test.

I think we could still make things clearer for linked issue. However this at least confirms there is a way to use our schema to iterate over all entries in the dataframe. Left a to-do because I didn't explore disjoint multiple indices which might require more investigation.
