### PR TITLE
Add Architecture Visualization 

### DIFF
--- a/.github/workflows/architecture_visualization.yml
+++ b/.github/workflows/architecture_visualization.yml
@@ -1,0 +1,14 @@
+name: Architecture Visualization
+on:
+  workflow_dispatch:
+
+jobs:
+  scan-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TangleGuard/GitHub-Action@0.1
+        with:
+          upload_results: "true"
+          make_public: "true"
+          language: "rust"
+          description: "An open source SDK for logging, storing, querying, and visualizing multimodal and multi-rate data."


### PR DESCRIPTION
This PR add the TangleGuard GitHub Action to the repository.

It create a dependency graph which can be viewed and analyzed at https://app.tangleguard.com/  

Since the action run on my fork, it's labeled as `jaads/rerun` currently, see https://app.tangleguard.com/project/github.com/jaads/rerun. To keep this up-to-day it would be nice to have it included in the original repository. Then the fork entry will be deleted on the web app.

The amount of interdependencies within `rerun` is relatively high.  TangleGuard's layout engine currently takes a couple of seconds to render the graph at deeper levels. I'm working on this. I hope, to see the diagram brings still some value. 

Let me know what you think :) 
