### PR TITLE
Better video stream errors for missing samples & key frames

### DIFF
--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -16,14 +16,33 @@ use crate::{
     resource_managers::{GpuTexture2D, SourceImageDataFormat},
 };
 
+/// Detailed error for lack of sample data.
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum InsufficientSampleDataError {
+    #[error("Video doesn't have any key frames.")]
+    NoKeyFrames,
+
+    #[error("Video doesn't have any samples.")]
+    NoSamples,
+
+    #[error("No key frames prior to current time.")]
+    NoKeyFramesPriorToRequestedTimestamp,
+
+    #[error("No frames prior to current time.")]
+    NoSamplesPriorToRequestedTimestamp,
+
+    #[error("The requested frame data is not, or no longer, available.")]
+    ExpectedSampleNotAvailable,
+}
+
 /// Error that can occur during playing videos.
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum VideoPlayerError {
     #[error("The decoder is lagging behind")]
     EmptyBuffer,
 
-    #[error("Video is empty.")]
-    EmptyVideo,
+    #[error(transparent)]
+    InsufficientSampleData(#[from] InsufficientSampleDataError),
 
     /// e.g. unsupported codec
     #[error("Failed to create video chunk: {0}")]
@@ -39,9 +58,6 @@ pub enum VideoPlayerError {
 
     #[error("The timestamp passed was negative.")]
     NegativeTimestamp,
-
-    #[error("The requested frame data is not, or no longer, available.")]
-    MissingSample,
 
     /// e.g. bad mp4, or bug in mp4 parse
     #[error("Bad data.")]

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -10,7 +10,10 @@ use super::{VideoFrameTexture, chunk_decoder::VideoSampleDecoder};
 use crate::{
     RenderContext,
     resource_managers::{GpuTexture2D, SourceImageDataFormat},
-    video::{DecoderDelayState, VideoPlayerError, chunk_decoder::update_video_texture_with_frame},
+    video::{
+        DecoderDelayState, InsufficientSampleDataError, VideoPlayerError,
+        chunk_decoder::update_video_texture_with_frame,
+    },
 };
 
 pub struct PlayerConfiguration {
@@ -200,6 +203,12 @@ impl VideoPlayer {
         video_description: &re_video::VideoDataDescription,
         video_buffers: &StableIndexDeque<&[u8]>,
     ) -> Result<VideoFrameTexture, VideoPlayerError> {
+        if video_description.gops.is_empty() {
+            return Err(InsufficientSampleDataError::NoKeyFrames.into());
+        }
+        if video_description.samples.is_empty() {
+            return Err(InsufficientSampleDataError::NoSamples.into());
+        }
         if requested_pts.0 < 0 {
             return Err(VideoPlayerError::NegativeTimestamp);
         }
@@ -207,7 +216,7 @@ impl VideoPlayer {
         // Find which sample best represents the requested PTS.
         let requested_sample_idx = video_description
             .latest_sample_index_at_presentation_timestamp(requested_pts)
-            .ok_or(VideoPlayerError::EmptyVideo)?;
+            .ok_or(InsufficientSampleDataError::NoSamplesPriorToRequestedTimestamp)?;
         let requested_sample = video_description.samples.get(requested_sample_idx); // This is only `None` if we no longer have the sample around.
         let requested_sample_pts =
             requested_sample.map_or(requested_pts, |s| s.presentation_timestamp);
@@ -330,7 +339,7 @@ impl VideoPlayer {
             .gop_index_containing_decode_timestamp(
                 video_description.samples[requested_sample_idx].decode_timestamp,
             )
-            .ok_or(VideoPlayerError::EmptyVideo)?;
+            .ok_or(InsufficientSampleDataError::NoKeyFramesPriorToRequestedTimestamp)?;
 
         let requested = SampleAndGopIndex {
             sample_idx: requested_sample_idx,
@@ -508,7 +517,7 @@ impl VideoPlayer {
         video_buffers: &StableIndexDeque<&[u8]>,
     ) -> Result<(), VideoPlayerError> {
         let Some(gop) = video_description.gops.get(gop_idx) else {
-            return Err(VideoPlayerError::MissingSample);
+            return Err(InsufficientSampleDataError::ExpectedSampleNotAvailable.into());
         };
 
         self.enqueue_samples_of_gop(video_description, gop_idx, &gop.sample_range, video_buffers)


### PR DESCRIPTION
Previously, we'd fairly eagerly showed "no video data" when in actually there _was_ data, just not enough for decoding. This can happen a lot when cutting chunks or sending incomplete data.

**Examples**

No key frames at all, but some samples:
<img width="779" height="521" alt="image" src="https://github.com/user-attachments/assets/23293628-0594-498d-ac15-f17da0d85b7d" />

No key frames prior to what we're looking at (there's some later on and as expected the video plays then):
<img width="1113" height="543" alt="image" src="https://github.com/user-attachments/assets/aa910109-045a-4120-bf33-cc8e0908fdf2" />
