### PR TITLE
[Python] Add missing `line_radii` and `fill_mode` params to `Capsules3DExt`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/archetypes/capsules3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/capsules3d_ext.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from ..error_utils import catch_and_log_exceptions
 
 if TYPE_CHECKING:
-    from .. import datatypes
+    from .. import components, datatypes
 
 
 class Capsules3DExt:
@@ -20,6 +20,8 @@ class Capsules3DExt:
         rotation_axis_angles: datatypes.RotationAxisAngleArrayLike | None = None,
         quaternions: datatypes.QuaternionArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
+        line_radii: datatypes.Float32ArrayLike | None = None,
+        fill_mode: components.FillModeLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
         show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
@@ -49,6 +51,10 @@ class Capsules3DExt:
             Note that this uses a [`components.PoseRotationQuat`][rerun.components.PoseRotationQuat] which is also used by [`archetypes.InstancePoses3D`][rerun.archetypes.InstancePoses3D].
         colors:
             Optional colors for the capsules.
+        line_radii:
+            Optional radii for the lines used when the cylinder is rendered as a wireframe.
+        fill_mode:
+            Optionally choose whether the cylinders are drawn with lines or solid.
         labels:
             Optional text labels for the capsules.
         show_labels:
@@ -68,6 +74,8 @@ class Capsules3DExt:
                 rotation_axis_angles=rotation_axis_angles,
                 quaternions=quaternions,
                 colors=colors,
+                line_radii=line_radii,
+                fill_mode=fill_mode,
                 labels=labels,
                 show_labels=show_labels,
                 class_ids=class_ids,


### PR DESCRIPTION
### Related

* Closes #11631

### What

Adds the currently missing `line_radii` and `fill_mode` params to `Capsules3DExt`.

### Test

I was able to build and test with the [official example from docs](https://rerun.io/docs/reference/types/archetypes/capsules3d#batch-of-capsules):

With `fill_mode="solid"`:

<img width="1820" height="1171" alt="_ 2025-10-26 at 12 34 15 PM" src="https://github.com/user-attachments/assets/dc3fff42-d5fa-44b6-98ed-e3feac470804" />

With `line_radii=0.1`:

<img width="1820" height="1171" alt="_ 2025-10-26 at 12 37 17 PM" src="https://github.com/user-attachments/assets/7a2d853d-d2b4-498d-baa4-b4bcc540b6da" />

With `line_radii=0.01`:

<img width="1728" height="1117" alt="_ 2025-10-26 at 12 37 30 PM" src="https://github.com/user-attachments/assets/e89b62a3-9407-4733-8ee6-e0afbd43970f" />


