### PR TITLE
Lower log level for unsupported `scan_parameters` message

### DIFF
--- a/crates/store/re_server/src/rerun_cloud.rs
+++ b/crates/store/re_server/src/rerun_cloud.rs
@@ -1039,7 +1039,7 @@ impl RerunCloudService for RerunCloudHandler {
         } = request.into_inner().try_into()?;
 
         if scan_parameters.is_some() {
-            re_log::warn_once!(
+            re_log::info_once!(
                 "query_dataset: scan_parameters are not yet implemented and will be ignored"
             );
         }


### PR DESCRIPTION
### What

Lower the severity of the log message about unsupported `scan_parameters` in the OSS server from WARNING to INFO.