### PR TITLE
Have perf_telemetry feature enabled by default

### DIFF
--- a/crates/store/re_redap_client/Cargo.toml
+++ b/crates/store/re_redap_client/Cargo.toml
@@ -16,7 +16,7 @@ version.workspace = true
 
 default = []
 
-## Enables integration with `re_perf_telemetry` (Tracy, Jaeger).
+## Enables integration with `re_perf_telemetry` (OpenTelemetry, Jaeger).
 ##
 ## This only works on native.
 perf_telemetry = ["dep:re_perf_telemetry"]
@@ -55,7 +55,7 @@ url.workspace = true
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-re_perf_telemetry = { workspace = true, features = ["tracy"], optional = true }
+re_perf_telemetry = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 tonic = { workspace = true, default-features = false, features = ["transport", "tls-native-roots"] }
 

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -44,7 +44,7 @@ doc = false
 default = ["web_viewer", "base"]
 
 ## Our base feature set, included in `default` and in `release`, but excludes the web viewer.
-base = ["native_viewer", "map_view", "oss_server"]
+base = ["native_viewer", "map_view", "oss_server", "perf_telemetry"]
 
 # !!!IMPORTANT!!!
 #
@@ -95,7 +95,7 @@ oss_server = ["rerun/oss_server"]
 # TODO(lancedb/lance#3073): remove feature flag
 lance = ["re_server/lance"]
 
-## Enables integration with `re_perf_telemetry` (Tracy, Jaeger).
+## Enables integration with `re_perf_telemetry` (OpenTelemetry, Jaeger).
 ##
 ## This only works on native, and only with `TELEMETRY_ENABLED` set.
 perf_telemetry = ["rerun/perf_telemetry"]

--- a/crates/top/rerun-cli/src/bin/rerun.rs
+++ b/crates/top/rerun-cli/src/bin/rerun.rs
@@ -19,7 +19,7 @@ static GLOBAL: AccountingAllocator<mimalloc::MiMalloc> =
 fn main() -> std::process::ExitCode {
     let main_thread_token = rerun::MainThreadToken::i_promise_i_am_on_the_main_thread();
 
-    if cfg!(feature = "perf_telemetry") && std::env::var("TELEMETRY_ENABLED").is_ok() {
+    if cfg!(feature = "perf_telemetry") && re_log::env_var_is_truthy("TELEMETRY_ENABLED") {
         // TODO(tracing/issues#2499): allow installing multiple tracing sinks (https://github.com/tokio-rs/tracing/issues/2499)
         eprintln!(
             "Turning off stderr logging because of perf_telemetry needs exclusive access to the global tracing subscriber"

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -93,7 +93,7 @@ native_viewer = ["dep:re_viewer", "dep:re_crash_handler"]
 ## Enable the in-memory Rerun Server, useful for testing.
 oss_server = ["dep:re_server"]
 
-## Enables integration with `re_perf_telemetry` (Tracy, Jaeger).
+## Enables integration with `re_perf_telemetry` (OpenTelemetry, Jaeger).
 ##
 ## This only works on native, and only with `TELEMETRY_ENABLED` set.
 perf_telemetry = [
@@ -101,6 +101,11 @@ perf_telemetry = [
   "re_redap_client/perf_telemetry",
   "re_viewer?/perf_telemetry",
 ]
+
+## Enables Tracy profiler integration on top of `perf_telemetry`.
+##
+## This only works on native.
+perf_telemetry_tracy = ["perf_telemetry", "re_perf_telemetry/tracy"]
 
 ## Add support for the [`run()`] function, which acts like a main-function for a CLI,
 ## acting the same as [the `rerun` binary](https://crates.io/crates/rerun-cli).
@@ -192,7 +197,7 @@ puffin.workspace = true
 rayon.workspace = true
 
 # Native, optional:
-re_perf_telemetry = { workspace = true, features = ["tracy"], optional = true }
+re_perf_telemetry = { workspace = true, optional = true }
 clap = { workspace = true, optional = true, features = ["derive"] }
 unindent = { workspace = true, optional = true }
 

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -585,7 +585,7 @@ where
     );
 
     #[cfg(not(target_arch = "wasm32"))]
-    if cfg!(feature = "perf_telemetry") && std::env::var("TELEMETRY_ENABLED").is_ok() {
+    if cfg!(feature = "perf_telemetry") && re_log::env_var_is_truthy("TELEMETRY_ENABLED") {
         eprintln!("Disabling crash handler because of perf_telemetry/TELEMETRY_ENABLED"); // Ask Clement why
     } else {
         re_crash_handler::install_crash_handlers(build_info.clone());

--- a/crates/utils/re_log/src/lib.rs
+++ b/crates/utils/re_log/src/lib.rs
@@ -204,6 +204,27 @@ fn is_log_enabled(filter: log::LevelFilter, metadata: &log::Metadata<'_>) -> boo
     metadata.level() <= filter
 }
 
+/// Check if an environment variable is set to a truthy value.
+///
+/// Returns `true` if the environment variable is set to "1", "true", or "yes" (case-insensitive).
+/// Returns `false` otherwise (including when the variable is not set).
+///
+/// # Example
+///
+/// ```ignore
+/// if env_var_is_truthy("TELEMETRY_ENABLED") {
+///     // enable telemetry
+/// }
+/// ```
+pub fn env_var_is_truthy(var_name: &str) -> bool {
+    std::env::var(var_name)
+        .map(|v| {
+            let v = v.to_lowercase();
+            v == "1" || v == "true" || v == "yes"
+        })
+        .unwrap_or(false)
+}
+
 /// Shorten a path to a Rust source file.
 ///
 /// Example input:

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -42,10 +42,16 @@ analytics = ["dep:re_analytics", "re_ui/analytics"]
 ## Enable the map view
 map_view = ["dep:re_view_map"]
 
-## Enables integration with `re_perf_telemetry` (Tracy, Jaeger).
+## Enables integration with `re_perf_telemetry` (OpenTelemetry, Jaeger).
 ##
 ## This only works on native.
 perf_telemetry = ["dep:re_perf_telemetry", "re_redap_client/perf_telemetry"]
+
+## Enables Tracy profiler integration on top of `perf_telemetry`.
+##
+## This only works on native.
+perf_telemetry_tracy = ["perf_telemetry", "re_perf_telemetry/tracy"]
+
 
 testing = ["dep:egui_kittest", "dep:tokio", "re_ui/testing", "re_analytics/testing"]
 
@@ -144,7 +150,7 @@ wgpu.workspace = true
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-re_perf_telemetry = { workspace = true, features = ["tracy"], optional = true }
+re_perf_telemetry = { workspace = true, optional = true }
 
 # web dependencies:
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -3096,7 +3096,7 @@ impl eframe::App for App {
     }
 
     fn update(&mut self, egui_ctx: &egui::Context, frame: &mut eframe::Frame) {
-        #[cfg(all(not(target_arch = "wasm32"), feature = "perf_telemetry"))]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "perf_telemetry_tracy"))]
         re_perf_telemetry::external::tracing_tracy::client::frame_mark();
 
         if let Some(seconds) = frame.info().cpu_usage {

--- a/pixi.toml
+++ b/pixi.toml
@@ -157,10 +157,10 @@ man = { cmd = "cargo --quiet run --package rerun-cli --all-features -- man > doc
 # You can also give an argument for what to view (e.g. an .rrd file).
 rerun = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer --"
 
-# Compile and run the rerun viewer, with performance telemetry.
+# Compile and run the rerun viewer, with performance telemetry including Tracy profiler.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-perf-debug = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer,perf_telemetry --"
+rerun-perf-debug = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer,rerun/perf_telemetry_tracy --"
 
 # Compile `rerun-cli` without the web-viewer.
 rerun-build = "cargo build --package rerun-cli --no-default-features --features release_no_web_viewer"
@@ -173,10 +173,10 @@ rerun-build-release = "cargo build --package rerun-cli --release --no-default-fe
 # You can also give an argument for what to view (e.g. an .rrd file).
 rerun-release = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer --release --"
 
-# Compile and run the rerun viewer in release, with performance telemetry.
+# Compile and run the rerun viewer in release mode, with performance telemetry including Tracy profiler.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-perf = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer,perf_telemetry --release --"
+rerun-perf = "cargo run --package rerun-cli --no-default-features --features release_no_web_viewer,rerun/perf_telemetry_tracy --release --"
 
 # Compile `rerun-cli` with the same feature set as we build for releases.
 rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features release_full --", depends-on = [
@@ -430,11 +430,11 @@ py-build = "pixi run -e py py-build-common"
 # Dedicated alias for building the python bindings in release mode for the `py` environment.
 py-build-release = "pixi run -e py py-build-common-release"
 
-# Dedicated alias for building the python bindings for the `py` environment, with performance telemetry.
-py-build-perf-debug = "pixi run -e py py-build-common --features perf_telemetry"
+# Dedicated alias for building the python bindings for the `py` environment with performance telemetry including Tracy profiler.
+py-build-perf-debug = "pixi run -e py py-build-common --features re_perf_telemetry/tracy"
 
-# Dedicated alias for building the python bindings in release mode for the `py` environment, with performance telemetry.
-py-build-perf = "pixi run -e py py-build-common-release --features perf_telemetry"
+# Dedicated alias for building the python bindings in release mode for the `py` environment with performance telemetry including Tracy profiler.
+py-build-perf = "pixi run -e py py-build-common-release --features re_perf_telemetry/tracy"
 
 py-check-signatures = "python scripts/ci/python_check_signatures.py"
 
@@ -477,14 +477,14 @@ rerun-from-path = "rerun"
 # Dedicated alias for building the python bindings for the `examples` environment.
 py-build-examples = "pixi run -e examples py-build-common"
 
-# Dedicated alias for building the python bindings for the `examples` environment, with perf telemetry.
-py-build-perf-debug-examples = "pixi run -e examples py-build-common --features perf_telemetry"
+# Dedicated alias for building the python bindings for the `examples` environment, with performance telemetry including Tracy profiler.
+py-build-perf-debug-examples = "pixi run -e examples py-build-common --features re_perf_telemetry/tracy"
 
 # Dedicated alias for building the python bindings for the `examples` environment, in release.
 py-build-release-examples = "pixi run -e examples py-build-common-release"
 
-# Dedicated alias for building the python bindings for the `examples` environment, in release, with perf telemetry.
-py-build-perf-examples = "pixi run -e examples py-build-common-release --features perf_telemetry"
+# Dedicated alias for building the python bindings for the `examples` environment in release, with performance telemetry including Tracy profiler.
+py-build-perf-examples = "pixi run -e examples py-build-common-release --features re_perf_telemetry/tracy"
 
 # Python example utilities
 py-run-all-examples = { cmd = "python scripts/run_all.py --skip-build", depends-on = [

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -22,7 +22,7 @@ extra = []
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.
-pypi = ["extension-module", "nasm", "web_viewer", "server"]
+pypi = ["extension-module", "nasm", "web_viewer", "server", "perf_telemetry"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we
@@ -35,7 +35,7 @@ extension-module = ["pyo3/extension-module"]
 ## You need to install [nasm](https://github.com/netwide-assembler/nasm) to compile with this feature.
 nasm = ["re_video/nasm"]
 
-## Enables integration with `re_perf_telemetry` (Tracy, Jaeger).
+## Enables integration with `re_perf_telemetry` (OpenTelemetry, Jaeger).
 ##
 ## This only works on native.
 perf_telemetry = [
@@ -113,7 +113,7 @@ thiserror.workspace = true
 
 # Native dependencies:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-re_perf_telemetry = { workspace = true, features = ["tracy", "pyo3"], optional = true }
+re_perf_telemetry = { workspace = true, features = ["pyo3"], optional = true }
 
 
 [build-dependencies]

--- a/rerun_py/rerun_sdk/rerun/catalog/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/catalog/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-# Conditionally compiled function - always exists at runtime but mypy can't verify
 from rerun_bindings import (
     AlreadyExistsError as AlreadyExistsError,
     DataframeQueryView as DataframeQueryView,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -142,7 +142,7 @@ fn init_perf_telemetry() -> parking_lot::MutexGuard<'static, re_perf_telemetry::
 #[pymodule]
 #[pyo3(name = "rerun_bindings")]
 fn rerun_bindings(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    if cfg!(feature = "perf_telemetry") && std::env::var("TELEMETRY_ENABLED").is_ok() {
+    if cfg!(feature = "perf_telemetry") && re_log::env_var_is_truthy("TELEMETRY_ENABLED") {
         // TODO(tracing/issues#2499): allow installing multiple tracing sinks (https://github.com/tokio-rs/tracing/issues/2499)
     } else {
         // NOTE: We set up the logging this here because some the inner init methods don't respond too kindly to being


### PR DESCRIPTION
### What

This change makes ``perf_telemetry`` feature enabled by default. We want to use rerun sdk with perf telemetry enabled in our benchmark tests, but also in every day workflows. 

Logging strategy for the SDK, cli or the viewer is not impacted by this change and is controller by the env var ``TELEMETRY_ENABLED``. When this env var is set, logs, traces and metric pipelines are enabled (and configured with default values from ``re_perf_telemetry``).

Targets like ``py-build-perf-debug`` will now enable ``tracy`` feature of ``re_perf_telemetry``, but ``tracy`` feature is **disabled** by default. It seems that ``{crate}/{feature}`` syntax works in some places, but not others, hence I had to define ``perf_telemetry_tracy`` feature in some places.

### Testing done

```
pixi run rerun

[2025-12-03T09:27:00Z DEBUG rerun::commands::entrypoint] Detected 14 cores. Using 12 compute threads.
Telemetry disabled. All logging will be ignored.
[2025-12-03T09:27:00Z DEBUG rerun::commands::entrypoint] Parsing --server-memory-limit (for gRPC server)
[2025-12-03T09:27:00Z DEBUG rerun::commands::entrypoint] Server memory limit: 0B
[2025-12-03T09:27:00Z DEBUG rerun::commands::entrypoint] Parsing --memory-limit (for Viewer)
[2025-12-03T09:27:00Z DEBUG re_memory::memory_limit] Setting memory limit to 27.0 GiB, which is 75% of total available memory (36.0 GiB).
[2025-12-03T09:27:00Z DEBUG re_memory::memory_limit] Setting memory limit to 27.0 GiB, which is 75% of total available memory (36.0 GiB).
[2025-12-03T09:27:00Z INFO  re_grpc_server] Listening for gRPC connections on 0.0.0.0:9876. Connect by running `rerun --connect rerun+http://127.0.0.1:9876/proxy`
[2025-12-03T09:27:00Z DEBUG eframe] Using the wgpu renderer
```
```
TELEMETRY_ENABLED=true pixi run rerun

Turning off stderr logging because of perf_telemetry needs exclusive access to the global tracing subscriber
Disabling crash handler because of perf_telemetry/TELEMETRY_ENABLED
  2025-12-03T09:28:14.725987Z  INFO  Telemetry initialized
    at crates/utils/re_perf_telemetry/src/telemetry.rs:456 on main ThreadId(1)

  2025-12-03T09:28:14.726077Z DEBUG  Parsing --server-memory-limit (for gRPC server)
    at crates/top/rerun/src/commands/entrypoint.rs:741 on main ThreadId(1)

  2025-12-03T09:28:14.726081Z DEBUG  Server memory limit: 0B
    at crates/top/rerun/src/commands/entrypoint.rs:753 on main ThreadId(1)

  2025-12-03T09:28:14.726292Z DEBUG  Parsing --memory-limit (for Viewer)
    at crates/top/rerun/src/commands/entrypoint.rs:954 on main ThreadId(1)

  2025-12-03T09:28:14.726355Z DEBUG  Setting memory limit to 27.0 GiB, which is 75% of total available memory (36.0 GiB).
    at crates/utils/re_memory/src/memory_limit.rs:37 on main ThreadId(1)

  2025-12-03T09:28:14.726379Z DEBUG  Setting memory limit to 27.0 GiB, which is 75% of total available memory (36.0 GiB).
    at crates/utils/re_memory/src/memory_limit.rs:37 on main ThreadId(1)

  2025-12-03T09:28:14.728692Z  INFO  re_log not initialized. You won't see log messages as GUI notifications.
    at crates/viewer/re_viewer/src/lib.rs:373 on main ThreadId(1)

  2025-12-03T09:28:14.728824Z  INFO  Listening for gRPC connections on 0.0.0.0:9876. Connect by running `rerun --connect rerun+http://127.0.0.1:9876/proxy`
    at crates/store/re_grpc_server/src/lib.rs:169 on tokio-runtime-worker ThreadId(26)

  2025-12-03T09:28:14.731535Z DEBUG  Using the wgpu renderer
    at /Users/zeljkomihaljcic/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/eframe-0.33.2/src/lib.rs:273 on main ThreadId(1)

```

Same behaviour (i.e. log config obviously being controller by the ``TELEMETRY_ENABLED`` env var) observed when using rerun sdk in benchmarks.  Also for ``rerun-cli`` logging is not impacted without the env var set, and when set, stderr logging is gone.