### PR TITLE
`StreamDecoder`: lift naming confusion regarding chunks

### DIFF
--- a/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
+++ b/crates/store/re_log_encoding/src/stream_rrd_from_http.rs
@@ -100,7 +100,7 @@ pub fn stream_rrd_from_http(url: String, on_msg: Arc<HttpMessageCallback>) {
                     }
 
                     re_tracing::profile_scope!("decoding_rrd_stream");
-                    decoder.borrow_mut().push_chunk(chunk);
+                    decoder.borrow_mut().push_byte_chunk(chunk);
                     loop {
                         match decoder.borrow_mut().try_read() {
                             Ok(message) => match message {


### PR DESCRIPTION
This is just a pure renaming pass.

`StreamDecoder`'s job is to deal with chunks of bytes, and it used to call those `chunks`. This was extremely confusing to me when trying to understand the code, since _chunk_ is such an overloaded term for us.
This PR just makes it as clear as possible that this is about _byte chunks_, not _Rerun chunks_.

---

This PR is part of an upcoming series of PRs to pay off organic growth debt in our encoding/decoding stack.

* DNM: requires #11450