### PR TITLE
Warn if an entity has multiple `CoordinateFrame` instances

### DIFF
--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -620,9 +620,10 @@ impl EntityTransformIdMapping {
                     fallback
                 },
                 |frame_id| {
-                    if results.results.component_mono_raw_with_log_level(re_log::Level::Debug, transform_frame_id_component).is_none() {
+                    let is_mono = results.results.component_mono_raw_quiet(transform_frame_id_component).is_some();
+                    if !is_mono {
                         re_log::warn_once!(
-                            "Entity {:?} has multiple `CoordinateFrame` instances, which is not supported. Using the first one.",
+                            "Entity {:?} has multiple coordinate frame instances, which is not supported. Using the first one.",
                             results.data_result.entity_path,
                         );
                     }


### PR DESCRIPTION
Make it transparent for users that we don't support this and pick the first one.

We already do something similar for transforms [here](https://github.com/rerun-io/rerun/blob/d1c73f07c92c053ce8667199ef1c40383916c7dc/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs#L76).

Relates to #12495.
