### PR TITLE
Add memory limit option to GrpcSink to prevent unbounded growth

### DIFF
--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -556,14 +556,17 @@ impl GrpcSink {
 
     /// Connect to the in-memory storage node over HTTP with custom options.
     ///
-    /// This allows you to configure memory limits and connection timeouts.
+    /// By default, the client will retry connections indefinitely and buffer unlimited messages.
+    /// This method allows you to opt-in to memory limits and connection timeouts for
+    /// resource-constrained scenarios (e.g., embedded devices, strict memory budgets).
     ///
     /// ### Example
     ///
     /// ```ignore
+    /// // Opt-in to limits for resource-constrained scenarios
     /// let options = GrpcSinkOptions {
-    ///     max_pending_messages: Some(5000),
-    ///     initial_connect_timeout: Some(Duration::from_secs(10)),
+    ///     max_pending_messages: Some(5000),           // Limit buffering to 5000 messages
+    ///     initial_connect_timeout: Some(Duration::from_secs(10)),  // Give up after 10s
     ///     ..Default::default()
     /// };
     /// GrpcSink::new_with_options("rerun+http://127.0.0.1:9434/proxy", options);


### PR DESCRIPTION
Fixes #11519 by adding configurable memory limits to prevent unbounded buffer growth when the client cannot connect to a server.

Changes:
- Add max_pending_messages option (default: 10,000 messages)
- Use bounded channel when limit is set, unbounded otherwise
- Drop new messages with warning when buffer is full
- Add GrpcSink::new_with_options() for custom configuration
- Include automated tests verifying the fix


Current implementation is to drop newest messages:
* When buffer is full, new messages are discarded
* Old/stale messages remain in the buffer
* When connection resumes, old data is sent first
* Result: Viewer shows stale data, not current state

A better approach could be to drop oldest:
* When buffer is full, old messages are discarded
* New messages are kept
* When connection resumes, recent data is sent
* Result: Viewer shows current state

Since `GrpcSink` uses `ChunkBatcherConfig::LOW_LATENCY` and is designed for live streaming to a viewer, users probably care more about seeing the current state than preserving historical data when the connection is down.

Implementing drop-oldest properly is complex:
1. Tokio's bounded channel doesn't support _evict oldest_ from sender side
2. Would need custom queue implementation (VecDeque + Mutex + Condvar?)
3. Potential for subtle bugs and race conditions
4. Much more code to test and maintain

*Option A*: Accept current implementation
* Pros: Simple, solves memory growth, flush works
* Cons: Poor UX for live visualization use case

*Option B*: Implement drop-oldest
* Pros: Better UX, sends recent data when reconnected
* Cons: Complex, requires custom queue, more testing needed

I could implement _Option B_ as a follow-up PR or as part of this one, just let me know!
