### PR TITLE
Add documentation section on `ros2_reflection`

### DIFF
--- a/docs/content/getting-started/mcap.md
+++ b/docs/content/getting-started/mcap.md
@@ -55,6 +55,7 @@ Each layer extracts different types of information from the MCAP source and each
 - **`stats`**: Extracts file-level metrics like message counts, time ranges, and channel statistics
 - **`protobuf`**: Automatically decodes protobuf-encoded messages using reflection
 - **`ros2msg`**: Provides semantic conversion of common ROS2 message types into Rerun's visualization components
+- **`ros2_reflection`**: Automatically decodes ROS2 messages using reflection
 - **`recording_info`**: Extracts recording metadata such as message counts, start time, and session information
 
 By default, Rerun analyzes an MCAP file to determine which layers are active to provide the most comprehensive view of your data, while avoiding duplication.

--- a/docs/content/reference/mcap/message-formats.md
+++ b/docs/content/reference/mcap/message-formats.md
@@ -29,6 +29,10 @@ The following are known limitations and link to the corresponding GitHub issues.
 <!-- TODO(#11174) -->
 - [Cannot express transforms defined via `tf` messages](https://github.com/rerun-io/rerun/issues/11174)
 
+## ROS2 reflection
+
+The `ros2_reflection` layer automatically decodes ROS2 messages using runtime reflection for message types that are not supported by the semantic `ros2msg` layer. Fields become queryable components in the dataframe view and selection panel, but no automatic visualizations are created.
+
 ## ROS1 message types
 
 ROS1 messages are not currently supported for semantic interpretation through any layer.


### PR DESCRIPTION
### Related

* #11367

### What

Adds a section on the new `ros2_reflection` layer to the mcap docs page.
