### PR TITLE
trim whitespace before/after token

### DIFF
--- a/crates/utils/re_auth/src/service/server.rs
+++ b/crates/utils/re_auth/src/service/server.rs
@@ -40,7 +40,8 @@ impl TryFrom<&MetadataValue<Ascii>> for Jwt {
         let token = value.to_str().map_err(|_err| Error::MalformedToken)?;
         let token = token
             .strip_prefix(TOKEN_PREFIX)
-            .ok_or(Error::MalformedToken)?;
+            .ok_or(Error::MalformedToken)?
+            .trim();
         Ok(Self(token.to_owned()))
     }
 }


### PR DESCRIPTION
### Related

* Closes RR-2562

### What

ignore spaces/newlines accidentally apsted before/after the token

