### PR TITLE
Add missing redirects

### DIFF
--- a/docs/content/getting-started/navigating-the-viewer.md
+++ b/docs/content/getting-started/navigating-the-viewer.md
@@ -1,0 +1,5 @@
+---
+title: Navigating the viewer
+order: 600
+redirect: getting-started/configure-the-viewer/navigating-the-viewer
+---

--- a/docs/content/getting-started/what-is-rerun.md
+++ b/docs/content/getting-started/what-is-rerun.md
@@ -1,0 +1,5 @@
+---
+title: What is Rerun?
+order: 0
+redirect: overview/what-is-rerun
+---


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/actions/runs/19102923956/job/54579147353

### What

Link redirects for `what-is-rerun` and `navigating-the-viewer` were missing.
