### PR TITLE
Order partitions by opening order

### DIFF
--- a/crates/viewer/re_recording_panel/src/data.rs
+++ b/crates/viewer/re_recording_panel/src/data.rs
@@ -376,9 +376,9 @@ impl<'a> ServerEntriesData<'a> {
                                 .collect();
 
                             if let Some(loading_partitions) = loading_partitions
-                                && let Some(sources) = loading_partitions.get(&entry.id())
+                                && let Some(smart_channels) = loading_partitions.get(&entry.id())
                             {
-                                displayed_partitions.extend(sources.iter().map(|source| {
+                                displayed_partitions.extend(smart_channels.iter().map(|source| {
                                     PartitionData::Loading {
                                         receiver: source.clone(),
                                     }

--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -427,9 +427,7 @@ fn dataset_entry_ui(
             .show_hierarchical_with_children(ui, id, true, list_item_content, |ui| {
                 for partition in displayed_partitions {
                     match partition {
-                        PartitionData::Loading { receiver, .. } => {
-                            receiver_ui(ctx, ui, receiver, true);
-                        }
+                        PartitionData::Loading { receiver } => receiver_ui(ctx, ui, receiver, true),
 
                         PartitionData::Loaded { entity_db } => {
                             let include_app_id = false; // we already show it in the parent item
@@ -648,8 +646,8 @@ fn loading_receivers_ui(
     ui: &mut egui::Ui,
     loading_receivers: &Vec<Arc<SmartChannelSource>>,
 ) {
-    for source in loading_receivers {
-        receiver_ui(ctx, ui, source, false);
+    for receiver in loading_receivers {
+        receiver_ui(ctx, ui, receiver, false);
     }
 }
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -2913,6 +2913,7 @@ impl eframe::App for App {
             .take()
             .expect("Failed to take store hub from the Viewer");
 
+        // Update data source order so it's based on opening order.
         store_hub.update_data_source_order(&self.rx_log.sources());
 
         #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
### Related

- Closes RR-2340
- Closes https://github.com/rerun-io/rerun/issues/9848

### What

Makes partitions order by opening order in the recordings panel, instead of loaded order.

### Details

This adds a static incrementing counter that's incremented for each new smart channel receiver. Which is then wrapped in a new-type struct which we can use to order receivers.