### PR TITLE
Update egui_table to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,8 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "egui_table"
-version = "0.5.0"
-source = "git+https://github.com/rerun-io/egui_table?branch=main#108c543d1f6a8da4ff063849bd64af4a72fcb294"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dda59864826b32b4ea1dc8f5f1035cea63bbe650beeb6263be1c72d3a6d6e36"
 dependencies = [
  "egui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ emath = "0.33.0"
 egui_commonmark = { version = "0.22.0", default-features = false }
 egui_dnd = { version = "0.14.0" }
 egui_plot = "0.34.0" # https://github.com/emilk/egui_plot
-egui_table = "0.5.0" # https://github.com/rerun-io/egui_table
+egui_table = "0.6.0" # https://github.com/rerun-io/egui_table
 egui_tiles = "0.14.0" # https://github.com/rerun-io/egui_tiles
 walkers = "0.47.0"
 
@@ -847,7 +847,7 @@ unnecessary_debug_formatting = "allow"
 # egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", branch = "emilk/update-egui" }
 # egui_tiles = { path = "../egui_tiles" }
 
-egui_table = { git = "https://github.com/rerun-io/egui_table", branch = "main" }
+# egui_table = { git = "https://github.com/rerun-io/egui_table", branch = "main" }
 # egui_table = { path = "../egui_table" }
 
 # egui_dnd = { git = "https://github.com/rerun-io/hello_egui.git", branch = "emilk/egui-0.33.0" }


### PR DESCRIPTION
### What

Updates egui_table to [0.6.0](https://github.com/rerun-io/egui_table/releases/tag/0.6.0), unblocking the release

- closes https://linear.app/rerun/issue/RR-2998/remove-egui-table-cratesio-patch