### PR TITLE
Enable `clippy::iter_over_hash_type` in remaining viewer crates

### DIFF
--- a/crates/viewer/re_arrow_ui/src/lib.rs
+++ b/crates/viewer/re_arrow_ui/src/lib.rs
@@ -1,4 +1,7 @@
 //! Show arrow data as a tree of rerun `list_items` or as a nicely formatted label with syntax highlighting.
+
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod arrow_node;
 mod arrow_ui;
 mod datatype_ui;

--- a/crates/viewer/re_component_fallbacks/src/lib.rs
+++ b/crates/viewer/re_component_fallbacks/src/lib.rs
@@ -15,6 +15,8 @@
 //!
 //! Otherwise the fallback should be registered in the view class it's used in, on that view classes' `on_register` method.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 use re_viewer_context::FallbackProviderRegistry;
 
 mod blueprint_component_fallbacks;

--- a/crates/viewer/re_memory_view/src/lib.rs
+++ b/crates/viewer/re_memory_view/src/lib.rs
@@ -1,5 +1,7 @@
 //! Flamegraph visualization for memory usage trees.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 use re_byte_size::NamedMemUsageTree;
 
 mod flamegraph;

--- a/crates/viewer/re_recording_panel/src/lib.rs
+++ b/crates/viewer/re_recording_panel/src/lib.rs
@@ -1,5 +1,7 @@
 //! The UI for the recording panel.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 #[cfg(feature = "testing")]
 pub mod data;
 

--- a/crates/viewer/re_renderer/src/file_resolver.rs
+++ b/crates/viewer/re_renderer/src/file_resolver.rs
@@ -177,6 +177,7 @@
 // TODO(cmc): might want to support implicitly dropping file suffixes at some point, e.g.
 // `#import <my_shader>` which works with "my_shader.wgsl"
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -473,7 +474,7 @@ pub fn new_recommended() -> RecommendedFileResolver {
 #[derive(Clone, Debug, Default)]
 pub struct InterpolatedFile {
     pub contents: String,
-    pub imports: HashSet<PathBuf>,
+    pub imports: BTreeSet<PathBuf>,
 }
 
 /// The `FileResolver` handles both resolving import clauses and doing the actual string
@@ -535,7 +536,7 @@ impl<Fs: FileSystem> FileResolver<Fs> {
             let contents = this.fs.read_to_string(&path)?;
 
             // Using implicit Vec<Result> -> Result<Vec> collection.
-            let mut imports = HashSet::new();
+            let mut imports = BTreeSet::new();
             let children: Result<Vec<_>, _> = contents
                 .lines()
                 .map(|line| {

--- a/crates/viewer/re_renderer/src/file_server.rs
+++ b/crates/viewer/re_renderer/src/file_server.rs
@@ -212,10 +212,15 @@ mod file_server_impl {
                     .with_context(|| format!("couldn't resolve imports for file at {path:?}"))?
                     .imports;
 
+                #[expect(clippy::iter_over_hash_type)]
+                // Each import path is watched independently; errors are logged, not propagated.
                 for path in imports {
-                    self.watcher
+                    if let Err(err) = self
+                        .watcher
                         .watch(path.as_ref(), RecursiveMode::NonRecursive)
-                        .with_context(|| format!("couldn't watch file at {path:?}"))?;
+                    {
+                        re_log::error!(%err, ?path, "couldn't watch imported dependency");
+                    }
                 }
             }
 
@@ -276,6 +281,8 @@ mod file_server_impl {
             // On the other hand, we don't care whether a file has dropped one of its imported
             // dependencies: worst case we'll watch a file that's not used anymore, that's
             // not an issue.
+            #[expect(clippy::iter_over_hash_type)]
+            // Each path is re-watched independently; errors are logged, not propagated.
             for path in &paths {
                 if let Err(err) = self.watch(resolver, path, false) {
                     re_log::error!(err=%re_error::format(err), "couldn't watch imported dependency");

--- a/crates/viewer/re_renderer/src/file_server.rs
+++ b/crates/viewer/re_renderer/src/file_server.rs
@@ -212,15 +212,10 @@ mod file_server_impl {
                     .with_context(|| format!("couldn't resolve imports for file at {path:?}"))?
                     .imports;
 
-                #[expect(clippy::iter_over_hash_type)]
-                // Each import path is watched independently; errors are logged, not propagated.
                 for path in imports {
-                    if let Err(err) = self
-                        .watcher
+                    self.watcher
                         .watch(path.as_ref(), RecursiveMode::NonRecursive)
-                    {
-                        re_log::error!(%err, ?path, "couldn't watch imported dependency");
-                    }
+                        .with_context(|| format!("couldn't watch file at {path:?}"))?;
                 }
             }
 

--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -28,6 +28,7 @@
 
 // TODO(#3408): remove unwrap()
 #![expect(clippy::unwrap_used)]
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
 
 mod allocator;
 pub mod device_caps;

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -144,6 +144,7 @@ impl Video {
     /// This is useful when the video description has changed since the decoders were created.
     pub fn reset_all_decoders(&self) {
         let mut players = self.players.lock();
+        #[expect(clippy::iter_over_hash_type)] // Each player is reset independently.
         for player in players.values_mut() {
             player
                 .player
@@ -248,6 +249,7 @@ impl Video {
         size_delta: isize,
     ) {
         let mut players = self.players.lock();
+        #[expect(clippy::iter_over_hash_type)] // Each player is updated based on its own state.
         for entry in players.values_mut() {
             let player = &mut entry.player;
 
@@ -292,6 +294,7 @@ impl Video {
         players.retain(|_id, entry| entry.used_last_frame);
 
         // Reset for the next frame:
+        #[expect(clippy::iter_over_hash_type)] // All entries receive the same value.
         for entry in players.values_mut() {
             entry.used_last_frame = false;
         }

--- a/crates/viewer/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/dynamic_resource_pool.rs
@@ -158,6 +158,7 @@ where
         };
 
         // Throw out any resources that we haven't reclaimed last frame.
+        #[expect(clippy::iter_over_hash_type)] // Resources destroyed via unique handles.
         for (desc, resources) in state.last_frame_deallocated.drain() {
             re_log::trace!(
                 count = resources.len(),

--- a/crates/viewer/re_renderer/src/wgpu_resources/static_resource_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/static_resource_pool.rs
@@ -75,6 +75,7 @@ where
     pub fn recreate_resources<F: FnMut(&Desc) -> Option<Res>>(&mut self, mut recreation_func: F) {
         re_tracing::profile_function!();
 
+        #[expect(clippy::iter_over_hash_type)] // Each resource is recreated independently.
         for (desc, handle) in self.lookup.get_mut() {
             if let Some(new_resource) = recreation_func(desc) {
                 let resource = self.resources.get_mut().get_mut(*handle).unwrap();

--- a/crates/viewer/re_test_context/src/lib.rs
+++ b/crates/viewer/re_test_context/src/lib.rs
@@ -1,6 +1,7 @@
 //! Provides a test context that builds on `re_viewer_context`.
 
 #![expect(clippy::unwrap_used)] // This is only a test
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;

--- a/crates/viewer/re_test_viewport/src/lib.rs
+++ b/crates/viewer/re_test_viewport/src/lib.rs
@@ -1,5 +1,7 @@
 //! Extends the `re_test_context` with viewport-related features.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod test_view;
 
 use ahash::HashMap;

--- a/crates/viewer/re_view_bar_chart/src/lib.rs
+++ b/crates/viewer/re_view_bar_chart/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A View that shows a single bar chart.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod view_class;
 mod visualizer_system;
 

--- a/crates/viewer/re_view_dataframe/src/lib.rs
+++ b/crates/viewer/re_view_dataframe/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A View that shows the data contained in entities in a table.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod dataframe_ui;
 
 mod expanded_rows;

--- a/crates/viewer/re_view_graph/src/layout/provider.rs
+++ b/crates/viewer/re_view_graph/src/layout/provider.rs
@@ -220,6 +220,7 @@ impl ForceLayoutProvider {
             layout.entities.push((entity.clone(), current_rect));
 
             // Multiple edges can occupy the same space in the layout.
+            #[expect(clippy::iter_over_hash_type)] // Each slot writes to a distinct edge key.
             for Slot { kind, edges } in
                 slotted_edges(graph.edges.values().flat_map(|ts| ts.iter())).values()
             {

--- a/crates/viewer/re_view_graph/src/lib.rs
+++ b/crates/viewer/re_view_graph/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A View that shows a graph (node-link diagram).
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod graph;
 mod layout;
 mod ui;

--- a/crates/viewer/re_view_map/src/lib.rs
+++ b/crates/viewer/re_view_map/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A View that shows geographic objects on a map.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod map_overlays;
 mod map_view;
 mod visualizers;

--- a/crates/viewer/re_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_view_map/src/visualizers/geo_points.rs
@@ -188,6 +188,7 @@ impl GeoPointsOutput {
 
             //TODO(ab, andreas): boilerplate copy-pasted from points2d
             let num_instances = positions.len() as u64;
+            #[expect(clippy::iter_over_hash_type)] // Non-overlapping per-instance mask ranges.
             for (highlighted_key, instance_mask_ids) in &outline.instances {
                 let highlighted_point_index =
                     (highlighted_key.get() < num_instances).then_some(highlighted_key.get());

--- a/crates/viewer/re_view_spatial/src/lib.rs
+++ b/crates/viewer/re_view_spatial/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Views that show entities in a 2D or 3D spatial relationship.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod caches;
 mod contexts;
 mod eye;

--- a/crates/viewer/re_view_spatial/src/spatial_topology.rs
+++ b/crates/viewer/re_view_spatial/src/spatial_topology.rs
@@ -143,6 +143,8 @@ impl re_byte_size::MemUsageTreeCapture for SpatialTopologyStoreSubscriber {
     fn capture_mem_usage_tree(&self) -> re_byte_size::MemUsageTree {
         use re_byte_size::SizeBytes as _;
         let mut node = re_byte_size::MemUsageNode::new();
+        #[expect(clippy::iter_over_hash_type)]
+        // Ordering for usage tree isn't generally all that important.
         for (store_id, topology) in &self.topologies {
             let name = format!(
                 "{}/{}",

--- a/crates/viewer/re_view_spatial/src/spatial_topology.rs
+++ b/crates/viewer/re_view_spatial/src/spatial_topology.rs
@@ -444,6 +444,7 @@ impl SpatialTopology {
         split_subspace.child_spaces.insert(new_space_origin.clone());
 
         // Patch parents of the child spaces that were moved to the new space.
+        #[expect(clippy::iter_over_hash_type)] // Same value written to disjoint keys.
         for child_origin in &new_space.child_spaces {
             let child_space = self
                 .subspaces

--- a/crates/viewer/re_view_spatial/src/ui.rs
+++ b/crates/viewer/re_view_spatial/src/ui.rs
@@ -571,6 +571,7 @@ pub fn draw_bounding_boxes(
 
     if state.show_per_entity_bbox {
         let mut batch = line_builder.batch("per_entity_regions_of_interest");
+        #[expect(clippy::iter_over_hash_type)] // Draw order of lines isn't important.
         for region_of_interest in state.bounding_boxes.region_of_interest_per_entity.values() {
             batch
                 .add_box_outline(region_of_interest)

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -370,6 +370,42 @@ impl SpatialView3D {
             );
         }
 
+        // TODO(andreas): Make configurable. Could pick up default radius for this view?
+        let box_line_radius = Size(*re_sdk_types::components::Radius::default().0);
+
+        // TODO(andreas): Make this an enum so the user can choose between showing
+        // the bounding box (all entities), the region of interest, or per-entity bounding boxes.
+        if show_bounding_box {
+            line_builder
+                .batch("scene_bbox_current")
+                .add_box_outline(&state.bounding_boxes.current)
+                .map(|lines| {
+                    lines
+                        .radius(box_line_radius)
+                        .color(ui.tokens().frustum_color)
+                });
+        }
+        if state.state_3d.show_smoothed_bbox {
+            line_builder
+                .batch("scene_region_of_interest_smoothed")
+                .add_box_outline(&state.bounding_boxes.region_of_interest_smoothed)
+                .map(|lines| {
+                    lines
+                        .radius(box_line_radius)
+                        .color(ctx.tokens().frustum_color)
+                });
+        }
+        if state.state_3d.show_per_entity_bbox {
+            let mut batch = line_builder.batch("per_entity_regions_of_interest");
+            #[expect(clippy::iter_over_hash_type)]
+            // Debug bounding boxes; all same color, depth-buffered.
+            for region_of_interest in state.bounding_boxes.region_of_interest_per_entity.values() {
+                batch
+                    .add_box_outline(region_of_interest)
+                    .map(|lines| lines.radius(box_line_radius).color(egui::Color32::YELLOW));
+            }
+        }
+
         show_orbit_eye_center(
             ui.ctx(),
             &mut state.state_3d,

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -370,42 +370,6 @@ impl SpatialView3D {
             );
         }
 
-        // TODO(andreas): Make configurable. Could pick up default radius for this view?
-        let box_line_radius = Size(*re_sdk_types::components::Radius::default().0);
-
-        // TODO(andreas): Make this an enum so the user can choose between showing
-        // the bounding box (all entities), the region of interest, or per-entity bounding boxes.
-        if show_bounding_box {
-            line_builder
-                .batch("scene_bbox_current")
-                .add_box_outline(&state.bounding_boxes.current)
-                .map(|lines| {
-                    lines
-                        .radius(box_line_radius)
-                        .color(ui.tokens().frustum_color)
-                });
-        }
-        if state.state_3d.show_smoothed_bbox {
-            line_builder
-                .batch("scene_region_of_interest_smoothed")
-                .add_box_outline(&state.bounding_boxes.region_of_interest_smoothed)
-                .map(|lines| {
-                    lines
-                        .radius(box_line_radius)
-                        .color(ctx.tokens().frustum_color)
-                });
-        }
-        if state.state_3d.show_per_entity_bbox {
-            let mut batch = line_builder.batch("per_entity_regions_of_interest");
-            #[expect(clippy::iter_over_hash_type)]
-            // Debug bounding boxes; all same color, depth-buffered.
-            for region_of_interest in state.bounding_boxes.region_of_interest_per_entity.values() {
-                batch
-                    .add_box_outline(region_of_interest)
-                    .map(|lines| lines.radius(box_line_radius).color(egui::Color32::YELLOW));
-            }
-        }
-
         show_orbit_eye_center(
             ui.ctx(),
             &mut state.state_3d,

--- a/crates/viewer/re_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/mod.rs
@@ -267,6 +267,7 @@ pub fn load_keypoint_connections(
     // TODO(andreas): Make configurable. Should we pick up the point's radius and make this proportional?
     let line_radius = re_renderer::Size(*re_sdk_types::components::Radius::default().0);
 
+    #[expect(clippy::iter_over_hash_type)] // Each class draws independently; depth-buffered.
     for ((class_id, _time), keypoints_in_class) in keypoints {
         let resolved_class_description = annotations.resolved_class_description(Some(*class_id));
 

--- a/crates/viewer/re_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/points2d.rs
@@ -107,6 +107,8 @@ impl Points2DVisualizer {
                 // Determine if there's any sub-ranges that need extra highlighting.
                 {
                     re_tracing::profile_scope!("marking additional highlight points");
+                    #[expect(clippy::iter_over_hash_type)]
+                    // Non-overlapping per-instance mask ranges.
                     for (highlighted_key, instance_mask_ids) in &ent_context.highlight.instances {
                         let highlighted_point_index = (highlighted_key.get()
                             < num_instances as u64)

--- a/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
@@ -326,6 +326,8 @@ impl Points3DVisualizer {
 
                 // Determine if there's any sub-ranges that need extra highlighting.
                 {
+                    #[expect(clippy::iter_over_hash_type)]
+                    // Non-overlapping per-instance mask ranges.
                     for (highlighted_key, instance_mask_ids) in &ent_context.highlight.instances {
                         let highlighted_point_index = (highlighted_key.get()
                             < num_instances as u64)

--- a/crates/viewer/re_view_tensor/src/lib.rs
+++ b/crates/viewer/re_view_tensor/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A view dedicated to visualizing tensors with arbitrary dimensionality.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod dimension_mapping;
 mod tensor_dimension_mapper;
 mod tensor_slice_to_gpu;

--- a/crates/viewer/re_view_text_document/src/lib.rs
+++ b/crates/viewer/re_view_text_document/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A simple Viewshows a single text document.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod view_class;
 mod visualizer_system;
 

--- a/crates/viewer/re_view_text_log/src/lib.rs
+++ b/crates/viewer/re_view_text_log/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! A View that shows `TextLog` entries in a table and scrolls with the active time.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod view_class;
 mod visualizer_system;
 

--- a/crates/viewer/re_viewport_blueprint/src/lib.rs
+++ b/crates/viewer/re_viewport_blueprint/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! This crate provides blueprint (i.e. description) for how to render the viewport.
 
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
+
 mod auto_layout;
 mod container;
 mod entity_add_info;

--- a/crates/viewer/re_viewport_blueprint/src/view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_contents.rs
@@ -286,12 +286,14 @@ impl ViewContents {
             re_tracing::profile_scope!("visualizable_entities_per_visualizer_in_view");
 
             let mut visualizable_entities_per_visualizer_in_view = IntMap::default();
+            #[expect(clippy::iter_over_hash_type)] // Filling another hash map.
             for (visualizer, visualizable_entities) in visualizable_entities_per_visualizer.iter() {
                 // Skip over visualizers that aren't used in this view.
                 if !visualizer_collection.contains_visualizer_type(*visualizer) {
                     continue;
                 }
 
+                #[expect(clippy::iter_over_hash_type)] // Filling another hash map.
                 for (entity_path, reason) in visualizable_entities.iter() {
                     visualizable_entities_per_visualizer_in_view
                         .entry(entity_path.hash())
@@ -327,6 +329,7 @@ impl ViewContents {
 
             // Figure out which components are relevant.
             let mut components_for_defaults = IntSet::default();
+            #[expect(clippy::iter_over_hash_type)] // Set union is order-independent.
             for (visualizer, entities) in visualizable_entities_per_visualizer.iter() {
                 if entities.is_empty() {
                     continue;

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -895,6 +895,7 @@ impl ViewportBlueprint {
         }
 
         // Now save any contents that are a container back to the blueprint
+        #[expect(clippy::iter_over_hash_type)] // Each container saves to its own unique path.
         for (tile_id, contents) in &contents_from_tile_id {
             if let Contents::Container(container_id) = contents
                 && let Some(egui_tiles::Tile::Container(container)) = self.tree.tiles.get(*tile_id)

--- a/crates/viewer/re_web_viewer_server/src/lib.rs
+++ b/crates/viewer/re_web_viewer_server/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(clippy::all, rust_2018_idioms)]
+#![warn(clippy::iter_over_hash_type)] //  TODO(#6198): enable everywhere
 
 use std::fmt::Display;
 use std::str::FromStr;


### PR DESCRIPTION
### Related

* Part of #6198 

### What

  - Enable `#![warn(clippy::iter_over_hash_type)]` in 17 viewer crates
       - 12 crates with no violations and 5 crates with violations
  - Suppress 16 sites where, in my understanding, iteration order is irrelevant
  - Fix one site in `re_renderer/src/file_server.rs` where `?` made the iteration order-dependent

