### PR TITLE
Make empty prefix error handling consistent with dpf

### DIFF
--- a/crates/store/re_server/src/rerun_cloud.rs
+++ b/crates/store/re_server/src/rerun_cloud.rs
@@ -212,6 +212,13 @@ impl RerunCloudHandler {
                     }
                 }
 
+                if files.is_empty() {
+                    return Err(tonic::Status::invalid_argument(format!(
+                        "no rrd files found in {:?}",
+                        source.storage_url
+                    )));
+                }
+
                 for file_path in files {
                     let mut file_url = source.storage_url.clone();
                     file_url.set_path(&file_path.to_string_lossy());

--- a/rerun_py/tests/e2e_redap_tests/test_registration.py
+++ b/rerun_py/tests/e2e_redap_tests/test_registration.py
@@ -67,7 +67,7 @@ def test_registration_invalidargs(
     try:
         with pytest.raises(ValueError, match="no data sources to register"):
             ds.register([])
-        with pytest.raises(ValueError, match="no data sources to register"):
+        with pytest.raises(ValueError, match="no rrd files found in"):
             ds.register_prefix(temp_empty_directory)
         with pytest.raises(ValueError, match="expected prefix / directory but got an object"):
             ds.register_prefix(temp_empty_file)


### PR DESCRIPTION
This fixes the e2e test for the empty prefix directory error and the related OSS server implementation such that it is consistent with dpf. This should fix the test failure on dpf side.