### PR TITLE
Stable sort-order for ROS2-based MCAP data loader test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8624,6 +8624,7 @@ dependencies = [
  "re_arrow_util",
  "re_build_info",
  "re_chunk",
+ "re_chunk_store",
  "re_crash_handler",
  "re_error",
  "re_log",

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -59,5 +59,7 @@ parquet = { workspace = true, features = ["arrow", "snap"] }
 re_crash_handler.workspace = true
 
 [dev-dependencies]
+re_chunk_store.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
+
 insta = { workspace = true, features = ["glob"] }

--- a/crates/store/re_data_loader/tests/snapshots/test_mcap_loader__tests__ros2.snap
+++ b/crates/store/re_data_loader/tests/snapshots/test_mcap_loader__tests__ros2.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e19c81cb0c088b81c803fc328cf3c47344861750bb79478a0a6cd96fbec5c45e
-size 528757
+oid sha256:2330940ae00ddb1a90a108c2f4eac80afdf7a123a4be8a25fd4b6448ceb8748f
+size 363676


### PR DESCRIPTION
### Related

* Closes #11576.

### What

This "downgrades" the test to a schema-based test, meaning we don't look at the values anymore and only check if the general structure matches what we expect.

This should make the sort order of this test stable, until we have better infrastructure for testing MCAP files in place.
