### PR TITLE
Make `crates.py` re-entrant when all crates have already been published

### DIFF
--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -521,6 +521,11 @@ def publish_unpublished_crates_in_parallel(
         else:
             unpublished_crates[name] = crate
 
+    if len(unpublished_crates) == 0:
+        # Building the DAG with an empty set of unpublished crates fails, so we exit early if no work needs to be done.
+        print("All crates have already been published.")
+        return
+
     # collect dependency graph (adjacency list of `crate -> dependencies`)
     print("Building dependency graph…")
     dependency_graph: dict[str, list[str]] = {}


### PR DESCRIPTION
### Related

* https://github.com/rerun-io/rerun/actions/runs/20844635555/job/59894033071 fails.
* https://github.com/rerun-io/rerun/actions/runs/20847883241/job/59895838885 passes.

> [!IMPORTANT]
> I've restructured the code a bit compared to the run above (https://github.com/rerun-io/rerun/pull/12343/changes/660c08f7f7d13d728a7bc4ee7d860db9d6a1cfc0) to exit even earlier.

### What

Our Publish Crates job that is part of the Release workflow would fail if all crates had already been published before. This would prevent the GitHub Release workflow from running.

This PR fixes this by exiting early, before hitting an error in the construction of an empty DAG.
