### PR TITLE
Do not depend on `re_format_arrow` from `re_arrow_utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8380,7 +8380,6 @@ dependencies = [
  "re_log",
  "re_tracing",
  "re_tuid",
- "re_types_core",
  "serde_json",
 ]
 

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -68,7 +68,7 @@ impl Loggable for Tuid {
 
         // NOTE: We don't even look at the validity, our datatype says we don't care.
 
-        let uuids: &[Self] = bytemuck::try_cast_slice(array.value_data()).map_err(|err| {
+        let uuids: &[Self] = Self::slice_from_bytes(array.value_data()).map_err(|err| {
             DeserializationError::ValidationError(format!("Bad length of Tuid array: {err}"))
         })?;
 

--- a/crates/utils/re_arrow_util/Cargo.toml
+++ b/crates/utils/re_arrow_util/Cargo.toml
@@ -25,8 +25,7 @@ all-features = true
 [dependencies]
 re_log.workspace = true
 re_tracing.workspace = true
-re_tuid.workspace = true
-re_types_core.workspace = true
+re_tuid = { workspace = true, features = ["bytemuck"] }
 
 anyhow.workspace = true
 arrow.workspace = true

--- a/crates/utils/re_arrow_util/src/format.rs
+++ b/crates/utils/re_arrow_util/src/format.rs
@@ -3,7 +3,7 @@
 use std::fmt::Formatter;
 
 use arrow::{
-    array::{Array, ArrayRef, ListArray},
+    array::{Array, ArrayRef, AsArray as _, ListArray},
     datatypes::{DataType, Field, Fields},
     util::display::{ArrayFormatter, FormatOptions},
 };
@@ -11,7 +11,6 @@ use comfy_table::{Cell, Row, Table, presets};
 use itertools::{Either, Itertools as _};
 
 use re_tuid::Tuid;
-use re_types_core::Loggable as _;
 
 use crate::{ArrowArrayDowncastRef as _, format_field_datatype};
 
@@ -78,7 +77,8 @@ fn custom_array_formatter<'a>(
 // TODO(#1775): This should be defined and registered by the `re_tuid` crate.
 fn parse_tuid(array: &dyn Array, index: usize) -> Option<Tuid> {
     fn parse_inner(array: &dyn Array, index: usize) -> Option<Tuid> {
-        let tuids = Tuid::from_arrow(array).ok()?;
+        let array = array.as_fixed_size_binary_opt()?;
+        let tuids = Tuid::slice_from_bytes(array.value_data()).ok()?;
         tuids.get(index).copied()
     }
 

--- a/crates/utils/re_tuid/src/lib.rs
+++ b/crates/utils/re_tuid/src/lib.rs
@@ -170,6 +170,12 @@ impl Tuid {
         Self::from_nanos_and_inc((id >> 64) as u64, (id & (!0 >> 64)) as u64)
     }
 
+    #[cfg(feature = "bytemuck")]
+    #[inline]
+    pub fn slice_from_bytes(bytes: &[u8]) -> Result<&[Self], bytemuck::PodCastError> {
+        bytemuck::try_cast_slice(bytes)
+    }
+
     #[inline]
     pub fn as_u128(&self) -> u128 {
         ((self.nanos_since_epoch() as u128) << 64) | (self.inc() as u128)


### PR DESCRIPTION
### Related

* cleans up after #11713

### What

Title. 