### PR TITLE
Do not include metadata when rendering table in html

### DIFF
--- a/rerun_py/src/catalog/dataframe_rendering.rs
+++ b/rerun_py/src/catalog/dataframe_rendering.rs
@@ -115,7 +115,10 @@ impl PyRerunHtmlTable {
         has_more: bool,
         table_uuid: &str,
     ) -> PyResult<String> {
-        let batch_opts = RecordBatchFormatOpts::default();
+        let batch_opts = RecordBatchFormatOpts {
+            include_metadata: false,
+            ..Default::default()
+        };
 
         let tables = batches
             .into_iter()


### PR DESCRIPTION
### Related

* Closes RR-2226

### What

This change updates the HTML rendering of record batches (e.g., when displayed in notebooks) to omit metadata from the formatted output.

This avoids situations like this:
<img width="715" height="344" alt="image" src="https://github.com/user-attachments/assets/01dd8eb9-4b26-4dab-867c-4eaa1338bc69" />

which now ends up looking like this:

<img width="757" height="191" alt="image" src="https://github.com/user-attachments/assets/d7c72289-25c0-4462-9582-d5ada6bd0e5f" />
