### PR TITLE
Include `FrameId` in error reporting for transform resolution

### DIFF
--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -205,6 +205,15 @@ impl TransformTreeContext {
     ) -> Option<&TransformFrameId> {
         self.frame_id_mapping.get(&frame_id_hash)
     }
+
+    /// Formats a frame ID hash as a human-readable string.
+    ///
+    /// Returns the frame name if known, otherwise returns a debug representation of the hash.
+    #[inline]
+    pub fn format_frame(&self, frame_id_hash: TransformFrameIdHash) -> String {
+        self.lookup_frame_id(frame_id_hash)
+            .map_or_else(|| format!("{frame_id_hash:?}"), ToString::to_string)
+    }
 }
 
 fn lookup_image_plane_distance(

--- a/crates/viewer/re_view_spatial/src/visualizers/transform_axes_3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/transform_axes_3d.rs
@@ -158,7 +158,7 @@ impl VisualizerSystem for TransformAxes3DVisualizer {
                     self.0
                         .ui_labels
                         .extend(transforms_to_draw.iter().map(|transform| UiLabel {
-                            text: frame_id.0.clone().into(),
+                            text: frame_id.to_string(),
                             style: UiLabelStyle::Default,
                             target: UiLabelTarget::Position3D(
                                 transform.transform_point3(glam::Vec3::ZERO),

--- a/crates/viewer/re_view_spatial/src/visualizers/utilities/transform_retrieval.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/utilities/transform_retrieval.rs
@@ -20,12 +20,8 @@ pub fn transform_info_for_entity_or_report_error<'a>(
         }
 
         Some(Err(re_tf::TransformFromToError::NoPathBetweenFrames { src, target, .. })) => {
-            let src = transform_context
-                .lookup_frame_id(*src)
-                .map_or_else(|| format!("{src:?}"), ToString::to_string);
-            let target = transform_context
-                .lookup_frame_id(*target)
-                .map_or_else(|| format!("{target:?}"), ToString::to_string);
+            let src = transform_context.format_frame(*src);
+            let target = transform_context.format_frame(*target);
             output.report_error_for(
                 entity_path.clone(),
                 format!("No transform path from {src} to the view's origin frame ({target})."),
@@ -36,9 +32,7 @@ pub fn transform_info_for_entity_or_report_error<'a>(
         Some(Err(re_tf::TransformFromToError::UnknownTargetFrame(target))) => {
             // The target frame is the view's origin.
             // This means this could be hit if the view's origin frame doesn't show up in any data.
-            let target = transform_context
-                .lookup_frame_id(*target)
-                .map_or_else(|| format!("{target:?}"), ToString::to_string);
+            let target = transform_context.format_frame(*target);
             output.report_error_for(
                 entity_path.clone(),
                 format!("The view's origin frame {target} is unknown."),
@@ -49,9 +43,7 @@ pub fn transform_info_for_entity_or_report_error<'a>(
         Some(Err(re_tf::TransformFromToError::UnknownSourceFrame(src))) => {
             // Unclear how we'd hit this. This means that when processing transforms we encountered a coordinate frame that the transform cache didn't know about.
             // That would imply that the cache is lagging behind.
-            let src = transform_context
-                .lookup_frame_id(*src)
-                .map_or_else(|| format!("{src:?}"), ToString::to_string);
+            let src = transform_context.format_frame(*src);
             output.report_error_for(
                 entity_path.clone(),
                 format!("The entity's coordinate frame {src} is unknown."),


### PR DESCRIPTION
### Related

* Closes RR-2997.
* [x] Merge after #11977.

### What

Now that we have `TransformHashId` lookup functionality in `TransformTreeContext` we can print better error message.
