### PR TITLE
Try making `compare_snippet_output.py` faster

### DIFF
--- a/scripts/roundtrip_utils.py
+++ b/scripts/roundtrip_utils.py
@@ -17,7 +17,10 @@ def get_repo_root() -> str:
     else:
         get_rev_parse = subprocess.run(["git", "rev-parse", "--show-toplevel"], check=False, capture_output=True)
         assert get_rev_parse.returncode == 0
-        return get_rev_parse.stdout.decode("utf-8").strip()
+        repo_root = get_rev_parse.stdout.decode(
+            "utf-8"
+        ).strip()  # Cache the output of repo root, so we don't have to parse the git rev every time.
+        return repo_root
 
 
 def run(


### PR DESCRIPTION
On windows we observed strange gaps in the execution of compare_snippet_output. See https://productionresultssa13.blob.core.windows.net/actions-results/0f1b8f01-78e1-45b0-ac46-fb783fcf7741/workflow-job-run-5e711dc9-47b3-5eca-bbae-50ef27ac9c34/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-12-17T14%3A58%3A15Z&sig=RFd5GeDG7XQzbZRzpxv91wBt8aCFp%2BnsBjw4BLERn%2B0%3D&ske=2025-12-18T02%3A32%3A32Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-12-17T14%3A32%3A32Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2025-12-17T14%3A48%3A10Z&sv=2025-11-05

The only thing running between those gaps seems to be `git rev-parse`. Since it's trivial to cache the result here, we do that here now. Maybe it helps!