### PR TITLE
Remove distinction of `ComponentSourceKind::Fallback` & `ComponentSourceKind::Default`

### DIFF
--- a/crates/store/re_sdk_types/definitions/rerun/blueprint/datatypes/visualizer_component_mapping.fbs
+++ b/crates/store/re_sdk_types/definitions/rerun/blueprint/datatypes/visualizer_component_mapping.fbs
@@ -10,21 +10,25 @@ enum ComponentSourceKind: ubyte (
     /// Use an explicit selection defined by `source_component`.
     ///
     /// May or may not make use of a selector string.
+    ///
+    /// If the source component is not found on the entity,
+    /// a heuristically determined value will be used instead.
     SourceComponent,
 
     /// Use a timeless override value that is defined in the blueprint.
     ///
     /// The override value is stored on the same entity as the visualizer instruction
     /// and uses the `target` as its component name.
+    ///
+    /// If there is no override value with the target component name,
+    /// a heuristically determined value will be used instead.
     Override,
 
     /// Default as specified on the view's blueprint.
+    ///
+    /// If the view doesn't specify a default for the target component name,
+    /// a heuristically determined value will be used instead.
     Default,
-
-    /// Make use of the viewer's fallback logic to produce a value.
-    Fallback,
-
-    // TODO(RR-3399): Merge Default & Fallback?
 }
 
 

--- a/crates/store/re_sdk_types/definitions/rerun/blueprint/datatypes/visualizer_component_mapping.fbs
+++ b/crates/store/re_sdk_types/definitions/rerun/blueprint/datatypes/visualizer_component_mapping.fbs
@@ -13,6 +13,7 @@ enum ComponentSourceKind: ubyte (
     ///
     /// If the source component is not found on the entity,
     /// a heuristically determined value will be used instead.
+    // TODO(andreas): this should probably be an error instead (unlike in override/default)?
     SourceComponent,
 
     /// Use a timeless override value that is defined in the blueprint.

--- a/crates/store/re_sdk_types/src/blueprint/datatypes/component_source_kind.rs
+++ b/crates/store/re_sdk_types/src/blueprint/datatypes/component_source_kind.rs
@@ -29,19 +29,25 @@ pub enum ComponentSourceKind {
     /// Use an explicit selection defined by `source_component`.
     ///
     /// May or may not make use of a selector string.
+    ///
+    /// If the source component is not found on the entity,
+    /// a heuristically determined value will be used instead.
     SourceComponent = 1,
 
     /// Use a timeless override value that is defined in the blueprint.
     ///
     /// The override value is stored on the same entity as the visualizer instruction
     /// and uses the `target` as its component name.
+    ///
+    /// If there is no override value with the target component name,
+    /// a heuristically determined value will be used instead.
     Override = 2,
 
     /// Default as specified on the view's blueprint.
+    ///
+    /// If the view doesn't specify a default for the target component name,
+    /// a heuristically determined value will be used instead.
     Default = 3,
-
-    /// Make use of the viewer's fallback logic to produce a value.
-    Fallback = 4,
 }
 
 ::re_types_core::macros::impl_into_cow!(ComponentSourceKind);
@@ -109,7 +115,6 @@ impl ::re_types_core::Loggable for ComponentSourceKind {
                 Some(1) => Ok(Some(Self::SourceComponent)),
                 Some(2) => Ok(Some(Self::Override)),
                 Some(3) => Ok(Some(Self::Default)),
-                Some(4) => Ok(Some(Self::Fallback)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),
@@ -128,7 +133,6 @@ impl std::fmt::Display for ComponentSourceKind {
             Self::SourceComponent => write!(f, "SourceComponent"),
             Self::Override => write!(f, "Override"),
             Self::Default => write!(f, "Default"),
-            Self::Fallback => write!(f, "Fallback"),
         }
     }
 }
@@ -136,25 +140,21 @@ impl std::fmt::Display for ComponentSourceKind {
 impl ::re_types_core::reflection::Enum for ComponentSourceKind {
     #[inline]
     fn variants() -> &'static [Self] {
-        &[
-            Self::SourceComponent,
-            Self::Override,
-            Self::Default,
-            Self::Fallback,
-        ]
+        &[Self::SourceComponent, Self::Override, Self::Default]
     }
 
     #[inline]
     fn docstring_md(self) -> &'static str {
         match self {
             Self::SourceComponent => {
-                "Use an explicit selection defined by `source_component`.\n\nMay or may not make use of a selector string."
+                "Use an explicit selection defined by `source_component`.\n\nMay or may not make use of a selector string.\n\nIf the source component is not found on the entity,\na heuristically determined value will be used instead."
             }
             Self::Override => {
-                "Use a timeless override value that is defined in the blueprint.\n\nThe override value is stored on the same entity as the visualizer instruction\nand uses the `target` as its component name."
+                "Use a timeless override value that is defined in the blueprint.\n\nThe override value is stored on the same entity as the visualizer instruction\nand uses the `target` as its component name.\n\nIf there is no override value with the target component name,\na heuristically determined value will be used instead."
             }
-            Self::Default => "Default as specified on the view's blueprint.",
-            Self::Fallback => "Make use of the viewer's fallback logic to produce a value.",
+            Self::Default => {
+                "Default as specified on the view's blueprint.\n\nIf the view doesn't specify a default for the target component name,\na heuristically determined value will be used instead."
+            }
         }
     }
 }

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -264,8 +264,7 @@ fn visualizer_components(
                 } => Some(*source_component),
 
                 re_viewer_context::VisualizerComponentSource::Override
-                | re_viewer_context::VisualizerComponentSource::Default
-                | re_viewer_context::VisualizerComponentSource::Fallback => {
+                | re_viewer_context::VisualizerComponentSource::Default => {
                     // TODO(RR-3338): Implement ui for other types.
                     None
                 }
@@ -606,8 +605,7 @@ fn source_component_ui(
                         } => Some(source_component.as_str()),
 
                         re_viewer_context::VisualizerComponentSource::Override
-                        | re_viewer_context::VisualizerComponentSource::Default
-                        | re_viewer_context::VisualizerComponentSource::Fallback => {
+                        | re_viewer_context::VisualizerComponentSource::Default => {
                             // TODO(RR-3338): Implement ui for other types.
                             None
                         }

--- a/crates/viewer/re_view/src/query.rs
+++ b/crates/viewer/re_view/src/query.rs
@@ -93,15 +93,8 @@ pub fn range_with_blueprint_resolved_data<'a>(
                     ComponentSourceKind::Override
                 } else if store_results.components.contains_key(component) {
                     ComponentSourceKind::SourceComponent
-                } else if ctx
-                    .query_result
-                    .view_defaults
-                    .components
-                    .contains_key(component)
-                {
-                    ComponentSourceKind::Default
                 } else {
-                    ComponentSourceKind::Fallback
+                    ComponentSourceKind::Default
                 };
 
                 entry.insert(source);
@@ -204,15 +197,8 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
                     ComponentSourceKind::Override
                 } else if store_results.components.contains_key(component) {
                     ComponentSourceKind::SourceComponent
-                } else if ctx
-                    .query_result
-                    .view_defaults
-                    .components
-                    .contains_key(component)
-                {
-                    ComponentSourceKind::Default
                 } else {
-                    ComponentSourceKind::Fallback
+                    ComponentSourceKind::Default
                 };
 
                 entry.insert(source);

--- a/crates/viewer/re_view/src/results_ext.rs
+++ b/crates/viewer/re_view/src/results_ext.rs
@@ -358,7 +358,6 @@ impl RangeResultsExt for HybridRangeResults<'_> {
                         ])
                     })
             }
-            ComponentSourceKind::Fallback => Cow::Owned(Vec::new()),
         };
 
         ChunksWithComponent { chunks, component }
@@ -384,7 +383,6 @@ impl RangeResultsExt for HybridLatestAtResults<'_> {
             }
             ComponentSourceKind::Override => self.overrides.get(component),
             ComponentSourceKind::Default => self.view_defaults.get(component),
-            ComponentSourceKind::Fallback => None,
         };
 
         if let Some(unit_chunk) = unit_chunk {

--- a/crates/viewer/re_view_time_series/tests/blueprint.rs
+++ b/crates/viewer/re_view_time_series/tests/blueprint.rs
@@ -305,14 +305,14 @@ fn setup_blueprint_with_explicit_mapping(test_context: &mut TestContext) -> View
         );
 
         // Two visualizers for the `speed` plot:
-        // * Lines:
-        //    * scalar - map to `LinearSpeed` component.
-        //    * color - explicitly use fallback.
-        //    * … everything else is auto, which will pick up the SeriesLines name from the store.
         // * Points:
         //    * scalar - map to `LinearSpeed` component.
-        //    * color - explicitly use provided override (green).
+        //    * color - explicitly use Default, leading to the fallback since the view default is on lines.
         //    * … everything else is auto, which will not pick up anything from the store.
+        // * Lines:
+        //    * scalar - map to `LinearSpeed` component.
+        //    * color - explicitly use Override
+        //    * … everything else is auto, which will pick up the SeriesLines name from the store.
         let scalar_mapping = VisualizerComponentMapping {
             target: Scalars::descriptor_scalars().component.as_str().into(),
             source_kind: ComponentSourceKind::SourceComponent,
@@ -323,16 +323,16 @@ fn setup_blueprint_with_explicit_mapping(test_context: &mut TestContext) -> View
             &EntityPath::from("plots/speed"),
             view.id,
             [
-                SeriesLines::new().visualizer().with_mappings([
+                SeriesPoints::new().visualizer().with_mappings([
                     blueprint::components::VisualizerComponentMapping(scalar_mapping.clone()),
                     blueprint::components::VisualizerComponentMapping(VisualizerComponentMapping {
-                        target: SeriesLines::descriptor_colors().component.as_str().into(),
-                        source_kind: ComponentSourceKind::Fallback,
+                        target: SeriesPoints::descriptor_colors().component.as_str().into(),
+                        source_kind: ComponentSourceKind::Default,
                         source_component: None,
                         selector: None,
                     }),
                 ]),
-                SeriesPoints::new()
+                SeriesLines::new()
                     .with_colors([components::Color::from_rgb(0, 255, 0)])
                     .visualizer()
                     .with_mappings([

--- a/crates/viewer/re_view_time_series/tests/snapshots/explicit_component_mapping.png
+++ b/crates/viewer/re_view_time_series/tests/snapshots/explicit_component_mapping.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f76f9c7009453098068fd160599cf9b89e80f19ddfc0bb4eebc162f02ca65545
-size 23215
+oid sha256:b02791195de6863ec85ba03383316755dabed493f7e7a2e1360e4286bf162c42
+size 23885

--- a/crates/viewer/re_viewer_context/src/view/view_query.rs
+++ b/crates/viewer/re_viewer_context/src/view/view_query.rs
@@ -28,9 +28,6 @@ pub enum VisualizerComponentSource {
 
     /// See [`ComponentSourceKind::Default`].
     Default,
-
-    /// See [`ComponentSourceKind::Fallback`].
-    Fallback,
 }
 
 impl VisualizerComponentSource {
@@ -53,8 +50,6 @@ impl VisualizerComponentSource {
             ComponentSourceKind::Override => Self::Override,
 
             ComponentSourceKind::Default => Self::Default,
-
-            ComponentSourceKind::Fallback => Self::Fallback,
         }
     }
 
@@ -63,7 +58,6 @@ impl VisualizerComponentSource {
             Self::SourceComponent { .. } => ComponentSourceKind::SourceComponent,
             Self::Override => ComponentSourceKind::Override,
             Self::Default => ComponentSourceKind::Default,
-            Self::Fallback => ComponentSourceKind::Fallback,
         }
     }
 }
@@ -151,13 +145,6 @@ impl VisualizerInstruction {
                     VisualizerComponentSource::Default => VisualizerComponentMapping {
                         target,
                         source_kind: ComponentSourceKind::Default,
-                        source_component: None,
-                        selector: None,
-                    },
-
-                    VisualizerComponentSource::Fallback => VisualizerComponentMapping {
-                        target,
-                        source_kind: ComponentSourceKind::Fallback,
                         source_component: None,
                         selector: None,
                     },

--- a/rerun_cpp/src/rerun/blueprint/datatypes/component_source_kind.hpp
+++ b/rerun_cpp/src/rerun/blueprint/datatypes/component_source_kind.hpp
@@ -26,19 +26,25 @@ namespace rerun::blueprint::datatypes {
         /// Use an explicit selection defined by `source_component`.
         ///
         /// May or may not make use of a selector string.
+        ///
+        /// If the source component is not found on the entity,
+        /// a heuristically determined value will be used instead.
         SourceComponent = 1,
 
         /// Use a timeless override value that is defined in the blueprint.
         ///
         /// The override value is stored on the same entity as the visualizer instruction
         /// and uses the `target` as its component name.
+        ///
+        /// If there is no override value with the target component name,
+        /// a heuristically determined value will be used instead.
         Override = 2,
 
         /// Default as specified on the view's blueprint.
+        ///
+        /// If the view doesn't specify a default for the target component name,
+        /// a heuristically determined value will be used instead.
         Default = 3,
-
-        /// Make use of the viewer's fallback logic to produce a value.
-        Fallback = 4,
     };
 } // namespace rerun::blueprint::datatypes
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/component_source_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/component_source_kind.py
@@ -28,6 +28,9 @@ class ComponentSourceKind(Enum):
     Use an explicit selection defined by `source_component`.
 
     May or may not make use of a selector string.
+
+    If the source component is not found on the entity,
+    a heuristically determined value will be used instead.
     """
 
     Override = 2
@@ -36,13 +39,18 @@ class ComponentSourceKind(Enum):
 
     The override value is stored on the same entity as the visualizer instruction
     and uses the `target` as its component name.
+
+    If there is no override value with the target component name,
+    a heuristically determined value will be used instead.
     """
 
     Default = 3
-    """Default as specified on the view's blueprint."""
+    """
+    Default as specified on the view's blueprint.
 
-    Fallback = 4
-    """Make use of the viewer's fallback logic to produce a value."""
+    If the view doesn't specify a default for the target component name,
+    a heuristically determined value will be used instead.
+    """
 
     @classmethod
     def auto(cls, val: str | int | ComponentSourceKind) -> ComponentSourceKind:
@@ -67,18 +75,14 @@ class ComponentSourceKind(Enum):
 
 ComponentSourceKindLike = (
     ComponentSourceKind
-    | Literal[
-        "Default", "Fallback", "Override", "SourceComponent", "default", "fallback", "override", "sourcecomponent"
-    ]
+    | Literal["Default", "Override", "SourceComponent", "default", "override", "sourcecomponent"]
     | int
 )
 """A type alias for any ComponentSourceKind-like object."""
 
 ComponentSourceKindArrayLike = (
     ComponentSourceKind
-    | Literal[
-        "Default", "Fallback", "Override", "SourceComponent", "default", "fallback", "override", "sourcecomponent"
-    ]
+    | Literal["Default", "Override", "SourceComponent", "default", "override", "sourcecomponent"]
     | int
     | Sequence[ComponentSourceKindLike]
 )


### PR DESCRIPTION
### Related

* Fixes RR-3399
* Direct follow-up to https://github.com/rerun-io/rerun/pull/12590

### What

I did the minimal thing I think it’s actually decent: removed `ComponentSourceKind::Fallback` and documented that _all_ the other variants today will pick fallback if there’s no fallback.

Failure to resolve `ComponentSourceKind::SourceComponent` should almost certainly be an error, but in the interest of small steps I haven't looked further into this and described status quo.

⚠️ as previously noted this removes the ability to enforce the fallback if there is a view default. Had to adjust my nascent mapping test for that a bit.