### PR TITLE
Switch to newly received recordings even if `SetStoreInfo` message is missing

### DIFF
--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -2131,8 +2131,8 @@ impl App {
             );
         }
 
-        let msg_will_add_new_store = matches!(&msg, LogMsg::SetStoreInfo(..))
-            && !store_hub.store_bundle().contains(store_id);
+        // Note that the `SetStoreInfo` message might be missing. It's not strictly necessary to add a new store.
+        let msg_will_add_new_store = !store_hub.store_bundle().contains(store_id);
 
         let entity_db = store_hub.entity_db_mut(store_id);
         if entity_db.data_source.is_none() {
@@ -2169,53 +2169,14 @@ impl App {
             }
         }
 
-        let is_example = entity_db.store_class().is_example();
-
+        #[expect(clippy::match_same_arms)]
         match &msg {
             LogMsg::SetStoreInfo(_) => {
-                if channel_source.select_when_loaded() {
-                    // Set the recording-id after potentially creating the store in the hub.
-                    // This ordering is important because the `StoreHub` internally
-                    // updates the app-id when changing the recording.
-                    match store_id.kind() {
-                        StoreKind::Recording => {
-                            re_log::trace!("Opening a new recording: '{store_id:?}'");
-                            self.make_store_active_and_highlight(store_hub, egui_ctx, store_id);
-                        }
-                        StoreKind::Blueprint => {
-                            // We wait with activating blueprints until they are fully loaded,
-                            // so that we don't run heuristics on half-loaded blueprints.
-                            // Otherwise on a mixed connection (SDK sending both blueprint and recording)
-                            // the blueprint won't be activated until the whole _recording_ has finished loading.
-                        }
-                    }
-                }
-
-                if cfg!(target_arch = "wasm32")
-                    && !self.startup_options.is_in_notebook
-                    && !is_example
-                {
-                    use std::sync::Once;
-                    static ONCE: Once = Once::new();
-                    ONCE.call_once(|| {
-                        // Tell the user there is a faster native viewer they can use instead of the web viewer:
-                        let notification = re_ui::notifications::Notification::new(
-                                re_ui::notifications::NotificationLevel::Tip, "For better performance, try the native Rerun Viewer!").with_link(
-                                re_ui::Link {
-                                    text: "Install…".into(),
-                                    url: "https://rerun.io/docs/getting-started/installing-viewer#installing-the-viewer".into(),
-                                }
-                            )
-                            .no_toast()
-                            .permanent_dismiss_id(egui::Id::new("install_native_viewer_prompt"));
-                        self.command_sender
-                            .send_system(SystemCommand::ShowNotification(notification));
-                    });
-                }
+                // Causes a new store typically. But that's handled below via `on_new_store`.
             }
 
             LogMsg::ArrowMsg(_, _) => {
-                // Handled by `EntityDb::add`
+                // Handled by `EntityDb::add`.
             }
 
             LogMsg::BlueprintActivationCommand(cmd) => match store_id.kind() {
@@ -2263,10 +2224,60 @@ impl App {
             },
         }
 
-        // Do analytics/events after ingesting the new message,
-        // because `entity_db.store_info` needs to be set.
+        // Handle any action that is triggered by a new store _after_ processing the message that caused it.
+        if msg_will_add_new_store {
+            self.on_new_store(egui_ctx, store_id, channel_source, store_hub);
+        }
+    }
+
+    fn on_new_store(
+        &self,
+        egui_ctx: &egui::Context,
+        store_id: &StoreId,
+        channel_source: &SmartChannelSource,
+        store_hub: &mut StoreHub,
+    ) {
+        if channel_source.select_when_loaded() {
+            // Set the recording-id after potentially creating the store in the hub.
+            // This ordering is important because the `StoreHub` internally
+            // updates the app-id when changing the recording.
+            match store_id.kind() {
+                StoreKind::Recording => {
+                    re_log::trace!("Opening a new recording: '{store_id:?}'");
+                    self.make_store_active_and_highlight(store_hub, egui_ctx, store_id);
+                }
+                StoreKind::Blueprint => {
+                    // We wait with activating blueprints until they are fully loaded,
+                    // so that we don't run heuristics on half-loaded blueprints.
+                    // Otherwise on a mixed connection (SDK sending both blueprint and recording)
+                    // the blueprint won't be activated until the whole _recording_ has finished loading.
+                }
+            }
+        }
+
         let entity_db = store_hub.entity_db_mut(store_id);
-        if msg_will_add_new_store && entity_db.store_kind() == StoreKind::Recording {
+        let is_example = entity_db.store_class().is_example();
+
+        if cfg!(target_arch = "wasm32") && !self.startup_options.is_in_notebook && !is_example {
+            use std::sync::Once;
+            static ONCE: Once = Once::new();
+            ONCE.call_once(|| {
+                // Tell the user there is a faster native viewer they can use instead of the web viewer:
+                let notification = re_ui::notifications::Notification::new(
+                        re_ui::notifications::NotificationLevel::Tip, "For better performance, try the native Rerun Viewer!").with_link(
+                        re_ui::Link {
+                            text: "Install…".into(),
+                            url: "https://rerun.io/docs/getting-started/installing-viewer#installing-the-viewer".into(),
+                        }
+                    )
+                    .no_toast()
+                    .permanent_dismiss_id(egui::Id::new("install_native_viewer_prompt"));
+                self.command_sender
+                    .send_system(SystemCommand::ShowNotification(notification));
+            });
+        }
+
+        if entity_db.store_kind() == StoreKind::Recording {
             #[cfg(feature = "analytics")]
             if let Some(analytics) = re_analytics::Analytics::global_or_init()
                 && let Some(event) =


### PR DESCRIPTION
### Related

* Mitigates https://github.com/rerun-io/rerun/issues/11556
    * well, the most immediate pain of it at least

### What

It can happen that the viewer becomes aware of new stores without ever seeing a `SetStoreInfo`. The easiest way to run into this is to connect to a 0byte GRPC server. Which we're actually recommending right now (should we really? is there more to fix here? 🤔)

Either way, it seems sensible that the viewer would do its "oh, ah new store"-procedure independent of `SetStoreInfo`