### PR TITLE
Update docs for py-build-examples and uv

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -102,10 +102,33 @@ Rerun is available as a package on PyPi and can be installed with `pip install r
 
 Additionally, nightly dev wheels from head of `main` are available at <https://github.com/rerun-io/rerun/releases/tag/prerelease>.
 
-If you want to build from source, you can do so easily in the Pixi environment:
-* Run `pixi run py-build` to build the SDK for Python (or `pixi run py-build --release` for a release build)
-* Then run examples via uv: `pixi run uv run examples/python/minimal/minimal.py`
 
+### Building from source
+If you want to build from source, you can do so easily in the Pixi environment:
+```sh
+pixi run py-build
+```
+
+Or to create a wheel:
+```sh
+pixi run py-build-wheel
+```
+
+You can run scripts that depend on rerun within the uv environment. For example:
+```sh
+pixi run uv run examples/python/minimal/minimal.py`
+```
+
+### Running the Python examples
+You can also install all rerun example and their dependencies into the same uv environment using:
+```sh
+pixi run py-build-examples
+```
+
+Each example is installed as a target within the uv environment. For example:
+```sh
+pixi run uv run plots
+```
 
 ### Tests & tooling
 

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -61,6 +61,17 @@ Now you can run examples via uv:
 pixi run uv run examples/python/minimal/minimal.py
 ```
 
+### Installing and running examples
+You can install all of the rerun python examples into the uv managed environment with:
+```shell
+pixi run py-build-examples
+```
+
+Then you can just examples based on their installed name, for example:
+```shell
+pixi run uv run plots
+```
+
 ## Datasets
 Some examples will download a small datasets before they run. They will do so the first time you run the example. The datasets will be added to a subdir called `dataset`, which is in the repo-wide `.gitignore`.
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -368,6 +368,8 @@ py-build-notebook-fast = { cmd = "uv sync --inexact --package rerun-notebook" }
 py-build-wheel = { cmd = "cp target/release/rerun$EXECUTABLE_EXTENSION rerun_py/rerun_sdk/rerun_cli/ && uv run maturin build --release --manifest-path rerun_py/Cargo.toml", depends-on = [
   "rerun-build-native-and-web-release",
 ] }
+py-build-examples = { cmd = "pixi run uv sync --group examples --inexact --no-install-package rerun-sdk" }
+
 
 # Build the `rerun-sdk` package in release mode.
 py-build-release = { cmd = "uv run maturin develop --uv --release --manifest-path rerun_py/Cargo.toml --extras=tests,datafusion", env = { RERUN_ALLOW_MISSING_BIN = "1" } }


### PR DESCRIPTION
This restores the `py-build-examples` target to install all of the rerun examples and their dependencies.

This lets you do:
```
pixi run py-build
pixi run py-build-examples
uv run plots
```