### PR TITLE
Add e2e test with s3 table creation

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -34467,7 +34467,7 @@ packages:
 - pypi: ./rerun_py
   name: rerun-sdk
   version: 0.28.0a1+dev
-  sha256: 3d5a4a63e6473c1480b88832f2b32fa2303bab1a52eed9a136f38dbb18740f41
+  sha256: f85746072785d859d82d3deea5de49e16120b39bd360bcba8acaafee74091e28
   requires_dist:
   - attrs>=23.1.0
   - numpy>=2

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -262,6 +262,7 @@ filterwarnings = """
 error
 """
 norecursedirs = ".* venv* target* build"
+addopts = "-m 'not aws_ci_credentials'"
 
 ######################
 # mypy configuration #

--- a/rerun_py/tests/e2e_redap_tests/conftest.py
+++ b/rerun_py/tests/e2e_redap_tests/conftest.py
@@ -61,6 +61,11 @@ def pytest_configure(config: pytest.Config) -> None:
         "creates_table: mark test as creating a table (which requires providing a server-accessible path)",
     )
 
+    config.addinivalue_line(
+        "markers",
+        "aws_ci_credentials: mark a test as requiring AWS CI credentials",
+    )
+
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Skip local-only tests when using remote resource prefix."""

--- a/rerun_py/tests/e2e_redap_tests/test_table_create.py
+++ b/rerun_py/tests/e2e_redap_tests/test_table_create.py
@@ -49,3 +49,15 @@ def test_create_table_from_dataset(prefilled_catalog: PrefilledCatalog, tmp_path
     for returned_field in returned_schema:
         original_field = original_schema.field(returned_field.name)
         assert returned_field.metadata == original_field.metadata
+
+@pytest.mark.aws_ci_credentials
+def test_create_table_on_s3(entry_factory: EntryFactory, resource_prefix: str) -> None:
+    table_name = "created_table"
+    table_location = f"{resource_prefix}{table_name}"
+
+    original_schema = pa.schema([("int64", pa.int64()), ("float32", pa.float32()), ("utf8", pa.utf8())])
+    table_entry = entry_factory.create_table_entry(table_name, original_schema, table_location)
+    df = table_entry.df()
+
+    returned_schema = df.schema().remove_metadata()
+    assert returned_schema == original_schema


### PR DESCRIPTION
This PR add unit tests for tables and datasets to be accessed via S3.

Leaving as draft until all combinations have been covered for s3:

- creating tables
- reading tables
- writing tables
- registering tables
- reading datasets
- registering datasets
- creating datasets

The first test did work manually with this command:

```shell
pixi run -e py pytest rerun_py/tests/e2e_redap_tests/test_table_create.py -k test_create_table_on_s3 -m aws_ci_credentials --resource-prefix 's3://dogfooding-test-remove/test' --redap-url 'rerun+http://localhost:51234'
```

Also we still need to figure out how to ensure two tests running concurrently do not step on each other.