### PR TITLE
Improved error message when `rrd compare --unordered` fails

### DIFF
--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -78,23 +78,6 @@ impl CompareCommand {
             re_format::format_uint(chunks2.len()),
         );
 
-        let mut unordered_failed = false;
-        if *unordered {
-            let mut chunks2_opt: Vec<Option<Arc<Chunk>>> =
-                chunks2.clone().into_iter().map(Some).collect_vec();
-            'outer: for chunk1 in &chunks1 {
-                for chunk2 in chunks2_opt.iter_mut().filter(|c| c.is_some()) {
-                    #[expect(clippy::unwrap_used)]
-                    if re_chunk::Chunk::ensure_similar(chunk1, chunk2.as_ref().unwrap()).is_ok() {
-                        *chunk2 = None;
-                        continue 'outer;
-                    }
-                }
-                unordered_failed = true;
-                break;
-            }
-        }
-
         fn format_chunk(chunk: &Chunk) -> String {
             re_arrow_util::format_record_batch_opts(
                 &chunk.to_record_batch().expect("Cannot fail in practice"),
@@ -110,7 +93,47 @@ impl CompareCommand {
             .to_string()
         }
 
-        if !*unordered || unordered_failed {
+        if *unordered {
+            let mut chunks2_remaining = chunks2;
+            let mut unmatched_chunks1 = Vec::new();
+
+            for chunk1 in &chunks1 {
+                if let Some(pos) = chunks2_remaining
+                    .iter()
+                    .position(|chunk2| re_chunk::Chunk::ensure_similar(chunk1, chunk2).is_ok())
+                {
+                    chunks2_remaining.swap_remove(pos);
+                } else {
+                    unmatched_chunks1.push(chunk1.clone());
+                }
+            }
+
+            if !unmatched_chunks1.is_empty() || !chunks2_remaining.is_empty() {
+                let mut error_msg = String::from("Unordered comparison failed:\n");
+
+                if !unmatched_chunks1.is_empty() {
+                    error_msg.push_str(&format!(
+                        "\n{} chunk(s) from {path_to_rrd1:?} could not be matched:\n",
+                        unmatched_chunks1.len()
+                    ));
+                    for chunk in &unmatched_chunks1 {
+                        error_msg.push_str(&format!("{}\n", format_chunk(chunk)));
+                    }
+                }
+
+                if !chunks2_remaining.is_empty() {
+                    error_msg.push_str(&format!(
+                        "\n{} chunk(s) from {path_to_rrd2:?} could not be matched:\n",
+                        chunks2_remaining.len()
+                    ));
+                    for chunk in &chunks2_remaining {
+                        error_msg.push_str(&format!("{}\n", format_chunk(chunk)));
+                    }
+                }
+
+                anyhow::bail!(error_msg);
+            }
+        } else {
             for (chunk1, chunk2) in izip!(chunks1, chunks2) {
                 re_chunk::Chunk::ensure_similar(&chunk1, &chunk2).with_context(|| {
                     format!(


### PR DESCRIPTION
### Related

* Closes RR-3214.
* Helped to debug #12281.

### What

The previous error reporting for `unordered` was entirely broken and showed wrong comparisons have chunks did not match. This provides a much more descriptive error message when the `--unordered` comparison fails. This hopefully will make it much quicker to debug future snippet problems too (looking at you nightly :trollface:).

Example (with omitted metadata):

```
1 chunk(s) from "<path>/load_urdf.rrd" could not be matched:
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ METADATA:                                                                                                                                                                                                                                                                             │
│ * entity_path: /transforms                                                                                                                                                                                                                                                            │
│ * heap_size_bytes: 1163                                                                                                                                                                                                                                                               │
│ * id: chunk_188045AD26B92A4745e230a1aa5143a9                                                                                                                                                                                                                                          │
│ * version: 0.1.2                                                                                                                                                                                                                                                                      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ ┌───────────────────────────────────────────────┬──────────────────────┬──────────────────────────────┬────────────────────────────────────┬─────────────────────────────────────┬────────────────────────────────────────────┬─────────────────────────────────────────────────────┐ │
│ │ rerun.controls.RowId                          ┆ log_tick             ┆ log_time                     ┆ Transform3D:child_frame            ┆ Transform3D:parent_frame            ┆ Transform3D:rotation_axis_angle            ┆ Transform3D:translation                             │ │
│ │ ---                                           ┆ ---                  ┆ ---                          ┆ ---                                ┆ ---                                 ┆ ---                                        ┆ ---                                                 │ │
│ │ type: FixedSizeBinary[16]                     ┆ type: nullable i64   ┆ type: nullable Timestamp(ns) ┆ type: nullable List[nullable Utf8] ┆ type: nullable List[nullable Utf8]  ┆ type: nullable List[nullable Struct[2]]    ┆ type: nullable List[nullable FixedSizeList[f32; 3]] │ │
│ │ ARROW:extension:metadata: {"namespace":"row"} ┆ index_name: log_tick ┆ index_name: log_time         ┆ archetype: Transform3D             ┆ archetype: Transform3D              ┆ archetype: Transform3D                     ┆ archetype: Transform3D                              │ │
│ │ ARROW:extension:name: TUID                    ┆ is_sorted: true      ┆ is_sorted: true              ┆ component: Transform3D:child_frame ┆ component: Transform3D:parent_frame ┆ component: Transform3D:rotation_axis_angle ┆ component: Transform3D:translation                  │ │
│ │ is_sorted: true                               ┆ kind: index          ┆ kind: index                  ┆ component_type: TransformFrameId   ┆ component_type: TransformFrameId    ┆ component_type: RotationAxisAngle          ┆ component_type: Translation3D                       │ │
│ │ kind: control                                 ┆                      ┆                              ┆ kind: data                         ┆ kind: data                          ┆ kind: data                                 ┆ kind: data                                          │ │
│ ╞═══════════════════════════════════════════════╪══════════════════════╪══════════════════════════════╪════════════════════════════════════╪═════════════════════════════════════╪════════════════════════════════════════════╪═════════════════════════════════════════════════════╡ │
│ │ row_188045AD26B47FF16034e0a1268c1371          ┆ 17                   ┆ 2025-12-11T21:14:23.910485   ┆ [child_link]                       ┆ [base_link]                         ┆ [{axis: [0.0, 0.0, 1.0], angle: 1.216}]    ┆ [[0.0, 0.0, 0.1]]                                   │ │
│ └───────────────────────────────────────────────┴──────────────────────┴──────────────────────────────┴────────────────────────────────────┴─────────────────────────────────────┴────────────────────────────────────────────┴─────────────────────────────────────────────────────┘ │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

1 chunk(s) from "<path>/load_urdf_python_shuffled.rrd" could not be matched:
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ METADATA:                                                                                                                                                                                                                                                                             │
│ * entity_path: /transforms                                                                                                                                                                                                                                                            │
│ * heap_size_bytes: 1163                                                                                                                                                                                                                                                               │
│ * id: chunk_18828F56B0DF297D12c1bfa9e12e18ac                                                                                                                                                                                                                                          │
│ * version: 0.1.2                                                                                                                                                                                                                                                                      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ ┌───────────────────────────────────────────────┬──────────────────────┬──────────────────────────────┬────────────────────────────────────┬─────────────────────────────────────┬────────────────────────────────────────────┬─────────────────────────────────────────────────────┐ │
│ │ rerun.controls.RowId                          ┆ log_tick             ┆ log_time                     ┆ Transform3D:child_frame            ┆ Transform3D:parent_frame            ┆ Transform3D:rotation_axis_angle            ┆ Transform3D:translation                             │ │
│ │ ---                                           ┆ ---                  ┆ ---                          ┆ ---                                ┆ ---                                 ┆ ---                                        ┆ ---                                                 │ │
│ │ type: FixedSizeBinary[16]                     ┆ type: nullable i64   ┆ type: nullable Timestamp(ns) ┆ type: nullable List[nullable Utf8] ┆ type: nullable List[nullable Utf8]  ┆ type: nullable List[nullable Struct[2]]    ┆ type: nullable List[nullable FixedSizeList[f32; 3]] │ │
│ │ ARROW:extension:metadata: {"namespace":"row"} ┆ index_name: log_tick ┆ index_name: log_time         ┆ archetype: Transform3D             ┆ archetype: Transform3D              ┆ archetype: Transform3D                     ┆ archetype: Transform3D                              │ │
│ │ ARROW:extension:name: TUID                    ┆ is_sorted: true      ┆ is_sorted: true              ┆ component: Transform3D:child_frame ┆ component: Transform3D:parent_frame ┆ component: Transform3D:rotation_axis_angle ┆ component: Transform3D:translation                  │ │
│ │ is_sorted: true                               ┆ kind: index          ┆ kind: index                  ┆ component_type: TransformFrameId   ┆ component_type: TransformFrameId    ┆ component_type: RotationAxisAngle          ┆ component_type: Translation3D                       │ │
│ │ kind: control                                 ┆                      ┆                              ┆ kind: data                         ┆ kind: data                          ┆ kind: data                                 ┆ kind: data                                          │ │
│ ╞═══════════════════════════════════════════════╪══════════════════════╪══════════════════════════════╪════════════════════════════════════╪═════════════════════════════════════╪════════════════════════════════════════════╪═════════════════════════════════════════════════════╡ │
│ │ row_18828F56B0DCB1A72f14fc92d8ecafcf          ┆ 0                    ┆ 2025-12-19T08:06:46.379970   ┆ [child_link]                       ┆ [base_link]                         ┆ [{axis: [0.0, 0.0, 1.0], angle: 1.216}]    ┆ [[0.0, 0.0, 0.1]]                                   │ │
│ └───────────────────────────────────────────────┴──────────────────────┴──────────────────────────────┴────────────────────────────────────┴─────────────────────────────────────┴────────────────────────────────────────────┴─────────────────────────────────────────────────────┘ │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```
