### PR TITLE
re_perf_telemetry: fix field formatting for spans

### DIFF
--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -264,7 +264,7 @@ impl Telemetry {
             // Everything is generically typed, which is why this is such a nightmare to do.
             macro_rules! handle_format {
                 ($format:ident) => {{
-                    let layer = layer.event_format(tracing_subscriber::fmt::format().$format());
+                    let layer = layer.$format();
                     if log_test_output {
                         layer.with_test_writer().boxed()
                     } else {


### PR DESCRIPTION
`layer.event_format(fmt::format().json())` would only set event
formatting, but lacks field formatters. This would later cause troubles
when JSON serializer tries to parse what DefaultFields rendered on empty
field values.
This would produce JSON logs without useful span fields:
```
  "span": {
    "field_error": "expected value at line 1 column 1",
    "name": "<request>"
  }
```

