### PR TITLE
Fix typo in build-wheels CI step name

### DIFF
--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           pixi run rerun-build-native-and-web-release
 
-      - name: Copy rerun-cli to wheel foldcer
+      - name: Copy rerun-cli to wheel folder
         run: |
           cp target/release/rerun rerun_py/rerun_sdk/rerun_cli
 


### PR DESCRIPTION
🕵️‍♂️ 

<img width="327" height="171" alt="Bildschirmfoto 2025-12-03 um 18 37 50" src="https://github.com/user-attachments/assets/25f5cf2f-a01e-45b3-a5d5-2d441565a321" />
