### PR TITLE
Reconcile historically messy RerunCloud extension types

### DIFF
--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
@@ -66,6 +66,10 @@ pub struct GetChunksRequest {
     pub partition_ids: Vec<crate::common::v1alpha1::ext::PartitionId>,
     pub chunk_ids: Vec<re_chunk::ChunkId>,
     pub entity_paths: Vec<EntityPath>,
+    pub select_all_entity_paths: bool,
+    pub fuzzy_descriptors: Vec<String>,
+    pub exclude_static_data: bool,
+    pub exclude_temporal_data: bool,
     pub query: Option<Query>,
 }
 
@@ -98,6 +102,13 @@ impl TryFrom<crate::cloud::v1alpha1::GetChunksRequest> for GetChunksRequest {
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,
+
+            select_all_entity_paths: value.select_all_entity_paths,
+
+            fuzzy_descriptors: value.fuzzy_descriptors,
+
+            exclude_static_data: value.exclude_static_data,
+            exclude_temporal_data: value.exclude_temporal_data,
 
             query: value.query.map(|q| q.try_into()).transpose()?,
         })

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
@@ -59,6 +59,68 @@ impl From<RegisterWithDatasetRequest> for crate::cloud::v1alpha1::RegisterWithDa
     }
 }
 
+// --- QueryDatasetRequest ---
+
+#[derive(Debug, Clone)]
+pub struct QueryDatasetRequest {
+    pub partition_ids: Vec<crate::common::v1alpha1::ext::PartitionId>,
+    pub chunk_ids: Vec<re_chunk::ChunkId>,
+    pub entity_paths: Vec<EntityPath>,
+    pub select_all_entity_paths: bool,
+    pub fuzzy_descriptors: Vec<String>,
+    pub exclude_static_data: bool,
+    pub exclude_temporal_data: bool,
+    pub scan_parameters: Option<crate::common::v1alpha1::ext::ScanParameters>,
+    pub query: Option<Query>,
+}
+
+impl TryFrom<crate::cloud::v1alpha1::QueryDatasetRequest> for QueryDatasetRequest {
+    type Error = tonic::Status;
+
+    fn try_from(value: crate::cloud::v1alpha1::QueryDatasetRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            partition_ids: value
+                .partition_ids
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
+
+            chunk_ids: value
+                .chunk_ids
+                .into_iter()
+                .map(|tuid| {
+                    let id: re_tuid::Tuid = tuid.try_into()?;
+                    Ok::<_, tonic::Status>(re_chunk::ChunkId::from_u128(id.as_u128()))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+
+            entity_paths: value
+                .entity_paths
+                .into_iter()
+                .map(|path| {
+                    path.try_into().map_err(|err| {
+                        tonic::Status::invalid_argument(format!("invalid entity path: {err}"))
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+
+            select_all_entity_paths: value.select_all_entity_paths,
+
+            fuzzy_descriptors: value.fuzzy_descriptors,
+
+            exclude_static_data: value.exclude_static_data,
+            exclude_temporal_data: value.exclude_temporal_data,
+
+            scan_parameters: value
+                .scan_parameters
+                .map(|params| params.try_into())
+                .transpose()?,
+
+            query: value.query.map(|q| q.try_into()).transpose()?,
+        })
+    }
+}
+
 // --- GetChunksRequest --
 
 #[derive(Debug, Clone)]

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.ext.rs
@@ -113,6 +113,25 @@ pub struct DoMaintenanceRequest {
     pub unsafe_allow_recent_cleanup: bool,
 }
 
+impl TryFrom<crate::cloud::v1alpha1::DoMaintenanceRequest> for DoMaintenanceRequest {
+    type Error = TypeConversionError;
+
+    fn try_from(value: crate::cloud::v1alpha1::DoMaintenanceRequest) -> Result<Self, Self::Error> {
+        let cleanup_before = value
+            .cleanup_before
+            .map(|ts| jiff::Timestamp::new(ts.seconds, ts.nanos))
+            .transpose()?;
+
+        Ok(Self {
+            optimize_indexes: value.optimize_indexes,
+            retrain_indexes: value.retrain_indexes,
+            compact_fragments: value.compact_fragments,
+            cleanup_before,
+            unsafe_allow_recent_cleanup: value.unsafe_allow_recent_cleanup,
+        })
+    }
+}
+
 impl From<DoMaintenanceRequest> for crate::cloud::v1alpha1::DoMaintenanceRequest {
     fn from(value: DoMaintenanceRequest) -> Self {
         Self {

--- a/crates/store/re_server/src/rerun_cloud.rs
+++ b/crates/store/re_server/src/rerun_cloud.rs
@@ -928,9 +928,11 @@ impl RerunCloudService for RerunCloudHandler {
             partition_ids,
             chunk_ids: _,
             entity_paths,
-
-            // We don't support queries, so you always get everything
             query: _,
+            select_all_entity_paths: _,
+            fuzzy_descriptors: _,
+            exclude_static_data: _,
+            exclude_temporal_data: _,
         } = GetChunksRequest::try_from(request.into_inner())?;
 
         let entity_paths: IntSet<EntityPath> = entity_paths.into_iter().collect();


### PR DESCRIPTION
Due to historical organic messiness, some extension types had to be forked/duplicated/etc across the OSS and enterprise servers. With the new entry headers, that's no longer needed. Clean up the mess.

* Sibling: https://github.com/rerun-io/dataplatform/pull/1806