### PR TITLE
Use `u64` for memory limits etc

### DIFF
--- a/crates/store/re_grpc_server/src/lib.rs
+++ b/crates/store/re_grpc_server/src/lib.rs
@@ -772,7 +772,7 @@ impl EventLoop {
             return;
         };
 
-        self.messages.gc(max_bytes as _);
+        self.messages.gc(max_bytes);
     }
 }
 

--- a/crates/utils/re_memory/src/memory_limit.rs
+++ b/crates/utils/re_memory/src/memory_limit.rs
@@ -14,7 +14,7 @@ pub struct MemoryLimit {
     /// This is primarily compared to what is reported by [`crate::AccountingAllocator`] ('counted').
     /// We limit based on this instead of `resident` (RSS) because `counted` is what we have immediate
     /// control over, while RSS depends on what our allocator (MiMalloc) decides to do.
-    pub max_bytes: Option<i64>,
+    pub max_bytes: Option<u64>,
 }
 
 impl MemoryLimit {
@@ -61,7 +61,7 @@ impl MemoryLimit {
         } else {
             re_format::parse_bytes(limit)
                 .map(|max_bytes| Self {
-                    max_bytes: Some(max_bytes),
+                    max_bytes: Some(max_bytes.max(0) as _),
                 })
                 .ok_or_else(|| format!("expected e.g. '16GB', got {limit:?}"))
         }

--- a/crates/utils/re_memory/src/memory_use.rs
+++ b/crates/utils/re_memory/src/memory_use.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::cast_possible_wrap)] // u64 -> i64
-
 /// How much RAM is the application using?
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct MemoryUse {
@@ -9,7 +7,7 @@ pub struct MemoryUse {
     /// Working Set on Windows.
     ///
     /// `None` if unknown.
-    pub resident: Option<i64>,
+    pub resident: Option<u64>,
 
     /// Bytes used by the application according to our own memory allocator's accounting.
     ///
@@ -17,7 +15,7 @@ pub struct MemoryUse {
     /// return all the memory we free to the OS.
     ///
     /// `None` if [`crate::AccountingAllocator`] is not used.
-    pub counted: Option<i64>,
+    pub counted: Option<u64>,
 }
 
 impl MemoryUse {
@@ -35,7 +33,7 @@ impl MemoryUse {
     /// This is either [`Self::counted`] if it's available, otherwise fallbacks to
     /// [`Self::resident`] if that's available, otherwise `None`.
     #[inline]
-    pub fn used(&self) -> Option<i64> {
+    pub fn used(&self) -> Option<u64> {
         self.counted.or(self.resident)
     }
 }
@@ -45,8 +43,8 @@ impl std::ops::Mul<f32> for MemoryUse {
 
     fn mul(self, factor: f32) -> Self::Output {
         Self {
-            resident: self.resident.map(|v| (v as f32 * factor) as i64),
-            counted: self.counted.map(|v| (v as f32 * factor) as i64),
+            resident: self.resident.map(|v| (v as f32 * factor) as u64),
+            counted: self.counted.map(|v| (v as f32 * factor) as u64),
         }
     }
 }
@@ -56,7 +54,7 @@ impl std::ops::Sub for MemoryUse {
 
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
-        fn sub(a: Option<i64>, b: Option<i64>) -> Option<i64> {
+        fn sub(a: Option<u64>, b: Option<u64>) -> Option<u64> {
             Some(a? - b?)
         }
 
@@ -74,12 +72,12 @@ impl std::ops::Sub for MemoryUse {
 /// Resident Set Size (RSS) on Linux, Android, Mac, iOS.
 /// Working Set on Windows.
 #[cfg(not(target_arch = "wasm32"))]
-fn bytes_resident() -> Option<i64> {
-    memory_stats::memory_stats().map(|usage| usage.physical_mem as i64)
+fn bytes_resident() -> Option<u64> {
+    memory_stats::memory_stats().map(|usage| usage.physical_mem as u64)
 }
 
 #[cfg(target_arch = "wasm32")]
-fn bytes_resident() -> Option<i64> {
+fn bytes_resident() -> Option<u64> {
     // blocked on https://github.com/Arc-blroth/memory-stats/issues/1
     None
 }

--- a/crates/utils/re_memory/src/ram_warner.rs
+++ b/crates/utils/re_memory/src/ram_warner.rs
@@ -59,8 +59,7 @@ impl RamLimitWarner {
             let used = crate::MemoryUse::capture();
             let used = used.counted.or(used.resident);
             if let Some(used) = used
-                && 0 <= used
-                && self.warn_limit <= used as u64
+                && self.warn_limit <= used
             {
                 self.has_warned = true;
                 re_log::warn!(

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -2703,7 +2703,7 @@ impl App {
     fn purge_memory_if_needed(&mut self, store_hub: &mut StoreHub) {
         re_tracing::profile_function!();
 
-        fn format_limit(limit: Option<i64>) -> String {
+        fn format_limit(limit: Option<u64>) -> String {
             if let Some(bytes) = limit {
                 format_bytes(bytes as _)
             } else {

--- a/crates/viewer/re_viewer/src/ui/memory_history.rs
+++ b/crates/viewer/re_viewer/src/ui/memory_history.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::cast_possible_wrap)] // u64 -> i64 is fine
-
 use emath::History;
 use re_renderer::WgpuResourcePoolStatistics;
 use re_viewer_context::store_hub::{StoreHubStats, StoreStats};
@@ -12,34 +10,34 @@ pub struct MemoryHistory {
     ///
     /// Resident Set Size (RSS) on Linux, Android, Mac, iOS.
     /// Working Set on Windows.
-    pub resident: History<i64>,
+    pub resident: History<u64>,
 
     /// Bytes used by the application according to our own memory allocator's accounting.
     ///
     /// This can be smaller than [`Self::resident`] because our memory allocator may not
     /// return all the memory we free to the OS.
-    pub counted_allocator: History<i64>,
+    pub counted_allocator: History<u64>,
 
     /// VRAM bytes used by the application according to its own accounting if a tracker was installed.
     ///
     /// Values are usually a rough estimate as the actual amount of VRAM used depends a lot
     /// on the specific GPU and driver. Accounted typically only raw buffer & texture sizes.
-    pub counted_vram: History<i64>,
+    pub counted_vram: History<u64>,
 
     /// Bytes used by all blueprints, (according to its own accounting).
-    pub counted_blueprints: History<i64>,
+    pub counted_blueprints: History<u64>,
 
     /// Bytes used by all recordings, (according to its own accounting).
-    pub counted_recordings: History<i64>,
+    pub counted_recordings: History<u64>,
 
     /// Bytes used by the primary caches (according to their own accounting).
-    pub counted_query_caches: History<i64>,
+    pub counted_query_caches: History<u64>,
 
     /// Bytes used by the viewer caches (according to their own accounting).
-    pub counted_viewer_caches: History<i64>,
+    pub counted_viewer_caches: History<u64>,
 
     /// Bytes used by table stores (according to their own accounting).
-    pub counted_table_stores: History<i64>,
+    pub counted_table_stores: History<u64>,
 }
 
 impl Default for MemoryHistory {
@@ -87,7 +85,7 @@ impl MemoryHistory {
             counted_allocator.add(now, updated_counted);
         }
         if let Some(gpu_resource_stats) = gpu_resource_stats {
-            counted_vram.add(now, gpu_resource_stats.total_bytes() as _);
+            counted_vram.add(now, gpu_resource_stats.total_bytes());
         }
 
         if let Some(store_stats) = store_stats {
@@ -124,11 +122,11 @@ impl MemoryHistory {
                 sum_viewer_caches += viewer_cache_size;
             }
 
-            counted_blueprints.add(now, sum_blueprints as _);
-            counted_recordings.add(now, sum_recordings as _);
-            counted_query_caches.add(now, sum_query_caches as _);
-            counted_viewer_caches.add(now, sum_viewer_caches as _);
-            counted_table_stores.add(now, sum_table_stores as _);
+            counted_blueprints.add(now, sum_blueprints);
+            counted_recordings.add(now, sum_recordings);
+            counted_query_caches.add(now, sum_query_caches);
+            counted_viewer_caches.add(now, sum_viewer_caches);
+            counted_table_stores.add(now, sum_table_stores);
         }
     }
 }

--- a/crates/viewer/re_viewer/src/ui/memory_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/memory_panel.rs
@@ -475,7 +475,7 @@ impl MemoryPanel {
 
         use itertools::Itertools as _;
 
-        fn to_line<'a>(name: &str, history: &egui::util::History<i64>) -> egui_plot::Line<'a> {
+        fn to_line<'a>(name: &str, history: &egui::util::History<u64>) -> egui_plot::Line<'a> {
             egui_plot::Line::new(
                 name,
                 history

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -120,10 +120,10 @@ fn settings_screen_ui_impl(
 }
 
 fn memory_budget_section_ui(ui: &mut Ui, startup_options: &mut StartupOptions) {
-    const BYTES_PER_GIB: i64 = 1024 * 1024 * 1024;
-    const UPPER_LIMIT_BYTES: i64 = 1_000 * BYTES_PER_GIB;
+    const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
+    const UPPER_LIMIT_BYTES: u64 = 1_000 * BYTES_PER_GIB;
 
-    let mut bytes = startup_options.memory_limit.max_bytes.unwrap_or(i64::MAX);
+    let mut bytes = startup_options.memory_limit.max_bytes.unwrap_or(u64::MAX);
 
     let speed = (0.02 * bytes as f32).clamp(0.01 * BYTES_PER_GIB as f32, BYTES_PER_GIB as f32);
 


### PR DESCRIPTION
We never have a negative amount of bytes allocated.