### PR TITLE
Upgrade remaining CI runners to `macos-26`-based images

### DIFF
--- a/.github/workflows/cpp_matrix_full.json
+++ b/.github/workflows/cpp_matrix_full.json
@@ -31,7 +31,7 @@
         },
         {
             "name": "Mac aarch64",
-            "runs_on": "macos-15-large",
+            "runs_on": "macos-26-large",
             "cache_key": "build-macos-arm64",
             "extra_env_vars": "RERUN_USE_ASAN=1 LSAN_OPTIONS=suppressions=.github/workflows/lsan_suppressions.supp",
             "pr_ci": true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         runs_on:
-          [ubuntu-latest-16-cores, macos-15-large, windows-latest-8-cores]
+          [ubuntu-latest-16-cores, macos-26-large, windows-latest-8-cores]
     runs-on: ${{ matrix.runs_on }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable_build_and_upload_rerun_c.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_c.yml
@@ -101,7 +101,7 @@ jobs:
               lib_name="rerun_c.lib"
               ;;
             macos-arm64)
-              runner="macos-15" # Small runners, because building rerun_c is fast
+              runner="macos-26" # Small runners, because building rerun_c is fast
               target="aarch64-apple-darwin"
               container="null"
               lib_name="librerun_c.a"

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -103,7 +103,7 @@ jobs:
               bin_name="rerun.exe"
               ;;
             macos-arm64)
-              runner="macos-15-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-26-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               bin_name="rerun"

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -130,7 +130,7 @@ jobs:
               compat="manylinux_2_28"
               ;;
             macos-arm64)
-              runner="macos-15-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
+              runner="macos-26-xlarge" # See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
               target="aarch64-apple-darwin"
               container="null"
               compat="manylinux_2_28"

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs_on: "macos-15-xlarge"
+          - runs_on: "macos-26-xlarge"
             name: "macos"
           - runs_on: "windows-latest-32-cores"
             name: "windows"
@@ -213,7 +213,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - runs_on: "macos-15-xlarge"
+          - runs_on: "macos-26-xlarge"
             name: "macos"
           - runs_on: "windows-latest-32-cores"
             name: "windows"

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -95,7 +95,7 @@ jobs:
               container="null"
               ;;
             macos-arm64)
-              runner="macos-15-xlarge" # This is an Arm vm, https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners
+              runner="macos-26-xlarge" # This is an Arm vm, https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners
               target="aarch64-apple-darwin"
               container="null"
               ;;


### PR DESCRIPTION
### Related

* CI failures: https://github.com/rerun-io/rerun/actions/runs/20911647913/job/60075575294

### What

This is an attempt to fix the frequent timeout problems in our macOS pipelines.

* [x] nightly build: https://github.com/rerun-io/rerun/actions/runs/20915597754/job/60088266161
