### PR TITLE
Telemetry: Allow initializing grpc_on_eos metrics

### DIFF
--- a/crates/utils/re_perf_telemetry/src/grpc.rs
+++ b/crates/utils/re_perf_telemetry/src/grpc.rs
@@ -19,7 +19,6 @@ pub struct GrpcMakeSpan {
 }
 
 impl GrpcMakeSpan {
-    #[expect(clippy::new_without_default)] // future-proofing
     pub fn new() -> Self {
         let meter = opentelemetry::global::meter("grpc");
         let gauge = meter
@@ -27,6 +26,12 @@ impl GrpcMakeSpan {
             .with_description("Size of the SpanMetadata state")
             .build();
         Self { gauge }
+    }
+}
+
+impl Default for GrpcMakeSpan {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -317,9 +322,13 @@ pub struct GrpcOnResponse {
     eos_counter: opentelemetry::metrics::Counter<u64>,
 }
 
+#[derive(Default)]
+pub struct GrpcOnResponseOptions {
+    pub fully_qualified_route_names: Option<Vec<String>>,
+}
+
 impl GrpcOnResponse {
-    #[expect(clippy::new_without_default)] // future-proofing
-    pub fn new() -> Self {
+    pub fn new(options: GrpcOnResponseOptions) -> Self {
         let meter = opentelemetry::global::meter("grpc");
         let histogram = meter
             .f64_histogram("grpc_on_response_ms")
@@ -332,10 +341,67 @@ impl GrpcOnResponse {
             .u64_counter("grpc_on_eos")
             .with_description("End-of-stream counter for all gRPC endpoints")
             .build();
+
+        if let Some(fully_qualified_rout_names) = options.fully_qualified_route_names {
+            for endpoint in &fully_qualified_rout_names {
+                eos_counter.add(
+                    0,
+                    &GrpcEosMetadata {
+                        endpoint: endpoint.clone(),
+                        grpc_status: String::new(),
+                        client_version: None,
+                        server_version: None,
+                        email: None,
+                        dataset_id: None,
+                    }
+                    .otel_kvs(),
+                );
+            }
+        }
         Self {
             histogram,
             eos_counter,
         }
+    }
+}
+
+struct GrpcEosMetadata {
+    endpoint: String,
+    grpc_status: String,
+    client_version: Option<String>,
+    server_version: Option<String>,
+    email: Option<String>,
+    dataset_id: Option<String>,
+}
+
+impl GrpcEosMetadata {
+    fn otel_kvs(self) -> Vec<opentelemetry::KeyValue> {
+        vec![
+            opentelemetry::KeyValue::new("endpoint", self.endpoint),
+            opentelemetry::KeyValue::new("grpc_status", self.grpc_status),
+            opentelemetry::KeyValue::new(
+                "client_version",
+                self.client_version
+                    .as_deref()
+                    .unwrap_or("undefined")
+                    .to_owned(),
+            ),
+            opentelemetry::KeyValue::new(
+                "server_version",
+                self.server_version
+                    .as_deref()
+                    .unwrap_or("undefined")
+                    .to_owned(),
+            ),
+            opentelemetry::KeyValue::new(
+                "email",
+                self.email.as_deref().unwrap_or("undefined").to_owned(),
+            ),
+            opentelemetry::KeyValue::new(
+                "dataset_id",
+                self.dataset_id.as_deref().unwrap_or("undefined").to_owned(),
+            ),
+        ]
     }
 }
 
@@ -408,21 +474,18 @@ impl<B> tower_http::trace::OnResponse<B> for GrpcOnResponse {
 
                 // For immediate errors, emit grpc_on_eos counter here since on_eos won't be called
                 let grpc_status = format!("{grpc_code:?}"); // NOTE: The debug repr is the enum variant name (e.g. DeadlineExceeded).
-                let client_version = client_version.as_deref().unwrap_or("undefined");
-                let server_version = server_version.as_deref().unwrap_or("undefined");
-                let email = email.as_deref().unwrap_or("undefined");
-                let dataset_id = dataset_id.as_deref().unwrap_or("undefined");
 
                 self.eos_counter.add(
                     1,
-                    &[
-                        opentelemetry::KeyValue::new("endpoint", endpoint.clone()),
-                        opentelemetry::KeyValue::new("grpc_status", grpc_status),
-                        opentelemetry::KeyValue::new("client_version", client_version.to_owned()),
-                        opentelemetry::KeyValue::new("server_version", server_version.to_owned()),
-                        opentelemetry::KeyValue::new("email", email.to_owned()),
-                        opentelemetry::KeyValue::new("dataset_id", dataset_id.to_owned()),
-                    ],
+                    &GrpcEosMetadata {
+                        endpoint: endpoint.clone(),
+                        grpc_status,
+                        client_version,
+                        server_version,
+                        email,
+                        dataset_id,
+                    }
+                    .otel_kvs(),
                 );
 
                 // Remove metadata since on_eos won't be called for immediate errors
@@ -625,6 +688,11 @@ pub type ServerTelemetryLayer = tower_http::trace::TraceLayer<
     GrpcOnEos,
 >;
 
+#[derive(Default)]
+pub struct TelemetryLayerOptions {
+    pub fully_qualified_route_names: Option<Vec<String>>,
+}
+
 /// Creates a new [`tower::Layer`] middleware that automatically:
 /// * Traces gRPC requests and responses.
 /// * Logs all gRPC responses (status, latency, etc).
@@ -637,11 +705,13 @@ pub type ServerTelemetryLayer = tower_http::trace::TraceLayer<
 /// * streaming endpoint immediate error (no stream started)  - `on_response` (error handling path) called and `on_failure` (again, not implemented)
 /// * streaming endpoint mid stream error - `on_response` called (but only initially with OK code, no error detected here), `on_eos` called (and existing error handling logic executed).
 ///   `on_failure` is not called here and from code inspection it seems that is only called for immediate failures and polling frame errors (transport errors, although not verified with testing)
-pub fn new_server_telemetry_layer() -> ServerTelemetryLayer {
+pub fn new_server_telemetry_layer(options: TelemetryLayerOptions) -> ServerTelemetryLayer {
     tower_http::trace::TraceLayer::new_for_grpc()
         .make_span_with(GrpcMakeSpan::new())
         .on_request(GrpcOnRequest::new())
-        .on_response(GrpcOnResponse::new())
+        .on_response(GrpcOnResponse::new(GrpcOnResponseOptions {
+            fully_qualified_route_names: options.fully_qualified_route_names,
+        }))
         .on_body_chunk(GrpcOnFirstBodyChunk::new())
         .on_eos(GrpcOnEos::new())
 }

--- a/crates/utils/re_perf_telemetry/src/lib.rs
+++ b/crates/utils/re_perf_telemetry/src/lib.rs
@@ -62,8 +62,9 @@ pub use self::{
     args::{LogFormat, TelemetryArgs},
     grpc::{
         ClientTelemetryLayer, GrpcMakeSpan, GrpcOnEos, GrpcOnFirstBodyChunk, GrpcOnRequest,
-        GrpcOnResponse, ServerTelemetryLayer, TraceIdLayer, TracingInjectorInterceptor,
-        new_client_telemetry_layer, new_server_telemetry_layer,
+        GrpcOnResponse, GrpcOnResponseOptions, ServerTelemetryLayer, TelemetryLayerOptions,
+        TraceIdLayer, TracingInjectorInterceptor, new_client_telemetry_layer,
+        new_server_telemetry_layer,
     },
     telemetry::{Telemetry, TelemetryDropBehavior},
     utils::to_short_str,


### PR DESCRIPTION
The server-side grpc_on_eos metric is generated in a callback. As a result, it doesn't exist until the first api call, making it impossible to observer the transition from zero to one or to differentiate "no request" from "this metric doesn't work".

This change adds an option to pass the endpoint names and if done so, the metric will get initialized.

### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
