### PR TITLE
Fix mypy type issue in ARKit Scenes example

### DIFF
--- a/examples/python/arkit_scenes/arkit_scenes/download_dataset.py
+++ b/examples/python/arkit_scenes/arkit_scenes/download_dataset.py
@@ -17,14 +17,7 @@ VALIDATION: Final = "Validation"
 HIGRES_DEPTH_ASSET_NAME: Final = "highres_depth"
 POINT_CLOUDS_FOLDER: Final = "laser_scanner_point_clouds"
 
-AVAILABLE_RECORDINGS: Final = [
-    "48458663",
-    "42444949",
-    "41069046",
-    "41125722",
-    "41125763",
-    "42446167",
-]
+AVAILABLE_RECORDINGS: Final = ["48458663", "42444949", "41069046", "41125722", "41125763", "42446167"]
 DATASET_DIR: Final = Path(__file__).parent.parent / "dataset"
 
 default_raw_dataset_assets = [


### PR DESCRIPTION
### What

Fix mypy lint error in ARKit Scenes example by casting `visit_id` to `float` to force the return type of `.iat`.