### PR TITLE
create SDK wheels for mac on push-to-main workflow

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -138,6 +138,15 @@ jobs:
       PLATFORM: linux-x64
     secrets: inherit
 
+  build-rerun_c-and-upload-macos-arm64:
+    needs: [checks]
+    name: "Mac-Arm64: Build & Upload rerun_c"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
+    with:
+      CONCURRENCY: nightly-macos-arm64
+      PLATFORM: macos-arm64
+    secrets: inherit
+
   # -----------------------------------------------------------------------------------
   # Build rerun-cli (rerun binaries):
 
@@ -157,6 +166,15 @@ jobs:
     with:
       CONCURRENCY: push-linux-x64-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
       PLATFORM: linux-x64
+    secrets: inherit
+
+  build-rerun-cli-and-upload-macos-arm64:
+    needs: [checks]
+    name: "Mac-arm64: Build & Upload rerun-cli"
+    uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
+    with:
+      CONCURRENCY: nightly-macos-arm64
+      PLATFORM: macos-arm64
     secrets: inherit
 
   # ---------------------------------------------------------------------------
@@ -184,6 +202,17 @@ jobs:
       MODE: "pypi"
     secrets: inherit
 
+  build-wheel-macos-arm64:
+    needs: [checks, build-rerun-cli-and-upload-macos-arm64]
+    name: "Macos-arm64: Build & Upload Wheels"
+    uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
+    with:
+      CONCURRENCY: nightly-macos-arm64
+      PLATFORM: macos-arm64
+      WHEEL_ARTIFACT_NAME: macos-arm64-wheel
+      MODE: "pypi"
+    secrets: inherit
+
   # ---------------------------------------------------------------------------
   # Test wheels:
 
@@ -207,9 +236,20 @@ jobs:
       WHEEL_ARTIFACT_NAME: linux-x64-wheel
     secrets: inherit
 
+  test-wheel-macos-arm64:
+    needs: [checks, build-wheel-macos-arm64]
+    name: "macos-arm64: Test Wheels"
+    uses: ./.github/workflows/reusable_test_wheels.yml
+    with:
+      CONCURRENCY: nightly-macos-arm64
+      PLATFORM: macos-arm64
+      WHEEL_ARTIFACT_NAME: macos-arm64-wheel
+    secrets: inherit
+
   generate-pip-index:
     name: "Generate Pip Index"
-    needs: [build-wheel-linux-arm64, build-wheel-linux-x64]
+    needs:
+      [build-wheel-linux-arm64, build-wheel-linux-x64, build-wheel-macos-arm64]
     uses: ./.github/workflows/reusable_pip_index.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -143,7 +143,7 @@ jobs:
     name: "Mac-Arm64: Build & Upload rerun_c"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_c.yml
     with:
-      CONCURRENCY: nightly-macos-arm64
+      CONCURRENCY: push-macos-arm64-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
       PLATFORM: macos-arm64
     secrets: inherit
 
@@ -173,7 +173,7 @@ jobs:
     name: "Mac-arm64: Build & Upload rerun-cli"
     uses: ./.github/workflows/reusable_build_and_upload_rerun_cli.yml
     with:
-      CONCURRENCY: nightly-macos-arm64
+      CONCURRENCY: push-macos-arm64-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
       PLATFORM: macos-arm64
     secrets: inherit
 
@@ -207,7 +207,7 @@ jobs:
     name: "Macos-arm64: Build & Upload Wheels"
     uses: ./.github/workflows/reusable_build_and_upload_wheels.yml
     with:
-      CONCURRENCY: nightly-macos-arm64
+      CONCURRENCY: push-macos-arm64-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
       PLATFORM: macos-arm64
       WHEEL_ARTIFACT_NAME: macos-arm64-wheel
       MODE: "pypi"
@@ -241,7 +241,7 @@ jobs:
     name: "macos-arm64: Test Wheels"
     uses: ./.github/workflows/reusable_test_wheels.yml
     with:
-      CONCURRENCY: nightly-macos-arm64
+      CONCURRENCY: push-macos-arm64-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
       PLATFORM: macos-arm64
       WHEEL_ARTIFACT_NAME: macos-arm64-wheel
     secrets: inherit


### PR DESCRIPTION
This will help our pixi setup in dataplatform.
See: https://rerunio.slack.com/archives/C045J1Z7DU7/p1759397428008379

Tested by starting the Push To Main workflow manually: https://github.com/rerun-io/rerun/actions/runs/18196593913


