### PR TITLE
Improve error message

### DIFF
--- a/rerun_py/rerun_sdk/rerun/any_batch_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_batch_value.py
@@ -155,7 +155,7 @@ class AnyBatchValue(ComponentBatchLike):
         value:
             The data to be logged as a component.
         drop_untyped_nones:
-            If True, any components that are None will be dropped unless they have been
+            If True, any components that are either None or `[]` will be dropped unless they have been
             previously logged with a type.
 
         """
@@ -176,9 +176,9 @@ class AnyBatchValue(ComponentBatchLike):
                 self.pa_array = value.as_arrow_array()
             else:
                 if pa_type is None:
-                    if value is None:
+                    if value is None or value == []:
                         if not drop_untyped_nones:
-                            raise ValueError("Cannot convert None to arrow array. Type is unknown.")
+                            raise ValueError(f"Cannot convert {value} to arrow array without an explicit type")
                     else:
                         self.pa_array = _parse_arrow_array(value, pa_type=None, np_type=np_type, descriptor=descriptor)
                 else:
@@ -239,7 +239,7 @@ class AnyBatchValue(ComponentBatchLike):
         value:
             The data to be logged as a component.
         drop_untyped_nones:
-            If True, any components that are None will be dropped unless they have been
+            If True, any components that are either None or `[]` will be dropped unless they have been
             previously logged with a type.
 
         """

--- a/rerun_py/rerun_sdk/rerun/any_value.py
+++ b/rerun_py/rerun_sdk/rerun/any_value.py
@@ -71,7 +71,7 @@ class AnyValues(AsComponents):
         Parameters
         ----------
         drop_untyped_nones:
-            If True, any components that are None will be dropped unless they
+            If True, any components that are either None or `[]` will be dropped unless they
             have been previously logged with a type.
         kwargs:
             The components to be logged.
@@ -168,7 +168,7 @@ class AnyValues(AsComponents):
         Parameters
         ----------
         drop_untyped_nones:
-            If True, any components that are None will be dropped unless they
+            If True, any components that are either None or `[]` will be dropped unless they
             have been previously logged with a type.
         kwargs:
             The components to be logged.

--- a/rerun_py/rerun_sdk/rerun/dynamic_archetype.py
+++ b/rerun_py/rerun_sdk/rerun/dynamic_archetype.py
@@ -80,7 +80,7 @@ class DynamicArchetype(AsComponents):
         archetype:
             All values in this class will be grouped under this archetype.
         drop_untyped_nones:
-            If True, any components that are None will be dropped unless they
+            If True, any components that are either None or `[]` will be dropped unless they
             have been previously logged with a type.
         components:
             The components to be logged.
@@ -216,7 +216,7 @@ class DynamicArchetype(AsComponents):
         archetype:
             All values in this class will be grouped under this archetype.
         drop_untyped_nones:
-            If True, any components that are None will be dropped unless they
+            If True, any components that are either None or `[]` will be dropped unless they
             have been previously logged with a type.
         components:
             The components to be logged.


### PR DESCRIPTION
### Related
* Merge https://github.com/rerun-io/rerun/pull/11321 first
* Closes https://github.com/rerun-io/rerun/issues/11320

### What
When using `AnyValues` we try to infer the type from the argument.
This does not work if the argument is `None`, so in those cases we just ignore that column.
This can be controlled with `drop_untyped_nones` (default: `True`).

It _also_ doesn't work when given an empty sequence, `[]`. However, we did not previously take this count into consideration. When logging `[]` we would assign the column the type `pa.null()`. If the user later logged actual data on that column (e.g. `[1, 2, 3]`) that would lead to an exception: "Invalid null value" (because we expected `[null, null, …]` but got `[1, 2, 3]`).

The new code now drops any `[]` calls until we know their type.
This means logging `[]` followed by `[1, 2, 3]` will result in just `[1, 2, 3]` showing up in your recorded data.
Logging `[1, 2, 3]` followed by `[]` will NOT discard the `[]` though.

### TODO
* [ ] Add tests
* [ ] Are there other empty sequences beyond `[]` we need to worry about? Like `[[]]`?
  * [ ] Is there a more robust way to handle this?