### PR TITLE
Fix assert in neural field notebook example

### DIFF
--- a/examples/notebook/notebook_neural_field_2d/neural_field_2d.ipynb
+++ b/examples/notebook/notebook_neural_field_2d/neural_field_2d.ipynb
@@ -74,7 +74,7 @@
     "            self.linears.append(torch.nn.Linear(in_size, out_size))\n",
     "\n",
     "        if self.pe_sigma is not None:\n",
-    "            assert isinstance(self.linears[0], torch.Tensor)\n",
+    "            assert isinstance(self.linears[0].weight, torch.Tensor)\n",
     "            torch.nn.init.normal_(self.linears[0].weight, 0.0, self.pe_sigma)\n",
     "\n",
     "    def __str__(self) -> str:\n",


### PR DESCRIPTION
### Related

* Failing nightly: https://github.com/rerun-io/rerun/actions/runs/20840495128/job/59874876044

### What

`self.linears` contains `nn.Linear` and not `Tensor`.

### Todo

* [x] `nightly` passes: https://github.com/rerun-io/rerun/actions/runs/20846990159/job/59894605430
