### PR TITLE
make sure we have the version in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,6 +395,7 @@ jobs:
           gh release create $version --verify-tag --draft --title $version $pre_arg
 
       - name: Create comment
+        if: inputs.release-type == 'rc' || inputs.release-type == 'final'
         env:
           GH_TOKEN: ${{ secrets.RERUN_BOT_TOKEN }}
         run: |


### PR DESCRIPTION
### What

Currently the release job doesn't get the "version" variable, this fixes that by making the tag and release different steps in the same job,
