### PR TITLE
Remove needless windows-only image comparision thresholds

### DIFF
--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -2,7 +2,6 @@
 
 use egui::Vec2;
 
-use egui_kittest::{OsThreshold, SnapshotOptions};
 use re_blueprint_tree::BlueprintTree;
 use re_chunk_store::RowId;
 use re_chunk_store::external::re_chunk::ChunkBuilder;
@@ -209,12 +208,5 @@ fn run_blueprint_panel_and_save_snapshot(
         });
 
     harness.run();
-    harness.snapshot_options(
-        snapshot_name,
-        // @wumpf's Windows machine needs a bit of a higher threshold to pass this test due to discrepancies in text rendering.
-        // (Software Rasterizer on CI seems fine with the default).
-        &SnapshotOptions::new()
-            .threshold(OsThreshold::new(SnapshotOptions::default().threshold).windows(0.8))
-            .failed_pixel_count_threshold(OsThreshold::new(0).windows(15)),
-    );
+    harness.snapshot(snapshot_name);
 }

--- a/crates/viewer/re_blueprint_tree/tests/range_selection_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/range_selection_test.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "testing")]
 
 use egui::{Modifiers, Vec2};
-use egui_kittest::{OsThreshold, SnapshotOptions, kittest::Queryable as _};
+use egui_kittest::kittest::Queryable as _;
 use re_blueprint_tree::BlueprintTree;
 use re_chunk_store::RowId;
 use re_chunk_store::external::re_chunk::ChunkBuilder;
@@ -91,14 +91,7 @@ fn test_range_selection_in_blueprint_tree() {
 
     harness.run();
 
-    harness.snapshot_options(
-        "range_selection_in_blueprint_tree",
-        // @wumpf's Windows machine needs a bit of a higher threshold to pass this test due to discrepancies in text rendering.
-        // (Software Rasterizer on CI seems fine with the default).
-        &SnapshotOptions::new()
-            .threshold(OsThreshold::new(SnapshotOptions::default().threshold).windows(0.8))
-            .failed_pixel_count_threshold(OsThreshold::new(0).windows(10)),
-    );
+    harness.snapshot("range_selection_in_blueprint_tree");
 }
 
 fn add_point_to_chunk_builder(builder: ChunkBuilder) -> ChunkBuilder {

--- a/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
@@ -4,7 +4,7 @@
 #![cfg(feature = "testing")]
 
 use egui::Vec2;
-use egui_kittest::{OsThreshold, SnapshotError, SnapshotOptions};
+use egui_kittest::{SnapshotError, SnapshotOptions};
 use itertools::Itertools as _;
 
 use re_blueprint_tree::BlueprintTree;
@@ -213,17 +213,12 @@ fn run_test_case(test_case: &TestCase, filter_query: Option<&str>) -> Result<(),
 
     harness.run();
 
-    let options = SnapshotOptions::new()
-        .output_path(format!(
-            "tests/snapshots/view_structure_test/{}",
-            filter_query
-                .map(|query| format!("query-{}", query.replace(' ', ",").replace('/', "_")))
-                .unwrap_or("no-query".to_owned())
-        ))
-        // @wumpf's Windows machine needs a bit of a higher threshold to pass this test due to discrepancies in text rendering.
-        // (Software Rasterizer on CI seems fine with the default).
-        .threshold(OsThreshold::new(SnapshotOptions::default().threshold).windows(0.8))
-        .failed_pixel_count_threshold(OsThreshold::new(0).windows(15));
+    let options = SnapshotOptions::new().output_path(format!(
+        "tests/snapshots/view_structure_test/{}",
+        filter_query
+            .map(|query| format!("query-{}", query.replace(' ', ",").replace('/', "_")))
+            .unwrap_or("no-query".to_owned())
+    ));
 
     harness.try_snapshot_options(test_case.name, &options)
 }


### PR DESCRIPTION
recent advances in egui technology made it unnecessary
