### PR TITLE
Allow setting build envs externally

### DIFF
--- a/crates/build/re_build_tools/README.md
+++ b/crates/build/re_build_tools/README.md
@@ -8,3 +8,17 @@ Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
 ![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
 
 Library to be used in `build.rs` files in order to build the build info defined in `re_build_info` by setting environment variables.
+
+Some information in `re_build_info` can be provided through env vars:
+
+- `GIT_HASH` (the full sha, like `e264b9decab9257ae79100a006bb69c0d289e20c`)
+- `GIT_BRANCH` (the `symbolic-ref --short`, like `asdf/my-branch`)
+- `DATETIME` (ISO8601, like `2025-12-10T15:49:52.089915278Z`)
+
+If these are required but not provided, they will be gathered by:
+
+- `GIT_HASH`: running `git rev-parse HEAD`
+- `GIT_BRANCH`: running `git symbolic-ref --short HEAD`
+- `DATETIME` retrieving system time during the build
+
+If you'd like to avoid these for whatever reason, then set them externally.

--- a/crates/build/re_build_tools/src/lib.rs
+++ b/crates/build/re_build_tools/src/lib.rs
@@ -149,7 +149,13 @@ pub fn export_build_info_vars_for_crate(crate_name: &str) {
         Environment::UsedAsDependency | Environment::CondaBuild => false,
     };
 
-    if export_datetime {
+    if export_datetime && is_tracked_env_var_set("DATETIME") {
+        // set externally:
+        set_env(
+            "RE_BUILD_DATETIME",
+            &std::env::var("DATETIME").unwrap_or_default(),
+        );
+    } else if export_datetime {
         set_env("RE_BUILD_DATETIME", &date_time());
 
         // The only way to make sure the build datetime is up-to-date is to run
@@ -160,7 +166,18 @@ pub fn export_build_info_vars_for_crate(crate_name: &str) {
         set_env("RE_BUILD_DATETIME", "");
     }
 
-    if export_git_info {
+    if export_git_info && is_tracked_env_var_set("GIT_HASH") && is_tracked_env_var_set("GIT_BRANCH")
+    {
+        // set externally:
+        set_env(
+            "RE_BUILD_GIT_HASH",
+            &std::env::var("GIT_HASH").unwrap_or_default(),
+        );
+        set_env(
+            "RE_BUILD_GIT_BRANCH",
+            &std::env::var("GIT_BRANCH").unwrap_or_default(),
+        );
+    } else if export_git_info {
         set_env(
             "RE_BUILD_GIT_HASH",
             &git::git_commit_hash().unwrap_or_default(),


### PR DESCRIPTION
Previously:
```
export CI=1
export IS_IN_RERUN_WORKSPACE=1

cargo build  # runs `git` commands
```

We need to be able to specify some of the build env vars externally. This is now possible:

```
export CI=1
export IS_IN_RERUN_WORKSPACE=1
export GIT_HASH=$(git rev-parse HEAD)
export GIT_BRANCH=$(git symbolic-ref --short HEAD)
export DATETIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")

cargo build  # does NOT run `git` commands
```