### PR TITLE
Force `chrono`s `serde` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9325,6 +9325,7 @@ version = "0.27.0-alpha.1+dev"
 dependencies = [
  "anyhow",
  "arrow",
+ "chrono",
  "datafusion",
  "futures",
  "insta",

--- a/crates/store/re_redap_tests/Cargo.toml
+++ b/crates/store/re_redap_tests/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 [features]
 
 default = []
-lance = ["dep:lance"]
+lance = ["dep:lance", "dep:chrono"]
 
 [lints]
 workspace = true
@@ -49,3 +49,5 @@ url.workspace = true
 
 # Lance is an optional dependency for re_server
 lance = { workspace = true, optional = true }
+# TODO(lancedb/lance#5075): we need to force activate this feature
+chrono = { workspace = true, optional = true, features = ["serde"] }


### PR DESCRIPTION
Should fix nightly. Caused by:
- https://github.com/lancedb/lance/issues/5075