### PR TITLE
When closing recordings (and blueprints), drop them on separate threads for UI responsiveness.

### DIFF
--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -345,7 +345,7 @@ impl StoreHub {
         // so that recursing through it and freeing the memory doesn’t block the UI thread.
         #[allow(
             clippy::allow_attributes,
-            clippy::disallowed_types
+            clippy::disallowed_types,
             reason = "If this thread spawn fails due to running on Wasm (or for any other reason),
                       the error will be ignored and the store will be dropped on this thread."
         )]


### PR DESCRIPTION
In `StoreHub::remove_store()`, execute drop of the store on a separate thread created for the purpose.

This prevents the UI from hanging while dropping a large recording, which is useful when the user is trying to close multiple recordings at once.

If threads are not available, automatically falls back to dropping on the current thread.