### PR TITLE
Fix 3D eye speed-up modifier not working with scroll-to-zoom

### DIFF
--- a/crates/viewer/re_view_spatial/src/eye.rs
+++ b/crates/viewer/re_view_spatial/src/eye.rs
@@ -487,12 +487,7 @@ impl ControlEye {
             // egui's default horizontal_scroll_modifier is shift, which is also our speed-up modifier.
             // This means that a user who wants to speed up scroll-to-zoom will generate a horizontal scroll delta.
             // To support that, we have to check and use the horizontal delta if no vertical delta is present (see: #11813).
-            let is_maybe_horizontal = input.smooth_scroll_delta.y == 0.;
-            let scroll_delta = if is_maybe_horizontal {
-                input.smooth_scroll_delta.x
-            } else {
-                input.smooth_scroll_delta.y
-            };
+            let scroll_delta = input.smooth_scroll_delta.x + input.smooth_scroll_delta.y;
             input.zoom_delta() * (scroll_delta / 200.0).exp()
         });
 


### PR DESCRIPTION
This is basically caused by egui's scroll behavior that changes when you press certain modifiers (see [here](https://github.com/emilk/egui/blob/31d313572b798d1924329cc074f0f22075fca712/crates/egui/src/input_state/mod.rs#L86)).

Pressing shift for horizontal scroll is useful in other views like the dataframe view, but in the spatial view it conflicts with the speed-up modifier.

This change ensures that scrolling always zooms the eye.

Fixes: #11813
