### PR TITLE
Fix flaky datafusion test

### DIFF
--- a/rerun_py/tests/unit/test_datafusion_tables.py
+++ b/rerun_py/tests/unit/test_datafusion_tables.py
@@ -331,10 +331,10 @@ def test_query_lance_table(server_instance: ServerInstance) -> None:
     assert len(entries) == 4
 
     tables = client.tables()
-    assert tables.collect()[0].num_rows == 3
+    assert pa.Table.from_batches(tables.collect()).num_rows == 4
 
-    table = client.get_table(name=expected_table_name)
-    assert table.collect()[0].num_rows > 0
+    client.get_table(name=expected_table_name)
+    assert pa.Table.from_batches(tables.collect()).num_rows > 0
 
     entry = client.get_table_entry(name=expected_table_name)
     assert entry.name == expected_table_name
@@ -376,19 +376,19 @@ def test_datafusion_catalog_get_tables(server_instance: ServerInstance) -> None:
 
     # Get by table name since it should be in the default catalog/schema
     df = ctx.table("simple_datatypes")
-    rb = df.collect()[0]
+    rb = pa.Table.from_batches(df.collect())
     assert rb.num_rows > 0
 
     # Get table by fully qualified name
     df = ctx.table("datafusion.public.simple_datatypes")
-    rb = df.collect()[0]
+    rb = pa.Table.from_batches(df.collect())
     assert rb.num_rows > 0
 
     # Verify SQL parsing for catalog provider works as expected
     df = ctx.sql("SELECT * FROM simple_datatypes")
-    rb = df.collect()[0]
+    rb = pa.Table.from_batches(df.collect())
     assert rb.num_rows > 0
 
     df = ctx.sql("SELECT * FROM datafusion.public.simple_datatypes")
-    rb = df.collect()[0]
+    rb = pa.Table.from_batches(df.collect())
     assert rb.num_rows > 0


### PR DESCRIPTION
Fix a flaky test due to the fact that OSS server's `__entries` table can have multiple record batches.