### PR TITLE
docs: Fix parameter name from 'color' to 'colors'

### DIFF
--- a/docs/content/concepts/entity-component.md
+++ b/docs/content/concepts/entity-component.md
@@ -26,7 +26,7 @@ All the data that you log within Rerun is mapped to the concepts of entities and
 For example, consider the case of logging a point:
 
 ```python
-rr.log("my_point", rr.Points2D([32.7, 45.9], color=[255, 0, 0]))
+rr.log("my_point", rr.Points2D([32.7, 45.9], colors=[255, 0, 0]))
 ```
 
 This statement uses the [`rr.Points2D`](https://ref.rerun.io/docs/python/stable/common/archetypes/#rerun.archetypes.Points2D) archetype.


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

None.

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->

Fixed a small typo in the documentation code example. The parameter name was wrong which might confuse new users.
