### PR TITLE
Share button on notebook no longer uses the current base url for web viewer urls

### DIFF
--- a/crates/viewer/re_viewer/src/startup_options.rs
+++ b/crates/viewer/re_viewer/src/startup_options.rs
@@ -80,8 +80,10 @@ pub struct StartupOptions {
     pub enable_history: bool,
 
     /// The base viewer url that's used when sharing a link in this viewer.
+    ///
+    /// If not set, the viewer will use the current base url.
     #[cfg(target_arch = "wasm32")]
-    pub viewer_url: Option<String>,
+    pub viewer_base_url: Option<String>,
 }
 
 impl StartupOptions {
@@ -104,7 +106,7 @@ impl StartupOptions {
     pub fn web_viewer_base_url(&self) -> Option<url::Url> {
         #[cfg(target_arch = "wasm32")]
         {
-            self.viewer_url
+            self.viewer_base_url
                 .as_ref()
                 .and_then(|url| url.parse().ok())
                 .or_else(|| crate::web_tools::current_base_url().ok())
@@ -156,7 +158,7 @@ impl Default for StartupOptions {
             enable_history: false,
 
             #[cfg(target_arch = "wasm32")]
-            viewer_url: None,
+            viewer_base_url: None,
         }
     }
 }

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -661,7 +661,7 @@ impl From<PanelState> for re_types::blueprint::components::PanelState {
 // Keep in sync with the `AppOptions` interface in `rerun_js/web-viewer/index.ts`.
 #[derive(Clone, Default, Deserialize)]
 pub struct AppOptions {
-    viewer_url: Option<String>,
+    viewer_base_url: Option<String>,
     url: Option<StringOrStringArray>,
     manifest_url: Option<String>,
     render_backend: Option<String>,
@@ -720,7 +720,7 @@ fn create_app(
     };
 
     let AppOptions {
-        viewer_url,
+        viewer_base_url,
         url,
         manifest_url,
         render_backend,
@@ -784,7 +784,7 @@ fn create_app(
         panel_state_overrides: panel_state_overrides.unwrap_or_default().into(),
 
         enable_history,
-        viewer_url,
+        viewer_base_url,
     };
     crate::customize_eframe_and_setup_renderer(cc)?;
 

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -101,6 +101,12 @@ export interface WebViewerOptions {
    * enclosing notebook environment, it should be used to set the fallback token.
    */
   fallback_token?: string;
+
+  /** The url that's used when sharing web viewer urls.
+   *
+   * If not set, the viewer will use the current base url.
+   */
+  viewer_base_url?: string;
 }
 
 // `AppOptions` and `WebViewerOptions` must be compatible
@@ -112,8 +118,6 @@ export interface WebViewerOptions {
  * @private
  */
 export interface AppOptions extends WebViewerOptions {
-  /** The url that's used when sharing web viewer urls */
-  viewer_url?: string;
   url?: string;
   manifest_url?: string;
   video_decoder?: VideoDecoder;

--- a/rerun_notebook/package-lock.json
+++ b/rerun_notebook/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../rerun_js/web-viewer": {
       "name": "@rerun-io/web-viewer",
-      "version": "0.25.0-alpha.1+dev",
+      "version": "0.26.0-alpha.1+dev",
       "license": "MIT",
       "devDependencies": {
         "dts-buddy": "^0.3.0",

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -176,6 +176,8 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
 
     _fallback_token = traitlets.Unicode(allow_none=True).tag(sync=True)
 
+    _version = traitlets.Unicode(allow_none=True).tag(sync=True)
+
     _raw_event_callbacks: list[Callable[[str], None]] = []
 
     def __init__(
@@ -193,6 +195,7 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
         self._width = width
         self._height = height
         self._url = url
+        self._version = __version__
 
         if panel_states:
             self.update_panel_states(panel_states)


### PR DESCRIPTION
### Related

* Fixes RR-2414


### What


Previously, web viewer links produced by notebooks would always be incorrect as they'd treat the current url like a viewer application, which is practically always incorrect.

Fixed:
<img width="1089" height="496" alt="image" src="https://github.com/user-attachments/assets/6da1c06f-daa8-46fc-ae4e-cd65e0dba79e" />

Better exposed the (renamed) `viewer_base_url` property for this. This was introduced after the last release, so not a breaking change.
