### PR TITLE
Fix re-exported symbols being listed with `rerun_bindings.rerun_bindings` prefix in the Python docs

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -593,19 +593,18 @@ of Python, you can use the table below to make sure you choose the proper Rerun 
                     bindings_class = False
                     if "rerun_bindings" in cls.canonical_path:
                         bindings_class = True
+                        # Get the docstring from the bindings package, but keep the rerun display path
                         cls = bindings_pkg[cls.canonical_path[len("rerun_bindings.") :]]
-                        class_name = cls.canonical_path
+                        # Don't overwrite class_name - keep the rerun module path for display
                     show_class = class_name
                     for maybe_strip in ["archetypes.", "components.", "datatypes."]:
                         if class_name.startswith(maybe_strip):
                             stripped = class_name.replace(maybe_strip, "")
                             if stripped in rerun_pkg.classes:
                                 show_class = stripped
-                    if bindings_class:
-                        show_class = class_name  # don't strip anything for bindings
-                    else:
-                        show_class = "rerun." + show_class
-                        class_name = "rerun." + class_name
+                    # Always show as rerun.* in documentation, even for bindings classes
+                    show_class = "rerun." + show_class
+                    class_name = "rerun." + class_name
                     if cls.docstring is None:
                         raise ValueError(f"No docstring for class {class_name}")
                     index_file.write(f"[`{show_class}`][{class_name}] | {cls.docstring.lines[0]}\n")


### PR DESCRIPTION
Fix an issue which I believe was introduced in #11650 where some symbols where displayed with `rerun_bindings.rerun_bindings` prefix in the front page tables of the Python docs:

<img width="773" height="530" alt="image" src="https://github.com/user-attachments/assets/ff9a877d-5f3b-4cfa-86da-6edfdb62b26d" />

My fix appears to do the right thing based on `pixi run py-docs-serve`.