### PR TITLE
Avoid irrelevant warning notifications in app kittest snapshot

### DIFF
--- a/crates/viewer/re_ui/src/context_ext.rs
+++ b/crates/viewer/re_ui/src/context_ext.rs
@@ -106,7 +106,7 @@ pub trait ContextExt {
         let traffic_button_sizes_fallback = egui::vec2(64.0, 24.0); // source: I measured /emilk
 
         #[cfg(target_os = "macos")]
-        let native_buttons_size_in_native_scale = {
+        let native_buttons_size_in_native_scale = if make_room_for_window_buttons {
             use crate::egui_ext::WindowChromeMetrics;
             use raw_window_handle::HasWindowHandle as _;
 
@@ -125,6 +125,8 @@ pub trait ContextExt {
                 }
                 traffic_button_sizes_fallback
             }
+        } else {
+            egui::Vec2::ZERO
         };
         #[cfg(not(target_os = "macos"))]
         let native_buttons_size_in_native_scale = traffic_button_sizes_fallback;

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -20,7 +20,7 @@ pub fn top_panel(
 ) {
     re_tracing::profile_function!();
 
-    let style_like_web = app.is_screenshotting();
+    let style_like_web = app.is_screenshotting() || app.app_env().is_test();
     let top_bar_style = ui.ctx().top_bar_style(frame, style_like_web);
     let top_panel_frame = ui.tokens().top_panel_frame();
 

--- a/crates/viewer/re_viewer/src/viewer_test_utils/mod.rs
+++ b/crates/viewer/re_viewer/src/viewer_test_utils/mod.rs
@@ -18,7 +18,11 @@ pub fn viewer_harness() -> Harness<'static, App> {
                 MainThreadToken::i_promise_i_am_only_using_this_for_a_test(),
                 build_info!(),
                 AppEnvironment::Test,
-                StartupOptions::default(),
+                StartupOptions {
+                    // Don't calculate memory limit in tests.
+                    memory_limit: re_memory::MemoryLimit::UNLIMITED,
+                    ..Default::default()
+                },
                 cc,
                 None,
                 AsyncRuntimeHandle::from_current_tokio_runtime_or_wasmbindgen()


### PR DESCRIPTION
This disables two warnings that showed up as notifications in the snapshots when I ran the re_viewer app_kittest on my computer.

1. Disable memory limit and its potential warnings in test harness
2. Don't measure Mac traffic light in snapshot tests
We don't care about this measurement in the app kittests, and also don't want to show the debug assertion warning if it fails in the notifications.

### Related

I had to do this in order to create the snapshot for #11353 without messy warnings via
```
UPDATE_SNAPSHOTS=1 cargo test -p re_viewer --test app_kittest --all-features 
```
(no idea why these showed up for me _now_, but these warnings don't make sense in tests anyway)

### Before / After
|Before|After|
|---|---|
| <img width="1500" height="1000" alt="menu_without_recording new" src="https://github.com/user-attachments/assets/485da5e0-3c1a-42ca-82d3-d107168ace88" /> | <img width="1500" height="1000" alt="menu_without_recording" src="https://github.com/user-attachments/assets/e384f8b8-ced1-4702-986a-e35e1e755b03" /> |


