### PR TITLE
Make python api doc search match more things

### DIFF
--- a/rerun_py/mkdocs.yml
+++ b/rerun_py/mkdocs.yml
@@ -19,6 +19,9 @@ theme:
 
 plugins:
   - search: # https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/
+      # Copy-pasted from https://squidfunk.github.io/mkdocs-material/plugins/search/#config.separator
+      # with the addition of underscore. Splits things for better partial matching.
+      # Further exploration of the parts at the link.
       separator: '[\s\-,:!=\[\]()"/_]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
   - autorefs
   - mkdocstrings: # https://mkdocstrings.github.io/usage/#global-options


### PR DESCRIPTION
### Related

#11902

### What

Our python search by default looked for perfect matches which is 😠. This does a lazy improvement to at least split things along various characters to make it easier to match approximately. There are other features we could continue to tweak if necessary (or could overhaul with a better external search support index).

I still don't really know how to get our python api docs to update besides releasing a new version so run `pixi run py-docs-serve` locally and see that we now math the motivating issue (or trust me).

I also added a share link so I can refer to searches in the future without screenshots.


<img width="762" height="746" alt="Screenshot 2025-11-21 at 2 32 24 PM" src="https://github.com/user-attachments/assets/4b02bbc7-5735-4ed6-948d-5c1e2664c2bd" />

