### PR TITLE
Fix race condition for ui adjustments while loading recordings from redap client

### DIFF
--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -1,4 +1,4 @@
-use re_log_types::{LogMsg, RecordingId};
+use re_log_types::{DataSourceMessage, RecordingId};
 use re_redap_client::ConnectionRegistryHandle;
 use re_smart_channel::{Receiver, SmartChannelSource, SmartMessageSource};
 
@@ -146,9 +146,8 @@ impl LogDataSource {
     pub fn stream(
         self,
         connection_registry: &ConnectionRegistryHandle,
-        on_ui_cmd: Option<Box<dyn Fn(re_redap_client::UiCommand) + Send + Sync>>,
         on_msg: Option<Box<dyn Fn() + Send + Sync>>,
-    ) -> anyhow::Result<Receiver<LogMsg>> {
+    ) -> anyhow::Result<Receiver<DataSourceMessage>> {
         re_tracing::profile_function!();
 
         match self {
@@ -254,7 +253,7 @@ impl LogDataSource {
                 let stream_partition = async move {
                     let client = connection_registry.client(uri_clone.origin.clone()).await?;
                     re_redap_client::stream_blueprint_and_partition_from_server(
-                        client, tx, uri_clone, on_ui_cmd, on_msg,
+                        client, tx, uri_clone, on_msg,
                     )
                     .await
                 };

--- a/crates/store/re_data_source/src/load_stdin.rs
+++ b/crates/store/re_data_source/src/load_stdin.rs
@@ -1,11 +1,11 @@
-use re_log_types::LogMsg;
+use re_log_types::DataSourceMessage;
 use re_smart_channel::Sender;
 
 /// Asynchronously loads RRD data streaming in from standard input.
 ///
 /// This fails synchronously iff the standard input stream could not be opened, otherwise errors
 /// are handled asynchronously (as in: they're logged).
-pub fn load_stdin(tx: Sender<LogMsg>) -> anyhow::Result<()> {
+pub fn load_stdin(tx: Sender<DataSourceMessage>) -> anyhow::Result<()> {
     let stdin = std::io::BufReader::new(std::io::stdin());
     let decoder = re_log_encoding::decoder::Decoder::new_concatenated(stdin)?;
 
@@ -20,7 +20,7 @@ pub fn load_stdin(tx: Sender<LogMsg>) -> anyhow::Result<()> {
                     continue;
                 }
             };
-            if tx.send(msg).is_err() {
+            if tx.send(msg.into()).is_err() {
                 break; // The other end has decided to hang up, not our problem.
             }
         }

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -14,7 +14,7 @@ use tower_http::cors::CorsLayer;
 
 use re_byte_size::SizeBytes;
 use re_log_encoding::codec::wire::decoder::Decode as _;
-use re_log_types::TableMsg;
+use re_log_types::{DataSourceMessage, TableMsg};
 use re_protos::sdk_comms::v1alpha1::{
     ReadTablesRequest, ReadTablesResponse, WriteMessagesRequest, WriteTableRequest,
     WriteTableResponse,
@@ -274,7 +274,7 @@ pub fn spawn_from_rx_set(
     addr: SocketAddr,
     options: ServerOptions,
     shutdown: shutdown::Shutdown,
-    rxs: re_smart_channel::ReceiveSet<re_log_types::LogMsg>,
+    rxs: re_smart_channel::ReceiveSet<re_log_types::DataSourceMessage>,
 ) {
     let message_proxy = MessageProxy::new(options);
     let event_tx = message_proxy.event_tx.clone();
@@ -317,6 +317,16 @@ pub fn spawn_from_rx_set(
                 continue;
             };
 
+            let msg = match msg {
+                DataSourceMessage::LogMsg(log_msg) => log_msg,
+                DataSourceMessage::UiCommand(ui_command) => {
+                    re_log::warn!(
+                        "Received a UI command, grpc server can't forward these yet: {ui_command:?}"
+                    );
+                    continue;
+                }
+            };
+
             let msg = match re_log_encoding::protobuf_conversions::log_msg_to_proto(
                 msg,
                 re_log_encoding::Compression::LZ4,
@@ -352,7 +362,7 @@ pub fn spawn_with_recv(
     options: ServerOptions,
     shutdown: shutdown::Shutdown,
 ) -> (
-    re_smart_channel::Receiver<re_log_types::LogMsg>,
+    re_smart_channel::Receiver<re_log_types::DataSourceMessage>,
     crossbeam::channel::Receiver<re_log_types::TableMsg>,
 ) {
     let uri = re_uri::ProxyUri::new(re_uri::Origin::from_scheme_and_socket_addr(
@@ -402,7 +412,7 @@ pub fn spawn_with_recv(
                         re_sorbet::timestamp_metadata::now_timestamp(),
                     );
 
-                    if channel_log_tx.send(log_msg).is_err() {
+                    if channel_log_tx.send(log_msg.into()).is_err() {
                         re_log::debug!(
                             "message proxy smart channel receiver closed, closing sender"
                         );

--- a/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
+++ b/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
@@ -3,7 +3,7 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use re_log::ResultExt as _;
-use re_log_types::LogMsg;
+use re_log_types::{DataSourceMessage, LogMsg};
 
 /// Stream an rrd file from a HTTP server.
 ///
@@ -15,7 +15,7 @@ pub fn stream_rrd_from_http_to_channel(
     url: String,
     follow: bool,
     on_msg: Option<Box<dyn Fn() + Send + Sync>>,
-) -> re_smart_channel::Receiver<LogMsg> {
+) -> re_smart_channel::Receiver<DataSourceMessage> {
     let (tx, rx) = re_smart_channel::smart_channel(
         re_smart_channel::SmartMessageSource::RrdHttpStream { url: url.clone() },
         re_smart_channel::SmartChannelSource::RrdHttpStream {
@@ -31,7 +31,7 @@ pub fn stream_rrd_from_http_to_channel(
             }
             match msg {
                 HttpMessage::LogMsg(msg) => {
-                    if tx.send(msg).is_ok() {
+                    if tx.send(msg.into()).is_ok() {
                         ControlFlow::Continue(())
                     } else {
                         re_log::info_once!("Closing connection to {url}");

--- a/crates/store/re_log_types/src/data_source_message.rs
+++ b/crates/store/re_log_types/src/data_source_message.rs
@@ -39,11 +39,11 @@ pub enum DataSourceUiCommand {
         time_range: AbsoluteTimeRange,
     },
 
-    /// Navigate to time/entities/anchors/etc. that are set in a [`re_uri::Fragment`].
+    /// Navigate to time/entities/anchors/etc. that are set in a `re_uri::Fragment`.
     SetUrlFragment {
         store_id: StoreId,
 
-        /// Uri fragment, see [`re_uri::Fragment`] on how to parse it.
+        /// Uri fragment, see `re_uri::Fragment` on how to parse it.
         // Not using `re_uri::Fragment` to avoid further dependency entanglement.
         fragment: String, //re_uri::Fragment,
     },

--- a/crates/store/re_log_types/src/data_source_message.rs
+++ b/crates/store/re_log_types/src/data_source_message.rs
@@ -1,0 +1,54 @@
+// TODO(andreas): Conceptually these should go to `re_data_source`.
+// However, `re_data_source` depends on everything that _implements_ a datasource, therefore we would get a circular dependency!
+
+use crate::{AbsoluteTimeRange, LogMsg, StoreId, TimelineName};
+
+/// Message from a data source.
+///
+/// May contain limited UI commands for instrumenting the state of the receiving end.
+#[derive(Clone, Debug)]
+pub enum DataSourceMessage {
+    /// See [`LogMsg`].
+    LogMsg(LogMsg),
+
+    /// A UI command that has to be sorted relative to `LogMsg`s.
+    ///
+    /// Non-ui receivers can safely ignore these.
+    UiCommand(DataSourceUiCommand),
+}
+
+impl From<LogMsg> for DataSourceMessage {
+    #[inline]
+    fn from(msg: LogMsg) -> Self {
+        Self::LogMsg(msg)
+    }
+}
+
+impl From<DataSourceUiCommand> for DataSourceMessage {
+    #[inline]
+    fn from(cmd: DataSourceUiCommand) -> Self {
+        Self::UiCommand(cmd)
+    }
+}
+
+/// UI commands issued when streaming in datasets.
+///
+/// If you're not in a ui context you can safely ignore these.
+#[derive(Clone, Debug)]
+pub enum DataSourceUiCommand {
+    AddValidTimeRange {
+        store_id: StoreId,
+
+        /// If `None`, signals that all timelines are entirely valid.
+        timeline: Option<TimelineName>,
+        time_range: AbsoluteTimeRange,
+    },
+
+    SetUrlFragment {
+        store_id: StoreId,
+
+        /// Uri fragment, see [`re_uri::Fragment`] on how to parse it.
+        // Not using `re_uri::Fragment` to avoid further dependency entanglement.
+        fragment: String, //re_uri::Fragment,
+    },
+}

--- a/crates/store/re_log_types/src/data_source_message.rs
+++ b/crates/store/re_log_types/src/data_source_message.rs
@@ -1,7 +1,7 @@
 // TODO(andreas): Conceptually these should go to `re_data_source`.
 // However, `re_data_source` depends on everything that _implements_ a datasource, therefore we would get a circular dependency!
 
-use crate::{AbsoluteTimeRange, LogMsg, StoreId, TimelineName};
+use crate::{AbsoluteTimeRange, LogMsg, StoreId, TimelineName, impl_into_enum};
 
 /// Message from a data source.
 ///
@@ -11,31 +11,26 @@ pub enum DataSourceMessage {
     /// See [`LogMsg`].
     LogMsg(LogMsg),
 
-    /// A UI command that has to be sorted relative to `LogMsg`s.
+    /// A UI command that has to be ordered relative to [`LogMsg`]s.
     ///
     /// Non-ui receivers can safely ignore these.
     UiCommand(DataSourceUiCommand),
 }
 
-impl From<LogMsg> for DataSourceMessage {
-    #[inline]
-    fn from(msg: LogMsg) -> Self {
-        Self::LogMsg(msg)
-    }
-}
-
-impl From<DataSourceUiCommand> for DataSourceMessage {
-    #[inline]
-    fn from(cmd: DataSourceUiCommand) -> Self {
-        Self::UiCommand(cmd)
-    }
-}
+impl_into_enum!(LogMsg, DataSourceMessage, LogMsg);
+impl_into_enum!(DataSourceUiCommand, DataSourceMessage, UiCommand);
 
 /// UI commands issued when streaming in datasets.
 ///
 /// If you're not in a ui context you can safely ignore these.
 #[derive(Clone, Debug)]
 pub enum DataSourceUiCommand {
+    /// Mark a time range as valid.
+    ///
+    /// Everything outside can still be navigated to, but will be considered potentially lacking some data and therefore "invalid".
+    /// Visually, it is outside of the normal time range and shown greyed out.
+    ///
+    /// If timeline is `None`, this signals that all timelines are considered to be valid entirely.
     AddValidTimeRange {
         store_id: StoreId,
 
@@ -44,6 +39,7 @@ pub enum DataSourceUiCommand {
         time_range: AbsoluteTimeRange,
     },
 
+    /// Navigate to time/entities/anchors/etc. that are set in a [`re_uri::Fragment`].
     SetUrlFragment {
         store_id: StoreId,
 

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -18,6 +18,7 @@
 //! `foo.transform * foo/bar.transform * foo/bar/baz.transform`.
 
 pub mod arrow_msg;
+mod data_source_message;
 mod entry_id;
 pub mod example_components;
 pub mod hash;
@@ -39,6 +40,7 @@ use re_byte_size::SizeBytes;
 
 pub use self::{
     arrow_msg::{ArrowMsg, ArrowRecordBatchReleaseCallback},
+    data_source_message::{DataSourceMessage, DataSourceUiCommand},
     entry_id::{EntryId, EntryIdOrName},
     index::{
         AbsoluteTimeRange, AbsoluteTimeRangeF, Duration, NonMinI64, TimeCell, TimeInt, TimePoint,

--- a/crates/store/re_redap_client/Cargo.toml
+++ b/crates/store/re_redap_client/Cargo.toml
@@ -34,9 +34,9 @@ all-features = true
 re_arrow_util.workspace = true
 re_auth.workspace = true
 re_chunk.workspace = true
-re_log.workspace = true
 re_log_encoding = { workspace = true, features = ["encoder", "decoder"] }
 re_log_types.workspace = true
+re_log.workspace = true
 re_protos.workspace = true
 re_smart_channel.workspace = true
 re_uri.workspace = true

--- a/crates/store/re_redap_client/src/lib.rs
+++ b/crates/store/re_redap_client/src/lib.rs
@@ -10,8 +10,7 @@ pub use self::{
         ClientConnectionError, ConnectionClient, ConnectionRegistry, ConnectionRegistryHandle,
     },
     grpc::{
-        ConnectionError, RedapClient, UiCommand, channel,
-        fetch_chunks_response_to_chunk_and_partition_id,
+        ConnectionError, RedapClient, channel, fetch_chunks_response_to_chunk_and_partition_id,
         get_chunks_response_to_chunk_and_partition_id, stream_blueprint_and_partition_from_server,
     },
 };

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -1490,7 +1490,7 @@ impl RecordingStream {
                     while let Some(msg) = rx.recv().ok().and_then(|msg| msg.into_data()) {
                         match msg {
                             re_log_types::DataSourceMessage::LogMsg(log_msg) => {
-                                this.record_msg(log_msg)
+                                this.record_msg(log_msg);
                             }
                             re_log_types::DataSourceMessage::UiCommand(ui_cmd) => {
                                 re_log::debug!(

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -15,9 +15,9 @@ use re_chunk::{
     ChunkComponents, ChunkError, ChunkId, PendingRow, RowId, TimeColumn,
 };
 use re_log_types::{
-    ApplicationId, ArrowRecordBatchReleaseCallback, BlueprintActivationCommand, DataSourceMessage,
-    EntityPath, LogMsg, RecordingId, StoreId, StoreInfo, StoreKind, StoreSource, TimeCell, TimeInt,
-    TimePoint, Timeline, TimelineName,
+    ApplicationId, ArrowRecordBatchReleaseCallback, BlueprintActivationCommand, EntityPath, LogMsg,
+    RecordingId, StoreId, StoreInfo, StoreKind, StoreSource, TimeCell, TimeInt, TimePoint,
+    Timeline, TimelineName,
 };
 use re_types::archetypes::RecordingInfo;
 use re_types::components::Timestamp;
@@ -1489,8 +1489,10 @@ impl RecordingStream {
                 move || {
                     while let Some(msg) = rx.recv().ok().and_then(|msg| msg.into_data()) {
                         match msg {
-                            DataSourceMessage::LogMsg(log_msg) => this.record_msg(log_msg),
-                            DataSourceMessage::UiCommand(ui_cmd) => {
+                            re_log_types::DataSourceMessage::LogMsg(log_msg) => {
+                                this.record_msg(log_msg)
+                            }
+                            re_log_types::DataSourceMessage::UiCommand(ui_cmd) => {
                                 re_log::debug!(
                                     "Ignoring unexpected ui command from file {:?}",
                                     ui_cmd

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -1243,7 +1243,7 @@ fn assert_receive_into_entity_db(
                             }
 
                             DataSourceMessage::UiCommand(ui_command) => {
-                                re_log::error!(
+                                anyhow::bail!(
                                     "Received a UI command which can't be stored in a entity_db: {ui_command:?}"
                                 );
                             }

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -5,7 +5,7 @@ use itertools::Itertools as _;
 use tokio::runtime::Runtime;
 
 use re_data_source::LogDataSource;
-use re_log_types::LogMsg;
+use re_log_types::DataSourceMessage;
 use re_smart_channel::{ReceiveSet, Receiver, SmartMessagePayload};
 
 use crate::{CallSource, commands::RrdCommands};
@@ -890,7 +890,7 @@ fn start_native_viewer(
     #[cfg(feature = "server")]
     if !connect {
         let (log_server, table_server): (
-            Receiver<LogMsg>,
+            Receiver<DataSourceMessage>,
             crossbeam::channel::Receiver<re_log_types::TableMsg>,
         ) = re_grpc_server::spawn_with_recv(
             server_addr,
@@ -1015,7 +1015,16 @@ fn connect_to_existing_server(
         while rx.is_connected() {
             while let Ok(msg) = rx.recv() {
                 if let Some(log_msg) = msg.into_data() {
-                    sink.send(log_msg);
+                    match log_msg {
+                        DataSourceMessage::LogMsg(log_msg) => {
+                            sink.send(log_msg);
+                        }
+                        DataSourceMessage::UiCommand(ui_command) => {
+                            re_log::warn!(
+                                "Received a UI command, can't pass this on to the server: {ui_command:?}"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -1156,7 +1165,7 @@ fn save_or_test_receive(
     #[cfg(feature = "server")]
     {
         let (log_server, table_server): (
-            Receiver<LogMsg>,
+            Receiver<DataSourceMessage>,
             crossbeam::channel::Receiver<re_log_types::TableMsg>,
         ) = re_grpc_server::spawn_with_recv(
             server_addr,
@@ -1194,7 +1203,7 @@ fn is_another_server_already_running(server_addr: std::net::SocketAddr) -> bool 
 
 // NOTE: This is only used as part of end-to-end tests.
 fn assert_receive_into_entity_db(
-    rx: &ReceiveSet<LogMsg>,
+    rx: &ReceiveSet<DataSourceMessage>,
 ) -> anyhow::Result<re_entity_db::EntityDb> {
     re_log::info!("Receiving messages into a EntityDb…");
 
@@ -1216,16 +1225,20 @@ fn assert_receive_into_entity_db(
 
                 match msg.payload {
                     SmartMessagePayload::Msg(msg) => {
-                        let mut_db = match msg.store_id().kind() {
-                            re_log_types::StoreKind::Recording => rec.get_or_insert_with(|| {
-                                re_entity_db::EntityDb::new(msg.store_id().clone())
-                            }),
-                            re_log_types::StoreKind::Blueprint => bp.get_or_insert_with(|| {
-                                re_entity_db::EntityDb::new(msg.store_id().clone())
-                            }),
-                        };
+                        if let DataSourceMessage::LogMsg(msg) = msg {
+                            let mut_db = match msg.store_id().kind() {
+                                re_log_types::StoreKind::Recording => {
+                                    rec.get_or_insert_with(|| {
+                                        re_entity_db::EntityDb::new(msg.store_id().clone())
+                                    })
+                                }
+                                re_log_types::StoreKind::Blueprint => bp.get_or_insert_with(|| {
+                                    re_entity_db::EntityDb::new(msg.store_id().clone())
+                                }),
+                            };
 
-                        mut_db.add(&msg)?;
+                            mut_db.add(&msg)?;
+                        }
                         num_messages += 1;
                     }
 
@@ -1313,7 +1326,7 @@ fn parse_size(size: &str) -> anyhow::Result<[f32; 2]> {
 // TODO(cmc): dedicated module for io utils, especially stdio streaming in and out.
 
 fn stream_to_rrd_on_disk(
-    rx: &re_smart_channel::ReceiveSet<LogMsg>,
+    rx: &re_smart_channel::ReceiveSet<DataSourceMessage>,
     path: &std::path::PathBuf,
 ) -> Result<(), re_log_encoding::FileSinkError> {
     use re_log_encoding::FileSinkError;
@@ -1336,7 +1349,16 @@ fn stream_to_rrd_on_disk(
     loop {
         if let Ok(msg) = rx.recv() {
             if let Some(payload) = msg.into_data() {
-                encoder.append(&payload)?;
+                match payload {
+                    DataSourceMessage::LogMsg(log_msg) => {
+                        encoder.append(&log_msg)?;
+                    }
+                    DataSourceMessage::UiCommand(ui_command) => {
+                        re_log::warn!(
+                            "Received a UI command which can't be stored in a file: {ui_command:?}"
+                        );
+                    }
+                }
             }
         } else {
             re_log::info!("Log stream disconnected, stopping.");
@@ -1393,7 +1415,7 @@ impl UrlParamProcessingConfig {
 /// Log receivers created from URLs or path parameters that were passed in on the CLI.
 struct ReceiversFromUrlParams {
     /// Log receivers that we want to hook up to a connection or viewer.
-    log_receivers: Vec<Receiver<LogMsg>>,
+    log_receivers: Vec<Receiver<DataSourceMessage>>,
 
     /// URLs that should be passed on to the viewer if possible.
     ///
@@ -1452,11 +1474,8 @@ impl ReceiversFromUrlParams {
         let log_receivers = data_sources
             .into_iter()
             .map(|data_source| {
-                // No need to handle redap UI commands since if there's a viewer, we always
-                // pass on the URL to the viewer directly anyways.
                 let on_msg = None;
-                let on_ui_cmd = None;
-                data_source.stream(connection_registry, on_ui_cmd, on_msg)
+                data_source.stream(connection_registry, on_msg)
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 

--- a/crates/viewer/re_global_context/src/command_sender.rs
+++ b/crates/viewer/re_global_context/src/command_sender.rs
@@ -24,7 +24,7 @@ pub enum SystemCommand {
     LoadDataSource(LogDataSource),
 
     /// Add a new receiver for log messages.
-    AddReceiver(re_smart_channel::Receiver<re_log_types::LogMsg>),
+    AddReceiver(re_smart_channel::Receiver<re_log_types::DataSourceMessage>),
 
     /// Add a new server to the redap browser.
     AddRedapServer(re_uri::Origin),

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1915,7 +1915,7 @@ impl App {
         }
     }
 
-    fn receive_messages(&self, store_hub: &mut StoreHub, egui_ctx: &egui::Context) {
+    fn receive_messages(&mut self, store_hub: &mut StoreHub, egui_ctx: &egui::Context) {
         re_tracing::profile_function!();
 
         // TODO(grtlr): Should we bring back analytics for this too?
@@ -1990,6 +1990,10 @@ impl App {
                 break; // don't block the main thread for too long
             }
         }
+
+        // Run pending system commands in case any of the messages resulted in additional commands.
+        // This avoid further frame delays on these commands.
+        self.run_pending_system_commands(store_hub, egui_ctx);
     }
 
     fn receive_log_msg(

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -7,7 +7,9 @@ use re_capabilities::MainThreadToken;
 use re_chunk::TimelineName;
 use re_data_source::{FileContents, LogDataSource};
 use re_entity_db::{InstancePath, entity_db::EntityDb};
-use re_log_types::{ApplicationId, FileSource, LogMsg, RecordingId, StoreId, StoreKind, TableMsg};
+use re_log_types::{
+    ApplicationId, DataSourceMessage, FileSource, LogMsg, RecordingId, StoreId, StoreKind, TableMsg,
+};
 use re_redap_client::ConnectionRegistryHandle;
 use re_renderer::WgpuResourcePoolStatistics;
 use re_smart_channel::{ReceiveSet, SmartChannelSource};
@@ -91,7 +93,7 @@ pub struct App {
 
     component_ui_registry: ComponentUiRegistry,
 
-    rx_log: ReceiveSet<LogMsg>,
+    rx_log: ReceiveSet<DataSourceMessage>,
     rx_table: ReceiveSetTable,
 
     #[cfg(target_arch = "wasm32")]
@@ -451,7 +453,7 @@ impl App {
     }
 
     #[allow(clippy::needless_pass_by_ref_mut)]
-    pub fn add_log_receiver(&mut self, rx: re_smart_channel::Receiver<LogMsg>) {
+    pub fn add_log_receiver(&mut self, rx: re_smart_channel::Receiver<DataSourceMessage>) {
         re_log::debug!("Adding new log receiver: {:?}", rx.source());
 
         // Make sure we wake up when a message is sent.
@@ -479,7 +481,7 @@ impl App {
         self.rx_table.lock().push(rx);
     }
 
-    pub fn msg_receive_set(&self) -> &ReceiveSet<LogMsg> {
+    pub fn msg_receive_set(&self) -> &ReceiveSet<DataSourceMessage> {
         &self.rx_log
     }
 
@@ -1106,31 +1108,10 @@ impl App {
                 egui_ctx.request_repaint_after(std::time::Duration::from_millis(10));
             })
         };
-        let on_ui_cmd = {
-            let command_sender = self.command_sender.clone();
-            Box::new(move |cmd| match cmd {
-                re_redap_client::UiCommand::AddValidTimeRange {
-                    store_id,
-                    timeline,
-                    time_range,
-                } => {
-                    command_sender.send_system(SystemCommand::AddValidTimeRange {
-                        store_id,
-                        timeline,
-                        time_range,
-                    });
-                }
-
-                re_redap_client::UiCommand::SetUrlFragment { store_id, fragment } => {
-                    command_sender
-                        .send_system(SystemCommand::SetUrlFragment { store_id, fragment });
-                }
-            })
-        };
 
         match data_source
             .clone()
-            .stream(&self.connection_registry, Some(on_ui_cmd), Some(waker))
+            .stream(&self.connection_registry, Some(waker))
         {
             Ok(rx) => self.add_log_receiver(rx),
             Err(err) => {
@@ -1994,168 +1975,222 @@ impl App {
                 }
             };
 
-            let store_id = msg.store_id();
-
-            if store_hub.is_active_blueprint(store_id) {
-                // TODO(#5514): handle loading of active blueprints.
-                re_log::warn_once!(
-                    "Loading a blueprint {store_id:?} that is active. See https://github.com/rerun-io/rerun/issues/5514 for details."
-                );
-            }
-
-            // TODO(cmc): we have to keep grabbing and releasing entity_db because everything references
-            // everything and some of it is mutable and some not… it's really not pretty, but it
-            // does the job for now.
-
-            let msg_will_add_new_store = matches!(&msg, LogMsg::SetStoreInfo(..))
-                && !store_hub.store_bundle().contains(store_id);
-
-            let was_empty = {
-                let entity_db = store_hub.entity_db_mut(store_id);
-                if entity_db.data_source.is_none() {
-                    entity_db.data_source = Some((*channel_source).clone());
-                }
-                entity_db.is_empty()
-            };
-
-            match store_hub.entity_db_mut(store_id).add(&msg) {
-                Ok(store_events) => {
-                    if let Some(caches) = store_hub.active_caches() {
-                        caches.on_store_events(&store_events);
-                    }
-
-                    self.validate_loaded_events(&store_events);
+            match msg {
+                DataSourceMessage::LogMsg(msg) => {
+                    self.receive_log_msg(&msg, store_hub, egui_ctx, &channel_source);
                 }
 
-                Err(err) => {
-                    re_log::error_once!("Failed to add incoming msg: {err}");
-                }
-            }
-
-            let entity_db = store_hub.entity_db_mut(store_id);
-
-            if was_empty && !entity_db.is_empty() {
-                // Hack: we cannot go to a specific timeline or entity until we know about it.
-                // Now we _hopefully_ do.
-                if let SmartChannelSource::RedapGrpcStream { uri, .. } = channel_source.as_ref() {
-                    self.go_to_dataset_data(uri.store_id(), uri.fragment.clone());
-                }
-            }
-
-            let is_example = entity_db.store_class().is_example();
-
-            match &msg {
-                LogMsg::SetStoreInfo(_) => {
-                    if channel_source.select_when_loaded() {
-                        // Set the recording-id after potentially creating the store in the hub.
-                        // This ordering is important because the `StoreHub` internally
-                        // updates the app-id when changing the recording.
-                        match store_id.kind() {
-                            StoreKind::Recording => {
-                                re_log::trace!("Opening a new recording: '{store_id:?}'");
-                                self.make_store_active_and_highlight(store_hub, egui_ctx, store_id);
-                            }
-                            StoreKind::Blueprint => {
-                                // We wait with activating blueprints until they are fully loaded,
-                                // so that we don't run heuristics on half-loaded blueprints.
-                                // Otherwise on a mixed connection (SDK sending both blueprint and recording)
-                                // the blueprint won't be activated until the whole _recording_ has finished loading.
-                            }
-                        }
-                    }
-
-                    if cfg!(target_arch = "wasm32")
-                        && !self.startup_options.is_in_notebook
-                        && !is_example
-                    {
-                        use std::sync::Once;
-                        static ONCE: Once = Once::new();
-                        ONCE.call_once(|| {
-                            // Tell the user there is a faster native viewer they can use instead of the web viewer:
-                            let notification = re_ui::notifications::Notification::new(
-                                    re_ui::notifications::NotificationLevel::Tip, "For better performance, try the native Rerun Viewer!").with_link(
-                                    re_ui::Link {
-                                        text: "Install…".into(),
-                                        url: "https://rerun.io/docs/getting-started/installing-viewer#installing-the-viewer".into(),
-                                    }
-                                )
-                                .no_toast()
-                                .permanent_dismiss_id(egui::Id::new("install_native_viewer_prompt"));
-                            self.command_sender
-                                .send_system(SystemCommand::ShowNotification(notification));
-                        });
-                    }
-                }
-
-                LogMsg::ArrowMsg(_, _) => {
-                    // Handled by `EntityDb::add`
-                }
-
-                LogMsg::BlueprintActivationCommand(cmd) => match store_id.kind() {
-                    StoreKind::Recording => {
-                        re_log::debug!(
-                            "Unexpected `BlueprintActivationCommand` message for {store_id:?}"
-                        );
-                    }
-                    StoreKind::Blueprint => {
-                        if let Some(info) = entity_db.store_info() {
-                            re_log::trace!(
-                                "Activating blueprint that was loaded from {channel_source}"
-                            );
-                            let app_id = info.application_id().clone();
-                            if cmd.make_default {
-                                store_hub
-                                    .set_default_blueprint_for_app(store_id)
-                                    .unwrap_or_else(|err| {
-                                        re_log::warn!("Failed to make blueprint default: {err}");
-                                    });
-                            }
-                            if cmd.make_active {
-                                store_hub
-                                    .set_cloned_blueprint_active_for_app(store_id)
-                                    .unwrap_or_else(|err| {
-                                        re_log::warn!("Failed to make blueprint active: {err}");
-                                    });
-
-                                // Switch to this app, e.g. on drag-and-drop of a blueprint file
-                                store_hub.set_active_app(app_id);
-
-                                // If the viewer is in the background, tell the user that it has received something new.
-                                egui_ctx.send_viewport_cmd(
-                                    egui::ViewportCommand::RequestUserAttention(
-                                        egui::UserAttentionType::Informational,
-                                    ),
-                                );
-                            }
-                        } else {
-                            re_log::warn!(
-                                "Got ActivateStore message without first receiving a SetStoreInfo"
-                            );
-                        }
-                    }
-                },
-            }
-
-            // Do analytics/events after ingesting the new message,
-            // because `entity_db.store_info` needs to be set.
-            let entity_db = store_hub.entity_db_mut(store_id);
-            if msg_will_add_new_store && entity_db.store_kind() == StoreKind::Recording {
-                #[cfg(feature = "analytics")]
-                if let Some(analytics) = re_analytics::Analytics::global_or_init()
-                    && let Some(event) =
-                        crate::viewer_analytics::event::open_recording(&self.app_env, entity_db)
-                {
-                    analytics.record(event);
-                }
-
-                if let Some(event_dispatcher) = self.event_dispatcher.as_ref() {
-                    event_dispatcher.on_recording_open(entity_db);
+                DataSourceMessage::UiCommand(ui_command) => {
+                    self.receive_data_sourceui_command(ui_command, &channel_source);
                 }
             }
 
             if start.elapsed() > web_time::Duration::from_millis(10) {
                 egui_ctx.request_repaint(); // make sure we keep receiving messages asap
                 break; // don't block the main thread for too long
+            }
+        }
+    }
+
+    fn receive_log_msg(
+        &self,
+        msg: &LogMsg,
+        store_hub: &mut StoreHub,
+        egui_ctx: &egui::Context,
+        channel_source: &SmartChannelSource,
+    ) {
+        let store_id = msg.store_id();
+
+        if store_hub.is_active_blueprint(store_id) {
+            // TODO(#5514): handle loading of active blueprints.
+            re_log::warn_once!(
+                "Loading a blueprint {store_id:?} that is active. See https://github.com/rerun-io/rerun/issues/5514 for details."
+            );
+        }
+
+        // TODO(cmc): we have to keep grabbing and releasing entity_db because everything references
+        // everything and some of it is mutable and some not… it's really not pretty, but it
+        // does the job for now.
+
+        let msg_will_add_new_store = matches!(&msg, LogMsg::SetStoreInfo(..))
+            && !store_hub.store_bundle().contains(store_id);
+
+        let was_empty = {
+            let entity_db = store_hub.entity_db_mut(store_id);
+            if entity_db.data_source.is_none() {
+                entity_db.data_source = Some((*channel_source).clone());
+            }
+            entity_db.is_empty()
+        };
+
+        match store_hub.entity_db_mut(store_id).add(msg) {
+            Ok(store_events) => {
+                if let Some(caches) = store_hub.active_caches() {
+                    caches.on_store_events(&store_events);
+                }
+
+                self.validate_loaded_events(&store_events);
+            }
+
+            Err(err) => {
+                re_log::error_once!("Failed to add incoming msg: {err}");
+            }
+        }
+
+        let entity_db = store_hub.entity_db_mut(store_id);
+
+        if was_empty && !entity_db.is_empty() {
+            // Hack: we cannot go to a specific timeline or entity until we know about it.
+            // Now we _hopefully_ do.
+            if let SmartChannelSource::RedapGrpcStream { uri, .. } = channel_source {
+                self.go_to_dataset_data(uri.store_id(), uri.fragment.clone());
+            }
+        }
+
+        let is_example = entity_db.store_class().is_example();
+
+        match &msg {
+            LogMsg::SetStoreInfo(_) => {
+                if channel_source.select_when_loaded() {
+                    // Set the recording-id after potentially creating the store in the hub.
+                    // This ordering is important because the `StoreHub` internally
+                    // updates the app-id when changing the recording.
+                    match store_id.kind() {
+                        StoreKind::Recording => {
+                            re_log::trace!("Opening a new recording: '{store_id:?}'");
+                            self.make_store_active_and_highlight(store_hub, egui_ctx, store_id);
+                        }
+                        StoreKind::Blueprint => {
+                            // We wait with activating blueprints until they are fully loaded,
+                            // so that we don't run heuristics on half-loaded blueprints.
+                            // Otherwise on a mixed connection (SDK sending both blueprint and recording)
+                            // the blueprint won't be activated until the whole _recording_ has finished loading.
+                        }
+                    }
+                }
+
+                if cfg!(target_arch = "wasm32")
+                    && !self.startup_options.is_in_notebook
+                    && !is_example
+                {
+                    use std::sync::Once;
+                    static ONCE: Once = Once::new();
+                    ONCE.call_once(|| {
+                        // Tell the user there is a faster native viewer they can use instead of the web viewer:
+                        let notification = re_ui::notifications::Notification::new(
+                                re_ui::notifications::NotificationLevel::Tip, "For better performance, try the native Rerun Viewer!").with_link(
+                                re_ui::Link {
+                                    text: "Install…".into(),
+                                    url: "https://rerun.io/docs/getting-started/installing-viewer#installing-the-viewer".into(),
+                                }
+                            )
+                            .no_toast()
+                            .permanent_dismiss_id(egui::Id::new("install_native_viewer_prompt"));
+                        self.command_sender
+                            .send_system(SystemCommand::ShowNotification(notification));
+                    });
+                }
+            }
+
+            LogMsg::ArrowMsg(_, _) => {
+                // Handled by `EntityDb::add`
+            }
+
+            LogMsg::BlueprintActivationCommand(cmd) => match store_id.kind() {
+                StoreKind::Recording => {
+                    re_log::debug!(
+                        "Unexpected `BlueprintActivationCommand` message for {store_id:?}"
+                    );
+                }
+                StoreKind::Blueprint => {
+                    if let Some(info) = entity_db.store_info() {
+                        re_log::trace!(
+                            "Activating blueprint that was loaded from {channel_source}"
+                        );
+                        let app_id = info.application_id().clone();
+                        if cmd.make_default {
+                            store_hub
+                                .set_default_blueprint_for_app(store_id)
+                                .unwrap_or_else(|err| {
+                                    re_log::warn!("Failed to make blueprint default: {err}");
+                                });
+                        }
+                        if cmd.make_active {
+                            store_hub
+                                .set_cloned_blueprint_active_for_app(store_id)
+                                .unwrap_or_else(|err| {
+                                    re_log::warn!("Failed to make blueprint active: {err}");
+                                });
+
+                            // Switch to this app, e.g. on drag-and-drop of a blueprint file
+                            store_hub.set_active_app(app_id);
+
+                            // If the viewer is in the background, tell the user that it has received something new.
+                            egui_ctx.send_viewport_cmd(
+                                egui::ViewportCommand::RequestUserAttention(
+                                    egui::UserAttentionType::Informational,
+                                ),
+                            );
+                        }
+                    } else {
+                        re_log::warn!(
+                            "Got ActivateStore message without first receiving a SetStoreInfo"
+                        );
+                    }
+                }
+            },
+        }
+
+        // Do analytics/events after ingesting the new message,
+        // because `entity_db.store_info` needs to be set.
+        let entity_db = store_hub.entity_db_mut(store_id);
+        if msg_will_add_new_store && entity_db.store_kind() == StoreKind::Recording {
+            #[cfg(feature = "analytics")]
+            if let Some(analytics) = re_analytics::Analytics::global_or_init()
+                && let Some(event) =
+                    crate::viewer_analytics::event::open_recording(&self.app_env, entity_db)
+            {
+                analytics.record(event);
+            }
+
+            if let Some(event_dispatcher) = self.event_dispatcher.as_ref() {
+                event_dispatcher.on_recording_open(entity_db);
+            }
+        }
+    }
+
+    fn receive_data_sourceui_command(
+        &self,
+        ui_command: re_log_types::DataSourceUiCommand,
+        channel_source: &SmartChannelSource,
+    ) {
+        match ui_command {
+            re_log_types::DataSourceUiCommand::AddValidTimeRange {
+                store_id,
+                timeline,
+                time_range,
+            } => {
+                self.command_sender
+                    .send_system(SystemCommand::AddValidTimeRange {
+                        store_id,
+                        timeline,
+                        time_range,
+                    });
+            }
+
+            re_log_types::DataSourceUiCommand::SetUrlFragment { store_id, fragment } => {
+                match re_uri::Fragment::from_str(&fragment) {
+                    Ok(fragment) => {
+                        self.command_sender
+                            .send_system(SystemCommand::SetUrlFragment { store_id, fragment });
+                    }
+
+                    Err(err) => {
+                        re_log::warn!(
+                            "Failed to parse fragment received from {channel_source:?}: {err}"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1981,7 +1981,7 @@ impl App {
                 }
 
                 DataSourceMessage::UiCommand(ui_command) => {
-                    self.receive_data_sourceui_command(ui_command, &channel_source);
+                    self.receive_data_source_ui_command(ui_command, &channel_source);
                 }
             }
 
@@ -2159,7 +2159,7 @@ impl App {
         }
     }
 
-    fn receive_data_sourceui_command(
+    fn receive_data_source_ui_command(
         &self,
         ui_command: re_log_types::DataSourceUiCommand,
         channel_source: &SmartChannelSource,

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -6,7 +6,7 @@ use egui::{Ui, text_edit::TextEditState, text_selection::LabelSelectionState};
 use re_chunk::TimelineName;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
-use re_log_types::{AbsoluteTimeRangeF, LogMsg, StoreId, TableId};
+use re_log_types::{AbsoluteTimeRangeF, DataSourceMessage, StoreId, TableId};
 use re_redap_browser::RedapServers;
 use re_redap_client::ConnectionRegistryHandle;
 use re_smart_channel::ReceiveSet;
@@ -168,7 +168,7 @@ impl AppState {
         reflection: &re_types_core::reflection::Reflection,
         component_ui_registry: &ComponentUiRegistry,
         view_class_registry: &ViewClassRegistry,
-        rx_log: &ReceiveSet<LogMsg>,
+        rx_log: &ReceiveSet<DataSourceMessage>,
         command_sender: &CommandSender,
         welcome_screen_state: &WelcomeScreenState,
         event_dispatcher: Option<&crate::event::ViewerEventDispatcher>,
@@ -775,7 +775,7 @@ fn table_ui(
 fn move_time(
     ctx: &ViewerContext<'_>,
     recording: &EntityDb,
-    rx: &ReceiveSet<LogMsg>,
+    rx: &ReceiveSet<DataSourceMessage>,
     events: Option<&ViewerEventDispatcher>,
 ) {
     let dt = ctx.egui_ctx().input(|i| i.stable_dt);

--- a/crates/viewer/re_viewer/src/native.rs
+++ b/crates/viewer/re_viewer/src/native.rs
@@ -103,7 +103,7 @@ pub fn run_native_viewer_with_messages(
         re_smart_channel::SmartChannelSource::Sdk,
     );
     for log_msg in log_messages {
-        tx.send(log_msg).ok();
+        tx.send(log_msg.into()).ok();
     }
 
     let force_wgpu_backend = startup_options.force_wgpu_backend.clone();

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -271,7 +271,7 @@ fn multi_pass_warning_dot_ui(ui: &mut egui::Ui) {
     );
 }
 
-fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>) {
+fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::DataSourceMessage>) {
     let sources = rx
         .sources()
         .into_iter()

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -24,7 +24,7 @@ static GLOBAL: AccountingAllocator<std::alloc::System> =
     AccountingAllocator::new(std::alloc::System);
 
 struct Channel {
-    log_tx: re_smart_channel::Sender<re_log_types::LogMsg>,
+    log_tx: re_smart_channel::Sender<re_log_types::DataSourceMessage>,
     table_tx: crossbeam::channel::Sender<re_log_types::TableMsg>,
 }
 
@@ -311,7 +311,7 @@ impl WebHandle {
                         use re_log_encoding::stream_rrd_from_http::HttpMessage;
                         match msg {
                             HttpMessage::LogMsg(msg) => {
-                                if tx.send(msg).is_ok() {
+                                if tx.send(msg.into()).is_ok() {
                                     ControlFlow::Continue(())
                                 } else {
                                     re_log::info_once!("Failed to dispatch log message to viewer.");

--- a/crates/viewer/re_viewer_context/src/open_url.rs
+++ b/crates/viewer/re_viewer_context/src/open_url.rs
@@ -692,7 +692,7 @@ fn handle_web_event_listener(egui_ctx: &egui::Context, command_sender: &CommandS
 
             match msg {
                 HttpMessage::LogMsg(msg) => {
-                    if tx.send(msg).is_ok() {
+                    if tx.send(msg.into()).is_ok() {
                         ControlFlow::Continue(())
                     } else {
                         re_log::info_once!(

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -68,7 +68,7 @@ pub struct ViewerContext<'a> {
     pub drag_and_drop_manager: &'a DragAndDropManager,
 
     /// Where we are getting our data from.
-    pub connected_receivers: &'a re_smart_channel::ReceiveSet<re_log_types::LogMsg>,
+    pub connected_receivers: &'a re_smart_channel::ReceiveSet<re_log_types::DataSourceMessage>,
 
     pub store_context: &'a StoreContext<'a>,
 }


### PR DESCRIPTION
### Related

* DNM: https://github.com/rerun-io/rerun/pull/11362
* Replaces previous attempt: https://github.com/rerun-io/rerun/pull/11352
* Fixes RR-2439


### What

Title is only for the changelog and the immediate outcome, but  the real change here is much wider:
Introduces a new `DataSourceMessage` that wraps `LogMsg` and the previously out-of-band sent `re_redap_client::UiCommand`. This allows data sources to send ui commands that have to be ordered relative to other data.

Refactor has been done in a minimal way so far, but I think we should as next step unify `TableMsg` into as well.