### PR TITLE
set url from provider details

### DIFF
--- a/rerun_py/src/catalog/catalog_client.rs
+++ b/rerun_py/src/catalog/catalog_client.rs
@@ -185,13 +185,14 @@ impl PyCatalogClientInternal {
             .map(|details| {
                 let id = Py::new(py, PyEntryId::from(details.id))?;
 
+                let table_entry = connection.read_table(py, details.id)?;
+                let table = PyTableEntry::new(&table_entry);
+
                 let entry = PyEntry {
                     client: self_.clone_ref(py),
                     id,
                     details,
                 };
-
-                let table = PyTableEntry::default();
 
                 Py::new(py, (table, entry))
             })
@@ -277,13 +278,13 @@ impl PyCatalogClientInternal {
 
         let table_entry = connection.read_table(py, id.borrow(py).id)?;
 
+        let table = PyTableEntry::new(&table_entry);
+
         let entry = PyEntry {
             client,
             id,
             details: table_entry.details,
         };
-
-        let table = PyTableEntry::default();
 
         Py::new(py, (table, entry))
     }
@@ -328,13 +329,13 @@ impl PyCatalogClientInternal {
 
         let entry_id = Py::new(py, PyEntryId::from(table_entry.details.id))?;
 
+        let table = PyTableEntry::new(&table_entry);
+
         let entry = PyEntry {
             client: self_.clone_ref(py),
             id: entry_id,
             details: table_entry.details,
         };
-
-        let table = PyTableEntry::default();
 
         Py::new(py, (table, entry))
     }

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -2,10 +2,9 @@ use std::str::FromStr as _;
 
 use pyo3::{Py, PyErr, PyResult, Python, exceptions::PyTypeError, pyclass, pymethods};
 
+use crate::catalog::PyCatalogClientInternal;
 use re_log_types::EntryId;
 use re_protos::cloud::v1alpha1::{EntryKind, ext::EntryDetails};
-
-use crate::catalog::PyCatalogClientInternal;
 
 /// A unique identifier for an entry in the catalog.
 #[pyclass(eq, name = "EntryId")]
@@ -125,19 +124,6 @@ impl PyEntry {
     #[getter]
     pub fn name(&self) -> String {
         self.details.name.clone()
-    }
-
-    /// The entry's URL
-    #[getter]
-    pub fn url(&self, py: Python<'_>) -> String {
-        let client = self.client.borrow(py);
-        let client_url = client.url();
-        let separator = if client_url.ends_with('/') {
-            ""
-        } else {
-            "/"
-        };
-        format!("{}{}entry/{}", client_url, separator, self.id)
     }
 
     /// The catalog client that this entry belongs to.

--- a/rerun_py/src/catalog/table_entry.rs
+++ b/rerun_py/src/catalog/table_entry.rs
@@ -10,22 +10,22 @@ use pyo3::{
 };
 use tracing::instrument;
 
-use re_datafusion::TableEntryTableProvider;
-
 use crate::catalog::to_py_err;
 use crate::{
     catalog::PyEntry,
     utils::{get_tokio_runtime, wait_for_future},
 };
+use re_datafusion::TableEntryTableProvider;
+use re_protos::cloud::v1alpha1::ext::{LanceTable, ProviderDetails as _, TableEntry};
 
 /// A table entry in the catalog.
 ///
 /// Note: this object acts as a table provider for DataFusion.
 //TODO(ab): expose metadata about the table (e.g. stuff found in `provider_details`).
 #[pyclass(name = "TableEntry", extends=PyEntry)] // NOLINT: skip pyclass_eq, non-trivial implementation
-#[derive(Default)]
 pub struct PyTableEntry {
     lazy_provider: Option<Arc<dyn TableProvider + Send>>,
+    url: Option<String>,
 }
 
 #[pymethods]
@@ -77,9 +77,25 @@ impl PyTableEntry {
             .getattr("RecordBatchReader")?
             .call_method1("from_stream", (df,))
     }
+
+    /// The entry's URL
+    #[getter]
+    pub fn url(&self) -> String {
+        self.url.clone().unwrap_or_default()
+    }
 }
 
 impl PyTableEntry {
+    pub fn new(table_entry: &TableEntry) -> Self {
+        let url = LanceTable::try_from_any(&table_entry.provider_details)
+            .map(|t| t.table_url.as_str().to_owned())
+            .ok();
+        Self {
+            lazy_provider: None,
+            url,
+        }
+    }
+
     fn table_provider(mut self_: PyRefMut<'_, Self>) -> PyResult<Arc<dyn TableProvider + Send>> {
         let py = self_.py();
         if self_.lazy_provider.is_none() {


### PR DESCRIPTION
Here is an example of what I was hoping to get. It's partially based on [this slack comment](https://rerunio.slack.com/archives/C045J1Z7DU7/p1761067484597669?thread_ts=1761065326.836149&cid=C045J1Z7DU7)

With this I get:

```python
for e in client.table_entries():
    print(e.url)
```

produces

```
file:///Users/tsaucer/src/rerun/tests/assets/table/lance/simple_datatypes/

```

As I would expect. The second entry is the system table which is in memory and doesn't have an associated URL, so I do expect it is blank. We could even improve that to return a None.