### PR TITLE
Allow flushing telemetry without a mutable reference

### DIFF
--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -47,7 +47,7 @@ pub enum TelemetryDropBehavior {
 }
 
 impl Telemetry {
-    pub fn flush(&mut self) {
+    pub fn flush(&self) {
         let Self {
             logs,
             traces,
@@ -75,7 +75,7 @@ impl Telemetry {
         }
     }
 
-    pub fn shutdown(&mut self) {
+    pub fn shutdown(&self) {
         // NOTE: We do both `force_flush` and `shutdown` because, even though they both flush the
         // pipeline, sometimes one has better error messages than the other (although, more often
         // than not, they both provide useless errors and you should make sure to look into the


### PR DESCRIPTION
I want to flush telemetry on crash, and I don't want to use a mutex.

We have enabled [`clippy::needless_pass_by_ref_mut`](https://github.com/rust-lang/rust-clippy/pull/10900), but it didn't trigger (false-negative), despite us also having `avoid-breaking-exported-api = false` in our `clippy.toml`.