### PR TITLE
Reduce trace level of poll_next

### DIFF
--- a/crates/store/re_datafusion/src/dataframe_query_provider.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_provider.rs
@@ -132,7 +132,7 @@ impl Stream for DataframeSegmentStream {
 
         #[cfg(not(target_arch = "wasm32"))]
         let _trace_guard = attach_trace_context(&this.trace_headers);
-        let _span = tracing::info_span!("poll_next").entered();
+        let _span = tracing::debug_span!("poll_next").entered();
 
         // If we have any errors on the worker thread, we want to ensure we pass them up
         // through the stream.


### PR DESCRIPTION
Reduces tracing of `DataframeSegmentStream::poll_next` from `info` to `debug` as it clogs up the trace log to a point where Grafana truncates the log.
