### PR TITLE
Viewer now crops incoming chunks if time range was requested

### DIFF
--- a/crates/store/re_chunk/src/slice.rs
+++ b/crates/store/re_chunk/src/slice.rs
@@ -179,6 +179,21 @@ impl Chunk {
     #[must_use]
     #[inline]
     pub fn component_sliced(&self, component_descr: &ComponentDescriptor) -> Self {
+        self.components_sliced(&[component_descr])
+    }
+
+    /// Slices the [`Chunk`] horizontally by keeping only the selected `component_descrs`.
+    ///
+    /// The result is a new [`Chunk`] with the same rows and at most only the selected component columns.
+    /// All non-component columns will be kept as-is.
+    ///
+    /// If none of the `component_descrs` are found within the [`Chunk`], the end result will be the same as the
+    /// current chunk but without any component column.
+    ///
+    /// WARNING: the returned chunk has the same old [`crate::ChunkId`]! Change it with [`Self::with_id`].
+    #[must_use]
+    #[inline]
+    pub fn components_sliced(&self, component_descrs: &[&ComponentDescriptor]) -> Self {
         let Self {
             id,
             entity_path,
@@ -197,10 +212,14 @@ impl Chunk {
             row_ids: row_ids.clone(),
             timelines: timelines.clone(),
             components: crate::ChunkComponents(
-                components
-                    .get(component_descr)
-                    .map(|list_array| (component_descr.clone(), list_array.clone()))
-                    .into_iter()
+                component_descrs
+                    .iter()
+                    .flat_map(|component_descr| {
+                        components
+                            .get(component_descr)
+                            .map(|list_array| ((*component_descr).clone(), list_array.clone()))
+                            .into_iter()
+                    })
                     .collect(),
             ),
         };

--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -344,6 +344,7 @@ impl ChunkStore {
                 type_registry: _,
                 per_column_metadata: _, // column metadata is additive only
                 chunks_per_chunk_id,
+                cropped_chunk_id_per_source_chunk_id,
                 chunk_ids_per_min_row_id,
                 temporal_chunk_ids_per_entity_per_component,
                 temporal_chunk_ids_per_entity,
@@ -430,6 +431,9 @@ impl ChunkStore {
                         }
                     }
                 }
+
+                cropped_chunk_id_per_source_chunk_id
+                    .retain(|_, cropped_chunk_id| !chunk_ids_dangling.contains(cropped_chunk_id));
 
                 diffs.extend(
                     chunk_ids_dangling
@@ -691,6 +695,9 @@ impl ChunkStore {
                 }
             }
         }
+
+        self.cropped_chunk_id_per_source_chunk_id
+            .retain(|_, cropped_chunk_id| !chunk_ids_removed.contains(cropped_chunk_id));
 
         {
             re_tracing::profile_scope!("last collect");

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -32,7 +32,10 @@ pub use self::{
     events::{ChunkCompactionReport, ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent},
     gc::{GarbageCollectionOptions, GarbageCollectionTarget},
     stats::{ChunkStoreChunkStats, ChunkStoreStats},
-    store::{ChunkStore, ChunkStoreConfig, ChunkStoreGeneration, ChunkStoreHandle, ColumnMetadata},
+    store::{
+        ChunkStore, ChunkStoreCompactionConfig, ChunkStoreConfig, ChunkStoreGeneration,
+        ChunkStoreHandle, ColumnMetadata,
+    },
     subscribers::{ChunkStoreSubscriber, ChunkStoreSubscriberHandle, PerStoreChunkSubscriber},
 };
 pub use re_sorbet::{ColumnDescriptor, ComponentColumnDescriptor, IndexColumnDescriptor};

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
+use ahash::HashMap;
 use arrow::datatypes::DataType as ArrowDataType;
 use nohash_hasher::IntMap;
 
@@ -440,6 +441,10 @@ pub struct ChunkStore {
 
     pub(crate) chunks_per_chunk_id: BTreeMap<ChunkId, Arc<Chunk>>,
 
+    /// For all cropped chunks (see [`ChunkStoreConfig::cropping_range`]),
+    /// this maps from their source chunk ID to the ID of the cropped chunk ID.
+    pub(crate) cropped_chunk_id_per_source_chunk_id: HashMap<ChunkId, ChunkId>,
+
     /// All [`ChunkId`]s currently in the store, indexed by the smallest [`RowId`] in each of them.
     ///
     /// This is effectively all chunks in global data order. Used for garbage collection.
@@ -512,6 +517,7 @@ impl Clone for ChunkStore {
             type_registry: self.type_registry.clone(),
             per_column_metadata: self.per_column_metadata.clone(),
             chunks_per_chunk_id: self.chunks_per_chunk_id.clone(),
+            cropped_chunk_id_per_source_chunk_id: self.cropped_chunk_id_per_source_chunk_id.clone(),
             chunk_ids_per_min_row_id: self.chunk_ids_per_min_row_id.clone(),
             temporal_chunk_ids_per_entity_per_component: self
                 .temporal_chunk_ids_per_entity_per_component
@@ -536,6 +542,7 @@ impl std::fmt::Display for ChunkStore {
             type_registry: _,
             per_column_metadata: _,
             chunks_per_chunk_id,
+            cropped_chunk_id_per_source_chunk_id: _,
             chunk_ids_per_min_row_id: chunk_id_per_min_row_id,
             temporal_chunk_ids_per_entity_per_component: _,
             temporal_chunk_ids_per_entity: _,
@@ -598,6 +605,7 @@ impl ChunkStore {
             per_column_metadata: Default::default(),
             chunk_ids_per_min_row_id: Default::default(),
             chunks_per_chunk_id: Default::default(),
+            cropped_chunk_id_per_source_chunk_id: Default::default(),
             temporal_chunk_ids_per_entity_per_component: Default::default(),
             temporal_chunk_ids_per_entity: Default::default(),
             temporal_chunks_stats: Default::default(),

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -25,11 +25,10 @@ pub struct ChunkStoreConfig {
     /// How incoming chunks will be compacted.
     pub compaction: ChunkStoreCompactionConfig,
 
-    /// If present, will crop incoming data to the specified range for a single given timeline.
-    /// Data for all other timelines will be discarded.
+    /// If present, will crop incoming chunks to the specified range for a single given timeline.
     ///
-    /// ⚠️ Does not discard any chunk whose time ranges are entirely before the range.
-    /// This is because on a per-chunk level it's not known whether it is relevant for latest-at queries within the range.
+    /// Data for other timelines remains untouched.
+    /// Practically this affects only the index of a chunk and is not very effective at saving memory.
     ///
     /// This property is typically set via [`re_log_types::StoreInfo::cropping_range`].
     pub cropping_range: Option<StoreCroppingRange>,
@@ -644,7 +643,7 @@ impl ChunkStore {
 
     /// Sets the chunk cropping range that should be used from now on.
     ///
-    /// Does *not* affect existing chunks.
+    /// Does *not* affect existing chunks, only newly incoming chunks.
     #[inline]
     pub fn set_cropping_range(&mut self, cropping_range: Option<StoreCroppingRange>) {
         self.config.cropping_range = cropping_range;

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -391,7 +391,7 @@ impl ChunkStoreHandle {
 /// A complete chunk store: covers all timelines, all entities, everything.
 ///
 /// The chunk store _always_ works at the chunk level, whether it is for write & read queries or
-/// garbage collection. It is completely oblivious to individual rows.
+/// garbage collection. It is completely oblivious to individual rows other than for optionally cropping incoming data.
 ///
 /// Use the `Display` implementation for a detailed view of the internals.
 #[derive(Debug)]

--- a/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/formatting__format_chunk_store.snap
@@ -4,7 +4,7 @@ expression: "format!(\"{:240}\", store)"
 ---
 ChunkStore {
     id: StoreId(Recording, "test_app", "test_id")
-    config: ChunkStoreConfig { enable_changelog: true, chunk_max_bytes: 393216, chunk_max_rows: 4096, chunk_max_rows_if_unsorted: 1024 }
+    config: ChunkStoreConfig { enable_changelog: true, compaction: ChunkStoreCompactionConfig { chunk_max_bytes: 393216, chunk_max_rows: 4096, chunk_max_rows_if_unsorted: 1024 }, cropping_range: None }
     stats: {
         num_chunks: 1
         total_size_bytes: 1.1 KiB

--- a/crates/store/re_data_loader/src/load_file.rs
+++ b/crates/store/re_data_loader/src/load_file.rs
@@ -104,6 +104,7 @@ pub(crate) fn prepare_store_info(
             cloned_from: None,
             store_source,
             store_version: Some(re_build_info::CrateVersion::LOCAL),
+            cropping_range: None,
         },
     })
 }

--- a/crates/store/re_data_loader/src/load_file.rs
+++ b/crates/store/re_data_loader/src/load_file.rs
@@ -101,10 +101,8 @@ pub(crate) fn prepare_store_info(
         row_id: *re_chunk::RowId::new(),
         info: re_log_types::StoreInfo {
             store_id: store_id.clone(),
-            cloned_from: None,
             store_source,
-            store_version: Some(re_build_info::CrateVersion::LOCAL),
-            cropping_range: None,
+            ..Default::default()
         },
     })
 }

--- a/crates/store/re_data_loader/src/loader_mcap.rs
+++ b/crates/store/re_data_loader/src/loader_mcap.rs
@@ -240,10 +240,8 @@ pub fn store_info(store_id: StoreId) -> SetStoreInfo {
         row_id: *RowId::new(),
         info: StoreInfo {
             store_id,
-            cloned_from: None,
             store_source: re_log_types::StoreSource::Other(MCAP_LOADER_NAME.to_owned()),
-            store_version: Some(re_build_info::CrateVersion::LOCAL),
-            cropping_range: None,
+            ..Default::default()
         },
     }
 }

--- a/crates/store/re_data_loader/src/loader_mcap.rs
+++ b/crates/store/re_data_loader/src/loader_mcap.rs
@@ -243,6 +243,7 @@ pub fn store_info(store_id: StoreId) -> SetStoreInfo {
             cloned_from: None,
             store_source: re_log_types::StoreSource::Other(MCAP_LOADER_NAME.to_owned()),
             store_version: Some(re_build_info::CrateVersion::LOCAL),
+            cropping_range: None,
         },
     }
 }

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -328,7 +328,6 @@ impl RetryableFileReader {
 
 #[cfg(test)]
 mod tests {
-    use re_build_info::CrateVersion;
     use re_chunk::RowId;
     use re_log_encoding::encoder::DroppableEncoder;
     use re_log_types::{LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource};
@@ -371,13 +370,11 @@ mod tests {
                 row_id: *RowId::new(),
                 info: StoreInfo {
                     store_id: StoreId::random(StoreKind::Recording, "test_app"),
-                    cloned_from: None,
                     store_source: StoreSource::RustSdk {
                         rustc_version: String::new(),
                         llvm_version: String::new(),
                     },
-                    store_version: Some(CrateVersion::LOCAL),
-                    cropping_range: None,
+                    ..Default::default()
                 },
             })
         }

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -377,6 +377,7 @@ mod tests {
                         llvm_version: String::new(),
                     },
                     store_version: Some(CrateVersion::LOCAL),
+                    cropping_range: None,
                 },
             })
         }

--- a/crates/store/re_dataframe/src/lib.rs
+++ b/crates/store/re_dataframe/src/lib.rs
@@ -8,8 +8,8 @@ pub use self::query::QueryHandle;
 
 #[doc(no_inline)]
 pub use self::external::re_chunk_store::{
-    ChunkStoreConfig, ChunkStoreHandle, Index, IndexRange, IndexValue, QueryExpression,
-    SparseFillStrategy, ViewContentsSelector,
+    ChunkStoreCompactionConfig, ChunkStoreConfig, ChunkStoreHandle, Index, IndexRange, IndexValue,
+    QueryExpression, SparseFillStrategy, ViewContentsSelector,
 };
 #[doc(no_inline)]
 pub use self::external::re_log_types::{

--- a/crates/store/re_entity_db/src/store_bundle.rs
+++ b/crates/store/re_entity_db/src/store_bundle.rs
@@ -103,6 +103,7 @@ impl StoreBundle {
                     cloned_from: None,
                     store_source: re_log_types::StoreSource::Other("viewer".to_owned()),
                     store_version: Some(re_build_info::CrateVersion::LOCAL),
+                    cropping_range: None,
                 },
             });
 

--- a/crates/store/re_entity_db/src/store_bundle.rs
+++ b/crates/store/re_entity_db/src/store_bundle.rs
@@ -100,10 +100,8 @@ impl StoreBundle {
                 row_id: *re_chunk::RowId::new(),
                 info: re_log_types::StoreInfo {
                     store_id: id.clone(),
-                    cloned_from: None,
                     store_source: re_log_types::StoreSource::Other("viewer".to_owned()),
-                    store_version: Some(re_build_info::CrateVersion::LOCAL),
-                    cropping_range: None,
+                    ..Default::default()
                 },
             });
 

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -1015,7 +1015,6 @@ mod tests {
     use super::*;
 
     use itertools::{Itertools as _, chain};
-    use re_build_info::CrateVersion;
     use re_chunk::RowId;
     use re_log_encoding::Compression;
     use re_log_encoding::protobuf_conversions::{log_msg_from_proto, log_msg_to_proto};

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -1062,13 +1062,11 @@ mod tests {
             row_id: *RowId::new(),
             info: StoreInfo {
                 store_id: store_id.clone(),
-                cloned_from: None,
                 store_source: StoreSource::RustSdk {
                     rustc_version: String::new(),
                     llvm_version: String::new(),
                 },
-                store_version: Some(CrateVersion::LOCAL),
-                cropping_range: None,
+                ..Default::default()
             },
         })
     }

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -1068,6 +1068,7 @@ mod tests {
                     llvm_version: String::new(),
                 },
                 store_version: Some(CrateVersion::LOCAL),
+                cropping_range: None,
             },
         })
     }

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -521,6 +521,7 @@ mod tests {
                         llvm_version: String::new(),
                     },
                     store_version: Some(CrateVersion::LOCAL),
+                    cropping_range: None,
                 },
             }),
             LogMsg::ArrowMsg(store_id.clone(), arrow_msg),

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -515,13 +515,11 @@ mod tests {
                 row_id: *RowId::new(),
                 info: StoreInfo {
                     store_id: store_id.clone(),
-                    cloned_from: None,
                     store_source: StoreSource::RustSdk {
                         rustc_version: String::new(),
                         llvm_version: String::new(),
                     },
-                    store_version: Some(CrateVersion::LOCAL),
-                    cropping_range: None,
+                    ..Default::default()
                 },
             }),
             LogMsg::ArrowMsg(store_id.clone(), arrow_msg),

--- a/crates/store/re_log_encoding/src/decoder/stream.rs
+++ b/crates/store/re_log_encoding/src/decoder/stream.rs
@@ -269,6 +269,7 @@ mod tests {
                 cloned_from: None,
                 store_source: StoreSource::Unknown,
                 store_version: Some(CrateVersion::LOCAL),
+                cropping_range: None,
             },
         })
     }

--- a/crates/store/re_log_encoding/src/decoder/stream.rs
+++ b/crates/store/re_log_encoding/src/decoder/stream.rs
@@ -254,7 +254,7 @@ fn is_chunk_empty(chunk: &Chunk) -> bool {
 #[cfg(test)]
 mod tests {
     use re_chunk::RowId;
-    use re_log_types::{ApplicationId, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource};
+    use re_log_types::{ApplicationId, SetStoreInfo, StoreId, StoreInfo, StoreKind};
 
     use crate::EncodingOptions;
     use crate::encoder::Encoder;
@@ -266,10 +266,7 @@ mod tests {
             row_id: *RowId::ZERO,
             info: StoreInfo {
                 store_id: StoreId::new(StoreKind::Recording, ApplicationId::unknown(), "test"),
-                cloned_from: None,
-                store_source: StoreSource::Unknown,
-                store_version: Some(CrateVersion::LOCAL),
-                cropping_range: None,
+                ..Default::default()
             },
         })
     }

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -600,6 +600,9 @@ pub struct StoreInfo {
     /// If present, will crop incoming data to the specified range for a single given timeline.
     /// Data for all other timelines will be discarded.
     ///
+    /// ⚠️ Does not discard any chunk whose time ranges are entirely before the range.
+    /// This is because on a per-chunk level it's not known whether it is relevant for latest-at queries within the range.
+    ///
     /// A cropped store gets always a new unique ID.
     /// TODO: make it happen.
     pub cropping_range: Option<StoreCroppingRange>,

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -597,11 +597,10 @@ pub struct StoreInfo {
     // would probably only lead to more issues down the line.
     pub store_version: Option<CrateVersion>,
 
-    /// If present, will crop incoming data to the specified range for a single given timeline.
-    /// Data for all other timelines will be discarded.
+    /// If present, will crop incoming chunks to the specified range for a single given timeline.
     ///
-    /// ⚠️ Does not discard any chunk whose time ranges are entirely before the range.
-    /// This is because on a per-chunk level it's not known whether it is relevant for latest-at queries within the range.
+    /// Data for other timelines remains untouched.
+    /// Practically this affects only the index of a chunk and is not very effective at saving memory.
     pub cropping_range: Option<StoreCroppingRange>,
 }
 

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -560,7 +560,7 @@ pub struct SetStoreInfo {
 /// Describes how a store should crop/discard incoming data.
 // TODO(#11315): In the future we will want to reduce this to a mere highlighting feature and no longer need this at the store level
 // as all data will be pulled on-demand from a server.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StoreCroppingRange {
     /// On which timeline to crop.
     pub timeline: TimelineName,

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -557,6 +557,19 @@ pub struct SetStoreInfo {
     pub info: StoreInfo,
 }
 
+/// Describes how a store should crop/discard incoming data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StoreCroppingRange {
+    /// On which timeline to crop.
+    pub timeline: TimelineName,
+
+    /// The range to crop to.
+    ///
+    /// Note that we keep data at or before the start of the range such that `latest_at` queries
+    /// at `range.min` will return data as-if all data was present.
+    pub range: AbsoluteTimeRange,
+}
+
 /// Information about a recording or blueprint.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StoreInfo {
@@ -583,6 +596,13 @@ pub struct StoreInfo {
     // NOTE: The version comes directly from the decoded RRD stream's header, duplicating it here
     // would probably only lead to more issues down the line.
     pub store_version: Option<CrateVersion>,
+
+    /// If present, will crop incoming data to the specified range for a single given timeline.
+    /// Data for all other timelines will be discarded.
+    ///
+    /// A cropped store gets always a new unique ID.
+    /// TODO: make it happen.
+    pub cropping_range: Option<StoreCroppingRange>,
 }
 
 impl StoreInfo {
@@ -918,6 +938,7 @@ impl SizeBytes for StoreInfo {
             cloned_from: _,
             store_source,
             store_version,
+            cropping_range: _,
         } = self;
 
         store_id.heap_size_bytes()

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -558,7 +558,7 @@ pub struct SetStoreInfo {
 }
 
 /// Describes how a store should crop/discard incoming data.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StoreCroppingRange {
     /// On which timeline to crop.
     pub timeline: TimelineName,

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -558,6 +558,8 @@ pub struct SetStoreInfo {
 }
 
 /// Describes how a store should crop/discard incoming data.
+// TODO(#11315): In the future we will want to reduce this to a mere highlighting feature and no longer need this at the store level
+// as all data will be pulled on-demand from a server.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StoreCroppingRange {
     /// On which timeline to crop.

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -602,10 +602,19 @@ pub struct StoreInfo {
     ///
     /// ⚠️ Does not discard any chunk whose time ranges are entirely before the range.
     /// This is because on a per-chunk level it's not known whether it is relevant for latest-at queries within the range.
-    ///
-    /// A cropped store gets always a new unique ID.
-    /// TODO: make it happen.
     pub cropping_range: Option<StoreCroppingRange>,
+}
+
+impl Default for StoreInfo {
+    fn default() -> Self {
+        Self {
+            store_id: StoreId::empty_recording(),
+            cloned_from: None,
+            store_source: StoreSource::Unknown,
+            store_version: Some(CrateVersion::LOCAL),
+            cropping_range: None,
+        }
+    }
 }
 
 impl StoreInfo {

--- a/crates/store/re_protos/src/v1alpha1/rerun.log_msg.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.log_msg.v1alpha1.ext.rs
@@ -250,10 +250,9 @@ impl TryFrom<crate::log_msg::v1alpha1::StoreInfo> for re_log_types::StoreInfo {
 
         Ok(Self {
             store_id,
-            cloned_from: None,
             store_source,
             store_version,
-            cropping_range: None,
+            ..Default::default()
         })
     }
 }
@@ -342,15 +341,13 @@ mod tests {
                 "test_app_id",
                 "test_recording_id",
             ),
-            cloned_from: None,
             store_source: re_log_types::StoreSource::PythonSdk(re_log_types::PythonVersion {
                 major: 3,
                 minor: 8,
                 patch: 0,
                 suffix: "a".to_owned(),
             }),
-            store_version: None,
-            cropping_range: None,
+            ..Default::default()
         };
         let proto_store_info: crate::log_msg::v1alpha1::StoreInfo = store_info.clone().into();
         let store_info2: re_log_types::StoreInfo = proto_store_info.try_into().unwrap();
@@ -367,15 +364,13 @@ mod tests {
                     "test_app_id",
                     "test_recording_id",
                 ),
-                cloned_from: None,
                 store_source: re_log_types::StoreSource::PythonSdk(re_log_types::PythonVersion {
                     major: 3,
                     minor: 8,
                     patch: 0,
                     suffix: "a".to_owned(),
                 }),
-                store_version: None,
-                cropping_range: None,
+                ..Default::default()
             },
         };
         let proto_set_store_info: crate::log_msg::v1alpha1::SetStoreInfo =

--- a/crates/store/re_protos/src/v1alpha1/rerun.log_msg.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.log_msg.v1alpha1.ext.rs
@@ -253,6 +253,7 @@ impl TryFrom<crate::log_msg::v1alpha1::StoreInfo> for re_log_types::StoreInfo {
             cloned_from: None,
             store_source,
             store_version,
+            cropping_range: None,
         })
     }
 }
@@ -349,6 +350,7 @@ mod tests {
                 suffix: "a".to_owned(),
             }),
             store_version: None,
+            cropping_range: None,
         };
         let proto_store_info: crate::log_msg::v1alpha1::StoreInfo = store_info.clone().into();
         let store_info2: re_log_types::StoreInfo = proto_store_info.try_into().unwrap();
@@ -373,6 +375,7 @@ mod tests {
                     suffix: "a".to_owned(),
                 }),
                 store_version: None,
+                cropping_range: None,
             },
         };
         let proto_set_store_info: crate::log_msg::v1alpha1::SetStoreInfo =

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -457,14 +457,6 @@ pub async fn stream_blueprint_and_partition_from_server(
         re_log::debug!("No blueprint dataset found for {uri}");
     }
 
-    let store_info = StoreInfo {
-        store_id: recording_store_id,
-        cloned_from: None,
-        store_source: StoreSource::Unknown,
-        store_version: None,
-        cropping_range: None, // TODO: make it happen.
-    };
-
     let re_uri::DatasetPartitionUri {
         origin: _,
         dataset_id,
@@ -472,6 +464,19 @@ pub async fn stream_blueprint_and_partition_from_server(
         time_range,
         fragment,
     } = uri;
+
+    let store_info = StoreInfo {
+        store_id: recording_store_id,
+        cloned_from: None,
+        store_source: StoreSource::Unknown,
+        store_version: None,
+        cropping_range: time_range
+            .as_ref()
+            .map(|time_range| re_log_types::StoreCroppingRange {
+                timeline: *time_range.timeline.name(),
+                range: time_range.range,
+            }),
+    };
 
     stream_partition_from_server(
         &mut client,

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -421,10 +421,8 @@ pub async fn stream_blueprint_and_partition_from_server(
 
         let blueprint_store_info = StoreInfo {
             store_id: blueprint_store_id.clone(),
-            cloned_from: None,
             store_source: StoreSource::Unknown,
-            store_version: None,
-            cropping_range: None,
+            ..Default::default()
         };
 
         stream_partition_from_server(
@@ -467,15 +465,14 @@ pub async fn stream_blueprint_and_partition_from_server(
 
     let store_info = StoreInfo {
         store_id: recording_store_id,
-        cloned_from: None,
         store_source: StoreSource::Unknown,
-        store_version: None,
         cropping_range: time_range
             .as_ref()
             .map(|time_range| re_log_types::StoreCroppingRange {
                 timeline: *time_range.timeline.name(),
                 range: time_range.range,
             }),
+        ..Default::default()
     };
 
     stream_partition_from_server(

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -424,6 +424,7 @@ pub async fn stream_blueprint_and_partition_from_server(
             cloned_from: None,
             store_source: StoreSource::Unknown,
             store_version: None,
+            cropping_range: None,
         };
 
         stream_partition_from_server(
@@ -461,6 +462,7 @@ pub async fn stream_blueprint_and_partition_from_server(
         cloned_from: None,
         store_source: StoreSource::Unknown,
         store_version: None,
+        cropping_range: None, // TODO: make it happen.
     };
 
     let re_uri::DatasetPartitionUri {

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -224,5 +224,6 @@ pub fn new_store_info(
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
         },
         store_version: Some(re_build_info::CrateVersion::LOCAL),
+        cropping_range: None,
     }
 }

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -218,12 +218,10 @@ pub fn new_store_info(
 
     re_log_types::StoreInfo {
         store_id,
-        cloned_from: None,
         store_source: re_log_types::StoreSource::RustSdk {
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
         },
-        store_version: Some(re_build_info::CrateVersion::LOCAL),
-        cropping_range: None,
+        ..Default::default()
     }
 }

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -751,10 +751,8 @@ impl RecordingStreamBuilder {
 
         let store_info = StoreInfo {
             store_id,
-            cloned_from: None,
             store_source,
-            store_version: Some(re_build_info::CrateVersion::LOCAL),
-            cropping_range: None,
+            ..Default::default()
         };
 
         (

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -754,6 +754,7 @@ impl RecordingStreamBuilder {
             cloned_from: None,
             store_source,
             store_version: Some(re_build_info::CrateVersion::LOCAL),
+            cropping_range: None,
         };
 
         (

--- a/crates/top/rerun/src/lib.rs
+++ b/crates/top/rerun/src/lib.rs
@@ -143,8 +143,8 @@ pub mod dataframe {
 
 /// Everything needed to build custom `ChunkStoreSubscriber`s.
 pub use re_entity_db::external::re_chunk_store::{
-    ChunkStore, ChunkStoreConfig, ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent,
-    ChunkStoreGeneration, ChunkStoreHandle, ChunkStoreSubscriber,
+    ChunkStore, ChunkStoreCompactionConfig, ChunkStoreConfig, ChunkStoreDiff, ChunkStoreDiffKind,
+    ChunkStoreEvent, ChunkStoreGeneration, ChunkStoreHandle, ChunkStoreSubscriber,
 };
 pub use re_log_types::StoreKind;
 

--- a/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
@@ -458,7 +458,17 @@ impl DatastoreUi {
                         .value_uint(compaction_config.chunk_max_rows_if_unsorted),
                 );
 
-                // TODO: cropping range
+                // If ranges are added over time the cropping range becomes a list that we don't keep
+                // track of right now.
+                // TODO(#11315): In the future we will want to reduce this to a mere highlighting feature and no longer need this at the store level
+                // as all data will be pulled on-demand from a server.
+                ui.list_item_flat_noninteractive(
+                    list_item::PropertyContent::new("Partial store")
+                        .value_bool(chunk_store.config().cropping_range.is_some()),
+                )
+                .on_hover_text(
+                    "If true, only a subset of the recording is presented in the viewer.",
+                );
             });
         });
 

--- a/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
@@ -440,21 +440,25 @@ impl DatastoreUi {
                         .value_bool(chunk_store.config().enable_changelog),
                 );
 
+                let compaction_config = &chunk_store.config().compaction;
+
                 ui.list_item_flat_noninteractive(
                     list_item::PropertyContent::new("Chunk max byte").value_text(
-                        re_format::format_bytes(chunk_store.config().chunk_max_bytes as f64),
+                        re_format::format_bytes(compaction_config.chunk_max_bytes as f64),
                     ),
                 );
 
                 ui.list_item_flat_noninteractive(
                     list_item::PropertyContent::new("Chunk max rows")
-                        .value_uint(chunk_store.config().chunk_max_rows),
+                        .value_uint(compaction_config.chunk_max_rows),
                 );
 
                 ui.list_item_flat_noninteractive(
                     list_item::PropertyContent::new("Chunk max rows (unsorted)")
-                        .value_uint(chunk_store.config().chunk_max_rows_if_unsorted),
+                        .value_uint(compaction_config.chunk_max_rows_if_unsorted),
                 );
+
+                // TODO: cropping range
             });
         });
 

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -36,18 +36,18 @@ pub fn redap_uri_button(
 
     let uri = RedapUri::from_str(url_str)?;
 
-    let loaded_recording_id = ctx.storage_context.bundle.recordings().find_map(|db| {
+    let loaded_recording_info = ctx.storage_context.bundle.recordings().find_map(|db| {
         if db
             .data_source
             .as_ref()
             .is_some_and(|source| source.stripped_redap_uri().as_ref() == Some(&uri))
         {
-            Some(db.store_id().clone())
+            db.store_info().clone()
         } else {
             None
         }
     });
-    let is_loading = loaded_recording_id.is_none()
+    let is_loading = loaded_recording_info.is_none()
         && ctx
             .connected_receivers
             .sources()
@@ -96,20 +96,31 @@ pub fn redap_uri_button(
             .0
     };
 
-    if let Some(loaded_recording_id) = loaded_recording_id {
-        let response = link_with_copy(ui, Link::new("Switch to")).on_hover_ui(|ui| {
-            ui.label("This recording is already loaded. Click to switch to it.");
-        });
+    ui.horizontal(|ui| {
+        if let Some(loaded_recording_info) = loaded_recording_info {
+            let is_partial_recording = loaded_recording_info.cropping_range.is_some();
+            if is_partial_recording {
+                let response = ui.add(Link::new("Open full")).on_hover_text(
+                    "Part of this recording is already loaded. Click to download the rest.",
+                );
+                handle_open_full_recording_link(ui, uri, &response);
+            }
 
-        if response.clicked() {
-            // Show it:
-            ctx.command_sender()
-                .send_system(SystemCommand::SetSelection(
-                    re_viewer_context::Item::StoreId(loaded_recording_id).into(),
-                ));
-        }
-    } else if is_loading {
-        ui.horizontal(|ui| {
+            let response =
+                link_with_copy(ui, Link::new("Switch to")).on_hover_text(if is_partial_recording {
+                    "Part of this recording is already loaded. Click to switch to it."
+                } else {
+                    "This recording is already loaded. Click to switch to it."
+                });
+            if response.clicked() {
+                // Show it:
+                ctx.command_sender()
+                    .send_system(SystemCommand::SetSelection(
+                        re_viewer_context::Item::StoreId(loaded_recording_info.store_id.clone())
+                            .into(),
+                    ));
+            }
+        } else if is_loading {
             ui.spinner();
 
             if ui
@@ -119,18 +130,22 @@ pub fn redap_uri_button(
             {
                 ctx.connected_receivers.remove_by_uri(&uri.to_string());
             }
-        });
-    } else {
-        let response = link_with_copy(ui, Link::new("Open")).on_hover_ui(|ui| {
-            ui.label(uri.to_string());
-        });
+        } else {
+            let response = link_with_copy(ui, Link::new("Open")).on_hover_ui(|ui| {
+                ui.label(uri.to_string());
+            });
 
-        if response.clicked_with_open_in_background() {
-            ui.ctx().open_url(egui::OpenUrl::new_tab(uri));
-        } else if response.clicked() {
-            ui.ctx().open_url(egui::OpenUrl::same_tab(uri));
+            handle_open_full_recording_link(ui, uri, &response);
         }
-    }
+    });
 
     Ok(())
+}
+
+fn handle_open_full_recording_link(ui: &Ui, uri: RedapUri, response: &egui::Response) {
+    if response.clicked_with_open_in_background() {
+        ui.ctx().open_url(egui::OpenUrl::new_tab(uri));
+    } else if response.clicked() {
+        ui.ctx().open_url(egui::OpenUrl::same_tab(uri));
+    }
 }

--- a/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
+++ b/crates/viewer/re_component_ui/src/variant_uis/redap_uri_button.rs
@@ -42,7 +42,7 @@ pub fn redap_uri_button(
             .as_ref()
             .is_some_and(|source| source.stripped_redap_uri().as_ref() == Some(&uri))
         {
-            db.store_info().clone()
+            db.store_info()
         } else {
             None
         }

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -80,16 +80,14 @@ impl crate::DataUi for EntityDb {
                     );
                 }
 
-                if let Some(cropping_range) = cropping_range {
-                    ui.grid_left_hand_label("Cropped timeline");
-                    ui.label(format!("{}", cropping_range.timeline));
-                    ui.end_row();
-
-                    // TODO: time fmt
-                    ui.grid_left_hand_label("Cropping range");
-                    ui.label(format!("{:?} - {:?}", cropping_range.range.min, cropping_range.range.max));
-                    ui.end_row();
-                }
+                // TODO(#11315): In the future we will want to reduce this to a mere highlighting feature and no longer need this at the store level
+                // as all data will be pulled on-demand from a server.
+                ui.grid_left_hand_label("Partial store");
+                ui.monospace(format!("{:?}", cropping_range.is_some()))
+                .on_hover_text(
+                    "If true, only a subset of the recording is presented in the viewer.",
+                );
+                ui.end_row();
 
                 ui.grid_left_hand_label("Kind");
                 ui.label(store_id.kind().to_string());

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -53,7 +53,7 @@ impl crate::DataUi for EntityDb {
                     cloned_from,
                     store_source,
                     store_version,
-                    cropping_range, // TODO: make use of this here
+                    cropping_range,
                 } = store_info;
 
                 if let Some(cloned_from) = cloned_from {
@@ -78,6 +78,17 @@ impl crate::DataUi for EntityDb {
                     re_log::debug_once!(
                         "store version is undefined for this recording, this is a bug"
                     );
+                }
+
+                if let Some(cropping_range) = cropping_range {
+                    ui.grid_left_hand_label("Cropped timeline");
+                    ui.label(format!("{}", cropping_range.timeline));
+                    ui.end_row();
+
+                    // TODO: time fmt
+                    ui.grid_left_hand_label("Cropping range");
+                    ui.label(format!("{:?} - {:?}", cropping_range.range.min, cropping_range.range.max));
+                    ui.end_row();
                 }
 
                 ui.grid_left_hand_label("Kind");

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -53,6 +53,7 @@ impl crate::DataUi for EntityDb {
                     cloned_from,
                     store_source,
                     store_version,
+                    cropping_range, // TODO: make use of this here
                 } = store_info;
 
                 if let Some(cloned_from) = cloned_from {

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -2,7 +2,7 @@ use jiff::SignedDuration;
 use jiff::fmt::friendly::{FractionalUnit, SpanPrinter};
 
 use re_byte_size::SizeBytes as _;
-use re_chunk_store::ChunkStoreConfig;
+use re_chunk_store::ChunkStoreCompactionConfig;
 use re_entity_db::EntityDb;
 use re_log_types::StoreKind;
 use re_smart_channel::SmartChannelSource;
@@ -142,12 +142,11 @@ impl crate::DataUi for EntityDb {
             }
 
             {
-                let &ChunkStoreConfig {
-                    enable_changelog: _,
+                let &ChunkStoreCompactionConfig {
                     chunk_max_bytes,
                     chunk_max_rows,
                     chunk_max_rows_if_unsorted,
-                } = self.storage_engine().store().config();
+                } = &self.storage_engine().store().config().compaction;
 
                 ui.grid_left_hand_label("Compaction");
                 ui.label(format!(
@@ -186,9 +185,9 @@ impl crate::DataUi for EntityDb {
                                                     re_format::format_uint(chunk_max_rows),
                                                     re_format::format_uint(chunk_max_rows_if_unsorted),
                                                     re_format::format_bytes(chunk_max_bytes as _),
-                                                    ChunkStoreConfig::ENV_CHUNK_MAX_ROWS,
-                                                    ChunkStoreConfig::ENV_CHUNK_MAX_ROWS_IF_UNSORTED,
-                                                    ChunkStoreConfig::ENV_CHUNK_MAX_BYTES,
+                                                    ChunkStoreCompactionConfig::ENV_CHUNK_MAX_ROWS,
+                                                    ChunkStoreCompactionConfig::ENV_CHUNK_MAX_ROWS_IF_UNSORTED,
+                                                    ChunkStoreCompactionConfig::ENV_CHUNK_MAX_BYTES,
                         )),
                     );
                 ui.end_row();

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -718,8 +718,17 @@ pub fn entity_db_button_ui(
     }
     .unwrap_or("<unknown>".to_owned());
 
+    let cropping_postfix = if entity_db
+        .store_info()
+        .is_some_and(|store_info| store_info.cropping_range.is_some())
+    {
+        " (partial)"
+    } else {
+        ""
+    };
+
     let size = re_format::format_bytes(entity_db.total_size_bytes() as _);
-    let title = format!("{app_id_prefix}{recording_name} - {size}");
+    let title = format!("{app_id_prefix}{recording_name}{cropping_postfix} - {size}");
 
     let store_id = entity_db.store_id().clone();
     let item = re_viewer_context::Item::StoreId(store_id.clone());

--- a/crates/viewer/re_selection_panel/tests/snapshots/selection_panel_recording.png
+++ b/crates/viewer/re_selection_panel/tests/snapshots/selection_panel_recording.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6df8c5de726b60e6834a3ff52657fd97f29edc60f56e7dc81e68286e32e1ae07
-size 52251
+oid sha256:51e30d172814f11670aa910d8139ddc3c78e7acfdd28d0bd9d5bcb046a1d5e93
+size 54364

--- a/crates/viewer/re_test_context/src/lib.rs
+++ b/crates/viewer/re_test_context/src/lib.rs
@@ -100,10 +100,8 @@ impl TestContext {
             row_id: Tuid::new(),
             info: StoreInfo {
                 store_id: recording_store.store_id().clone(),
-                cloned_from: None,
                 store_source: StoreSource::Other("test".into()),
-                store_version: None,
-                cropping_range: None,
+                ..Default::default()
             },
         });
         {

--- a/crates/viewer/re_test_context/src/lib.rs
+++ b/crates/viewer/re_test_context/src/lib.rs
@@ -101,6 +101,7 @@ impl TestContext {
             info: StoreInfo {
                 store_id: recording_store.store_id().clone(),
                 store_source: StoreSource::Other("test".into()),
+                store_version: None, // Don't set a version so this stays constant for snapshot tests.
                 ..Default::default()
             },
         });

--- a/crates/viewer/re_test_context/src/lib.rs
+++ b/crates/viewer/re_test_context/src/lib.rs
@@ -103,6 +103,7 @@ impl TestContext {
                 cloned_from: None,
                 store_source: StoreSource::Other("test".into()),
                 store_version: None,
+                cropping_range: None,
             },
         });
         {

--- a/crates/viewer/re_view_spatial/tests/bgr_images.rs
+++ b/crates/viewer/re_view_spatial/tests/bgr_images.rs
@@ -10,7 +10,7 @@ use re_test_context::{
 };
 use re_test_viewport::TestContextExt as _;
 use re_types::{
-    Archetype, blueprint::components::BackgroundKind, datatypes::ColorModel,
+    Archetype as _, blueprint::components::BackgroundKind, datatypes::ColorModel,
     image::ImageChannelType,
 };
 use re_viewer_context::{ViewClass as _, ViewId};

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -734,6 +734,17 @@ impl App {
                     return;
                 }
 
+                // Suppress loading screen if we're loading a recording that's already loaded, even if only partially.
+                if let DisplayMode::Loading(source) = &display_mode
+                    && let Some(re_uri::RedapUri::DatasetData(dataset_uri)) = source.redap_uri()
+                    && store_hub
+                        .store_bundle()
+                        .entity_dbs()
+                        .any(|db| db.store_id() == &dataset_uri.store_id())
+                {
+                    return;
+                }
+
                 if matches!(display_mode, DisplayMode::Loading(_)) {
                     self.state
                         .selection_state

--- a/crates/viewer/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/event.rs
@@ -71,6 +71,7 @@ pub fn open_recording(
             store_source,
             store_version,
             cloned_from: _,
+            cropping_range: _,
         } = store_info;
 
         let application_id = store_id.application_id();

--- a/tests/rust/test_data_density_graph/src/main.rs
+++ b/tests/rust/test_data_density_graph/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> anyhow::Result<()> {
         .spawn_opts(&rerun::SpawnOptions {
             wait_for_bind: true,
             extra_env: {
-                use re_chunk_store::ChunkStoreConfig as C;
+                use re_chunk_store::ChunkStoreCompactionConfig as C;
                 vec![
                     (C::ENV_CHUNK_MAX_BYTES.into(), "0".into()),
                     (C::ENV_CHUNK_MAX_ROWS.into(), "0".into()),


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/10692
* This is in many ways just part of a workaround for inspecting large episodes, making it related to https://github.com/rerun-io/rerun/issues/11315

### What

Datastore URLs allow querying only a time range. This then leads us to pulling down the necessary chunks, causing arbitrarily more data in the Viewer to arrive, depending on how big the chunks are.

This PR introduces crop-on-insert in order to crop chunks to the specified range, thus honoring the previously requested time bounds more accurately.
@abey79 and me decided to crop only on the specified timeline (not cropping on any other) and allow recombining cropped chunks into an existing store. This video demonstrates what this means in practice and feature some slight ui changes:


https://github.com/user-attachments/assets/395223c3-4025-439f-a9ae-806f191713f2


While the cropping itself is a saimple range query on incoming chunks, in practice this gives rise to a whole slew of issues like how to deal with overlapping data, chunk ids, row ids, etc.. The most important ones like "what happens if I load the recording after all" & "what happens if I load overlapping ranges" are well-enough addressed here, but it's not a clean solution overall as you easily may end up in a situation with duplicated data in-memory.
I firmly believe that we should remove this mechanism again once we have dynamic occupancy handling for continuous streaming within a memory budget (#11315). We'll still want a way to highlight selected time ranges, but we can do that on a per-visualization basis as needed.