### PR TITLE
CI: Increase Windows test timout

### DIFF
--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -149,7 +149,7 @@ jobs:
   # Run some basics tests on Mac and Windows
   mac-windows-tests:
     name: Test on ${{ matrix.name }}
-    timeout-minutes: 60
+    timeout-minutes: 100 # Windows is very slow
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Nightly is timing out: https://github.com/rerun-io/rerun/actions/runs/19102923956/job/54668558815