### PR TITLE
Update cargo-deny to 0.18

### DIFF
--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -238,7 +238,7 @@ def cargo_deny(results: list[Result]) -> None:
     # Note: running just `cargo deny check` without a `--target` can result in
     # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
     # Installing is quite quick if it's already installed.
-    results.append(run_cargo("install", "--locked cargo-deny@^0.17"))
+    results.append(run_cargo("install", "--locked cargo-deny@^0.18"))
 
     for target in deny_targets:
         results.append(


### PR DESCRIPTION
### What

Update `cargo-deny` to version 0.18, as version 0.17 fails to parse the latest advisories:

```
parse error: TOML parse error at line 8, column 8
  |
8 | cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unsupported CVSS version: 4.0
```