### PR TITLE
Fix `get_partition_table_schema` and `get_dataset_manifest_schema` missing properties columns

### DIFF
--- a/crates/store/re_server/src/store/dataset.rs
+++ b/crates/store/re_server/src/store/dataset.rs
@@ -119,7 +119,6 @@ impl Dataset {
         self.partitions.keys().cloned()
     }
 
-    //TODO(RR-2604): add support for property columns
     pub fn partition_table(&self) -> Result<RecordBatch, Error> {
         let row_count = self.partitions.len();
 


### PR DESCRIPTION
### Related

* part of https://linear.app/rerun/project/demo-ready-oss-server-for-data-transformation-pipelines-d0a110693312/
* part of https://linear.app/rerun/issue/RR-2532/pr-tracking-demo-read-oss-server-for-data-transformation-pipelines

### What

I forgot to update `get_partition_table_schema` and `get_dataset_manifest_schema` in my last PR. Done, including the testing part.

Note: no sibling pr, but I checked that `dataplatform` passes this test (trivial, since it uses the same cheat as we do here).