### PR TITLE
Update docs and migration guide notes on `protoc` requirements

### DIFF
--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -41,7 +41,6 @@ There are many ways to install the viewer. Please pick whatever works best for y
 -   Via Cargo
     -   `cargo binstall rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
     -   `cargo install rerun-cli --locked` - build it from source (this requires Rust 1.88+)
-        -   This requires a `protoc` installation on the `PATH` or `PROTOC` environment variable. To install it on macOS, run `brew install protobuf`. It is also available at https://github.com/protocolbuffers/protobuf/releases. For more information see https://docs.rs/prost-build/#sourcing-protoc.
 -   Via Snap (_community maintained_)
     -   `snap install rerun` - download the viewer from the [Store](https://snapcraft.io/rerun).
 -   Together with the Rerun [Python SDK](./quick-start/python.md):

--- a/docs/content/reference/migration/migration-0-26.md
+++ b/docs/content/reference/migration/migration-0-26.md
@@ -4,7 +4,9 @@ order: 984
 ---
 <!--   ^^^ this number must be _decremented_ when you copy/paste this file -->
 
-## `cargo install rerun-cli` requires `protoc`
+## `cargo install rerun-cli` requires `protoc` (0.26.0 only)
+
+**NOTE**: this has been fixed in 0.26.1 and no longer applies.
 
 In order to install the Rerun CLI via cargo, you have to have a `protoc` installation on the `PATH` or `PROTOC` environment variable.
 


### PR DESCRIPTION
Small doc update cherry picked from the 0.26.1 branch.