### PR TITLE
Add `thread_rng` feature to `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,7 @@ puffin_http = "0.16.1"
 pyo3 = "0.24.2"
 pyo3-build-config = "0.24.2"
 quote = "1.0"
-rand = { version = "0.9.2", default-features = false, features = ["small_rng"] }
+rand = { version = "0.9.2", default-features = false, features = ["small_rng", "thread_rng"] }
 rand_distr = { version = "0.5.1", default-features = false }
 raw-window-handle = "0.6.2"
 rayon = "1.11"


### PR DESCRIPTION
This should fix nightly.

### Backstory

Many tests, benchmarks, and possibly other pieces of code use `rand::rng()` (which needs `thread_rng`), but only use `rand.workspace = true`. They tend to work anyways because that feature is _very_ commonly activated by something else... unless it's not (e.g. when the given test/bench is run in isolation).

Example: https://github.com/rerun-io/rerun/actions/runs/18768650053/job/53548855998

To avoid this footgun, this feature is now activated in our workspace.


