### PR TITLE
Fix running pytest in strict mode

### DIFF
--- a/rerun_py/tests/unit/test_any_values.py
+++ b/rerun_py/tests/unit/test_any_values.py
@@ -36,6 +36,8 @@ def test_any_value_datatypes() -> None:
 
 
 def test_bad_any_value() -> None:
+    rr.set_strict_mode(False)
+
     class Foo:
         pass
 
@@ -151,6 +153,8 @@ def test_iterable_any_value() -> None:
 
 @pytest.mark.parametrize("container_type", [list, tuple, set, np.array])
 def test_empty_any_values(container_type: type[Any]) -> None:
+    rr.set_strict_mode(False)
+
     values = rr.AnyValues(**{
         f"int_array_{container_type.__name__}": container_type([]),
         f"float_array_{container_type.__name__}": container_type([]),

--- a/rerun_py/tests/unit/test_any_values.py
+++ b/rerun_py/tests/unit/test_any_values.py
@@ -36,11 +36,10 @@ def test_any_value_datatypes() -> None:
 
 
 def test_bad_any_value() -> None:
-    rr.set_strict_mode(False)
-
     class Foo:
         pass
 
+    rr.set_strict_mode(False)
     with pytest.warns(RerunWarning) as warnings:
         values = rr.AnyValues(bad_data=[Foo()])
 
@@ -78,6 +77,7 @@ def test_bad_any_value() -> None:
 
 
 def test_none_any_value() -> None:
+    rr.set_strict_mode(False)
     with pytest.warns(RerunWarning) as warnings:
         running_warning_count = 0
 
@@ -153,8 +153,6 @@ def test_iterable_any_value() -> None:
 
 @pytest.mark.parametrize("container_type", [list, tuple, set, np.array])
 def test_empty_any_values(container_type: type[Any]) -> None:
-    rr.set_strict_mode(False)
-
     values = rr.AnyValues(**{
         f"int_array_{container_type.__name__}": container_type([]),
         f"float_array_{container_type.__name__}": container_type([]),
@@ -166,6 +164,7 @@ def test_empty_any_values(container_type: type[Any]) -> None:
         f"str_array_{container_type.__name__}": container_type(["str"]),
     })
 
+    rr.set_strict_mode(False)
     with pytest.warns(RerunWarning) as warnings:
         batches = list(values.as_component_batches())
         assert len(batches) == 0
@@ -193,6 +192,7 @@ def test_any_values_numpy() -> None:
 
 
 def test_any_values_with_field() -> None:
+    rr.set_strict_mode(False)
     with pytest.warns(DeprecationWarning, match="`rr.AnyValues.with_field` using a component descriptor is deprecated"):
         values = rr.AnyValues().with_component_from_data(
             descriptor=rr.ComponentDescriptor("value"),


### PR DESCRIPTION
The pytests would fail if you had `RERUN_STRICT=1` set when running them 🤦 

Not sure what a nicer fix for this is. Global mutable state is… awful.