### PR TITLE
Add reason for why an entity is a `VisualizableEntity`

### DIFF
--- a/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
+++ b/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
@@ -93,14 +93,16 @@ fn recommended_views_for_selection(ctx: &ContextMenuContext<'_>) -> IntSet<ViewC
         // "visualizable" with it. By "visualizable" we mean that either the entity itself, or any
         // of its sub-entities, are visualizable.
 
-        let covered = entities_of_interest.iter().all(|entity| {
+        let covered = entities_of_interest.iter().all(|candidate_entity| {
             ctx.viewer_context
                 .iter_visualizable_entities_for_view_class(entry.identifier)
-                .any(|(_visualizer, entities)| {
-                    entities
+                .any(|(_visualizer, visualizable_entities)| {
+                    visualizable_entities
                         .0
                         .iter()
-                        .any(|visualizable_entity| visualizable_entity.starts_with(entity))
+                        .any(|(visualizable_entity, _reason)| {
+                            visualizable_entity.starts_with(candidate_entity)
+                        })
                 })
         });
 

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -612,8 +612,9 @@ fn available_inactive_visualizers(
 
     ctx.viewer_ctx
         .iter_visualizable_entities_for_view_class(view_class.identifier)
-        .filter(|(vis, ents)| {
-            ents.contains(&data_result.entity_path) && !active_visualizers.contains(vis)
+        .filter(|(vis, visualizable_ents)| {
+            visualizable_ents.contains_key(&data_result.entity_path)
+                && !active_visualizers.contains(vis)
         })
         .map(|(vis, _)| vis)
         .sorted()

--- a/crates/viewer/re_view_bar_chart/src/view_class.rs
+++ b/crates/viewer/re_view_bar_chart/src/view_class.rs
@@ -114,7 +114,7 @@ impl ViewClass for BarChartView {
         // Keeping this implementation simple: We know there's only a single visualizer here.
         if visualizable_entities_per_visualizer
             .get(&BarChartVisualizerSystem::identifier())
-            .is_some_and(|entities| entities.contains(entity_path))
+            .is_some_and(|entities| entities.contains_key(entity_path))
         {
             std::iter::once(BarChartVisualizerSystem::identifier()).collect()
         } else {

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -9,10 +9,10 @@ use re_ui::{self, Help, IconText, MouseButtonText, UiExt as _, icons};
 use re_view::controls::DRAG_PAN2D_BUTTON;
 use re_view::view_property_ui;
 use re_viewer_context::{
-    IdentifiedViewSystem as _, Item, RecommendedView, SystemCommand, SystemCommandSender as _,
-    SystemExecutionOutput, ViewClass, ViewClassExt as _, ViewClassLayoutPriority,
-    ViewClassRegistryError, ViewId, ViewQuery, ViewSpawnHeuristics, ViewState, ViewStateExt as _,
-    ViewSystemExecutionError, ViewSystemRegistrator, ViewerContext,
+    Item, SystemCommand, SystemCommandSender as _, SystemExecutionOutput, ViewClass,
+    ViewClassExt as _, ViewClassLayoutPriority, ViewClassRegistryError, ViewId, ViewQuery,
+    ViewSpawnHeuristics, ViewState, ViewStateExt as _, ViewSystemExecutionError,
+    ViewSystemRegistrator, ViewerContext, suggest_view_for_each_entity,
 };
 use re_viewport_blueprint::ViewProperty;
 
@@ -145,21 +145,7 @@ impl ViewClass for GraphView {
         ctx: &ViewerContext<'_>,
         include_entity: &dyn Fn(&EntityPath) -> bool,
     ) -> ViewSpawnHeuristics {
-        // TODO(grtlr): Consider using `suggest_view_for_each_entity` here too.
-        if let Some(maybe_visualizable) = ctx
-            .visualizable_entities_per_visualizer
-            .get(&NodeVisualizer::identifier())
-        {
-            ViewSpawnHeuristics::new(maybe_visualizable.iter().cloned().filter_map(|entity| {
-                if include_entity(&entity) {
-                    Some(RecommendedView::new_single_entity(entity))
-                } else {
-                    None
-                }
-            }))
-        } else {
-            ViewSpawnHeuristics::empty()
-        }
+        suggest_view_for_each_entity::<NodeVisualizer>(ctx, include_entity)
     }
 
     /// Additional UI displayed when the view is selected.

--- a/crates/viewer/re_view_spatial/src/heuristics.rs
+++ b/crates/viewer/re_view_spatial/src/heuristics.rs
@@ -70,7 +70,11 @@ fn default_visualized_entities_for_visualizer_kind(
             if data.preferred_view_kind == Some(visualizer_kind) {
                 let indicator_matching = ctx.indicated_entities_per_visualizer.get(&id)?;
                 let visualizable = ctx.visualizable_entities_per_visualizer.get(&id)?;
-                Some(indicator_matching.intersection(visualizable))
+                Some(
+                    indicator_matching
+                        .iter()
+                        .filter(|e| visualizable.contains_key(e)),
+                )
             } else {
                 None
             }

--- a/crates/viewer/re_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_view_spatial/src/view_3d.rs
@@ -327,13 +327,7 @@ impl ViewClass for SpatialView3D {
 
         let visualizable: HashSet<&ViewSystemIdentifier> = visualizable_entities_per_visualizer
             .iter()
-            .filter_map(|(visualizer, ents)| {
-                if ents.contains(entity_path) {
-                    Some(visualizer)
-                } else {
-                    None
-                }
-            })
+            .filter_map(|(visualizer, ents)| ents.contains_key(entity_path).then_some(visualizer))
             .collect();
 
         let indicated: HashSet<&ViewSystemIdentifier> = indicated_entities_per_visualizer

--- a/crates/viewer/re_view_tensor/src/view_class.rs
+++ b/crates/viewer/re_view_tensor/src/view_class.rs
@@ -109,7 +109,7 @@ Set the displayed dimensions in a selection panel.",
         // Keeping this implementation simple: We know there's only a single visualizer here.
         if visualizable_entities_per_visualizer
             .get(&TensorSystem::identifier())
-            .is_some_and(|entities| entities.contains(entity_path))
+            .is_some_and(|entities| entities.contains_key(entity_path))
         {
             std::iter::once(TensorSystem::identifier()).collect()
         } else {

--- a/crates/viewer/re_view_time_series/src/view_class.rs
+++ b/crates/viewer/re_view_time_series/src/view_class.rs
@@ -324,7 +324,7 @@ impl ViewClass for TimeSeriesView {
         {
             indicated_entities
                 .0
-                .extend(maybe_visualizable.iter().cloned());
+                .extend(maybe_visualizable.keys().cloned());
         }
 
         // Ensure we don't modify this list anymore before we check the `include_entity`.
@@ -386,7 +386,7 @@ impl ViewClass for TimeSeriesView {
             visualizable_entities_per_visualizer
                 .iter()
                 .filter_map(|(visualizer, ents)| {
-                    if ents.contains(entity_path) {
+                    if ents.contains_key(entity_path) {
                         Some(visualizer)
                     } else {
                         None

--- a/crates/viewer/re_viewer_context/src/heuristics.rs
+++ b/crates/viewer/re_viewer_context/src/heuristics.rs
@@ -30,8 +30,9 @@ where
         return ViewSpawnHeuristics::empty();
     };
 
-    let recommended_views = visualizable_entities
-        .intersection(indicator_matching_entities)
+    let recommended_views = indicator_matching_entities
+        .iter()
+        .filter(|entity| visualizable_entities.contains_key(entity))
         .filter_map(|entity| {
             if include_entity(entity) {
                 Some(RecommendedView::new_single_entity(entity.clone()))

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -106,6 +106,7 @@ pub use self::time_control::{
 };
 pub use self::typed_entity_collections::{
     IndicatedEntities, PerVisualizer, PerVisualizerInViewClass, VisualizableEntities,
+    VisualizableReason,
 };
 pub use self::undo::BlueprintUndoState;
 pub use self::utils::{

--- a/crates/viewer/re_viewer_context/src/view/view_class.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_class.rs
@@ -119,7 +119,7 @@ pub trait ViewClass: Send + Sync {
             visualizable_entities_per_visualizer
                 .iter()
                 .filter_map(|(visualizer, ents)| {
-                    if ents.contains(entity_path) {
+                    if ents.contains_key(entity_path) {
                         Some(visualizer)
                     } else {
                         None

--- a/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/view/visualizer_system.rs
@@ -75,7 +75,7 @@ pub struct VisualizerQueryInfo {
     /// Order should reflect order in archetype docs & user code as well as possible.
     ///
     /// Note that we need full descriptors here in order to write overrides from the UI.
-    pub queried: SortedComponentSet,
+    pub queried: SortedComponentSet, // TODO(grtlr, wumpf): This can probably be removed?
 }
 
 impl VisualizerQueryInfo {

--- a/crates/viewer/re_viewport_blueprint/benches/data_query.rs
+++ b/crates/viewer/re_viewport_blueprint/benches/data_query.rs
@@ -13,7 +13,7 @@ use re_sdk_types::components::Position2D;
 use re_types_core::ViewClassIdentifier;
 use re_viewer_context::{
     Caches, PerVisualizerInViewClass, StoreContext, ViewClassRegistry, VisualizableEntities,
-    blueprint_timeline,
+    VisualizableReason, blueprint_timeline,
 };
 use re_viewport_blueprint::ViewContents;
 
@@ -184,6 +184,7 @@ fn build_entity_tree(
         .iter()
         .filter(|_| rng.random_bool(0.7)) // 70% of entities are visualizable
         .cloned()
+        .map(|e| (e, VisualizableReason::Always))
         .collect();
 
     visualizable_entities

--- a/crates/viewer/re_viewport_blueprint/src/entity_add_info.rs
+++ b/crates/viewer/re_viewport_blueprint/src/entity_add_info.rs
@@ -72,7 +72,7 @@ pub fn create_entity_add_info(
 
     tree.visit_children_recursively(|entity_path| {
         let can_add: CanAddToView =
-            if ctx.iter_visualizable_entities_for_view_class(view.class_identifier()).any(|(_vis, entities)| entities.contains(entity_path)) {
+            if ctx.iter_visualizable_entities_for_view_class(view.class_identifier()).any(|(_vis, entities)| entities.contains_key(entity_path)) {
                 CanAddToView::Compatible {
                     already_added: query_result.result_for_entity(entity_path).is_some(),
                 }

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -459,7 +459,7 @@ mod tests {
     use re_test_context::TestContext;
     use re_viewer_context::{
         IndicatedEntities, OverridePath, PerVisualizer, PerVisualizerInViewClass,
-        ViewClassPlaceholder, VisualizableEntities,
+        ViewClassPlaceholder, VisualizableEntities, VisualizableReason,
     };
 
     use super::*;
@@ -494,21 +494,19 @@ mod tests {
             visualizable_entities
                 .0
                 .entry("Points3D".into())
-                .or_insert_with(|| VisualizableEntities(entity_paths.into_iter().collect()));
+                .or_insert_with(|| {
+                    VisualizableEntities(
+                        entity_paths
+                            .into_iter()
+                            .map(|ent| (ent, VisualizableReason::Always))
+                            .collect(),
+                    )
+                });
         }
 
         let visualizable_entities = PerVisualizerInViewClass::<VisualizableEntities> {
             view_class_identifier: ViewClassPlaceholder::identifier(),
-            per_visualizer: visualizable_entities
-                .0
-                .iter()
-                .map(|(id, entities)| {
-                    (
-                        *id,
-                        VisualizableEntities(entities.iter().cloned().collect()),
-                    )
-                })
-                .collect(),
+            per_visualizer: visualizable_entities.0.clone(),
         };
 
         // Basic blueprint - a single view that queries everything.

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -347,8 +347,10 @@ impl ViewContents {
         re_tracing::profile_function!();
 
         let mut visualizers_per_entity = IntMap::default();
-        for (visualizer, entities) in visualizable_entities_for_visualizer_systems.iter() {
-            for entity_path in entities.iter() {
+        for (visualizer, visualizable_entities) in
+            visualizable_entities_for_visualizer_systems.iter()
+        {
+            for entity_path in visualizable_entities.keys() {
                 visualizers_per_entity
                     .entry(entity_path.hash())
                     .or_insert_with(SmallVec::new)
@@ -656,7 +658,7 @@ mod tests {
     use re_entity_db::EntityDb;
     use re_log_types::example_components::{MyPoint, MyPoints};
     use re_log_types::{StoreId, TimePoint, Timeline};
-    use re_viewer_context::{Caches, StoreContext, blueprint_timeline};
+    use re_viewer_context::{Caches, StoreContext, VisualizableReason, blueprint_timeline};
 
     use super::*;
 
@@ -703,8 +705,11 @@ mod tests {
             .or_insert_with(|| {
                 VisualizableEntities(
                     [
-                        EntityPath::from("parent"),
-                        EntityPath::from("parent/skipped/child1"),
+                        (EntityPath::from("parent"), VisualizableReason::Always),
+                        (
+                            EntityPath::from("parent/skipped/child1"),
+                            VisualizableReason::Always,
+                        ),
                     ]
                     .into_iter()
                     .collect(),

--- a/examples/rust/custom_view/src/points3d_color_view.rs
+++ b/examples/rust/custom_view/src/points3d_color_view.rs
@@ -116,7 +116,7 @@ impl ViewClass for ColorCoordinatesView {
         if ctx
             .visualizable_entities_per_visualizer
             .get(&Points3DColorVisualizer::identifier())
-            .is_some_and(|entities| entities.iter().any(include_entity))
+            .is_some_and(|entities| entities.keys().any(include_entity))
         {
             ViewSpawnHeuristics::root()
         } else {
@@ -137,7 +137,7 @@ impl ViewClass for ColorCoordinatesView {
     ) -> SmallVisualizerSet {
         if visualizable_entities_per_visualizer
             .get(&Points3DColorVisualizer::identifier())
-            .is_some_and(|entities| entities.contains(entity_path))
+            .is_some_and(|entities| entities.contains_key(entity_path))
         {
             SmallVisualizerSet::from_slice(&[Points3DColorVisualizer::identifier()])
         } else {


### PR DESCRIPTION
This makes more information from the observation of the chunk store available downstream, for example to be used by heuristics and view spawning.

