### PR TITLE
Update wgpu to 27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,7 +1842,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -3209,7 +3209,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.8",
 ]
 
 [[package]]
@@ -3257,7 +3257,7 @@ checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 [[package]]
 name = "ecolor"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -3274,7 +3274,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "accesskit",
  "ahash",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -3414,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "ahash",
  "egui",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "bytemuck",
  "egui",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "dify",
  "eframe",
@@ -3521,7 +3521,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "emath"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
+source = "git+https://github.com/emilk/egui.git?branch=main#f6fe3bff180d8f93ebd4ccf7c29201cf2fb8894d"
 
 [[package]]
 name = "equivalent"
@@ -13243,7 +13243,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25ae84c0260bdf5df07796d7cc4882460de26a2b406ec0e6c42461a723b271b"
+checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
 dependencies = [
  "enumn",
  "serde",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bd41de2e54451a8ca0dd95ebf45b54d349d29ebceb7f20be264eee14e3d477"
+checksum = "29f73a9b855b6f4af4962a94553ef0c092b80cf5e17038724d5e30945d036f69"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfae7c152994a31dc7d99b8eeac7784a919f71d1b306f4b83217e110fd3824c"
+checksum = "bdd06f5fea9819250fffd4debf926709f3593ac22f8c1541a2573e5ee0ca01cd"
 dependencies = [
  "accesskit",
  "hashbrown 0.15.4",
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.20.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692dd318ff8a7a0ffda67271c4bd10cf32249656f4e49390db0b26ca92b095f2"
+checksum = "93fbaf15815f39084e0cb24950c232f0e3634702c2dfbf182ae3b4919a4a1d45"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.15.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f7474c36606d0fe4f438291d667bae7042ea2760f506650ad2366926358fc8"
+checksum = "64926a930368d52d95422b822ede15014c04536cabaa2394f99567a1f4788dc6"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a042b62c9c05bf7b616f015515c17d2813f3ba89978d6f4fc369735d60700a"
+checksum = "792991159fa9ba57459de59e12e918bb90c5346fea7d40ac1a11f8632b41e63a"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.27.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1f0d3d13113d8857542a4f8d1a1c24d1dc1527b77aee8426127f4901588708"
+checksum = "cd9db0ea66997e3f4eae4a5f2c6b6486cf206642639ee629dbbb860ace1dec87"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -1842,7 +1842,7 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.1",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -3209,7 +3209,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.8",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3257,7 +3257,7 @@ checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
 [[package]]
 name = "ecolor"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -3274,7 +3274,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "accesskit",
  "ahash",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -3351,7 +3351,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -3414,7 +3414,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "ahash",
  "egui",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "bytemuck",
  "egui",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "dify",
  "eframe",
@@ -3521,7 +3521,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "emath"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -3657,7 +3657,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.32.3"
-source = "git+https://github.com/emilk/egui.git?branch=main#48d903d8797d0869b5d2b43a22346dede7d471d2"
+source = "git+https://github.com/emilk/egui.git?branch=main#427c0766fdd38e75dd422a995c4ba4005fb07800"
 
 [[package]]
 name = "equivalent"
@@ -3873,6 +3873,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -4456,7 +4462,16 @@ checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -5218,8 +5233,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "kittest"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1bfc4cb16136b6f00fb85a281e4b53d026401cf5dff9a427c466bde5891f0b"
+source = "git+https://github.com/rerun-io/kittest.git#028d5311f475e64839bcbc04f259a0d20532d2c1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -6319,9 +6333,9 @@ checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "naga"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916cbc7cb27db60be930a4e2da243cf4bc39569195f22fd8ee419cd31d5b662c"
+checksum = "12b2e757b11b47345d44e7760e45458339bc490463d9548cd8651c53ae523153"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -6330,7 +6344,7 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "hexf-parse",
  "indexmap 2.10.0",
  "libm",
@@ -13101,16 +13115,16 @@ checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wgpu"
-version = "26.0.1"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b6ff82bbf6e9206828e1a3178e851f8c20f1c9028e74dd3a8090741ccd5798"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "js-sys",
  "log",
  "naga",
@@ -13130,17 +13144,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "26.0.1"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f62f1053bd28c2268f42916f31588f81f64796e2ff91b81293515017ca8bd9"
+checksum = "e3d654c0b6c6335edfca18c11bdaed964def641b8e9997d3a495a2ff4077c922"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
  "bitflags 2.9.1",
+ "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "indexmap 2.10.0",
  "log",
  "naga",
@@ -13162,45 +13177,45 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae5fbde6a4cbebae38358aa73fcd6e0f15c6144b67ef5dc91ded0db125dbdf"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7670e390f416006f746b4600fdd9136455e3627f5bd763abf9a65daa216dd2d"
+checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03b9f9e1a50686d315fc6debe4980cc45cd37b0e919351917df494e8fdc8885"
+checksum = "9b1027dcf3b027a877e44819df7ceb0e2e98578830f8cd34cd6c3c7c2a7a50b7"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720a5cb9d12b3d337c15ff0e24d3e97ed11490ff3f7506e7f3d98c68fa5d6f14"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "26.0.4"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df2c64ac282a91ad7662c90bc4a77d4a2135bc0b2a2da5a4d4e267afc034b9e"
+checksum = "fd6a4ade7d7e2df367703226457845fa8c3acfbb07bfba2290b3925fde999b66"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -13217,7 +13232,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -13227,7 +13242,8 @@ dependencies = [
  "naga",
  "ndk-sys",
  "objc",
- "ordered-float 5.0.0",
+ "once_cell",
+ "ordered-float 4.6.0",
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
@@ -13246,9 +13262,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "26.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca7a8d8af57c18f57d393601a1fb159ace8b2328f1b6b5f80893f7d672c9ae2"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,6 @@ eframe = { version = "0.32.3", default-features = false, features = [
 egui = { version = "0.32.3", features = [
   "callstack",
   "color-hex",
-  "log",
   "rayon",
 ] }
 egui_commonmark = { version = "0.21", default-features = false }
@@ -410,7 +409,7 @@ webbrowser = "1.0"
 winit = { version = "0.30.12", default-features = false }
 # TODO(andreas): Try to get rid of `fragile-send-sync-non-atomic-wasm`. This requires re_renderer being aware of single-thread restriction on resources.
 # See also https://gpuweb.github.io/gpuweb/explainer/#multithreading-transfer (unsolved part of the Spec as of writing!)
-wgpu = { version = "26.0.1", default-features = false, features = [
+wgpu = { version = "27.0.0", default-features = false, features = [
   # Backends (see https://docs.rs/wgpu/latest/wgpu/#feature-flags)
   "gles",
   "metal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,11 +165,7 @@ eframe = { version = "0.32.3", default-features = false, features = [
   "wayland",
   "x11",
 ] }
-egui = { version = "0.32.3", features = [
-  "callstack",
-  "color-hex",
-  "rayon",
-] }
+egui = { version = "0.32.3", features = ["callstack", "color-hex", "rayon"] }
 egui_commonmark = { version = "0.21", default-features = false }
 egui_dnd = { version = "0.13" }
 egui_extras = { version = "0.32.3", features = [

--- a/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
@@ -311,6 +311,12 @@ impl GpuReadbackBelt {
     /// Prepare used buffers for CPU read.
     ///
     /// This should be called after the command encoder(s) used in [`GpuReadbackBuffer`] copy operations are submitted.
+    ///
+    /// Implementation note:
+    /// We can't use [`wgpu::CommandEncoder::map_buffer_on_submit`] here because for that we'd need to know which
+    /// command encoder is the last one scheduling any gpu->cpu copy operations.
+    /// Note that if chunks were fully tied to a single encoder, we could call [`wgpu::CommandEncoder::map_buffer_on_submit`]
+    /// once we know a chunk has all its gpu->cpu copy operations scheduled on that very encoder.
     pub fn after_queue_submit(&mut self) {
         re_tracing::profile_function!();
 

--- a/crates/viewer/re_renderer/src/context_test.rs
+++ b/crates/viewer/re_renderer/src/context_test.rs
@@ -48,7 +48,12 @@ impl RenderContext {
 
         // Wait for all GPU work to finish.
         self.device
-            .poll(wgpu::PollType::Wait)
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                // More than 1 second seems crazy for GPU workloads in tests.
+                // Windows will reset driver at 2 seconds.
+                timeout: Some(std::time::Duration::from_secs(1)),
+            })
             .expect("Failed to wait for GPU work to finish");
 
         // Start a new frame in order to handle the previous' frame errors.

--- a/crates/viewer/re_renderer/src/context_test.rs
+++ b/crates/viewer/re_renderer/src/context_test.rs
@@ -50,9 +50,9 @@ impl RenderContext {
         self.device
             .poll(wgpu::PollType::Wait {
                 submission_index: None,
-                // More than 1 second seems crazy for GPU workloads in tests.
-                // Windows will reset driver at 2 seconds.
-                timeout: Some(std::time::Duration::from_secs(1)),
+                // Native Windows driver will reset driver at 2 seconds.
+                // But lavapipe sometimes takes a bit longer.
+                timeout: Some(std::time::Duration::from_secs(10)),
             })
             .expect("Failed to wait for GPU work to finish");
 

--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -326,8 +326,7 @@ impl DeviceCaps {
             label: Some("re_renderer device"),
             required_features: self.tier.features(),
             required_limits: self.limits(),
-            memory_hints: Default::default(),
-            trace: wgpu::Trace::Off,
+            ..Default::default()
         }
     }
 }

--- a/crates/viewer/re_renderer_examples/framework.rs
+++ b/crates/viewer/re_renderer_examples/framework.rs
@@ -132,8 +132,7 @@ impl<E: Example + 'static> Application<E> {
                 label: None,
                 required_features: wgpu::Features::empty(),
                 required_limits: device_caps.limits(),
-                memory_hints: Default::default(),
-                trace: wgpu::Trace::Off,
+                ..Default::default()
             })
             .await
             .context("failed to create device")?;


### PR DESCRIPTION
Allows us to remove some very dreaded `unsafe` code \o/

Went on a rabbit-hole trip to use the fancy new `map_buffer_on_submit` methods. But it's actually really hard to do so because by design, our read/write belts can use a single chunk (==buffer) on multiple command encoders. Therefore, it's really hard to know which command encoder is the one that you call `map_buffer_on_submit` on.
I noted down my learnings in the code comments, hopefully that prevents future generations to get confused by this.


Testing
* [x] Windows native
* [ ] Linux native
* [x] Mac native
* [x] WebGL
* [x] WebGPU