### PR TITLE
Update `walkers` (map widget) to 0.50.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12962,10 +12962,11 @@ dependencies = [
 
 [[package]]
 name = "walkers"
-version = "0.47.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d486e75fbc4a6284398c5434f8fe371038f0ec845cbb9f3a3d7bcbcd9b692fb"
+checksum = "7a443c518c081ef29fafc4c53c32c6f8cba953b019854080214cad1e6d47c297"
 dependencies = [
+ "bytes",
  "egui",
  "egui_extras",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ egui_dnd = { version = "0.14.0" }
 egui_plot = "0.34.0" # https://github.com/emilk/egui_plot
 egui_table = "0.5.0" # https://github.com/rerun-io/egui_table
 egui_tiles = "0.14.0" # https://github.com/rerun-io/egui_tiles
-walkers = "0.47.0"
+walkers = "0.50.0"
 
 # All of our direct external dependencies should be found here:
 ahash = "0.8"


### PR DESCRIPTION
I didn't notice any degradation.

<img width="672" height="515" alt="image" src="https://github.com/user-attachments/assets/23b3f603-f8f5-4fbc-bf40-5a6f468af55f" />

