### PR TITLE
Fix(web-viewer): clean up loader when startup is interrupted

### DIFF
--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -344,11 +344,6 @@ export class WebViewer {
     setupGlobalEventListeners();
   }
 
-  #clearLoader() {
-    this.#loader?.remove();
-    this.#loader = null;
-  }
-
   /**
    * Start the viewer.
    *
@@ -716,6 +711,11 @@ export class WebViewer {
     }
 
     this.stop();
+  }
+
+  #clearLoader() {
+    this.#loader?.remove();
+    this.#loader = null;
   }
 
   /**


### PR DESCRIPTION
### Related
Closes #12695
<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What
This fixes a loader lifecycle race in `rerun_js/web-viewer`.

`WebViewer.start()` creates and appends the `Loading Rerun…` overlay before several async startup steps. If `stop()` is called during that window, the in-flight `start()` can later resume, detect that the state is no longer `"starting"`, and return early without removing the loader. In React integrations, this can happen during remounts or unmounts, leaving a stale overlay covering a working canvas.

- Promoted the loader from a local `start()` variable to an instance field
- Added a shared `#clearLoader()` helper
- Cleared the loader on all startup exit paths:
  - `load()` failure
  - `handle.start()` failure
  - early return after interrupted startup
  - normal startup completion
- Cleared the loader from `stop()` as well

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
