### PR TITLE
Improve robustness of rrd loader

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -93,7 +93,7 @@
             }
         },
         {
-            "name": "Debug 'rerun' colmap.rrd from url",
+            "name": "Debug 'rerun' bar_chart.rrd from url",
             "type": "lldb",
             "request": "launch",
             "cargo": {
@@ -110,9 +110,12 @@
                 }
             },
             "args": [
-                "https://demo.rerun.io/commit/0f89b62/examples/colmap/data.rrd"
+                "https://app.rerun.io/version/0.25.0/examples/snippets/bar_chart.rrd"
             ],
-            "cwd": "${workspaceFolder}"
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "RUST_LOG": "trace"
+            }
         },
         {
             "name": "Debug 'minimal' example",

--- a/crates/store/re_log_encoding/src/codec/file/decoder.rs
+++ b/crates/store/re_log_encoding/src/codec/file/decoder.rs
@@ -19,9 +19,8 @@ pub(crate) fn decode_to_app(
     app_id_injector: &mut impl ApplicationIdInjector,
     data: &mut impl std::io::Read,
 ) -> Result<(u64, Option<LogMsg>), DecodeError> {
-    let mut read_bytes = 0u64;
     let header = MessageHeader::decode(data)?;
-    read_bytes += std::mem::size_of::<MessageHeader>() as u64 + header.len;
+    let read_bytes = std::mem::size_of::<MessageHeader>() as u64 + header.len;
 
     let mut buf = vec![0; header.len as usize];
     data.read_exact(&mut buf[..])?;
@@ -39,9 +38,8 @@ pub(crate) fn decode_to_app(
 pub(crate) fn decode_to_transport(
     data: &mut impl std::io::Read,
 ) -> Result<(u64, Option<re_protos::log_msg::v1alpha1::log_msg::Msg>), DecodeError> {
-    let mut read_bytes = 0u64;
     let header = MessageHeader::decode(data)?;
-    read_bytes += std::mem::size_of::<MessageHeader>() as u64 + header.len;
+    let read_bytes = std::mem::size_of::<MessageHeader>() as u64 + header.len;
 
     let mut buf = vec![0; header.len as usize];
     data.read_exact(&mut buf[..])?;

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -405,15 +405,6 @@ impl<R: std::io::Read> Decoder<R> {
                 self.next_impl(decoder)
             } else {
                 re_log::trace!("Reached end of stream, iterator complete");
-
-                if cfg!(debug_assertions) {
-                    let mut trailing_bytes = vec![];
-                    self.read.read_to_end(&mut trailing_bytes).ok();
-                    if !trailing_bytes.is_empty() {
-                        re_log::error!("Found {} trailing bytes after rrd", trailing_bytes.len());
-                    }
-                }
-
                 None
             }
         }

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -418,11 +418,14 @@ impl<R: std::io::Read> Decoder<R> {
                 }
 
                 let mut read = std::io::Cursor::new(read.buffer());
-                if FileHeader::decode(&mut read).is_err() {
-                    return false;
+                match FileHeader::decode(&mut read) {
+                    Ok(_) => true,
+                    Err(DecodeError::Read { .. }) => false,
+                    Err(err) => {
+                        re_log::warn_once!("Error when expecting rrd header: {err}");
+                        false
+                    }
                 }
-
-                true
             }
         }
     }

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -257,13 +257,7 @@ impl<R: std::io::Read> Decoder<R> {
 
         let (version, options) = options_from_bytes(&data)?;
 
-        Ok(Self {
-            version,
-            options,
-            read: Reader::Raw(read),
-            size_bytes: FileHeader::SIZE as _,
-            app_id_cache: CachingApplicationIdInjector::default(),
-        })
+        Ok(Self::new_with_options(options, version, read))
     }
 
     pub fn new_with_options(options: EncodingOptions, version: CrateVersion, read: R) -> Self {

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -410,7 +410,7 @@ impl<R: std::io::Read> Decoder<R> {
                     let mut trailing_bytes = vec![];
                     self.read.read_to_end(&mut trailing_bytes).ok();
                     if !trailing_bytes.is_empty() {
-                        re_log::warn!("Found {} trailing bytes after rrd", trailing_bytes.len());
+                        re_log::error!("Found {} trailing bytes after rrd", trailing_bytes.len());
                     }
                 }
 

--- a/crates/store/re_log_encoding/src/decoder/stream.rs
+++ b/crates/store/re_log_encoding/src/decoder/stream.rs
@@ -123,7 +123,7 @@ impl StreamDecoder {
                             if is_first_header {
                                 return Err(err);
                             } else {
-                                re_log::error!("Trailing bytes in rrd stream: {header:?}");
+                                re_log::error!("Trailing bytes in rrd stream: {header:?} ({err})");
                                 self.state = State::Done;
                                 return Ok(None);
                             }

--- a/crates/store/re_log_encoding/src/decoder/stream.rs
+++ b/crates/store/re_log_encoding/src/decoder/stream.rs
@@ -66,7 +66,7 @@ enum State {
     Message(crate::codec::file::MessageHeader),
 
     /// Stop reading
-    Done,
+    Aborted,
 }
 
 impl StreamDecoder {
@@ -120,11 +120,12 @@ impl StreamDecoder {
                     let (version, options) = match options_from_bytes(header) {
                         Ok(ok) => ok,
                         Err(err) => {
+                            // We expected a header, but didn't find one!
                             if is_first_header {
                                 return Err(err);
                             } else {
                                 re_log::error!("Trailing bytes in rrd stream: {header:?} ({err})");
-                                self.state = State::Done;
+                                self.state = State::Aborted;
                                 return Ok(None);
                             }
                         }
@@ -199,7 +200,7 @@ impl StreamDecoder {
                     }
                 }
             }
-            State::Done => {
+            State::Aborted => {
                 return Ok(None);
             }
         }

--- a/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
+++ b/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
@@ -75,11 +75,14 @@ pub fn stream_rrd_from_http(url: String, on_msg: Arc<HttpMessageCallback>) {
         move |part| match part {
             Ok(part) => match part {
                 ehttp::streaming::Part::Response(ehttp::PartialResponse {
+                    url,
                     ok,
                     status,
                     status_text,
-                    ..
+                    headers,
                 }) => {
+                    re_log::trace!("{url} status: {status} - {status_text}");
+                    re_log::trace!("{url} headers: {headers:#?}");
                     if ok {
                         re_log::debug!("Decoding .rrd file from {url:?}…");
                         ControlFlow::Continue(())


### PR DESCRIPTION
### Related
* Part of investigation of https://github.com/rerun-io/rerun/issues/11274
* Part of https://github.com/rerun-io/rerun/issues/11266

### What
Part of an aborted investigation into the bug linked above.

Mostly improved the logging, but also makes the streaming file loader more robust when there are trailing bytes in an .rrd file, logging a warning instead of returning an error.