### PR TITLE
Ensure `Cargo.toml` is read as utf-8

### DIFF
--- a/rerun_py/tests/unit/test_version.py
+++ b/rerun_py/tests/unit/test_version.py
@@ -9,6 +9,7 @@ import tomli
 
 def test_version() -> None:
     cargo_toml_path = Path(__file__).parent.parent.parent.parent / "Cargo.toml"
+    # ensure Cargo.toml file is loaded as UTF-8 (this can fail on Windows otherwise)
     cargo_toml = tomli.loads(cargo_toml_path.read_text(encoding="utf-8"))
     assert rr.__version__ == cargo_toml["workspace"]["package"]["version"]
 


### PR DESCRIPTION
### What

This ensures the `Cargo.toml` file is read as a utf8 (This can fail on Windows).

e.g.
- https://github.com/rerun-io/rerun/actions/runs/18509381989/job/52749673656
- https://github.com/rerun-io/rerun/actions/runs/18484529203/job/52667372148
-https://github.com/rerun-io/rerun/actions/runs/18454318441/job/52574806149
