### PR TITLE
Allow selection via up/down + enter keys in `autocomplete_text_edit`

### DIFF
--- a/crates/viewer/re_ui/src/text_edit.rs
+++ b/crates/viewer/re_ui/src/text_edit.rs
@@ -18,7 +18,7 @@ pub fn autocomplete_text_edit(
     }
     let mut response = ui.add(text_edit);
 
-    // Filter suggestions based on current input.
+    // Filter suggestions based on current text input.
     let filtered_suggestions: Vec<_> = suggestions
         .iter()
         .filter(|suggestion| {
@@ -26,14 +26,58 @@ pub fn autocomplete_text_edit(
         })
         .collect();
 
+    let num_suggestions = filtered_suggestions.len();
+
+    // In addition to mouse, allow also to select suggestions with up/down arrow keys and Enter.
+    let (index_delta, enter_pressed) = ui.input(|i| {
+        let delta =
+            i.key_pressed(egui::Key::ArrowDown) as i32 - i.key_pressed(egui::Key::ArrowUp) as i32;
+        (delta, i.key_pressed(egui::Key::Enter))
+    });
+
     let suggestions_open =
-        (response.has_focus() || response.lost_focus()) && !filtered_suggestions.is_empty();
+        (response.has_focus() || response.lost_focus() || index_delta != 0) && num_suggestions > 0;
+
+    // Persist the selected index using egui's temporary data storage if the suggestions popup is open.
+    let selected_index: Option<usize> = if suggestions_open {
+        let previous_index = ui.ctx().data(|d| d.get_temp::<usize>(response.id));
+        let index = if index_delta != 0 {
+            // (prev + n + delta) % n handles both directions correctly.
+            let base = previous_index.map_or(if index_delta > 0 { usize::MAX } else { 0 }, |i| i);
+            Some(
+                (base
+                    .wrapping_add(num_suggestions)
+                    .wrapping_add_signed(index_delta as isize))
+                    % num_suggestions,
+            )
+        } else {
+            previous_index
+        };
+        if let Some(i) = index {
+            ui.ctx().data_mut(|d| d.insert_temp(response.id, i));
+        }
+        index
+    } else {
+        ui.ctx().data_mut(|d| d.remove::<usize>(response.id));
+        None
+    };
+
+    // If enter was pressed, confirm the selection and don't show the suggestion popup.
+    if enter_pressed
+        && let Some(idx) = selected_index
+        && let Some(suggestion) = filtered_suggestions.get(idx)
+    {
+        text_buffer.replace_with(suggestion);
+        response.mark_changed();
+        return response;
+    }
 
     let width = response.rect.width();
 
     let mut changed = false;
     let suggestions_ui = |ui: &mut egui::Ui| {
-        for suggestion in &filtered_suggestions {
+        for (idx, suggestion) in filtered_suggestions.iter().enumerate() {
+            let is_selected = selected_index == Some(idx);
             let completion = suggestion.strip_prefix(text_buffer.as_str()).unwrap_or("");
 
             let mut layout_job = egui::text::LayoutJob::default();
@@ -54,10 +98,17 @@ pub fn autocomplete_text_edit(
                 ),
             );
 
-            if ui
-                .add(egui::Button::new(layout_job).min_size(egui::vec2(width, 0.0)))
-                .clicked()
-            {
+            let button = egui::Button::new(layout_job)
+                .min_size(egui::vec2(width, 0.0))
+                .selected(is_selected);
+            let button_response = ui.add(button);
+
+            if is_selected {
+                // Make sure the selected item is visible also when using up/down keys.
+                button_response.scroll_to_me(Some(egui::Align::Center));
+            }
+
+            if button_response.clicked() {
                 changed = true;
                 text_buffer.replace_with(suggestion);
             }


### PR DESCRIPTION
Makes it behave like similar text inputs in other applications that allow both mouse/scroll and up/down + enter to select a suggestion.

https://github.com/user-attachments/assets/fb96513b-15cb-4cab-b0c8-b23706825118

Scrolling behavior:

https://github.com/user-attachments/assets/c6dce81d-4726-44ac-b93d-6d75df129d79

