### PR TITLE
Ignore 403 in link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -40,6 +40,7 @@ accept = [
   "100..=103", # Informational codes.
   "200..=299", # Success codes.
   "429", # Too many requests. This is practically never a sign of a broken link.
+  "403", # A lot of endpoints always return 403 for the link checker
 ]
 
 # Exclude these filesystem paths from getting checked.


### PR DESCRIPTION
We have already allow-listed (opted-out of) many domains because of 403, and there are more every week.