### PR TITLE
Remove remainders of indicator components

### DIFF
--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -11,7 +11,7 @@ use re_dataframe_ui::{ColumnBlueprint, default_display_name_for_column};
 use re_log_types::{EntityPathPart, EntryId};
 use re_protos::cloud::v1alpha1::{EntryKind, ScanPartitionTableResponse};
 use re_redap_client::ConnectionRegistryHandle;
-use re_sorbet::{BatchType, ColumnDescriptorRef};
+use re_sorbet::ColumnDescriptorRef;
 use re_ui::alert::Alert;
 use re_ui::{UiExt as _, icons};
 use re_viewer_context::{AsyncRuntimeHandle, GlobalContext, ViewerContext};
@@ -215,19 +215,8 @@ impl Server {
             let default_visible = if desc.entity_path().is_some_and(|entity_path| {
                 entity_path.starts_with(&std::iter::once(EntityPathPart::properties()).collect())
             }) {
-                // Property column, just hide indicator components
-                // TODO(grtlr): Indicators are gone, but since servers might still
-                // have this column we keep this check for now.
-                let is_indicator = desc
-                    .column_name(BatchType::Dataframe)
-                    .ends_with("Indicator");
-                if is_indicator {
-                    re_log::warn_once!(
-                        "Encountered unexpected indicator column name: {}",
-                        desc.column_name(BatchType::Dataframe)
-                    );
-                }
-                !is_indicator
+                // Property columns are visible by default
+                true
             } else {
                 matches!(
                     desc.display_name().as_str(),

--- a/crates/viewer/re_view_spatial/src/heuristics.rs
+++ b/crates/viewer/re_view_spatial/src/heuristics.rs
@@ -9,7 +9,7 @@ use crate::{view_kind::SpatialViewKind, visualizers::SpatialViewVisualizerData};
 /// Returns all entities for which a visualizer of the given kind would be picked.
 ///
 /// I.e. all entities for which at least one visualizer of the specified kind is "maybe visualizable"
-/// *and* has a matching indicator component.
+/// *and* has a relevant archetype.
 /// (we can't reason with "visualizable" because that can be influenced by view properties like its origin)
 pub fn default_visualized_entities_for_visualizer_kind(
     ctx: &ViewerContext<'_>,

--- a/crates/viewer/re_viewer_context/src/view/visualizer_entity_subscriber.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_entity_subscriber.rs
@@ -86,10 +86,10 @@ struct VisualizerEntityMapping {
     /// Which entities the visualizer can be applied to.
     maybe_visualizable_entities: MaybeVisualizableEntities,
 
-    /// List of all entities in this store that at some point in time had any of the indicator components.
+    /// List of all entities in this store that at some point in time had any of the relevant archetypes.
     ///
     /// Special case:
-    /// If the visualizer has no indicator components, this list will contain all entities in the store.
+    /// If the visualizer has no relevant archetypes, this list will contain all entities in the store.
     indicated_entities: IndicatedEntities,
 }
 
@@ -171,7 +171,7 @@ impl ChunkStoreSubscriber for VisualizerEntitySubscriber {
 
             let entity_path = event.diff.chunk.entity_path();
 
-            // Update indicator component tracking:
+            // Update archetype tracking:
             if self.relevant_archetypes.is_empty()
                 || self.relevant_archetypes.iter().any(|archetype| {
                     event

--- a/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
@@ -46,13 +46,11 @@ pub struct VisualizerQueryInfo {
     pub relevant_archetypes: UnorderedArchetypeSet,
 
     /// Returns the minimal set of components that the system _requires_ in order to be instantiated.
-    ///
-    /// This does not include indicator components.
     pub required: ComponentSet,
 
     /// Returns the list of components that the system _queries_.
     ///
-    /// Must include required, usually excludes indicators.
+    /// Must include required components.
     /// Order should reflect order in archetype docs & user code as well as possible.
     ///
     /// Note that we need full descriptors here in order to write overrides from the UI.

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -36,10 +36,10 @@ pub struct ViewerContext<'a> {
     /// TODO(andreas): This should have a generation id, allowing to update heuristics(?)/visualizable entities etc.
     pub maybe_visualizable_entities_per_visualizer: &'a PerVisualizer<MaybeVisualizableEntities>,
 
-    /// For each visualizer, the set of entities that have at least one matching indicator component.
+    /// For each visualizer, the set of entities with relevant archetypes.
     ///
     /// TODO(andreas): Should we always do the intersection with `maybe_visualizable_entities_per_visualizer`
-    ///                 or are we ever interested in a (definitely-)non-visualizable but indicator-matching entity?
+    ///                 or are we ever interested in a (definitely-)non-visualizable but archetype-matching entity?
     pub indicated_entities_per_visualizer: &'a PerVisualizer<IndicatedEntities>,
 
     /// All the query results for this frame.

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -269,9 +269,9 @@ pub fn entity_path_for_view_property(
     // We want to search the subtree for occurrences of the property archetype here.
     // Only if none is found we make up a new (standardized) path.
     // There's some nuances to figure out what happens when we find the archetype several times.
-    // Also, we need to specify what it means to "find" the archetype (likely just matching the indicator?).
+    // Also, we need to specify what it means to "find" the archetype.
     let view_blueprint_path = view_id.as_entity_path();
 
-    // Use short_name instead of full_name since full_name has dots and looks too much like an indicator component.
+    // Use short_name instead of full_name since full_name has dots.
     view_blueprint_path.join(&EntityPath::from_single_string(archetype_name.short_name()))
 }


### PR DESCRIPTION
### Related

* Follow-up of #10513.
* Indicators were removed in `v0.24`. 

### What

Removes outdated documentation and hopefully the last code path that mentions indicator components (except for migration code in `re_sorbet` ofc).
