### PR TITLE
Use ": " separator in re_error::format to match anyhow's {:#} format

### DIFF
--- a/crates/utils/re_error/src/lib.rs
+++ b/crates/utils/re_error/src/lib.rs
@@ -11,9 +11,11 @@ pub fn format(error: impl AsRef<dyn std::error::Error>) -> String {
 ///
 /// Always use this when displaying an error, especially `anyhow::Error`.
 pub fn format_ref(error: &dyn std::error::Error) -> String {
+    // Use ": " as separator to match anyhow's `format!("{:#}", err)` output
+    // See: https://github.com/rerun-io/rerun/issues/8681
     let mut string = error.to_string();
     for source in std::iter::successors(error.source(), |error| error.source()) {
-        string.push_str(" -> ");
+        string.push_str(": ");
         string.push_str(&source.to_string());
     }
     string
@@ -28,5 +30,5 @@ fn test_format() {
     assert_eq!(err.to_string(), "outer_context"); // Oh no, we don't see the root cause!
 
     // Now we do:
-    assert_eq!(format(&err), "outer_context -> inner_context -> root_cause");
+    assert_eq!(format(&err), "outer_context: inner_context: root_cause");
 }


### PR DESCRIPTION
Instead of using " -> " as the separator between error contexts, use ": " which matches the output of anyhow's `format!("{:#}", err)`.

Fixes #8681
