### PR TITLE
Don't smooth velocity after WASD input

### DIFF
--- a/crates/viewer/re_view_spatial/src/eye.rs
+++ b/crates/viewer/re_view_spatial/src/eye.rs
@@ -533,6 +533,8 @@ impl ControlEye {
 
             let world_movement = rot * (self.speed as f32 * local_movement);
 
+            // If input is zero, don't continue moving with velocity. Since we're no longer interacting
+            // we don't want to continue writing to blueprint and creating undo points.
             eye_state.velocity = if local_movement == Vec3::ZERO {
                 Vec3::ZERO
             } else {


### PR DESCRIPTION
### Related

- Follow-up from #11788
- Closes https://github.com/rerun-io/rerun/issues/11867

### What

Stops smoothing down velocity after moving with WASD.

This wasn't written to the blueprint so caused rubber banding that's visible on high speeds.