### PR TITLE
Turn on `http2_adaptive_window`

### DIFF
--- a/crates/store/re_grpc_client/src/read.rs
+++ b/crates/store/re_grpc_client/src/read.rs
@@ -50,7 +50,12 @@ async fn stream_async(
         };
 
         #[cfg(not(target_arch = "wasm32"))]
-        let tonic_client = { tonic::transport::Endpoint::new(url)?.connect().await? };
+        let tonic_client = {
+            tonic::transport::Endpoint::new(url)?
+                .http2_adaptive_window(true) // Optimize for throughput
+                .connect()
+                .await?
+        };
 
         MessageProxyServiceClient::new(tonic_client)
             .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)

--- a/crates/store/re_grpc_client/src/write_table.rs
+++ b/crates/store/re_grpc_client/src/write_table.rs
@@ -21,6 +21,8 @@ pub async fn channel(origin: Origin) -> Result<tonic::transport::Channel, tonic:
             .assume_http2(true),
     )?;
 
+    endpoint = endpoint.http2_adaptive_window(true); // Optimize for throughput
+
     if false {
         // NOTE: Tried it, had no noticeable effects in any of my benchmarks.
         endpoint = endpoint.initial_stream_window_size(Some(4 * 1024 * 1024));

--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -1161,6 +1161,12 @@ mod tests {
             let completion = completion.clone();
             async move {
                 tonic::transport::Server::builder()
+                    // NOTE: This NODELAY very likely does nothing because of the call to
+                    // `serve_with_incoming_shutdown` below, but we better be on the defensive here so
+                    // we don't get surprised when things inevitably change.
+                    .tcp_nodelay(true)
+                    .accept_http1(true)
+                    .http2_adaptive_window(Some(true)) // Optimize for throughput
                     .add_service(
                         MessageProxyServiceServer::new(super::MessageProxy::new(options))
                             .max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE)

--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -42,7 +42,8 @@ pub async fn channel(origin: Origin) -> Result<tonic::transport::Channel, ApiErr
                         .assume_http2(true),
                 )
             })
-            .map_err(|err| ApiError::connection(err, "connecting to server"))?;
+            .map_err(|err| ApiError::connection(err, "connecting to server"))?
+            .http2_adaptive_window(true); // Optimize for throughput
 
         if false {
             // NOTE: Tried it, had no noticeable effects in any of my benchmarks.
@@ -74,6 +75,8 @@ pub async fn channel(origin: Origin) -> Result<tonic::transport::Channel, ApiErr
             let Ok(endpoint) = Endpoint::new(origin.coerce_http_url()) else {
                 return Err(original_error);
             };
+
+            let endpoint = endpoint.http2_adaptive_window(true); // Optimize for throughput
 
             if endpoint.connect().await.is_ok() {
                 Err(ApiError {

--- a/crates/store/re_server/src/server.rs
+++ b/crates/store/re_server/src/server.rs
@@ -138,6 +138,7 @@ impl Server {
                 // we don't get surprised when things inevitably change.
                 .tcp_nodelay(true)
                 .accept_http1(true)
+                .http2_adaptive_window(Some(true)) // Optimize for high throughput
                 .layer(middlewares);
 
             let _ = builder


### PR DESCRIPTION
This is done in the hope that it will improve throughput when streaming with high latency (e.g. connecting to us-east-1 from Europe).

Docs:
* https://docs.rs/tonic/latest/tonic/transport/struct.Server.html#method.http2_adaptive_window
* https://docs.rs/tonic/latest/tonic/transport/struct.Endpoint.html#method.http2_adaptive_window

## Related
* Sibling PR: https://github.com/rerun-io/dataplatform/pull/2069