### PR TITLE
Fix wrong variable in error message for extra args in log()

### DIFF
--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -125,7 +125,7 @@ def log(
         else:
             raise TypeError(
                 f"Expected an object implementing rerun.AsComponents or an iterable of rerun.DescribedComponentBatch, "
-                f"but got {type(entity)} instead.",
+                f"but got {type(ext)} instead.",
             )
 
     _log_components(


### PR DESCRIPTION
The error message for invalid items in the `extra` parameter of `log()` reported `type(entity)` (the already-validated first argument) instead of `type(ext)` (the actual offending extra argument). This made the error misleading when debugging.