### PR TITLE
Fix dropping of entities when using `rerun rrd filter`

### DIFF
--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -109,7 +109,7 @@ impl FilterCommand {
                         re_log_types::LogMsg::ArrowMsg(store_id, mut msg) => {
                             match re_sorbet::ChunkBatch::try_from(&msg.batch) {
                                 Ok(batch) => {
-                                    if !dropped_entity_paths.contains(batch.entity_path()) {
+                                    if dropped_entity_paths.contains(batch.entity_path()) {
                                         None
                                     } else {
                                         let (fields, columns): (Vec<_>, Vec<_>) = itertools::izip!(


### PR DESCRIPTION
### Related

* Closes #12572 

### What

This fixes a bug where `--drop-entities` would do the opposite and instead keep those entities. I also checked timelines, which should be handled correctly.

Thanks @pschmutz for reporting!
