### PR TITLE
feat(re_uri): Support path prefix in re_uri for sub-path reverse proxy routing

### DIFF
--- a/crates/store/re_uri/src/origin.rs
+++ b/crates/store/re_uri/src/origin.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use crate::{Error, Scheme};
 
-/// `scheme://hostname:port`
+/// `scheme://hostname:port[/path_prefix]`
 #[derive(
     Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
@@ -10,6 +10,13 @@ pub struct Origin {
     pub scheme: Scheme,
     pub host: url::Host<String>,
     pub port: u16,
+
+    /// Optional path prefix for reverse proxy setups.
+    ///
+    /// For example, `rerun+http://host/my/prefix/proxy` will have
+    /// `path_prefix = Some("my/prefix".to_owned())`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_prefix: Option<String>,
 }
 
 impl Origin {
@@ -21,6 +28,7 @@ impl Origin {
                 std::net::IpAddr::V6(ipv6_addr) => url::Host::Ipv6(ipv6_addr),
             },
             port: socket_addr.port(),
+            path_prefix: None,
         }
     }
 
@@ -32,9 +40,13 @@ impl Origin {
     ///
     /// This is the URL to connect to. An ip of "0.0.0.0" will be shown as "127.0.0.1".
     pub fn as_url(&self) -> String {
-        let Self { scheme, host, port } = self;
+        let Self { scheme, host, port, path_prefix } = self;
         let host = format_host(host);
-        format!("{}://{host}:{port}", scheme.as_http_scheme())
+        let base = format!("{}://{host}:{port}", scheme.as_http_scheme());
+        match path_prefix {
+            Some(prefix) => format!("{base}/{prefix}"),
+            None => base,
+        }
     }
 
     pub fn format_host(&self) -> String {
@@ -49,9 +61,14 @@ impl Origin {
             scheme: _,
             host,
             port,
+            path_prefix,
         } = self;
         let host = format_host(host);
-        format!("http://{host}:{port}")
+        let base = format!("http://{host}:{port}");
+        match path_prefix {
+            Some(prefix) => format!("{base}/{prefix}"),
+            None => base,
+        }
     }
 
     /// Parses a URL and returns the [`crate::Origin`] and the canonical URL (i.e. one that
@@ -109,7 +126,7 @@ impl Origin {
             return Err(Error::UnexpectedOpaqueOrigin(input.to_owned()));
         };
 
-        let origin = Self { scheme, host, port };
+        let origin = Self { scheme, host, port, path_prefix: None };
 
         Ok((origin, http_url))
     }
@@ -125,9 +142,13 @@ impl std::str::FromStr for Origin {
 
 impl std::fmt::Display for Origin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { scheme, host, port } = self;
+        let Self { scheme, host, port, path_prefix } = self;
         let host = format_host(host);
-        write!(f, "{scheme}://{host}:{port}")
+        write!(f, "{scheme}://{host}:{port}")?;
+        if let Some(prefix) = path_prefix {
+            write!(f, "/{prefix}")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/store/re_uri/src/redap_uri.rs
+++ b/crates/store/re_uri/src/redap_uri.rs
@@ -77,16 +77,41 @@ impl std::str::FromStr for RedapUri {
 
         let (origin, http_url) = Origin::replace_and_parse(input, Some(default_localhost_port))?;
 
-        // :warning: We limit the amount of segments, which might need to be
-        // adjusted when adding additional resources.
-        let segments = http_url
+        // Collect all path segments (no limit - we need to find the endpoint keyword)
+        let all_segments: Vec<_> = http_url
             .path_segments()
             .ok_or_else(|| Error::UnexpectedBaseUrl(input.to_owned()))?
-            .take(2)
             .filter(|s| !s.is_empty()) // handle trailing slashes
-            .collect::<Vec<_>>();
+            .collect();
 
-        match segments.as_slice() {
+        // Find the endpoint keyword and split prefix from it.
+        // Supported endpoints: proxy, catalog, entry, dataset
+        let endpoint_pos = all_segments
+            .iter()
+            .position(|s| *s == "proxy" || *s == "catalog" || *s == "entry" || *s == "dataset");
+
+        let (prefix, endpoint_segments): (Vec<String>, Vec<&str>) = match endpoint_pos {
+            Some(pos) => {
+                let prefix: Vec<String> =
+                    all_segments[..pos].iter().map(|s| (*s).to_owned()).collect();
+                // Take at most 2 segments from the endpoint onwards (matching original behavior)
+                let endpoint: Vec<&str> = all_segments[pos..].iter().take(2).copied().collect();
+                (prefix, endpoint)
+            }
+            None => (Vec::new(), all_segments),
+        };
+
+        // Store path prefix in origin so all endpoints automatically get it
+        let origin = if prefix.is_empty() {
+            origin
+        } else {
+            Origin {
+                path_prefix: Some(prefix.join("/")),
+                ..origin
+            }
+        };
+
+        match endpoint_segments.as_slice() {
             ["proxy"] => Ok(Self::Proxy(ProxyUri::new(origin))),
 
             ["catalog"] | [] => Ok(Self::Catalog(CatalogUri::new(origin))),
@@ -154,6 +179,7 @@ mod tests {
             scheme: Scheme::Rerun,
             host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
             port: 1234,
+            path_prefix: None,
         };
         assert_eq!(origin.as_url(), "https://127.0.0.1:1234");
 
@@ -161,6 +187,7 @@ mod tests {
             scheme: Scheme::RerunHttp,
             host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
             port: 1234,
+            path_prefix: None,
         };
         assert_eq!(origin.as_url(), "http://127.0.0.1:1234");
 
@@ -168,6 +195,7 @@ mod tests {
             scheme: Scheme::RerunHttps,
             host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
             port: 1234,
+            path_prefix: None,
         };
         assert_eq!(origin.as_url(), "https://127.0.0.1:1234");
     }
@@ -320,7 +348,8 @@ mod tests {
                 origin: Origin {
                     scheme: Scheme::RerunHttp,
                     host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
-                    port: 50051
+                    port: 50051,
+                    path_prefix: None,
                 },
             })
         ));
@@ -337,7 +366,8 @@ mod tests {
                 origin: Origin {
                     scheme: Scheme::RerunHttps,
                     host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
-                    port: 50051
+                    port: 50051,
+                    path_prefix: None,
                 }
             })
         ));
@@ -354,7 +384,8 @@ mod tests {
                 origin: Origin {
                     scheme: Scheme::RerunHttp,
                     host: url::Host::<String>::Domain("localhost".to_owned()),
-                    port: 51234
+                    port: 51234,
+                    path_prefix: None,
                 }
             })
         );
@@ -389,7 +420,9 @@ mod tests {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
                 port: 51234,
+                path_prefix: None,
             },
+
         });
 
         assert_eq!(address.unwrap(), expected);
@@ -410,10 +443,72 @@ mod tests {
                 scheme: Scheme::RerunHttp,
                 host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
                 port: 9876,
+                path_prefix: None,
             },
         });
 
         assert_eq!(address.unwrap(), expected);
+    }
+
+    #[test]
+    fn resolved_endpoints_with_prefix() {
+        let cases = [
+            // HTTP
+            (
+                "rerun+http://localhost/a/b/proxy",
+                "http://localhost:9876/a/b",
+            ),
+            (
+                "rerun+http://localhost/a/b/catalog",
+                "http://localhost:51234/a/b",
+            ),
+            (
+                "rerun+http://localhost/a/b/entry/1830B33B45B963E7774455beb91701ae",
+                "http://localhost:51234/a/b",
+            ),
+            (
+                "rerun+http://localhost/a/b/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid",
+                "http://localhost:51234/a/b",
+            ),
+            // HTTPS
+            (
+                "rerun://example.com/foo/bar/proxy",
+                "https://example.com:443/foo/bar",
+            ),
+            (
+                "rerun://example.com/foo/bar/catalog",
+                "https://example.com:443/foo/bar",
+            ),
+            (
+                "rerun://example.com/foo/bar/entry/1830B33B45B963E7774455beb91701ae",
+                "https://example.com:443/foo/bar",
+            ),
+            (
+                "rerun://example.com/foo/bar/dataset/1830B33B45B963E7774455beb91701ae/data?partition_id=pid",
+                "https://example.com:443/foo/bar",
+            ),
+        ];
+
+        for (url, expected) in cases {
+            let result: RedapUri = url.parse().expect("failed to parse proxy URL");
+            assert_eq!(
+                expected,
+                result.origin().as_url(),
+                "failed to resolve {url}"
+            );
+        }
+
+        // Round-trip: Display should produce a parseable URI that resolves the same way
+        for (url, expected) in cases {
+            let result: RedapUri = url.parse().expect("failed to parse URL");
+            let displayed = result.to_string();
+            let reparsed: RedapUri = displayed.parse().expect("failed to re-parse displayed URL");
+            assert_eq!(
+                expected,
+                reparsed.origin().as_url(),
+                "round-trip failed for {url} (displayed as {displayed})"
+            );
+        }
     }
 
     #[test]
@@ -426,6 +521,7 @@ mod tests {
                         scheme: Scheme::Rerun,
                         host: url::Host::Domain("localhost".to_owned()),
                         port: DEFAULT_REDAP_PORT,
+                        path_prefix: None,
                     },
                 }),
             ),
@@ -436,6 +532,7 @@ mod tests {
                         scheme: Scheme::RerunHttp,
                         host: url::Host::Domain("localhost".to_owned()),
                         port: DEFAULT_REDAP_PORT,
+                        path_prefix: None,
                     },
                 }),
             ),
@@ -446,7 +543,9 @@ mod tests {
                         scheme: Scheme::RerunHttp,
                         host: url::Host::Domain("localhost".to_owned()),
                         port: DEFAULT_PROXY_PORT,
+                        path_prefix: None,
                     },
+        
                 }),
             ),
             (
@@ -456,7 +555,9 @@ mod tests {
                         scheme: Scheme::RerunHttp,
                         host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
                         port: DEFAULT_PROXY_PORT,
+                        path_prefix: None,
                     },
+        
                 }),
             ),
             (
@@ -466,6 +567,7 @@ mod tests {
                         scheme: Scheme::RerunHttp,
                         host: url::Host::Domain("example.com".to_owned()),
                         port: 80,
+                        path_prefix: None,
                     },
                 }),
             ),
@@ -476,6 +578,7 @@ mod tests {
                         scheme: Scheme::RerunHttps,
                         host: url::Host::Domain("example.com".to_owned()),
                         port: 443,
+                        path_prefix: None,
                     },
                 }),
             ),
@@ -486,6 +589,7 @@ mod tests {
                         scheme: Scheme::Rerun,
                         host: url::Host::Domain("example.com".to_owned()),
                         port: 443,
+                        path_prefix: None,
                     },
                 }),
             ),
@@ -496,6 +600,7 @@ mod tests {
                         scheme: Scheme::Rerun,
                         host: url::Host::Domain("example.com".to_owned()),
                         port: 420,
+                        path_prefix: None,
                     },
                 }),
             ),
@@ -521,6 +626,7 @@ mod tests {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
                 port: 51234,
+                path_prefix: None,
             },
         });
 
@@ -541,6 +647,7 @@ mod tests {
                 scheme: Scheme::Rerun,
                 host: url::Host::Domain("localhost".to_owned()),
                 port: 123,
+                path_prefix: None,
             },
         });
 

--- a/crates/viewer/re_redap_browser/src/lib.rs
+++ b/crates/viewer/re_redap_browser/src/lib.rs
@@ -23,6 +23,7 @@ pub static LOCAL_ORIGIN: LazyLock<re_uri::Origin> = LazyLock::new(|| re_uri::Ori
     scheme: Scheme::RerunHttps,
     host: url::Host::Domain(String::from("_local_recordings.rerun.io")),
     port: 443,
+    path_prefix: None,
 });
 
 /// Utility function to switch to the examples screen.

--- a/crates/viewer/re_redap_browser/src/server_modal.rs
+++ b/crates/viewer/re_redap_browser/src/server_modal.rs
@@ -118,7 +118,7 @@ impl ServerModal {
                 }
             }
             ServerModalMode::Edit(edit) => {
-                let re_uri::Origin { scheme, host, port } = edit.origin.clone();
+                let re_uri::Origin { scheme, host, port, .. } = edit.origin.clone();
 
                 let credentials = connection_registry.credentials(&edit.origin);
                 let auth = match credentials {
@@ -311,6 +311,7 @@ impl ServerModal {
                     scheme: self.scheme,
                     host,
                     port: self.port,
+                    path_prefix: None,
                 });
 
                 let credentials = match &self.auth.kind {

--- a/crates/viewer/re_viewer_context/src/open_url.rs
+++ b/crates/viewer/re_viewer_context/src/open_url.rs
@@ -28,6 +28,7 @@ pub static EXAMPLES_ORIGIN: LazyLock<re_uri::Origin> = LazyLock::new(|| re_uri::
     scheme: Scheme::RerunHttps,
     host: url::Host::Domain(String::from("_examples.rerun.io")),
     port: 443,
+    path_prefix: None,
 });
 
 /// Types of URLs that can be opened directly in the viewer.

--- a/tests/rust/re_integration_test/src/lib.rs
+++ b/tests/rust/re_integration_test/src/lib.rs
@@ -54,6 +54,7 @@ impl TestServer {
             host: Host::Domain("localhost".to_owned()),
             port: self.port,
             scheme: re_uri::Scheme::RerunHttp,
+            path_prefix: None,
         };
         ConnectionRegistry::new_without_stored_credentials()
             .client(origin)


### PR DESCRIPTION
### Related

* Closes #10373
* Part of #10409

### What

When connecting through a reverse proxy at a sub-path (e.g. rerun+http://host/my-prefix/proxy), the path prefix is dropped and gRPC connections go to the root URL instead.

This is a follow-up to #10409, reworked based on the review feedback there: the path prefix is now stored on Origin rather than on the endpoint structs, so origin.as_url() includes it automatically without needing to patch individual call sites. I'm using this branch successfully in my project which is served from https://HOST/cell/data-viewer

Includes the test case from @jprochazk in the #10409 review.