### PR TITLE
URDF loader: use `InstancePoses3D` for geometry scale

### DIFF
--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -742,7 +742,7 @@ fn log_geometry(
                     store_id,
                     entity_path.clone(),
                     timepoint,
-                    &Transform3D::update_fields().with_scale([x as f32, y as f32, z as f32]),
+                    &InstancePoses3D::update_fields().with_scales([(x as f32, y as f32, z as f32)]),
                 )?;
             }
 


### PR DESCRIPTION
### What

In #12005 we started logging the origin transforms for geometry using `InstancePoses3D`. However the mesh scale was still being logged using a normal `Transform3D`, this fixes that and now meshes with a scale attribute should be scaled correctly.

Originally reported on our discord: https://discord.com/channels/1062300748202921994/1458859702359167106