### PR TITLE
Move the often-used `TrackingAllocator` into `re_byte_size`

### DIFF
--- a/crates/utils/re_byte_size/Cargo.toml
+++ b/crates/utils/re_byte_size/Cargo.toml
@@ -22,9 +22,6 @@ all-features = true
 [features]
 glam = ["dep:glam"]
 
-## Enable special testing utilities
-testing = []
-
 
 [dependencies]
 arrow.workspace = true

--- a/crates/utils/re_byte_size/src/lib.rs
+++ b/crates/utils/re_byte_size/src/lib.rs
@@ -9,7 +9,6 @@ mod smallvec_sizes;
 mod std_sizes;
 mod tuple_sizes;
 
-#[cfg(feature = "testing")]
 pub mod testing;
 
 pub use self::bookkeeping_btreemap::BookkeepingBTreeMap;

--- a/crates/utils/re_byte_size/src/testing.rs
+++ b/crates/utils/re_byte_size/src/testing.rs
@@ -1,3 +1,5 @@
+//! Testing utilities for byte size measurements.
+
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 thread_local! {
@@ -7,11 +9,13 @@ thread_local! {
 /// Allocator that can be used in test for byte-accurate measurement of memory usage:
 ///
 /// ```
+/// # use re_byte_size::testing::TrackingAllocator;
+///
 /// #[global_allocator]
 /// pub static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator::system();
 ///
-/// fn size_of_thing() -> usize {
-///     let num_bytes = memory_use(|| {
+/// fn test_size_of_thing() {
+///     let (_thing, num_bytes) = TrackingAllocator::memory_use(|| {
 ///         vec![0u8; 1024 * 1024]
 ///     });
 ///     assert_eq!(num_bytes, 1024 * 1024);

--- a/crates/utils/re_int_histogram/Cargo.toml
+++ b/crates/utils/re_int_histogram/Cargo.toml
@@ -19,11 +19,6 @@ workspace = true
 all-features = true
 
 
-[features]
-## Enable special testing utilities
-testing = ["re_byte_size/testing"]
-
-
 [dependencies]
 re_byte_size.workspace = true
 smallvec.workspace = true

--- a/crates/utils/re_int_histogram/tests/memory_test.rs
+++ b/crates/utils/re_int_histogram/tests/memory_test.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "testing")]
-
 use insta::assert_debug_snapshot;
 use re_byte_size::testing::TrackingAllocator;
 


### PR DESCRIPTION
This is to unlock exact tests of size measurements in `re_byte_size`, so the size estimations for things like `BTreeMap` and `HashMap` can be improved.