### PR TITLE
Python SDK: remove `blocking` argument of `flush`

### DIFF
--- a/docs/content/reference/migration.md
+++ b/docs/content/reference/migration.md
@@ -1,5 +1,5 @@
 ---
 title: Migration Guides
 order: 1000
-redirect: reference/migration/migration-0-25
+redirect: reference/migration/migration-0-26
 ---

--- a/docs/content/reference/migration/migration-0-26.md
+++ b/docs/content/reference/migration/migration-0-26.md
@@ -7,3 +7,5 @@ order: 984
 ## Python SDK: Removed `blocking` argument for `flush`
 Use the new `timeout_sec` argument instead.
 For non-blocking, use `timeout_sec=0`.
+Mostly you can just call `.flush()` with no arguments.
+That will block until all writes either finishes or an error occurs (e.g. the gRPC connection is severed).

--- a/docs/content/reference/migration/migration-0-26.md
+++ b/docs/content/reference/migration/migration-0-26.md
@@ -4,7 +4,7 @@ order: 984
 ---
 <!--   ^^^ this number must be _decremented_ when you copy/paste this file -->
 
-## Python SDK: Removed `blocking` argument for `flush`
+## Python SDK: removed `blocking` argument for `flush`
 Use the new `timeout_sec` argument instead.
 For non-blocking, use `timeout_sec=0`.
 Mostly you can just call `.flush()` with no arguments.

--- a/docs/content/reference/migration/migration-0-26.md
+++ b/docs/content/reference/migration/migration-0-26.md
@@ -1,0 +1,9 @@
+---
+title: Migrating from 0.25 to 0.26
+order: 984
+---
+<!--   ^^^ this number must be _decremented_ when you copy/paste this file -->
+
+## Python SDK: Removed `blocking` argument for `flush`
+Use the new `timeout_sec` argument instead.
+For non-blocking, use `timeout_sec=0`.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1083,8 +1083,7 @@ def disconnect(recording: PyRecordingStream | None = None) -> None:
     Subsequent log messages will be buffered and either sent on the next call to `connect_grpc` or `spawn`.
     """
 
-# TODO(#11294): remove `blocking` argument and put the `*` first
-def flush(blocking: bool = True, recording: PyRecordingStream | None = None, *, timeout_sec: float = 1e38) -> None:
+def flush(*, timeout_sec: float = 1e38, recording: PyRecordingStream | None = None) -> None:
     """Block until outstanding data has been flushed to the sink."""
 
 #

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -471,22 +471,19 @@ class RecordingStream:
     def to_native(self) -> bindings.PyRecordingStream:
         return self.inner
 
-    # TODO(#11294): remove `blocking` argument
-    def flush(self, blocking: bool = True, *, timeout_sec: float = 1e38) -> None:
+    def flush(self, *, timeout_sec: float = 1e38) -> None:
         """
         Initiates a flush the batching pipeline and optionally waits for it to propagate to the underlying file descriptor (if any).
 
         Parameters
         ----------
-        blocking:
-            If true, the flush will block until the flush is complete.
         timeout_sec:
             Wait at most this many seconds.
             If the timeout is reached, an error is raised.
             If set to zero, the flush will be started but not waited for.
 
         """
-        bindings.flush(blocking=blocking, recording=self.to_native(), timeout_sec=timeout_sec)
+        bindings.flush(timeout_sec=timeout_sec, recording=self.to_native())
 
     def __del__(self) -> None:  # type: ignore[no-untyped-def]
         recording = self.to_native()


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/11294

### What
The argument is no longer needed. You have better control with `timeout_sec`, but mostly you can just call `.flush()` with no argument. It will block until it either finishes or produces an error.