### PR TITLE
Add dataloader for encoded depth image (to allow `log_from_file` & dragdrop)

### DIFF
--- a/crates/store/re_data_loader/src/lib.rs
+++ b/crates/store/re_data_loader/src/lib.rs
@@ -471,6 +471,8 @@ pub const SUPPORTED_IMAGE_EXTENSIONS: &[&str] = &[
     "pbm", "pgm", "png", "ppm", "tga", "tif", "tiff", "webp",
 ];
 
+pub const SUPPORTED_DEPTH_IMAGE_EXTENSIONS: &[&str] = &["rvl", "png"];
+
 pub const SUPPORTED_VIDEO_EXTENSIONS: &[&str] = &["mp4"];
 
 pub const SUPPORTED_MESH_EXTENSIONS: &[&str] = &["glb", "gltf", "obj", "stl"];
@@ -492,6 +494,7 @@ pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
         .iter()
         .chain(SUPPORTED_THIRD_PARTY_FORMATS)
         .chain(SUPPORTED_IMAGE_EXTENSIONS)
+        .chain(SUPPORTED_DEPTH_IMAGE_EXTENSIONS)
         .chain(SUPPORTED_VIDEO_EXTENSIONS)
         .chain(SUPPORTED_MESH_EXTENSIONS)
         .chain(SUPPORTED_POINT_CLOUD_EXTENSIONS)

--- a/crates/store/re_sdk_types/src/archetypes/encoded_depth_image_ext.rs
+++ b/crates/store/re_sdk_types/src/archetypes/encoded_depth_image_ext.rs
@@ -1,0 +1,33 @@
+use super::EncodedDepthImage;
+
+impl EncodedDepthImage {
+    /// Creates a new depth image from the file contents at `path`.
+    ///
+    /// The [`MediaType`][crate::components::MediaType] will first be guessed from the file contents.
+    ///
+    /// Returns an error if the file cannot be read.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[inline]
+    pub fn from_file(filepath: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
+        let filepath = filepath.as_ref();
+        let contents = std::fs::read(filepath)?;
+        Ok(Self::from_file_contents(contents))
+    }
+
+    /// Construct a depth image given the encoded content of some image file, e.g. a PNG or RVL.
+    ///
+    /// [`Self::media_type`] will be guessed from the bytes.
+    pub fn from_file_contents(bytes: Vec<u8>) -> Self {
+        #[cfg(feature = "image")]
+        {
+            if let Some(media_type) = image::guess_format(&bytes)
+                .ok()
+                .map(|format| crate::components::MediaType::from(format.to_mime_type()))
+            {
+                return Self::new(bytes).with_media_type(media_type);
+            }
+        }
+
+        Self::new(bytes)
+    }
+}

--- a/crates/store/re_sdk_types/src/archetypes/mod.rs
+++ b/crates/store/re_sdk_types/src/archetypes/mod.rs
@@ -24,6 +24,7 @@ mod depth_image_ext;
 mod ellipsoids3d;
 mod ellipsoids3d_ext;
 mod encoded_depth_image;
+mod encoded_depth_image_ext;
 mod encoded_image;
 mod encoded_image_ext;
 mod geo_line_strings;


### PR DESCRIPTION
### Related

* Small follow-up to https://github.com/rerun-io/rerun/pull/11877

### What

Allows drag & drop for encoded depth images `rvl` files into the Viewer.