### PR TITLE
Fix alternating relink issue in C++ snippets (#8312)

### DIFF
--- a/docs/snippets/CMakeLists.txt
+++ b/docs/snippets/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16...3.27)
 
 # Setup builds for examples
-file(GLOB_RECURSE sources_list true ${CMAKE_CURRENT_SOURCE_DIR}/all/*.cpp)
+file(GLOB_RECURSE sources_list CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/all/*.cpp)
 
 # Not complete examples:
 list(FILTER sources_list EXCLUDE REGEX .*/concepts/static/*)


### PR DESCRIPTION
Replace invalid 'true' argument with CONFIGURE_DEPENDS flag in file(GLOB_RECURSE) command. This ensures CMake re-evaluates the glob pattern at the beginning of each build, not just during configure phase.

Without CONFIGURE_DEPENDS, the build would alternate between:
- Fast builds (~2s) using cached state
- Slow builds (~40s) relinking all 116 snippet executables

Fixes #8312.

First build takes a while, as it should.
```
pixi run -e cpp cpp-build-all  1556.80s user 90.71s system 1037% cpu 2:38.77 total
```

But further builds go fast.
```
pixi run -e cpp cpp-build-all  0.87s user 0.59s system 75% cpu 1.945 total
pixi run -e cpp cpp-build-all  0.87s user 0.55s system 76% cpu 1.868 total
pixi run -e cpp cpp-build-all  0.87s user 0.56s system 75% cpu 1.889 total
pixi run -e cpp cpp-build-all  0.87s user 0.55s system 76% cpu 1.873 total
```
