### PR TITLE
We do not show the analytics disclaimer if a user is authenticating with a rerun account

### DIFF
--- a/crates/utils/re_auth/src/oauth.rs
+++ b/crates/utils/re_auth/src/oauth.rs
@@ -234,9 +234,11 @@ impl InMemoryCredentials {
         // we show an analytics diclaimer. But, during SDK usage with the Catalog
         // it's possible to hit this code-path during a first run in a new
         // environment. Given the user already has a Rerun identity (or else there
-        // would be no credentials to store!), we assume they are already opted-in
-        // to rerun analytics and do not need a disclaimer. By manually forcing the
-        // creation of the analytics config we bypass the first_run check.
+        // would be no credentials to store!), we assume they are already aware of
+        // rerun analytics and do not need a disclaimer. They can still use the shell
+        // to run `rerun analytics disable` if they wish to opt out.
+        //
+        // By manually forcing the creation of the analytics config we bypass the first_run check.
         if let Ok(config) = re_analytics::Config::load_or_default() {
             if config.is_first_run() {
                 config.save().ok();


### PR DESCRIPTION
### What

Without this, any time a user wants to create an authenticated session in a clean notebook environment, the experience ends up looking like.
<img width="720" height="478" alt="image" src="https://github.com/user-attachments/assets/df7d6fee-3ac9-443f-a1ce-d7a8bfc5e697" />
