### PR TITLE
Update outdated links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,7 +253,7 @@ See respective readme files for more details.
 
 ## Tools
 
-We use the [`pixi`](https://prefix.dev/) for managing dev-tool versioning, download and task running. To see available tasks, use `pixi task list`.
+We use the [`pixi`](https://pixi.sh/) for managing dev-tool versioning, download and task running. To see available tasks, use `pixi task list`.
 
 We use [cargo deny](https://github.com/EmbarkStudios/cargo-deny) to check our dependency tree for copy-left licenses, duplicate dependencies and [rustsec advisories](https://rustsec.org/advisories). You can configure it in `deny.toml`. Usage: `cargo deny check`
 Configure your editor to run `cargo fmt` on save. Also configure it to strip trailing whitespace, and to end each file with a newline. Settings for VSCode can be found in the `.vscode` folder and should be applied automatically. If you are using another editor, consider adding good setting to this repository!

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 #
 # Type `pixi shell` to enter the pixi environment.
 #
-# https://prefix.dev/docs/pixi/overview
+# https://pixi.sh/latest/
 
 # We currently assume pixi version 0.34.0
 # You can check that your environment is correct by running:

--- a/rerun_cpp/arrow_cpp_install.md
+++ b/rerun_cpp/arrow_cpp_install.md
@@ -16,7 +16,7 @@ For more information about CMake config options see [C++ SDK CMake](cmake_setup_
 
 ## Install arrow-cpp with Pixi
 
-[Pixi](https://prefix.dev/docs/pixi/overview) is a convenient tool for managing cross-platform project dependencies. In
+[Pixi](https://pixi.sh/latest/) is a convenient tool for managing cross-platform project dependencies. In
 fact, Rerun uses it for our own internal development dependency management, and you will find `pixi.toml` files in most
 of our external examples.
 
@@ -41,7 +41,7 @@ Alternatively if you are already a `cargo` user, you can install `pixi` via:
 cargo install pixi
 ```
 
-See the [Pixi installation guide](https://prefix.dev/docs/pixi/overview#installation) for other installation options.
+See the [Pixi installation guide](https://pixi.sh/latest/installation/) for other installation options.
 
 ### Adding Pixi to your own project
 

--- a/rerun_py/README.md
+++ b/rerun_py/README.md
@@ -61,7 +61,7 @@ Note that SDK and Viewer can run on different machines!
 
 # Building Rerun from source
 
-We use the [`pixi`](https://prefix.dev/) for managing dev-tool versioning, download and task running. See [here](https://github.com/casey/just#installation) for installation instructions.
+We use the [`pixi`](https://pixi.sh/) for managing dev-tool versioning, download and task running. See [here](https://github.com/casey/just#installation) for installation instructions.
 
 ```sh
 pixi run py-build --release

--- a/scripts/ci/setup_software_rasterizer.py
+++ b/scripts/ci/setup_software_rasterizer.py
@@ -168,9 +168,9 @@ def setup_lavapipe_for_windows() -> dict[str, str]:
             print(f"Error listing Vulkan runtime directory: {e}")
 
     # On CI we run with elevated privileges, therefore VK_DRIVER_FILES is ignored.
-    # See: https://github.com/KhronosGroup/Vulkan-Loader/blob/sdk-1.3.261/docs/LoaderInterfaceArchitecture.md#elevated-privilege-caveats
+    # See: https://github.com/KhronosGroup/Vulkan-Loader/blob/vulkan-sdk-1.4.304/docs/LoaderInterfaceArchitecture.md#elevated-privilege-caveats
     # Therefore, we have to set one of the registry keys that is checked to find the driver.
-    # See: https://vulkan.lunarg.com/doc/view/1.3.243.0/windows/LoaderDriverInterface.html#user-content-driver-discovery-on-windows
+    # See: https://vulkan.lunarg.com/doc/view/1.4.304.1/windows/LoaderDriverInterface.html#driver-discovery-on-windows
 
     # Write registry keys to configure Vulkan drivers
     import winreg


### PR DESCRIPTION
### What

Updates several outdated links, notably: pixi docs: https://prefix.dev/ -> https://pixi.sh/