### PR TITLE
Fix `rerun-build-web` failure when `CARGO_TARGET_DIR` is set outside workspace

### DIFF
--- a/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
@@ -94,8 +94,8 @@ pub fn build(
     // in order to support recursive cargo builds (calling `cargo` from within a `build.rs`).
     let target_wasm_dir = Utf8PathBuf::from(format!("{}_wasm", target_directory()));
 
-    // Repository root
-    let root_dir = target_wasm_dir.parent().unwrap();
+    // Workspace root
+    let root_dir = workspace_root();
 
     // Where we will place the final .wasm and .js artifacts.
     assert!(
@@ -149,7 +149,7 @@ pub fn build(
 
         eprintln!("{root_dir}> {cmd:?}");
         let status = cmd
-            .current_dir(root_dir)
+            .current_dir(&root_dir)
             .status()
             .context("Failed to build Wasm")?;
 


### PR DESCRIPTION
### Related

* Closes #12664

### What

* replace `target_wasm_dir.parent().unwrap()` with `workspace_root()` when deriving the repository root directory