### PR TITLE
logging: filter noisy dependency logs (dataplatform)

### DIFF
--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -215,6 +215,7 @@ impl Telemetry {
                 .add_directive_if_absent(base, "tower", forced)?
                 .add_directive_if_absent(base, "tower_http", forced)?
                 .add_directive_if_absent(base, "tower_web", forced)?
+                .add_directive_if_absent(base, "typespec_client_core", forced)?
                 //
                 .add_directive_if_absent(base, "lance::index", "off")?
                 .add_directive_if_absent(base, "lance::dataset::scanner", "off")?


### PR DESCRIPTION
`typespec_client_core` is a dependency brought in by the Azure SDKs.
They turn out to be (surprisingly) extremely noisy when it comes to queue interactions.

This filters non warn items out.
