### PR TITLE
Expose `executable_name` and `executable_path` in Python `spawn()`

### DIFF
--- a/crates/top/re_sdk/src/spawn.rs
+++ b/crates/top/re_sdk/src/spawn.rs
@@ -44,7 +44,7 @@ pub struct SpawnOptions {
     /// Defaults to `rerun`.
     pub executable_name: String,
 
-    /// Enforce a specific executable to use instead of searching though PATH
+    /// Enforce a specific executable to use instead of searching through PATH
     /// for [`Self::executable_name`].
     ///
     /// Unspecified by default.

--- a/rerun_cpp/src/rerun/c/rerun.h
+++ b/rerun_cpp/src/rerun/c/rerun.h
@@ -150,7 +150,7 @@ typedef struct rr_spawn_options {
     /// Defaults to `rerun` if null.
     rr_string executable_name;
 
-    /// Enforce a specific executable to use instead of searching though PATH
+    /// Enforce a specific executable to use instead of searching through PATH
     /// for [`Self::executable_name`].
     ///
     /// Unspecified by default.

--- a/rerun_cpp/src/rerun/spawn_options.hpp
+++ b/rerun_cpp/src/rerun/spawn_options.hpp
@@ -51,7 +51,7 @@ namespace rerun {
         /// Defaults to `rerun` if unset.
         std::string_view executable_name = "rerun";
 
-        /// Enforce a specific executable to use instead of searching though PATH
+        /// Enforce a specific executable to use instead of searching through PATH
         /// for `SpawnOptions::executable_name`.
         std::string_view executable_path;
 

--- a/rerun_py/rerun_sdk/rerun/_spawn.py
+++ b/rerun_py/rerun_sdk/rerun/_spawn.py
@@ -10,6 +10,8 @@ def _spawn_viewer(
     server_memory_limit: str = "1GiB",
     hide_welcome_screen: bool = False,
     detach_process: bool = True,
+    executable_name: str = "rerun",
+    executable_path: str | None = None,
 ) -> None:
     """
     Internal helper to spawn a Rerun Viewer, listening on the given port.
@@ -37,6 +39,16 @@ def _spawn_viewer(
         Hide the normal Rerun welcome screen.
     detach_process:
         Detach Rerun Viewer process from the application process.
+    executable_name:
+        Specifies the name of the Rerun executable.
+        You can omit the `.exe` suffix on Windows.
+
+        Defaults to `rerun`.
+    executable_path:
+        Enforce a specific executable to use instead of searching
+        through PATH for `executable_name`.
+
+        Unspecified by default.
 
     """
 
@@ -56,4 +68,6 @@ def _spawn_viewer(
         server_memory_limit=server_memory_limit,
         hide_welcome_screen=hide_welcome_screen,
         detach_process=detach_process,
+        executable_name=executable_name,
+        executable_path=executable_path,
     )

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -462,6 +462,8 @@ def spawn(
     server_memory_limit: str = "1GiB",
     hide_welcome_screen: bool = False,
     detach_process: bool = True,
+    executable_name: str = "rerun",
+    executable_path: str | None = None,
     default_blueprint: BlueprintLike | None = None,
     recording: RecordingStream | None = None,
 ) -> None:
@@ -494,6 +496,16 @@ def spawn(
         Hide the normal Rerun welcome screen.
     detach_process:
         Detach Rerun Viewer process from the application process.
+    executable_name:
+        Specifies the name of the Rerun executable.
+        You can omit the `.exe` suffix on Windows.
+
+        Defaults to `rerun`.
+    executable_path:
+        Enforce a specific executable to use instead of searching
+        through PATH for `executable_name`.
+
+        Unspecified by default.
     recording:
         Specifies the [`rerun.RecordingStream`][] to use if `connect = True`.
         If left unspecified, defaults to the current active data recording, if there is one.
@@ -516,6 +528,8 @@ def spawn(
         server_memory_limit=server_memory_limit,
         hide_welcome_screen=hide_welcome_screen,
         detach_process=detach_process,
+        executable_name=executable_name,
+        executable_path=executable_path,
     )
 
     if connect:


### PR DESCRIPTION
### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
 The Python spawn() and _spawn_viewer() functions were missing two parameters that were already supported in the Rust SDK, C++ SDK, and even the PyO3       
  bindings layer (python_bridge.rs):                              
                                                                                                                                                             
  - executable_name — Specifies the name of the Rerun executable to search for in PATH (defaults to "rerun").                                                
  - executable_path — Enforces a specific executable path, bypassing PATH lookup entirely.
                                                                                                                                                             
  This PR surfaces both parameters through the Python API with documentation matching the Rust/C++ SDKs.                                                     
                                                                                                                                                             
  Additionally fixes a minor typo in the doc comments for executable_path across three files — "searching though PATH" → "searching through PATH":           
  - crates/top/re_sdk/src/spawn.rs                                
  - rerun_cpp/src/rerun/spawn_options.hpp                                                                                                                    
  - rerun_cpp/src/rerun/c/rerun.h 