### PR TITLE
Fix race condition in urdf snippet rrd comparison

### DIFF
--- a/docs/snippets/all/howto/load_urdf.py
+++ b/docs/snippets/all/howto/load_urdf.py
@@ -2,10 +2,9 @@ from pathlib import Path
 
 import rerun as rr
 from rerun import RecordingStream
-import time
 
-with RecordingStream("rerun_example_load_urdf", spawn=True) as rec:
-    rr.init("rerun_example_load_urdf", spawn=True)
+with RecordingStream("rerun_example_load_urdf") as rec:
+    rec.spawn()
 
     # `log_file_from_path` automatically uses the built-in URDF data-loader.
     urdf_path = Path(__file__).parent / "minimal.urdf"


### PR DESCRIPTION
I thought `rerun rrd compare --unordered` handled chunks out of order but apparently not in this case. Since logging is async we can get a race where sometimes the urdf logs before/after the transform. Functionally this shouldn't be an issue but our rrd comparison test appears to be brittle.

Force a flush so the ordering is always fixed.

* [x] full check green
