### PR TITLE
Use dynamically assigned port for test server

### DIFF
--- a/rerun_py/tests/unit/test_datafusion_tables.py
+++ b/rerun_py/tests/unit/test_datafusion_tables.py
@@ -140,8 +140,7 @@ def server_instance() -> Generator[ServerInstance, None, None]:
         f"second_schema.second_table={TABLE_FILEPATH}",
         "--table",
         f"alternate_catalog.third_schema.third_table={TABLE_FILEPATH}",
-        "--port",
-        str(port),
+        f"--port={port}",
     ]
     server_process = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 


### PR DESCRIPTION
### Related

* Fixes bug in #11393

### What

This passes the dynamically assigned port to the test server process.
