### PR TITLE
Fix snippet compare

### DIFF
--- a/crates/build/re_dev_tools/src/build_examples/snippets.rs
+++ b/crates/build/re_dev_tools/src/build_examples/snippets.rs
@@ -243,6 +243,7 @@ struct Config {
 struct OptOut {
     /// example name -> languages
     run: HashMap<String, Vec<String>>,
+
     /// example name (for backwards compatibility check opt-out)
     backwards_check: Vec<String>,
 }


### PR DESCRIPTION
### Related
Failing CI on main

### What
I don't actually understand how this overlaps with out snippet compare script. They look to both do quite similar things? The uv transition seems to have highlighted this or maybe I just needed the full check on my last PR and doing the snippet compare wasn't enough.

If we aren't doing a backwards comparison we shouldn't require an rrd gets generated. This is a bandaid to unblock doing cloud docs. We probably need a broader updated approach to make all the snippet/examples less rrd centric.