### PR TITLE
Improve migration guide about `connect_grpc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Rerun has experimental, partial support for importing data from MCAP files. We s
 
 We removed the `--serve`, `--drop-at-latency` and `-o` CLI arguments, deprecated Python 3.9 and changed `archetype` specification in `AnyValues`.
 
+We also removed `flush_timeout_sec` parameter to out connect functions. Instead you can specify a maximum wait time in the calls to `flush`, but usually this isn't needed, as the new blocking behavior is also much smarter.
+
 See the
 🧳 [Migration guide](https://rerun.io/docs/reference/migration/migration-0-25) for more details.
 

--- a/docs/content/reference/migration/migration-0-25.md
+++ b/docs/content/reference/migration/migration-0-25.md
@@ -28,6 +28,14 @@ In the C++ and Python APIs, negative timeouts used to have special meaning. Now 
 
 The Python flush calls now raises an error if the flushing did not complete successfully.
 
+The timeout behavior is also improved: it will only block as long as there is _hope of progress_. If the gRPC connection is severed, the flush will aborted with an error. This means it should be very rare that you need to configure a flush timeout, as it will only block for a long time if there is a very slow connection.
+
+Removed:
+ * Python: `flush_timeout_sec` argument of `connect_grpc`
+ * Rust: `flush_timeout_sec` argument of `connect_grpc_opts`
+ * C++: `rerun::GrpcSink::flush_timeout_sec`
+
+
 ## ❗ Deprecations
 
 ### Python 3.9


### PR DESCRIPTION
* Guide originally added in https://github.com/rerun-io/rerun/pull/11008