### PR TITLE
Add a section for OSS server in changelog

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log & send APIs, 📉 performance, sdk-python, sdk-cpp, sdk-rust, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🔨 testing, ui, 🕸️ web, 🧢 MCAP"
+          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log & send APIs, 📉 performance, sdk-python, sdk-cpp, sdk-rust, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🔨 testing, ui, 🕸️ web, 🧢 MCAP, OSS-server"
 
   wasm-bindgen-check:
     name: Check wasm-bindgen version

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -210,6 +210,7 @@ def main() -> None:
     enhancement = []
     examples = []
     log_api = []
+    oss_server = []
     mcap = []
     misc = []
     performance = []
@@ -304,6 +305,8 @@ def main() -> None:
                     web.append(summary)
                 elif "🧢 MCAP" in labels:
                     mcap.append(summary)
+                elif "OSS-server" in labels:
+                    oss_server.append(summary)
                 elif "enhancement" in labels:
                     enhancement.append(summary)
                 elif "🚜 refactor" in labels:
@@ -343,6 +346,7 @@ def main() -> None:
     print_section("🦀 Rust API", rust)
     print_section("🪳 Bug fixes", bugs)
     print_section("🌁 Viewer improvements", viewer)
+    print_section("🗄️ OSS server", oss_server)
     print_section("🚀 Performance improvements", performance)
     print_section("🧑‍🏫 Examples", examples)
     print_section("📚 Docs", docs)


### PR DESCRIPTION
Add a section for OSS server in the changelog, based on the existing `OSS-server` issue label.