### PR TITLE
Fix url edit warning spam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8785,7 +8785,6 @@ dependencies = [
 name = "re_uri"
 version = "0.26.0-alpha.1+dev"
 dependencies = [
- "re_log",
  "re_log_types",
  "re_tuid",
  "serde",

--- a/crates/utils/re_uri/Cargo.toml
+++ b/crates/utils/re_uri/Cargo.toml
@@ -15,7 +15,6 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-re_log.workspace = true
 re_log_types = { workspace = true, features = ["serde"] }
 re_tuid.workspace = true
 

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -67,7 +67,7 @@ impl DatasetPartitionUri {
                     time_range = Some(value.parse::<TimeSelection>()?);
                 }
                 _ => {
-                    re_log::debug_once!("Unknown query parameter: {key}={value}");
+                    // We ignore unknown query keys that may be from urls from prior/newer versions.
                 }
             }
         }

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -67,7 +67,7 @@ impl DatasetPartitionUri {
                     time_range = Some(value.parse::<TimeSelection>()?);
                 }
                 _ => {
-                    re_log::warn_once!("Unknown query parameter: {key}={value}");
+                    re_log::debug_once!("Unknown query parameter: {key}={value}");
                 }
             }
         }

--- a/crates/utils/re_uri/src/fragment.rs
+++ b/crates/utils/re_uri/src/fragment.rs
@@ -53,15 +53,12 @@ impl std::str::FromStr for Fragment {
         let mut when = None;
 
         for part in split_on_unescaped_ampersand(fragment) {
+            // If there isn't an equals in this part we skip it as it doesn't contain any data.
             if let Some((key, value)) = split_at_first_unescaped_equals(part) {
                 match key {
                     "selection" => match value.parse() {
                         Ok(path) => {
-                            if selection.is_some() {
-                                re_log::debug_once!(
-                                    "Multiple paths set in uri #fragment {fragment:?}. Ignoring all but last."
-                                );
-                            }
+                            // If there were selection fragments before this we override them.
                             selection = Some(path);
                         }
                         Err(err) => {
@@ -73,11 +70,7 @@ impl std::str::FromStr for Fragment {
                             let timeline = TimelineName::from(timeline);
                             match time.parse::<TimeCell>() {
                                 Ok(time_cell) => {
-                                    if when.is_some() {
-                                        re_log::debug_once!(
-                                            "Multiple times set in uri #fragment {fragment:?}. Ignoring all but last."
-                                        );
-                                    }
+                                    // If there were when fragments before this we ignore them.
                                     when = Some((timeline, time_cell));
                                 }
                                 Err(err) => {
@@ -92,8 +85,6 @@ impl std::str::FromStr for Fragment {
                         ));
                     }
                 }
-            } else {
-                re_log::debug_once!("Contained a part {part:?} without any equal sign in it");
             }
         }
 
@@ -102,12 +93,14 @@ impl std::str::FromStr for Fragment {
 }
 
 impl Fragment {
-    /// Parse fragment, excluding hash
+    /// Parse fragment, excluding hash.
+    ///
+    /// Returns `Fragment::default()` if parsing fails.
     pub fn parse_forgiving(fragment: &str) -> Self {
         match fragment.parse() {
             Ok(fragment) => fragment,
             Err(err) => {
-                re_log::debug_once!("Failed to parse #fragment {fragment:?}: {err}");
+                // Just return the default if parsing failed.
                 Self::default()
             }
         }

--- a/crates/utils/re_uri/src/fragment.rs
+++ b/crates/utils/re_uri/src/fragment.rs
@@ -97,13 +97,7 @@ impl Fragment {
     ///
     /// Returns `Fragment::default()` if parsing fails.
     pub fn parse_forgiving(fragment: &str) -> Self {
-        match fragment.parse() {
-            Ok(fragment) => fragment,
-            Err(err) => {
-                // Just return the default if parsing failed.
-                Self::default()
-            }
-        }
+        fragment.parse().unwrap_or_default()
     }
 
     /// True if this fragment doesn't contain any information.

--- a/crates/utils/re_uri/src/fragment.rs
+++ b/crates/utils/re_uri/src/fragment.rs
@@ -58,7 +58,7 @@ impl std::str::FromStr for Fragment {
                     "selection" => match value.parse() {
                         Ok(path) => {
                             if selection.is_some() {
-                                re_log::warn_once!(
+                                re_log::debug_once!(
                                     "Multiple paths set in uri #fragment {fragment:?}. Ignoring all but last."
                                 );
                             }
@@ -74,7 +74,7 @@ impl std::str::FromStr for Fragment {
                             match time.parse::<TimeCell>() {
                                 Ok(time_cell) => {
                                     if when.is_some() {
-                                        re_log::warn_once!(
+                                        re_log::debug_once!(
                                             "Multiple times set in uri #fragment {fragment:?}. Ignoring all but last."
                                         );
                                     }
@@ -93,7 +93,7 @@ impl std::str::FromStr for Fragment {
                     }
                 }
             } else {
-                re_log::warn_once!("Contained a part {part:?} without any equal sign in it");
+                re_log::debug_once!("Contained a part {part:?} without any equal sign in it");
             }
         }
 
@@ -107,7 +107,7 @@ impl Fragment {
         match fragment.parse() {
             Ok(fragment) => fragment,
             Err(err) => {
-                re_log::warn_once!("Failed to parse #fragment {fragment:?}: {err}");
+                re_log::debug_once!("Failed to parse #fragment {fragment:?}: {err}");
                 Self::default()
             }
         }


### PR DESCRIPTION
### Related

Closes RR-2369

### What

Fixes warnings spam when editing an invalid url in open url modal / command palatte.