### PR TITLE
Adding Recording Context in ViewerContext to keep timeline for different storeIds

### DIFF
--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -96,6 +96,7 @@ fn shift_through_recordings(
         // TODO(#11792): this whole feature would be massively more useful if we left the selection
         // alone and tried to maintain viewer state when switching recording (including current
         // timeline, time point, selection, etc.)
+
         ctx.command_sender()
             .send_system(SystemCommand::SetSelection(
                 Item::StoreId(store_collection[new_idx].store_id().clone()).into(),

--- a/crates/viewer/re_test_context/src/lib.rs
+++ b/crates/viewer/re_test_context/src/lib.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use ahash::HashMap;
+use ahash::{HashMap, HashMapExt};
 use egui::os::OperatingSystem;
 use parking_lot::{Mutex, RwLock};
 
@@ -537,6 +537,7 @@ impl TestContext {
             blueprint_query: &self.blueprint_query,
             focused_item: &focused_item,
             drag_and_drop_manager: &drag_and_drop_manager,
+            recordings_context: HashMap::new(),
         };
 
         func(&ctx);

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -526,6 +526,7 @@ impl App {
             };
 
             let dt = self.egui_ctx.input(|i| i.stable_dt);
+
             if let Some(recording) = store_hub.active_recording() {
                 // Are we still connected to the data source for the current store?
                 let more_data_is_coming =
@@ -554,6 +555,8 @@ impl App {
                     self.egui_ctx.request_repaint();
                 }
 
+                // println!("command to change time has recieved for storeId: {:?}" , store_id.clone());
+                // println!("triggetring handle time ctrl from active recording if clause");
                 handle_time_ctrl_event(recording, self.event_dispatcher.as_ref(), &response);
             }
 
@@ -1092,6 +1095,10 @@ impl App {
             }
 
             SystemCommand::SetSelection(set) => {
+
+
+                let current_store_id = self.store_hub.unwrap().active_store_id();
+
                 if let Some(item) = set.selection.single_item() {
                     // If the selected item has its own page, switch to it.
                     if let Some(display_mode) = DisplayMode::from_item(item) {
@@ -2903,6 +2910,7 @@ impl eframe::App for App {
             }
         }
 
+
         // We move the time at the very start of the frame,
         // so that we always show the latest data when we're in "follow" mode.
         self.move_time();
@@ -3505,14 +3513,17 @@ fn handle_time_ctrl_event(
     };
 
     if let Some(playing) = response.playing_change {
+        println!("Play state changed");
         events.on_play_state_change(recording, playing);
     }
 
     if let Some((timeline, time)) = response.timeline_change {
+        println!("Timeline has been changed");
         events.on_timeline_change(recording, timeline, time);
     }
 
     if let Some(time) = response.time_change {
+        println!("Clicked on some random time");
         events.on_time_update(recording, time);
     }
 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -555,8 +555,6 @@ impl App {
                     self.egui_ctx.request_repaint();
                 }
 
-                // println!("command to change time has recieved for storeId: {:?}" , store_id.clone());
-                // println!("triggetring handle time ctrl from active recording if clause");
                 handle_time_ctrl_event(recording, self.event_dispatcher.as_ref(), &response);
             }
 
@@ -3513,17 +3511,14 @@ fn handle_time_ctrl_event(
     };
 
     if let Some(playing) = response.playing_change {
-        println!("Play state changed");
         events.on_play_state_change(recording, playing);
     }
 
     if let Some((timeline, time)) = response.timeline_change {
-        println!("Timeline has been changed");
         events.on_timeline_change(recording, timeline, time);
     }
 
     if let Some(time) = response.time_change {
-        println!("Clicked on some random time");
         events.on_time_update(recording, time);
     }
 }

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -367,7 +367,7 @@ impl AppState {
 
                     if let Some(ctx) = recordings_context.get(&current_store_id) {
                         selection_state.set_selection(ctx.selection.clone());
-                        
+
                     }
 
                     *previous_store_id = Some(current_store_id.clone());
@@ -402,7 +402,7 @@ impl AppState {
                     maybe_visualizable_entities_per_visualizer:
                         &maybe_visualizable_entities_per_visualizer,
                     indicated_entities_per_visualizer: &indicated_entities_per_visualizer,
-
+                    query_results: &query_results,
                     time_ctrl,
                     blueprint_time_ctrl: blueprint_time_control,
                     selection_state,
@@ -410,7 +410,6 @@ impl AppState {
                     focused_item,
                     drag_and_drop_manager: &drag_and_drop_manager,
                     recordings_context,
-                    query_results: &query_results,
                 };
 
 

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, str::FromStr as _};
 
-use ahash::HashMap;
+use ahash::{HashMap, HashMapExt};
 use egui::{Ui, text_edit::TextEditState, text_selection::LabelSelectionState};
 
 use re_chunk::{Timeline, TimelineName};
@@ -17,9 +17,10 @@ use re_viewer_context::{
     BlueprintUndoState, CommandSender, ComponentUiRegistry, DataQueryResult, DisplayMode,
     DragAndDropManager, FallbackProviderRegistry, GlobalContext, IndicatedEntities, Item,
     MaybeVisualizableEntities, PerVisualizer, SelectionChange, StorageContext, StoreContext,
-    StoreHub, SystemCommand, SystemCommandSender as _, TableStore, TimeControl, TimeControlCommand,
-    ViewClassRegistry, ViewId, ViewStates, ViewerContext, blueprint_timeline,
+    StoreHub, SystemCommand,    SystemCommandSender as _, TimeControl, TimeControlCommand, ViewClassRegistry, ViewId,
+    ViewStates, ViewerContext, blueprint_timeline,
     open_url::{self, ViewerOpenUrl},
+    recording_context::RecordingContext,
 };
 use re_viewport::ViewportUi;
 use re_viewport_blueprint::ViewportBlueprint;
@@ -107,6 +108,14 @@ pub struct AppState {
     /// that last several frames.
     #[serde(skip)]
     pub(crate) focused_item: Option<Item>,
+
+    /// State for each recording (timeline, time, selection, etc.)
+    #[serde(skip)]
+    pub recordings_context: HashMap<StoreId, RecordingContext>,
+
+    /// Track the previous recording to detect switches
+    #[serde(skip)]
+    pub previous_store_id: Option<StoreId>,
 }
 
 impl Default for AppState {
@@ -130,6 +139,8 @@ impl Default for AppState {
             view_states: Default::default(),
             selection_state: Default::default(),
             focused_item: Default::default(),
+            recordings_context: Default::default(),
+            previous_store_id: Default::default(),
 
             #[cfg(feature = "testing")]
             test_hook: None,
@@ -371,6 +382,7 @@ impl AppState {
                     blueprint_query: &blueprint_query,
                     focused_item,
                     drag_and_drop_manager: &drag_and_drop_manager,
+                    recordings_context: HashMap::new(),
                 };
 
                 // enable the heuristics if we must this frame
@@ -427,6 +439,7 @@ impl AppState {
                     blueprint_query: &blueprint_query,
                     focused_item,
                     drag_and_drop_manager: &drag_and_drop_manager,
+                    recordings_context: HashMap::new(),
                 };
 
                 //
@@ -730,6 +743,7 @@ impl AppState {
     }
 
     pub fn time_control(&self, rec_id: &StoreId) -> Option<&TimeControl> {
+        println!("Time control fn called for storedId: {:?}" , rec_id);
         self.time_controls.get(rec_id)
     }
 

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -41,6 +41,8 @@ mod utils;
 mod view;
 mod viewer_context;
 
+mod recording_context;
+
 // TODO(andreas): Move to its own crate?
 pub mod gpu_bridge;
 mod visitor_flow_control;

--- a/crates/viewer/re_viewer_context/src/recording_context.rs
+++ b/crates/viewer/re_viewer_context/src/recording_context.rs
@@ -1,0 +1,115 @@
+use re_chunk::TimelineName;
+use re_log_types::{AbsoluteTimeRange, TimeInt, TimeType, Timeline};
+
+use crate::ItemCollection;
+
+#[derive(Default)]
+pub struct RecordingContext {
+    pub current_selection: Timeline,
+    pub current_time_selection: AbsoluteTimeRange,
+    pub time_point: AbsoluteTimeRange,
+    pub selection: ItemCollection,
+}
+
+impl RecordingContext {
+    pub fn new(
+        current_selection: Timeline,
+        current_time_selection: AbsoluteTimeRange,
+        time_point: AbsoluteTimeRange,
+        selection: ItemCollection,
+    ) -> Self {
+        Self {
+            current_selection,
+            current_time_selection,
+            time_point,
+            selection,
+        }
+    }
+
+    /// Set the current timeline selection.
+    pub fn set_current_selection(&mut self, timeline: Timeline) {
+        self.current_selection = timeline;
+    }
+
+    /// Set the current timeline selection by name and type.
+    pub fn set_current_selection_by_name(&mut self, name: impl Into<TimelineName>, typ: TimeType) {
+        self.current_selection = Timeline::new(name, typ);
+    }
+
+    /// Update the current timeline selection's name.
+    pub fn set_current_selection_name(&mut self, name: impl Into<TimelineName>) {
+        self.current_selection = Timeline::new(name, self.current_selection.typ());
+    }
+
+    /// Update the current timeline selection's type.
+    pub fn set_current_selection_type(&mut self, typ: TimeType) {
+        self.current_selection = Timeline::new(*self.current_selection.name(), typ);
+    }
+
+    /// Set the current time selection range.
+    pub fn set_current_time_selection(&mut self, time_range: AbsoluteTimeRange) {
+        self.current_time_selection = time_range;
+    }
+
+    /// Set the current time selection range from min and max values.
+    pub fn set_current_time_selection_range(
+        &mut self,
+        min: impl TryInto<TimeInt>,
+        max: impl TryInto<TimeInt>,
+    ) {
+        self.current_time_selection = AbsoluteTimeRange::new(min, max);
+    }
+
+    /// Update the minimum time of the current time selection.
+    pub fn set_current_time_selection_min(&mut self, min: impl TryInto<TimeInt>) {
+        self.current_time_selection.set_min(min);
+    }
+
+    /// Update the maximum time of the current time selection.
+    pub fn set_current_time_selection_max(&mut self, max: impl TryInto<TimeInt>) {
+        self.current_time_selection.set_max(max);
+    }
+
+    /// Set the time point range.
+    pub fn set_time_point(&mut self, time_range: AbsoluteTimeRange) {
+        self.time_point = time_range;
+    }
+
+    /// Set the time point range from min and max values.
+    pub fn set_time_point_range(&mut self, min: impl TryInto<TimeInt>, max: impl TryInto<TimeInt>) {
+        self.time_point = AbsoluteTimeRange::new(min, max);
+    }
+
+    /// Set the time point to a single point in time.
+    pub fn set_time_point_to(&mut self, time: impl TryInto<TimeInt>) {
+        self.time_point = AbsoluteTimeRange::point(time);
+    }
+
+    /// Update the minimum time of the time point.
+    pub fn set_time_point_min(&mut self, min: impl TryInto<TimeInt>) {
+        self.time_point.set_min(min);
+    }
+
+    /// Update the maximum time of the time point.
+    pub fn set_time_point_max(&mut self, max: impl TryInto<TimeInt>) {
+        self.time_point.set_max(max);
+    }
+
+    /// Update all fields at once.
+    pub fn update_all(
+        &mut self,
+        current_selection: Option<Timeline>,
+        current_time_selection: Option<AbsoluteTimeRange>,
+        time_point: Option<AbsoluteTimeRange>,
+    ) {
+        if let Some(selection) = current_selection {
+            self.current_selection = selection;
+        }
+        if let Some(time_selection) = current_time_selection {
+            self.current_time_selection = time_selection;
+        }
+        if let Some(point) = time_point {
+            self.time_point = point;
+        }
+    }
+}

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -3,7 +3,7 @@ use ahash::HashMap;
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::InstancePath;
 use re_entity_db::entity_db::EntityDb;
-use re_log_types::{EntryId, TableId};
+use re_log_types::{EntryId, StoreId, TableId};
 use re_query::StorageEngineReadGuard;
 use re_ui::ContextExt as _;
 use re_ui::list_item::ListItem;
@@ -19,6 +19,7 @@ use crate::{
     query_context::DataQueryResult,
 };
 use crate::{DisplayMode, GlobalContext, Item, StorageContext, StoreHub, SystemCommand};
+use crate::recording_context::RecordingContext;
 
 /// Common things needed by many parts of the viewer.
 pub struct ViewerContext<'a> {
@@ -75,6 +76,8 @@ pub struct ViewerContext<'a> {
     pub connected_receivers: &'a re_smart_channel::ReceiveSet<re_log_types::DataSourceMessage>,
 
     pub store_context: &'a StoreContext<'a>,
+
+    pub recordings_context: &'a mut HashMap<StoreId, RecordingContext>,
 }
 
 // Forwarding of `GlobalContext` methods to `ViewerContext`. Leaving this as a


### PR DESCRIPTION
This is not the final change, this is just an approach i am taking to fix the following Issue: #11792 

The approach is to basically keep a recording_context map based on storeId in viewer_context and set current selection if any recording switch happens. Currently testing it in my local but just wanted to get some feedback from you guys.
@abey79 @Wumpf @lucasmerlin 