### PR TITLE
fix datafusion import

### DIFF
--- a/rerun_py/rerun_sdk/rerun/catalog/_entry.py
+++ b/rerun_py/rerun_sdk/rerun/catalog/_entry.py
@@ -4,7 +4,6 @@ from abc import ABC
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar
 
-import datafusion
 import pyarrow as pa
 from pyarrow import RecordBatchReader
 from typing_extensions import deprecated
@@ -25,6 +24,8 @@ _BatchesType: TypeAlias = (
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    import datafusion
 
     from rerun.recording import Recording
 
@@ -448,6 +449,8 @@ class DatasetEntry(Entry[DatasetEntryInternal]):
         ```
 
         """
+
+        import datafusion
 
         if isinstance(segment_ids, str):
             segment_ids = [segment_ids]
@@ -937,6 +940,8 @@ class DatasetView:
             A new view filtered to the given segments.
 
         """
+        import datafusion
+
         if isinstance(segment_ids, str):
             segment_ids = [segment_ids]
         elif isinstance(segment_ids, datafusion.DataFrame):


### PR DESCRIPTION
Remove global import of `datafusion`. This is obviously a short-term fix that remains extremely fragile. Ideally, we should test that we can `import rerun` in an environment without datafusion. Or better yet, split the catalog API from the rest of the SDK, so we can properly depend on datafusion.

I tested this by uninstalling datafusion from my environment, and:

```sh
❯ python -c "from rerun import catalog"
# no error

❯ python -c "from rerun import catalog; catalog.CatalogClient('localhost')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/hhip/src/rerun/rerun_py/rerun_sdk/rerun/catalog/_catalog_client.py", line 72, in __init__
    raise RerunMissingDependencyError("datafusion", "datafusion")
rerun.error_utils.RerunMissingDependencyError: 'datafusion' could not be imported. Please install it, or install rerun as rerun-sdk[datafusion]/rerun-sdk[all] to use this functionality.
```