### PR TITLE
[Python] Improve errors in mesh3d_ext.

### DIFF
--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
@@ -93,13 +93,15 @@ class Mesh3DExt:
             albedo_texture = _to_numpy(albedo_texture)
 
             if len(albedo_texture.shape) != 3:
-                _send_warning_or_raise("Bad albedo texture shape: {albedo_texture.shape}")
+                _send_warning_or_raise(f"Bad albedo texture shape: {albedo_texture.shape}, expected 3 dimensions")
             else:
                 h = albedo_texture.shape[0]
                 w = albedo_texture.shape[1]
                 c = albedo_texture.shape[2]
                 if c not in (3, 4):
-                    _send_warning_or_raise("Bad albedo texture shape: {albedo_texture.shape}")
+                    _send_warning_or_raise(
+                        f"Bad albedo texture shape: {albedo_texture.shape}, expected 3 or 4 channels"
+                    )
                 else:
                     color_model = ColorModel.RGB if c == 3 else ColorModel.RGBA
                     try:


### PR DESCRIPTION
This changes the strings into formatting strings and clarifies the problem encountered.

### Related
Tiny drive by PR after I encountered some errors while iterating on https://github.com/rerun-io/rerun/issues/1531, fyi @Wumpf .

### What

I passed an `rr.Image()` to `Mesh3D`'s `albedo_texture` argument in Python, this gave me this error:
```
/tmp/venv/lib/python3.13/site-packages/rerun_sdk/rerun/archetypes/mesh3d_ext.py:96: RerunWarning: Bad albedo texture shape: {albedo_texture.shape}
  _send_warning_or_raise("Bad albedo texture shape: {albedo_texture.shape}")
```
Which required me to open that file to figure out what the check was that was failing. The `f` prefix was clearly missing, and I used this opportunity to make the two errors distinct to clearly state what the problem is.

Untested, don't have time to figure out how to run tests locally this evening, :crossed_fingers: it passes ci.