### PR TITLE
Remove unneeded lifetime constraint in `ChunkComponentSlicer`

### DIFF
--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -319,12 +319,10 @@ pub trait ChunkComponentSlicer {
     type Item<'a>;
 
     fn slice<'a>(
-        // TODO(#10460): A reference to component descriptor should be enough since the returned iterator doesn't depend on it being alive.
-        // However, I wasn't able to get this idea across to the borrow checker.
         component: ComponentIdentifier,
         array: &'a dyn ArrowArray,
         component_spans: impl Iterator<Item = Span<usize>> + 'a,
-    ) -> impl Iterator<Item = Self::Item<'a>> + 'a;
+    ) -> impl Iterator<Item = Self::Item<'a>>;
 }
 
 /// The actual implementation of `impl_native_type!`, so that we don't have to work in a macro.
@@ -357,7 +355,7 @@ macro_rules! impl_native_type {
                 component: ComponentIdentifier,
                 array: &'a dyn ArrowArray,
                 component_spans: impl Iterator<Item = Span<usize>> + 'a,
-            ) -> impl Iterator<Item = Self::Item<'a>> + 'a {
+            ) -> impl Iterator<Item = Self::Item<'a>> {
                 slice_as_native::<$arrow_primitive_type, $native_type>(
                     component,
                     array,
@@ -432,7 +430,7 @@ macro_rules! impl_array_native_type {
                 component: ComponentIdentifier,
                 array: &'a dyn ArrowArray,
                 component_spans: impl Iterator<Item = Span<usize>> + 'a,
-            ) -> impl Iterator<Item = Self::Item<'a>> + 'a {
+            ) -> impl Iterator<Item = Self::Item<'a>> {
                 slice_as_array_native::<N, $arrow_primitive_type, $native_type>(
                     component,
                     array,
@@ -560,7 +558,7 @@ macro_rules! impl_buffer_native_type {
                 component: ComponentIdentifier,
                 array: &'a dyn ArrowArray,
                 component_spans: impl Iterator<Item = Span<usize>> + 'a,
-            ) -> impl Iterator<Item = Self::Item<'a>> + 'a {
+            ) -> impl Iterator<Item = Self::Item<'a>> {
                 slice_as_buffer_native::<$primitive_type, $native_type>(
                     component,
                     array,
@@ -579,7 +577,7 @@ impl ChunkComponentSlicer for &[u8] {
         component: ComponentIdentifier,
         array: &'a dyn ArrowArray,
         component_spans: impl Iterator<Item = Span<usize>> + 'a,
-    ) -> impl Iterator<Item = Self::Item<'a>> + 'a {
+    ) -> impl Iterator<Item = Self::Item<'a>> {
         slice_as_u8(component, array, component_spans)
     }
 }
@@ -669,7 +667,7 @@ macro_rules! impl_array_list_native_type {
                 component: ComponentIdentifier,
                 array: &'a dyn ArrowArray,
                 component_spans: impl Iterator<Item = Span<usize>> + 'a,
-            ) -> impl Iterator<Item = Self::Item<'a>> + 'a {
+            ) -> impl Iterator<Item = Self::Item<'a>> {
                 slice_as_array_list_native::<N, $primitive_type, $native_type>(
                     component,
                     array,
@@ -701,7 +699,7 @@ impl ChunkComponentSlicer for String {
         component: ComponentIdentifier,
         array: &'a dyn ArrowArray,
         component_spans: impl Iterator<Item = Span<usize>> + 'a,
-    ) -> impl Iterator<Item = Vec<ArrowString>> + 'a {
+    ) -> impl Iterator<Item = Vec<ArrowString>> {
         let Some(utf8_array) = array.downcast_array_ref::<ArrowStringArray>() else {
             error_on_downcast_failure(component, "ArrowStringArray", array.data_type());
             return Either::Left(std::iter::empty());
@@ -729,7 +727,7 @@ impl ChunkComponentSlicer for bool {
         component: ComponentIdentifier,
         array: &'a dyn ArrowArray,
         component_spans: impl Iterator<Item = Span<usize>> + 'a,
-    ) -> impl Iterator<Item = Self::Item<'a>> + 'a {
+    ) -> impl Iterator<Item = Self::Item<'a>> {
         let Some(values) = array.downcast_array_ref::<ArrowBooleanArray>() else {
             error_on_downcast_failure(component, "ArrowBooleanArray", array.data_type());
             return Either::Left(std::iter::empty());

--- a/crates/store/re_sorbet/src/column_descriptor.rs
+++ b/crates/store/re_sorbet/src/column_descriptor.rs
@@ -1,7 +1,3 @@
-// TODO(#10460): At some point all these descriptors needs to be interned and have handles or
-// something. And of course they need to be codegen. But we'll get there once we're back to
-// natively tagged components.
-
 use arrow::datatypes::{
     DataType as ArrowDatatype, Field as ArrowField, FieldRef as ArrowFieldRef,
     Fields as ArrowFields,


### PR DESCRIPTION
### Related

* Closes #10460.

### What

This seems like a left-over of the `ComponentIdentifier` swap. It also closes #10460. I've not replaced the todo, because the underlying problem is prevalent in the entire code base. 
