### PR TITLE
Drop cached videos once all referencing episodes are loaded

### DIFF
--- a/crates/store/re_data_loader/src/lerobot/datasetv3.rs
+++ b/crates/store/re_data_loader/src/lerobot/datasetv3.rs
@@ -181,9 +181,8 @@ impl LeRobotDatasetV3 {
 
     /// Release video blob references for a completed episode.
     fn release_episode_videos(&self, episode: EpisodeIndex) {
-        let episode_data = match self.metadata.get_episode_data(episode) {
-            Some(data) => data,
-            None => return,
+        let Some(episode_data) = self.metadata.get_episode_data(episode) else {
+            return;
         };
 
         let mut cache = self.video_cache.write();


### PR DESCRIPTION
### What

This makes the LeRobot dataset loader a bit smarter, by dropping the cached video blobs from memory as soon as all episodes referencing the blob have been loaded.

This makes the loader a bit better at handling larger datasets.