### PR TITLE
Fix `sensor_msgs::PointCloud2` MCAP parser for empty point clouds

### DIFF
--- a/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/point_cloud_2.rs
+++ b/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/point_cloud_2.rs
@@ -335,8 +335,9 @@ impl MessageParser for PointCloud2MessageParser {
         let point_cloud = cdr::try_decode_message::<sensor_msgs::PointCloud2>(msg.data.as_ref())
             .map_err(|err| Error::Other(anyhow::anyhow!(err)))?;
 
-        ctx.add_timestamp_cell(crate::util::TimestampCell::guess_from_nanos_ros2(
+        ctx.add_timestamp_cell(crate::util::TimestampCell::from_nanos_ros2(
             point_cloud.header.stamp.as_nanos() as u64,
+            ctx.time_type(),
         ));
 
         let Self {


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->
Closes #12683

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
Fixes a panic in the ROS 2 `sensor_msgs/msg/PointCloud2` MCAP parser when loading empty / placeholder point clouds.

Some MCAP files contain `PointCloud2` messages with `point_step == 0`, no fields, and no payload. Rerun previously tried to chunk the point blob using that zero step size, which caused a panic (`chunk size must be non-zero`) and crashed the viewer.

This change adds guards to skip semantic point extraction and per-field extraction when `point_step == 0`, and adds a regression test covering a valid point cloud followed by an empty placeholder message.

No breaking changes.