### PR TITLE
Do not ever link with tracy by default

### DIFF
--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -199,7 +199,7 @@ rayon.workspace = true
 # Native, optional:
 clap = { workspace = true, optional = true, features = ["derive"] }
 jiff = { workspace = true, optional = true }
-re_perf_telemetry = { workspace = true, features = ["tracy"], optional = true }
+re_perf_telemetry = { workspace = true, optional = true }
 unindent = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 


### PR DESCRIPTION
Title.

* Fixes https://github.com/conda-forge/rerun-sdk-feedstock/pull/92#issuecomment-3674204272 (or so I hope)