### PR TITLE
Use `macos-15-xlarge` for building test wheels

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -86,7 +86,7 @@ jobs:
               container="null"
               ;;
             macos-arm64)
-              runner="macos-13-xlarge" # This is an Arm vm, https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners
+              runner="macos-15-xlarge" # This is an Arm vm, https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners
               target="aarch64-apple-darwin"
               container="null"
               ;;


### PR DESCRIPTION
### Related

* Warning occurs on https://github.com/rerun-io/rerun/pull/11815
* https://github.com/rerun-io/rerun/actions/runs/19160654551

### What

`macos-13-xlarge` is deprecated:

* https://github.com/actions/runner-images/issues/13046

<img width="847" height="304" alt="image" src="https://github.com/user-attachments/assets/36cf0790-1235-4d62-85f2-5c9b6323d495" />

### TODO

* [x] full-check
