### PR TITLE
Add the ability to apply diffs from `python_check_signatures.py`

### DIFF
--- a/scripts/ci/python_check_signatures.py
+++ b/scripts/ci/python_check_signatures.py
@@ -226,7 +226,8 @@ def load_runtime_signatures(module_name: str) -> TotalSignature:
                     # Get the actual docstring from __init__ (though PyO3 usually has a useless default)
                     init_doc = (
                         method_obj.__doc__
-                        if method_obj.__doc__ != "Initialize self.  See help(type(self)) for accurate signature."
+                        if method_obj.__doc__
+                        != "Initialize self.  See help(type(self)) for accurate signature."  # NOLINT
                         else None
                     )
                     # Create a new APIDef with the correct docstring


### PR DESCRIPTION
Like the rest of the file already this was done with heavy llm assist.

Tested this on changes in https://github.com/rerun-io/rerun/pull/12405 because I got annoyed by applying diffs manually

Try it out yourself: do some change on the rust side of the python bindings, then:
```
pixi py-build
pixi run uvpy scripts/ci/python_check_signatures.py --apply
```
and verify with
```
pixi run uvpy scripts/ci/python_check_signatures.py
```