### PR TITLE
Migrate serde-yaml to serde_yaml_bw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,6 +4424,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -8865,7 +8880,7 @@ dependencies = [
  "rustdoc-types",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_bw",
  "tempfile",
  "toml 0.9.8",
  "ureq",
@@ -10641,9 +10656,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -10653,9 +10668,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -11188,6 +11203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
+
+[[package]]
 name = "saturating_cast"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11434,16 +11459,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_bw"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "6e243647f07ad8fdbef8019c17df67dd4a1547b5cf0c1fe2b83728ff1ee3d4cc"
 dependencies = [
+ "base64 0.22.1",
  "indexmap 2.11.4",
  "itoa",
- "ryu",
+ "num-traits",
+ "regex",
+ "saphyr-parser",
  "serde",
- "unsafe-libyaml",
+ "unsafe-libyaml-norway",
+ "zmij",
 ]
 
 [[package]]
@@ -12965,10 +12994,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"
@@ -14688,6 +14717,12 @@ name = "zlib-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zmij"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -356,7 +356,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.19"
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
 serde-wasm-bindgen = "0.6.5"
-serde_yaml = { version = "0.9.34", default-features = false }
+serde_yaml_bw = { version = "2.5.2", default-features = false }
 sha2 = "0.10.9"
 similar-asserts = "1.7.0"
 slotmap = { version = "1.0.7", features = ["serde"] }

--- a/crates/build/re_dev_tools/Cargo.toml
+++ b/crates/build/re_dev_tools/Cargo.toml
@@ -38,7 +38,7 @@ rustdoc-json.workspace = true
 rustdoc-types.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-serde_yaml.workspace = true
+serde_yaml_bw.workspace = true
 tempfile.workspace = true
 toml = { workspace = true, features = ["parse", "preserve_order", "serde"] }
 ureq = { workspace = true, features = ["json"] }

--- a/crates/build/re_dev_tools/src/build_search_index/ingest/docs.rs
+++ b/crates/build/re_dev_tools/src/build_search_index/ingest/docs.rs
@@ -61,7 +61,7 @@ fn parse_docs_frontmatter<P: AsRef<Path>>(path: P) -> anyhow::Result<(DocsFrontm
     let end = start + end;
 
     let frontmatter: DocsFrontmatter =
-        serde_yaml::from_str(content[start..end].trim()).map_err(|err| {
+        serde_yaml_bw::from_str(content[start..end].trim()).map_err(|err| {
             anyhow::anyhow!(
                 "Failed to parse YAML metadata of {:?}: {err}",
                 path.parent().unwrap().file_name().unwrap()


### PR DESCRIPTION
This change replaces the unmaintained [`serde_yaml`](https://crates.io/crates/serde_yaml) crate with the maintained [`serde_yaml_bw`](https://crates.io/crates/serde_yaml_bw).

`rerun` uses YAML only in a limited capacity. Depending on the fast-moving `serde-saphyr` backend, which introduces frequent changes and additional features, does not appear necessary. `serde_yaml_bw` is more stable and better aligned with the project’s needs, while also offering improved robustness when handling malformed YAML.

The public APIs of the two crates are largely compatible, so the impact of this change should be minimal.
