### PR TITLE
Simplify `Field` declarations in `re_arrow_combinators`

### DIFF
--- a/crates/store/re_arrow_combinators/src/map.rs
+++ b/crates/store/re_arrow_combinators/src/map.rs
@@ -44,8 +44,7 @@ where
                 })?;
 
         let transformed = self.transform.transform(downcast)?;
-        let new_field = Arc::new(Field::new(
-            "item",
+        let new_field = Arc::new(Field::new_list_field(
             transformed.data_type().clone(),
             transformed.is_nullable(),
         ));

--- a/crates/store/re_arrow_combinators/tests/explode.rs
+++ b/crates/store/re_arrow_combinators/tests/explode.rs
@@ -56,11 +56,11 @@ fn test_explode_nested_lists() {
     // Manually build List<List<Int32>>
     let inner_values = Int32Array::from(vec![1, 2, 3, 4, 5, 6]);
     let inner_offsets = OffsetBuffer::new(vec![0, 2, 3, 6].into());
-    let inner_field = Arc::new(Field::new("item", DataType::Int32, true));
+    let inner_field = Arc::new(Field::new_list_field(DataType::Int32, true));
     let inner_list = ListArray::new(inner_field, inner_offsets, Arc::new(inner_values), None);
 
     let outer_offsets = OffsetBuffer::new(vec![0, 2, 3].into());
-    let outer_field = Arc::new(Field::new("item", inner_list.data_type().clone(), true));
+    let outer_field = Arc::new(Field::new_list_field(inner_list.data_type().clone(), true));
     let input = ListArray::new(
         outer_field,
         outer_offsets,
@@ -101,7 +101,7 @@ fn test_explode_with_skips_in_offset_buffer() {
     let values = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     let offsets = OffsetBuffer::new(vec![0, 2, 7, 10].into());
     let validity = arrow::buffer::NullBuffer::from(vec![true, false, true]);
-    let field = Arc::new(Field::new("item", DataType::Int32, true));
+    let field = Arc::new(Field::new_list_field(DataType::Int32, true));
 
     let input = ListArray::new(field, offsets, Arc::new(values), Some(validity));
     println!("Input:\n{}", DisplayRB(input.clone()));

--- a/crates/store/re_arrow_combinators/tests/transform.rs
+++ b/crates/store/re_arrow_combinators/tests/transform.rs
@@ -27,8 +27,7 @@ fn create_nasty_component_column() -> ListArray {
     // Middle struct schema: {poses: List<Struct<x: Float32>>}
     let middle_struct_fields = Fields::from(vec![Field::new(
         "poses",
-        DataType::List(Arc::new(Field::new(
-            "item",
+        DataType::List(Arc::new(Field::new_list_field(
             DataType::Struct(inner_struct_fields.clone()),
             false,
         ))),
@@ -44,11 +43,9 @@ fn create_nasty_component_column() -> ListArray {
         ],
     );
 
-    let list_builder = ListBuilder::new(inner_struct_builder).with_field(Arc::new(Field::new(
-        "item",
-        DataType::Struct(inner_struct_fields),
-        false,
-    )));
+    let list_builder = ListBuilder::new(inner_struct_builder).with_field(Arc::new(
+        Field::new_list_field(DataType::Struct(inner_struct_fields), false),
+    ));
 
     let struct_builder = StructBuilder::new(middle_struct_fields, vec![Box::new(list_builder)]);
 


### PR DESCRIPTION
Arrow has `Field::new_list_field`, which needs one argument less for our use case:
https://docs.rs/arrow/latest/arrow/datatypes/struct.Field.html#method.new_list_field

