### PR TITLE
Fix missing example in examples/manifest.toml

### DIFF
--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -168,6 +168,7 @@ examples = [
 examples = [
   "_empty_rerun_sdk",
   "all_examples",
+  "blueprint", # Not very pretty
   "custom_callback",
   "custom_collection_adapter",
   "custom_data_loader",

--- a/scripts/check_example_manifest_coverage.py
+++ b/scripts/check_example_manifest_coverage.py
@@ -25,9 +25,12 @@ def gather_example_in_repo() -> Iterable[Path]:
                 yield child
 
 
+def manifest_path() -> Path:
+    return Path(__file__).parent.parent / "examples" / "manifest.toml"
+
+
 def gather_example_in_manifest() -> Iterable[str]:
-    manifest_path = Path(__file__).parent.parent / "examples" / "manifest.toml"
-    manifest = tomli.loads(manifest_path.read_text())
+    manifest = tomli.loads(manifest_path().read_text())
     for cat in manifest["categories"].values():
         yield from cat["examples"]
 
@@ -53,6 +56,7 @@ def main() -> None:
         print("Unlisted examples:")
         for example_path in unlisted_examples:
             print(f"- {example_path.parent.name}/{example_path.name}")
+        print(f"Please add them to {manifest_path()}")
         sys.exit(1)
     else:
         print("all ok")


### PR DESCRIPTION
Needed because of missing contrib CI checks in
* https://github.com/rerun-io/rerun/pull/12307