### PR TITLE
Add `NavSatService::Unknown` to ROS2 parsing

### DIFF
--- a/crates/store/re_mcap/src/parsers/ros2msg/definitions/sensor_msgs.rs
+++ b/crates/store/re_mcap/src/parsers/ros2msg/definitions/sensor_msgs.rs
@@ -334,6 +334,9 @@ pub struct NavSatStatus {
 #[serde(from = "i8", into = "i8")]
 #[repr(i8)]
 pub enum NavSatFixStatus {
+    /// Status is unknown.
+    Unknown = -2,
+
     /// Unable to fix position.
     NoFix = -1,
 
@@ -350,10 +353,11 @@ pub enum NavSatFixStatus {
 impl From<i8> for NavSatFixStatus {
     fn from(value: i8) -> Self {
         match value {
+            -1 => Self::NoFix,
             0 => Self::Fix,
             1 => Self::SbasFix,
             2 => Self::GbasFix,
-            _ => Self::NoFix,
+            _ => Self::Unknown,
         }
     }
 }


### PR DESCRIPTION
### What

This adds `NavSatService::Unknown` to the `NavSatService` enum and `NavSatFixStatus::Unknown` to `NavSatFixStatus`, which were added in [jazzy](https://docs.ros.org/en/jazzy/p/sensor_msgs/msg/NavSatStatus.html).
