### PR TITLE
Remove `target_pixi` again & address env var changes that caused rebuilds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,6 +12,17 @@ run-wasm = "run --release --package run_wasm --"
 # so that we don't run them on cargo publish or on users machines.
 IS_IN_RERUN_WORKSPACE = "yes"
 
+# Depending on the pixi environment, we get different `CONDA_PREFIX` values.
+# This means that changing the pixi environment (or not using it in the first place) will cause rebuilds.
+# To avoid unnecessary rebuilds, we set a fixed value here.
+# For details see:
+# https://pyo3.rs/main/building-and-distribution.html#configuring-the-python-version
+PYO3_PYTHON = "python"
+
+# TODO(rust-lang/stacker#127): Work around until wasm build on mac is resolved
+[target.osx-arm64.activation.env]
+AR = "llvm-ar"
+
 # `web_sys_unstable_apis` is required to enable the web_sys clipboard API which egui_web uses.
 # https://wasm-bindgen.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
 # https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Copy rerun-cli to wheel foldcer
         run: |
-          cp target_pixi/release/rerun rerun_py/rerun_sdk/rerun_cli
+          cp target/release/rerun rerun_py/rerun_sdk/rerun_cli
 
       - name: Build the wheel
         run: |

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -167,7 +167,7 @@ jobs:
       - name: "Upload rerun_c (commit)"
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "./target_pixi/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.LIB_NAME }}"
+          path: "./target/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.LIB_NAME }}"
           destination: "rerun-builds/commit/${{ steps.get-sha.outputs.sha }}/rerun_c/${{ inputs.PLATFORM }}"
           parent: false
           process_gcloudignore: false
@@ -176,7 +176,7 @@ jobs:
         if: ${{ inputs.ADHOC_NAME != '' }}
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "./target_pixi/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.LIB_NAME }}"
+          path: "./target/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.LIB_NAME }}"
           destination: "rerun-builds/adhoc/${{inputs.ADHOC_NAME}}/rerun_c/${{ inputs.PLATFORM }}"
           parent: false
           process_gcloudignore: false

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Compare man page to CLI docs
         if: runner.os == 'Linux'
         run: |
-          pixi run ./scripts/ci/check_cli_docs.py --rerun-exe "./target_pixi/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.BIN_NAME }}"
+          pixi run ./scripts/ci/check_cli_docs.py --rerun-exe "./target/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.BIN_NAME }}"
 
       - name: Get sha
         id: get-sha
@@ -187,7 +187,7 @@ jobs:
       - name: "Upload rerun-cli (commit)"
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "./target_pixi/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.BIN_NAME }}"
+          path: "./target/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.BIN_NAME }}"
           destination: "rerun-builds/commit/${{ steps.get-sha.outputs.sha }}/rerun-cli/${{ inputs.PLATFORM }}"
           parent: false
           process_gcloudignore: false
@@ -196,7 +196,7 @@ jobs:
         if: ${{ inputs.ADHOC_NAME != '' }}
         uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "./target_pixi/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.BIN_NAME }}"
+          path: "./target/${{ needs.set-config.outputs.TARGET }}/release/${{ needs.set-config.outputs.BIN_NAME }}"
           destination: "rerun-builds/adhoc/${{inputs.ADHOC_NAME}}/rerun-cli/${{ inputs.PLATFORM }}"
           parent: false
           process_gcloudignore: false

--- a/lychee.toml
+++ b/lychee.toml
@@ -61,8 +61,6 @@ exclude_path = [
   "rerun_js/node_modules/",
   "rerun_notebook/node_modules/",
   "rerun_py/site/",
-  "target_pixi_wasm",
-  "target_pixi",
   "target_ra",
   "target_wasm",
   "target",

--- a/pixi.lock
+++ b/pixi.lock
@@ -34223,7 +34223,7 @@ packages:
 - pypi: ./rerun_py
   name: rerun-sdk
   version: 0.27.0a8+dev
-  sha256: b386e17b005f92c35f4bfc1a4c67acbe6ee4df0cba70e2eda2713db2c560af4a
+  sha256: 302c772b5c76b0240035b66bef436351afe9503740ecb6ab62b8f92b76536efe
   requires_dist:
   - attrs>=23.1.0
   - numpy>=2

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,24 +50,9 @@ libc = "2.28"
 # The executable extension for binaries on the current platform.
 EXECUTABLE_EXTENSION = ""
 
-# Put pixi builds in its own build dir, otherwise `pixi run cargo build`
-# conflicts with vanilla`cargo build`, and running one invalidates (parts) of the other.
-# See https://github.com/rerun-io/rerun/issues/10934 for more.
-#
-# TODO(prefix-dev/pixi#4431): Environment variable resolving doesn't work with this on Windows,
-# which is why we have to use the `%` syntax for Windows instead of `$`.
-CARGO_TARGET_DIR = "$PIXI_PROJECT_ROOT/target_pixi"
-
 [target.win-64.activation.env]
 # The executable extension for binaries on the current platform.
 EXECUTABLE_EXTENSION = ".exe"
-
-# See `target.unix.activation.env`.
-CARGO_TARGET_DIR = "%PIXI_PROJECT_ROOT%/target_pixi"
-
-# TODO(rust-lang/stacker#127): Work around until wasm build on mac is resolved
-[target.osx-arm64.activation.env]
-AR = "llvm-ar"
 
 # python-dev
 
@@ -420,7 +405,7 @@ py-build-notebook-js = { cmd = "npm --prefix rerun_notebook run build", depends-
 
 # Build an installable wheel.
 # The wheel will contain the rerun executable including the web viewer.
-py-build-wheel = { cmd = "cp target_pixi/release/rerun$EXECUTABLE_EXTENSION rerun_py/rerun_sdk/rerun_cli/ && maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
+py-build-wheel = { cmd = "cp target/release/rerun$EXECUTABLE_EXTENSION rerun_py/rerun_sdk/rerun_cli/ && maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
   "rerun-build-native-and-web-release",
 ] }
 

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -69,8 +69,6 @@ lint.explicit-preview-rules = true
 
 extend-exclude = [
   # Automatically generated test artifacts
-  "target_pixi/",
-  "target_pixi_wasm/",
   "target_ra/",
   "target_wasm/",
   "target/",

--- a/rerun_py/rerun/__init__.py
+++ b/rerun_py/rerun/__init__.py
@@ -30,7 +30,7 @@ if "RERUN_CLI_PATH" not in os.environ:
     import rerun_bindings as bindings  # noqa: TID251
 
     flavor = "debug" if bindings.is_dev_build() else "release"
-    target_path = pathlib.Path(__file__).parent.parent.parent.joinpath(f"target_pixi/{flavor}/rerun").resolve()
+    target_path = pathlib.Path(__file__).parent.parent.parent.joinpath(f"target/{flavor}/rerun").resolve()
     os.environ["RERUN_CLI_PATH"] = str(target_path)
 
 sys.path.insert(0, str(real_path))

--- a/rerun_py/rerun_cli/__init__.py
+++ b/rerun_py/rerun_cli/__init__.py
@@ -27,7 +27,7 @@ real_path = pathlib.Path(__file__).parent.parent.joinpath("rerun_sdk").resolve()
 print(f"DEV ENVIRONMENT DETECTED! Re-importing rerun from: {real_path}", file=sys.stderr)
 
 if "RERUN_CLI_PATH" not in os.environ:
-    target_path = pathlib.Path(__file__).parent.parent.parent.joinpath("target_pixi/debug/rerun").resolve()
+    target_path = pathlib.Path(__file__).parent.parent.parent.joinpath("target/debug/rerun").resolve()
     os.environ["RERUN_CLI_PATH"] = str(target_path)
 
 sys.path.insert(0, str(real_path))


### PR DESCRIPTION
I got annoyed by having two (four with _wasm variants) target folders around because of unintentionally switching between the pixi environment & "raw" invocations.

This PR removes `target_pixi` again and addresses the reason we introduced this in the first place: there are certain environment variables in the pixi environment that get picked up by rust build scripts.
Using `CARGO_LOG=cargo::core::compiler::fingerprint=info` I identified two:
* `AR`: we set this on MacOS to solve some issues with our wasm build, see https://github.com/rerun-io/rerun/pull/10828
* `CONDA_PREFIX`: py03 uses this to govern which python install to use

The fix in both cases is to move those env vars to `.cargo/config.toml`. For `AR` that's trivial, for `CONDA_PREFIX` not so much! Every pixi environment has its own conda prefix (and yes that would also cause rebuilds between pixi environments!). So instead I'm setting `PYO3_PYTHON` which directly governs which python install pyo3 uses for linking. Here be dragons (a little bit ;-)): This means we no longer fix the python version used and instead rely on whatever `python` points to.


things I tried to verify this:
* [x] `pixi run cargo check` & `cargo check` not causing to rebuild each other
* [x] clean pixi environment, then run `pixi run py-build` then execute some script that needs a Rerun install
* [x] macos web build via `pixi run rerun-web`
* [x] full-ci


out of pragmatism I left the pixi target folder in git & prettier ignore lists 🤷 