### PR TITLE
Load chunks in batches

### DIFF
--- a/crates/store/re_redap_client/src/grpc.rs
+++ b/crates/store/re_redap_client/src/grpc.rs
@@ -611,7 +611,7 @@ fn chunk_id_column(batch: &RecordBatch) -> Option<&[ChunkId]> {
 
 /// Load only static chunks
 async fn load_static_chunks(
-    client: &mut ConnectionClient,
+    client: &ConnectionClient,
     tx: &re_log_channel::LogSender,
     store_id: &StoreId,
     rrd_manifest: re_log_encoding::RrdManifest,


### PR DESCRIPTION
### Related
* https://linear.app/rerun/issue/RR-3322/latency-spikes-towards-rerun-cloud

### What
Previously, we would load all chunks of a store in one big request. This caused a big "blockage" with symptoms being a latency spike, and long time until first data arrived.

This is an attempt to address this.

### Results
Previously we would get everything in one or two big batches: [main behavior](https://rerun.io/viewer/version/main?url=rerun%3A%2F%2Fapi.latest.cloud.rerun.io%3A443%2Fdataset%2F1888C7A31503A35E35e832070692f160%3Fsegment_id%3DILIAD_50aee79f_2023_07_12_20h_28m_36s)

Now, data instead streams in: [PR behavior](https://rerun.io/viewer/pr/12434?url=rerun%3A%2F%2Fapi.latest.cloud.rerun.io%3A443%2Fdataset%2F1888C7A31503A35E35e832070692f160%3Fsegment_id%3DILIAD_50aee79f_2023_07_12_20h_28m_36s)