### PR TITLE
Skip empty component lists

### DIFF
--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -563,12 +563,11 @@ fn source_component_ui(
                 egui::ComboBox::new("source_component_combo_box", "")
                     .selected_text(current)
                     .show_ui(ui, |ui| {
-                        for source_option in [""].into_iter().chain(all_source_options.into_iter())
-                        {
-                            if ui.button(source_option).clicked() {
+                        for option in [""].into_iter().chain(all_source_options.into_iter()) {
+                            if ui.button(option).clicked() {
                                 changed_component_mappings.push(
                                     re_viewer_context::VisualizerComponentMapping {
-                                        source: source_option.into(),
+                                        source: option.into(),
                                         target: component_descr.component,
                                     },
                                 );


### PR DESCRIPTION
Doesn't show the component selector if there are no compatible fields on the entity.