### PR TITLE
Add `Dataset[Entry|View].index_ranges()` to the API sandbox

### DIFF
--- a/rerun_py/tests/api_sandbox/rerun_draft/catalog.py
+++ b/rerun_py/tests/api_sandbox/rerun_draft/catalog.py
@@ -287,7 +287,7 @@ class DatasetEntry(Entry):
         )
 
     def index_ranges(self, index: str | IndexColumnDescriptor) -> datafusion.DataFrame:
-        view = DatasetView(self._inner, LazyDatasetState())
+        view = DatasetView(self._inner, _LazyDatasetState())
         return view.index_ranges(index)
 
     def create_fts_index(

--- a/rerun_py/tests/api_sandbox/test_draft/test_index_ranges.py
+++ b/rerun_py/tests/api_sandbox/test_draft/test_index_ranges.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from rerun_draft.catalog import DatasetEntry
 
 
-def test_index_statistics(complex_dataset: DatasetEntry) -> None:
+def test_index_ranges(complex_dataset: DatasetEntry) -> None:
     df = complex_dataset.index_ranges("timeline").sort("rerun_segment_id")
 
     assert str(df) == inline_snapshot("""\
@@ -35,7 +35,7 @@ def test_index_statistics(complex_dataset: DatasetEntry) -> None:
 """)
 
 
-def test_index_statistics_dataset_view(complex_dataset: DatasetEntry) -> None:
+def test_index_ranges_dataset_view(complex_dataset: DatasetEntry) -> None:
     view = complex_dataset.filter_segments(["complex_recording_0", "complex_recording_1"])
 
     df = view.index_ranges("timeline").sort("rerun_segment_id")


### PR DESCRIPTION
### Related

* part of https://linear.app/rerun/issue/RR-2901/pr-tracking-clean-up-cloud-apis-project

### What

Introduces `.index_ranges` to datasets and datasets view.