### PR TITLE
re_auth: use `wasm-bindgen.workspace` instead of pinning

### DIFF
--- a/crates/utils/re_auth/Cargo.toml
+++ b/crates/utils/re_auth/Cargo.toml
@@ -70,14 +70,7 @@ tiny_http = { workspace = true, optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ehttp = { workspace = true, optional = true, features = ["json"] }
 js-sys.workspace = true
-# TODO(#8766): `rerun_js/web-viewer/build-wasm.mjs` is HIGHLY sensitive to changes in `wasm-bindgen`.
-#     Whenever updating `wasm-bindgen`, update this and the narrower dependency specifications in
-#     `crates/viewer/re_viewer/Cargo.toml`, and make sure that notebooks still work:
-#         See `rerun_notebook/README.md` for how to run notebooks.
-#         Try running a cell which starts a viewer, and then running it again.
-#         There should be no errors in the browser console.
-#     For details see https://github.com/rerun-io/rerun/issues/8766
-wasm-bindgen = "=0.2.100" # ⚠️ read above notice before touching this!
+wasm-bindgen.workspace = true
 web-sys = { workspace = true, features = ["Storage", "Window"] }
 
 [dev-dependencies]


### PR DESCRIPTION
We pin `wasm-bindgen` in `re_viewer` to avoid unintentional upgrades of it, since we depend on its output staying exactly the same across compilations to be able to patch the output. That is not the case for `re_auth`, so it doesn't need to be pinned.
