### PR TITLE
Remove `TableEntry.to_polars()` from API sandbox

### DIFF
--- a/rerun_py/tests/api_sandbox/rerun_draft/catalog.py
+++ b/rerun_py/tests/api_sandbox/rerun_draft/catalog.py
@@ -568,10 +568,6 @@ class TableEntry(Entry):
         """Returns the schema of the table."""
         return self.reader().schema()
 
-    def to_polars(self) -> Any:
-        """Returns the table as a Polars DataFrame."""
-        return self.reader().to_polars()
-
 
 AlreadyExistsError = _catalog.AlreadyExistsError
 EntryId = _catalog.EntryId

--- a/rerun_py/tests/api_sandbox/test_draft/test_polars_interop.py
+++ b/rerun_py/tests/api_sandbox/test_draft/test_polars_interop.py
@@ -25,7 +25,7 @@ def test_table_to_polars(tmp_path: Path) -> None:
 
         table.append(int16=[12], string_list=[["a", "b", "c"]])
 
-        df = client.get_table(name="my_table").to_polars()
+        df = client.get_table(name="my_table").reader().to_polars()
 
         assert str(df) == inline_snapshot("""\
 shape: (1, 2)


### PR DESCRIPTION
### Related

* part of https://linear.app/rerun/issue/RR-2901/pr-tracking-clean-up-cloud-apis-project

### What

I was reviewing the remaining diff between the api_sandbox and the real thing, and beyond the [get_index_ranges/using_index_values](https://linear.app/rerun/issue/RR-3189/improve-using-index-values-and-implement-get-index-ranges) story Tim is working on, the only remaining difference that I could spot is this `TableEntry.to_polars()` API.

This PR proposes to get rid of it.

Rationale:
- forcing the `reader()` call builds up the "entry -> dataframe conversion" mental model
- the required boilerplate is minimal
- singling-out polar is weird (what about pyarrow, pandas, etc?)
