### PR TITLE
Update the generator to match the new CLI manual

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -639,8 +639,8 @@ where
                 let web_header = unindent::unindent(
                     "\
                     ---
-                    title: CLI manual
-                    order: 250
+                    title: ⌨️ CLI manual
+                    order: 1150
                     ---\
                     ",
                 );


### PR DESCRIPTION
This was changed in https://github.com/rerun-io/rerun/pull/12355 and is now failing CI.