### PR TITLE
No need to retry mac tests on failure

### DIFF
--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -190,13 +190,9 @@ jobs:
       - name: Rust tests (`main` channel)
         if: ${{ inputs.CHANNEL == 'main' }}
         # We've seen some jobs fail on macOS because of a rendering adapter.
-        # Let's retry and hope for the best.
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 2
-          retry_wait_seconds: 30
-          timeout_minutes: 60
-          command: pixi run rs-check --only tests
+        # Unfortunately, just retrying it using e.g. https://github.com/nick-fields/retry does NOT help
+        # TODO(#11359): fix the Mac snapshot tests
+        run: pixi run rs-check --only tests
 
       - name: Rust all checks & tests (`nightly` channel)
         if: ${{ inputs.CHANNEL == 'nightly' }}


### PR DESCRIPTION
### Related
* The problem: https://github.com/rerun-io/rerun/issues/11359
* Attempted workaround: https://github.com/rerun-io/rerun/pull/11171

### What
Restarting the whole job sometimes work, but retrying the action never did, and only delayed the time until we showed the workflow as failing.