### PR TITLE
Fix comment about `np.arange` in typos file

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -158,7 +158,7 @@ extend-ignore-re = [
   "_[a-f0-9]{16}",
 
 
-  "np.arange", # numpy spells "arrange" wrong
+  "np.arange", # Stands for "array range" and isn't a misspelling of "arrange".
   "phc_[a-zA-Z0-9]*", # Posthog public key
   "PNG.?", # Workaround for https://github.com/crate-ci/typos/issues/967
 


### PR DESCRIPTION
See also https://stackoverflow.com/q/55102806
