### PR TITLE
Fix transform3d_hierarchy_frames snippet error

### DIFF
--- a/docs/snippets/all/archetypes/transform3d_hierarchy_frames.cpp
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy_frames.cpp
@@ -43,6 +43,11 @@ int main() {
         rerun::CoordinateFrame("moon_frame")
     );
 
+    rec.log(
+        "sun_transforms",
+        rerun::Transform3D().with_child_frame("sun_frame")
+    );
+
     // The viewer automatically creates a 3D view at `/`. To connect it to our transform hierarchy, we set its coordinate frame
     // to `sun_frame` as well. Alternatively, we could also set a blueprint that makes `/sun` the space origin.
     rec.log("/", rerun::CoordinateFrame("sun_frame"));

--- a/docs/snippets/all/archetypes/transform3d_hierarchy_frames.py
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy_frames.py
@@ -48,6 +48,13 @@ rr.log(
     rr.CoordinateFrame("moon_frame"),
 )
 
+rr.log(
+    "sun_transforms",
+    rr.Transform3D(
+        child_frame="sun_frame",
+    ),
+)
+
 # The viewer automatically creates a 3D view at `/`. To connect it to our transform hierarchy, we set its coordinate frame
 # to `sun_frame` as well. Alternatively, we could also set a blueprint that makes `/sun` the space origin.
 rr.log("/", rr.CoordinateFrame("sun_frame"))

--- a/docs/snippets/all/archetypes/transform3d_hierarchy_frames.rs
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy_frames.rs
@@ -48,6 +48,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
     )?;
 
+    rec.log(
+        "sun_transforms",
+        &rerun::Transform3D::new().with_child_frame("sun_frame"),
+    )?;
+
     // The viewer automatically creates a 3D view at `/`. To connect it to our transform hierarchy, we set its coordinate frame
     // to `sun_frame` as well. Alternatively, we could also set a blueprint that makes `/sun` the space origin.
     rec.log("/", &rerun::CoordinateFrame::new("sun_frame"))?;


### PR DESCRIPTION
### What

Fixes a visualizer error that was happening on the `transform3d_hierarchy_frames` snippet because `sun_frame` wasn't logged as a child frame.