### PR TITLE
Gracefully exit on `ctrl c`

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -18,7 +18,6 @@ use crate::commands::AnalyticsCommands;
 #[cfg(feature = "data_loaders")]
 use crate::commands::McapCommands;
 use crate::commands::RrdCommands;
-use crate::external::re_ui::{UICommand, UICommandSender as _};
 
 // ---
 
@@ -866,6 +865,8 @@ fn start_native_viewer(
     #[cfg(feature = "server")] server_addr: std::net::SocketAddr,
     #[cfg(feature = "server")] server_options: re_sdk::ServerOptions,
 ) -> anyhow::Result<()> {
+    use crate::external::re_ui::{UICommand, UICommandSender as _};
+
     let startup_options = native_startup_options_from_args(args)?;
 
     let connect = args.connect.is_some();


### PR DESCRIPTION
### Related

* closes https://linear.app/rerun/issue/RR-3060/closing-the-viewer-seems-to-not-always-save-list-of-servers

### What
Adds a ctrl c handler so that we can gracefully exit when closing rerun with ctrl c. This ensures the state is saved.

Testing with Rerun started by....
* [x] cli standalone
    * [x] Windows
    * [x] Linux
    * [x] Mac
* [x] via python package
    * [x] Windows
    * [x] Linux (if `python -m rerun` is correct here)
    * [x] Mac
* [x] via `spawn`
    * [x] Windows - still has https://github.com/rerun-io/rerun/issues/6356 
    * [x] Linux - behaves correctly and does not close the viewer
    * [x] Mac