### PR TITLE
Rename `ServerInternal` to `_ServerInternal`

### DIFF
--- a/rerun_py/rerun_bindings/__init__.py
+++ b/rerun_py/rerun_bindings/__init__.py
@@ -1,3 +1,6 @@
 from __future__ import annotations
 
 from .rerun_bindings import *
+
+# Private classes don't automatically get re-exported
+from .rerun_bindings import _ServerInternal as _ServerInternal

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1926,7 +1926,7 @@ class NotFoundError(Exception):
 class AlreadyExistsError(Exception):
     """Raised when trying to create a resource that already exists."""
 
-class ServerInternal:
+class _ServerInternal:
     """
     Internal Rerun server instance.
 

--- a/rerun_py/rerun_sdk/rerun/server.py
+++ b/rerun_py/rerun_sdk/rerun/server.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import socket
 from typing import TYPE_CHECKING
 
-from rerun_bindings import ServerInternal
+from rerun_bindings import _ServerInternal
 
 from .catalog import CatalogClient
 
@@ -77,7 +77,7 @@ class Server:
         else:
             resolved_port = port
 
-        self._internal = ServerInternal(
+        self._internal = _ServerInternal(
             address=address,
             port=resolved_port,
             datasets={name: str(path) for name, path in (datasets or {}).items()},

--- a/rerun_py/src/server.rs
+++ b/rerun_py/src/server.rs
@@ -11,7 +11,7 @@ use pyo3::{
 };
 use re_server::{self, Args as ServerArgs};
 
-#[pyclass(name = "ServerInternal", module = "rerun_bindings.rerun_bindings")] // NOLINT: ignore[py-cls-eq], non-trivial implementation
+#[pyclass(name = "_ServerInternal", module = "rerun_bindings.rerun_bindings")] // NOLINT: ignore[py-cls-eq], non-trivial implementation
 pub struct PyServerInternal {
     handle: Option<re_server::ServerHandle>,
     address: SocketAddr,


### PR DESCRIPTION
### What

This renames the internal `ServerInternal` class to `_ServerInternal`, and then properly re-exports it from `rerun_binding`. This makes the internal type more explicitly internal.