### PR TITLE
Fix case of unstable camera image plane distance

### DIFF
--- a/crates/viewer/re_view_spatial/src/eye.rs
+++ b/crates/viewer/re_view_spatial/src/eye.rs
@@ -232,7 +232,7 @@ impl EyeController {
         Eye {
             world_from_rub_view: IsoTransform::look_at_rh(
                 self.pos,
-                if self.pos == self.look_target {
+                if self.pos.distance_squared(self.look_target) < 1e-6 {
                     self.pos + Vec3::Y
                 } else {
                     self.look_target

--- a/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
@@ -207,12 +207,9 @@ impl CamerasVisualizer {
             }
         }
 
-        // world_from_camera is the transform to the pinhole origin
-        self.data.add_bounding_box_from_points(
-            ent_path.hash(),
-            std::iter::once(glam::Vec3::ZERO),
-            world_from_camera,
-        );
+        // world_from_camera is the transform to the pinhole origin.
+        self.data
+            .add_bounding_box(ent_path.hash(), macaw::BoundingBox::ZERO, world_from_camera);
 
         Ok(())
     }

--- a/crates/viewer/re_view_spatial/src/visualizers/utilities/spatial_view_visualizer.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/utilities/spatial_view_visualizer.rs
@@ -74,20 +74,6 @@ impl SpatialViewVisualizerData {
         }
     }
 
-    pub fn add_bounding_box_from_points(
-        &mut self,
-        entity: EntityPathHash,
-        points: impl Iterator<Item = glam::Vec3>,
-        world_from_obj: glam::Affine3A,
-    ) {
-        re_tracing::profile_function!();
-        self.add_bounding_box(
-            entity,
-            macaw::BoundingBox::from_points(points),
-            world_from_obj,
-        );
-    }
-
     pub fn as_any(&self) -> &dyn std::any::Any {
         self
     }


### PR DESCRIPTION
While testing a very degenerated scene in https://github.com/rerun-io/rerun/pull/12558 I had some trouble with jumpy bounding boxes causing flickering in image plane lengths. This fixes it. Also, works around a debug assertion I occasionally ran into