### PR TITLE
Avoid potential underflow during GC

### DIFF
--- a/crates/utils/re_memory/src/memory_use.rs
+++ b/crates/utils/re_memory/src/memory_use.rs
@@ -55,7 +55,7 @@ impl std::ops::Sub for MemoryUse {
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
         fn sub(a: Option<u64>, b: Option<u64>) -> Option<u64> {
-            Some(a? - b?)
+            Some(a?.saturating_sub(b?))
         }
 
         Self {


### PR DESCRIPTION
New error because of https://github.com/rerun-io/rerun/pull/12230

Only an error in debug builds. Function was only used for logging amount freed.