### PR TITLE
Fix rare issue where video stream sample indices would be determined incorrectly, breaking video inspection UI & playback

### DIFF
--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -191,10 +191,10 @@ impl Chunk {
         }
     }
 
-    /// Returns an iterator over the offsets (`(offset, len)`) of a [`Chunk`], for a given
+    /// Returns an iterator over the offsets & lengths of component arrays within [`Chunk`], for a given
     /// component.
     ///
-    /// I.e. each `(offset, len)` pair describes the position of a component batch in the
+    /// I.e. each span describes the position of a component batch in the
     /// underlying arrow array of values.
     pub fn iter_component_offsets<'a>(
         &'a self,


### PR DESCRIPTION
This is fairly difficult to hit in the wild, but would happen when receiving chunks that for some reason either:
* have unused extra data in their video sample component array
* have video sample components that are used only on some arrays

I've hit this on on my ongoing chunk cropping PR because at the moment the cropping doesn't necessarily discard underlying sample data, causing previously unexpected array offsets.