### PR TITLE
Make `py-fmt` cover the entire repo

### DIFF
--- a/docs/snippets/all/tutorials/data_out.py
+++ b/docs/snippets/all/tutorials/data_out.py
@@ -37,9 +37,7 @@ print(pd_df["/blendshapes/0/jawOpen:Scalars:scalars"][160:180])
 # convert the "jawOpen" column to a flat list of floats
 print(pd_df)
 # region: explode_jaw
-pd_df["jawOpen"] = (
-    pd_df["/blendshapes/0/jawOpen:Scalars:scalars"].explode().astype(float)
-)
+pd_df["jawOpen"] = pd_df["/blendshapes/0/jawOpen:Scalars:scalars"].explode().astype(float)
 print(pd_df["jawOpen"][160:180])
 # endregion: explode_jaw
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -276,12 +276,11 @@ nb-strip = "python scripts/nbstripout.py --directories mypy examples/ scripts/ t
 nb-strip-check = "python scripts/nbstripout.py --directories mypy examples/ scripts/ tests/python/ docs/snippets/ -- --verify --extra-keys='metadata.language_info metadata.vscode metadata.kernelspec cell.metadata.vscode' --drop-empty-cells"
 
 
-# TODO(jleibs): tests/ scripts/ examples/ docs/ should be included in our format code
 # Run first ruff fix, then ruff format, order is important see also https://twitter.com/charliermarsh/status/1717229721954799727
 py-fmt = { cmd = "uv run ruff check --fix {{ files }} && uv run ruff format {{ files }}", args = [
-  { arg = "files", default = "rerun_py rerun_notebook" },
+  { arg = "files", default = "." },
 ] }
-py-fmt-check = "uv run ruff check rerun_py rerun_notebook && uv run ruff format --check rerun_py rerun_notebook"
+py-fmt-check = "uv run ruff check . && uv run ruff format --check ."
 # Get non-internal things that are ok to not check rerun on
 py-lint-non-sdk = { cmd = "uv run mypy --config-file rerun_py/.non_sdk_mypy.ini --no-warn-unused-ignore --cache-dir .mypy_cache_rerun_other" }
 # I couldn't get the config to work correctly, so placing relevant directories in command line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,8 @@ members = [
 ]
 
 [tool.ruff]
+line-length = 120
+preview = true
 src = ["rerun_py", "rerun_py/rerun_sdk", "rerun_notebook"]
 extend-exclude = [
   "crates",

--- a/rerun_notebook/src/rerun_notebook/__init__.py
+++ b/rerun_notebook/src/rerun_notebook/__init__.py
@@ -115,13 +115,9 @@ else:  # remote widget
     ESM_MOD = ASSET_ENV
     # note that the JS expects the Wasm binary to exist at the same path as itself
     if not (ASSET_ENV.startswith(("http://", "https://"))):
-        raise ValueError(
-            f"RERUN_NOTEBOOK_ASSET should be a URL starting with http or https. Found: {ASSET_ENV}"
-        )
+        raise ValueError(f"RERUN_NOTEBOOK_ASSET should be a URL starting with http or https. Found: {ASSET_ENV}")
     if not (ASSET_ENV.endswith("widget.js")):
-        raise ValueError(
-            f"RERUN_NOTEBOOK_ASSET should be a URL pointing to a `widget.js` file. Found: {ASSET_ENV}"
-        )
+        raise ValueError(f"RERUN_NOTEBOOK_ASSET should be a URL pointing to a `widget.js` file. Found: {ASSET_ENV}")
     ASSET_IS_URL = True
 
 
@@ -137,9 +133,7 @@ class ErrorWidget:
         )
         js_base64 = base64.b64encode(js.encode()).decode()
         onload = f"eval(atob('{js_base64}'))"
-        self._html = HTML(
-            value=f'<div id="{widget_id}"><style onload="{onload}"></style></div>'
-        )
+        self._html = HTML(value=f'<div id="{widget_id}"><style onload="{onload}"></style></div>')
 
     def _ipython_display_(self) -> None:
         from IPython.display import display
@@ -254,12 +248,8 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
                 poll(1)
                 time.sleep(0.1)
 
-    def update_panel_states(
-        self, panel_states: Mapping[Panel, PanelState | Literal["default"]]
-    ) -> None:
-        new_panel_states = (
-            dict(self._panel_states.items()) if self._panel_states else {}
-        )
+    def update_panel_states(self, panel_states: Mapping[Panel, PanelState | Literal["default"]]) -> None:
+        new_panel_states = dict(self._panel_states.items()) if self._panel_states else {}
         for panel, state in panel_states.items():
             if state == "default":
                 new_panel_states.pop(panel, None)
@@ -268,9 +258,7 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
         self._panel_states = new_panel_states
 
     def set_time_ctrl(self, timeline: str | None, time: int | None, play: bool) -> None:
-        self.send(
-            {"type": "time_ctrl", "timeline": timeline, "time": time, "play": play}
-        )
+        self.send({"type": "time_ctrl", "timeline": timeline, "time": time, "play": play})
 
     def set_active_recording(self, recording_id: str) -> None:
         self.send({"type": "recording_id", "recording_id": recording_id})
@@ -282,13 +270,11 @@ class Viewer(anywidget.AnyWidget):  # type: ignore[misc]
         self.send({"type": "close_url", "url": url})
 
     def set_credentials(self, access_token: str, email: str) -> None:
-        self.send(
-            {
-                "type": "set_credentials",
-                "access_token": access_token,
-                "email": email,
-            }
-        )
+        self.send({
+            "type": "set_credentials",
+            "access_token": access_token,
+            "email": email,
+        })
 
     def _on_raw_event(self, callback: Callable[[str], None]) -> None:
         """Register a set of callbacks with this instance of the Viewer."""

--- a/rerun_notebook/src/rerun_notebook/asset_server.py
+++ b/rerun_notebook/src/rerun_notebook/asset_server.py
@@ -10,9 +10,7 @@ from . import WASM_PATH, WIDGET_PATH
 
 
 class _Asset:
-    def __init__(
-        self, path: str | Path, content_type: str, encode_gzip: bool = False
-    ) -> None:
+    def __init__(self, path: str | Path, content_type: str, encode_gzip: bool = False) -> None:
         self.data = Path(path).read_bytes()
         self.headers = {
             "Content-Type": content_type,
@@ -90,16 +88,12 @@ def serve_assets(
         print("Loading assets into memory…")
         assets = {
             "widget.js": _Asset(WIDGET_PATH, "text/javascript"),
-            "re_viewer_bg.wasm": _Asset(
-                WASM_PATH, "application/wasm", encode_gzip=True
-            ),
+            "re_viewer_bg.wasm": _Asset(WASM_PATH, "application/wasm", encode_gzip=True),
         }
 
     httpd = socketserver.TCPServer((bind_address, port), AssetHandler)
     bound_addr = httpd.server_address
-    print(
-        f"Serving rerun notebook assets at http://{bound_addr[0]!s}:{bound_addr[1]!s}"
-    )
+    print(f"Serving rerun notebook assets at http://{bound_addr[0]!s}:{bound_addr[1]!s}")
 
     if background:
         import threading

--- a/scripts/ci/approve_workflow_runs.py
+++ b/scripts/ci/approve_workflow_runs.py
@@ -55,9 +55,7 @@ def main() -> None:
         assert isinstance(user, NamedUser), f"Expected NamedUser, got {type(user)}"
 
         can_user_approve_workflows = (
-            repo.owner.login == user.login
-            or repo.organization.has_in_members(user)
-            or repo.has_in_collaborators(user)
+            repo.owner.login == user.login or repo.organization.has_in_members(user) or repo.has_in_collaborators(user)
         )
         if not can_user_approve_workflows:
             continue

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -92,7 +92,9 @@ def run_cargo(
     env.update(additional_env_vars)
 
     # Use encoding='utf-8' with errors='replace' to handle binary data in cargo/linker output on Windows
-    result = subprocess.run(args, env=env, check=False, capture_output=capture, text=True, encoding="utf-8", errors="replace")
+    result = subprocess.run(
+        args, env=env, check=False, capture_output=capture, text=True, encoding="utf-8", errors="replace"
+    )
     success = result.returncode == 0
 
     if success:


### PR DESCRIPTION
### What

In the recent move to uv stuff, the scope of `py-fmt` was reduced to only some of our packages. This PR attempt to bring back coverage to the entire repo. This did incur some diff on some files, but they actually seem ok.