### PR TITLE
Run `publish_wheels.py` using `uvpy`

### DIFF
--- a/.github/workflows/reusable_publish_wheels.yml
+++ b/.github/workflows/reusable_publish_wheels.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Publish to PyPI
         run: |
-          pixi run python scripts/ci/publish_wheels.py \
+          pixi run uvpy scripts/ci/publish_wheels.py \
             --version ${{ inputs.release-version }} \
             --dir "commit/${{ needs.get-commit-sha.outputs.short-sha }}/wheels" \
             --repository "${{ vars.PYPI_REPOSITORY }}" \


### PR DESCRIPTION
### Related

* CI failure: https://github.com/rerun-io/rerun/actions/runs/20917103469/job/60100602980

### What

`maturin` is installed using `uv`, so we need to call the script in the right environment.
