### PR TITLE
Fix detect and track objects example

### DIFF
--- a/examples/python/detect_and_track_objects/detect_and_track_objects.py
+++ b/examples/python/detect_and_track_objects/detect_and_track_objects.py
@@ -176,28 +176,12 @@ class Tracker:
     next_tracking_id = 0
     MAX_TIMES_UNDETECTED = 2
 
-    @staticmethod
-    def _create_tracker() -> Any:
-        """Create a CSRT tracker, handling OpenCV API variations."""
-        # Try cv2.legacy first (most common in opencv-contrib-python >4.5)
-        try:
-            return cv2.legacy.TrackerCSRT_create()  # type: ignore[attr-defined]
-        except AttributeError:
-            pass
-        # Try cv2.TrackerCSRT.create() (some versions)
-        try:
-            return cv2.TrackerCSRT.create()  # type: ignore[attr-defined]
-        except AttributeError:
-            pass
-        # Try cv2.TrackerCSRT_create() (older API)
-        return cv2.TrackerCSRT_create()  # type: ignore[attr-defined]
-
     def __init__(self, tracking_id: int, detection: Detection, bgr: cv2.typing.MatLike) -> None:
         self.tracking_id = tracking_id
         self.tracked = detection.scaled_to_fit_image(bgr)
         self.num_recent_undetected_frames = 0
 
-        self.tracker = self._create_tracker()
+        self.tracker = cv2.TrackerCSRT.create()  # type: ignore[attr-defined]
         bbox_xywh_rounded = [int(val) for val in self.tracked.bbox_xywh]
         self.tracker.init(bgr, bbox_xywh_rounded)
         self.log_tracked()
@@ -241,7 +225,7 @@ class Tracker:
     def update_with_detection(self, detection: Detection, bgr: cv2.typing.MatLike) -> None:
         self.num_recent_undetected_frames = 0
         self.tracked = detection.scaled_to_fit_image(bgr)
-        self.tracker = self._create_tracker()
+        self.tracker = cv2.TrackerCSRT.create()  # type: ignore[attr-defined]
         bbox_xywh_rounded = [int(val) for val in self.tracked.bbox_xywh]
         self.tracker.init(bgr, bbox_xywh_rounded)
         self.log_tracked()

--- a/examples/python/detect_and_track_objects/pyproject.toml
+++ b/examples/python/detect_and_track_objects/pyproject.toml
@@ -23,3 +23,8 @@ extra-args = "--max-frame=10"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv]
+# opencv-contrib-python conflicts with opencv-python (both provide cv2 module)
+# torch depends on opencv-python, but we need opencv-contrib-python for tracker APIs
+override-dependencies = ["opencv-contrib-python>4.9"]


### PR DESCRIPTION
### Related

* try 2 of https://github.com/rerun-io/rerun/pull/12505

### What

Oops, even in the full check it didn't run the detect and track objects example. Is there a good way to test this before merging?

This is the fix claude came up with. Locally it works.
