### PR TITLE
Fix logging empty overrides

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -194,7 +194,7 @@ class View:
             visualizer = visualizer.visualizer()
 
         if isinstance(visualizer, Visualizer):
-            if visualizer.overrides is not None:
+            if visualizer.overrides is not None and len(visualizer.overrides) > 0:
                 stream.log(log_path, visualizer.overrides)
             return visualizer.visualizer_type
         else:  # has to be AsComponents (EntityBehavior, VisibleTimeRanges, etc.)


### PR DESCRIPTION
this caused warnings which got picked up by our CI

Tested locally with: `RERUN_PANIC_ON_WARN=1 python docs/snippets/all/tutorials/visualizer-overrides.py`
(before this would indeed panic!