### PR TITLE
Add missing doc page redirect for viewer install page

### DIFF
--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -1,0 +1,5 @@
+---
+title: Installing the Viewer
+order: 1
+redirect: overview/installing-viewer#installing-the-viewer
+---


### PR DESCRIPTION
Redirects this link properly: https://landing-4nvchk51q-rerun.vercel.app/docs/getting-started/installing-viewer