### PR TITLE
move tower on failure logs to debug level

### DIFF
--- a/crates/utils/re_perf_telemetry/src/grpc.rs
+++ b/crates/utils/re_perf_telemetry/src/grpc.rs
@@ -743,6 +743,8 @@ pub type ClientTelemetryLayer = tower::layer::util::Stack<
 // we ultimately can add all the same things that we have on the server as we need them.
 pub fn new_client_telemetry_layer() -> ClientTelemetryLayer {
     let trace_layer = tower_http::trace::TraceLayer::new_for_grpc()
+        // Note: we're actually disabling all DEBUG level logs for `tower` in re_log, so if you want to enable it
+        // you'll need to adjust that as well. See crates/utils/re_log/src/lib.rs
         .on_failure(DefaultOnFailure::new().level(tracing::Level::DEBUG))
         .make_span_with(GrpcMakeSpan::new());
 


### PR DESCRIPTION
### What

We get error logs on grpc failure from ``tower-http`` and this is unwanted verbosity that shows up in difference places, notebook for example. 

```
[2026-01-08T10:00:17Z ERROR tower_http::trace::on_failure] response failed classification=Code: 16 latency=203 ms
```

This is an attempt to make sure those logs are only shown at DEBUG level.  

I'm failing to test this as I can't use locally built rerun sdk for some reason anymore, but I believe the relevant callback is responsible for the spammy logs. 

Note: see @emilk's comment below, this will basically permanently remove on_failure logs for tower as we have a rule in ``re_log`` for the ``tower`` lib. Added a code comment in case someone wants to look at these specific logs.