### PR TITLE
Improve `VisualizerOverrides` ergonomics in Rust

### DIFF
--- a/crates/store/re_sdk_types/definitions/rerun/archetypes/transform_axes3d.fbs
+++ b/crates/store/re_sdk_types/definitions/rerun/archetypes/transform_axes3d.fbs
@@ -8,7 +8,7 @@ table TransformAxes3D (
   "attr.docs.view_types": "Spatial3DView",
   "attr.docs.unreleased",
   "attr.rerun.state": "stable",
-  "attr.rerun.visualizer": "Transform3DArrows",
+  "attr.rerun.visualizer": "TransformAxes3D",
   "attr.rust.derive": "PartialEq"
 ) {
   /// Visual length of the 3 axes.

--- a/crates/store/re_sdk_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/arrows2d.rs
@@ -189,6 +189,12 @@ impl Arrows2D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Arrows2D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/arrows3d.rs
@@ -185,6 +185,12 @@ impl Arrows3D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Arrows3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/asset3d.rs
@@ -117,6 +117,12 @@ impl Asset3D {
             component_type: Some("rerun.components.AlbedoFactor".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Asset3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_sdk_types/src/archetypes/bar_chart.rs
@@ -123,6 +123,12 @@ impl BarChart {
             component_type: Some("rerun.components.Length".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("BarChart".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/boxes2d.rs
@@ -181,6 +181,12 @@ impl Boxes2D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Boxes2D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/boxes3d.rs
@@ -234,6 +234,12 @@ impl Boxes3D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Boxes3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/capsules3d.rs
@@ -261,6 +261,12 @@ impl Capsules3D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Capsules3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 2usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/cylinders3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/cylinders3d.rs
@@ -258,6 +258,12 @@ impl Cylinders3D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Cylinders3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 2usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_sdk_types/src/archetypes/depth_image.rs
@@ -204,6 +204,12 @@ impl DepthImage {
             component_type: Some("rerun.components.DrawOrder".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("DepthImage".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 2usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/ellipsoids3d.rs
@@ -249,6 +249,12 @@ impl Ellipsoids3D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Ellipsoids3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/encoded_depth_image.rs
+++ b/crates/store/re_sdk_types/src/archetypes/encoded_depth_image.rs
@@ -181,6 +181,12 @@ impl EncodedDepthImage {
             component_type: Some("rerun.components.DrawOrder".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("EncodedDepthImage".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_sdk_types/src/archetypes/encoded_image.rs
@@ -126,6 +126,12 @@ impl EncodedImage {
             component_type: Some("rerun.components.DrawOrder".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("EncodedImage".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_sdk_types/src/archetypes/geo_line_strings.rs
@@ -108,6 +108,12 @@ impl GeoLineStrings {
             component_type: Some("rerun.components.Color".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("GeoLineStrings".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_sdk_types/src/archetypes/geo_points.rs
@@ -116,6 +116,12 @@ impl GeoPoints {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("GeoPoints".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_sdk_types/src/archetypes/graph_edges.rs
@@ -89,6 +89,12 @@ impl GraphEdges {
             component_type: Some("rerun.components.GraphType".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("GraphEdges".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_sdk_types/src/archetypes/graph_nodes.rs
@@ -148,6 +148,12 @@ impl GraphNodes {
             component_type: Some("rerun.components.Radius".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("GraphNodes".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/image.rs
+++ b/crates/store/re_sdk_types/src/archetypes/image.rs
@@ -201,6 +201,12 @@ impl Image {
             component_type: Some("rerun.components.DrawOrder".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Image".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 2usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/line_strips2d.rs
@@ -207,6 +207,12 @@ impl LineStrips2D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Lines2D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/line_strips3d.rs
@@ -202,6 +202,12 @@ impl LineStrips3D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Lines3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/mesh3d.rs
@@ -265,6 +265,12 @@ impl Mesh3D {
             component_type: Some("rerun.components.ClassId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Mesh3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_sdk_types/src/archetypes/pinhole.rs
@@ -279,6 +279,12 @@ impl Pinhole {
             component_type: Some("rerun.components.Radius".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Cameras".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/points2d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/points2d.rs
@@ -242,6 +242,12 @@ impl Points2D {
             component_type: Some("rerun.components.KeypointId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Points2D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/points3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/points3d.rs
@@ -313,6 +313,12 @@ impl Points3D {
             component_type: Some("rerun.components.KeypointId".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Points3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_sdk_types/src/archetypes/segmentation_image.rs
@@ -135,6 +135,12 @@ impl SegmentationImage {
             component_type: Some("rerun.components.DrawOrder".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("SegmentationImage".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 2usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/series_lines.rs
+++ b/crates/store/re_sdk_types/src/archetypes/series_lines.rs
@@ -177,6 +177,12 @@ impl SeriesLines {
             component_type: Some("rerun.components.AggregationPolicy".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("SeriesLines".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 0usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/series_points.rs
+++ b/crates/store/re_sdk_types/src/archetypes/series_points.rs
@@ -169,6 +169,12 @@ impl SeriesPoints {
             component_type: Some("rerun.components.MarkerSize".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("SeriesPoints".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/tensor.rs
+++ b/crates/store/re_sdk_types/src/archetypes/tensor.rs
@@ -96,6 +96,12 @@ impl Tensor {
             component_type: Some("rerun.components.ValueRange".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("Tensor".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/text_document.rs
+++ b/crates/store/re_sdk_types/src/archetypes/text_document.rs
@@ -129,6 +129,12 @@ impl TextDocument {
             component_type: Some("rerun.components.MediaType".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("TextDocument".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/text_log.rs
+++ b/crates/store/re_sdk_types/src/archetypes/text_log.rs
@@ -111,6 +111,12 @@ impl TextLog {
             component_type: Some("rerun.components.Color".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("TextLog".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/transform_axes3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/transform_axes3d.rs
@@ -111,6 +111,12 @@ impl TransformAxes3D {
             component_type: Some("rerun.components.ShowLabels".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("TransformAxes3D".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_sdk_types/src/archetypes/video_frame_reference.rs
@@ -209,6 +209,12 @@ impl VideoFrameReference {
             component_type: Some("rerun.components.DrawOrder".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("VideoFrameReference".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/store/re_sdk_types/src/archetypes/video_stream.rs
+++ b/crates/store/re_sdk_types/src/archetypes/video_stream.rs
@@ -124,6 +124,12 @@ impl VideoStream {
             component_type: Some("rerun.components.DrawOrder".into()),
         }
     }
+
+    /// Returns the visualizer type name that corresponds to this archetype.
+    #[inline]
+    pub fn visualizer() -> crate::blueprint::components::VisualizerType {
+        crate::blueprint::components::VisualizerType("VideoStream".into())
+    }
 }
 
 static REQUIRED_COMPONENTS: std::sync::LazyLock<[ComponentDescriptor; 1usize]> =

--- a/crates/viewer/re_view_spatial/tests/transform_child_parent_single_time.rs
+++ b/crates/viewer/re_view_spatial/tests/transform_child_parent_single_time.rs
@@ -234,7 +234,10 @@ fn test_transform_axes_for_explicit_transforms() {
         );
         ctx.save_blueprint_archetype(
             transforms_override_path.clone(),
-            &blueprint::archetypes::VisualizerOverrides::new(["TransformAxes3D"]),
+            &blueprint::archetypes::VisualizerOverrides::new([
+                // TODO(RR-3153): remove the `as_str()`.
+                archetypes::TransformAxes3D::visualizer().as_str(),
+            ]),
         );
         ctx.save_blueprint_archetype(
             transforms_override_path,

--- a/crates/viewer/re_view_time_series/tests/blueprint.rs
+++ b/crates/viewer/re_view_time_series/tests/blueprint.rs
@@ -182,7 +182,10 @@ fn setup_blueprint(
         ctx.save_blueprint_archetype(
             cos_override_path.clone(),
             // Override which visualizer to use for the `cos` plot.
-            &blueprint::archetypes::VisualizerOverrides::new(["SeriesPoints"]),
+            &blueprint::archetypes::VisualizerOverrides::new([
+                // TODO(RR-3153): remove the `as_str()`.
+                archetypes::SeriesPoints::visualizer().as_str(),
+            ]),
         );
         ctx.save_blueprint_archetype(
             cos_override_path,

--- a/rerun_py/rerun_sdk/rerun/blueprint/visualizers/mapping.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/visualizers/mapping.py
@@ -38,7 +38,7 @@ SeriesPoints = "SeriesPoints"
 Tensor = "Tensor"
 TextDocument = "TextDocument"
 TextLog = "TextLog"
-TransformAxes3D = "Transform3DArrows"
+TransformAxes3D = "TransformAxes3D"
 VideoFrameReference = "VideoFrameReference"
 VideoStream = "VideoStream"
 
@@ -162,7 +162,7 @@ class _GeneratedVisualizerClasses:
 
     class TransformAxes3D(Visualizer):
         def __init__(self, *, overrides: Any = None, mappings: Any = None) -> None:
-            super().__init__("Transform3DArrows", overrides=overrides, mappings=mappings)
+            super().__init__("TransformAxes3D", overrides=overrides, mappings=mappings)
 
     class VideoFrameReference(Visualizer):
         def __init__(self, *, overrides: Any = None, mappings: Any = None) -> None:


### PR DESCRIPTION
### Related

* Part of RR-3153
* Follow up of #12182.
* [x] Requires #12262.

### What

This adds a `fn visualizer()` method to applicable archetypes to prevent hardcoding their identifiers. We don't have a Rust blueprint API yet, but this is still a nice contract to uphold.
