### PR TITLE
Simplify `CreateIndexResponse`

### DIFF
--- a/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
+++ b/crates/store/re_protos/proto/rerun/v1alpha1/cloud.proto
@@ -330,7 +330,8 @@ message CreateIndexRequest {
 }
 
 message CreateIndexResponse {
-  rerun.common.v1alpha1.DataframePart data = 1;
+  reserved 1;
+  reserved "data";
 }
 
 message IndexConfig {

--- a/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
+++ b/crates/store/re_protos/src/v1alpha1/rerun.cloud.v1alpha1.rs
@@ -304,11 +304,8 @@ impl ::prost::Name for CreateIndexRequest {
         "/rerun.cloud.v1alpha1.CreateIndexRequest".into()
     }
 }
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct CreateIndexResponse {
-    #[prost(message, optional, tag = "1")]
-    pub data: ::core::option::Option<super::super::common::v1alpha1::DataframePart>,
-}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CreateIndexResponse {}
 impl ::prost::Name for CreateIndexResponse {
     const NAME: &'static str = "CreateIndexResponse";
     const PACKAGE: &'static str = "rerun.cloud.v1alpha1";


### PR DESCRIPTION
I.e. nothing.

* Part of https://linear.app/rerun/issue/RR-2741/simplify-reruncloudservicecreateindex
* Part of https://linear.app/rerun/issue/RR-2728/error-when-calling-create-vector-index-with-different-index-parameters
* Sibling: https://github.com/rerun-io/dataplatform/pull/1906