### PR TITLE
Remove non-existant `urdf` example

### DIFF
--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -34,7 +34,6 @@ examples = [
   # display order, most interesting first
   "droid_dataset",
   "animated_urdf",
-  "urdf",
   "ros_node",
   "chess_robby_fischer",
   "nuscenes_dataset",


### PR DESCRIPTION
### What

Removes the old name used for the `animated_urdf` python example, which somehow survived the rename.