### PR TITLE
Fix logic in RRD loader file extension check

### DIFF
--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -30,7 +30,7 @@ impl crate::DataLoader for RrdLoader {
 
         let mut extension = crate::extension(&filepath);
         if !matches!(extension.as_str(), "rbl" | "rrd") {
-            if !filepath.is_file() {
+            if filepath.is_file() || filepath.is_dir() {
                 // NOTE: blueprints and recordings have the same file format
                 return Err(crate::DataLoaderError::Incompatible(filepath.clone()));
             } else {


### PR DESCRIPTION
### Related

* Closes RR-2795
* Closes RR-2717

### What

In the RRD dataloader, return `DataLoaderError::Incompatible` if the filepath is a directory. I suspect this is a logic issue introduced in #11486


### Checklist

* [x] `check_lerobot_dataloader.py`
* [x] `pixi run rerun <(curl https://app.rerun.io/version/0.25.1/examples/arkit_scenes.rrd)`
* [x] `curl https://app.rerun.io/version/0.25.1/examples/arkit_scenes.rrd | pixi run rerun -`
* [x] `curl https://app.rerun.io/version/0.25.1/examples/arkit_scenes.rrd > arkit_scenes.rrd && pixi run rerun arkit_scenes.rrd`
* [x] `curl https://app.rerun.io/version/0.25.1/examples/arkit_scenes.rrd > arkit_scenes.rrd && pixi run rerun <(cat arkit_scenes.rrd)`
* [x] `pixi run rerun https://app.rerun.io/version/0.25.1/examples/arkit_scenes.rrd`
