### PR TITLE
Fix color picker on default & override disappearing when trying to edit

### DIFF
--- a/crates/viewer/re_ui/src/list_item/item_buttons.rs
+++ b/crates/viewer/re_ui/src/list_item/item_buttons.rs
@@ -58,6 +58,7 @@ impl<'a> ItemButtons<'a> {
         rect: &mut egui::Rect,
     ) {
         if self.buttons.is_empty() || !self.should_show_buttons(context) {
+            ui.skip_ahead_auto_ids(1); // Make sure the id of `ui` remains the same after the call regardless
             return;
         }
 


### PR DESCRIPTION
### Related

* Fixes RR-2761
* Closes https://github.com/rerun-io/rerun/pull/11646

### What
Creating a child ui advances the "auto-id" of the parent ui. So if the button goes from visible to invisible, that changes the `id` of e.g. the color picker widget