### PR TITLE
Prevent mutual access to a `Harness` in `TestContext`

### DIFF
--- a/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
+++ b/crates/viewer/re_blueprint_tree/tests/blueprint_tree_tests.rs
@@ -27,7 +27,7 @@ fn basic_blueprint_panel_should_match_snapshot() {
     });
 
     let blueprint_tree = BlueprintTree::default();
-    run_blueprint_panel_and_save_snapshot(&test_context, blueprint_tree, "basic_blueprint_panel");
+    run_blueprint_panel_and_save_snapshot(&mut test_context, blueprint_tree, "basic_blueprint_panel");
 }
 
 // ---
@@ -96,10 +96,10 @@ fn collapse_expand_all_blueprint_panel_should_match_snapshot() {
 
 #[test]
 fn blueprint_panel_filter_active_inside_origin_should_match_snapshot() {
-    let (test_context, blueprint_tree) = setup_filter_test(Some("left"));
+    let (mut test_context, blueprint_tree) = setup_filter_test(Some("left"));
 
     run_blueprint_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         blueprint_tree,
         "blueprint_panel_filter_active_inside_origin",
     );
@@ -107,10 +107,10 @@ fn blueprint_panel_filter_active_inside_origin_should_match_snapshot() {
 
 #[test]
 fn blueprint_panel_filter_active_outside_origin_should_match_snapshot() {
-    let (test_context, blueprint_tree) = setup_filter_test(Some("out"));
+    let (mut test_context, blueprint_tree) = setup_filter_test(Some("out"));
 
     run_blueprint_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         blueprint_tree,
         "blueprint_panel_filter_active_outside_origin",
     );
@@ -118,10 +118,10 @@ fn blueprint_panel_filter_active_outside_origin_should_match_snapshot() {
 
 #[test]
 fn blueprint_panel_filter_active_above_origin_should_match_snapshot() {
-    let (test_context, blueprint_tree) = setup_filter_test(Some("path"));
+    let (mut test_context, blueprint_tree) = setup_filter_test(Some("path"));
 
     run_blueprint_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         blueprint_tree,
         "blueprint_panel_filter_active_above_origin",
     );
@@ -178,7 +178,7 @@ fn add_point_to_chunk_builder(builder: ChunkBuilder) -> ChunkBuilder {
 }
 
 fn run_blueprint_panel_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     mut blueprint_tree: BlueprintTree,
     snapshot_name: &str,
 ) {

--- a/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
+++ b/crates/viewer/re_blueprint_tree/tests/view_structure_test.rs
@@ -161,7 +161,7 @@ fn test_all_snapshot_test_cases() {
 }
 
 fn run_test_case(test_case: &TestCase, filter_query: Option<&str>) -> Result<(), SnapshotError> {
-    let test_context = test_context(test_case);
+    let mut test_context = test_context(test_case);
     let view_id = ViewId::hashed_from_str(VIEW_ID);
 
     let mut blueprint_tree = BlueprintTree::default();

--- a/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
+++ b/crates/viewer/re_component_ui/tests/test_all_components_ui.rs
@@ -215,7 +215,7 @@ fn test_cases(reflection: &Reflection) -> Vec<TestCase> {
 /// Test all components UI in a narrow list item context.
 #[test]
 pub fn test_all_components_ui_as_list_items_narrow() {
-    let test_context = get_test_context();
+    let mut test_context = get_test_context();
     let test_cases = test_cases(&test_context.reflection);
     let snapshot_options =
         SnapshotOptions::new().output_path("tests/snapshots/all_components_list_item_narrow");
@@ -224,7 +224,7 @@ pub fn test_all_components_ui_as_list_items_narrow() {
         .iter()
         .map(|test_case| {
             test_single_component_ui_as_list_item(
-                &test_context,
+                &mut test_context,
                 test_case,
                 200.0,
                 &snapshot_options,
@@ -239,7 +239,7 @@ pub fn test_all_components_ui_as_list_items_narrow() {
 /// Test all components UI in a wide list item context.
 #[test]
 pub fn test_all_components_ui_as_list_items_wide() {
-    let test_context = get_test_context();
+    let mut test_context = get_test_context();
     let test_cases = test_cases(&test_context.reflection);
     let snapshot_options =
         SnapshotOptions::new().output_path("tests/snapshots/all_components_list_item_wide");
@@ -248,7 +248,7 @@ pub fn test_all_components_ui_as_list_items_wide() {
         .iter()
         .map(|test_case| {
             test_single_component_ui_as_list_item(
-                &test_context,
+                &mut test_context,
                 test_case,
                 600.0,
                 &snapshot_options,
@@ -261,7 +261,7 @@ pub fn test_all_components_ui_as_list_items_wide() {
 }
 
 fn test_single_component_ui_as_list_item(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     test_case: &TestCase,
     ui_width: f32,
     _snapshot_options: &SnapshotOptions,

--- a/crates/viewer/re_dataframe_ui/tests/ascending_descending.rs
+++ b/crates/viewer/re_dataframe_ui/tests/ascending_descending.rs
@@ -16,7 +16,7 @@ use re_viewer_context::AsyncRuntimeHandle;
 #[tokio::test]
 async fn test_no_sort() {
     let (session_context, table_ref) = prepare_session_context();
-    let test_context = TestContext::new();
+    let mut test_context = TestContext::new();
     let runtime_handle = AsyncRuntimeHandle::from_current_tokio_runtime_or_wasmbindgen().unwrap();
 
     let table_status = Arc::new(Mutex::new(None::<TableStatus>));
@@ -39,7 +39,7 @@ async fn test_no_sort() {
 #[tokio::test]
 async fn test_ascending() {
     let (session_context, table_ref) = prepare_session_context();
-    let test_context = TestContext::new();
+    let mut test_context = TestContext::new();
     let runtime_handle = AsyncRuntimeHandle::from_current_tokio_runtime_or_wasmbindgen().unwrap();
 
     let table_status = Arc::new(Mutex::new(None::<TableStatus>));
@@ -66,7 +66,7 @@ async fn test_ascending() {
 #[tokio::test]
 async fn test_descending() {
     let (session_context, table_ref) = prepare_session_context();
-    let test_context = TestContext::new();
+    let mut test_context = TestContext::new();
     let runtime_handle = AsyncRuntimeHandle::from_current_tokio_runtime_or_wasmbindgen().unwrap();
 
     let table_status = Arc::new(Mutex::new(None::<TableStatus>));
@@ -93,7 +93,7 @@ async fn test_descending() {
 #[tokio::test]
 async fn test_column_menu_button() {
     let (session_context, table_ref) = prepare_session_context();
-    let test_context = TestContext::new();
+    let mut test_context = TestContext::new();
     let runtime_handle = AsyncRuntimeHandle::from_current_tokio_runtime_or_wasmbindgen().unwrap();
 
     let table_status = Arc::new(Mutex::new(None::<TableStatus>));

--- a/crates/viewer/re_test_context/src/lib.rs
+++ b/crates/viewer/re_test_context/src/lib.rs
@@ -370,8 +370,12 @@ impl TestContext {
     }
 
     /// Set up for rendering UI, with not 3D/2D in it.
+    ///
+    /// Note: This method takes `&mut self` to ensure only one harness can be created at a time
+    /// via the borrow checker, preventing accidentally nesting tests where harnesses interact
+    /// with each other.
     pub fn setup_kittest_for_rendering_ui(
-        &self,
+        &mut self,
         size: impl Into<egui::Vec2>,
     ) -> egui_kittest::HarnessBuilder<()> {
         self.setup_kittest_for_rendering(re_ui::testing::TestOptions::Gui, size.into())
@@ -380,15 +384,20 @@ impl TestContext {
     /// Set up for rendering 3D/2D and maybe UI.
     ///
     /// This has slightly higher error tolerances than [`Self::setup_kittest_for_rendering_ui`].
+    ///
+    /// Note: This method takes `&mut self` to ensure only one harness can be created at a time
+    /// via the borrow checker, preventing accidentally nesting tests where harnesses interact
+    /// with each other.
     pub fn setup_kittest_for_rendering_3d(
-        &self,
+        &mut self,
         size: impl Into<egui::Vec2>,
     ) -> egui_kittest::HarnessBuilder<()> {
         self.setup_kittest_for_rendering(re_ui::testing::TestOptions::Rendering3D, size.into())
     }
 
+    #[expect(clippy::needless_pass_by_ref_mut)]
     fn setup_kittest_for_rendering(
-        &self,
+        &mut self,
         option: re_ui::testing::TestOptions,
         size: egui::Vec2,
     ) -> egui_kittest::HarnessBuilder<()> {

--- a/crates/viewer/re_test_viewport/src/lib.rs
+++ b/crates/viewer/re_test_viewport/src/lib.rs
@@ -28,7 +28,7 @@ pub trait TestContextExt {
     fn run_with_single_view(&self, ui: &mut egui::Ui, view_id: ViewId);
 
     fn run_view_ui_and_save_snapshot(
-        &self,
+        &mut self,
         view_id: ViewId,
         snapshot_name: &str,
         size: egui::Vec2,
@@ -182,7 +182,7 @@ impl TestContextExt for TestContext {
     }
 
     fn run_view_ui_and_save_snapshot(
-        &self,
+        &mut self,
         view_id: ViewId,
         snapshot_name: &str,
         size: egui::Vec2,

--- a/crates/viewer/re_time_panel/tests/time_panel_filter_tests.rs
+++ b/crates/viewer/re_time_panel/tests/time_panel_filter_tests.rs
@@ -34,7 +34,7 @@ pub fn test_various_filter_ui_snapshot() {
     TimePanel::ensure_registered_subscribers();
 
     for filter_query in filter_queries() {
-        let test_context = prepare_test_context();
+        let mut test_context = prepare_test_context();
 
         let mut time_panel = TimePanel::default();
         if let Some(query) = filter_query {
@@ -42,7 +42,7 @@ pub fn test_various_filter_ui_snapshot() {
         }
 
         run_time_panel_and_save_snapshot(
-            &test_context,
+            &mut test_context,
             time_panel,
             &format!(
                 "various_filters-{}",
@@ -57,7 +57,7 @@ pub fn test_various_filter_ui_snapshot() {
 #[test]
 pub fn test_various_filter_insta_snapshot() {
     for filter_query in filter_queries() {
-        let test_context = prepare_test_context();
+        let mut test_context = prepare_test_context();
 
         let streams_tree_data = test_context.run_once_in_egui_central_panel(|viewer_ctx, _| {
             let mut filter_state = FilterState::default();
@@ -114,7 +114,7 @@ fn add_point_to_chunk_builder(builder: ChunkBuilder) -> ChunkBuilder {
 }
 
 fn run_time_panel_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     mut time_panel: TimePanel,
     snapshot_name: &str,
 ) {

--- a/crates/viewer/re_time_panel/tests/time_panel_tests.rs
+++ b/crates/viewer/re_time_panel/tests/time_panel_tests.rs
@@ -42,7 +42,7 @@ pub fn time_panel_two_sections() {
     add_sparse_data(&mut test_context);
 
     run_time_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         TimePanel::default(),
         300.0,
         false,
@@ -72,7 +72,7 @@ pub fn time_panel_two_sections_with_valid_range() {
     );
 
     run_time_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         TimePanel::default(),
         300.0,
         false,
@@ -89,7 +89,7 @@ pub fn time_panel_two_sections_with_valid_range() {
     );
 
     run_time_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         TimePanel::default(),
         300.0,
         false,
@@ -128,7 +128,7 @@ pub fn time_panel_two_sections_with_two_valid_ranges() {
     );
 
     run_time_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         TimePanel::default(),
         300.0,
         false,
@@ -145,7 +145,7 @@ pub fn time_panel_two_sections_with_two_valid_ranges() {
     );
 
     run_time_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         TimePanel::default(),
         300.0,
         false,
@@ -190,7 +190,7 @@ pub fn time_panel_dense_data() {
     });
 
     run_time_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         TimePanel::default(),
         300.0,
         false,
@@ -254,7 +254,7 @@ pub fn run_time_panel_filter_tests(filter_active: bool, query: &str, snapshot_na
         time_panel.activate_filter(query);
     }
 
-    run_time_panel_and_save_snapshot(&test_context, time_panel, 300.0, false, snapshot_name);
+    run_time_panel_and_save_snapshot(&mut test_context, time_panel, 300.0, false, snapshot_name);
 }
 
 // --
@@ -287,7 +287,7 @@ pub fn test_various_entity_kinds_in_time_panel() {
             let time_panel = TimePanel::default();
 
             run_time_panel_and_save_snapshot(
-                &test_context,
+                &mut test_context,
                 time_panel,
                 1200.0,
                 true,
@@ -316,7 +316,7 @@ pub fn test_focused_item_is_focused() {
     let time_panel = TimePanel::default();
 
     run_time_panel_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         time_panel,
         200.0,
         false,
@@ -389,7 +389,7 @@ pub fn log_static_data(test_context: &mut TestContext, entity_path: impl Into<En
 }
 
 fn run_time_panel_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     mut time_panel: TimePanel,
     height: f32,
     expand_all: bool,

--- a/crates/viewer/re_view_dataframe/tests/basic.rs
+++ b/crates/viewer/re_view_dataframe/tests/basic.rs
@@ -64,7 +64,7 @@ pub fn test_unknown_timeline() {
     );
 
     run_view_selection_panel_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_id,
         "unknown_timeline_selection_panel_ui",
         egui::vec2(300.0, 450.0),
@@ -95,7 +95,7 @@ fn setup_blueprint(test_context: &mut TestContext, timeline_name: &TimelineName)
 }
 
 fn run_view_selection_panel_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_spatial/tests/annotations.rs
+++ b/crates/viewer/re_view_spatial/tests/annotations.rs
@@ -59,7 +59,7 @@ pub fn test_annotations() {
         ))
     });
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_id,
         "annotations",
         // We need quite a bunch of pixels to be able to stack the double hover pop-ups.
@@ -79,7 +79,7 @@ fn get_test_context() -> TestContext {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_spatial/tests/draw_order.rs
+++ b/crates/viewer/re_view_spatial/tests/draw_order.rs
@@ -146,7 +146,7 @@ pub fn test_draw_order() {
         ))
     });
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_id,
         "draw_order",
         egui::vec2(300.0, 150.0) * 2.0,
@@ -154,7 +154,7 @@ pub fn test_draw_order() {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_spatial/tests/latest_at_partial_updates.rs
+++ b/crates/viewer/re_view_spatial/tests/latest_at_partial_updates.rs
@@ -74,7 +74,7 @@ fn test_latest_at_partial_update() {
 
     let view_id = setup_blueprint(&mut test_context);
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_id,
         "latest_at_partial_updates",
         egui::vec2(200.0, 200.0),
@@ -110,7 +110,7 @@ fn setup_blueprint(test_context: &mut TestContext) -> ViewId {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_spatial/tests/pinhole_camera.rs
+++ b/crates/viewer/re_view_spatial/tests/pinhole_camera.rs
@@ -27,10 +27,10 @@ pub fn test_pinhole_camera() {
         blueprint.add_view_at_root(view)
     });
 
-    run_view_ui_and_save_snapshot(&test_context, view_id, egui::vec2(300.0, 300.0));
+    run_view_ui_and_save_snapshot(&mut test_context, view_id, egui::vec2(300.0, 300.0));
 }
 
-fn run_view_ui_and_save_snapshot(test_context: &TestContext, view_id: ViewId, size: egui::Vec2) {
+fn run_view_ui_and_save_snapshot(test_context: &mut TestContext, view_id: ViewId, size: egui::Vec2) {
     let mut harness = test_context
         .setup_kittest_for_rendering_3d(size)
         .build_ui(|ui| {

--- a/crates/viewer/re_view_spatial/tests/static_overwrite.rs
+++ b/crates/viewer/re_view_spatial/tests/static_overwrite.rs
@@ -65,7 +65,7 @@ pub fn test_static_overwrite_original() {
     let view_id = setup_blueprint(&mut test_context, &entity_path, None, None);
 
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_id,
         "static_overwrite_original",
         SNAPSHOT_SIZE,
@@ -84,7 +84,7 @@ pub fn test_static_overwrite_radius_default() {
     let view_id = setup_blueprint(&mut test_context, &entity_path, Some(&radius_default), None);
 
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_id,
         "static_overwrite_radius_default",
         SNAPSHOT_SIZE,
@@ -105,7 +105,7 @@ pub fn test_static_overwrite_color_override() {
     let view_id = setup_blueprint(&mut test_context, &entity_path, None, Some(&color_override));
 
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_id,
         "static_overwrite_color_override",
         SNAPSHOT_SIZE,
@@ -113,7 +113,7 @@ pub fn test_static_overwrite_color_override() {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_spatial/tests/transform_clamping.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_clamping.rs
@@ -156,7 +156,7 @@ pub fn test_transform_clamping() {
 
     let view_ids = setup_blueprint(&mut test_context);
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         view_ids,
         "transform_clamping",
         egui::vec2(300.0, 300.0),
@@ -210,7 +210,7 @@ fn setup_blueprint(test_context: &mut TestContext) -> (ViewId, ViewId, ViewId) {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     (view_id_boxes, view_id_spheres, view_id_points): (ViewId, ViewId, ViewId),
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_spatial/tests/transform_hierarchy.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_hierarchy.rs
@@ -140,7 +140,7 @@ pub fn test_transform_hierarchy() {
     let view_id = setup_blueprint(&mut test_context);
 
     run_view_ui_and_save_snapshot(
-        &test_context,
+        &mut test_context,
         timeline_step,
         view_id,
         "transform_hierarchy",
@@ -161,7 +161,7 @@ fn setup_blueprint(test_context: &mut TestContext) -> ViewId {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     timeline: Timeline,
     view_id: ViewId,
     name: &str,

--- a/crates/viewer/re_view_spatial/tests/transform_tree_origins.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_tree_origins.rs
@@ -143,7 +143,7 @@ pub fn test_transform_tree_origins() {
     for origin in ["/sun", "/sun/planet", "/sun/planet/moon"] {
         let view_id = setup_blueprint(&mut test_context, origin);
         run_view_ui_and_save_snapshot(
-            &test_context,
+            &mut test_context,
             view_id,
             &format!("transform_tree_origins_{}", origin.replace('/', "_")),
             egui::vec2(400.0, 250.0),
@@ -176,7 +176,7 @@ fn setup_blueprint(test_context: &mut TestContext, origin: &str) -> ViewId {
 
 #[track_caller]
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_tensor/tests/tensor_2d.rs
+++ b/crates/viewer/re_view_tensor/tests/tensor_2d.rs
@@ -57,7 +57,7 @@ fn test_tensor() {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_view_text_document/tests/text_document_test.rs
+++ b/crates/viewer/re_view_text_document/tests/text_document_test.rs
@@ -53,7 +53,7 @@ fn test_text_documents() {
 }
 
 fn run_view_ui_and_save_snapshot(
-    test_context: &TestContext,
+    test_context: &mut TestContext,
     view_id: ViewId,
     name: &str,
     size: egui::Vec2,

--- a/crates/viewer/re_viewer/tests/blueprint_test.rs
+++ b/crates/viewer/re_viewer/tests/blueprint_test.rs
@@ -77,7 +77,7 @@ fn load_blueprint_from_file(test_context: &mut TestContext, path: &Path) {
     test_context.setup_viewport_blueprint(|_ctx, _blueprint| {});
 }
 
-fn take_snapshot(test_context: &TestContext, snapshot_name: &str) {
+fn take_snapshot(test_context: &mut TestContext, snapshot_name: &str) {
     let mut harness = test_context
         .setup_kittest_for_rendering_ui([600.0, 400.0])
         .build_ui(|ui| {
@@ -118,7 +118,7 @@ fn test_blueprint_change_and_restore() {
     });
 
     load_blueprint_from_file(&mut test_context, rbl_path);
-    take_snapshot(&test_context, "blueprint_change_and_restore");
+    take_snapshot(&mut test_context, "blueprint_change_and_restore");
 }
 
 #[test]
@@ -131,11 +131,11 @@ fn test_blueprint_load_into_new_context() {
 
     setup_viewport(&mut test_context);
     save_blueprint_to_file(&test_context, rbl_path);
-    take_snapshot(&test_context, "blueprint_load_into_new_context_1");
+    take_snapshot(&mut test_context, "blueprint_load_into_new_context_1");
 
     let mut test_context_2 = TestContext::new();
     log_test_data_and_register_views(&mut test_context_2, 20);
 
     load_blueprint_from_file(&mut test_context_2, rbl_path);
-    take_snapshot(&test_context_2, "blueprint_load_into_new_context_2");
+    take_snapshot(&mut test_context_2, "blueprint_load_into_new_context_2");
 }


### PR DESCRIPTION
### Related

* Follow-up of #11572.

### What

I ran into a weird problem where I accidentally had two active `Harness`es for a single `TestContext`.

The inputs of the two harnesses seemed to interact with each other. I've changed `TestContext` to require `&mut` to create a `HarnessBuilder`. This should prevent the probem in the future.

This PR changes the definitions in `crates/viewer/re_test_context/src/lib.rs`. The rest is following the compiler breadcrumbs.
