### PR TITLE
Fix standalone build of `re_auth`

### DIFF
--- a/crates/utils/re_auth/Cargo.toml
+++ b/crates/utils/re_auth/Cargo.toml
@@ -48,7 +48,7 @@ jsonwebtoken.workspace = true
 parking_lot.workspace = true
 saturating_cast.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["time"] }
 tonic.workspace = true
 tower.workspace = true
 


### PR DESCRIPTION
Tested
* `cargo clippy -p re_auth`
* `cargo clippy -p re_auth --all-features`
* `cargo clippy -p re_auth --target wasm32-unknown-unknown`