### PR TITLE
Use public re-export of `EncodingOptions`

### DIFF
--- a/crates/store/re_log_encoding/src/decoder/streaming.rs
+++ b/crates/store/re_log_encoding/src/decoder/streaming.rs
@@ -9,8 +9,7 @@ use re_chunk::Span;
 use re_log::external::log::warn;
 
 use crate::{
-    EncodingOptions,
-    codec::file::{FileHeader, MessageHeader, MessageKind},
+    codec::file::{EncodingOptions, FileHeader, MessageHeader, MessageKind},
     decoder::DecodeError,
 };
 


### PR DESCRIPTION
### What

Uses the public re-export of `EncodingOptions`, to which isn't hidden behind a feature gate.