### PR TITLE
Support URLs with origins and path prefixes

### DIFF
--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -252,7 +252,7 @@ impl LogDataSource {
                 let uri_clone = uri.clone();
                 let stream_partition = async move {
                     let client = connection_registry
-                        .client(uri_clone.origin.clone())
+                        .client(uri_clone.endpoint_addr.origin.clone())
                         .await
                         .map_err(|err| ApiError::connection(err, "failed to connect to server"))?;
                     re_redap_client::stream_blueprint_and_partition_from_server(

--- a/crates/store/re_grpc_client/src/read.rs
+++ b/crates/store/re_grpc_client/src/read.rs
@@ -39,7 +39,7 @@ async fn stream_async(
     on_msg: Option<Box<dyn Fn() + Send + Sync>>,
 ) -> Result<(), StreamError> {
     let mut client = {
-        let url = uri.origin.as_url();
+        let url = uri.endpoint_addr.origin.as_url();
 
         #[cfg(target_arch = "wasm32")]
         let tonic_client = {

--- a/crates/store/re_grpc_client/src/write.rs
+++ b/crates/store/re_grpc_client/src/write.rs
@@ -314,7 +314,7 @@ async fn message_proxy_client(
     compression: Compression,
     status: Arc<AtomicCell<ClientConnectionState>>,
 ) {
-    let endpoint = match Endpoint::from_shared(uri.origin.as_url()) {
+    let endpoint = match Endpoint::from_shared(uri.endpoint_addr.origin.as_url()) {
         Ok(endpoint) => endpoint,
         Err(err) => {
             status.store(ClientConnectionState::Disconnected(Err(

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -360,10 +360,9 @@ pub fn spawn_with_recv(
     re_smart_channel::Receiver<re_log_types::DataSourceMessage>,
     crossbeam::channel::Receiver<re_log_types::TableMsg>,
 ) {
-    let uri = re_uri::ProxyUri::new(
+    let uri = re_uri::ProxyUri::new(re_uri::EndpointAddr::new(
         re_uri::Origin::from_scheme_and_socket_addr(re_uri::Scheme::RerunHttp, addr),
-        String::new(),
-    );
+    ));
     let (channel_log_tx, channel_log_rx) = re_smart_channel::smart_channel(
         re_smart_channel::SmartMessageSource::MessageProxy(uri.clone()),
         re_smart_channel::SmartChannelSource::MessageProxy(uri),

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -360,10 +360,10 @@ pub fn spawn_with_recv(
     re_smart_channel::Receiver<re_log_types::DataSourceMessage>,
     crossbeam::channel::Receiver<re_log_types::TableMsg>,
 ) {
-    let uri = re_uri::ProxyUri::new(re_uri::Origin::from_scheme_and_socket_addr(
-        re_uri::Scheme::RerunHttp,
-        addr,
-    ));
+    let uri = re_uri::ProxyUri::new(
+        re_uri::Origin::from_scheme_and_socket_addr(re_uri::Scheme::RerunHttp, addr),
+        String::new(),
+    );
     let (channel_log_tx, channel_log_rx) = re_smart_channel::smart_channel(
         re_smart_channel::SmartMessageSource::MessageProxy(uri.clone()),
         re_smart_channel::SmartChannelSource::MessageProxy(uri),

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -351,6 +351,7 @@ pub async fn stream_blueprint_and_partition_from_server(
 
     let re_uri::DatasetPartitionUri {
         origin: _,
+        prefix: _,
         dataset_id,
         partition_id,
         time_range,

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -350,8 +350,7 @@ pub async fn stream_blueprint_and_partition_from_server(
     }
 
     let re_uri::DatasetPartitionUri {
-        origin: _,
-        prefix: _,
+        endpoint_addr: _,
         dataset_id,
         partition_id,
         time_range,

--- a/crates/top/re_sdk/src/grpc_server.rs
+++ b/crates/top/re_sdk/src/grpc_server.rs
@@ -34,10 +34,13 @@ impl GrpcServerSink {
 
         let grpc_server_addr = format!("{bind_ip}:{grpc_port}").parse()?;
 
-        let uri = re_uri::ProxyUri::new(re_uri::Origin::from_scheme_and_socket_addr(
-            re_uri::Scheme::RerunHttp,
-            grpc_server_addr,
-        ));
+        let uri = re_uri::ProxyUri::new(
+            re_uri::Origin::from_scheme_and_socket_addr(
+                re_uri::Scheme::RerunHttp,
+                grpc_server_addr,
+            ),
+            String::new(),
+        );
         let (channel_tx, channel_rx) = re_smart_channel::smart_channel::<re_log_types::LogMsg>(
             re_smart_channel::SmartMessageSource::MessageProxy(uri.clone()),
             re_smart_channel::SmartChannelSource::Sdk,

--- a/crates/top/re_sdk/src/grpc_server.rs
+++ b/crates/top/re_sdk/src/grpc_server.rs
@@ -34,13 +34,12 @@ impl GrpcServerSink {
 
         let grpc_server_addr = format!("{bind_ip}:{grpc_port}").parse()?;
 
-        let uri = re_uri::ProxyUri::new(
+        let uri = re_uri::ProxyUri::new(re_uri::EndpointAddr::new(
             re_uri::Origin::from_scheme_and_socket_addr(
                 re_uri::Scheme::RerunHttp,
                 grpc_server_addr,
             ),
-            String::new(),
-        );
+        ));
         let (channel_tx, channel_rx) = re_smart_channel::smart_channel::<re_log_types::LogMsg>(
             re_smart_channel::SmartMessageSource::MessageProxy(uri.clone()),
             re_smart_channel::SmartChannelSource::Sdk,

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -49,13 +49,12 @@ impl WebViewerSink {
         let (server_shutdown_signal, shutdown) = re_grpc_server::shutdown::shutdown();
 
         let grpc_server_addr = format!("{bind_ip}:{grpc_port}").parse()?;
-        let uri = re_uri::ProxyUri::new(
+        let uri = re_uri::ProxyUri::new(re_uri::EndpointAddr::new(
             re_uri::Origin::from_scheme_and_socket_addr(
                 re_uri::Scheme::RerunHttp,
                 grpc_server_addr,
             ),
-            String::new(),
-        );
+        ));
         let (channel_tx, channel_rx) = re_smart_channel::smart_channel::<re_log_types::LogMsg>(
             re_smart_channel::SmartMessageSource::MessageProxy(uri),
             re_smart_channel::SmartChannelSource::Sdk,

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -49,10 +49,13 @@ impl WebViewerSink {
         let (server_shutdown_signal, shutdown) = re_grpc_server::shutdown::shutdown();
 
         let grpc_server_addr = format!("{bind_ip}:{grpc_port}").parse()?;
-        let uri = re_uri::ProxyUri::new(re_uri::Origin::from_scheme_and_socket_addr(
-            re_uri::Scheme::RerunHttp,
-            grpc_server_addr,
-        ));
+        let uri = re_uri::ProxyUri::new(
+            re_uri::Origin::from_scheme_and_socket_addr(
+                re_uri::Scheme::RerunHttp,
+                grpc_server_addr,
+            ),
+            String::new(),
+        );
         let (channel_tx, channel_rx) = re_smart_channel::smart_channel::<re_log_types::LogMsg>(
             re_smart_channel::SmartMessageSource::MessageProxy(uri),
             re_smart_channel::SmartChannelSource::Sdk,

--- a/crates/utils/re_uri/src/endpoint_addr.rs
+++ b/crates/utils/re_uri/src/endpoint_addr.rs
@@ -1,0 +1,102 @@
+use crate::Origin;
+
+/// A Rerun endpoint address, consisting of an origin and an optional path prefix.
+///
+/// Example: `https://rerun.io:443/custom/prefix`
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct EndpointAddr {
+    pub origin: Origin,
+
+    /// An optional path prefix, e.g. `/my/prefix`.
+    ///
+    /// The prefix is guaranteed to start with a slash if it is not empty,
+    /// and guaranteed not to end with a slash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_prefix: Option<String>,
+}
+
+impl EndpointAddr {
+    /// Create a new [`EndpointAddr`] with the given origin and no path prefix.
+    pub fn new(origin: Origin) -> Self {
+        Self {
+            origin,
+            path_prefix: None,
+        }
+    }
+
+    /// Add a path prefix to the endpoint address.
+    ///
+    /// The prefix is normalized:
+    /// - It will be ensured to start with a `/` if not empty.
+    /// - Trailing slashes will be removed.
+    pub fn with_path_prefix(mut self, path_prefix: impl Into<String>) -> Self {
+        let path_prefix = path_prefix.into();
+        if path_prefix.is_empty() || path_prefix == "/" {
+            self.path_prefix = None;
+            return self;
+        }
+
+        let mut path_prefix = path_prefix.trim_end_matches('/').to_owned();
+        if !path_prefix.starts_with('/') {
+            path_prefix.insert(0, '/');
+        }
+
+        self.path_prefix = Some(path_prefix);
+        self
+    }
+}
+
+impl std::fmt::Display for EndpointAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            origin,
+            path_prefix,
+        } = self;
+
+        write!(f, "{origin}")?;
+        if let Some(prefix) = path_prefix {
+            write!(f, "{prefix}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Scheme;
+
+    fn test_origin() -> Origin {
+        Origin::from_scheme_and_socket_addr(Scheme::Rerun, "127.0.0.1:1234".parse().unwrap())
+    }
+
+    #[test]
+    fn test_serialization() {
+        let origin = test_origin();
+        let addr = EndpointAddr::new(origin.clone());
+        assert_eq!(addr.path_prefix, None);
+        assert_eq!(addr.to_string(), "rerun://127.0.0.1:1234");
+
+        let addr = EndpointAddr::new(origin.clone()).with_path_prefix("");
+        assert_eq!(addr.path_prefix, None);
+
+        let addr = EndpointAddr::new(origin.clone()).with_path_prefix("/");
+        assert_eq!(addr.path_prefix, None);
+
+        let addr = EndpointAddr::new(origin.clone()).with_path_prefix("foo");
+        assert_eq!(addr.path_prefix.as_deref(), Some("/foo"));
+        assert_eq!(addr.to_string(), "rerun://127.0.0.1:1234/foo");
+
+        let addr = EndpointAddr::new(origin.clone()).with_path_prefix("/foo");
+        assert_eq!(addr.path_prefix.as_deref(), Some("/foo"));
+        assert_eq!(addr.to_string(), "rerun://127.0.0.1:1234/foo");
+
+        let addr = EndpointAddr::new(origin.clone()).with_path_prefix("foo/");
+        assert_eq!(addr.path_prefix.as_deref(), Some("/foo"));
+        assert_eq!(addr.to_string(), "rerun://127.0.0.1:1234/foo");
+
+        let addr = EndpointAddr::new(origin.clone()).with_path_prefix("/foo/bar");
+        assert_eq!(addr.path_prefix.as_deref(), Some("/foo/bar"));
+        assert_eq!(addr.to_string(), "rerun://127.0.0.1:1234/foo/bar");
+    }
+}

--- a/crates/utils/re_uri/src/endpoints/catalog.rs
+++ b/crates/utils/re_uri/src/endpoints/catalog.rs
@@ -4,17 +4,18 @@ use crate::{Origin, RedapUri};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CatalogUri {
     pub origin: Origin,
+    pub prefix: String,
 }
 
 impl std::fmt::Display for CatalogUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/catalog", self.origin)
+        write!(f, "{}{}/catalog", self.origin, self.prefix)
     }
 }
 
 impl CatalogUri {
-    pub fn new(origin: Origin) -> Self {
-        Self { origin }
+    pub fn new(origin: Origin, prefix: String) -> Self {
+        Self { origin, prefix }
     }
 }
 

--- a/crates/utils/re_uri/src/endpoints/catalog.rs
+++ b/crates/utils/re_uri/src/endpoints/catalog.rs
@@ -1,21 +1,21 @@
-use crate::{Origin, RedapUri};
+use crate::{EndpointAddr, RedapUri};
 
 /// `scheme://hostname:port/catalog`
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CatalogUri {
-    pub origin: Origin,
-    pub prefix: String,
+    pub endpoint_addr: EndpointAddr,
 }
 
 impl std::fmt::Display for CatalogUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}/catalog", self.origin, self.prefix)
+        let Self { endpoint_addr } = self;
+        write!(f, "{endpoint_addr}/catalog")
     }
 }
 
 impl CatalogUri {
-    pub fn new(origin: Origin, prefix: String) -> Self {
-        Self { origin, prefix }
+    pub fn new(endpoint_addr: EndpointAddr) -> Self {
+        Self { endpoint_addr }
     }
 }
 

--- a/crates/utils/re_uri/src/endpoints/dataset.rs
+++ b/crates/utils/re_uri/src/endpoints/dataset.rs
@@ -1,6 +1,6 @@
 use re_log_types::StoreId;
 
-use crate::{Error, Fragment, Origin, RedapUri, TimeSelection};
+use crate::{EndpointAddr, Error, Fragment, RedapUri, TimeSelection};
 
 /// URI pointing at the data underlying a dataset.
 ///
@@ -11,8 +11,7 @@ use crate::{Error, Fragment, Origin, RedapUri, TimeSelection};
 /// In the future we will add richer queries.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DatasetPartitionUri {
-    pub origin: Origin,
-    pub prefix: String,
+    pub endpoint_addr: EndpointAddr,
     pub dataset_id: re_tuid::Tuid,
 
     // Query parameters: these affect what data is returned.
@@ -26,22 +25,26 @@ pub struct DatasetPartitionUri {
 
 impl std::fmt::Display for DatasetPartitionUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}{}/dataset/{}",
-            self.origin, self.prefix, self.dataset_id
-        )?;
+        let Self {
+            endpoint_addr,
+            dataset_id,
+            partition_id,
+            time_range,
+            fragment,
+        } = self;
+
+        write!(f, "{endpoint_addr}/dataset/{dataset_id}")?;
 
         // ?query:
         {
-            write!(f, "?partition_id={}", self.partition_id)?;
+            write!(f, "?partition_id={partition_id}")?;
         }
-        if let Some(time_range) = &self.time_range {
+        if let Some(time_range) = time_range {
             write!(f, "&time_range={time_range}")?;
         }
 
         // #fragment:
-        let fragment = self.fragment.to_string();
+        let fragment = fragment.to_string();
         if !fragment.is_empty() {
             write!(f, "#{fragment}")?;
         }
@@ -52,8 +55,7 @@ impl std::fmt::Display for DatasetPartitionUri {
 
 impl DatasetPartitionUri {
     pub fn new(
-        origin: Origin,
-        prefix: String,
+        endpoint_addr: EndpointAddr,
         dataset_id: re_tuid::Tuid,
         url: &url::Url,
     ) -> Result<Self, Error> {
@@ -87,8 +89,7 @@ impl DatasetPartitionUri {
         }
 
         Ok(Self {
-            origin,
-            prefix,
+            endpoint_addr,
             dataset_id,
             partition_id,
             time_range,
@@ -99,10 +100,9 @@ impl DatasetPartitionUri {
     /// Returns [`Self`] without any (optional) `?query` or `#fragment`.
     pub fn without_query_and_fragment(mut self) -> Self {
         let Self {
-            origin: _,       // Mandatory
-            prefix: _,       // Mandatory
-            dataset_id: _,   // Mandatory
-            partition_id: _, // Mandatory
+            endpoint_addr: _, // Mandatory
+            dataset_id: _,    // Mandatory
+            partition_id: _,  // Mandatory
             time_range,
             fragment,
         } = &mut self;
@@ -116,10 +116,9 @@ impl DatasetPartitionUri {
     /// Returns [`Self`] without any (optional) `#fragment`.
     pub fn without_fragment(mut self) -> Self {
         let Self {
-            origin: _,       // Mandatory
-            prefix: _,       // Mandatory
-            dataset_id: _,   // Mandatory
-            partition_id: _, // Mandatory
+            endpoint_addr: _, // Mandatory
+            dataset_id: _,    // Mandatory
+            partition_id: _,  // Mandatory
             time_range: _,
             fragment,
         } = &mut self;

--- a/crates/utils/re_uri/src/endpoints/entry.rs
+++ b/crates/utils/re_uri/src/endpoints/entry.rs
@@ -1,26 +1,28 @@
 use re_log_types::EntryId;
 
-use crate::{Error, Origin, RedapUri};
+use crate::{EndpointAddr, Error, RedapUri};
 
 /// URI for a remote entry.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct EntryUri {
-    pub origin: Origin,
-    pub prefix: String,
+    pub endpoint_addr: EndpointAddr,
     pub entry_id: EntryId,
 }
 
 impl std::fmt::Display for EntryUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}/entry/{}", self.origin, self.prefix, self.entry_id)
+        let Self {
+            endpoint_addr,
+            entry_id,
+        } = self;
+        write!(f, "{endpoint_addr}/entry/{entry_id}")
     }
 }
 
 impl EntryUri {
-    pub fn new(origin: Origin, prefix: String, entry_id: EntryId) -> Self {
+    pub fn new(endpoint_addr: EndpointAddr, entry_id: EntryId) -> Self {
         Self {
-            origin,
-            prefix,
+            endpoint_addr,
             entry_id,
         }
     }

--- a/crates/utils/re_uri/src/endpoints/entry.rs
+++ b/crates/utils/re_uri/src/endpoints/entry.rs
@@ -6,19 +6,23 @@ use crate::{Error, Origin, RedapUri};
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct EntryUri {
     pub origin: Origin,
+    pub prefix: String,
     pub entry_id: EntryId,
 }
 
 impl std::fmt::Display for EntryUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { origin, entry_id } = self;
-        write!(f, "{origin}/entry/{entry_id}")
+        write!(f, "{}{}/entry/{}", self.origin, self.prefix, self.entry_id)
     }
 }
 
 impl EntryUri {
-    pub fn new(origin: Origin, entry_id: EntryId) -> Self {
-        Self { origin, entry_id }
+    pub fn new(origin: Origin, prefix: String, entry_id: EntryId) -> Self {
+        Self {
+            origin,
+            prefix,
+            entry_id,
+        }
     }
 }
 

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -1,20 +1,20 @@
-use crate::{Origin, RedapUri};
+use crate::{EndpointAddr, RedapUri};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ProxyUri {
-    pub origin: Origin,
-    pub prefix: String,
+    pub endpoint_addr: EndpointAddr,
 }
 
 impl std::fmt::Display for ProxyUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}/proxy", self.origin, self.prefix)
+        let Self { endpoint_addr } = self;
+        write!(f, "{endpoint_addr}/proxy")
     }
 }
 
 impl ProxyUri {
-    pub fn new(origin: Origin, prefix: String) -> Self {
-        Self { origin, prefix }
+    pub fn new(endpoint_addr: EndpointAddr) -> Self {
+        Self { endpoint_addr }
     }
 }
 

--- a/crates/utils/re_uri/src/endpoints/proxy.rs
+++ b/crates/utils/re_uri/src/endpoints/proxy.rs
@@ -3,17 +3,18 @@ use crate::{Origin, RedapUri};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ProxyUri {
     pub origin: Origin,
+    pub prefix: String,
 }
 
 impl std::fmt::Display for ProxyUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/proxy", self.origin)
+        write!(f, "{}{}/proxy", self.origin, self.prefix)
     }
 }
 
 impl ProxyUri {
-    pub fn new(origin: Origin) -> Self {
-        Self { origin }
+    pub fn new(origin: Origin, prefix: String) -> Self {
+        Self { origin, prefix }
     }
 }
 

--- a/crates/utils/re_uri/src/lib.rs
+++ b/crates/utils/re_uri/src/lib.rs
@@ -33,6 +33,7 @@
 //!
 //! ```
 
+mod endpoint_addr;
 mod endpoints;
 mod error;
 mod fragment;
@@ -42,6 +43,7 @@ mod scheme;
 mod time_selection;
 
 pub use self::{
+    endpoint_addr::EndpointAddr,
     endpoints::{
         catalog::CatalogUri, dataset::DatasetPartitionUri, entry::EntryUri, proxy::ProxyUri,
     },

--- a/crates/viewer/re_recording_panel/src/data.rs
+++ b/crates/viewer/re_recording_panel/src/data.rs
@@ -74,7 +74,7 @@ impl<'a> RecordingPanelData<'a> {
 
                 SmartChannelSource::RedapGrpcStream { uri, .. } => {
                     loading_partitions
-                        .entry(uri.origin.clone())
+                        .entry(uri.endpoint_addr.origin.clone())
                         .or_default()
                         .entry(EntryId::from(uri.dataset_id))
                         .or_default()
@@ -344,11 +344,10 @@ impl<'a> ServerEntriesData<'a> {
                         name: entry.name().to_owned(),
                         icon: entry.icon(),
                         is_selected: ctx.is_selected_or_loading(&Item::RedapEntry(
-                            re_uri::EntryUri {
-                                origin: origin.clone(),
-                                prefix: String::new(),
-                                entry_id: entry.id(),
-                            },
+                            re_uri::EntryUri::new(
+                                re_uri::EndpointAddr::new(origin.clone()),
+                                entry.id(),
+                            ),
                         )),
                         is_active: ctx.active_redap_entry() == Some(entry.id()),
                     };
@@ -363,7 +362,7 @@ impl<'a> ServerEntriesData<'a> {
                                     if let EntityDbClass::DatasetPartition(uri) =
                                         entity_db.store_class()
                                     {
-                                        if &uri.origin == origin
+                                        if &uri.endpoint_addr.origin == origin
                                             && EntryId::from(uri.dataset_id) == entry.id()
                                         {
                                             Some(PartitionData::Loaded { entity_db })
@@ -506,14 +505,12 @@ impl EntryData {
     }
 
     pub fn entry_uri(&self) -> re_uri::EntryUri {
-        re_uri::EntryUri {
-            origin: self.origin.clone(),
-            prefix: String::new(),
-            entry_id: self.entry_id,
-        }
+        re_uri::EntryUri::new(
+            re_uri::EndpointAddr::new(self.origin.clone()),
+            self.entry_id,
+        )
     }
 }
-
 // ---
 
 #[derive(Debug)]

--- a/crates/viewer/re_recording_panel/src/data.rs
+++ b/crates/viewer/re_recording_panel/src/data.rs
@@ -346,6 +346,7 @@ impl<'a> ServerEntriesData<'a> {
                         is_selected: ctx.is_selected_or_loading(&Item::RedapEntry(
                             re_uri::EntryUri {
                                 origin: origin.clone(),
+                                prefix: String::new(),
                                 entry_id: entry.id(),
                             },
                         )),
@@ -507,6 +508,7 @@ impl EntryData {
     pub fn entry_uri(&self) -> re_uri::EntryUri {
         re_uri::EntryUri {
             origin: self.origin.clone(),
+            prefix: String::new(),
             entry_id: self.entry_id,
         }
     }

--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -451,8 +451,11 @@ fn dataset_entry_ui(
         list_item.show_hierarchical(ui, list_item_content)
     };
 
-    let new_display_mode =
-        DisplayMode::RedapEntry(re_uri::EntryUri::new(origin.clone(), *entry_id));
+    let new_display_mode = DisplayMode::RedapEntry(re_uri::EntryUri::new(
+        origin.clone(),
+        String::new(),
+        *entry_id,
+    ));
 
     item_response.context_menu(|ui| {
         let url = ViewerOpenUrl::from_display_mode(ctx.storage_context.hub, &new_display_mode)
@@ -522,7 +525,7 @@ fn remote_table_entry_ui(
             .send_system(SystemCommand::set_selection(item));
         ctx.command_sender()
             .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
-                re_uri::EntryUri::new(origin.clone(), *entry_id),
+                re_uri::EntryUri::new(origin.clone(), String::new(), *entry_id),
             )));
     }
 }
@@ -557,7 +560,7 @@ fn failed_entry_ui(
             .send_system(SystemCommand::set_selection(item));
         ctx.command_sender()
             .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
-                re_uri::EntryUri::new(origin.clone(), *entry_id),
+                re_uri::EntryUri::new(origin.clone(), String::new(), *entry_id),
             )));
     }
 

--- a/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
+++ b/crates/viewer/re_recording_panel/src/recording_panel_ui.rs
@@ -452,8 +452,7 @@ fn dataset_entry_ui(
     };
 
     let new_display_mode = DisplayMode::RedapEntry(re_uri::EntryUri::new(
-        origin.clone(),
-        String::new(),
+        re_uri::EndpointAddr::new(origin.clone()),
         *entry_id,
     ));
 
@@ -525,7 +524,7 @@ fn remote_table_entry_ui(
             .send_system(SystemCommand::set_selection(item));
         ctx.command_sender()
             .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
-                re_uri::EntryUri::new(origin.clone(), String::new(), *entry_id),
+                re_uri::EntryUri::new(re_uri::EndpointAddr::new(origin.clone()), *entry_id),
             )));
     }
 }
@@ -560,7 +559,7 @@ fn failed_entry_ui(
             .send_system(SystemCommand::set_selection(item));
         ctx.command_sender()
             .send_system(SystemCommand::ChangeDisplayMode(DisplayMode::RedapEntry(
-                re_uri::EntryUri::new(origin.clone(), String::new(), *entry_id),
+                re_uri::EntryUri::new(re_uri::EndpointAddr::new(origin.clone()), *entry_id),
             )));
     }
 

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -200,7 +200,13 @@ impl Server {
             dataset.name(),
         )
         .title(dataset.name())
-        .url(re_uri::EntryUri::new(dataset.origin.clone(), String::new(), dataset.id()).to_string())
+        .url(
+            re_uri::EntryUri::new(
+                re_uri::EndpointAddr::new(dataset.origin.clone()),
+                dataset.id(),
+            )
+            .to_string(),
+        )
         .column_blueprint(|desc| {
             let mut name = default_display_name_for_column(desc);
 
@@ -252,7 +258,10 @@ impl Server {
     fn table_entry_ui(&self, viewer_ctx: &ViewerContext<'_>, ui: &mut egui::Ui, table: &Table) {
         re_dataframe_ui::DataFusionTableWidget::new(self.tables_session_ctx.clone(), table.name())
             .title(table.name())
-            .url(re_uri::EntryUri::new(table.origin.clone(), String::new(), table.id()).to_string())
+            .url(
+                re_uri::EntryUri::new(re_uri::EndpointAddr::new(table.origin.clone()), table.id())
+                    .to_string(),
+            )
             .show(viewer_ctx, &self.runtime, ui);
     }
 }

--- a/crates/viewer/re_redap_browser/src/servers.rs
+++ b/crates/viewer/re_redap_browser/src/servers.rs
@@ -200,7 +200,7 @@ impl Server {
             dataset.name(),
         )
         .title(dataset.name())
-        .url(re_uri::EntryUri::new(dataset.origin.clone(), dataset.id()).to_string())
+        .url(re_uri::EntryUri::new(dataset.origin.clone(), String::new(), dataset.id()).to_string())
         .column_blueprint(|desc| {
             let mut name = default_display_name_for_column(desc);
 
@@ -252,7 +252,7 @@ impl Server {
     fn table_entry_ui(&self, viewer_ctx: &ViewerContext<'_>, ui: &mut egui::Ui, table: &Table) {
         re_dataframe_ui::DataFusionTableWidget::new(self.tables_session_ctx.clone(), table.name())
             .title(table.name())
-            .url(re_uri::EntryUri::new(table.origin.clone(), table.id()).to_string())
+            .url(re_uri::EntryUri::new(table.origin.clone(), String::new(), table.id()).to_string())
             .show(viewer_ctx, &self.runtime, ui);
     }
 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -503,7 +503,9 @@ impl App {
         // which is unnecessary and can get us into a strange ui state.
         if let SmartChannelSource::RedapGrpcStream { uri, .. } = rx.source() {
             self.command_sender
-                .send_system(SystemCommand::AddRedapServer(uri.origin.clone()));
+                .send_system(SystemCommand::AddRedapServer(
+                    uri.endpoint_addr.origin.clone(),
+                ));
         }
 
         self.rx_log.add(rx);

--- a/crates/viewer/re_viewer/src/open_url_description.rs
+++ b/crates/viewer/re_viewer/src/open_url_description.rs
@@ -58,7 +58,7 @@ impl ViewerOpenUrlDescription {
 
             ViewerOpenUrl::RedapCatalog(uri) => Self {
                 category: "Catalog",
-                target_short: Some(uri.origin.host.to_string()),
+                target_short: Some(uri.endpoint_addr.origin.host.to_string()),
             },
 
             ViewerOpenUrl::RedapEntry(uri) => Self {

--- a/crates/viewer/re_viewer/src/ui/share_modal.rs
+++ b/crates/viewer/re_viewer/src/ui/share_modal.rs
@@ -422,7 +422,7 @@ mod tests {
 
         modal.lock().url = Some(ViewerOpenUrl::RedapDatasetPartition(
             re_uri::DatasetPartitionUri {
-                origin: origin.clone(),
+                endpoint_addr: re_uri::EndpointAddr::new(origin.clone()),
                 dataset_id,
                 partition_id: "partition_id".to_owned(),
                 time_range: None,
@@ -446,7 +446,7 @@ mod tests {
 
         modal.lock().url = Some(ViewerOpenUrl::RedapDatasetPartition(
             re_uri::DatasetPartitionUri {
-                origin: origin.clone(),
+                endpoint_addr: re_uri::EndpointAddr::new(origin.clone()),
                 dataset_id,
                 partition_id: "partition_id".to_owned(),
                 time_range: Some(re_uri::TimeSelection {

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -262,8 +262,7 @@ impl PyDatasetEntry {
                 ),
             });
         Ok(re_uri::DatasetPartitionUri {
-            origin: connection.origin().clone(),
-            prefix: Default::default(),
+            endpoint_addr: re_uri::EndpointAddr::new(connection.origin().clone()),
             dataset_id: super_.details.id.id,
             partition_id,
 

--- a/rerun_py/src/catalog/dataset_entry.rs
+++ b/rerun_py/src/catalog/dataset_entry.rs
@@ -263,6 +263,7 @@ impl PyDatasetEntry {
             });
         Ok(re_uri::DatasetPartitionUri {
             origin: connection.origin().clone(),
+            prefix: Default::default(),
             dataset_id: super_.details.id.id,
             partition_id,
 


### PR DESCRIPTION
### What

This PR updates the URL parser to support path prefixes. This allows Rerun instances to be hosted at non-root paths (e.g., behind a reverse proxy).

Before: The parser assumed Rerun endpoints existed at the root:
- `http://example.com/catalog`
- `http://example.com/proxy`

After: The parser now accepts arbitrary sub-paths:
- `http://example.com/custom/prefix/catalog`
- `http://example.com/custom/prefix/proxy`

</details>

### Motivation

Currently, hosting Rerun behind a reverse proxy at a specific sub-path triggers a "Failed to parse URL" error.

For example, if `example.com` hosts a Rerun instance at `example.com/hosted_rerun/`, the current parser cannot handle the gRPC proxy link:
```
https://example.com/hosted_rerun/url?=rerun%2Bhttps://example.com/hosted_rerun_grpc_data/proxy
```

You get a "Failed to parse URL error"! Hence motivating this PR.

I am trying to host a Rerun web viewer behind such a reverse proxy and getting this issue.

### Additional Concerns

Some of the URL parsing logic needs to search for keywords to then extract arguments from.

Consider:
```
http://example.com/sub/path/entry/entry_id/dataset/dataset_id
```

Should this be an "entry" or a "dataset" URL?

I decided it would be a "dataset" URL, to support cases where an external page has a really long, accidentally clobbering path prefix, by having the **last** occurence of a keyword be what determines what kind of page it is e.g.:
```
http://example.com/path/that/contains/example/dataset/and/then/hosts/rerun/dataset/dataset_id
```

If we searched the first, the chance of an unintentional collision is higher.

### Tests

I added more unit tests and adjusted the pre-existing one.