### PR TITLE
Fix timeline line drawing bug on (at least some) Nvidia GPUs

### DIFF
--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -1675,13 +1675,17 @@ fn paint_time_ranges_gaps(
         .cloned()
         .collect::<Vec<_>>();
 
+    // Margin for the (left or right) end of a gap.
+    // Don't use an arbitrarily large value since it can cause platform-specific rendering issues.
+    const GAP_END_MARGIN: f32 = 100.0;
+
     if let Some(segment_subrange) = valid_time_ranges.first() {
         let gap_edge = *segment_subrange.start() as f32;
+        let gap_edge_left_side = ui.ctx().content_rect().left() - GAP_END_MARGIN;
 
         if zig_zag_first_and_last_edges {
-            // Careful with subtracting a too large number here. Nvidia @ Windows was observed not drawing the rect correctly for -100_000.0
             // Left side of first segment - paint as a very wide gap that we only see the right side of
-            paint_time_gap(gap_edge - 10_000.0, gap_edge);
+            paint_time_gap(gap_edge_left_side, gap_edge);
         } else {
             // Careful with subtracting a too large number here. Nvidia @ Windows was observed not drawing the rect correctly for -100_000.0
             painter.rect_filled(
@@ -1699,13 +1703,14 @@ fn paint_time_ranges_gaps(
 
     if let Some(segment_subrange) = valid_time_ranges.last() {
         let gap_edge = *segment_subrange.end() as f32;
+        let gap_edge_right_side = ui.ctx().content_rect().right() + GAP_END_MARGIN;
+
         if zig_zag_first_and_last_edges {
-            // Careful with adding a too large number here. Nvidia @ Windows was observed not drawing the rect correctly for -100_000.0
             // Right side of last segment - paint as a very wide gap that we only see the left side of
-            paint_time_gap(gap_edge, gap_edge + 10_000.0);
+            paint_time_gap(gap_edge, gap_edge_right_side);
         } else {
             painter.rect_filled(
-                Rect::from_min_max(pos2(gap_edge, top), pos2(gap_edge + 100_000.0, bottom)),
+                Rect::from_min_max(pos2(gap_edge, top), pos2(gap_edge_right_side, bottom)),
                 0.0,
                 fill_color,
             );


### PR DESCRIPTION
Fixes a curious rasterization issue we ran into before that shows up in the image comparision tests (there's similar code nearby to the site of the fix)


Running timeline_panel fixes on my Windows Nvidia machine without this fix:
<img width="700" height="300" alt="time_panel_two_sections_with_two_valid_ranges_zoomed_out new" src="https://github.com/user-attachments/assets/775a8630-1e2c-4675-a217-6bdb81b7c68b" />


What is should look like / what it does look like with the fix:
<img width="700" height="300" alt="time_panel_two_sections_with_two_valid_ranges_zoomed_out" src="https://github.com/user-attachments/assets/51b1789a-ada0-4295-8c41-40fffb941b55" />


Diff:
<img width="700" height="300" alt="time_panel_two_sections_with_two_valid_ranges_zoomed_out diff" src="https://github.com/user-attachments/assets/8d07b6a8-d2ad-4763-9ca0-c299d04b8dce" />

