### PR TITLE
Show info message after screenshot from command palette

### DIFF
--- a/crates/viewer/re_viewer/src/screenshotter.rs
+++ b/crates/viewer/re_viewer/src/screenshotter.rs
@@ -101,6 +101,7 @@ impl Screenshotter {
             }
         } else {
             egui_ctx.copy_image(image.clone());
+            re_log::info!("Screenshot copied to clipboard");
         }
     }
 }


### PR DESCRIPTION
Since this can be invoked through the command palette by any user, it's good to show a short notification that the image is on the clipboard and not saved to disk somewhere.

Note: the individual views have this context menu where you can choose between copy & save, maybe we could have the same for the full window screenshot at some point (not part of this PR).

https://github.com/user-attachments/assets/b96afedf-0a1c-4c18-9b36-abdf107496a2

