### PR TITLE
End-to-end out-of-band entry headers: datasets (part 2)

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -46,7 +46,9 @@ service RerunCloudService {
 
   /* Write data */
 
-  // Register new partitions with the Dataset
+  // Register new partitions with the Dataset.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc RegisterWithDataset(RegisterWithDatasetRequest) returns (RegisterWithDatasetResponse) {}
 
   // Write chunks to one or more partitions.
@@ -71,22 +73,30 @@ service RerunCloudService {
   // Inspect the contents of the partition table.
   //
   // The data will follow the schema returned by `GetPartitionTableSchema`.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc ScanPartitionTable(ScanPartitionTableRequest) returns (stream ScanPartitionTableResponse) {}
 
   // Returns the schema of the dataset.
   //
   // This is the union of all the schemas from all the underlying partitions. It will contain all the indexes,
   // entities and components present in the dataset.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc GetDatasetSchema(GetDatasetSchemaRequest) returns (GetDatasetSchemaResponse) {}
 
   /* Indexing */
 
   // Creates a custom index for a specific column (vector search, full-text search, etc).
+  //
+  // This endpoint requires the standard dataset headers.
   rpc CreateIndex(CreateIndexRequest) returns (CreateIndexResponse) {}
 
   /* Queries */
 
   // Search a previously created index.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc SearchDataset(SearchDatasetRequest) returns (stream SearchDatasetResponse) {}
 
   // Perform Rerun-native queries on a dataset, returning the matching chunk IDs, as well
@@ -103,6 +113,8 @@ service RerunCloudService {
   // To fetch the actual chunks themselves, see `GetChunks`.
   //
   // Passing chunk IDs to this method effectively acts as a IF_EXIST filter.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc QueryDataset(QueryDatasetRequest) returns (stream QueryDatasetResponse) {}
 
   // Perform Rerun-native queries on a dataset, returning the underlying chunks.
@@ -113,6 +125,8 @@ service RerunCloudService {
   // * Arbitrary Lance filters.
   //
   // To fetch only the actual chunk IDs rather than the chunks themselves, see `QueryDataset`.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc GetChunks(GetChunksRequest) returns (stream GetChunksResponse) {}
 
   // Fetch specific chunks from Rerun Cloud. In a 2-step query process, result of 1st phase,
@@ -146,6 +160,8 @@ service RerunCloudService {
   // --- Utilities ---
 
   // Rerun Manifests maintenance operations: scalar index creation, compaction, etc.
+  //
+  // This endpoint requires the standard dataset headers.
   rpc DoMaintenance(DoMaintenanceRequest) returns (DoMaintenanceResponse) {}
 
   // Run global maintenance operations on the platform: this includes optimization

--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -610,8 +610,6 @@ message ScanTableResponse {
 // --- Maintenance ---
 
 message DoMaintenanceRequest {
-  rerun.common.v1alpha1.EntryId dataset_id = 1;
-
   // Optimize all builtin and user-defined indexes on this dataset.
   //
   // This merges all individual index deltas back in the main index, improving runtime performance
@@ -646,6 +644,9 @@ message DoMaintenanceRequest {
   //
   // ⚠️ Do not ever use this unless you know exactly what you're doing. Improper use will lead to data loss.
   bool unsafe_allow_recent_cleanup = 5;
+
+  reserved 1;
+  reserved "dataset_id";
 }
 
 message DoMaintenanceResponse {

--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -515,8 +515,6 @@ message QueryRange {
 }
 
 message GetChunksRequest {
-  rerun.common.v1alpha1.EntryId dataset_id = 1;
-
   // Client can specify from which partitions to get chunks. If left unspecified (empty list),
   // data from all partition (that match other query parameters) will be included.
   repeated rerun.common.v1alpha1.PartitionId partition_ids = 2;
@@ -562,6 +560,9 @@ message GetChunksRequest {
 
   // Query details
   Query query = 5;
+
+  reserved 1;
+  reserved "dataset_id";
 }
 
 message GetChunksResponse {

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
@@ -106,7 +106,6 @@ impl TryFrom<crate::cloud::v1alpha1::GetChunksRequest> for GetChunksRequest {
 
 #[derive(Debug, Clone)]
 pub struct DoMaintenanceRequest {
-    pub dataset_id: Option<crate::common::v1alpha1::EntryId>,
     pub optimize_indexes: bool,
     pub retrain_indexes: bool,
     pub compact_fragments: bool,
@@ -117,7 +116,6 @@ pub struct DoMaintenanceRequest {
 impl From<DoMaintenanceRequest> for crate::cloud::v1alpha1::DoMaintenanceRequest {
     fn from(value: DoMaintenanceRequest) -> Self {
         Self {
-            dataset_id: value.dataset_id,
             optimize_indexes: value.optimize_indexes,
             retrain_indexes: value.retrain_indexes,
             compact_fragments: value.compact_fragments,

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
@@ -63,7 +63,6 @@ impl From<RegisterWithDatasetRequest> for crate::cloud::v1alpha1::RegisterWithDa
 
 #[derive(Debug, Clone)]
 pub struct GetChunksRequest {
-    pub dataset_id: EntryId,
     pub partition_ids: Vec<crate::common::v1alpha1::ext::PartitionId>,
     pub chunk_ids: Vec<re_chunk::ChunkId>,
     pub entity_paths: Vec<EntityPath>,
@@ -75,11 +74,6 @@ impl TryFrom<crate::cloud::v1alpha1::GetChunksRequest> for GetChunksRequest {
 
     fn try_from(value: crate::cloud::v1alpha1::GetChunksRequest) -> Result<Self, Self::Error> {
         Ok(Self {
-            dataset_id: value
-                .dataset_id
-                .ok_or_else(|| tonic::Status::invalid_argument("dataset_id is required"))?
-                .try_into()?,
-
             partition_ids: value
                 .partition_ids
                 .into_iter()

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -674,8 +674,6 @@ impl ::prost::Name for QueryRange {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetChunksRequest {
-    #[prost(message, optional, tag = "1")]
-    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
     /// Client can specify from which partitions to get chunks. If left unspecified (empty list),
     /// data from all partition (that match other query parameters) will be included.
     #[prost(message, repeated, tag = "2")]

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -850,8 +850,6 @@ impl ::prost::Name for ScanTableResponse {
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct DoMaintenanceRequest {
-    #[prost(message, optional, tag = "1")]
-    pub dataset_id: ::core::option::Option<super::super::common::v1alpha1::EntryId>,
     /// Optimize all builtin and user-defined indexes on this dataset.
     ///
     /// This merges all individual index deltas back in the main index, improving runtime performance

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -1930,7 +1930,9 @@ pub mod rerun_cloud_service_client {
             ));
             self.inner.unary(req, path, codec).await
         }
-        /// Register new partitions with the Dataset
+        /// Register new partitions with the Dataset.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn register_with_dataset(
             &mut self,
             request: impl tonic::IntoRequest<super::RegisterWithDatasetRequest>,
@@ -2006,6 +2008,8 @@ pub mod rerun_cloud_service_client {
         /// Inspect the contents of the partition table.
         ///
         /// The data will follow the schema returned by `GetPartitionTableSchema`.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn scan_partition_table(
             &mut self,
             request: impl tonic::IntoRequest<super::ScanPartitionTableRequest>,
@@ -2031,6 +2035,8 @@ pub mod rerun_cloud_service_client {
         ///
         /// This is the union of all the schemas from all the underlying partitions. It will contain all the indexes,
         /// entities and components present in the dataset.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn get_dataset_schema(
             &mut self,
             request: impl tonic::IntoRequest<super::GetDatasetSchemaRequest>,
@@ -2051,6 +2057,8 @@ pub mod rerun_cloud_service_client {
             self.inner.unary(req, path, codec).await
         }
         /// Creates a custom index for a specific column (vector search, full-text search, etc).
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn create_index(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateIndexRequest>,
@@ -2071,6 +2079,8 @@ pub mod rerun_cloud_service_client {
             self.inner.unary(req, path, codec).await
         }
         /// Search a previously created index.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn search_dataset(
             &mut self,
             request: impl tonic::IntoRequest<super::SearchDatasetRequest>,
@@ -2106,6 +2116,8 @@ pub mod rerun_cloud_service_client {
         /// To fetch the actual chunks themselves, see `GetChunks`.
         ///
         /// Passing chunk IDs to this method effectively acts as a IF_EXIST filter.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn query_dataset(
             &mut self,
             request: impl tonic::IntoRequest<super::QueryDatasetRequest>,
@@ -2135,6 +2147,8 @@ pub mod rerun_cloud_service_client {
         /// * Arbitrary Lance filters.
         ///
         /// To fetch only the actual chunk IDs rather than the chunks themselves, see `QueryDataset`.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn get_chunks(
             &mut self,
             request: impl tonic::IntoRequest<super::GetChunksRequest>,
@@ -2305,6 +2319,8 @@ pub mod rerun_cloud_service_client {
             self.inner.server_streaming(req, path, codec).await
         }
         /// Rerun Manifests maintenance operations: scalar index creation, compaction, etc.
+        ///
+        /// This endpoint requires the standard dataset headers.
         pub async fn do_maintenance(
             &mut self,
             request: impl tonic::IntoRequest<super::DoMaintenanceRequest>,
@@ -2395,7 +2411,9 @@ pub mod rerun_cloud_service_server {
             &self,
             request: tonic::Request<super::ReadTableEntryRequest>,
         ) -> std::result::Result<tonic::Response<super::ReadTableEntryResponse>, tonic::Status>;
-        /// Register new partitions with the Dataset
+        /// Register new partitions with the Dataset.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn register_with_dataset(
             &self,
             request: tonic::Request<super::RegisterWithDatasetRequest>,
@@ -2432,6 +2450,8 @@ pub mod rerun_cloud_service_server {
         /// Inspect the contents of the partition table.
         ///
         /// The data will follow the schema returned by `GetPartitionTableSchema`.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn scan_partition_table(
             &self,
             request: tonic::Request<super::ScanPartitionTableRequest>,
@@ -2440,11 +2460,15 @@ pub mod rerun_cloud_service_server {
         ///
         /// This is the union of all the schemas from all the underlying partitions. It will contain all the indexes,
         /// entities and components present in the dataset.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn get_dataset_schema(
             &self,
             request: tonic::Request<super::GetDatasetSchemaRequest>,
         ) -> std::result::Result<tonic::Response<super::GetDatasetSchemaResponse>, tonic::Status>;
         /// Creates a custom index for a specific column (vector search, full-text search, etc).
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn create_index(
             &self,
             request: tonic::Request<super::CreateIndexRequest>,
@@ -2455,6 +2479,8 @@ pub mod rerun_cloud_service_server {
             > + std::marker::Send
             + 'static;
         /// Search a previously created index.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn search_dataset(
             &self,
             request: tonic::Request<super::SearchDatasetRequest>,
@@ -2478,6 +2504,8 @@ pub mod rerun_cloud_service_server {
         /// To fetch the actual chunks themselves, see `GetChunks`.
         ///
         /// Passing chunk IDs to this method effectively acts as a IF_EXIST filter.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn query_dataset(
             &self,
             request: tonic::Request<super::QueryDatasetRequest>,
@@ -2495,6 +2523,8 @@ pub mod rerun_cloud_service_server {
         /// * Arbitrary Lance filters.
         ///
         /// To fetch only the actual chunk IDs rather than the chunks themselves, see `QueryDataset`.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn get_chunks(
             &self,
             request: tonic::Request<super::GetChunksRequest>,
@@ -2552,6 +2582,8 @@ pub mod rerun_cloud_service_server {
             request: tonic::Request<super::QueryTasksOnCompletionRequest>,
         ) -> std::result::Result<tonic::Response<Self::QueryTasksOnCompletionStream>, tonic::Status>;
         /// Rerun Manifests maintenance operations: scalar index creation, compaction, etc.
+        ///
+        /// This endpoint requires the standard dataset headers.
         async fn do_maintenance(
             &self,
             request: tonic::Request<super::DoMaintenanceRequest>,

--- a/crates/store/re_redap_client/src/connection_client.rs
+++ b/crates/store/re_redap_client/src/connection_client.rs
@@ -381,17 +381,20 @@ where
         unsafe_allow_recent_cleanup: bool,
     ) -> Result<(), StreamError> {
         self.inner()
-            .do_maintenance(tonic::Request::new(
-                re_protos::cloud::v1alpha1::ext::DoMaintenanceRequest {
-                    dataset_id: Some(dataset_id.into()),
-                    optimize_indexes,
-                    retrain_indexes,
-                    compact_fragments,
-                    cleanup_before,
-                    unsafe_allow_recent_cleanup,
-                }
-                .into(),
-            ))
+            .do_maintenance(
+                tonic::Request::new(
+                    re_protos::cloud::v1alpha1::ext::DoMaintenanceRequest {
+                        optimize_indexes,
+                        retrain_indexes,
+                        compact_fragments,
+                        cleanup_before,
+                        unsafe_allow_recent_cleanup,
+                    }
+                    .into(),
+                )
+                .with_entry_id(dataset_id)
+                .map_err(|err| StreamEntryError::InvalidId(err.into()))?,
+            )
             .await
             .map_err(|err| StreamEntryError::Maintenance(err.into()))?;
 

--- a/crates/store/re_redap_client/src/connection_client.rs
+++ b/crates/store/re_redap_client/src/connection_client.rs
@@ -370,6 +370,23 @@ where
         Ok(response.table_entry)
     }
 
+    pub async fn get_chunks(
+        &mut self,
+        dataset_id: EntryId,
+        req: re_protos::cloud::v1alpha1::GetChunksRequest,
+    ) -> Result<tonic::Streaming<re_protos::cloud::v1alpha1::GetChunksResponse>, StreamError> {
+        Ok(self
+            .inner()
+            .get_chunks(
+                tonic::Request::new(req)
+                    .with_entry_id(dataset_id)
+                    .map_err(|err| StreamEntryError::InvalidId(err.into()))?,
+            )
+            .await
+            .map_err(|err| crate::StreamPartitionError::StreamingChunks(err.into()))?
+            .into_inner())
+    }
+
     #[allow(clippy::fn_params_excessive_bools)]
     pub async fn do_maintenance(
         &mut self,

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -8,12 +8,11 @@ use re_protos::cloud::v1alpha1::GetChunksRequest;
 use re_protos::cloud::v1alpha1::ext::{Query, QueryLatestAt, QueryRange};
 use re_protos::cloud::v1alpha1::rerun_cloud_service_client::RerunCloudServiceClient;
 use re_protos::common::v1alpha1::ext::PartitionId;
-use re_protos::headers::RerunHeadersInjectorExt as _;
 use re_uri::{Origin, TimeSelection};
 
 use tokio_stream::{Stream, StreamExt as _};
 
-use crate::{ConnectionClient, MAX_DECODING_MESSAGE_SIZE, StreamError, StreamPartitionError};
+use crate::{ConnectionClient, MAX_DECODING_MESSAGE_SIZE, StreamError};
 
 // TODO(ab): do not publish this out of this crate (for now it is still being used by rerun_py
 // the viewer grpc connection). Ideally we'd only publish `ClientConnectionError`.

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -284,6 +284,8 @@ pub fn fetch_chunks_response_to_chunk_and_partition_id(
 pub fn get_chunks_response_to_chunk_and_partition_id(
     response: tonic::Streaming<re_protos::cloud::v1alpha1::GetChunksResponse>,
 ) -> impl Stream<Item = Result<Vec<(Chunk, Option<String>)>, StreamError>> {
+    use crate::StreamPartitionError;
+
     response.map(|resp| {
         let resp = resp.map_err(|err| StreamPartitionError::StreamingChunks(err.into()))?;
 
@@ -314,6 +316,8 @@ pub fn get_chunks_response_to_chunk_and_partition_id(
 pub fn fetch_chunks_response_to_chunk_and_partition_id(
     response: tonic::Streaming<re_protos::cloud::v1alpha1::FetchChunksResponse>,
 ) -> impl Stream<Item = Result<Vec<(Chunk, Option<String>)>, StreamError>> {
+    use crate::StreamPartitionError;
+
     response.map(|resp| {
         let resp = resp.map_err(|err| StreamPartitionError::StreamingChunks(err.into()))?;
 

--- a/rerun_py/src/catalog/connection_handle.rs
+++ b/rerun_py/src/catalog/connection_handle.rs
@@ -543,28 +543,23 @@ impl ConnectionHandle {
                 // that it runs in a dedicated task, so that it can actually get scheduled properly
                 // when running with `block_on`.
                 let get_chunks_response_stream = tokio::spawn(async move {
-                    let request = GetChunksRequest {
-                        partition_ids,
-                        chunk_ids: vec![],
-                        entity_paths,
-                        select_all_entity_paths,
-                        fuzzy_descriptors,
-                        exclude_static_data: false,
-                        exclude_temporal_data: false,
-                        query: Some(query.into()),
-                    };
-
                     let resp = client
-                        .inner()
                         .get_chunks(
-                            tonic::Request::new(request)
-                                .with_entry_id(dataset_id)
-                                .map_err(to_py_err)?,
+                            dataset_id,
+                            GetChunksRequest {
+                                partition_ids,
+                                chunk_ids: vec![],
+                                entity_paths,
+                                select_all_entity_paths,
+                                fuzzy_descriptors,
+                                exclude_static_data: false,
+                                exclude_temporal_data: false,
+                                query: Some(query.into()),
+                            },
                         )
                         .instrument(tracing::trace_span!("get_chunks::grpc"))
                         .await
-                        .map_err(to_py_err)?
-                        .into_inner();
+                        .map_err(to_py_err)?;
 
                     Ok::<_, PyErr>(resp)
                 })

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -360,21 +360,26 @@ impl PyDatasetEntry {
 
         //TODO(ab): use `ConnectionHandle::get_chunk()`
         let store: PyResult<ChunkStore> = wait_for_future(self_.py(), async move {
+            let request = GetChunksRequest {
+                partition_ids: vec![partition_id.clone().into()],
+                chunk_ids: vec![],
+                entity_paths: vec![],
+                select_all_entity_paths: true,
+                fuzzy_descriptors: vec![],
+                exclude_static_data: false,
+                exclude_temporal_data: false,
+                query: None,
+            };
+
             let catalog_chunk_stream = connection
                 .client()
                 .await?
                 .inner()
-                .get_chunks(GetChunksRequest {
-                    dataset_id: Some(dataset_id.into()),
-                    partition_ids: vec![partition_id.clone().into()],
-                    chunk_ids: vec![],
-                    entity_paths: vec![],
-                    select_all_entity_paths: true,
-                    fuzzy_descriptors: vec![],
-                    exclude_static_data: false,
-                    exclude_temporal_data: false,
-                    query: None,
-                })
+                .get_chunks(
+                    tonic::Request::new(request)
+                        .with_entry_id(dataset_id)
+                        .map_err(to_py_err)?,
+                )
                 .await
                 .map_err(to_py_err)?
                 .into_inner();


### PR DESCRIPTION
With this second part, everything related to the manifest registry is now fully migrated.
As usual, the interesting stuff happens in the sibling.

* Sibling: https://github.com/rerun-io/dataplatform/pull/1796