### PR TITLE
Telemetry: late-binding for service name

### DIFF
--- a/crates/utils/re_perf_telemetry/src/args.rs
+++ b/crates/utils/re_perf_telemetry/src/args.rs
@@ -66,11 +66,19 @@ pub struct TelemetryArgs {
     /// feature flags instead: <https://docs.rs/tracing/0.1.41/tracing/level_filters/index.html>.
     #[cfg_attr(
         feature = "enabled",
-        clap(long, env = "TELEMETRY_ENABLED", default_value_t = true)
+        clap(
+            long = "telemetry-enabled",
+            env = "TELEMETRY_ENABLED",
+            default_value_t = true
+        )
     )]
     #[cfg_attr(
         not(feature = "enabled"),
-        clap(long, env = "TELEMETRY_ENABLED", default_value_t = false)
+        clap(
+            long = "telemetry-enabled",
+            env = "TELEMETRY_ENABLED",
+            default_value_t = false
+        )
     )]
     pub enabled: bool,
 

--- a/crates/utils/re_perf_telemetry/src/args.rs
+++ b/crates/utils/re_perf_telemetry/src/args.rs
@@ -121,9 +121,12 @@ pub struct TelemetryArgs {
 
     /// The service name used for all things telemetry.
     ///
+    /// This is mandatory, but we leave it as optional to give users a chance to set it at initialization
+    /// time (as opposed to e.g. via env configuration) if needed.
+    ///
     /// Part of the `OpenTelemetry` spec.
     #[clap(long, env = "OTEL_SERVICE_NAME")]
-    pub service_name: String,
+    pub service_name: Option<String>,
 
     /// The service attributes used for all things telemetry.
     ///

--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -169,6 +169,12 @@ impl Telemetry {
             });
         }
 
+        let Some(service_name) = service_name else {
+            anyhow::bail!(
+                "either `OTEL_SERVICE_NAME` or `TelemetryArgs::service_name` must be set in order to initialize telemetry"
+            );
+        };
+
         // For these things, all we need to do is make sure that the right OTEL env var is set.
         // All the downstream libraries will do the right thing if they are.
         //


### PR DESCRIPTION
`TelemetryArgs` can now be instantiated without a service name, but initialization won't work until one is specified.

This allows end-users to specify a service name at runtime without having to use `set_var`.