### PR TITLE
make sure we don't crate spans when telemetry is not enabled

### DIFF
--- a/crates/utils/re_perf_telemetry/src/grpc.rs
+++ b/crates/utils/re_perf_telemetry/src/grpc.rs
@@ -24,6 +24,7 @@ pub struct GrpcMakeSpan {
 
 impl GrpcMakeSpan {
     pub fn new() -> Self {
+        // if telemetry is not explicitly enabled through an env var, we create noop spans
         let create_noop_spans = !std::env::var("TELEMETRY_ENABLED")
             .is_ok_and(|v| v == "1" || v.to_lowercase() == "true" || v.to_lowercase() == "yes");
 


### PR DESCRIPTION
### Related
* Part of https://linear.app/rerun/issue/RR-3112/log-spam-in-viewer

### What

After enabling perf telemetry feature in https://github.com/rerun-io/rerun/pull/12065 we started spamming the viewer with tracing spans. This quick fix ensures we don't create the spans if tracing feature is not enabled. 

I tried doing this check earlier in the setup of the client telemetry, but since we have predefined client type, I just couldn't find a way without making this much more complicated. 

### Testing done
Tested adding local Redap server and with this fix the spammy messages are gone.