### PR TITLE
rerun-export: Fix url in example README

### DIFF
--- a/examples/python/rerun_export/README.md
+++ b/examples/python/rerun_export/README.md
@@ -60,7 +60,7 @@ Videos are specified as `key:path`:
 - `key`: Camera identifier (e.g., `front`, `wrist`)
 - `path`: Entity path to the video stream (e.g., `/camera/front`)
 
-The converter expects [VideoStream](../../../docs/content/reference/types/archetypes/video_stream.md) components at the specified paths.
+The converter expects [VideoStream](https://www.rerun.io/docs/reference/types/archetypes/video_stream), components at the specified paths.
 
 ## Example workflow
 


### PR DESCRIPTION
### What

The README for the `rerun-export` example used a relative url to the `VideoStream` archetype page. This isn't supported by our docs build for examples and therefore they fail.
