### PR TITLE
OpenStreetMap example: Descriptive error if API request fails

### DIFF
--- a/examples/python/openstreetmap_data/openstreetmap_data.py
+++ b/examples/python/openstreetmap_data/openstreetmap_data.py
@@ -41,6 +41,10 @@ def execute_query(query: str) -> dict[str, Any]:
         encoded_query = urlencode(params)
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         response = requests.post(OVERPASS_API_URL, data=encoded_query, headers=headers)
+
+        if not response.ok:
+            raise RuntimeError(f"Overpass API request failed: {response.status_code} {response.text}")
+
         result = response.json()
 
         cache_file.write_text(json.dumps(result))


### PR DESCRIPTION
### What

If for whatever reason the API call in the [OpenStreetMap example](https://github.com/rerun-io/rerun/tree/main/examples/python/openstreetmap_data) fails, this will raise a `RuntimeException` with a clear error message.