### PR TITLE
Don't capture test output on mac runners

### DIFF
--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -84,10 +84,13 @@ def run_cargo(
             f"{os.getcwd()}/{clippy_conf}"
         )
 
+    # TODO(#11359): We don't capture output on mac runners to help debug random hangs.
+    capture = sys.platform != "darwin"
+
     env = os.environ.copy()
     env.update(additional_env_vars)
 
-    result = subprocess.run(args, env=env, check=False, capture_output=True, text=True)
+    result = subprocess.run(args, env=env, check=False, capture_output=capture, text=True)
     success = result.returncode == 0
 
     if success:


### PR DESCRIPTION
### Related

- https://github.com/rerun-io/rerun/issues/11359

### What

Our mac ci runs sometimes hang. Since we capture the output we don't see which test are being executed before it hangs. 
This turns off capturing, which should hopefully show us if we always hang at the same test or if it's random. 
