### PR TITLE
Store (and display) recordings in insertion order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8719,6 +8719,7 @@ dependencies = [
  "anyhow",
  "document-features",
  "emath",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "nohash-hasher",
  "parking_lot",

--- a/crates/store/re_entity_db/Cargo.toml
+++ b/crates/store/re_entity_db/Cargo.toml
@@ -47,6 +47,7 @@ re_uri.workspace = true
 ahash.workspace = true
 document-features.workspace = true
 emath.workspace = true
+indexmap.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
 parking_lot.workspace = true

--- a/crates/store/re_entity_db/src/store_bundle.rs
+++ b/crates/store/re_entity_db/src/store_bundle.rs
@@ -16,9 +16,13 @@ pub enum StoreLoadError {
 // ---
 
 /// Stores many [`EntityDb`]s of recordings and blueprints.
+///
+/// The stores are kept and iterated in insertion order to allow the UI to display them by default
+/// in opening order.
 #[derive(Default)]
 pub struct StoreBundle {
-    recording_store: ahash::HashMap<StoreId, EntityDb>,
+    // `indexmap` is used to keep track of the insertion order.
+    recording_store: indexmap::IndexMap<StoreId, EntityDb>,
 }
 
 impl StoreBundle {
@@ -38,24 +42,18 @@ impl StoreBundle {
         Ok(slf)
     }
 
-    /// All loaded [`EntityDb`], both recordings and blueprints, in arbitrary order.
+    /// All loaded [`EntityDb`], both recordings and blueprints, in insertion order.
     pub fn entity_dbs(&self) -> impl Iterator<Item = &EntityDb> {
         self.recording_store.values()
     }
 
-    /// All loaded [`EntityDb`], both recordings and blueprints, in arbitrary order.
+    /// All loaded [`EntityDb`], both recordings and blueprints, in insertion order.
     pub fn entity_dbs_mut(&mut self) -> impl Iterator<Item = &mut EntityDb> {
         self.recording_store.values_mut()
     }
 
-    pub fn append(&mut self, mut other: Self) {
-        for (id, entity_db) in other.recording_store.drain() {
-            self.recording_store.insert(id, entity_db);
-        }
-    }
-
     pub fn remove(&mut self, id: &StoreId) -> Option<EntityDb> {
-        self.recording_store.remove(id)
+        self.recording_store.shift_remove(id)
     }
 
     // --
@@ -113,18 +111,11 @@ impl StoreBundle {
             .insert(entity_db.store_id().clone(), entity_db);
     }
 
-    /// In no particular order.
+    /// In insertion order.
     pub fn recordings(&self) -> impl Iterator<Item = &EntityDb> {
         self.recording_store
             .values()
             .filter(|log| log.store_kind() == StoreKind::Recording)
-    }
-
-    /// In no particular order.
-    pub fn blueprints(&self) -> impl Iterator<Item = &EntityDb> {
-        self.recording_store
-            .values()
-            .filter(|log| log.store_kind() == StoreKind::Blueprint)
     }
 
     // --
@@ -133,9 +124,9 @@ impl StoreBundle {
         self.recording_store.retain(|_, db| f(db));
     }
 
-    /// In no particular order.
+    /// In insertion order.
     pub fn drain_entity_dbs(&mut self) -> impl Iterator<Item = EntityDb> + '_ {
-        self.recording_store.drain().map(|(_, store)| store)
+        self.recording_store.drain(..).map(|(_, store)| store)
     }
 
     // --


### PR DESCRIPTION
### Related

* closes https://linear.app/rerun/issue/RR-2340/order-partitions-by-the-opening-order

### What

This PR changes `StoreBundle` to use an `indexmap` instead of a `HashMap`, such that all iterator are sorted by insertion order. The main benefit is that recordings (and, in particular, partitions) are now ordered by opening order in the recording panel.