### PR TITLE
Enable "Close current recording" only when there's a recording

### DIFF
--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -75,7 +75,10 @@ impl App {
 
         UICommand::SaveBlueprint.menu_button_ui(ui, &self.command_sender);
 
-        UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
+        let has_recording = _store_context.is_some_and(|ctx| !ctx.recording.is_empty());
+        ui.add_enabled_ui(has_recording, |ui| {
+            UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
+        });
 
         ui.add_space(SPACING);
 

--- a/crates/viewer/re_viewer/src/viewer_test_utils/mod.rs
+++ b/crates/viewer/re_viewer/src/viewer_test_utils/mod.rs
@@ -18,7 +18,12 @@ pub fn viewer_harness() -> Harness<'static, App> {
                 MainThreadToken::i_promise_i_am_only_using_this_for_a_test(),
                 build_info!(),
                 AppEnvironment::Test,
-                StartupOptions::default(),
+                StartupOptions {
+                    // Don't show the welcome / example screen in tests.
+                    // See also: https://github.com/rerun-io/rerun/issues/10989
+                    hide_welcome_screen: true,
+                    ..Default::default()
+                },
                 cc,
                 None,
                 AsyncRuntimeHandle::from_current_tokio_runtime_or_wasmbindgen()

--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -41,6 +41,16 @@ async fn settings_screen() {
     harness.snapshot("settings_screen");
 }
 
+/// Opens the Rerun menu without an active recording and snapshots the app.
+/// Tests that certain recording-related entries are disabled (e.g. save or close recording).
+#[tokio::test]
+async fn menu_without_recording() {
+    let mut harness = viewer_test_utils::viewer_harness();
+    harness.get_by_label("Menu").click();
+    harness.run_ok();
+    harness.snapshot("menu_without_recording");
+}
+
 /// Tests the colormap selector UI with snapshot testing.
 /// This is defined here instead of in `re_viewer/tests` because it depends on `re_test_context`,
 /// which depends on `re_viewer_context`.

--- a/crates/viewer/re_viewer/tests/snapshots/menu_without_recording.png
+++ b/crates/viewer/re_viewer/tests/snapshots/menu_without_recording.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b0fe397b3046d15bec5f7779e593b1a301822050a3fa763d82bef54200e6877
+size 137050


### PR DESCRIPTION
Trivial change, but as co-author of the app kittest I also felt obliged to add a test 🙃

### Before

<img width="500" height="444" alt="Bildschirmfoto 2025-09-26 um 18 46 54" src="https://github.com/user-attachments/assets/cf6fbf33-86be-4d66-b102-7c8d8c97bacc" />

### Now

https://github.com/user-attachments/assets/e75c89fd-c736-417c-a232-70ea6e100b51





