### PR TITLE
Fix: enabling `auth` should not pull in all of `re_viewer`

### DIFF
--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -36,7 +36,7 @@ default = [
 ]
 
 ## Support the `rerun auth` command
-auth = ["dep:re_viewer", "re_auth/cli"]
+auth = ["re_auth/cli"]
 
 ## Enable anonymized telemetry using our analytics SDK.
 analytics = [
@@ -105,6 +105,7 @@ perf_telemetry = [
 ## Add support for the [`run()`] function, which acts like a main-function for a CLI,
 ## acting the same as [the `rerun` binary](https://crates.io/crates/rerun-cli).
 run = [
+  "auth",
   "clap",
   "dep:re_chunk_store",
   "dep:re_crash_handler",
@@ -113,7 +114,6 @@ run = [
   "re_log_encoding/encoder",
   "sdk",
   "unindent",
-  "auth",
 ]
 
 ## Embed the Rerun SDK & built-in types and re-export all of their public symbols.

--- a/crates/top/rerun/src/commands/auth.rs
+++ b/crates/top/rerun/src/commands/auth.rs
@@ -1,5 +1,4 @@
 use clap::{Parser, Subcommand};
-use re_viewer::AsyncRuntimeHandle;
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum AuthCommands {
@@ -39,10 +38,8 @@ pub struct LoginCommand {
 pub struct TokenCommand {}
 
 impl AuthCommands {
-    pub fn run(&self, runtime: &AsyncRuntimeHandle) -> Result<(), re_auth::cli::Error> {
-        let context = runtime
-            .inner()
-            .block_on(re_auth::workos::AuthContext::load())?;
+    pub fn run(&self, runtime: &tokio::runtime::Handle) -> Result<(), re_auth::cli::Error> {
+        let context = runtime.block_on(re_auth::workos::AuthContext::load())?;
 
         match self {
             Self::Login(args) => {
@@ -51,12 +48,10 @@ impl AuthCommands {
                     open_browser: !args.no_open_browser,
                     force_login: args.force,
                 };
-                runtime
-                    .inner()
-                    .block_on(re_auth::cli::login(&context, options))
+                runtime.block_on(re_auth::cli::login(&context, options))
             }
 
-            Self::Token(_) => runtime.inner().block_on(re_auth::cli::token(&context)),
+            Self::Token(_) => runtime.block_on(re_auth::cli::token(&context)),
         }
     }
 }

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -627,11 +627,7 @@ where
     let res = if let Some(command) = args.command {
         match command {
             #[cfg(feature = "auth")]
-            Command::Auth(cmd) => {
-                let runtime =
-                    re_viewer::AsyncRuntimeHandle::new_native(tokio_runtime.handle().clone());
-                cmd.run(&runtime).map_err(Into::into)
-            }
+            Command::Auth(cmd) => cmd.run(tokio_runtime.handle()).map_err(Into::into),
 
             #[cfg(feature = "analytics")]
             Command::Analytics(analytics) => analytics.run().map_err(Into::into),

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 import time
+from functools import partial
 from glob import glob
 from typing import Callable
 
@@ -291,7 +292,7 @@ def denied_sdk_deps(results: list[Result]) -> None:
                 # -f '{lib}' is used here because otherwise cargo tree would print links to repositories of patched crates
                 # which would cause false positives e.g. when checking for egui.
                 f"-p rerun --target {target} -f '{{lib}}' -F {features}",
-                output_checks=lambda output: check_sdk_tree_with_default_features(output, features),
+                output_checks=partial(check_sdk_tree_with_default_features, features=features),
             )
             result.command = f"Check dependencies in `{result.command}`"
             results.append(result)


### PR DESCRIPTION
Building `rerun-cli` with the `auth` feature should not pull in `winit`, `wgpu`, etc…