### PR TITLE
Simplify `CreateIndexRequest`

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -306,21 +306,19 @@ message GetDatasetSchemaResponse {
 /* Indexing */
 
 message CreateIndexRequest {
-  // List of specific partitions that will be indexed (all if left empty).
-  repeated rerun.common.v1alpha1.PartitionId partition_ids = 2;
-
-  // List of specific partition layers that will be indexed (all if left empty).
-  //
-  // If non-empty, this must match the length of `partition_ids`.
-  repeated string partition_layers = 5;
-
   IndexConfig config = 3;
-
-  // Specify behavior when index for a partition was already created.
-  rerun.common.v1alpha1.IfDuplicateBehavior on_duplicate = 4;
 
   reserved 1;
   reserved "dataset_id";
+
+  reserved 2;
+  reserved "partition_ids";
+
+  reserved 4;
+  reserved "on_duplicate";
+
+  reserved 5;
+  reserved "partition_layers";
 }
 
 message CreateIndexResponse {

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -289,24 +289,10 @@ impl ::prost::Name for GetDatasetSchemaResponse {
         "/rerun.cloud.v1alpha1.GetDatasetSchemaResponse".into()
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CreateIndexRequest {
-    /// List of specific partitions that will be indexed (all if left empty).
-    #[prost(message, repeated, tag = "2")]
-    pub partition_ids: ::prost::alloc::vec::Vec<super::super::common::v1alpha1::PartitionId>,
-    /// List of specific partition layers that will be indexed (all if left empty).
-    ///
-    /// If non-empty, this must match the length of `partition_ids`.
-    #[prost(string, repeated, tag = "5")]
-    pub partition_layers: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "3")]
     pub config: ::core::option::Option<IndexConfig>,
-    /// Specify behavior when index for a partition was already created.
-    #[prost(
-        enumeration = "super::super::common::v1alpha1::IfDuplicateBehavior",
-        tag = "4"
-    )]
-    pub on_duplicate: i32,
 }
 impl ::prost::Name for CreateIndexRequest {
     const NAME: &'static str = "CreateIndexRequest";

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -22,7 +22,7 @@ use re_protos::{
         ext::{DatasetDetails, IndexProperties},
         index_query_properties,
     },
-    common::v1alpha1::{IfDuplicateBehavior, ext::DatasetHandle},
+    common::v1alpha1::ext::DatasetHandle,
     headers::RerunHeadersInjectorExt as _,
 };
 use re_redap_client::fetch_chunks_response_to_chunk_and_partition_id;
@@ -533,16 +533,11 @@ impl PyDatasetEntry {
         };
 
         let request = CreateIndexRequest {
-            partition_ids: vec![],
-            partition_layers: vec![],
-
             config: Some(IndexConfig {
                 properties: Some(properties.into()),
                 column: Some(component_descriptor.0.into()),
                 time_index: Some(time_selector.timeline.into()),
             }),
-
-            on_duplicate: IfDuplicateBehavior::Overwrite as i32,
         };
 
         wait_for_future(self_.py(), async {
@@ -599,16 +594,11 @@ impl PyDatasetEntry {
         };
 
         let request = CreateIndexRequest {
-            partition_ids: vec![],
-            partition_layers: vec![],
-
             config: Some(IndexConfig {
                 properties: Some(properties.into()),
                 column: Some(component_descriptor.0.into()),
                 time_index: Some(time_selector.timeline.into()),
             }),
-
-            on_duplicate: IfDuplicateBehavior::Overwrite as i32,
         };
 
         wait_for_future(self_.py(), async {


### PR DESCRIPTION
The interesting stuff will happen in the sibling (and its children).

* Part of https://linear.app/rerun/issue/RR-2741/simplify-reruncloudservicecreateindex
* Sibling: https://github.com/rerun-io/dataplatform/pull/1898