### PR TITLE
flatten error hierarchy a bit more

### DIFF
--- a/crates/viewer/re_redap_browser/src/entries.rs
+++ b/crates/viewer/re_redap_browser/src/entries.rs
@@ -137,10 +137,7 @@ async fn fetch_entries_and_register_tables(
     origin: re_uri::Origin,
     session_ctx: Arc<SessionContext>,
 ) -> EntryResult<HashMap<EntryId, Entry>> {
-    let mut client = connection_registry
-        .client(origin.clone())
-        .await
-        .map_err(|err| ApiError::client_connection(err, "failed establishing client connection"))?;
+    let mut client = connection_registry.client(origin.clone()).await?;
 
     let entries = client
         .find_entries(EntryFilter {

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -118,9 +118,7 @@ impl Server {
     fn server_ui(&self, viewer_ctx: &ViewerContext<'_>, ctx: &Context<'_>, ui: &mut egui::Ui) {
         if let Poll::Ready(Err(err)) = self.entries.state() {
             self.title_ui(self.origin.host.to_string(), ctx, ui, |ui| {
-                if let Some(conn_err) = err.as_client_connection_error()
-                    && conn_err.is_token_error()
-                {
+                if let Some(conn_err) = err.as_client_credentials_error() {
                     let message = if conn_err.is_missing_token() {
                         "This server requires a token to access its data."
                     } else {

--- a/rerun_py/src/catalog/errors.rs
+++ b/rerun_py/src/catalog/errors.rs
@@ -21,7 +21,7 @@ use pyo3::exceptions::{
     PyTimeoutError, PyValueError,
 };
 
-use re_redap_client::{ApiErrorKind, ClientConnectionError, ConnectionError};
+use re_redap_client::ApiErrorKind;
 
 // ---
 
@@ -30,12 +30,6 @@ use re_redap_client::{ApiErrorKind, ClientConnectionError, ConnectionError};
 #[derive(Debug, thiserror::Error)]
 #[expect(clippy::enum_variant_names)] // this is by design
 enum ExternalError {
-    #[error("{0}")]
-    ClientConnectionError(#[from] ClientConnectionError),
-
-    #[error("{0}")]
-    ConnectionError(#[from] ConnectionError),
-
     #[error("{0}")]
     TonicStatusError(Box<tonic::Status>),
 
@@ -108,12 +102,6 @@ impl_from_boxed!(re_protos::TypeConversionError, TypeConversionError);
 impl From<ExternalError> for PyErr {
     fn from(err: ExternalError) -> Self {
         match err {
-            ExternalError::ClientConnectionError(err) => {
-                PyConnectionError::new_err(err.to_string())
-            }
-
-            ExternalError::ConnectionError(err) => PyConnectionError::new_err(err.to_string()),
-
             ExternalError::TonicStatusError(status) => {
                 if status.code() == tonic::Code::DeadlineExceeded {
                     PyTimeoutError::new_err("Deadline expired before operation could complete")

--- a/tests/rust/re_integration_test/src/lib.rs
+++ b/tests/rust/re_integration_test/src/lib.rs
@@ -4,7 +4,7 @@ mod kittest_harness_ext;
 mod test_data;
 
 pub use kittest_harness_ext::HarnessExt;
-use re_redap_client::{ClientConnectionError, ConnectionClient, ConnectionRegistry};
+use re_redap_client::{ApiError, ConnectionClient, ConnectionRegistry};
 use re_server::ServerHandle;
 use re_uri::external::url::Host;
 use std::net::TcpListener;
@@ -45,7 +45,7 @@ impl TestServer {
         self.port
     }
 
-    pub async fn client(&self) -> Result<ConnectionClient, ClientConnectionError> {
+    pub async fn client(&self) -> Result<ConnectionClient, ApiError> {
         let origin = re_uri::Origin {
             host: Host::Domain("localhost".to_owned()),
             port: self.port,


### PR DESCRIPTION
### Related

- #11513

### What

This is a quick follow up to #11513. It removes some extra error wrapping and further simplifies code.

Specifically:
* `ClientConnectionError` becomes more simply `ClientCredentialsError`, with the only role of helping identify token errors. 
* `ConnectionError` is gone, we use `ApiError` directly.
