### PR TITLE
Fix load_urdf.rrd

### DIFF
--- a/tests/assets/rrd/snippets/howto/load_urdf.rrd
+++ b/tests/assets/rrd/snippets/howto/load_urdf.rrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e90d614ffe7520f832525e242d82c11a2b8909ec2132f4ec72dda5df9fb10a6
-size 5297199
+oid sha256:d5b906bc0b59158078a712a856a2aef740e516a4c61304c6f51d09552c8f360c
+size 63773


### PR DESCRIPTION
...I accidentally used an rrd of the  `animated_urdf` example 🤦🏻‍♂️

Passes now:
```
> /Users/michael/code/rerun/.pixi/envs/py/bin/python docs/snippets/all/howto/load_urdf.py
----------------------------------------------------------
Active languages: ['rust', 'cpp', 'py']
Comparing 1 examples…

Comparing 'howto/load_urdf'…
> rerun rrd compare --unordered --ignore-chunks-without-components tests/assets/rrd/snippets/howto/load_urdf.rrd docs/snippets/all/howto/load_urdf_python.rrd
Skipping cpp completely
> rerun rrd compare --unordered --ignore-chunks-without-components docs/snippets/all/howto/load_urdf_python.rrd docs/snippets/all/howto/load_urdf_python.rrd
All tests passed!
```