### PR TITLE
minor: set supported versions for datafusion-python

### DIFF
--- a/rerun_py/rerun_sdk/rerun/catalog.py
+++ b/rerun_py/rerun_sdk/rerun/catalog.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 # Known FFI compatible releases of Datafusion.
 DATAFUSION_MAJOR_VERSION_COMPATIBILITY_SETS = [
-    {47, 48},
+    {49, 50},
 ]
 
 


### PR DESCRIPTION
Correct check for datafusion-python to support 49 or 50.
