### PR TITLE
Revert "Fix clearing credentials"

### DIFF
--- a/crates/utils/re_auth/src/oauth.rs
+++ b/crates/utils/re_auth/src/oauth.rs
@@ -49,16 +49,6 @@ pub fn load_credentials() -> Result<Option<Credentials>, CredentialsLoadError> {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("failed to load credentials: {0}")]
-pub struct CredentialsClearError(#[from] storage::ClearError);
-
-pub fn clear_credentials() -> Result<(), CredentialsClearError> {
-    storage::clear()?;
-
-    Ok(())
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum CredentialsRefreshError {
     #[error("failed to refresh credentials: {0}")]
     Api(#[from] api::Error),

--- a/crates/utils/re_auth/src/oauth/storage.rs
+++ b/crates/utils/re_auth/src/oauth/storage.rs
@@ -36,29 +36,15 @@ pub enum StoreError {
     NoLocalStorage,
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ClearError {
-    #[error("failed to clear credentials: {0}")]
-    Io(#[from] std::io::Error),
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[error("could not find a valid config location, please ensure $HOME is set")]
-    UnknownConfigLocation,
-
-    #[cfg(target_arch = "wasm32")]
-    #[error("failed to get window.localStorage")]
-    NoLocalStorage,
-}
-
 #[cfg(not(target_arch = "wasm32"))]
-pub use file::{clear, load, store};
+pub use file::{load, store};
 
 #[cfg(target_arch = "wasm32")]
-pub use web::{clear, load, store};
+pub use web::{load, store};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod file {
-    use super::{ClearError, Credentials, LoadError, StoreError};
+    use super::{Credentials, LoadError, StoreError};
     use std::path::PathBuf;
 
     fn credentials_path() -> Option<PathBuf> {
@@ -85,24 +71,13 @@ mod file {
         std::fs::write(path, data)?;
         Ok(())
     }
-
-    pub fn clear() -> Result<(), ClearError> {
-        let path = credentials_path().ok_or(ClearError::UnknownConfigLocation)?;
-
-        match std::fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            // If the file didn't exist this isn't a failure.
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(err) => Err(ClearError::Io(err)),
-        }
-    }
 }
 
 #[cfg(target_arch = "wasm32")]
 mod web {
     use wasm_bindgen::JsCast as _;
 
-    use super::{ClearError, Credentials, LoadError, StoreError};
+    use super::{Credentials, LoadError, StoreError};
 
     const STORAGE_KEY: &str = "rerun_auth";
 
@@ -115,12 +90,6 @@ mod web {
     }
 
     impl From<NoLocalStorage> for StoreError {
-        fn from(_: NoLocalStorage) -> Self {
-            Self::NoLocalStorage
-        }
-    }
-
-    impl From<NoLocalStorage> for ClearError {
         fn from(_: NoLocalStorage) -> Self {
             Self::NoLocalStorage
         }
@@ -168,14 +137,6 @@ mod web {
         let data = serde_json::to_string(credentials)?;
         local_storage
             .set_item(STORAGE_KEY, &data)
-            .map_err(|err| std::io::Error::other(string_from_js_value(err)))?;
-        Ok(())
-    }
-
-    pub fn clear() -> Result<(), ClearError> {
-        let local_storage = get_local_storage()?;
-        local_storage
-            .remove_item(STORAGE_KEY)
             .map_err(|err| std::io::Error::other(string_from_js_value(err)))?;
         Ok(())
     }

--- a/crates/viewer/re_redap_browser/src/server_modal.rs
+++ b/crates/viewer/re_redap_browser/src/server_modal.rs
@@ -369,15 +369,8 @@ fn auth_ui(ui: &mut egui::Ui, cmd: &CommandSender, auth: &mut Authentication) {
                         .on_hover_text("Clear login status")
                         .clicked()
                     {
-                        match re_auth::oauth::clear_credentials() {
-                            Ok(()) => {
-                                auth.email = None;
-                                auth.start_login_flow(ui);
-                            }
-                            Err(err) => {
-                                auth.error = Some(err.to_string());
-                            }
-                        }
+                        auth.error = None;
+                        auth.start_login_flow(ui);
                     }
                 } else if auth.error.is_some() {
                     if ui


### PR DESCRIPTION
This is not the behavior we intended for the server modal - it should only tell the server to not use those credentials, which it was doing correctly. The issue identified on Slack was separate from this one.

We have a separate design for "logging out", which would actually _remove_ the credentials.