### PR TITLE
Don't install signal handlers into rerun_c outside of DEBUG mode

### DIFF
--- a/crates/top/rerun_c/src/lib.rs
+++ b/crates/top/rerun_c/src/lib.rs
@@ -537,9 +537,9 @@ fn rr_recording_stream_new_impl(
         static INIT: Once = Once::new();
         INIT.call_once(|| {
             re_log::setup_logging();
-            re_crash_handler::install_crash_handlers(re_build_info::build_info!());
             if cfg!(debug_assertions) {
-                re_log::info!("Using a DEBUG BUILD of the Rerun SDK!");
+                re_crash_handler::install_crash_handlers(re_build_info::build_info!());
+                re_log::warn!("Using a DEBUG BUILD of the Rerun SDK with Rerun crash handlers!");
             }
         });
     }


### PR DESCRIPTION
The SDK shouldn't have a signal handler. This overrides signal handlers in applications that use the SDK and can cause confusion.

Relates to: #11950
