### PR TITLE
Automatically build the web viewer

### DIFF
--- a/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
@@ -135,9 +135,9 @@ pub fn build(
             cmd.arg("--profile=web-release");
         }
 
-        // Note that we can't use RUSTFLAGS here directly since having more than one flag on set via
+        // Note: .cargo/config.toml is automatically loaded by cargo, so we don't need to specify it.
+        // We can't use RUSTFLAGS directly since having more than one flag set via
         // `cmd.env("RUSTFLAGS", rustflags)` completely messes up the rustc invocation no matter how we quote it.
-        cmd.arg("--config=.cargo/config.toml");
 
         // When executing this script from a Rust build script, do _not_, under any circumstances,
         // allow pre-encoded `RUSTFLAGS` to leak into the current environment.

--- a/crates/viewer/re_web_viewer_server/build.rs
+++ b/crates/viewer/re_web_viewer_server/build.rs
@@ -16,9 +16,99 @@ fn main() {
         let viewer_js_path = std::path::Path::new("./web_viewer/re_viewer.js");
         let viewer_wasm_path = std::path::Path::new("./web_viewer/re_viewer_bg.wasm");
 
-        assert!(
-            viewer_js_path.exists() && viewer_wasm_path.exists(),
-            "Web viewer not found, run `pixi run rerun-build-web` to build it!"
-        );
+        if !viewer_js_path.exists() || !viewer_wasm_path.exists() {
+            // Detect build profile to choose the right pixi command
+            let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
+            let is_release = profile == "release" || profile == "web-release";
+
+            let pixi_command = if is_release {
+                "rerun-build-web-release"
+            } else {
+                "rerun-build-web"
+            };
+
+            eprintln!("Web viewer not found, building it automatically...");
+            eprintln!("Running: pixi run {}\n", pixi_command);
+
+            // Try to automatically build the web viewer
+            let mut command = std::process::Command::new("pixi");
+            command.args(["run", pixi_command]);
+
+            // Running `cargo` from within a build-script inherits the workspace lock which
+            // causes nested invocations to wait forever.  `pixi run` ultimately launches a
+            // `cargo run` which needs its own target directory in order to avoid that lock.
+            // Compute the workspace target directory from `OUT_DIR` and point the nested
+            // invocation at a separate subdirectory.
+            if let Ok(out_dir) = std::env::var("OUT_DIR") {
+                let target_dir = std::path::Path::new(&out_dir)
+                    .ancestors()
+                    .find(|path| path.file_name().map_or(false, |name| name == "target"))
+                    .or_else(|| std::path::Path::new(&out_dir).ancestors().nth(3));
+
+                if let Some(target_dir) = target_dir {
+                    command.env(
+                        "CARGO_TARGET_DIR",
+                        target_dir.join("web_viewer_build"),
+                    );
+                }
+            }
+
+            let result = command.status();
+
+            match result {
+                Ok(status) if status.success() => {
+                    eprintln!("\n✓ Web viewer built successfully!\n");
+                    // Verify the files were actually created
+                    if !viewer_js_path.exists() || !viewer_wasm_path.exists() {
+                        panic!(
+                            "\n\nWeb viewer build succeeded but files are still missing!\n\
+                             Expected files:\n  • {}\n  • {}\n",
+                            viewer_js_path.display(),
+                            viewer_wasm_path.display()
+                        );
+                    }
+                }
+                Ok(status) => {
+                    // Pixi command failed, show helpful error
+                    panic!(
+                        "\n\n\
+                        ╔══════════════════════════════════════════════════════════════════╗\n\
+                        ║  Failed to build web viewer automatically                        ║\n\
+                        ╠══════════════════════════════════════════════════════════════════╣\n\
+                        ║  Command 'pixi run {}' failed with exit code: {:?}         ║\n\
+                        ║                                                                  ║\n\
+                        ║  Please try building manually:                                   ║\n\
+                        ║    Debug:   pixi run rerun-build-web                             ║\n\
+                        ║    Release: pixi run rerun-build-web-release                     ║\n\
+                        ║                                                                  ║\n\
+                        ║  Or disable the web viewer server:                               ║\n\
+                        ║    export RERUN_DISABLE_WEB_VIEWER_SERVER=1                      ║\n\
+                        ╚══════════════════════════════════════════════════════════════════╝\n",
+                        pixi_command,
+                        status.code()
+                    );
+                }
+                Err(e) => {
+                    // Pixi not found or other error
+                    panic!(
+                        "\n\n\
+                        ╔══════════════════════════════════════════════════════════════════╗\n\
+                        ║  Failed to execute pixi command                                  ║\n\
+                        ╠══════════════════════════════════════════════════════════════════╣\n\
+                        ║  Error: {:<59} ║\n\
+                        ║                                                                  ║\n\
+                        ║  Make sure 'pixi' is installed and in your PATH                 ║\n\
+                        ║                                                                  ║\n\
+                        ║  Or build the web viewer manually:                               ║\n\
+                        ║    pixi run rerun-build-web                                      ║\n\
+                        ║                                                                  ║\n\
+                        ║  Or disable the web viewer server:                               ║\n\
+                        ║    export RERUN_DISABLE_WEB_VIEWER_SERVER=1                      ║\n\
+                        ╚══════════════════════════════════════════════════════════════════╝\n",
+                        e
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
It's annoying to have to interrupt the Rust build to build the web viewer. This PR replaces the hard assertion with automatic web viewer building when WASM files are missing. Also, it detects build profile and runs the appropriate `pixi` command with a custom `CARGO_TARGET_DIR` to prevent workspace lock conflicts.
