### PR TITLE
Merge `DroppableEncoder` and `Encoder` into a single facility

### DIFF
--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -329,7 +329,7 @@ impl RetryableFileReader {
 #[cfg(test)]
 mod tests {
     use re_chunk::RowId;
-    use re_log_encoding::encoder::DroppableEncoder;
+    use re_log_encoding::encoder::Encoder;
     use re_log_types::{LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource};
 
     use super::*;
@@ -358,7 +358,7 @@ mod tests {
             .open(rrd_file_path.to_str().unwrap())
             .unwrap();
 
-        let mut encoder = DroppableEncoder::new(
+        let mut encoder = Encoder::new(
             re_build_info::CrateVersion::LOCAL,
             re_log_encoding::EncodingOptions::PROTOBUF_UNCOMPRESSED,
             rrd_file,

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -485,7 +485,7 @@ mod tests {
     use super::*;
     use crate::Compression;
     use crate::codec::arrow::encode_arrow;
-    use crate::encoder::DroppableEncoder;
+    use crate::encoder::Encoder;
 
     pub fn fake_log_messages() -> Vec<LogMsg> {
         let store_id = StoreId::random(StoreKind::Blueprint, "test_app");
@@ -676,7 +676,7 @@ mod tests {
         for options in options {
             let mut file = vec![];
 
-            let mut encoder = DroppableEncoder::new(rrd_version, options, &mut file).unwrap();
+            let mut encoder = Encoder::new(rrd_version, options, &mut file).unwrap();
             for message in messages.clone() {
                 encoder
                     .append_proto(message)
@@ -735,7 +735,7 @@ mod tests {
         for options in options {
             let mut file = vec![];
 
-            let mut encoder = DroppableEncoder::new(rrd_version, options, &mut file).unwrap();
+            let mut encoder = Encoder::new(rrd_version, options, &mut file).unwrap();
             for message in out_of_order_messages.clone() {
                 encoder
                     .append_proto(message)
@@ -824,23 +824,28 @@ mod tests {
             let messages = fake_log_messages();
 
             // (2 encoders as each encoder writes a file header)
-            let writer = std::io::Cursor::new(&mut data);
-            let mut encoder1 =
-                crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
-            for message in &messages {
-                encoder1.append(message).unwrap();
+            {
+                let writer = std::io::Cursor::new(&mut data);
+                let mut encoder1 =
+                    crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+                for message in &messages {
+                    encoder1.append(message).unwrap();
+                }
+                encoder1.finish().unwrap();
             }
-            encoder1.finish().unwrap();
 
             let written = data.len() as u64;
-            let mut writer = std::io::Cursor::new(&mut data);
-            writer.set_position(written);
-            let mut encoder2 =
-                crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
-            for message in &messages {
-                encoder2.append(message).unwrap();
+
+            {
+                let mut writer = std::io::Cursor::new(&mut data);
+                writer.set_position(written);
+                let mut encoder2 =
+                    crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+                for message in &messages {
+                    encoder2.append(message).unwrap();
+                }
+                encoder2.finish().unwrap();
             }
-            encoder2.finish().unwrap();
 
             let decoder =
                 Decoder::new_concatenated(std::io::BufReader::new(data.as_slice())).unwrap();

--- a/crates/store/re_log_encoding/src/decoder/stream.rs
+++ b/crates/store/re_log_encoding/src/decoder/stream.rs
@@ -330,15 +330,14 @@ mod tests {
     fn test_data(options: EncodingOptions, n: usize) -> (Vec<LogMsg>, Vec<u8>) {
         let messages: Vec<_> = (0..n).map(|_| fake_log_msg()).collect();
 
-        let mut buffer = Vec::new();
-        let mut encoder = Encoder::new(CrateVersion::LOCAL, options, &mut buffer).unwrap();
+        let mut encoder = Encoder::new(CrateVersion::LOCAL, options, vec![]).unwrap();
         for message in &messages {
             encoder.append(message).unwrap();
         }
 
         encoder.finish().unwrap();
 
-        (messages, buffer)
+        (messages, encoder.into_inner().unwrap())
     }
 
     macro_rules! assert_message_ok {

--- a/crates/store/re_log_encoding/src/encoder.rs
+++ b/crates/store/re_log_encoding/src/encoder.rs
@@ -1,14 +1,15 @@
 //! Encoding of [`LogMsg`]es as a binary stream, e.g. to store in an `.rrd` file, or send over network.
 
+use re_build_info::CrateVersion;
+use re_chunk::{ChunkError, ChunkResult};
+use re_log_types::LogMsg;
+use re_protos::log_msg::v1alpha1::LogMsg as LogMsgProto;
+
 use crate::FileHeader;
 use crate::Serializer;
 use crate::codec;
 use crate::codec::file::{self, encoder};
 use crate::{Compression, EncodingOptions};
-use re_build_info::CrateVersion;
-use re_chunk::{ChunkError, ChunkResult};
-use re_log_types::LogMsg;
-use re_protos::log_msg::v1alpha1::LogMsg as LogMsgProto;
 
 // ----------------------------------------------------------------------------
 
@@ -49,23 +50,6 @@ impl From<ChunkError> for EncodeError {
     fn from(err: ChunkError) -> Self {
         Self::Chunk(Box::new(err))
     }
-}
-
-// ----------------------------------------------------------------------------
-
-pub fn encode_to_bytes<'a>(
-    version: CrateVersion,
-    options: EncodingOptions,
-    msgs: impl IntoIterator<Item = &'a LogMsg>,
-) -> Result<Vec<u8>, EncodeError> {
-    let mut bytes: Vec<u8> = vec![];
-    {
-        let mut encoder = Encoder::new(version, options, std::io::Cursor::new(&mut bytes))?;
-        for msg in msgs {
-            encoder.append(msg)?;
-        }
-    }
-    Ok(bytes)
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/store/re_log_encoding/src/file_sink.rs
+++ b/crates/store/re_log_encoding/src/file_sink.rs
@@ -95,7 +95,7 @@ impl FileSink {
 
         let file = std::fs::File::create(&path)
             .map_err(|err| FileSinkError::CreateFile(path.clone(), err))?;
-        let encoder = crate::encoder::DroppableEncoder::new(
+        let encoder = crate::encoder::Encoder::new(
             re_build_info::CrateVersion::LOCAL,
             encoding_options,
             file,
@@ -117,7 +117,7 @@ impl FileSink {
 
         re_log::debug!("Writing to stdout…");
 
-        let encoder = crate::encoder::DroppableEncoder::new(
+        let encoder = crate::encoder::Encoder::new(
             re_build_info::CrateVersion::LOCAL,
             encoding_options,
             std::io::stdout(),
@@ -158,7 +158,7 @@ impl FileSink {
 /// Set `filepath` to `None` to stream to standard output.
 fn spawn_and_stream<W: std::io::Write + Send + 'static>(
     filepath: Option<&std::path::Path>,
-    mut encoder: crate::encoder::DroppableEncoder<W>,
+    mut encoder: crate::encoder::Encoder<W>,
     rx: Receiver<Option<Command>>,
 ) -> Result<std::thread::JoinHandle<()>, FileSinkError> {
     let (name, target) = if let Some(filepath) = filepath {

--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -451,7 +451,7 @@ impl MemorySinkStorage {
 
         encoder.finish()?;
 
-        Ok(encoder.into_inner())
+        encoder.into_inner()
     }
 
     /// Drain the stored messages and return them as an in-memory RRD.

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -1347,7 +1347,7 @@ fn stream_to_rrd_on_disk(
     let encoding_options = re_log_encoding::EncodingOptions::PROTOBUF_COMPRESSED;
     let file =
         std::fs::File::create(path).map_err(|err| FileSinkError::CreateFile(path.clone(), err))?;
-    let mut encoder = re_log_encoding::encoder::DroppableEncoder::new(
+    let mut encoder = re_log_encoding::encoder::Encoder::new(
         re_build_info::CrateVersion::LOCAL,
         encoding_options,
         file,

--- a/crates/top/rerun/src/commands/mcap/mod.rs
+++ b/crates/top/rerun/src/commands/mcap/mod.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, fs::File, io::BufWriter, sync::mpsc::Receiver};
 
 use clap::Subcommand;
-use re_log_encoding::encoder::DroppableEncoder;
+use re_log_encoding::encoder::Encoder;
 use re_log_types::{LogMsg, RecordingId};
 use re_mcap::{LayerIdentifier, SelectedLayers};
 use re_sdk::{
@@ -132,7 +132,7 @@ fn process_mcap<W: std::io::Write>(
     let mut topics = BTreeSet::new();
     let options = re_log_encoding::EncodingOptions::PROTOBUF_COMPRESSED;
     let version = re_build_info::CrateVersion::LOCAL;
-    let mut encoder = DroppableEncoder::new(version, options, writer)?;
+    let mut encoder = Encoder::new(version, options, writer)?;
 
     while let Ok(res) = receiver.recv() {
         num_total_msgs += 1;

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -87,7 +87,7 @@ impl FilterCommand {
                     // TODO(cmc): encoding options & version should match the original.
                     let version = CrateVersion::LOCAL;
                     let options = re_log_encoding::EncodingOptions::PROTOBUF_COMPRESSED;
-                    re_log_encoding::encoder::DroppableEncoder::new(version, options, &mut rrd_out)
+                    re_log_encoding::encoder::Encoder::new(version, options, &mut rrd_out)
                         .context("couldn't init encoder")?
                 };
 

--- a/crates/top/rerun/src/commands/rrd/route.rs
+++ b/crates/top/rerun/src/commands/rrd/route.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::BufWriter};
 
 use crossbeam::channel::Receiver;
-use re_log_encoding::encoder::DroppableEncoder;
+use re_log_encoding::encoder::Encoder;
 use re_protos::{
     common::v1alpha1::ApplicationId,
     log_msg::v1alpha1::{
@@ -108,7 +108,7 @@ fn process_messages<W: std::io::Write>(
     // TODO(grtlr): encoding should match the original (just like in `rrd stats`).
     let options = re_log_encoding::EncodingOptions::PROTOBUF_COMPRESSED;
     let version = re_build_info::CrateVersion::LOCAL;
-    let mut encoder = DroppableEncoder::new(version, options, writer)?;
+    let mut encoder = Encoder::new(version, options, writer)?;
 
     while let Ok((_input, res)) = receiver.recv() {
         let mut is_success = true;


### PR DESCRIPTION
Our RRD encoding facilities are currently implemented by two distinct types: `DroppableEncoder` & `Encoder`.

This makes understanding how to use the API unnecessarily painful. Turns out the only reason things are done this way is because of an implementation detail related to the `Drop` implementation.
Instead of passing off that complexity to end-users of the API, we now contain it to the implementation instead.

In addition to that, the `AlreadyFinished` logic was broken, so fix too while we're at it.

---

This PR is part of an upcoming series of PRs to pay off organic growth debt in our encoding/decoding stack.