### PR TITLE
Update mimalloc allocator from v2 to v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -272,7 +272,7 @@ macaw = "0.30.0"
 mcap = "0.23.3"
 memmap2 = "0.9.8"
 memory-stats = "1.2"
-mimalloc = "0.1.48"
+mimalloc = { version = "0.1.48", features = ["v3"] }
 mime_guess2 = "2.3" # infer MIME type by file extension, and map mime to file extension
 mint = "0.5.9"
 natord = "1.0.9"


### PR DESCRIPTION
### Related

- Follow up to RR-2771

### What

In the dataplatform, we have observed substantial benefits in terms of memory usage when switching
from mimalloc v2 to v3, with little-to-no performance regression in current benchmarks.

According to v3 maintaners ([source](https://github.com/microsoft/mimalloc/issues/1073#issuecomment-2973066198)), v3 is to be considered production ready and preferrable to v2.

I have run some very shallow testing on the viewer (just logging loads of random point clouds) and haven't seen
any substantial difference between v2 and v3.

Still may be worth to update to v3.
