### PR TITLE
`rerun auth token`: print newline

### DIFF
--- a/crates/utils/re_auth/src/cli.rs
+++ b/crates/utils/re_auth/src/cli.rs
@@ -63,6 +63,7 @@ struct NoCredentialsError;
 #[error("Your credentials are expired, run `rerun auth login` first")]
 struct ExpiredCredentialsError;
 
+/// Prints the token to stdout
 pub async fn token(context: &AuthContext) -> Result<(), Error> {
     let mut credentials = match workos::Credentials::load() {
         Ok(Some(credentials)) => credentials,
@@ -88,9 +89,7 @@ pub async fn token(context: &AuthContext) -> Result<(), Error> {
         unreachable!("bug: no access token after refresh");
     };
 
-    use std::io::Write as _;
-    let mut stdout = std::io::stdout();
-    write!(stdout, "{}", token.as_str()).ok();
+    println!("{}", token.as_str());
 
     Ok(())
 }


### PR DESCRIPTION
Previously `rerun auth token` would not print a newline, which made it hard to accurately copy the token.
In my case, I got an extra `%` suffix on the token. The viewer didn't complain about it, but the server did.