### PR TITLE
Load pinhole in `mcap_protobuf` example

### DIFF
--- a/examples/rust/mcap_protobuf/src/main.rs
+++ b/examples/rust/mcap_protobuf/src/main.rs
@@ -1,4 +1,4 @@
-use arrow::array::{Float32Array, Float64Array, ListArray};
+use arrow::array::{Float32Array, Float64Array, ListArray, UInt32Array};
 // `re_arrow_combinators` provides the building blocks from which we compose the conversions.
 use re_arrow_combinators::{
     Transform as _,
@@ -14,7 +14,8 @@ use rerun::external::re_log;
 use rerun::lenses::{Lens, LensesSink, Op, OpError};
 use rerun::sink::GrpcSink;
 use rerun::{
-    CoordinateFrame, EncodedImage, InstancePoses3D, Transform3D, TransformAxes3D, VideoStream,
+    CoordinateFrame, EncodedImage, InstancePoses3D, Pinhole, Transform3D, TransformAxes3D,
+    VideoStream,
 };
 
 /// Foxglove timestamp fields are by definition relative to a custom epoch.


### PR DESCRIPTION
Part of https://linear.app/rerun/issue/RR-2327

Requires the combinators from: #12031 ✅ 