### PR TITLE
Allow uploading non-images with `--single`

### DIFF
--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -127,10 +127,6 @@ class Uploader:
         gcs = storage.Client("rerun-open")
         self.bucket = gcs.bucket("rerun-static-img")
 
-    def _check_image_aspect_ratio(self, image: Path | Image) -> None:
-        if isinstance(image, Path):
-            image = PIL.Image.open(image)
-
     def upload_file(self, path: Path) -> str:
         """
         Upload a single file to Google Cloud.
@@ -151,8 +147,6 @@ class Uploader:
         digest = data_hash(data)
         object_name = f"{digest}_{path.name}"
         content_type, content_encoding = mimetypes.guess_type(path)
-        if content_type and content_type.startswith("image/"):
-            self._check_image_aspect_ratio(path)
 
         self.upload_data(data, object_name, content_type, content_encoding)
 
@@ -176,7 +170,6 @@ class Uploader:
 
         """
         image = PIL.Image.open(image_path)
-        self._check_image_aspect_ratio(image)
 
         content_type, _ = mimetypes.guess_type(image_path)
 
@@ -207,7 +200,6 @@ class Uploader:
         clipboard = image_from_clipboard()
         if isinstance(clipboard, PIL.Image.Image):
             image = clipboard
-            self._check_image_aspect_ratio(image)
 
             return self.upload_stack(
                 image,


### PR DESCRIPTION
This will now work:
```
pixi run upload-image --single path_to_video.mp4
```

Of course, the encoding of that video will depend on whatever recording/editing software was used. Whoever is uploading the video has to ensure that will work across browsers.