### PR TITLE
Add grpc endpoint for layer table and cleanup helper objects

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -77,6 +77,21 @@ service RerunCloudService {
   // This endpoint requires the standard dataset headers.
   rpc ScanPartitionTable(ScanPartitionTableRequest) returns (stream ScanPartitionTableResponse) {}
 
+  // Returns the schema of the layer table.
+  //
+  // To inspect the data of the partition table, which is guaranteed to match the schema returned by
+  // this endpoint, check out `ScanLayerTable`.
+  //
+  // This endpoint requires the standard dataset headers.
+  rpc GetLayerTableSchema(GetLayerTableSchemaRequest) returns (GetLayerTableSchemaResponse) {}
+
+  // Inspect the contents of the layer table.
+  //
+  // The data will follow the schema returned by `GetLayerTableSchema`.
+  //
+  // This endpoint requires the standard dataset headers.
+  rpc ScanLayerTable(ScanLayerTableRequest) returns (stream ScanLayerTableResponse) {}
+
   // Returns the schema of the dataset.
   //
   // This is the union of all the schemas from all the underlying partitions. It will contain all the indexes,
@@ -268,6 +283,29 @@ message ScanPartitionTableRequest {
 
 message ScanPartitionTableResponse {
   // Partitions metadata as arrow RecordBatch
+  rerun.common.v1alpha1.DataframePart data = 1;
+}
+
+message GetLayerTableSchemaRequest {
+  reserved "dataset_id";
+}
+
+message GetLayerTableSchemaResponse {
+  rerun.common.v1alpha1.Schema schema = 1;
+}
+
+message ScanLayerTableRequest {
+  // A list of column names to be projected server-side.
+  //
+  // All of them if left empty.
+  repeated string columns = 3;
+
+  reserved "dataset_id";
+  reserved "scan_parameters";
+}
+
+message ScanLayerTableResponse {
+  // Layer metadata as arrow RecordBatch
   rerun.common.v1alpha1.DataframePart data = 1;
 }
 

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -197,6 +197,67 @@ impl ::prost::Name for ScanPartitionTableResponse {
     }
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct GetLayerTableSchemaRequest {}
+impl ::prost::Name for GetLayerTableSchemaRequest {
+    const NAME: &'static str = "GetLayerTableSchemaRequest";
+    const PACKAGE: &'static str = "rerun.cloud.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.cloud.v1alpha1.GetLayerTableSchemaRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.cloud.v1alpha1.GetLayerTableSchemaRequest".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetLayerTableSchemaResponse {
+    #[prost(message, optional, tag = "1")]
+    pub schema: ::core::option::Option<super::super::common::v1alpha1::Schema>,
+}
+impl ::prost::Name for GetLayerTableSchemaResponse {
+    const NAME: &'static str = "GetLayerTableSchemaResponse";
+    const PACKAGE: &'static str = "rerun.cloud.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.cloud.v1alpha1.GetLayerTableSchemaResponse".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.cloud.v1alpha1.GetLayerTableSchemaResponse".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ScanLayerTableRequest {
+    /// A list of column names to be projected server-side.
+    ///
+    /// All of them if left empty.
+    #[prost(string, repeated, tag = "3")]
+    pub columns: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+impl ::prost::Name for ScanLayerTableRequest {
+    const NAME: &'static str = "ScanLayerTableRequest";
+    const PACKAGE: &'static str = "rerun.cloud.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.cloud.v1alpha1.ScanLayerTableRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.cloud.v1alpha1.ScanLayerTableRequest".into()
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ScanLayerTableResponse {
+    /// Layer metadata as arrow RecordBatch
+    #[prost(message, optional, tag = "1")]
+    pub data: ::core::option::Option<super::super::common::v1alpha1::DataframePart>,
+}
+impl ::prost::Name for ScanLayerTableResponse {
+    const NAME: &'static str = "ScanLayerTableResponse";
+    const PACKAGE: &'static str = "rerun.cloud.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "rerun.cloud.v1alpha1.ScanLayerTableResponse".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "/rerun.cloud.v1alpha1.ScanLayerTableResponse".into()
+    }
+}
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct GetDatasetSchemaRequest {}
 impl ::prost::Name for GetDatasetSchemaRequest {
     const NAME: &'static str = "GetDatasetSchemaRequest";
@@ -2031,6 +2092,57 @@ pub mod rerun_cloud_service_client {
             ));
             self.inner.server_streaming(req, path, codec).await
         }
+        /// Returns the schema of the layer table.
+        ///
+        /// To inspect the data of the partition table, which is guaranteed to match the schema returned by
+        /// this endpoint, check out `ScanLayerTable`.
+        ///
+        /// This endpoint requires the standard dataset headers.
+        pub async fn get_layer_table_schema(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetLayerTableSchemaRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetLayerTableSchemaResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.cloud.v1alpha1.RerunCloudService/GetLayerTableSchema",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.cloud.v1alpha1.RerunCloudService",
+                "GetLayerTableSchema",
+            ));
+            self.inner.unary(req, path, codec).await
+        }
+        /// Inspect the contents of the layer table.
+        ///
+        /// The data will follow the schema returned by `GetLayerTableSchema`.
+        ///
+        /// This endpoint requires the standard dataset headers.
+        pub async fn scan_layer_table(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ScanLayerTableRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::ScanLayerTableResponse>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.cloud.v1alpha1.RerunCloudService/ScanLayerTable",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.cloud.v1alpha1.RerunCloudService",
+                "ScanLayerTable",
+            ));
+            self.inner.server_streaming(req, path, codec).await
+        }
         /// Returns the schema of the dataset.
         ///
         /// This is the union of all the schemas from all the underlying partitions. It will contain all the indexes,
@@ -2456,6 +2568,30 @@ pub mod rerun_cloud_service_server {
             &self,
             request: tonic::Request<super::ScanPartitionTableRequest>,
         ) -> std::result::Result<tonic::Response<Self::ScanPartitionTableStream>, tonic::Status>;
+        /// Returns the schema of the layer table.
+        ///
+        /// To inspect the data of the partition table, which is guaranteed to match the schema returned by
+        /// this endpoint, check out `ScanLayerTable`.
+        ///
+        /// This endpoint requires the standard dataset headers.
+        async fn get_layer_table_schema(
+            &self,
+            request: tonic::Request<super::GetLayerTableSchemaRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetLayerTableSchemaResponse>, tonic::Status>;
+        /// Server streaming response type for the ScanLayerTable method.
+        type ScanLayerTableStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::ScanLayerTableResponse, tonic::Status>,
+            > + std::marker::Send
+            + 'static;
+        /// Inspect the contents of the layer table.
+        ///
+        /// The data will follow the schema returned by `GetLayerTableSchema`.
+        ///
+        /// This endpoint requires the standard dataset headers.
+        async fn scan_layer_table(
+            &self,
+            request: tonic::Request<super::ScanLayerTableRequest>,
+        ) -> std::result::Result<tonic::Response<Self::ScanLayerTableStream>, tonic::Status>;
         /// Returns the schema of the dataset.
         ///
         /// This is the union of all the schemas from all the underlying partitions. It will contain all the indexes,
@@ -3175,6 +3311,93 @@ pub mod rerun_cloud_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ScanPartitionTableSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.cloud.v1alpha1.RerunCloudService/GetLayerTableSchema" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetLayerTableSchemaSvc<T: RerunCloudService>(pub Arc<T>);
+                    impl<T: RerunCloudService>
+                        tonic::server::UnaryService<super::GetLayerTableSchemaRequest>
+                        for GetLayerTableSchemaSvc<T>
+                    {
+                        type Response = super::GetLayerTableSchemaResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetLayerTableSchemaRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as RerunCloudService>::get_layer_table_schema(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetLayerTableSchemaSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.cloud.v1alpha1.RerunCloudService/ScanLayerTable" => {
+                    #[allow(non_camel_case_types)]
+                    struct ScanLayerTableSvc<T: RerunCloudService>(pub Arc<T>);
+                    impl<T: RerunCloudService>
+                        tonic::server::ServerStreamingService<super::ScanLayerTableRequest>
+                        for ScanLayerTableSvc<T>
+                    {
+                        type Response = super::ScanLayerTableResponse;
+                        type ResponseStream = T::ScanLayerTableStream;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ScanLayerTableRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as RerunCloudService>::scan_layer_table(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = ScanLayerTableSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/store/re_server/src/rerun_cloud.rs
+++ b/crates/store/re_server/src/rerun_cloud.rs
@@ -10,12 +10,15 @@ use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use datafusion::prelude::SessionContext;
 use nohash_hasher::IntSet;
 use tokio_stream::StreamExt as _;
-use tonic::{Code, Status};
+use tonic::{Code, Request, Response, Status};
 
 use re_byte_size::SizeBytes as _;
 use re_chunk_store::{Chunk, ChunkStore, ChunkStoreConfig, ChunkStoreHandle};
 use re_log_encoding::codec::wire::{decoder::Decode as _, encoder::Encode as _};
 use re_log_types::{EntityPath, EntryId, StoreId, StoreKind};
+use re_protos::cloud::v1alpha1::{
+    GetLayerTableSchemaRequest, GetLayerTableSchemaResponse, ScanLayerTableRequest,
+};
 use re_protos::{
     cloud::v1alpha1::{
         DeleteEntryResponse, EntryDetails, EntryKind, FetchTaskOutputRequest,
@@ -165,6 +168,7 @@ decl_stream!(FetchChunksResponseStream<manifest:FetchChunksResponse>);
 decl_stream!(GetChunksResponseStream<manifest:GetChunksResponse>);
 decl_stream!(QueryDatasetResponseStream<manifest:QueryDatasetResponse>);
 decl_stream!(ScanPartitionTableResponseStream<manifest:ScanPartitionTableResponse>);
+decl_stream!(ScanLayerTableResponseStream<manifest:ScanLayerTableResponse>);
 decl_stream!(SearchDatasetResponseStream<manifest:SearchDatasetResponse>);
 decl_stream!(ScanTableResponseStream<rerun_cloud:ScanTableResponse>);
 decl_stream!(QueryTasksOnCompletionResponseStream<tasks:QueryTasksOnCompletionResponse>);
@@ -663,6 +667,28 @@ impl RerunCloudService for RerunCloudHandler {
 
         Ok(tonic::Response::new(
             Box::pin(stream) as Self::ScanPartitionTableStream
+        ))
+    }
+
+    type ScanLayerTableStream = ScanLayerTableResponseStream;
+
+    async fn get_layer_table_schema(
+        &self,
+        _request: Request<GetLayerTableSchemaRequest>,
+    ) -> Result<Response<GetLayerTableSchemaResponse>, Status> {
+        //TODO(RR-2482)
+        Err(tonic::Status::unimplemented(
+            "get_layer_table_schema not implemented",
+        ))
+    }
+
+    async fn scan_layer_table(
+        &self,
+        _request: Request<ScanLayerTableRequest>,
+    ) -> Result<Response<Self::ScanLayerTableStream>, Status> {
+        //TODO(RR-2482)
+        Err(tonic::Status::unimplemented(
+            "scan_layer_table not implemented",
         ))
     }
 

--- a/crates/store/re_server/src/store.rs
+++ b/crates/store/re_server/src/store.rs
@@ -16,6 +16,7 @@ use itertools::Itertools as _;
 use jiff::Timestamp;
 use lance::datafusion::LanceTableProvider;
 
+use re_byte_size::SizeBytes as _;
 use re_chunk_store::{ChunkStore, ChunkStoreConfig, ChunkStoreHandle};
 use re_log_types::{EntryId, StoreKind};
 use re_protos::{
@@ -131,34 +132,34 @@ impl Dataset {
     }
 
     pub fn partition_table(&self) -> arrow::error::Result<RecordBatch> {
-        let (partition_ids, registration_times): (Vec<_>, Vec<_>) = self
-            .partitions
-            .iter()
-            .map(|(store_id, partition)| {
-                (
-                    store_id.to_string(),
-                    partition.registration_time.as_nanosecond() as i64,
-                )
-            })
-            .unzip();
+        let (partition_ids, last_updated_at, num_chunks, size_bytes): (
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+            Vec<_>,
+        ) = itertools::multiunzip(self.partitions.iter().map(|(store_id, partition)| {
+            let store = partition.store_handle.read();
+            let size_bytes: u64 = store
+                .iter_chunks()
+                .map(|chunk| chunk.heap_size_bytes())
+                .sum();
 
-        let partition_types = vec!["rrd".to_owned(); partition_ids.len()];
+            (
+                store_id.to_string(),
+                partition.registration_time.as_nanosecond() as i64,
+                store.num_chunks() as u64,
+                size_bytes,
+            )
+        }));
 
-        let storage_urls = partition_ids
-            .iter()
-            .map(|partition_id| format!("memory:///{}/{partition_id}", self.id))
-            .collect();
-
-        let partition_manifest_updated_ats = vec![None; partition_ids.len()];
-        let partition_manifest_urls = vec![None; partition_ids.len()];
+        let layers = vec![vec!["base".to_owned()]; partition_ids.len()];
 
         ScanPartitionTableResponse::create_dataframe(
             partition_ids,
-            partition_types,
-            storage_urls,
-            registration_times,
-            partition_manifest_updated_ats,
-            partition_manifest_urls,
+            layers,
+            last_updated_at,
+            num_chunks,
+            size_bytes,
         )
     }
 


### PR DESCRIPTION
### Related

* part of https://linear.app/rerun/project/demo-ready-oss-server-for-data-transformation-pipelines-d0a110693312/
* part of https://linear.app/rerun/issue/RR-2532/pr-tracking-demo-read-oss-server-for-data-transformation-pipelines
* part of https://linear.app/rerun/issue/RR-2476/remove-layer-specific-columns-from-the-partition-table-and-introduce-a
* sibling of TODO

### What

Introduces new grpc endpoint for layer table:
```
rpc GetLayerTableSchema(GetLayerTableSchemaRequest) returns (GetLayerTableSchemaResponse) {}
rpc ScanLayerTable(ScanLayerTableRequest) returns (stream ScanLayerTableResponse) {}
```

- [x] add new grpc endpoints to proto
- [x] update `ext` utilities
- [x] fix OSS server
- [ ] update `ConnectionClient`
- [ ] update Python SDK API
