### PR TITLE
Exclude flaky unicode license link

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -152,7 +152,7 @@ exclude = [
   'https://www.reddit.com/*', # Gives 403 forbidden on CI.
   'https://www.shadertoy.com/*', # 403 on CI
   'https://www.tensorflow.org/*', # tensorflow.org apparently blocks CI.
-  'https://www.unicode.org/license.txt' # Gives network error on CI.
+  'https://www.unicode.org/license.txt', # Gives network error on CI.
 
   # Need GitHub login.
   'https://github.com/rerun-io/landing',


### PR DESCRIPTION
### Related

* Fixes part of https://github.com/rerun-io/rerun/actions/runs/19123953837/job/54650276978

### What

Excludes unicode license link that CI failed on.
