### PR TITLE
Add context menu button to copy partition name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9154,6 +9154,7 @@ dependencies = [
  "itertools 0.14.0",
  "re_data_ui",
  "re_entity_db",
+ "re_log",
  "re_log_types",
  "re_redap_browser",
  "re_smart_channel",

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -804,6 +804,11 @@ pub fn entity_db_button_ui(
             ctx.command_sender()
                 .send_system(SystemCommand::CopyViewerUrl(url));
         }
+
+        if ui.button("Copy partition name").clicked() {
+            re_log::info!("Copied {recording_name:?} to clipboard");
+            ui.ctx().copy_text(recording_name);
+        }
     });
 
     if response.clicked() {

--- a/crates/viewer/re_recording_panel/Cargo.toml
+++ b/crates/viewer/re_recording_panel/Cargo.toml
@@ -25,6 +25,7 @@ testing = ["dep:serde", "re_viewer_context/testing", "re_log_types/serde"]
 [dependencies]
 re_data_ui.workspace = true
 re_entity_db.workspace = true
+re_log.workspace = true
 re_log_types.workspace = true
 re_redap_browser.workspace = true
 re_smart_channel.workspace = true


### PR DESCRIPTION
### Related

Closes RR-2412

### What

Adds context menu button to partitions and datasets to copy their names. And adds the same context menu as partitions have to loading partitions.
