### PR TITLE
Default to WebGPU on Safari

### DIFF
--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -475,8 +475,7 @@ pub fn default_backends() -> wgpu::Backends {
         // For changing the backend we use standard wgpu env var, i.e. WGPU_BACKEND.
         wgpu::Backends::from_env()
             .unwrap_or(wgpu::Backends::VULKAN | wgpu::Backends::METAL | wgpu::Backends::GL)
-    } else if is_safari_browser() || is_firefox_browser() {
-        // TODO(#8559): Fix WebGPU on Safari
+    } else if is_firefox_browser() {
         // TODO(#11009): Fix videos on WebGPU firefox
         wgpu::Backends::GL
     } else {


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/10609

### What
Works great now on Safari 26.0 on macOS 26.0.

### TODO
* [ ] Test on older macOS (@abey79 ?) 