### PR TITLE
Use the correct label for macos runners

### DIFF
--- a/.github/workflows/cpp_matrix_full.json
+++ b/.github/workflows/cpp_matrix_full.json
@@ -31,7 +31,7 @@
         },
         {
             "name": "Mac aarch64",
-            "runs_on": "macos-26-large",
+            "runs_on": "macos-26-xlarge",
             "cache_key": "build-macos-arm64",
             "extra_env_vars": "RERUN_USE_ASAN=1 LSAN_OPTIONS=suppressions=.github/workflows/lsan_suppressions.supp",
             "pr_ci": true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         runs_on:
-          [ubuntu-latest-16-cores, macos-26-large, windows-latest-8-cores]
+          [ubuntu-latest-16-cores, macos-26-xlarge, windows-latest-8-cores]
     runs-on: ${{ matrix.runs_on }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`macos-26-large` doesn't exist, causing some jobs to get stuck