### PR TITLE
Clarify note about patch release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -80,7 +80,7 @@ You can do this either using `git` on your command line, or through the UI:
 
 Once the branch has been created, push it to the remote repository.
 
-**NOTE (for patch release)**: upon creation of the branch, the version is set to the final version of the previous release. This can create issues when testing the patch release, since it has a non-"+dev" version identical to an existing release. Because of that, an RC should preferably be created before testing.
+**NOTE (for patch releases)**: upon creation of the branch, the version is set to the final version of the previous release. This can create issues when testing the patch release, since it has a non-"+dev" version identical to/conflicting with an existing release. Because of that, an RC should preferably be created before testing.
 
 ### 3. If this is a patch release, cherry-pick commits for inclusion in the release into the branch
 


### PR DESCRIPTION
This note was outright wrong: it would break our build (0.x.y+dev) are not correctly parsed by our build scripts). The underlying concern is still valid (I think?) This PR tries to convey that.
