### PR TITLE
Share button on notebook no longer uses the current base url for web viewer urls

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -984,9 +984,7 @@ fn native_startup_options_from_args(args: &Args) -> anyhow::Result<re_viewer::St
         force_wgpu_backend: args.renderer.clone(),
         video_decoder_hw_acceleration,
 
-        on_event: None,
-
-        panel_state_overrides: Default::default(),
+        ..Default::default()
     })
 }
 

--- a/crates/viewer/re_viewer/src/startup_options.rs
+++ b/crates/viewer/re_viewer/src/startup_options.rs
@@ -80,8 +80,10 @@ pub struct StartupOptions {
     pub enable_history: bool,
 
     /// The base viewer url that's used when sharing a link in this viewer.
+    ///
+    /// If not set, the viewer will use the url of the page it is embedded in.
     #[cfg(target_arch = "wasm32")]
-    pub viewer_url: Option<String>,
+    pub viewer_base_url: Option<String>,
 }
 
 impl StartupOptions {
@@ -104,7 +106,7 @@ impl StartupOptions {
     pub fn web_viewer_base_url(&self) -> Option<url::Url> {
         #[cfg(target_arch = "wasm32")]
         {
-            self.viewer_url
+            self.viewer_base_url
                 .as_ref()
                 .and_then(|url| url.parse().ok())
                 .or_else(|| crate::web_tools::current_base_url().ok())
@@ -156,7 +158,7 @@ impl Default for StartupOptions {
             enable_history: false,
 
             #[cfg(target_arch = "wasm32")]
-            viewer_url: None,
+            viewer_base_url: None,
         }
     }
 }

--- a/crates/viewer/re_viewer/src/startup_options.rs
+++ b/crates/viewer/re_viewer/src/startup_options.rs
@@ -82,7 +82,7 @@ pub struct StartupOptions {
     /// The base viewer url that's used when sharing a link in this viewer.
     ///
     /// If not set:
-    /// * notebooks & native: use rerun.io/viewer with the the crate's last known stable version
+    /// * notebooks & native: use rerun.io/viewer with the crate's last known stable version
     /// * web viewers: use the url of the page it is embedded in
     pub viewer_base_url: Option<String>,
 }

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -661,21 +661,24 @@ impl From<PanelState> for re_types::blueprint::components::PanelState {
 // Keep in sync with the `AppOptions` interface in `rerun_js/web-viewer/index.ts`.
 #[derive(Clone, Default, Deserialize)]
 pub struct AppOptions {
-    viewer_url: Option<String>,
-    url: Option<StringOrStringArray>,
     manifest_url: Option<String>,
     render_backend: Option<String>,
     video_decoder: Option<String>,
     hide_welcome_screen: Option<bool>,
+    // allow_fullscreen: Option<bool>, // Not serialized from js as it governs how the `fullscreen` option is used.
+    enable_history: Option<bool>,
+    // width: Option<String>, // Width & height aren't serialized and only used to configure the canvas.
+    // height: Option<String>,
+    fallback_token: Option<String>,
+
+    // Hidden `WebViewerOptions`
+    // ------------
+    viewer_base_url: Option<String>,
+    notebook: Option<bool>,
+    url: Option<StringOrStringArray>,
     panel_state_overrides: Option<PanelStateOverrides>,
     on_viewer_event: Option<Callback>,
     fullscreen: Option<FullscreenOptions>,
-    enable_history: Option<bool>,
-
-    notebook: Option<bool>,
-    persist: Option<bool>,
-
-    fallback_token: Option<String>,
 }
 
 // Keep in sync with the `FullscreenOptions` interface in `rerun_js/web-viewer/index.ts`
@@ -720,7 +723,7 @@ fn create_app(
     };
 
     let AppOptions {
-        viewer_url,
+        viewer_base_url,
         url,
         manifest_url,
         render_backend,
@@ -732,7 +735,6 @@ fn create_app(
         enable_history,
 
         notebook,
-        persist,
 
         fallback_token,
     } = app_options;
@@ -762,7 +764,7 @@ fn create_app(
             max_bytes: Some(2_500_000_000),
         },
         location: Some(cc.integration_info.web_info.location.clone()),
-        persist_state: persist.unwrap_or(true),
+        persist_state: true,
         is_in_notebook: notebook.unwrap_or(false),
         expect_data_soon: None,
         force_wgpu_backend: render_backend.clone(),
@@ -784,7 +786,7 @@ fn create_app(
         panel_state_overrides: panel_state_overrides.unwrap_or_default().into(),
 
         enable_history,
-        viewer_url,
+        viewer_base_url,
     };
     crate::customize_eframe_and_setup_renderer(cc)?;
 

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -4,9 +4,7 @@ import type { WebHandle, wasm_bindgen } from "./re_viewer";
 let get_wasm_bindgen: (() => typeof wasm_bindgen) | null = null;
 let _wasm_module: WebAssembly.Module | null = null;
 
-async function fetch_viewer_js(
-  base_url?: string,
-): Promise<() => typeof wasm_bindgen> {
+async function fetch_viewer_js(base_url?: string): Promise<(() => typeof wasm_bindgen)> {
   // @ts-ignore
   return (await import("./re_viewer")).default;
 }
@@ -14,7 +12,7 @@ async function fetch_viewer_js(
 async function fetch_viewer_wasm(base_url?: string): Promise<Response> {
   //!<INLINE-MARKER-OPEN>
   if (base_url) {
-    return fetch(new URL("./re_viewer_bg.wasm", base_url));
+    return fetch(new URL("./re_viewer_bg.wasm", base_url))
   } else {
     return fetch(new URL("./re_viewer_bg.wasm", import.meta.url));
   }
@@ -150,7 +148,7 @@ export type ViewerEventBase = {
   application_id: string;
   recording_id: string;
   partition_id?: string;
-};
+}
 
 /**
  * Fired when the timeline starts playing.
@@ -164,7 +162,7 @@ export type PlayEvent = ViewerEventBase & {
  */
 export type PauseEvent = ViewerEventBase & {
   type: "pause";
-};
+}
 
 /**
  * Fired when the timepoint changes.
@@ -172,7 +170,7 @@ export type PauseEvent = ViewerEventBase & {
 export type TimeUpdateEvent = ViewerEventBase & {
   type: "time_update";
   time: number;
-};
+}
 
 /**
  * Fired when a different timeline is selected.
@@ -181,7 +179,7 @@ export type TimelineChangeEvent = ViewerEventBase & {
   type: "timeline_change";
   timeline: string;
   time: number;
-};
+}
 
 /**
  * Fired when the selection changes.
@@ -193,7 +191,7 @@ export type TimelineChangeEvent = ViewerEventBase & {
 export type SelectionChangeEvent = ViewerEventBase & {
   type: "selection_change";
   items: SelectionChangeItem[];
-};
+}
 
 /**
  * Fired when a new recording is opened in the Viewer.
@@ -221,14 +219,15 @@ export type RecordingOpenEvent = ViewerEventBase & {
    * Uses semver format.
    */
   version?: string;
-};
+}
 
 // A bit of TypeScript metaprogramming to automatically produce a
 // mapping of event names to event payloads given the above type
 // definitions.
 
 // Yield the event with type `K`.
-type _GetViewerEvent<K> = Extract<ViewerEvent, { type: K }>;
+type _GetViewerEvent<K> =
+  Extract<ViewerEvent, { type: K }>;
 
 // `ViewerEvent` is a union of all events, so its `type` field
 // is a union of all `type` fields.
@@ -236,8 +235,8 @@ type _ViewerEventNames = ViewerEvent["type"];
 
 // For every event, get its payload type.
 type ViewerEventMap = {
-  [K in _ViewerEventNames]: _GetViewerEvent<K>;
-};
+  [K in _ViewerEventNames]: _GetViewerEvent<K>
+}
 
 /**
  * Selected an entity, or an instance of an entity.
@@ -285,16 +284,16 @@ export interface WebViewerEvents extends ViewerEventMap {
 // https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as
 export type EventsWithValue = {
   [K in keyof WebViewerEvents as WebViewerEvents[K] extends void
-    ? never
-    : K]: WebViewerEvents[K] extends any[]
-    ? WebViewerEvents[K]
-    : [WebViewerEvents[K]];
+  ? never
+  : K]: WebViewerEvents[K] extends any[]
+  ? WebViewerEvents[K]
+  : [WebViewerEvents[K]];
 };
 
 export type EventsWithoutValue = {
   [K in keyof WebViewerEvents as WebViewerEvents[K] extends void
-    ? K
-    : never]: WebViewerEvents[K];
+  ? K
+  : never]: WebViewerEvents[K];
 };
 
 function delay(ms: number) {
@@ -378,9 +377,9 @@ export class WebViewer {
 
     const fullscreen = this.#allow_fullscreen
       ? {
-          get_state: () => this.#fullscreen,
-          on_toggle: () => this.toggle_fullscreen(),
-        }
+        get_state: () => this.#fullscreen,
+        on_toggle: () => this.toggle_fullscreen(),
+      }
       : undefined;
 
     const on_viewer_event = (event_json: string) => {
@@ -391,8 +390,11 @@ export class WebViewer {
 
       // for JS users, we dispatch the parsed event
       let event: ViewerEvent = JSON.parse(event_json);
-      this.#dispatch_event(event.type as any, event);
-    };
+      this.#dispatch_event(
+        event.type as any,
+        event,
+      );
+    }
 
     this.#handle = new WebHandle_class({
       ...options,
@@ -673,7 +675,7 @@ export class WebViewer {
         this.stop();
         throw e;
       }
-    };
+    }
 
     const on_close = () => {
       if (!this.#handle) {
@@ -785,8 +787,7 @@ export class WebViewer {
   set_playing(recording_id: string, value: boolean) {
     if (!this.#handle) {
       throw new Error(
-        `attempted to set play state to ${
-          value ? "playing" : "paused"
+        `attempted to set play state to ${value ? "playing" : "paused"
         } in a stopped web viewer`,
       );
     }
@@ -914,7 +915,7 @@ export class WebViewer {
     }
   }
 
-  #minimize = () => {};
+  #minimize = () => { };
 
   #maximize = () => {
     _minimize_current_fullscreen_viewer?.();
@@ -1012,7 +1013,7 @@ export class LogChannel {
 
   send_table(table_bytes: Uint8Array) {
     if (!this.ready) return;
-    this.#on_send_table(table_bytes);
+    this.#on_send_table(table_bytes)
   }
 
   /**

--- a/rerun_notebook/src/js/widget.ts
+++ b/rerun_notebook/src/js/widget.ts
@@ -26,11 +26,7 @@ interface WidgetModel {
 
 type Opt<T> = T | null | undefined;
 
-function _resize(
-  el: HTMLElement,
-  width: number | string,
-  height: number | string,
-) {
+function _resize(el: HTMLElement, width: number | string, height: number | string) {
   const style = el.style;
 
   if (typeof width === "string" && width === "auto") {
@@ -58,8 +54,8 @@ class ViewerWidget {
   url: Opt<string> = null;
   panel_states: Opt<PanelStates> = null;
   options: AppOptions = {
-    hide_welcome_screen: true,
     notebook: true,
+    hide_welcome_screen: true,
     width: "100%",
     height: "100%",
   };
@@ -72,12 +68,8 @@ class ViewerWidget {
     this.panel_states = model.get("_panel_states");
     model.on("change:_panel_states", this.on_change_panel_states);
 
-    model.on("change:_width", (_, width) =>
-      this.on_resize(el, width, model.get("_height")),
-    );
-    model.on("change:_height", (_, height) =>
-      this.on_resize(el, model.get("_width"), height),
-    );
+    model.on("change:_width", (_, width) => this.on_resize(el, width, model.get("_height")));
+    model.on("change:_height", (_, height) => this.on_resize(el, model.get("_width"), height));
 
     model.on("msg:custom", this.on_custom_message);
 
@@ -100,13 +92,9 @@ class ViewerWidget {
     this.viewer.stop();
   }
 
-  on_resize(
-    parent: HTMLElement,
-    width: number | string,
-    height: number | string,
-  ) {
-    _resize(parent, width, height);
-  }
+  on_resize(parent: HTMLElement, width: number | string, height: number | string) {
+    _resize(parent, width, height)
+  };
 
   on_change_panel_states = (
     _: unknown,
@@ -129,40 +117,38 @@ class ViewerWidget {
       }
       case "table": {
         if (!this.channel)
-          throw new Error("on_custom_message called before channel init");
+          throw new Error("on_custom_message called before channel init")
         this.channel.send_table(new Uint8Array(buffers[0].buffer));
         break;
       }
       case "time_ctrl": {
-        this.set_time_ctrl(
-          msg.timeline ?? null,
-          msg.time ?? null,
-          msg.play ?? false,
-        );
+        this.set_time_ctrl(msg.timeline ?? null, msg.time ?? null, msg.play ?? false);
         break;
       }
       case "recording_id": {
-        this.set_recording_id(msg.recording_id ?? null);
+        this.set_recording_id(msg.recording_id ?? null)
         break;
       }
       case "open_url": {
-        this.viewer.open(msg.url);
+        this.viewer.open(msg.url)
         break;
       }
       case "close_url": {
-        this.viewer.close(msg.url);
+        this.viewer.close(msg.url)
         break;
       }
       default: {
         console.error("received unknown message type", msg, buffers);
-        throw new Error(
-          `unknown message type ${msg}, check console for more details`,
-        );
+        throw new Error(`unknown message type ${msg}, check console for more details`);
       }
     }
   };
 
-  set_time_ctrl(timeline: string | null, time: number | null, play: boolean) {
+  set_time_ctrl(
+    timeline: string | null,
+    time: number | null,
+    play: boolean,
+  ) {
     let recording_id = this.viewer.get_active_recording_id();
     if (recording_id === null) {
       return;
@@ -187,7 +173,7 @@ class ViewerWidget {
     if (time !== null) {
       this.viewer.set_current_time(recording_id, timeline, time);
     }
-  }
+  };
 
   set_recording_id(recording_id: string | null) {
     if (recording_id === null) {
@@ -195,8 +181,10 @@ class ViewerWidget {
     }
 
     this.viewer.set_active_recording_id(recording_id);
-  }
+  };
 }
+
+
 
 const render: Render<WidgetModel> = ({ model, el }) => {
   el.classList.add("rerun_notebook");
@@ -222,5 +210,6 @@ function error_boundary<Fn extends (...args: any[]) => any>(f: Fn): Fn {
 
   return wrapper as any;
 }
+
 
 export default { render: error_boundary(render) };

--- a/rerun_notebook/src/js/widget.ts
+++ b/rerun_notebook/src/js/widget.ts
@@ -3,7 +3,7 @@ import {
   type Panel,
   type PanelState,
   WebViewer,
-  type WebViewerOptions,
+  type AppOptions,
 } from "@rerun-io/web-viewer";
 
 import type { AnyModel, Render } from "@anywidget/types";
@@ -26,7 +26,11 @@ interface WidgetModel {
 
 type Opt<T> = T | null | undefined;
 
-function _resize(el: HTMLElement, width: number | string, height: number | string) {
+function _resize(
+  el: HTMLElement,
+  width: number | string,
+  height: number | string,
+) {
   const style = el.style;
 
   if (typeof width === "string" && width === "auto") {
@@ -53,8 +57,9 @@ class ViewerWidget {
   viewer: WebViewer = new WebViewer();
   url: Opt<string> = null;
   panel_states: Opt<PanelStates> = null;
-  options: WebViewerOptions = {
+  options: AppOptions = {
     hide_welcome_screen: true,
+    notebook: true,
     width: "100%",
     height: "100%",
   };
@@ -67,8 +72,12 @@ class ViewerWidget {
     this.panel_states = model.get("_panel_states");
     model.on("change:_panel_states", this.on_change_panel_states);
 
-    model.on("change:_width", (_, width) => this.on_resize(el, width, model.get("_height")));
-    model.on("change:_height", (_, height) => this.on_resize(el, model.get("_width"), height));
+    model.on("change:_width", (_, width) =>
+      this.on_resize(el, width, model.get("_height")),
+    );
+    model.on("change:_height", (_, height) =>
+      this.on_resize(el, model.get("_width"), height),
+    );
 
     model.on("msg:custom", this.on_custom_message);
 
@@ -91,9 +100,13 @@ class ViewerWidget {
     this.viewer.stop();
   }
 
-  on_resize(parent: HTMLElement, width: number | string, height: number | string) {
-    _resize(parent, width, height)
-  };
+  on_resize(
+    parent: HTMLElement,
+    width: number | string,
+    height: number | string,
+  ) {
+    _resize(parent, width, height);
+  }
 
   on_change_panel_states = (
     _: unknown,
@@ -116,38 +129,40 @@ class ViewerWidget {
       }
       case "table": {
         if (!this.channel)
-          throw new Error("on_custom_message called before channel init")
+          throw new Error("on_custom_message called before channel init");
         this.channel.send_table(new Uint8Array(buffers[0].buffer));
         break;
       }
       case "time_ctrl": {
-        this.set_time_ctrl(msg.timeline ?? null, msg.time ?? null, msg.play ?? false);
+        this.set_time_ctrl(
+          msg.timeline ?? null,
+          msg.time ?? null,
+          msg.play ?? false,
+        );
         break;
       }
       case "recording_id": {
-        this.set_recording_id(msg.recording_id ?? null)
+        this.set_recording_id(msg.recording_id ?? null);
         break;
       }
       case "open_url": {
-        this.viewer.open(msg.url)
+        this.viewer.open(msg.url);
         break;
       }
       case "close_url": {
-        this.viewer.close(msg.url)
+        this.viewer.close(msg.url);
         break;
       }
       default: {
         console.error("received unknown message type", msg, buffers);
-        throw new Error(`unknown message type ${msg}, check console for more details`);
+        throw new Error(
+          `unknown message type ${msg}, check console for more details`,
+        );
       }
     }
   };
 
-  set_time_ctrl(
-    timeline: string | null,
-    time: number | null,
-    play: boolean,
-  ) {
+  set_time_ctrl(timeline: string | null, time: number | null, play: boolean) {
     let recording_id = this.viewer.get_active_recording_id();
     if (recording_id === null) {
       return;
@@ -172,7 +187,7 @@ class ViewerWidget {
     if (time !== null) {
       this.viewer.set_current_time(recording_id, timeline, time);
     }
-  };
+  }
 
   set_recording_id(recording_id: string | null) {
     if (recording_id === null) {
@@ -180,10 +195,8 @@ class ViewerWidget {
     }
 
     this.viewer.set_active_recording_id(recording_id);
-  };
+  }
 }
-
-
 
 const render: Render<WidgetModel> = ({ model, el }) => {
   el.classList.add("rerun_notebook");
@@ -209,6 +222,5 @@ function error_boundary<Fn extends (...args: any[]) => any>(f: Fn): Fn {
 
   return wrapper as any;
 }
-
 
 export default { render: error_boundary(render) };


### PR DESCRIPTION
### Related

* Much improved version of https://github.com/rerun-io/rerun/pull/11377
* Fixes https://linear.app/rerun/issue/RR-2414/link-sharing-is-strange-from-rerun-cloud-in-notebook

### What

Also, fixes the Viewer reporting "have you tired native" on notebooks. Turns out our settings transfer from JS/TS to Rust was a bit in a dire state and didn't transmitt `notebook`

Once fixed, it was easy to have `notebook` mean different web viewer base urls by default.



* [x] needs a `landing` PR to update due to renamed parameter
    * https://github.com/rerun-io/landing/pull/1105