### PR TITLE
Fix infinite redraw that sometimes happened in a spatial 3d view

### DIFF
--- a/crates/viewer/re_view_spatial/src/eye.rs
+++ b/crates/viewer/re_view_spatial/src/eye.rs
@@ -1000,6 +1000,7 @@ impl EyeState {
 
                 interpolation.start.lerp(&target_eye, t)
             } else {
+                self.stop_interpolation();
                 target_eye
             }
         } else {


### PR DESCRIPTION
### Related

- Closes RR-3063

### What

Fixes infinite redraw bug that sometimes happened after the first input in spatial views.
