### PR TITLE
Use thread-safe ChunkId when splitting chunks

### DIFF
--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -767,6 +767,7 @@ impl ChunkStore {
 
         let mut result = Vec::new();
         let mut start_idx = 0;
+        let mut cur_chunk_id = ChunkId::new();
 
         while start_idx < chunk.num_rows() {
             let remaining_rows = chunk.num_rows() - start_idx;
@@ -774,7 +775,9 @@ impl ChunkStore {
 
             let split_chunk = chunk
                 .row_sliced(start_idx, chunk_size)
-                .with_id(ChunkId::new());
+                // TODO(#11971): keep track of the split chunks' lineage
+                .with_id(cur_chunk_id);
+            cur_chunk_id = cur_chunk_id.next();
 
             result.push(std::sync::Arc::new(split_chunk));
 


### PR DESCRIPTION
### What

In #11921 we use `chunk_id.next()` to get the chunk id for the next few chunks whilst splitting chunks, this causes problems in scenarios where multiple chunks are rapidly constructed sequentially on the client before they're being sent over the network because the client assumes those chunk ids aren't taken yet.

This fixes that by calling the thread-safe `ChunkId::new()` and just going for a fully new chunk id instead, to avoid any possible clashes.