### PR TITLE
Rename `ControlEye` to `EyeController`

### DIFF
--- a/crates/viewer/re_view_spatial/src/eye.rs
+++ b/crates/viewer/re_view_spatial/src/eye.rs
@@ -294,7 +294,7 @@ impl EyeController {
         })
     }
 
-    /// Saves the eye controls that have changed their values to the blueprint.
+    /// Saves the subset of eye controls that can change through user input to the blueprint.
     /// Does nothing if no interaction happened.
     fn save_to_blueprint(
         &self,


### PR DESCRIPTION
Improves readability. The new name makes it clearer that it's only an utility for mutating eye controls, not an eye itself.

Also renames awkward constructs like `eye.get_eye()` to `eye_controller.get_eye()`.

This is a cleanup in preparation for https://linear.app/rerun/issue/RR-178, where we noticed that the current eye code is a bit confusing to read (this might not be the last pure refactor, but let's go step by step)

