### PR TITLE
Fix instances of `newest_first` not working correctly

### DIFF
--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -710,6 +710,7 @@ class RecordingStream:
             default_blueprint=default_blueprint,
             server_memory_limit=server_memory_limit,
             recording=self,
+            newest_first=newest_first,
         )
 
     @deprecated(

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -374,6 +374,7 @@ def serve_grpc(
         server_memory_limit=server_memory_limit,
         default_blueprint=blueprint_storage,
         recording=recording.to_native() if recording is not None else None,
+        newest_first=newest_first,
     )
 
 


### PR DESCRIPTION
### Related
* Found thanks to https://github.com/rerun-io/rerun/issues/11319

### What
The `newest_first` argument was ignored when used from the Python SDK