### PR TITLE
Fix opening link with only time selection in fragment

### DIFF
--- a/crates/viewer/re_viewer_context/src/time_control.rs
+++ b/crates/viewer/re_viewer_context/src/time_control.rs
@@ -951,13 +951,20 @@ impl TimeControl {
                 }
             }
             TimeControlCommand::SetTimeSelection(time_range) => {
-                if let Some(state) = self.states.get_mut(self.timeline.name()) {
-                    if let Some(blueprint_ctx) = blueprint_ctx {
-                        blueprint_ctx.set_time_selection(*time_range);
-                    }
+                if let Some(blueprint_ctx) = blueprint_ctx {
+                    blueprint_ctx.set_time_selection(*time_range);
+                }
 
-                    state.time_selection = Some((*time_range).into());
+                let state = self
+                    .states
+                    .entry(*self.timeline_name())
+                    .or_insert_with(|| TimeState::new(time_range.min));
 
+                let repaint = state.time_selection.map(|r| r.to_int()) != Some(*time_range);
+
+                state.time_selection = Some((*time_range).into());
+
+                if repaint {
                     NeedsRepaint::Yes
                 } else {
                     NeedsRepaint::No


### PR DESCRIPTION
### Related

- Closes RR-3296

### What

Fix opening link with only time selection in fragment, which now only worked if time fragment was also specified.