### PR TITLE
Mask platform-specific menu entry in app kittest

### DIFF
--- a/crates/viewer/re_viewer/tests/app_kittest.rs
+++ b/crates/viewer/re_viewer/tests/app_kittest.rs
@@ -48,6 +48,8 @@ async fn menu_without_recording() {
     let mut harness = viewer_test_utils::viewer_harness();
     harness.get_by_label("Menu").click();
     harness.run_ok();
+    // Mask the shortcut for quitting, it's platform-dependent.
+    harness.mask(harness.get_by_label_contains("Quit").rect());
     harness.snapshot_options(
         "menu_without_recording",
         &SnapshotOptions::new().failed_pixel_count_threshold(2),

--- a/crates/viewer/re_viewer/tests/snapshots/menu_without_recording.png
+++ b/crates/viewer/re_viewer/tests/snapshots/menu_without_recording.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a80c548a463ab2883f176dfcbf37729f5d745a4727e7b52932a1c20b006616c6
-size 137919
+oid sha256:0d708f2f212f2fe6a16e16ccfb9e39388b931e71425ff31d8eddaf8a7b8dd5af
+size 136512


### PR DESCRIPTION
Failed on Windows because Alt-F4 is displayed there.

