### PR TITLE
URDF: Bundle pose + mesh scale in single `InstancePoses3D`

### DIFF
--- a/crates/store/re_data_loader/src/loader_urdf.rs
+++ b/crates/store/re_data_loader/src/loader_urdf.rs
@@ -539,24 +539,12 @@ fn log_debug_format(
     )
 }
 
-fn is_identity_scale(x: f64, y: f64, z: f64) -> bool {
-    const EPS: f64 = 1e-12;
-    (x - 1.0).abs() < EPS && (y - 1.0).abs() < EPS && (z - 1.0).abs() < EPS
-}
-
 fn extract_instance_scale(geometry: &Geometry) -> Option<Vec3D> {
     match geometry {
         Geometry::Mesh {
             scale: Some(Vec3([x, y, z])),
             ..
-        } => {
-            // Only log a scale component if it isn't the identity.
-            if is_identity_scale(*x, *y, *z) {
-                None
-            } else {
-                Some(Vec3D::new(*x as f32, *y as f32, *z as f32))
-            }
-        }
+        } => Some(Vec3D::new(*x as f32, *y as f32, *z as f32)),
         _ => None,
     }
 }


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

The URDF loader now correctly applies `<mesh scale>` attributes to visual and collision geometries by emitting all pose components (translation, rotation, and scale) together in a single InstancePoses3D archetype instance.

- Why
Previously, mesh scale was logged as a separate component update in a different chunk row from the translation and rotation data. This violates the principle of atomic archetype emission and can result in incomplete or out-of-order component data, causing the renderer to receive poses without scale information. Scaled meshes would render at their unscaled size despite correct metadata being present in the store.

- How
1. Extract mesh scale at the point of use (`log_link()`) via `extract_instance_scale()`
2. Pass scale through the call chain: `log_link()` → `send_instance_pose_with_frame()` → `instance_poses_from_pose()`
3. Emit translation + rotation + scale as a single InstancePoses3D row via one `send_archetype()` call
4. Remove redundant scale handling from `log_geometry()` to eliminate duplication

- Result
  - Scaled mesh visuals and collisions render at correct dimensions
  - InstancePoses3D data is emitted atomically, preventing order-dependent rendering artifacts
  - Cleaner separation of concerns: mesh scale is handled at the pose level, not the geometry level

Doosan Robotics URDF example: https://github.com/DoosanRobotics/doosan-robot2/blob/humble/dsr_description2/urdf/p3020.urdf

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
