### PR TITLE
dataplatform tests: new test helper

### DIFF
--- a/crates/store/re_redap_tests/src/lib.rs
+++ b/crates/store/re_redap_tests/src/lib.rs
@@ -24,10 +24,10 @@ pub use self::utils::{
     arrow::{FieldsExt, RecordBatchExt, SchemaExt},
     path::TempPath,
     rerun::{
-        TuidPrefix, create_nasty_recording, create_recording_with_embeddings,
-        create_recording_with_properties, create_recording_with_scalars,
-        create_recording_with_text, create_simple_blueprint, create_simple_recording,
-        create_simple_recording_in,
+        TuidPrefix, create_minimal_binary_recording_in, create_nasty_recording,
+        create_recording_with_embeddings, create_recording_with_properties,
+        create_recording_with_scalars, create_recording_with_text, create_simple_blueprint,
+        create_simple_recording, create_simple_recording_in,
     },
 };
 


### PR DESCRIPTION
### Related

- Part of RR-2978
- DPF PR: https://github.com/rerun-io/dataplatform/pull/2049


### What

Adds a small utility to create a minimal recording with some binary data that
can be arrow-encoded as either List[u8] or Binary.

