### PR TITLE
Fix incorrect displayed transform for some cases of logging transforms at a previously shown time

### DIFF
--- a/crates/store/re_tf/src/transform_resolution_cache.rs
+++ b/crates/store/re_tf/src/transform_resolution_cache.rs
@@ -508,7 +508,7 @@ fn add_invalidated_entry_if_not_already_cleared<T: PartialEq>(
     if let Entry::Vacant(vacant_entry) = entry {
         vacant_entry.insert(CachedTransformValue::Invalidated);
     } else if let Entry::Occupied(mut occupied_entry) = entry
-        && occupied_entry.get() == &CachedTransformValue::Cleared
+        && occupied_entry.get() != &CachedTransformValue::Cleared
     {
         occupied_entry.insert(CachedTransformValue::Invalidated);
     }


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/11929
    * I'm not 100% sure of that, but this fits the description well enough that I think we should close now and re-open later

### What

We had a bug that the Viewer would sometimes display transforms incorrectly when transforms were coming in at a later point in time.

As far as I can tell there are two scenarios where this bug would have been hit:

(1), this fits the description of #11929 :
* a chunk that has _some_ transforms but none at a given time `t` gets send to the viewer
* the viewer displays time `t`, thus populating the internal transform cache
* another chunk comes in that has transform information at time `t` gets send to the viewer

(2) a simple "update" (simpler, but probably less common):
* a chunk that has _some_ transforms at a given time `t` gets send to the viewer
* the viewer displays time `t`, thus populating the internal transform cache
* another chunk comes in that has _new_ transform information at time `t` gets send to the viewer
