### PR TITLE
Revert "Fix detect and track objects example (#12505)"

### DIFF
--- a/examples/python/detect_and_track_objects/detect_and_track_objects.py
+++ b/examples/python/detect_and_track_objects/detect_and_track_objects.py
@@ -181,7 +181,8 @@ class Tracker:
         self.tracked = detection.scaled_to_fit_image(bgr)
         self.num_recent_undetected_frames = 0
 
-        self.tracker = cv2.TrackerCSRT.create()  # type: ignore[attr-defined]
+        # TODO(nick): Figure out why this fails mpyp but imports locally
+        self.tracker = cv2.legacy.TrackerCSRT_create()  # type: ignore[attr-defined]
         bbox_xywh_rounded = [int(val) for val in self.tracked.bbox_xywh]
         self.tracker.init(bgr, bbox_xywh_rounded)
         self.log_tracked()
@@ -225,7 +226,8 @@ class Tracker:
     def update_with_detection(self, detection: Detection, bgr: cv2.typing.MatLike) -> None:
         self.num_recent_undetected_frames = 0
         self.tracked = detection.scaled_to_fit_image(bgr)
-        self.tracker = cv2.TrackerCSRT.create()  # type: ignore[attr-defined]
+        # TODO(nick): Figure out why this fails mypy but imports locally
+        self.tracker = cv2.legacy.TrackerCSRT_create()  # type: ignore[attr-defined]
         bbox_xywh_rounded = [int(val) for val in self.tracked.bbox_xywh]
         self.tracker.init(bgr, bbox_xywh_rounded)
         self.log_tracked()

--- a/examples/python/detect_and_track_objects/pyproject.toml
+++ b/examples/python/detect_and_track_objects/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 readme = "README.md"
 dependencies = [
   "numpy",
-  "opencv-contrib-python>4.9",
+  "opencv-contrib-python>4.6",
   "pillow",
   "requests>=2.31,<3",
   "rerun-sdk",

--- a/uv.lock
+++ b/uv.lock
@@ -968,7 +968,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "numpy" },
-    { name = "opencv-contrib-python", specifier = ">4.9" },
+    { name = "opencv-contrib-python", specifier = ">4.6" },
     { name = "pillow" },
     { name = "requests", specifier = ">=2.31,<3" },
     { name = "rerun-sdk", editable = "rerun_py" },


### PR DESCRIPTION
This reverts commit feda1bd8ee79ac4aede97e3333b17240aeb31588.

### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
