### PR TITLE
minor: rename test so it will run in pytest

### DIFF
--- a/rerun_py/tests/e2e_redap_tests/test_dataset_query.py
+++ b/rerun_py/tests/e2e_redap_tests/test_dataset_query.py
@@ -133,7 +133,7 @@ def test_query_view_from_schema(readonly_test_dataset: DatasetEntry) -> None:
             assert contents.count() > 0
 
 
-def readonly_test_dataset_schema_comparison_self_consistent(readonly_test_dataset: DatasetEntry) -> None:
+def test_readonly_dataset_schema_comparison_self_consistent(readonly_test_dataset: DatasetEntry) -> None:
     schema_0 = readonly_test_dataset.schema()
     schema_1 = readonly_test_dataset.schema()
     set_diff = set(schema_0).symmetric_difference(schema_1)


### PR DESCRIPTION
This is a one line change to get a unit test to run in pytest.

```shell
pixi run -e py pytest rerun_py/tests/e2e_redap_tests/test_dataset_query.py --verbose
```

Produces:

```
collected 5 items

rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_component_filtering PASSED                            [ 20%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_partition_ordering PASSED                             [ 40%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_tables_to_arrow_reader SKIPPED (This currently fa...) [ 60%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_tables_to_arrow_reader_patched PASSED                 [ 80%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_query_view_from_schema PASSED                         [100%]
```

And with this change

```

collected 6 items

rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_component_filtering PASSED                                                                [ 16%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_partition_ordering PASSED                                                                 [ 33%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_tables_to_arrow_reader SKIPPED (This currently fails because of #11852)                   [ 50%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_tables_to_arrow_reader_patched PASSED                                                     [ 66%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_query_view_from_schema PASSED                                                             [ 83%]
rerun_py/tests/e2e_redap_tests/test_dataset_query.py::test_readonly_dataset_schema_comparison_self_consistent PASSED                                 [100%]
```