### PR TITLE
Turn off incremental Rust compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,12 @@ codegen = "run --package re_types_builder --"
 # Temporary solution while we wait for our own xtasks!
 run-wasm = "run --release --package run_wasm --"
 
+
+[build]
+# Incremental compilation blows up the size of the target folder, and is also buggy.
+incremental = false
+
+
 [env]
 # Some of our build.rs files only run if this is set,
 # so that we don't run them on cargo publish or on users machines.
@@ -19,8 +25,6 @@ IS_IN_RERUN_WORKSPACE = "yes"
 # https://pyo3.rs/main/building-and-distribution.html#configuring-the-python-version
 PYO3_PYTHON = "python"
 
-# Incremental compilation blows up the size of the target folder, and is also buggy.
-CARGO_INCREMENTAL = "0"
 
 # TODO(rust-lang/stacker#127): Work around until wasm build on mac is resolved
 [target.osx-arm64.activation.env]


### PR DESCRIPTION
Incremental compilation blows up the size of the target folder,
but it is also buggy, causing spurious "link failures" that requires a complete clean of the `target` folder.

Note that the incremental part is for each individual crate. Even with `CARGO_INCREMENTAL` we only recompile the crates that we need to recompile (but we will recompile them in their entirety).

https://doc.rust-lang.org/cargo/reference/profiles.html#incremental