### PR TITLE
Hide the 'Server tables' example by default

### DIFF
--- a/examples/python/server_tables/README.md
+++ b/examples/python/server_tables/README.md
@@ -3,7 +3,6 @@ title = "Server tables"
 tags = ["DataFrame", "Tables", "Server", "Cloud",]
 thumbnail = "https://static.rerun.io/server_tables/d5155346d84caed5c53de507708c780727c075ef/480w.png"
 thumbnail_dimensions = [480, 358]
-channel = "main"
 -->
 
 ## Writing server tables example


### PR DESCRIPTION
Added by @timsaucer but it should not be on https://rerun.io/viewer