### PR TITLE
Disable toast when copying component path

### DIFF
--- a/crates/viewer/re_viewer_context/src/item_collection.rs
+++ b/crates/viewer/re_viewer_context/src/item_collection.rs
@@ -210,7 +210,6 @@ impl ItemCollection {
             AppId,
             StoreId,
             EntityPath,
-            Component,
         }
 
         #[expect(clippy::match_same_arms)]
@@ -218,6 +217,8 @@ impl ItemCollection {
             .iter()
             .filter_map(|(item, _)| match item {
                 Item::Container(_) => None,
+                // TODO(gijsd): These are copyable, but we're currently unable to display a meaningful toast.
+                Item::ComponentPath(_) => None,
                 Item::View(_) => None,
                 // TODO(lucasmerlin): Should these be copyable as URLs?
                 Item::RedapServer(_) => None,
@@ -254,10 +255,6 @@ impl ItemCollection {
                     ClipboardTextDesc::EntityPath,
                     instance_path.entity_path.to_string(),
                 )),
-                Item::ComponentPath(component_path) => Some((
-                    ClipboardTextDesc::Component,
-                    component_path.component.to_string(),
-                )),
             })
             .chunk_by(|(desc, _)| *desc);
 
@@ -273,7 +270,6 @@ impl ItemCollection {
                 ClipboardTextDesc::AppId => "app id",
                 ClipboardTextDesc::StoreId => "store id",
                 ClipboardTextDesc::EntityPath => "entity path",
-                ClipboardTextDesc::Component => "component",
             };
             if !content_description.is_empty() {
                 content_description.push_str(", ");


### PR DESCRIPTION
### Related

* Part of RR-2629

### What

Removes the notification that pops up when copying a component path.

Originally the toast said: 
```
Copied entity path to clipboard: /__properties
```

<img width="642" height="144" alt="2025-10-10_14-32-12@2x" src="https://github.com/user-attachments/assets/5f0297ee-b914-43f5-bebb-ecf67af38808" />