### PR TITLE
Upload extensionless HTML aliases to GCS for clean URLs

### DIFF
--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -104,6 +104,16 @@ jobs:
         run: |
           pixi run rerun-build-web-release
 
+      - name: "Create HTML aliases without extensions"
+        run: |
+          cd crates/viewer/re_web_viewer_server/web_viewer
+          for f in *.html; do
+            name="${f%.html}"
+            if [ "$name" != "index" ] && [ "$name" != "index_bundled" ]; then
+              cp "$f" "$name"
+            fi
+          done
+
       - name: Build examples
         run: |
           pixi run build-examples rrd --install \

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -62,6 +62,17 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
+      - name: "Create HTML aliases without extensions"
+        run: |
+          cd crates/viewer/re_web_viewer_server/web_viewer
+          for f in *.html; do
+            name="${f%.html}"
+            # Don't create aliases for index.html (GCS serves it as directory index)
+            if [ "$name" != "index" ] && [ "$name" != "index_bundled" ]; then
+              cp "$f" "$name"
+            fi
+          done
+
       - name: Get sha
         id: get-sha
         run: |


### PR DESCRIPTION
Resolves: RR-3687

## Summary
- Adds a CI step to both `reusable_upload_web.yml` and `reusable_publish_web.yml` that copies HTML files (e.g. `signed-in.html`) to extensionless objects (e.g. `signed-in`) before uploading to GCS
- This allows `app.rerun.io/signed-in` to work in addition to `app.rerun.io/signed-in.html`, since the GCS backend bucket + load balancer don't strip `.html` extensions automatically
- `index.html` and `index_bundled.html` are excluded since GCS handles directory index resolution for those

## Test plan
- [x] Manually copied `signed-in.html` → `signed-in` and `signed-out.html` → `signed-out` in `gs://rerun-web-viewer/version/latest/` and verified `app.rerun.io/signed-in` works