### PR TITLE
Add `ApiError::Unimplemented`

### DIFF
--- a/crates/store/re_redap_client/src/lib.rs
+++ b/crates/store/re_redap_client/src/lib.rs
@@ -92,6 +92,9 @@ pub enum ApiErrorKind {
     AlreadyExists,
     PermissionDenied,
     Unauthenticated,
+
+    /// The gRPC endpoint has not been implemented
+    Unimplemented,
     Connection,
     Timeout,
     Internal,
@@ -107,6 +110,7 @@ impl From<tonic::Code> for ApiErrorKind {
             tonic::Code::AlreadyExists => Self::AlreadyExists,
             tonic::Code::PermissionDenied => Self::PermissionDenied,
             tonic::Code::Unauthenticated => Self::Unauthenticated,
+            tonic::Code::Unimplemented => Self::Unimplemented,
             tonic::Code::Unavailable => Self::Connection,
             tonic::Code::InvalidArgument => Self::InvalidArguments,
             tonic::Code::DeadlineExceeded => Self::Timeout,
@@ -122,6 +126,7 @@ impl std::fmt::Display for ApiErrorKind {
             Self::AlreadyExists => write!(f, "AlreadyExists"),
             Self::PermissionDenied => write!(f, "PermissionDenied"),
             Self::Unauthenticated => write!(f, "Unauthenticated"),
+            Self::Unimplemented => write!(f, "Unimplemented"),
             Self::Connection => write!(f, "Connection"),
             Self::Internal => write!(f, "Internal"),
             Self::InvalidArguments => write!(f, "InvalidArguments"),

--- a/rerun_py/src/catalog/errors.rs
+++ b/rerun_py/src/catalog/errors.rs
@@ -159,7 +159,9 @@ impl From<ExternalError> for PyErr {
                 ApiErrorKind::NotFound => NotFoundError::new_err(err.to_string()),
                 ApiErrorKind::AlreadyExists => AlreadyExistsError::new_err(err.to_string()),
                 ApiErrorKind::Timeout => PyTimeoutError::new_err(err.to_string()),
-                ApiErrorKind::Internal => PyRuntimeError::new_err(err.to_string()),
+                ApiErrorKind::Unimplemented | ApiErrorKind::Internal => {
+                    PyRuntimeError::new_err(err.to_string())
+                }
             },
 
             ExternalError::ArrowError(err) => PyValueError::new_err(format!("Arrow error: {err}")),


### PR DESCRIPTION
Will be useful for endpoints that are not implemented on cloud or OSS