### PR TITLE
cloud telemetry: enrich span fields with trace_id

### DIFF
--- a/crates/utils/re_perf_telemetry/src/lib.rs
+++ b/crates/utils/re_perf_telemetry/src/lib.rs
@@ -62,7 +62,7 @@ pub use self::{
     args::{LogFormat, TelemetryArgs},
     grpc::{
         ClientTelemetryLayer, GrpcMakeSpan, GrpcOnEos, GrpcOnFirstBodyChunk, GrpcOnRequest,
-        GrpcOnResponse, ServerTelemetryLayer, TracingInjectorInterceptor,
+        GrpcOnResponse, ServerTelemetryLayer, TraceIdLayer, TracingInjectorInterceptor,
         new_client_telemetry_layer, new_server_telemetry_layer,
     },
     telemetry::{Telemetry, TelemetryDropBehavior},

--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer as _};
 
-use crate::{LogFormat, TelemetryArgs, shared_reader::SharedManualReader};
+use crate::{LogFormat, TelemetryArgs, TraceIdLayer, shared_reader::SharedManualReader};
 
 // ---
 
@@ -414,6 +414,7 @@ impl Telemetry {
                     .with(layer_logs_otlp)
                     .with(layer_logs_and_traces_stdio)
                     .with(layer_traces_otlp)
+                    .with(TraceIdLayer::default())
                     .with(self::tracy::tracy_layer())
                     .try_init()?;
             }
@@ -427,6 +428,7 @@ impl Telemetry {
                 .with(layer_logs_otlp)
                 .with(layer_logs_and_traces_stdio)
                 .with(layer_traces_otlp)
+                .with(TraceIdLayer::default())
                 .try_init()?;
         }
 


### PR DESCRIPTION
This will add trace_id and benchmark_id as span fileds explicitly.

The main use of this is that they will be included in log lines span
contexts so that we can filter by it.

