### PR TITLE
Fix false errors when first logging temporal and then static transforms

### DIFF
--- a/crates/store/re_tf/src/transform_resolution_cache.rs
+++ b/crates/store/re_tf/src/transform_resolution_cache.rs
@@ -1117,7 +1117,7 @@ impl TransformResolutionCache {
                 #[cfg_attr(not(debug_assertions), expect(clippy::for_kv_map))]
                 for (_timeline, per_timeline) in &mut self.per_timeline {
                     // Don't call `get_or_create_tree_transforms_temporal` here since we may not yet know a temporal entity that this is associated with.
-                    // Also, this may be the first time we associate with a static entity instead.
+                    // Also, this may be the first time we associate with a static entity instead which `get_or_create_tree_transforms_static` takes care of.
                     let transforms = per_timeline.get_or_create_tree_transforms_static(
                         entity_path,
                         frame,
@@ -1162,7 +1162,7 @@ impl TransformResolutionCache {
                 #[cfg_attr(not(debug_assertions), expect(clippy::for_kv_map))]
                 for (_timeline, per_timeline) in &mut self.per_timeline {
                     // Don't call `get_or_create_tree_transforms_temporal` here since we may not yet know a temporal entity that this is associated with.
-                    // Also, this may be the first time we associate with a static entity instead.
+                    // Also, this may be the first time we associate with a static entity instead which `get_or_create_tree_transforms_static` takes care of.
                     let transforms = per_timeline.get_or_create_tree_transforms_static(
                         entity_path,
                         frame,


### PR DESCRIPTION
* Fixes RR-3140

We didn't correctly associate transforms with static entities in some cases