### PR TITLE
Point users to `rerun-sdk` (not `rerun`) in python import error

### DIFF
--- a/rerun_py/rerun_sdk/rerun/error_utils.py
+++ b/rerun_py/rerun_sdk/rerun/error_utils.py
@@ -279,7 +279,7 @@ class RerunMissingDependencyError(ImportError):
     def __init__(self, package: str, optional_dep: str) -> None:
         super().__init__(
             f"'{package}' could not be imported. "
-            f"Please install it, or install rerun as rerun[{optional_dep}]/rerun[all] "
+            f"Please install it, or install rerun as rerun-sdk[{optional_dep}]/rerun-sdk[all] "
             "to use this functionality."
         )
 


### PR DESCRIPTION
Pretty clear cut change!