### PR TITLE
Fix issue with pyopf

### DIFF
--- a/examples/python/open_photogrammetry_format/open_photogrammetry_format.py
+++ b/examples/python/open_photogrammetry_format/open_photogrammetry_format.py
@@ -90,7 +90,7 @@ class OPFProject:
 
         """
         self.path = path
-        self.project = resolve(load(str(self.path)pi))
+        self.project = resolve(load(str(self.path)))
         self.log_as_frames = log_as_frames
 
     @classmethod


### PR DESCRIPTION
Apparently pyopf doesn't want a Path here 🤷🏻 

My theory of why that happened is:

0) we dont have a pin on pyopf and, for some reason, pyopf 1.2+ wants pillow >10,<11
1) at some point, we use the fact that pyopf >=1.2 supports `Path`
2) everything is great for a while
3) something somewhere (actually in conda-land) is insistent on having Pillow 11.3.0
4) silently, pixi downgrades pyopf to 1.1.1, which was before `Path` was supported
5) boom

related:
- https://github.com/Pix4D/pyopf/issues/15
