### PR TITLE
Update README.md with working `run_wasm` example

### DIFF
--- a/run_wasm/README.md
+++ b/run_wasm/README.md
@@ -7,5 +7,5 @@ This is a temporary solution while we're in the process of building our own `xta
 
 You can try it e.g. with the standalone re_renderer demo:
 ```
-cargo run-wasm --example 2d
+cargo run-wasm -p re_renderer_examples --bin 2d
 ```


### PR DESCRIPTION
The example is in a separate crate now, changed the build command to reflect that.