### PR TITLE
Remove anyhow from store-layer crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8645,7 +8645,6 @@ name = "re_chunk_store"
 version = "0.31.0-alpha.1+dev"
 dependencies = [
  "ahash",
- "anyhow",
  "arrow",
  "criterion",
  "document-features",
@@ -8998,7 +8997,6 @@ name = "re_entity_db"
 version = "0.31.0-alpha.1+dev"
 dependencies = [
  "ahash",
- "anyhow",
  "arrow",
  "document-features",
  "emath",

--- a/crates/store/re_chunk_store/Cargo.toml
+++ b/crates/store/re_chunk_store/Cargo.toml
@@ -42,7 +42,6 @@ re_types_core.workspace = true
 
 # External dependencies:
 ahash.workspace = true
-anyhow.workspace = true
 arrow.workspace = true
 document-features.workspace = true
 indent.workspace = true
@@ -58,7 +57,6 @@ web-time.workspace = true
 re_format.workspace = true
 re_sdk_types = { workspace = true, features = ["testing"] }
 
-anyhow.workspace = true
 criterion.workspace = true
 insta = { workspace = true, features = ["filters"] }
 mimalloc.workspace = true

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -614,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn store_events() -> anyhow::Result<()> {
+    fn store_events() -> crate::ChunkStoreResult<()> {
         let mut store = ChunkStore::new(
             re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
             Default::default(),

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -78,11 +78,20 @@ pub enum ChunkStoreError {
     #[error(transparent)]
     Chunk(#[from] re_chunk::ChunkError),
 
-    #[error("Failed to load data, parsing error: {0:#}")]
-    Codec(#[from] re_log_encoding::CodecError),
-
     #[error("Failed to load data, semantic error: {0:#}")]
     Sorbet(#[from] re_sorbet::SorbetError),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] re_types_core::SerializationError),
+
+    #[error("Failed to decode: {0:#}")]
+    Decode(#[from] re_log_encoding::DecodeError),
+
+    #[error("I/O error on {}: {err}", path.display())]
+    Io { path: std::path::PathBuf, err: std::io::Error },
+
+    #[error("Unknown store ID: {0:?}")]
+    UnknownStoreId(re_log_types::StoreId),
 
     /// Error when parsing configuration from environment.
     #[error("Failed to parse config: '{name}={value}': {err}")]

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -1002,9 +1002,8 @@ impl ChunkStore {
         let decoder = re_log_encoding::Decoder::decode_eager(std::io::BufReader::new(rrd_file))?;
 
         // TODO(cmc): offload the decoding to a background thread.
-        for res in decoder {
-            let msg = res?;
-            match msg {
+        for msg in decoder {
+            match msg? {
                 re_log_types::LogMsg::SetStoreInfo(info) => {
                     stores.entry(info.info.store_id.clone()).or_insert_with(|| {
                         Self::new(info.info.store_id.clone(), store_config.clone())

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 use ahash::{HashMap, HashSet};
 use itertools::Itertools as _;
@@ -987,24 +987,23 @@ impl ChunkStore {
     pub fn from_rrd_filepath(
         store_config: &ChunkStoreConfig,
         path_to_rrd: impl AsRef<std::path::Path>,
-    ) -> anyhow::Result<BTreeMap<StoreId, Self>> {
+    ) -> ChunkStoreResult<BTreeMap<StoreId, Self>> {
         let path_to_rrd = path_to_rrd.as_ref();
 
         re_tracing::profile_function!(path_to_rrd.to_string_lossy());
 
-        use anyhow::Context as _;
-
         let mut stores = BTreeMap::new();
 
-        let rrd_file = std::fs::File::open(path_to_rrd)
-            .with_context(|| format!("couldn't open {path_to_rrd:?}"))?;
+        let rrd_file = std::fs::File::open(path_to_rrd).map_err(|err| ChunkStoreError::Io {
+            path: path_to_rrd.to_owned(),
+            err,
+        })?;
 
-        let decoder = re_log_encoding::Decoder::decode_eager(std::io::BufReader::new(rrd_file))
-            .with_context(|| format!("couldn't decode {path_to_rrd:?}"))?;
+        let decoder = re_log_encoding::Decoder::decode_eager(std::io::BufReader::new(rrd_file))?;
 
         // TODO(cmc): offload the decoding to a background thread.
         for res in decoder {
-            let msg = res.with_context(|| format!("couldn't decode message {path_to_rrd:?}"))?;
+            let msg = res?;
             match msg {
                 re_log_types::LogMsg::SetStoreInfo(info) => {
                     stores.entry(info.info.store_id.clone()).or_insert_with(|| {
@@ -1014,15 +1013,12 @@ impl ChunkStore {
 
                 re_log_types::LogMsg::ArrowMsg(store_id, msg) => {
                     let Some(store) = stores.get_mut(&store_id) else {
-                        anyhow::bail!("unknown store ID: {store_id:?}");
+                        return Err(ChunkStoreError::UnknownStoreId(store_id));
                     };
 
-                    let chunk = Chunk::from_arrow_msg(&msg)
-                        .with_context(|| format!("couldn't decode chunk {path_to_rrd:?}"))?;
+                    let chunk = Chunk::from_arrow_msg(&msg)?;
 
-                    store
-                        .insert_chunk(&Arc::new(chunk))
-                        .with_context(|| format!("couldn't insert chunk {path_to_rrd:?}"))?;
+                    store.insert_chunk(&Arc::new(chunk))?;
                 }
 
                 re_log_types::LogMsg::BlueprintActivationCommand(_) => {}
@@ -1041,10 +1037,8 @@ impl ChunkStore {
     pub fn from_log_msgs(
         store_config: &ChunkStoreConfig,
         log_msgs: impl IntoIterator<Item = re_log_types::LogMsg>,
-    ) -> anyhow::Result<BTreeMap<StoreId, Self>> {
+    ) -> ChunkStoreResult<BTreeMap<StoreId, Self>> {
         re_tracing::profile_function!();
-
-        use anyhow::Context as _;
 
         let mut stores = BTreeMap::new();
 
@@ -1060,15 +1054,12 @@ impl ChunkStore {
 
                 re_log_types::LogMsg::ArrowMsg(store_id, msg) => {
                     let Some(store) = stores.get_mut(&store_id) else {
-                        anyhow::bail!("unknown store ID: {store_id:?}");
+                        return Err(ChunkStoreError::UnknownStoreId(store_id));
                     };
 
-                    let chunk = Chunk::from_arrow_msg(&msg)
-                        .with_context(|| "couldn't decode chunk".to_owned())?;
+                    let chunk = Chunk::from_arrow_msg(&msg)?;
 
-                    store
-                        .insert_chunk(&Arc::new(chunk))
-                        .with_context(|| "couldn't insert chunk".to_owned())?;
+                    store.insert_chunk(&Arc::new(chunk))?;
                 }
 
                 re_log_types::LogMsg::BlueprintActivationCommand(_) => {}
@@ -1090,7 +1081,7 @@ impl ChunkStore {
     pub fn handle_from_rrd_filepath(
         store_config: &ChunkStoreConfig,
         path_to_rrd: impl AsRef<std::path::Path>,
-    ) -> anyhow::Result<BTreeMap<StoreId, ChunkStoreHandle>> {
+    ) -> ChunkStoreResult<BTreeMap<StoreId, ChunkStoreHandle>> {
         Ok(Self::from_rrd_filepath(store_config, path_to_rrd)?
             .into_iter()
             .map(|(store_id, store)| (store_id, ChunkStoreHandle::new(store)))

--- a/crates/store/re_chunk_store/src/subscribers.rs
+++ b/crates/store/re_chunk_store/src/subscribers.rs
@@ -164,8 +164,8 @@ impl ChunkStore {
 
     /// Registers a [`PerStoreChunkSubscriber`] type so it gets automatically notified when data gets added and/or
     /// removed to/from a [`ChunkStore`].
-    pub fn register_per_store_subscriber<S: PerStoreChunkSubscriber + Default + 'static>()
-    -> ChunkStoreSubscriberHandle {
+    pub fn register_per_store_subscriber<S: PerStoreChunkSubscriber + Default + 'static>(
+    ) -> ChunkStoreSubscriberHandle {
         let mut subscribers = SUBSCRIBERS.write();
         subscribers.push(RwLock::new(Box::new(
             PerStoreStoreSubscriberWrapper::<S>::default(),
@@ -351,7 +351,7 @@ mod tests {
     }
 
     #[test]
-    fn store_subscriber() -> anyhow::Result<()> {
+    fn store_subscriber() -> crate::ChunkStoreResult<()> {
         let mut store1 = ChunkStore::new(
             re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
             Default::default(),

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -1049,7 +1049,7 @@ mod tests {
     // We can re-assess later if things turns out to be shaky in practice.
 
     #[test]
-    fn compaction_simple() -> anyhow::Result<()> {
+    fn compaction_simple() -> crate::ChunkStoreResult<()> {
         re_log::setup_logging();
 
         let mut store = ChunkStore::new(
@@ -1240,7 +1240,7 @@ mod tests {
     }
 
     #[test]
-    fn no_components() -> anyhow::Result<()> {
+    fn no_components() -> crate::ChunkStoreResult<()> {
         re_log::setup_logging();
         let mut store = ChunkStore::new(
             re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
@@ -1304,7 +1304,7 @@ mod tests {
     }
 
     #[test]
-    fn static_overwrites() -> anyhow::Result<()> {
+    fn static_overwrites() -> crate::ChunkStoreResult<()> {
         re_log::setup_logging();
 
         let mut store = ChunkStore::new(
@@ -1441,7 +1441,7 @@ mod tests {
     }
 
     #[test]
-    fn row_id_min_overwrites() -> anyhow::Result<()> {
+    fn row_id_min_overwrites() -> crate::ChunkStoreResult<()> {
         re_log::setup_logging();
 
         let entity_path = EntityPath::from("this/that");
@@ -1557,7 +1557,7 @@ mod tests {
     }
 
     #[test]
-    fn compaction_blobs() -> anyhow::Result<()> {
+    fn compaction_blobs() -> crate::ChunkStoreResult<()> {
         #![expect(clippy::cloned_ref_to_slice_refs)]
 
         re_log::setup_logging();

--- a/crates/store/re_chunk_store/tests/correctness.rs
+++ b/crates/store/re_chunk_store/tests/correctness.rs
@@ -7,8 +7,8 @@ use re_chunk::{Chunk, ChunkId, RowId, TimelineName};
 use re_chunk_store::{ChunkStore, ChunkStoreError, ChunkTrackingMode, LatestAtQuery};
 use re_log_types::example_components::{MyIndex, MyPoint, MyPoints};
 use re_log_types::{
-    Duration, EntityPath, TimeInt, TimePoint, TimeType, Timeline, Timestamp, build_frame_nr,
-    build_log_time,
+    build_frame_nr, build_log_time, Duration, EntityPath, TimeInt, TimePoint, TimeType, Timeline,
+    Timestamp,
 };
 use re_sdk_types::ComponentIdentifier;
 
@@ -46,7 +46,7 @@ fn query_latest_component<C: re_types_core::Component>(
 // ---
 
 #[test]
-fn row_id_ordering_semantics() -> anyhow::Result<()> {
+fn row_id_ordering_semantics() -> re_chunk_store::ChunkStoreResult<()> {
     let entity_path: EntityPath = "some_entity".into();
 
     let timeline_frame = Timeline::new_sequence("frame");
@@ -265,7 +265,7 @@ fn row_id_ordering_semantics() -> anyhow::Result<()> {
 // ---
 
 #[test]
-fn write_errors() -> anyhow::Result<()> {
+fn write_errors() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let entity_path = EntityPath::from("this/that");
@@ -304,7 +304,7 @@ fn write_errors() -> anyhow::Result<()> {
 // ---
 
 #[test]
-fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
+fn latest_at_emptiness_edge_cases() -> re_chunk_store::ChunkStoreResult<()> {
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
         Default::default(),
@@ -384,7 +384,7 @@ fn latest_at_emptiness_edge_cases() -> anyhow::Result<()> {
 // ---
 
 #[test]
-fn entity_min_time_correct() -> anyhow::Result<()> {
+fn entity_min_time_correct() -> re_chunk_store::ChunkStoreResult<()> {
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
         Default::default(),
@@ -413,11 +413,9 @@ fn entity_min_time_correct() -> anyhow::Result<()> {
         .build()?;
     store.insert_chunk(&Arc::new(chunk))?;
 
-    assert!(
-        store
-            .entity_min_time(timeline_wrong_name.name(), &entity_path)
-            .is_none()
-    );
+    assert!(store
+        .entity_min_time(timeline_wrong_name.name(), &entity_path)
+        .is_none());
     assert_eq!(
         store.entity_min_time(timeline_frame_nr.name(), &entity_path),
         Some(TimeInt::new_temporal(42))
@@ -426,11 +424,9 @@ fn entity_min_time_correct() -> anyhow::Result<()> {
         store.entity_min_time(timeline_log_time.name(), &entity_path),
         Some(TimeInt::from(now))
     );
-    assert!(
-        store
-            .entity_min_time(timeline_frame_nr.name(), &wrong_entity_path)
-            .is_none()
-    );
+    assert!(store
+        .entity_min_time(timeline_frame_nr.name(), &wrong_entity_path)
+        .is_none());
 
     // insert row in the future, these shouldn't be visible
     let chunk = Chunk::builder(entity_path.clone())
@@ -444,11 +440,9 @@ fn entity_min_time_correct() -> anyhow::Result<()> {
         .build()?;
     store.insert_chunk(&Arc::new(chunk))?;
 
-    assert!(
-        store
-            .entity_min_time(timeline_wrong_name.name(), &entity_path)
-            .is_none()
-    );
+    assert!(store
+        .entity_min_time(timeline_wrong_name.name(), &entity_path)
+        .is_none());
     assert_eq!(
         store.entity_min_time(timeline_frame_nr.name(), &entity_path),
         Some(TimeInt::new_temporal(42))
@@ -457,11 +451,9 @@ fn entity_min_time_correct() -> anyhow::Result<()> {
         store.entity_min_time(timeline_log_time.name(), &entity_path),
         Some(TimeInt::from(now))
     );
-    assert!(
-        store
-            .entity_min_time(timeline_frame_nr.name(), &wrong_entity_path)
-            .is_none()
-    );
+    assert!(store
+        .entity_min_time(timeline_frame_nr.name(), &wrong_entity_path)
+        .is_none());
 
     // insert row in the past, these should be visible
     let chunk = Chunk::builder(entity_path.clone())
@@ -475,11 +467,9 @@ fn entity_min_time_correct() -> anyhow::Result<()> {
         .build()?;
     store.insert_chunk(&Arc::new(chunk))?;
 
-    assert!(
-        store
-            .entity_min_time(timeline_wrong_name.name(), &entity_path)
-            .is_none()
-    );
+    assert!(store
+        .entity_min_time(timeline_wrong_name.name(), &entity_path)
+        .is_none());
     assert_eq!(
         store.entity_min_time(timeline_frame_nr.name(), &entity_path),
         Some(TimeInt::new_temporal(32))
@@ -488,11 +478,9 @@ fn entity_min_time_correct() -> anyhow::Result<()> {
         store.entity_min_time(timeline_log_time.name(), &entity_path),
         Some(TimeInt::from(now_minus_one))
     );
-    assert!(
-        store
-            .entity_min_time(timeline_frame_nr.name(), &wrong_entity_path)
-            .is_none()
-    );
+    assert!(store
+        .entity_min_time(timeline_frame_nr.name(), &wrong_entity_path)
+        .is_none());
 
     Ok(())
 }

--- a/crates/store/re_chunk_store/tests/dataframe.rs
+++ b/crates/store/re_chunk_store/tests/dataframe.rs
@@ -7,13 +7,13 @@ use re_chunk_store::{
     ViewContentsSelector,
 };
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoints};
-use re_log_types::{EntityPath, build_frame_nr};
+use re_log_types::{build_frame_nr, EntityPath};
 use re_sdk_types::{AnyValues, AsComponents as _};
 use re_sorbet::ChunkColumnDescriptors;
 
 #[test]
 /// Tests whether the store has the expected schema after populating it with a chunk.
-fn schema() -> anyhow::Result<()> {
+fn schema() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -68,7 +68,7 @@ fn schema() -> anyhow::Result<()> {
 
 #[test]
 /// Tests whether the `schema_for_query` for a given query has the expected contents.
-fn schema_for_query() -> anyhow::Result<()> {
+fn schema_for_query() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -136,7 +136,7 @@ fn schema_for_query() -> anyhow::Result<()> {
 }
 
 #[test]
-fn schema_static_columns() -> anyhow::Result<()> {
+fn schema_static_columns() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(

--- a/crates/store/re_chunk_store/tests/drop_time_range.rs
+++ b/crates/store/re_chunk_store/tests/drop_time_range.rs
@@ -9,7 +9,7 @@ use re_log_types::example_components::{MyColor, MyPoints};
 use re_log_types::{AbsoluteTimeRange, EntityPath, TimePoint, Timeline};
 
 #[test]
-fn drop_time_range() -> anyhow::Result<()> {
+fn drop_time_range() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let entity_path = EntityPath::from("this/that");

--- a/crates/store/re_chunk_store/tests/formatting.rs
+++ b/crates/store/re_chunk_store/tests/formatting.rs
@@ -4,12 +4,12 @@ use insta::Settings;
 use re_chunk::{Chunk, ChunkId, RowId};
 use re_chunk_store::ChunkStore;
 use re_log_types::example_components::{MyColor, MyIndex, MyPoints};
-use re_log_types::{ApplicationId, EntityPath, Timestamp, build_frame_nr, build_log_time};
+use re_log_types::{build_frame_nr, build_log_time, ApplicationId, EntityPath, Timestamp};
 use re_types_core::ComponentBatch as _;
 
 /// Ensure that `ChunkStore::to_string()` is nice and readable.
 #[test]
-fn format_chunk_store() -> anyhow::Result<()> {
+fn format_chunk_store() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(

--- a/crates/store/re_chunk_store/tests/gc.rs
+++ b/crates/store/re_chunk_store/tests/gc.rs
@@ -10,9 +10,9 @@ use re_chunk_store::{
     GarbageCollectionTarget,
 };
 use re_log_types::example_components::{MyColor, MyIndex, MyPoint, MyPoints};
-use re_log_types::{AbsoluteTimeRange, EntityPath, Timestamp, build_frame_nr, build_log_time};
-use re_sdk_types::ComponentDescriptor;
+use re_log_types::{build_frame_nr, build_log_time, AbsoluteTimeRange, EntityPath, Timestamp};
 use re_sdk_types::testing::{build_some_large_structs, large_struct_descriptor};
+use re_sdk_types::ComponentDescriptor;
 
 // ---
 
@@ -44,7 +44,7 @@ fn query_latest_array(
 // ---
 
 #[test]
-fn simple() -> anyhow::Result<()> {
+fn simple() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut rng = rand::rng();
@@ -105,7 +105,7 @@ fn simple() -> anyhow::Result<()> {
 }
 
 #[test]
-fn simple_static() -> anyhow::Result<()> {
+fn simple_static() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -221,7 +221,7 @@ fn simple_static() -> anyhow::Result<()> {
 }
 
 #[test]
-fn protected() -> anyhow::Result<()> {
+fn protected() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -351,7 +351,7 @@ fn protected() -> anyhow::Result<()> {
 }
 
 #[test]
-fn protected_time_ranges() -> anyhow::Result<()> {
+fn protected_time_ranges() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -449,7 +449,7 @@ fn protected_time_ranges() -> anyhow::Result<()> {
 // ---
 
 #[test]
-fn manual_drop_entity_path() -> anyhow::Result<()> {
+fn manual_drop_entity_path() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -8,7 +8,7 @@ use re_chunk_store::{
     TimeInt,
 };
 use re_log_types::example_components::{MyColor, MyIndex, MyPoint, MyPoints};
-use re_log_types::{EntityPath, TimeType, Timeline, build_frame_nr};
+use re_log_types::{build_frame_nr, EntityPath, TimeType, Timeline};
 use re_sdk_types::testing::{build_some_large_structs, large_struct_descriptor};
 use re_sdk_types::{ComponentDescriptor, ComponentSet};
 
@@ -47,7 +47,7 @@ fn query_latest_array(
 // ---
 
 #[test]
-fn all_components() -> anyhow::Result<()> {
+fn all_components() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let entity_path = EntityPath::from("this/that");
@@ -129,7 +129,7 @@ fn all_components() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_all_components_on_timeline() -> anyhow::Result<()> {
+fn test_all_components_on_timeline() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let entity_path1 = EntityPath::from("both/timeline");
@@ -164,32 +164,24 @@ fn test_all_components_on_timeline() -> anyhow::Result<()> {
     store.insert_chunk(&Arc::new(chunk))?;
 
     // entity1 is on both timelines
-    assert!(
-        !store
-            .all_components_on_timeline(timeline1.name(), &entity_path1)
-            .unwrap()
-            .is_empty()
-    );
-    assert!(
-        !store
-            .all_components_on_timeline(timeline2.name(), &entity_path1)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(!store
+        .all_components_on_timeline(timeline1.name(), &entity_path1)
+        .unwrap()
+        .is_empty());
+    assert!(!store
+        .all_components_on_timeline(timeline2.name(), &entity_path1)
+        .unwrap()
+        .is_empty());
 
     // entity2 is only on timeline1
-    assert!(
-        !store
-            .all_components_on_timeline(timeline1.name(), &entity_path2)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(!store
+        .all_components_on_timeline(timeline1.name(), &entity_path2)
+        .unwrap()
+        .is_empty());
 
-    assert!(
-        store
-            .all_components_on_timeline(timeline2.name(), &entity_path2)
-            .is_none()
-    );
+    assert!(store
+        .all_components_on_timeline(timeline2.name(), &entity_path2)
+        .is_none());
 
     Ok(())
 }
@@ -197,7 +189,7 @@ fn test_all_components_on_timeline() -> anyhow::Result<()> {
 // ---
 
 #[test]
-fn latest_at() -> anyhow::Result<()> {
+fn latest_at() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -377,7 +369,7 @@ fn latest_at() -> anyhow::Result<()> {
 }
 
 #[test]
-fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
+fn latest_at_sparse_component_edge_case() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -520,7 +512,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
 }
 
 #[test]
-fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
+fn latest_at_overlapped_chunks() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -690,7 +682,7 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
 // ---
 
 #[test]
-fn range() -> anyhow::Result<()> {
+fn range() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(
@@ -1058,7 +1050,7 @@ fn range() -> anyhow::Result<()> {
 }
 
 #[test]
-fn range_overlapped_chunks() -> anyhow::Result<()> {
+fn range_overlapped_chunks() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(

--- a/crates/store/re_chunk_store/tests/stats.rs
+++ b/crates/store/re_chunk_store/tests/stats.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use re_chunk::{Chunk, RowId, TimePoint};
 use re_chunk_store::{ChunkStore, ChunkStoreConfig, TimeInt};
 use re_log_types::example_components::{MyColor, MyPoint, MyPoints};
-use re_log_types::{EntityPath, build_frame_nr};
+use re_log_types::{build_frame_nr, EntityPath};
 
 #[test]
-fn stats() -> anyhow::Result<()> {
+fn stats() -> re_chunk_store::ChunkStoreResult<()> {
     re_log::setup_logging();
 
     let mut store = ChunkStore::new(

--- a/crates/store/re_entity_db/Cargo.toml
+++ b/crates/store/re_entity_db/Cargo.toml
@@ -64,7 +64,6 @@ web-time.workspace = true
 [dev-dependencies]
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
 
-anyhow.workspace = true
 insta.workspace = true
 similar-asserts.workspace = true
 

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -28,9 +28,9 @@ use re_query::{
     QueryCache, QueryCacheHandle, StorageEngine, StorageEngineArcReadGuard, StorageEngineReadGuard,
 };
 
-use crate::Error;
 use crate::ingestion_statistics::IngestionStatistics;
 use crate::rrd_manifest_index::RrdManifestIndex;
+use crate::Error;
 
 // ----------------------------------------------------------------------------
 
@@ -1380,7 +1380,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_with_components() -> anyhow::Result<()> {
+    fn format_with_components() -> crate::Result<()> {
         re_log::setup_logging();
 
         let mut db = EntityDb::new(StoreId::random(

--- a/crates/store/re_entity_db/src/entity_tree.rs
+++ b/crates/store/re_entity_db/src/entity_tree.rs
@@ -223,7 +223,7 @@ mod tests {
     use crate::EntityDb;
 
     #[test]
-    fn deleting_descendants() -> anyhow::Result<()> {
+    fn deleting_descendants() -> crate::Result<()> {
         re_log::setup_logging();
 
         let mut db = EntityDb::new(StoreId::random(

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -8,9 +8,9 @@ use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
 use re_log_types::example_components::{MyColor, MyIndex, MyPoint, MyPoints};
 use re_log_types::{EntityPath, StoreId, TimeInt, TimePoint, Timeline};
-use re_types_core::ComponentBatch as _;
 use re_types_core::archetypes::Clear;
 use re_types_core::components::ClearIsRecursive;
+use re_types_core::ComponentBatch as _;
 
 // ---
 
@@ -55,7 +55,7 @@ fn query_latest_component_clear(
 
 /// Complete test suite for the clear & pending clear paths.
 #[test]
-fn clears() -> anyhow::Result<()> {
+fn clears() -> re_entity_db::Result<()> {
     re_log::setup_logging();
 
     let mut db = EntityDb::new(StoreId::random(
@@ -183,24 +183,20 @@ fn clears() -> anyhow::Result<()> {
             let query = LatestAtQuery::new(*timeline_frame.name(), 11);
 
             // parent
-            assert!(
-                query_latest_component::<MyPoint>(
-                    &db,
-                    &entity_path_parent,
-                    &query,
-                    MyPoints::descriptor_points().component
-                )
-                .is_none()
-            );
-            assert!(
-                query_latest_component::<MyColor>(
-                    &db,
-                    &entity_path_parent,
-                    &query,
-                    MyPoints::descriptor_colors().component
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyPoint>(
+                &db,
+                &entity_path_parent,
+                &query,
+                MyPoints::descriptor_points().component
+            )
+            .is_none());
+            assert!(query_latest_component::<MyColor>(
+                &db,
+                &entity_path_parent,
+                &query,
+                MyPoints::descriptor_colors().component
+            )
+            .is_none());
             // the `Clear` component itself doesn't get cleared!
             let (_, _, got_clear) =
                 query_latest_component_clear(&db, &entity_path_parent, &query).unwrap();
@@ -212,26 +208,22 @@ fn clears() -> anyhow::Result<()> {
             );
 
             // child1
-            assert!(
-                query_latest_component::<MyPoint>(
-                    &db,
-                    &entity_path_child1,
-                    &query,
-                    MyPoints::descriptor_points().component
-                )
-                .is_some()
-            );
+            assert!(query_latest_component::<MyPoint>(
+                &db,
+                &entity_path_child1,
+                &query,
+                MyPoints::descriptor_points().component
+            )
+            .is_some());
 
             // child2
-            assert!(
-                query_latest_component::<MyColor>(
-                    &db,
-                    &entity_path_child2,
-                    &query,
-                    MyPoints::descriptor_colors().component
-                )
-                .is_some()
-            );
+            assert!(query_latest_component::<MyColor>(
+                &db,
+                &entity_path_child2,
+                &query,
+                MyPoints::descriptor_colors().component
+            )
+            .is_some());
         }
     }
 
@@ -253,24 +245,20 @@ fn clears() -> anyhow::Result<()> {
             let query = LatestAtQuery::new(*timeline_frame.name(), 11);
 
             // parent
-            assert!(
-                query_latest_component::<MyPoint>(
-                    &db,
-                    &entity_path_parent,
-                    &query,
-                    MyPoints::descriptor_points().component
-                )
-                .is_none()
-            );
-            assert!(
-                query_latest_component::<MyColor>(
-                    &db,
-                    &entity_path_parent,
-                    &query,
-                    MyPoints::descriptor_colors().component
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyPoint>(
+                &db,
+                &entity_path_parent,
+                &query,
+                MyPoints::descriptor_points().component
+            )
+            .is_none());
+            assert!(query_latest_component::<MyColor>(
+                &db,
+                &entity_path_parent,
+                &query,
+                MyPoints::descriptor_colors().component
+            )
+            .is_none());
             // the `Clear` component itself doesn't get cleared!
             let (_, _, got_clear) =
                 query_latest_component_clear(&db, &entity_path_parent, &query).unwrap();
@@ -282,26 +270,22 @@ fn clears() -> anyhow::Result<()> {
             );
 
             // child1
-            assert!(
-                query_latest_component::<MyPoint>(
-                    &db,
-                    &entity_path_child1,
-                    &query,
-                    MyPoints::descriptor_points().component
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyPoint>(
+                &db,
+                &entity_path_child1,
+                &query,
+                MyPoints::descriptor_points().component
+            )
+            .is_none());
 
             // child2
-            assert!(
-                query_latest_component::<MyColor>(
-                    &db,
-                    &entity_path_child2,
-                    &query,
-                    MyPoints::descriptor_colors().component
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyColor>(
+                &db,
+                &entity_path_child2,
+                &query,
+                MyPoints::descriptor_colors().component
+            )
+            .is_none());
         }
     }
 
@@ -339,15 +323,13 @@ fn clears() -> anyhow::Result<()> {
 
         {
             let query = LatestAtQuery::new(*timeline_frame.name(), 11);
-            assert!(
-                query_latest_component::<MyIndex>(
-                    &db,
-                    &entity_path_parent,
-                    &query,
-                    MyIndex::partial_descriptor().component,
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyIndex>(
+                &db,
+                &entity_path_parent,
+                &query,
+                MyIndex::partial_descriptor().component,
+            )
+            .is_none());
         }
     }
 
@@ -393,24 +375,20 @@ fn clears() -> anyhow::Result<()> {
 
         {
             let query = LatestAtQuery::new(*timeline_frame.name(), 11);
-            assert!(
-                query_latest_component::<MyPoint>(
-                    &db,
-                    &entity_path_child1,
-                    &query,
-                    MyPoints::descriptor_points().component
-                )
-                .is_none()
-            );
-            assert!(
-                query_latest_component::<MyColor>(
-                    &db,
-                    &entity_path_child1,
-                    &query,
-                    MyPoints::descriptor_colors().component
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyPoint>(
+                &db,
+                &entity_path_child1,
+                &query,
+                MyPoints::descriptor_points().component
+            )
+            .is_none());
+            assert!(query_latest_component::<MyColor>(
+                &db,
+                &entity_path_child1,
+                &query,
+                MyPoints::descriptor_colors().component
+            )
+            .is_none());
         }
     }
 
@@ -456,24 +434,20 @@ fn clears() -> anyhow::Result<()> {
 
         {
             let query = LatestAtQuery::new(*timeline_frame.name(), 11);
-            assert!(
-                query_latest_component::<MyPoint>(
-                    &db,
-                    &entity_path_child2,
-                    &query,
-                    MyPoints::descriptor_points().component
-                )
-                .is_none()
-            );
-            assert!(
-                query_latest_component::<MyColor>(
-                    &db,
-                    &entity_path_child2,
-                    &query,
-                    MyPoints::descriptor_colors().component
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyPoint>(
+                &db,
+                &entity_path_child2,
+                &query,
+                MyPoints::descriptor_points().component
+            )
+            .is_none());
+            assert!(query_latest_component::<MyColor>(
+                &db,
+                &entity_path_child2,
+                &query,
+                MyPoints::descriptor_colors().component
+            )
+            .is_none());
         }
     }
 
@@ -509,15 +483,13 @@ fn clears() -> anyhow::Result<()> {
 
         {
             let query = LatestAtQuery::new(*timeline_frame.name(), 11);
-            assert!(
-                query_latest_component::<MyColor>(
-                    &db,
-                    &entity_path_grandchild,
-                    &query,
-                    MyPoints::descriptor_colors().component
-                )
-                .is_none()
-            );
+            assert!(query_latest_component::<MyColor>(
+                &db,
+                &entity_path_grandchild,
+                &query,
+                MyPoints::descriptor_colors().component
+            )
+            .is_none());
         }
     }
 
@@ -525,7 +497,7 @@ fn clears() -> anyhow::Result<()> {
 }
 
 #[test]
-fn clears_respect_index_order() -> anyhow::Result<()> {
+fn clears_respect_index_order() -> re_entity_db::Result<()> {
     re_log::setup_logging();
 
     let mut db = EntityDb::new(StoreId::random(
@@ -609,15 +581,13 @@ fn clears_respect_index_order() -> anyhow::Result<()> {
     {
         let query = LatestAtQuery::new(*timeline_frame.name(), 11);
 
-        assert!(
-            query_latest_component::<MyPoint>(
-                &db,
-                &entity_path,
-                &query,
-                MyPoints::descriptor_points().component
-            )
-            .is_none()
-        );
+        assert!(query_latest_component::<MyPoint>(
+            &db,
+            &entity_path,
+            &query,
+            MyPoints::descriptor_points().component
+        )
+        .is_none());
 
         // the `Clear` component itself doesn't get cleared!
         let (_, _, got_clear) = query_latest_component_clear(&db, &entity_path, &query).unwrap();

--- a/crates/store/re_query/Cargo.toml
+++ b/crates/store/re_query/Cargo.toml
@@ -41,7 +41,6 @@ re_types_core.workspace = true
 
 # External dependencies:
 ahash.workspace = true
-anyhow.workspace = true
 arrow.workspace = true
 indent.workspace = true
 itertools.workspace = true
@@ -56,6 +55,7 @@ thiserror.workspace = true
 re_log_encoding.workspace = true
 re_sdk_types.workspace = true
 
+anyhow.workspace = true
 bytemuck.workspace = true
 criterion.workspace = true
 mimalloc.workspace = true

--- a/crates/store/re_query/examples/query_latest_at.rs
+++ b/crates/store/re_query/examples/query_latest_at.rs
@@ -8,7 +8,7 @@ use re_chunk::{Chunk, RowId, TimelineName};
 use re_chunk_store::{ChunkStore, ChunkStoreHandle, LatestAtQuery};
 use re_log_types::build_frame_nr;
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoints};
-use re_query::{LatestAtResults, clamped_zip_1x2};
+use re_query::{clamped_zip_1x2, LatestAtResults};
 use re_types_core::Archetype as _;
 
 // ---

--- a/crates/store/re_query/examples/query_range.rs
+++ b/crates/store/re_query/examples/query_range.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use itertools::{Itertools as _, izip};
+use itertools::{izip, Itertools as _};
 use re_chunk::{Chunk, RowId};
 use re_chunk_store::{ChunkStore, ChunkStoreHandle, RangeQuery};
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoints};
-use re_log_types::{AbsoluteTimeRange, TimeType, Timeline, build_frame_nr};
-use re_query::{RangeResults, clamped_zip_1x2, range_zip_1x2};
+use re_log_types::{build_frame_nr, AbsoluteTimeRange, TimeType, Timeline};
+use re_query::{clamped_zip_1x2, range_zip_1x2, RangeResults};
 use re_types_core::Archetype as _;
 
 // ---

--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -69,8 +69,6 @@ pub enum QueryError {
     #[error("Not implemented")]
     NotImplemented,
 
-    #[error("{}", re_error::format(.0))]
-    Other(#[from] anyhow::Error),
 }
 
 const _: () = assert!(

--- a/crates/store/re_query/tests/range.rs
+++ b/crates/store/re_query/tests/range.rs
@@ -10,14 +10,14 @@ use re_chunk_store::{
     AbsoluteTimeRange, ChunkStore, ChunkStoreSubscriber as _, RangeQuery, TimeInt,
 };
 use re_log_types::example_components::{MyColor, MyPoint, MyPoints};
-use re_log_types::{EntityPath, TimePoint, build_frame_nr};
+use re_log_types::{build_frame_nr, EntityPath, TimePoint};
 use re_query::QueryCache;
 use re_types_core::{Archetype as _, ComponentBatch as _};
 
 // ---
 
 #[test]
-fn simple_range() -> anyhow::Result<()> {
+fn simple_range() -> re_chunk::ChunkResult<()> {
     let store = ChunkStore::new_handle(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
         Default::default(),
@@ -117,7 +117,7 @@ fn simple_range() -> anyhow::Result<()> {
 }
 
 #[test]
-fn simple_range_with_differently_tagged_components() -> anyhow::Result<()> {
+fn simple_range_with_differently_tagged_components() -> re_chunk::ChunkResult<()> {
     let store = ChunkStore::new_handle(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
         Default::default(),
@@ -225,7 +225,7 @@ fn simple_range_with_differently_tagged_components() -> anyhow::Result<()> {
 }
 
 #[test]
-fn static_range() -> anyhow::Result<()> {
+fn static_range() -> re_chunk::ChunkResult<()> {
     let store = ChunkStore::new_handle(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
         Default::default(),

--- a/crates/store/re_server/src/store/dataset.rs
+++ b/crates/store/re_server/src/store/dataset.rs
@@ -673,7 +673,7 @@ impl Dataset {
         re_log::info!("Loading RRD: {}", path.display());
         let contents =
             ChunkStore::handle_from_rrd_filepath(&InMemoryStore::chunk_store_config(), path)
-                .map_err(Error::RrdLoadingError)?;
+                .map_err(|err| Error::RrdLoadingError(err.into()))?;
 
         let layer_name = layer_name.unwrap_or(DataSource::DEFAULT_LAYER);
 


### PR DESCRIPTION

### Related

- Part of #1845

### What
Replace anyhow with thiserror in re_query, re_chunk_store, and re_entity_db library crates.
<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
