### PR TITLE
Make `Debug` for Utf8 datatype derived component types readable

### DIFF
--- a/crates/store/re_types/definitions/rerun/datatypes/utf8.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/utf8.fbs
@@ -9,7 +9,7 @@ table Utf8 (
   "attr.arrow.transparent",
   "attr.python.aliases": "str",
   "attr.python.array_aliases": "str | Sequence[str] | npt.ArrayLike",
-  "attr.rust.derive": "Default, PartialEq, Eq, PartialOrd, Ord, Hash",
+  "attr.rust.derive_only": "Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash",
   "attr.rust.override_crate": "re_types_core",
   "attr.rust.repr": "transparent",
   "attr.rust.tuple_struct"

--- a/crates/store/re_types_core/src/datatypes/utf8.rs
+++ b/crates/store/re_types_core/src/datatypes/utf8.rs
@@ -22,7 +22,7 @@ use crate::{ComponentDescriptor, ComponentType};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A string of text, encoded as UTF-8.
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Utf8(pub crate::ArrowString);
 

--- a/crates/store/re_types_core/src/datatypes/utf8_ext.rs
+++ b/crates/store/re_types_core/src/datatypes/utf8_ext.rs
@@ -50,3 +50,9 @@ impl std::ops::Deref for Utf8 {
         self.as_str()
     }
 }
+
+impl std::fmt::Debug for Utf8 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.as_str())
+    }
+}


### PR DESCRIPTION
Previously you'd get a dump of the arrow data and no readable string at all. That pretty much makes never sense imho, so `Debug` is no derived to actually write out the string.