### PR TITLE
Visualizer queries (`HybridResults`) now apply `ComponentSourceKind` if present

### DIFF
--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -520,14 +520,12 @@ fn coordinate_frame_ui(ui: &mut egui::Ui, ctx: &ViewContext<'_>, data_result: &D
 
     let component_descr = archetypes::CoordinateFrame::descriptor_frame();
     let component = component_descr.component;
-    let query_shadowed_components = true;
     let query_result = latest_at_with_blueprint_resolved_data(
         ctx,
         None,
         &ctx.current_query(),
         data_result,
         [component],
-        query_shadowed_components,
         None, // coordinate frames aren't associated with any particular visualizer
     );
 

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -280,7 +280,7 @@ fn visualizer_components(
         let raw_override =
             result_override.and_then(|c| c.non_empty_component_batch_raw(target_component));
 
-        let result_store = query_result.results.get(mapped_component);
+        let result_store = query_result.store_results.get(mapped_component);
         let raw_store =
             result_store.and_then(|c| c.non_empty_component_batch_raw(mapped_component));
 

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -284,7 +284,7 @@ fn visualizer_components(
         let raw_store =
             result_store.and_then(|c| c.non_empty_component_batch_raw(mapped_component));
 
-        let result_default = query_result.defaults.get(target_component);
+        let result_default = query_result.view_defaults.get(target_component);
         let raw_default =
             result_default.and_then(|c| c.non_empty_component_batch_raw(target_component));
 

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -211,14 +211,12 @@ fn visualizer_components(
     let query_ctx = ctx.query_context(data_result, &store_query);
 
     // Query fully resolved data.
-    let query_shadowed_defaults = true;
     let query_result = latest_at_with_blueprint_resolved_data(
         ctx,
         None, // TODO(andreas): Figure out how to deal with annotation context here.
         &store_query,
         data_result,
         query_info.queried_components(),
-        query_shadowed_defaults,
         Some(instruction),
     );
 

--- a/crates/viewer/re_view/src/chunks_with_component.rs
+++ b/crates/viewer/re_view/src/chunks_with_component.rs
@@ -31,6 +31,14 @@ impl ChunksWithComponent<'_> {
             component: self.component,
         })
     }
+
+    #[inline]
+    pub fn empty(component: ComponentIdentifier) -> Self {
+        Self {
+            chunks: Cow::Borrowed(&[]),
+            component,
+        }
+    }
 }
 
 /// Like [`ChunksWithComponent`] but for a single chunk.

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -63,10 +63,11 @@ pub fn range_with_blueprint_resolved_data<'a>(
             }
         }
 
-        let mut results =
-            ctx.recording_engine()
-                .cache()
-                .range(range_query, &data_result.entity_path, components.iter().copied());
+        let mut results = ctx.recording_engine().cache().range(
+            range_query,
+            &data_result.entity_path,
+            components.iter().copied(),
+        );
 
         // Apply mapping to the results.
         for (target, selector) in &active_remappings {

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -1,8 +1,9 @@
-use nohash_hasher::IntSet;
+use nohash_hasher::{IntMap, IntSet};
 use re_chunk_store::{LatestAtQuery, RangeQuery, RowId};
 use re_log_types::hash::Hash64;
 use re_log_types::{TimeInt, TimelineName};
 use re_query::LatestAtResults;
+use re_sdk_types::blueprint::datatypes::ComponentSourceKind;
 use re_types_core::{Archetype, ComponentIdentifier};
 use re_viewer_context::{DataResult, QueryRange, ViewContext, ViewQuery, ViewerContext};
 
@@ -32,6 +33,9 @@ pub fn range_with_blueprint_resolved_data<'a>(
 ) -> HybridRangeResults<'a> {
     re_tracing::profile_function!(data_result.entity_path.to_string());
 
+    // TODO(andreas): It would be great to avoid querying for overrides & store values that aren't used due to explicit source components.
+    // Logic gets surprisingly complicated quickly though.
+
     let mut components = components.into_iter().collect::<IntSet<_>>();
 
     let overrides = query_overrides(
@@ -40,37 +44,29 @@ pub fn range_with_blueprint_resolved_data<'a>(
         components.iter().copied(),
     );
 
-    // No need to query for components that have overrides.
-    components.retain(|component| overrides.get(*component).is_none());
-
+    // Apply component mappings when querying the recording.
     let mut active_remappings = Vec::new();
+    let mut component_sources = IntMap::default();
     let store_results = {
         // Apply component mappings when querying the recording.]
+        for (target, source) in &visualizer_instruction.component_mappings {
+            component_sources.insert(*target, source.source_kind());
 
-        for (target, selector) in &visualizer_instruction.component_mappings {
-            match selector {
-                re_viewer_context::VisualizerComponentSource::SourceComponent {
-                    source_component,
-                    selector: _, // TODO(RR-3308): implement selector logic
-                } => {
-                    if components.remove(target) {
-                        components.insert(*source_component);
-                        active_remappings.push((*target, *source_component));
-                    }
-                }
-
-                re_viewer_context::VisualizerComponentSource::Override
-                | re_viewer_context::VisualizerComponentSource::Default
-                | re_viewer_context::VisualizerComponentSource::Fallback => {
-                    // TODO(RR-3400): implement the rest of the selectors
-                }
+            if let re_viewer_context::VisualizerComponentSource::SourceComponent {
+                source_component,
+                selector: _, // TODO(RR-3308): implement selector logic
+            } = source
+                && components.remove(target)
+            {
+                components.insert(*source_component);
+                active_remappings.push((*target, *source_component));
             }
         }
 
         let mut results =
             ctx.recording_engine()
                 .cache()
-                .range(range_query, &data_result.entity_path, components);
+                .range(range_query, &data_result.entity_path, components.iter().copied());
 
         // Apply mapping to the results.
         for (target, selector) in &active_remappings {
@@ -86,10 +82,37 @@ pub fn range_with_blueprint_resolved_data<'a>(
         results
     };
 
+    // Auto-determine remaining mapping sources.
+    #[expect(clippy::iter_over_hash_type)] // Doing that to fill another hashmap.
+    for component in &components {
+        match component_sources.entry(*component) {
+            std::collections::hash_map::Entry::Occupied(_) => {}
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let source = if overrides.get(*component).is_some() {
+                    ComponentSourceKind::Override
+                } else if store_results.components.contains_key(component) {
+                    ComponentSourceKind::SourceComponent
+                } else if ctx
+                    .query_result
+                    .view_defaults
+                    .components
+                    .contains_key(component)
+                {
+                    ComponentSourceKind::Default
+                } else {
+                    ComponentSourceKind::Fallback
+                };
+
+                entry.insert(source);
+            }
+        }
+    }
+
     HybridRangeResults {
         overrides,
         store_results,
         view_defaults: &ctx.query_result.view_defaults,
+        component_sources,
         component_mappings_hash: Hash64::hash(&active_remappings),
     }
 }
@@ -113,10 +136,12 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
     latest_at_query: &LatestAtQuery,
     data_result: &'a re_viewer_context::DataResult,
     components: impl IntoIterator<Item = ComponentIdentifier>,
-    query_shadowed_components: bool,
     visualizer_instruction: Option<&re_viewer_context::VisualizerInstruction>,
 ) -> HybridLatestAtResults<'a> {
     // This is called very frequently, don't put a profile scope here.
+
+    // TODO(andreas): It would be great to avoid querying for overrides & store values that aren't used due to explicit source components.
+    // Logic gets surprisingly complicated quickly though.
 
     let mut components = components.into_iter().collect::<IntSet<_>>();
     let overrides = if let Some(visualizer_instruction) = visualizer_instruction {
@@ -133,58 +158,75 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
         )
     };
 
-    // No need to query for components that have overrides unless opted in!
-    if !query_shadowed_components {
-        components.retain(|component| overrides.get(*component).is_none());
-    }
-
     // Apply component mappings when querying the recording.
     let mut active_remappings = Vec::new();
+    let mut component_sources = IntMap::default();
     if let Some(visualizer_instruction) = visualizer_instruction {
-        for (target, selector) in &visualizer_instruction.component_mappings {
-            match selector {
-                re_viewer_context::VisualizerComponentSource::SourceComponent {
-                    source_component,
-                    selector: _, // TODO(RR-3308): implement selector logic
-                } => {
-                    if components.remove(target) {
-                        components.insert(*source_component);
-                        active_remappings.push((*target, *source_component));
-                    }
-                }
+        for (target, source) in &visualizer_instruction.component_mappings {
+            component_sources.insert(*target, source.source_kind());
 
-                re_viewer_context::VisualizerComponentSource::Override
-                | re_viewer_context::VisualizerComponentSource::Default
-                | re_viewer_context::VisualizerComponentSource::Fallback => {
-                    // TODO(RR-3400): implement the rest of the selectors
-                }
+            if let re_viewer_context::VisualizerComponentSource::SourceComponent {
+                source_component,
+                selector: _, // TODO(RR-3308): implement selector logic
+            } = source
+                && components.remove(target)
+            {
+                components.insert(*source_component);
+                active_remappings.push((*target, *source_component));
             }
         }
     }
 
-    let mut results = ctx.viewer_ctx.recording_engine().cache().latest_at(
+    let mut store_results = ctx.viewer_ctx.recording_engine().cache().latest_at(
         latest_at_query,
         &data_result.entity_path,
-        components,
+        components.iter().copied(),
     );
 
     // Apply mapping to the results.
     for (target, selector) in &active_remappings {
-        if let Some(chunk) = results.components.remove(selector) {
+        if let Some(chunk) = store_results.components.remove(selector) {
             let chunk = std::sync::Arc::new(chunk.with_renamed_component(*selector, *target))
                 .to_unit()
                 .expect("The source chunk was a unit chunk.");
-            results.components.insert(*target, chunk);
+            store_results.components.insert(*target, chunk);
+        }
+    }
+
+    // Auto-determine remaining mapping sources.
+    #[expect(clippy::iter_over_hash_type)] // Doing that to fill another hashmap.
+    for component in &components {
+        match component_sources.entry(*component) {
+            std::collections::hash_map::Entry::Occupied(_) => {}
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let source = if overrides.get(*component).is_some() {
+                    ComponentSourceKind::Override
+                } else if store_results.components.contains_key(component) {
+                    ComponentSourceKind::SourceComponent
+                } else if ctx
+                    .query_result
+                    .view_defaults
+                    .components
+                    .contains_key(component)
+                {
+                    ComponentSourceKind::Default
+                } else {
+                    ComponentSourceKind::Fallback
+                };
+
+                entry.insert(source);
+            }
         }
     }
 
     HybridLatestAtResults {
         overrides,
-        store_results: results,
+        store_results,
         view_defaults: &ctx.query_result.view_defaults,
         ctx,
         query: latest_at_query.clone(),
         data_result,
+        component_sources,
         component_indices_hash: Hash64::hash(&active_remappings),
     }
 }
@@ -219,14 +261,12 @@ pub fn query_archetype_with_history<'a>(
         }
         QueryRange::LatestAt => {
             let latest_query = LatestAtQuery::new(*timeline, timeline_cursor);
-            let query_shadowed_defaults = false;
             let results = latest_at_with_blueprint_resolved_data(
                 ctx,
                 None,
                 &latest_query,
                 data_result,
                 components,
-                query_shadowed_defaults,
                 Some(visualizer_instruction),
             );
             (latest_query, results).into()
@@ -335,14 +375,12 @@ impl DataResultQuery for DataResult {
         latest_at_query: &'a LatestAtQuery,
         visualizer_instruction: Option<&re_viewer_context::VisualizerInstruction>,
     ) -> HybridLatestAtResults<'a> {
-        let query_shadowed_components = false;
         latest_at_with_blueprint_resolved_data(
             ctx,
             None,
             latest_at_query,
             self,
             A::all_component_identifiers(),
-            query_shadowed_components,
             visualizer_instruction,
         )
     }
@@ -354,14 +392,12 @@ impl DataResultQuery for DataResult {
         component: ComponentIdentifier,
         visualizer_instruction: Option<&re_viewer_context::VisualizerInstruction>,
     ) -> HybridLatestAtResults<'a> {
-        let query_shadowed_components = false;
         latest_at_with_blueprint_resolved_data(
             ctx,
             None,
             latest_at_query,
             self,
             std::iter::once(component),
-            query_shadowed_components,
             visualizer_instruction,
         )
     }

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -44,7 +44,7 @@ pub fn range_with_blueprint_resolved_data<'a>(
     components.retain(|component| overrides.get(*component).is_none());
 
     let mut active_remappings = Vec::new();
-    let results = {
+    let store_results = {
         // Apply component mappings when querying the recording.]
 
         for (target, selector) in &visualizer_instruction.component_mappings {
@@ -88,7 +88,7 @@ pub fn range_with_blueprint_resolved_data<'a>(
 
     HybridRangeResults {
         overrides,
-        results,
+        store_results,
         view_defaults: &ctx.query_result.view_defaults,
         component_mappings_hash: Hash64::hash(&active_remappings),
     }
@@ -180,12 +180,12 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
 
     HybridLatestAtResults {
         overrides,
-        results,
+        store_results: results,
         view_defaults: &ctx.query_result.view_defaults,
         ctx,
         query: latest_at_query.clone(),
         data_result,
-        component_mappings_hash: Hash64::hash(&active_remappings),
+        component_indices_hash: Hash64::hash(&active_remappings),
     }
 }
 

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -89,7 +89,7 @@ pub fn range_with_blueprint_resolved_data<'a>(
     HybridRangeResults {
         overrides,
         results,
-        defaults: &ctx.query_result.component_defaults,
+        view_defaults: &ctx.query_result.view_defaults,
         component_mappings_hash: Hash64::hash(&active_remappings),
     }
 }
@@ -181,7 +181,7 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
     HybridLatestAtResults {
         overrides,
         results,
-        defaults: &ctx.query_result.component_defaults,
+        view_defaults: &ctx.query_result.view_defaults,
         ctx,
         query: latest_at_query.clone(),
         data_result,

--- a/crates/viewer/re_view/src/results_ext.rs
+++ b/crates/viewer/re_view/src/results_ext.rs
@@ -29,7 +29,7 @@ pub struct HybridLatestAtResults<'a> {
 
     pub component_sources: IntMap<ComponentIdentifier, ComponentSourceKind>,
 
-    /// Hash of mappings applied to [`Self::results`].
+    /// Hash of mappings applied to [`Self::store_results`].
     pub component_indices_hash: Hash64,
 }
 
@@ -45,7 +45,7 @@ pub struct HybridRangeResults<'a> {
 
     pub(crate) component_sources: IntMap<ComponentIdentifier, ComponentSourceKind>,
 
-    /// Hash of mappings applied to [`Self::results`].
+    /// Hash of mappings applied to [`Self::store_results`].
     pub(crate) component_mappings_hash: Hash64,
 }
 

--- a/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/depth_offsets.rs
@@ -83,14 +83,12 @@ fn collect_draw_order_per_visualizer(
     let mut default_draw_order = None; // determined lazily
 
     for (data_result, instruction) in query.iter_visualizer_instruction_for(visualizer_identifier) {
-        let query_shadowed_components = false;
         let draw_order = latest_at_with_blueprint_resolved_data(
             ctx,
             None,
             &latest_at_query,
             data_result,
             [draw_order_descriptor.component],
-            query_shadowed_components,
             Some(instruction),
         )
         .get_mono::<DrawOrder>(draw_order_descriptor.component)

--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -620,7 +620,7 @@ impl EntityTransformIdMapping {
                     fallback
                 },
                 |frame_id| {
-                    let is_mono = results.results.component_mono_raw_quiet(transform_frame_id_component).is_some();
+                    let is_mono = results.store_results.component_mono_raw_quiet(transform_frame_id_component).is_some();
                     if !is_mono {
                         re_log::warn_once!(
                             "Entity {:?} has multiple coordinate frame instances, which is not supported. Using the first one.",

--- a/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
+++ b/crates/viewer/re_view_spatial/src/contexts/transform_tree_context.rs
@@ -213,14 +213,12 @@ impl ViewContextSystem for TransformTreeContext {
                 let transform_frame_id_component =
                     archetypes::CoordinateFrame::descriptor_frame().component;
 
-                let query_shadowed_components = false;
                 latest_at_with_blueprint_resolved_data(
                     ctx,
                     None,
                     &latest_at_query,
                     data_result,
                     [transform_frame_id_component],
-                    query_shadowed_components,
                     None, // Coordinate frame is not visualizer-specific.
                 )
             })
@@ -578,14 +576,12 @@ impl EntityTransformIdMapping {
             let transform_frame_id_component =
                 archetypes::CoordinateFrame::descriptor_frame().component;
 
-            let query_shadowed_components = false;
             let results = latest_at_with_blueprint_resolved_data(
                 ctx,
                 None,
                 &latest_at_query,
                 origin_data_result,
                 [transform_frame_id_component],
-                query_shadowed_components,
                 None,
             );
 

--- a/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/cameras.rs
@@ -245,14 +245,12 @@ impl VisualizerSystem for CamerasVisualizer {
         {
             let time_query = re_chunk_store::LatestAtQuery::new(query.timeline, query.latest_at);
 
-            let query_shadowed_components = false;
             let query_results = latest_at_with_blueprint_resolved_data(
                 ctx,
                 None,
                 &time_query,
                 data_result,
                 Pinhole::all_component_identifiers(),
-                query_shadowed_components,
                 Some(instruction),
             );
 

--- a/crates/viewer/re_view_spatial/src/visualizers/transform_axes_3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/transform_axes_3d.rs
@@ -154,7 +154,6 @@ impl VisualizerSystem for TransformAxes3DVisualizer {
                 &latest_at_query,
                 data_result,
                 [axis_length_identifier, show_frame_identifier],
-                false,
                 Some(instruction),
             );
 

--- a/crates/viewer/re_view_spatial/tests/transparent_geometry.rs
+++ b/crates/viewer/re_view_spatial/tests/transparent_geometry.rs
@@ -66,9 +66,10 @@ fn test_transparent_geometry<A: AsComponents>(
     harness.with_options(
         re_ui::testing::default_snapshot_options_for_3d(size)
             // Transparency rendering on MacOS diverges significantly from the other platforms.
-            .threshold(OsThreshold::new(default_options.threshold).macos(2.2))
+            // (not just on CI but also locally)
+            .threshold(OsThreshold::new(default_options.threshold).macos(2.5))
             .failed_pixel_count_threshold(
-                OsThreshold::new(default_options.failed_pixel_count_threshold).macos(125),
+                OsThreshold::new(default_options.failed_pixel_count_threshold).macos(150),
             ),
     );
     let mut harness = harness.build_ui(|ui| {

--- a/crates/viewer/re_view_spatial/tests/transparent_geometry.rs
+++ b/crates/viewer/re_view_spatial/tests/transparent_geometry.rs
@@ -7,6 +7,7 @@ use re_sdk_types::blueprint::archetypes::EyeControls3D;
 use re_sdk_types::components::{FillMode, Position3D};
 use re_sdk_types::{AsComponents, RowId, archetypes};
 use re_test_context::TestContext;
+use re_test_context::external::egui_kittest::OsThreshold;
 use re_test_viewport::TestContextExt as _;
 use re_view_spatial::SpatialView3D;
 use re_viewer_context::{BlueprintContext as _, RecommendedView, ViewClass as _};
@@ -60,11 +61,19 @@ fn test_transparent_geometry<A: AsComponents>(
 
     let size = egui::vec2(300.0, 300.0);
 
-    let mut harness = test_context
-        .setup_kittest_for_rendering_3d(size)
-        .build_ui(|ui| {
-            test_context.run_with_single_view(ui, view_id);
-        });
+    let default_options = re_ui::testing::default_snapshot_options_for_3d(size);
+    let mut harness = test_context.setup_kittest_for_rendering_3d(size);
+    harness.with_options(
+        re_ui::testing::default_snapshot_options_for_3d(size)
+            // Transparency rendering on MacOS diverges significantly from the other platforms.
+            .threshold(OsThreshold::new(default_options.threshold).macos(2.2))
+            .failed_pixel_count_threshold(
+                OsThreshold::new(default_options.failed_pixel_count_threshold).macos(125),
+            ),
+    );
+    let mut harness = harness.build_ui(|ui| {
+        test_context.run_with_single_view(ui, view_id);
+    });
 
     for (i, orientation_y) in [-1.0, 1.0].into_iter().enumerate() {
         // Flip the camera orientation to ensure sorting works as expected.

--- a/crates/viewer/re_view_tensor/src/visualizer_system.rs
+++ b/crates/viewer/re_view_tensor/src/visualizer_system.rs
@@ -47,14 +47,12 @@ impl VisualizerSystem for TensorSystem {
             let timeline_query = LatestAtQuery::new(query.timeline, query.latest_at);
 
             let annotations = None;
-            let query_shadowed_defaults = false;
             let results = latest_at_with_blueprint_resolved_data(
                 ctx,
                 annotations,
                 &timeline_query,
                 data_result,
                 Tensor::all_component_identifiers(),
-                query_shadowed_defaults,
                 Some(instruction),
             );
 

--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -195,14 +195,12 @@ impl SeriesLinesSystem {
             // * For the secondary components (colors, radii, names, etc), this is a problem
             //   though: you don't want your plot to change color depending on what the currently
             //   visible time range is! Secondary components have to be bootstrapped.
-            let query_shadowed_components = false;
             let bootstrapped_results = latest_at_with_blueprint_resolved_data(
                 ctx,
                 None,
                 &LatestAtQuery::new(query.timeline, query.range.min()),
                 data_result,
                 archetypes::SeriesLines::all_component_identifiers(),
-                query_shadowed_components,
                 Some(instruction),
             );
 

--- a/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/point_visualizer_system.rs
@@ -199,14 +199,12 @@ impl SeriesPointsSystem {
             // * For the secondary components (colors, radii, names, etc), this is a problem
             //   though: you don't want your plot to change color depending on what the currently
             //   visible time range is! Secondary components have to be bootstrapped.
-            let query_shadowed_components = false;
             let bootstrapped_results = latest_at_with_blueprint_resolved_data(
                 ctx,
                 None,
                 &LatestAtQuery::new(query.timeline, query.range.min()),
                 data_result,
                 archetypes::SeriesPoints::all_component_identifiers(),
-                query_shadowed_components,
                 Some(instruction),
             );
 

--- a/crates/viewer/re_view_time_series/tests/blueprint.rs
+++ b/crates/viewer/re_view_time_series/tests/blueprint.rs
@@ -308,11 +308,11 @@ fn setup_blueprint_with_explicit_mapping(test_context: &mut TestContext) -> View
         // * Lines:
         //    * scalar - map to `LinearSpeed` component.
         //    * color - explicitly use fallback.
-        //    * ... everything else is auto, which will pick up the SeriesLines name from the store.
+        //    * … everything else is auto, which will pick up the SeriesLines name from the store.
         // * Points:
         //    * scalar - map to `LinearSpeed` component.
         //    * color - explicitly use provided override (green).
-        //    * ... everything else is auto, which will not pick up anything from the store.
+        //    * … everything else is auto, which will not pick up anything from the store.
         let scalar_mapping = VisualizerComponentMapping {
             target: Scalars::descriptor_scalars().component.as_str().into(),
             source_kind: ComponentSourceKind::SourceComponent,

--- a/crates/viewer/re_view_time_series/tests/snapshots/explicit_component_mapping.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/explicit_component_mapping.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f76f9c7009453098068fd160599cf9b89e80f19ddfc0bb4eebc162f02ca65545
+size 23215

--- a/crates/viewer/re_viewer_context/src/query_context.rs
+++ b/crates/viewer/re_viewer_context/src/query_context.rs
@@ -84,7 +84,7 @@ pub struct DataQueryResult {
     pub num_visualized_entities: usize,
 
     /// Latest-at results for all component defaults in this view.
-    pub component_defaults: re_query::LatestAtResults,
+    pub view_defaults: re_query::LatestAtResults,
 }
 
 impl Default for DataQueryResult {
@@ -93,7 +93,7 @@ impl Default for DataQueryResult {
             tree: Default::default(),
             num_matching_entities: 0,
             num_visualized_entities: 0,
-            component_defaults: re_query::LatestAtResults {
+            view_defaults: re_query::LatestAtResults {
                 entity_path: "<defaults>".into(),
                 query: re_chunk_store::LatestAtQuery::latest(blueprint_timeline()),
                 missing: Default::default(),
@@ -125,7 +125,7 @@ impl Clone for DataQueryResult {
             tree: self.tree.clone(),
             num_matching_entities: self.num_matching_entities,
             num_visualized_entities: self.num_visualized_entities,
-            component_defaults: self.component_defaults.clone(),
+            view_defaults: self.view_defaults.clone(),
         }
     }
 }

--- a/crates/viewer/re_viewer_context/src/view/view_query.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_query.rs
@@ -57,6 +57,15 @@ impl VisualizerComponentSource {
             ComponentSourceKind::Fallback => Self::Fallback,
         }
     }
+
+    pub fn source_kind(&self) -> ComponentSourceKind {
+        match self {
+            Self::SourceComponent { .. } => ComponentSourceKind::SourceComponent,
+            Self::Override => ComponentSourceKind::Override,
+            Self::Default => ComponentSourceKind::Default,
+            Self::Fallback => ComponentSourceKind::Fallback,
+        }
+    }
 }
 
 /// Component mappings for a visualizer instruction.
@@ -82,6 +91,7 @@ pub struct VisualizerInstruction {
     /// Component mappings from target to source (selector).
     ///
     /// Keys are target components, values describe where to source components (selectors).
+    /// Any target component not present here uses an auto-mapping strategy.
     pub component_mappings: VisualizerComponentMappings,
 }
 

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -329,7 +329,7 @@ impl ViewContents {
             tree: DataResultTree::new(data_results, root_handle),
             num_matching_entities,
             num_visualized_entities,
-            component_defaults,
+            view_defaults: component_defaults,
         };
 
         // TODO(andreas): integrate with `add_entity_tree_to_data_results_recursive` above.


### PR DESCRIPTION
### Related

* Fixes RR-3400

### What

This allows to explicitly select default/fallback/store/override (tbd if we merge default/fallback) and have the effects be visible on all visualizers.

Note that this general ability is not limited to plots and not gated behind a feature flag. What is though is the (unfinished) UI as well as flexible remapping in the time series plot. Also, we don't expose writing these mappings in Rust/Python blueprint api.