### PR TITLE
Update the release workflow such that alpha releases are tagged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,9 +347,8 @@ jobs:
           git push --force origin refs/heads/${{ github.ref_name }}:refs/heads/latest
           git push --force origin refs/heads/${{ github.ref_name }}:refs/heads/docs-latest
 
-  github-release:
-    name: "GitHub Release"
-    if: inputs.release-type == 'rc' || inputs.release-type == 'final'
+  tag-release:
+    name: "Tag Release"
     needs:
       [
         version,
@@ -376,14 +375,34 @@ jobs:
           version="${{ needs.version.outputs.git_tag }}"
           commit="${{ needs.version.outputs.release-commit }}"
 
+          git tag $version $commit
+          git push origin $version
+
+  github-release:
+    name: "GitHub Release"
+    if: inputs.release-type == 'rc' || inputs.release-type == 'final'
+    needs: [tag-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RERUN_BOT_TOKEN }}
+
+      - name: Create GH release
+        env:
+          GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
+        run: |
+          version="${{ needs.version.outputs.git_tag }}"
+          commit="${{ needs.version.outputs.release-commit }}"
+
           if [ ${{ inputs.release-type }} = "final" ]; then
             pre_arg=""
           else
             pre_arg="--prerelease"
           fi
 
-          git tag $version $commit
-          git push origin $version
           gh release create $version --verify-tag --draft --title $version $pre_arg
 
       - name: Create comment


### PR DESCRIPTION
Title. Before only rc and final releases would have a tag. This was particularly annoying given we might consider some alpha to be 0.XX-pre release.