### PR TITLE
URDF loader: Use global material if inline material is absent

### DIFF
--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -495,7 +495,7 @@ fn log_link(
         let name = name.clone().unwrap_or_else(|| format!("visual_{i}"));
         let vis_entity = link_entity / EntityPathPart::new(name);
 
-        // Prefer inline defined material properties, if there's no properties fall back to global material.
+        // Prefer inline defined material properties if present, otherwise fall back to global material.
         let material = material.as_ref().and_then(|mat| {
             if mat.color.is_some() || mat.texture.is_some() {
                 Some(mat)


### PR DESCRIPTION
### What

If a `visual`’s inline material does not specify a color or texture, use the matching global material instead (if any).