### PR TITLE
Enable serde feature to fix re_protos

### DIFF
--- a/crates/store/re_protos/Cargo.toml
+++ b/crates/store/re_protos/Cargo.toml
@@ -25,9 +25,9 @@ re_arrow_util.workspace = true
 re_build_info.workspace = true
 re_byte_size.workspace = true
 re_chunk.workspace = true
-re_log_types.workspace = true
+re_log_types = { workspace = true, features = ["serde"] }
 re_sorbet.workspace = true
-re_types_core.workspace = true
+re_types_core = { workspace = true, features = ["serde"] }
 re_tuid.workspace = true
 
 # External


### PR DESCRIPTION
Fixes this issue https://github.com/rerun-io/rerun/actions/runs/19056901227/job/54429077622#step:7:213

Which is caused by the serde features not being enabled on some dependencies in `re_protos`.
