### PR TITLE
Ensure the presence of `sorbet:version` for migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9728,6 +9728,7 @@ dependencies = [
  "itertools 0.14.0",
  "nohash-hasher",
  "re_arrow_util",
+ "re_chunk",
  "re_log",
  "re_log_types",
  "re_tracing",

--- a/crates/store/re_sorbet/Cargo.toml
+++ b/crates/store/re_sorbet/Cargo.toml
@@ -36,3 +36,6 @@ thiserror.workspace = true
 web-time.workspace = true
 
 # Keep this crate simple, with few dependencies.
+
+[dev-dependencies]
+re_chunk.workspace = true

--- a/crates/store/re_sorbet/src/migrations/mod.rs
+++ b/crates/store/re_sorbet/src/migrations/mod.rs
@@ -161,3 +161,37 @@ pub fn migrate_schema_ref(schema: SchemaRef) -> SchemaRef {
     re_tracing::profile_function!();
     migrate_record_batch_impl(RecordBatch::new_empty(schema)).schema()
 }
+
+#[cfg(test)]
+mod test {
+    use arrow::array::{ArrayRef, Int32Builder, ListBuilder};
+    use re_log_types::{EntityPath, TimePoint};
+    use re_types_core::{ChunkId, ComponentDescriptor, RowId};
+
+    #[test]
+    fn sorbet_version_presence() {
+        let mut array_builder = ListBuilder::new(Int32Builder::new());
+
+        array_builder.append_value([Some(1), Some(2), Some(3)]);
+
+        let array = std::sync::Arc::new(array_builder.finish());
+        let chunk = re_chunk::ChunkBuilder::new(ChunkId::new(), EntityPath::root())
+            .with_row(
+                RowId::new(),
+                TimePoint::STATIC,
+                [(ComponentDescriptor::partial("test"), array as ArrayRef)],
+            )
+            .build()
+            .unwrap();
+
+        let rb = chunk.to_record_batch().unwrap();
+        let schema = rb.schema();
+        let metadata = schema.metadata();
+
+        println!("{metadata:?}");
+        assert!(
+            metadata.contains_key("sorbet:version"),
+            "migration code relies on `sorbet:version` to be present"
+        );
+    }
+}


### PR DESCRIPTION
### What

This is a small sanity check that ensures changes to `sorbet:version` will show up in our test cases directly.
