### PR TITLE
Adress a few wording nits in OSS server docs

### DIFF
--- a/docs/content/getting-started/data-out/query-data.md
+++ b/docs/content/getting-started/data-out/query-data.md
@@ -21,7 +21,7 @@ rerun server
 You can also pass a directory containing RRDs to be opened as a dataset in the server:
 
 ```console
-rerun server -d <directory_containing_rrds>
+rerun server -d directory_containing_rrds/
 ```
 
 For all available options, run:


### PR DESCRIPTION
- consistency with rest of docs, e.g. capitalized `Rerun CLI` or `RRDs`
- "open redap server" seems to be the wrong command for the palette (fixed to "Add Redap server")
- other small improvements to the wording

