### PR TITLE
CI: run bash with '-euo pipefail'

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -44,14 +44,14 @@ runs:
       if: ${{ runner.os == 'macOS' }}
       run: |
         echo "$(brew --prefix llvm@18)/bin" >> $GITHUB_PATH
-      shell: bash
+      shell: bash -euo pipefail
 
     - name: Check clang version
       if: ${{ runner.os == 'macOS' }}
       run: |
         clang --version
         which clang
-      shell: bash
+      shell: bash -euo pipefail
 
     - name: Set up GCP credentials
       uses: google-github-actions/auth@v2
@@ -60,7 +60,7 @@ runs:
         service_account: ${{ inputs.service_account }}
 
     - name: Ensure correct version of Rust is installed
-      shell: bash
+      shell: bash -euo pipefail
       run: |
         # This is the only way to force rustup to install the version of Rust
         # and the components/targets specified in our `rust-toolchain` file.
@@ -69,12 +69,12 @@ runs:
 
     - name: Install additional targets
       if: ${{ inputs.targets != '' }}
-      shell: bash
+      shell: bash -euo pipefail
       run: rustup target add ${{ inputs.targets }}
 
     - name: Install additional toolchains
       if: ${{ inputs.toolchains }}
-      shell: bash
+      shell: bash -euo pipefail
       run: |
         for toolchain in ${{ inputs.toolchains }}; do
           rustup install $toolchain
@@ -89,7 +89,7 @@ runs:
         gcs_read_only: false
 
     - name: Verify sccache
-      shell: bash
+      shell: bash -euo pipefail
       run: |
         sccache --show-stats
 

--- a/.github/workflows/adhoc_wheels.yml
+++ b/.github/workflows/adhoc_wheels.yml
@@ -14,7 +14,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -7,7 +7,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/auto_docs.yml
+++ b/.github/workflows/auto_docs.yml
@@ -10,7 +10,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 # The lack of `concurrency` is intentional.
 # We want this job to run on every commit, even if multiple are merged in a row.

--- a/.github/workflows/auto_docs_check.yml
+++ b/.github/workflows/auto_docs_check.yml
@@ -16,7 +16,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}-auto-docs-check

--- a/.github/workflows/checkboxes.yml
+++ b/.github/workflows/checkboxes.yml
@@ -16,7 +16,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -36,7 +36,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"
@@ -70,7 +70,7 @@ jobs:
           environments: py-docs
 
       - name: Build via mkdocs
-        shell: bash
+        shell: bash -euo pipefail
         run: |
           pixi run -e py-docs mkdocs build --strict -f rerun_py/mkdocs.yml
 

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -30,7 +30,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/on_gh_release.yml
+++ b/.github/workflows/on_gh_release.yml
@@ -19,7 +19,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   # required for updating the release

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -12,7 +12,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -14,7 +14,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 jobs:
   # Get latest release version from crates.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
 
           echo "PR does not exist, creating…"
 
-          cat <<EOF > pr-body.txt
+          cat <<'EOF' > pr-body.txt
           ### Next steps
           - Test the release
           - For alpha releases:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,6 +402,7 @@ jobs:
           GitHub release draft: [$version](https://github.com/rerun-io/rerun/releases/tag/$version)
 
           Add a description, changelog, and a nice header video/picture, then click 'Publish release'.
+          EOF
 
           gh pr comment $pr_number --body-file comment-body.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,13 +181,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
         run: |
-          set +e
           pr=$(gh pr view --json headRefName 2>/dev/null || echo "{}")
           if echo "$pr" | jq '. | has("headRefName")' | grep -q 'true'; then
             echo "PR already exists"
             exit 0
           fi
-          set -e
 
           echo "PR does not exist, creating…"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 # wants to push commits and create a PR
 permissions: write-all

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -42,7 +42,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   # contents permission to update benchmark contents in gh-pages branch

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -62,7 +62,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -64,7 +64,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"
@@ -181,7 +181,7 @@ jobs:
       # Now that we already have a CLI binary, we can use it to check whether our man page is up to date.
       - name: Compare man page to CLI docs
         if: runner.os == 'Linux'
-        shell: bash
+        shell: bash -euo pipefail
         run: |
           pixi run ./scripts/ci/check_cli_docs.py --rerun-exe "./target_pixi/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.BIN_NAME }}"
 

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -81,7 +81,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -34,7 +34,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_build_js.yml
+++ b/.github/workflows/reusable_build_js.yml
@@ -28,7 +28,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -35,7 +35,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
+++ b/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
@@ -20,7 +20,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -33,7 +33,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"
@@ -72,7 +72,7 @@ jobs:
   # NOTE: We don't want spurious failures caused by issues being closed, so this does not run on CI,
   # at least for the time being.
   # - name: Check for zombie TODOs
-  #   shell: bash
+  #   shell: bash -euo pipefail
   #   run: |
   #     pixi run ./scripts/zombie_todos.py --token ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -36,7 +36,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_checks_protobuf.yml
+++ b/.github/workflows/reusable_checks_protobuf.yml
@@ -18,7 +18,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -16,7 +16,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"
@@ -59,6 +59,6 @@ jobs:
           environments: py-docs
 
       - name: Build via mkdocs
-        shell: bash
+        shell: bash -euo pipefail
         run: |
           pixi run -e py-docs mkdocs build --strict -f rerun_py/mkdocs.yml

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -41,7 +41,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -32,7 +32,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/reusable_deploy_landing_preview.yml
+++ b/.github/workflows/reusable_deploy_landing_preview.yml
@@ -16,7 +16,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/reusable_pip_index.yml
+++ b/.github/workflows/reusable_pip_index.yml
@@ -21,7 +21,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_publish_js.yml
+++ b/.github/workflows/reusable_publish_js.yml
@@ -20,7 +20,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -25,7 +25,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/reusable_publish_wheels.yml
+++ b/.github/workflows/reusable_publish_wheels.yml
@@ -22,7 +22,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -16,7 +16,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -18,7 +18,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_sync_release_assets.yml
+++ b/.github/workflows/reusable_sync_release_assets.yml
@@ -21,7 +21,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -47,7 +47,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"
@@ -182,7 +182,7 @@ jobs:
           max_attempts: 2
           retry_wait_seconds: 30
           timeout_minutes: 60
-          shell: bash
+          shell: bash -euo pipefail
           command: cd rerun_py/tests && pixi run -e wheel-test-min pytest -c ../pyproject.toml
 
       - name: Run e2e test

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -15,7 +15,7 @@ on:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: write

--- a/.github/workflows/reusable_upload_examples.yml
+++ b/.github/workflows/reusable_upload_examples.yml
@@ -32,7 +32,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "read"

--- a/.github/workflows/reusable_upload_js.yml
+++ b/.github/workflows/reusable_upload_js.yml
@@ -33,7 +33,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -33,7 +33,7 @@ concurrency:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -euo pipefail
 
 permissions:
   contents: "write"


### PR DESCRIPTION
I noticed some warnings when running the release job:

<img width="920" height="257" alt="image" src="https://github.com/user-attachments/assets/27ef3a83-49a0-483d-970b-63bde253c8cc" />

Leading to missing words in the release PR description:

https://github.com/rerun-io/rerun/pull/11374

Check the commit messages for details