### PR TITLE
Add lint to check if rust classes have __str__, fix or exclude all existing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10714,6 +10714,7 @@ dependencies = [
  "datafusion-ffi",
  "document-features",
  "futures",
+ "indent",
  "infer",
  "itertools 0.14.0",
  "jiff",

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -80,6 +80,7 @@ crossbeam.workspace = true
 datafusion.workspace = true
 datafusion-ffi.workspace = true
 document-features.workspace = true
+indent.workspace = true
 futures.workspace = true
 itertools.workspace = true
 jiff.workspace = true

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -1419,6 +1419,9 @@ class RecordingStream:
 
         send_columns(entity_path=entity_path, indexes=indexes, columns=columns, strict=strict, recording=self)
 
+    def __str__(self) -> str:
+        return str(self.inner)
+
 
 class BinaryStream:
     """An encoded stream of bytes that can be saved as an rrd or sent to the viewer."""

--- a/rerun_py/src/catalog/dataframe_query.rs
+++ b/rerun_py/src/catalog/dataframe_query.rs
@@ -439,6 +439,18 @@ impl PyDataframeQueryView {
             self_.partition_ids.as_slice(),
         )
     }
+
+    pub fn __str__(&self, py: Python<'_>) -> String {
+        let dataset_str = PyDatasetEntry::__str__(self.dataset.borrow(py));
+        let query_expr_str = format!("{:#?}", self.query_expression);
+
+        let dataset_line = indent::indent_all_by(1, format!("dataset={dataset_str},"));
+        let query_line = indent::indent_all_by(1, format!("query_expression={query_expr_str},"));
+        let partition_line =
+            indent::indent_all_by(1, format!("partition_ids={:?}", self.partition_ids));
+
+        format!("DataframeQueryView(\n{dataset_line}\n{query_line}\n{partition_line}\n)")
+    }
 }
 
 impl PyDataframeQueryView {

--- a/rerun_py/src/catalog/dataframe_rendering.rs
+++ b/rerun_py/src/catalog/dataframe_rendering.rs
@@ -95,7 +95,7 @@ impl PyRerunHtmlTable {
     }
 }
 
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyRerunHtmlTable {
     #[new]
     #[pyo3(signature = (max_width=None, max_height=None))]

--- a/rerun_py/src/catalog/datafusion_catalog.rs
+++ b/rerun_py/src/catalog/datafusion_catalog.rs
@@ -34,7 +34,7 @@ impl PyDataFusionCatalogProvider {
     }
 }
 
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyDataFusionCatalogProvider {
     /// Returns a DataFusion catalog provider capsule.
     fn __datafusion_catalog_provider__<'py>(

--- a/rerun_py/src/catalog/datafusion_table.rs
+++ b/rerun_py/src/catalog/datafusion_table.rs
@@ -71,4 +71,8 @@ impl PyDataFusionTable {
     fn name(&self) -> String {
         self.name.clone()
     }
+
+    pub fn __str__(&self) -> String {
+        format!("DataFusionTable(name='{}')", self.name)
+    }
 }

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -942,6 +942,15 @@ impl PyDatasetEntry {
             unsafe_allow_recent_cleanup,
         )
     }
+
+    pub fn __str__(self_: PyRef<'_, Self>) -> String {
+        let super_ = self_.as_super();
+        format!(
+            "DatasetEntry(name='{}', id='{}')",
+            super_.name(),
+            super_.details.id
+        )
+    }
 }
 
 impl PyDatasetEntry {

--- a/rerun_py/src/catalog/entry.rs
+++ b/rerun_py/src/catalog/entry.rs
@@ -66,7 +66,8 @@ pub enum PyEntryKind {
     BlueprintDataset = 5,
 }
 
-#[pymethods]
+// Enums don't need str
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyEntryKind {
     // This allows for EntryType.DATASET syntax in Python
     #[classattr]

--- a/rerun_py/src/catalog/indexes.rs
+++ b/rerun_py/src/catalog/indexes.rs
@@ -72,6 +72,11 @@ impl PyIndexingResult {
             None => Ok(None),
         }
     }
+
+    pub fn __repr__(&self) -> String {
+        // Technically not a repr, but nice to printout when this is in a list.
+        format!("IndexingResult(index={})", self.index)
+    }
 }
 
 // ---

--- a/rerun_py/src/catalog/table_entry.rs
+++ b/rerun_py/src/catalog/table_entry.rs
@@ -83,6 +83,10 @@ impl PyTableEntry {
     pub fn storage_url(&self) -> String {
         self.url.clone().unwrap_or_default()
     }
+
+    pub fn __str__(&self) -> String {
+        format!("TableEntry(url='{}')", self.url.clone().unwrap_or_default())
+    }
 }
 
 impl PyTableEntry {

--- a/rerun_py/src/catalog/task.rs
+++ b/rerun_py/src/catalog/task.rs
@@ -119,4 +119,8 @@ impl PyTasks {
             id: self.ids[index].clone(),
         })
     }
+
+    pub fn __str__(&self) -> String {
+        format!("Tasks(client={}, ids={:#?})", self.client, self.ids)
+    }
 }

--- a/rerun_py/src/dataframe/recording.rs
+++ b/rerun_py/src/dataframe/recording.rs
@@ -126,7 +126,7 @@ impl PyRecording {
     }
 }
 
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyRecording {
     /// The schema describing all the columns available in the recording.
     fn schema(&self) -> PySchema {

--- a/rerun_py/src/dataframe/recording_view.rs
+++ b/rerun_py/src/dataframe/recording_view.rs
@@ -78,7 +78,7 @@ impl PyRecordingView {
 /// was logged to a given index multiple times, only the most recent row will be included in the view, as determined
 /// by the `row_id` column. This will generally be the last value logged, as row_ids are guaranteed to be monotonically
 /// increasing when data is sent from a single process.
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyRecordingView {
     /// The schema describing all the columns available in the view.
     ///

--- a/rerun_py/src/dataframe/rrd.rs
+++ b/rerun_py/src/dataframe/rrd.rs
@@ -17,7 +17,7 @@ pub struct PyRRDArchive {
     pub datasets: BTreeMap<StoreId, ChunkStoreHandle>,
 }
 
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyRRDArchive {
     /// The number of recordings in the archive.
     fn num_recordings(&self) -> usize {

--- a/rerun_py/src/dataframe/schema.rs
+++ b/rerun_py/src/dataframe/schema.rs
@@ -18,7 +18,7 @@ pub struct SchemaIterator {
     iter: std::vec::IntoIter<PyObject>,
 }
 
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl SchemaIterator {
     fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -468,6 +468,10 @@ impl PyChunkBatcherConfig {
     fn NEVER() -> Self {
         Self(ChunkBatcherConfig::NEVER)
     }
+
+    pub fn __str__(&self) -> String {
+        format!("{:#?}", self.0)
+    }
 }
 
 /// Create a new recording stream.
@@ -636,6 +640,10 @@ impl PyRecordingStream {
     /// Calling operations such as flush or set_sink will result in an error.
     fn is_forked_child(&self) -> bool {
         self.0.is_forked_child()
+    }
+
+    pub fn __str__(&self) -> String {
+        format!("RecordingStream({:#?})", self.0.store_info())
     }
 }
 
@@ -925,6 +933,10 @@ impl PyGrpcSink {
 
         Ok(Self { uri })
     }
+
+    pub fn __repr__(&self) -> String {
+        format!("GrpcSink({:#?})", self.uri)
+    }
 }
 
 #[pyclass(
@@ -946,6 +958,10 @@ impl PyFileSink {
     #[pyo3(text_signature = "(self, path)")]
     fn new(path: PathBuf) -> Self {
         Self { path }
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("FileSink({:#?})", self.path)
     }
 }
 
@@ -1367,6 +1383,10 @@ impl PyMemorySinkStorage {
         .map(|bytes| PyBytes::new(py, bytes.as_slice()))
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))
     }
+
+    pub fn __repr__(&self) -> String {
+        format!("MemorySinkStorage({:#?})", self.inner.store_id())
+    }
 }
 
 #[pyclass(frozen, module = "rerun_bindings.rerun_bindings")] // NOLINT: ignore[py-cls-eq] non-trivial implementation
@@ -1375,7 +1395,7 @@ struct PyBinarySinkStorage {
     inner: BinaryStreamStorage,
 }
 
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyBinarySinkStorage {
     /// Read the bytes from the binary sink.
     ///

--- a/rerun_py/src/server.rs
+++ b/rerun_py/src/server.rs
@@ -17,7 +17,7 @@ pub struct PyServerInternal {
     address: SocketAddr,
 }
 
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyServerInternal {
     #[new]
     #[pyo3(signature = (*, address="0.0.0.0", port=51234, datasets=None, tables=None))]

--- a/rerun_py/src/viewer.rs
+++ b/rerun_py/src/viewer.rs
@@ -20,7 +20,7 @@ pub(crate) fn register(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()>
 pub struct PyViewerClient {
     conn: ViewerConnectionHandle,
 }
-#[pymethods]
+#[pymethods] // NOLINT: ignore[py-mthd-str]
 impl PyViewerClient {
     /// Create a new viewer client object.
     #[new]

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1353,8 +1353,6 @@ def lint_file(filepath: str, args: Any) -> int:
                         source.error(error)
                         + f"\n\tUnqualified NOLINT not allowed for pymethods lints. Use `NOLINT: ignore[{error_code}]` instead."
                     )
-                    if error_code == "py-mthd-str":
-                        continue
                     valid_pymethods_errors += 1
             num_errors += valid_pymethods_errors
 


### PR DESCRIPTION
### Related
https://github.com/rerun-io/rerun/pull/11650

### What
I hate seeing `<rerun_bindings.rerun_bindings.DataFusionTable object at 0x10d4220b0>` when I print things.
* Updated our lint.py to use git for file discovery. This is ~1000x faster than the package walk. Don't have a way to confirm we aren't missing new things now 😬 if not correct by inspection I guess I could try doing a set diff and manually inspecting
* I also asked a robot to generate a new lint rule to check for __str__ in our pymethods
* Implemented a whole bunch and added no lint when I got tired of it

Here is my minimal repro script to exercise most code paths:
```python
import rerun as rr
client = rr.catalog.CatalogClient("rerun://sandbox.redap.rerun.io")
print(client)
print(client.table_entries())
dataset = client.get_dataset(name="droid:raw")
print(dataset)
print(dataset.partition_table())
print(dataset.list_indexes())
first_partition = dataset.partition_ids()[0]
qv = dataset.dataframe_query_view(index="real_time", contents="/observation/gripper_position").filter_partition_id(first_partition)
print(qv)
print(rr.RecordingStream("foo"))
print(rr.GrpcSink("rerun+http://127.0.0.1:9876/proxy"))
print(rr.FileSink("out.rerun"))
```

Before
```console
CatalogClient(rerun://sandbox.redap.rerun.io:443)
[Entry(Table, '__entries')]
Entry(Dataset, 'droid:raw')
<rerun_bindings.rerun_bindings.DataFusionTable object at 0x10d4220b0>
[<rerun_bindings.rerun_bindings.IndexingResult object at 0x10d1e5b00>]
<rerun_bindings.rerun_bindings.DataframeQueryView object at 0x10d0e7660>
<rerun.recording_stream.RecordingStream object at 0x103232cf0>
<rerun_bindings.rerun_bindings.GrpcSink object at 0x10cff4540>
<rerun_bindings.rerun_bindings.FileSink object at 0x10cff4540>
```

After ( a little verbose but definitely better than above and we can adjust as needed).

```console
CatalogClient(rerun://sandbox.redap.rerun.io:443)
[Entry(Table, '__entries')]
DatasetEntry(name='droid:raw', id='187514A5086F1F1D5906873e499c6436')
DataFusionTable(name='droid:raw_partition_table')
[IndexingResult(index='/camera/wrist/embedding:embeddings' on 'real_time': VectorIvfPq { num_sub_vectors: 16, metric: cosine })]
DataframeQueryView(
 dataset=DatasetEntry(name='droid:raw', id='187514A5086F1F1D5906873e499c6436'),
 query_expression=QueryExpression {
     view_contents: Some(
         ViewContentsSelector(
             {
                 /observation/gripper_position: None,
             },
         ),
     ),
     include_semantically_empty_columns: false,
     include_tombstone_columns: false,
     include_static_columns: Both,
     filtered_index: Some(
         "real_time",
     ),
     filtered_index_range: None,
     filtered_index_values: None,
     using_index_values: None,
     filtered_is_not_null: None,
     sparse_fill_strategy: None,
     selection: None,
 },
 partition_ids=["ILIAD_50aee79f_2023_07_12_20h_28m_36s"]
)
RecordingStream(Some(
    StoreInfo {
        store_id: StoreId(
            Recording,
            "foo",
            "935b03a47f834753b5329a70dc991556",
        ),
        cloned_from: None,
        store_source: PythonSdk(
            3.11.13,
        ),
        store_version: Some(
            CrateVersion {
                major: 0,
                minor: 28,
                patch: 0,
                meta: Some(
                    DevAlpha {
                        alpha: 1,
                        commit: None,
                    },
                ),
            },
        ),
        is_partial: false,
    },
))
GrpcSink(ProxyUri {
    origin: Origin {
        scheme: RerunHttp,
        host: Ipv4(
            127.0.0.1,
        ),
        port: 9876,
    },
})
FileSink("out.rerun")
```

