### PR TITLE
Fix `dataset_ui_test` broken by the dataset name now appearing twice in the UI

### DIFF
--- a/tests/rust/re_integration_test/tests/re_integration.rs
+++ b/tests/rust/re_integration_test/tests/re_integration.rs
@@ -38,12 +38,21 @@ pub async fn dataset_ui_test() {
     viewer_test_utils::step_until(
         "Redap server dataset appears",
         &mut harness,
-        |harness| harness.query_by_label_contains("my_dataset").is_some(),
+        // The label eventually appears twice: first in the left panel, and in the entries table
+        // when it refreshes. Here we wait for both to appear. Later we pick the first one (in the
+        // left panel).
+        |harness| harness.query_all_by_label_contains("my_dataset").count() == 2,
         Duration::from_millis(100),
         Duration::from_secs(5),
     );
 
-    harness.get_by_label("my_dataset").click();
+    // We pick the first one.
+    harness
+        .get_all_by_label("my_dataset")
+        .next()
+        .unwrap()
+        .click();
+
     viewer_test_utils::step_until(
         "Redap recording id appears",
         &mut harness,


### PR DESCRIPTION
### Related

* triggered by #11872

### What

The test assumed that the dataset name appeared only once, which it did only because the OSS server's entry list was broken until #11872. Then it would also fail flakily since the entries table can take a while to refresh and appear in the UI.