### PR TITLE
Fix deprecated decorator ordering

### DIFF
--- a/rerun_py/rerun_sdk/rerun/event.py
+++ b/rerun_py/rerun_sdk/rerun/event.py
@@ -18,8 +18,8 @@ class ViewerEventBase:
     recording_id: str
     segment_id: str | None
 
-    @deprecated("Use `segment_id` instead.")
     @property
+    @deprecated("Use `segment_id` instead.")
     def partition_id(self) -> str | None:
         return self.segment_id
 


### PR DESCRIPTION
### What

Puts the `@deprecated` decorator on the function instead of the `@property` decorator.
This will fix the CI failing to build/test examples

