### PR TITLE
remove re_perf_telemetry's log line when it's disabled

### DIFF
--- a/crates/utils/re_perf_telemetry/src/telemetry.rs
+++ b/crates/utils/re_perf_telemetry/src/telemetry.rs
@@ -164,8 +164,6 @@ impl Telemetry {
                 }
             }
 
-            eprintln!("Telemetry disabled. All logging will be ignored.");
-
             return Ok(Self {
                 logs: None,
                 metrics: None,


### PR DESCRIPTION
This is bit confusing to see in the notebook or in viewer side logs, hence disabling. We'll figure out how to make debugging easier if you disable this and really appreciate this line on the redap side.