### PR TITLE
Load URDF file into the current recording, if one exists already

### DIFF
--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -85,7 +85,7 @@ impl DataLoader for UrdfDataLoader {
             robot,
             &filepath,
             &tx,
-            &settings.recommended_store_id(),
+            &settings.opened_store_id_or_recommended(),
             &settings.entity_path_prefix,
             &settings.timepoint.clone().unwrap_or_default(),
         )
@@ -114,7 +114,7 @@ impl DataLoader for UrdfDataLoader {
             robot,
             &filepath,
             &tx,
-            &settings.recommended_store_id(),
+            &settings.opened_store_id_or_recommended(),
             &settings.entity_path_prefix,
             &settings.timepoint.clone().unwrap_or_default(),
         )


### PR DESCRIPTION
Previous behavior: if you dragged the URDF file into the viewer, it created its own new recording. Same for "Import into current recording" menu (note: requires #11941), which is counter-intuitive.

A recording containing only an URDF is pretty useless, and it's more common that you have some recording and want to add the model to it.

Loosely related to https://linear.app/rerun/issue/RR-2995