### PR TITLE
Improve text log view performance with cached indexing and virtualized rendering

### DIFF
--- a/crates/viewer/re_view_text_log/Cargo.toml
+++ b/crates/viewer/re_view_text_log/Cargo.toml
@@ -19,6 +19,8 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_byte_size.workspace = true
+re_chunk.workspace = true
 re_chunk_store.workspace = true
 re_data_ui.workspace = true
 re_entity_db.workspace = true
@@ -32,8 +34,8 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 
-egui_extras.workspace = true
 egui.workspace = true
+egui_table.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]

--- a/crates/viewer/re_view_text_log/src/cache.rs
+++ b/crates/viewer/re_view_text_log/src/cache.rs
@@ -1,0 +1,503 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use re_byte_size::{MemUsageTree, MemUsageTreeCapture, SizeBytes};
+use re_chunk::{Chunk, ChunkId, RowId};
+use re_chunk_store::ChunkStoreEvent;
+use re_entity_db::EntityDb;
+use re_log_types::{EntityPath, TimeInt, TimePoint, TimelineName};
+use re_sdk_types::archetypes::TextLog;
+use re_sdk_types::components::{Color, Text, TextLogLevel};
+use re_viewer_context::Cache;
+
+/// Lightweight metadata for one visible text-log instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextLogRowMeta {
+    pub row_idx: usize,
+    pub instance_idx: usize,
+    pub row_id: RowId,
+    pub timepoint: TimePoint,
+    pub level: Option<TextLogLevel>,
+    pub color: Option<Color>,
+    pub line_count: u32,
+}
+
+impl SizeBytes for TextLogRowMeta {
+    /// Reports the heap usage of the cloned metadata we keep per text-log instance.
+    fn heap_size_bytes(&self) -> u64 {
+        self.timepoint.heap_size_bytes()
+            + self.level.heap_size_bytes()
+            + self.color.heap_size_bytes()
+    }
+
+    /// Reports that row metadata is not plain old data because it owns heap allocations.
+    fn is_pod() -> bool {
+        false
+    }
+}
+
+/// Sort key plus chunk-local lookup information for one projected text-log row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextLogRowHandle {
+    pub chunk_id: ChunkId,
+    pub row_meta_idx: usize,
+    pub sort_time: TimeInt,
+    pub row_id: RowId,
+    pub instance_idx: usize,
+}
+
+impl PartialOrd for TextLogRowHandle {
+    /// Compares row handles by the same stable key used by the legacy eager table.
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TextLogRowHandle {
+    /// Compares row handles by `(sort_time, chunk_id, row_id, instance_idx)`.
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.sort_time, self.chunk_id, self.row_id, self.instance_idx).cmp(&(
+            other.sort_time,
+            other.chunk_id,
+            other.row_id,
+            other.instance_idx,
+        ))
+    }
+}
+
+/// Indexed representation of one chunk that contains text-log data.
+#[derive(Debug)]
+pub struct IndexedTextLogChunk {
+    pub chunk: Arc<Chunk>,
+    pub row_metas: Vec<TextLogRowMeta>,
+}
+
+impl IndexedTextLogChunk {
+    /// Returns the entity path shared by all rows in this indexed chunk.
+    pub fn entity_path(&self) -> &EntityPath {
+        self.chunk.entity_path()
+    }
+
+    /// Returns one row's cached metadata by index.
+    pub fn row_meta(&self, row_meta_idx: usize) -> Option<&TextLogRowMeta> {
+        self.row_metas.get(row_meta_idx)
+    }
+
+    /// Appends projected row handles for a specific timeline.
+    pub fn append_row_handles_for_timeline(
+        &self,
+        timeline: TimelineName,
+        handles: &mut Vec<TextLogRowHandle>,
+    ) {
+        let chunk_id = self.chunk.id();
+        handles.extend(self.row_metas.iter().enumerate().map(|(row_meta_idx, row_meta)| {
+            TextLogRowHandle {
+                chunk_id,
+                row_meta_idx,
+                sort_time: row_sort_time(&row_meta.timepoint, timeline),
+                row_id: row_meta.row_id,
+                instance_idx: row_meta.instance_idx,
+            }
+        }));
+    }
+
+    /// Resolves the text body for one projected row on demand.
+    pub fn resolve_body(&self, row_meta_idx: usize) -> Option<Text> {
+        let row_meta = self.row_meta(row_meta_idx)?;
+        let bodies = self
+            .chunk
+            .component_batch::<Text>(TextLog::descriptor_text().component, row_meta.row_idx)?
+            .ok()?;
+
+        bodies.get(row_meta.instance_idx).cloned()
+    }
+}
+
+impl SizeBytes for IndexedTextLogChunk {
+    /// Reports the heap owned by the cached row metadata for one indexed chunk.
+    fn heap_size_bytes(&self) -> u64 {
+        self.row_metas.heap_size_bytes()
+    }
+
+    /// Reports that indexed chunks are not plain old data because they own metadata vectors.
+    fn is_pod() -> bool {
+        false
+    }
+}
+
+/// Cache of indexed text-log chunks for the active store.
+#[derive(Default)]
+pub struct TextLogCache {
+    chunks: BTreeMap<ChunkId, Arc<IndexedTextLogChunk>>,
+    addition_log: Vec<(u64, ChunkId)>,
+    revision: u64,
+    non_additive_revision: u64,
+    initialized: bool,
+    needs_rebuild: bool,
+}
+
+impl TextLogCache {
+    /// Ensures that the cache has been seeded from the current store contents.
+    pub fn ensure_initialized(&mut self, entity_db: &EntityDb) {
+        if self.initialized && !self.needs_rebuild {
+            return;
+        }
+
+        self.rebuild_from_store(entity_db);
+    }
+
+    /// Returns the current cache revision.
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Reports whether every change since `revision` was append-only.
+    pub fn is_additive_since(&self, revision: u64) -> bool {
+        revision >= self.non_additive_revision && revision <= self.revision
+    }
+
+    /// Collects indexed chunks for the currently included entities.
+    pub fn collect_chunks_for_entities(
+        &self,
+        included_entities: &std::collections::BTreeSet<EntityPath>,
+    ) -> Vec<Arc<IndexedTextLogChunk>> {
+        self.chunks
+            .values()
+            .filter(|chunk| included_entities.contains(chunk.entity_path()))
+            .cloned()
+            .collect()
+    }
+
+    /// Collects append-only chunk additions that happened after `revision`.
+    pub fn collect_added_chunks_since(
+        &self,
+        included_entities: &std::collections::BTreeSet<EntityPath>,
+        revision: u64,
+    ) -> Vec<Arc<IndexedTextLogChunk>> {
+        self.addition_log
+            .iter()
+            .filter(|(entry_revision, _)| *entry_revision > revision)
+            .filter_map(|(_, chunk_id)| self.chunks.get(chunk_id))
+            .filter(|chunk| included_entities.contains(chunk.entity_path()))
+            .cloned()
+            .collect()
+    }
+
+    /// Rebuilds the cache from the currently loaded physical chunks.
+    fn rebuild_from_store(&mut self, entity_db: &EntityDb) {
+        re_tracing::profile_function!();
+
+        let store = entity_db.storage_engine();
+        let physical_chunks = store
+            .store()
+            .iter_physical_chunks()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        self.rebuild_from_chunks(physical_chunks);
+    }
+
+    /// Rebuilds the cache from a supplied chunk list.
+    fn rebuild_from_chunks(&mut self, chunks: impl IntoIterator<Item = Arc<Chunk>>) {
+        let chunks = chunks
+            .into_iter()
+            .filter_map(Self::index_chunk)
+            .map(|chunk| (chunk.chunk.id(), chunk))
+            .collect::<BTreeMap<_, _>>();
+
+        self.chunks = chunks;
+        self.addition_log.clear();
+        self.initialized = true;
+        self.needs_rebuild = false;
+
+        if self.revision == 0 {
+            self.revision = 1;
+            self.non_additive_revision = self.revision;
+        }
+    }
+
+    /// Adds a newly appended chunk without rebuilding the existing index.
+    fn append_delta_chunk(&mut self, chunk: Arc<Chunk>) {
+        let Some(indexed_chunk) = Self::index_chunk(chunk) else {
+            return;
+        };
+
+        self.revision += 1;
+        self.addition_log
+            .push((self.revision, indexed_chunk.chunk.id()));
+        self.chunks.insert(indexed_chunk.chunk.id(), indexed_chunk);
+    }
+
+    /// Marks the cache as needing a full rebuild before the next access.
+    fn mark_non_additive(&mut self) {
+        self.revision += 1;
+        self.non_additive_revision = self.revision;
+        self.needs_rebuild = true;
+        self.addition_log.clear();
+    }
+
+    /// Builds an indexed chunk by expanding only the lightweight metadata we need for drawing.
+    fn index_chunk(chunk: Arc<Chunk>) -> Option<Arc<IndexedTextLogChunk>> {
+        re_tracing::profile_function!();
+
+        let text_component = TextLog::descriptor_text().component;
+        let level_component = TextLog::descriptor_level().component;
+        let color_component = TextLog::descriptor_color().component;
+
+        if chunk.num_events_for_component(text_component).unwrap_or(0) == 0 {
+            return None;
+        }
+
+        let row_ids = chunk.row_ids_slice();
+        let mut row_metas = Vec::new();
+        let mut latest_levels: Option<Vec<TextLogLevel>> = None;
+        let mut latest_colors: Option<Vec<Color>> = None;
+
+        for (row_idx, timepoint) in chunk.iter_timepoints().enumerate() {
+            if let Some(Ok(levels)) = chunk.component_batch::<TextLogLevel>(level_component, row_idx)
+                && !levels.is_empty()
+            {
+                latest_levels = Some(levels);
+            }
+
+            if let Some(Ok(colors)) = chunk.component_batch::<Color>(color_component, row_idx)
+                && !colors.is_empty()
+            {
+                latest_colors = Some(colors);
+            }
+
+            let Some(Ok(bodies)) = chunk.component_batch::<Text>(text_component, row_idx) else {
+                continue;
+            };
+
+            if bodies.is_empty() {
+                continue;
+            }
+
+            let row_id = row_ids[row_idx];
+            let level_slice = latest_levels.as_deref();
+            let color_slice = latest_colors.as_deref();
+
+            for (instance_idx, body) in bodies.into_iter().enumerate() {
+                row_metas.push(TextLogRowMeta {
+                    row_idx,
+                    instance_idx,
+                    row_id,
+                    timepoint: timepoint.clone(),
+                    level: clamped_value(level_slice, instance_idx),
+                    color: clamped_value(color_slice, instance_idx),
+                    line_count: explicit_line_count(body.as_str()),
+                });
+            }
+        }
+
+        (!row_metas.is_empty()).then_some(Arc::new(IndexedTextLogChunk { chunk, row_metas }))
+    }
+}
+
+impl Cache for TextLogCache {
+    /// Returns the cache name used by viewer diagnostics.
+    fn name(&self) -> &'static str {
+        "TextLogCache"
+    }
+
+    /// Keeps the current index alive because it is the steady-state performance win.
+    fn purge_memory(&mut self) {}
+
+    /// Applies store events incrementally while falling back to rebuilds on non-additive changes.
+    fn on_store_events(&mut self, events: &[&ChunkStoreEvent], _entity_db: &EntityDb) {
+        if !self.initialized || self.needs_rebuild {
+            return;
+        }
+
+        for event in events {
+            if event.diff.is_deletion() {
+                self.mark_non_additive();
+                return;
+            }
+
+            let Some(delta_chunk) = event.diff.delta_chunk() else {
+                continue;
+            };
+
+            if event.diff.is_addition() {
+                self.append_delta_chunk(Arc::clone(delta_chunk));
+            }
+        }
+    }
+}
+
+impl MemUsageTreeCapture for TextLogCache {
+    /// Reports the memory owned by the lightweight text-log index structures.
+    fn capture_mem_usage_tree(&self) -> MemUsageTree {
+        MemUsageTree::Bytes(
+            self.chunks
+                .values()
+                .map(|chunk| chunk.heap_size_bytes())
+                .sum::<u64>()
+                + self.addition_log.heap_size_bytes()
+        )
+    }
+}
+
+/// Returns the sort key used by the text-log table for one row.
+pub fn row_sort_time(timepoint: &TimePoint, timeline: TimelineName) -> TimeInt {
+    timepoint
+        .get(&timeline)
+        .map(TimeInt::from)
+        .unwrap_or(TimeInt::STATIC)
+}
+
+/// Clamps a slice exactly like the old eager visualizer did for per-instance values.
+fn clamped_value<T: Clone>(values: Option<&[T]>, instance_idx: usize) -> Option<T> {
+    let values = values?;
+    values
+        .get(instance_idx)
+        .cloned()
+        .or_else(|| values.last().cloned())
+}
+
+/// Counts explicit lines exactly like the old row-height code path.
+fn explicit_line_count(body: &str) -> u32 {
+    (1 + body.bytes().filter(|&byte| byte == b'\n').count()) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TextLogCache, TextLogRowMeta, explicit_line_count};
+    use std::sync::Arc;
+
+    use re_chunk::{Chunk, RowId, Timeline};
+    use re_sdk_types::archetypes::TextLog;
+    use re_sdk_types::components::{Color, Text, TextLogLevel};
+
+    /// Builds a small text-log chunk with sparse rows for indexing tests.
+    fn sparse_text_log_chunk() -> Arc<Chunk> {
+        let mut chunk = Chunk::builder("logs/test")
+            .with_component_batches(
+                RowId::new(),
+                [(Timeline::log_time(), 1)],
+                [(
+                    TextLog::descriptor_text(),
+                    &[Text::from("alpha"), Text::from("beta\nbeta")] as _,
+                )],
+            )
+            .with_component_batches(
+                RowId::new(),
+                [(Timeline::log_time(), 2)],
+                [(
+                    TextLog::descriptor_level(),
+                    &[TextLogLevel::from(TextLogLevel::WARN)] as _,
+                )],
+            )
+            .with_component_batches(
+                RowId::new(),
+                [(Timeline::log_time(), 3)],
+                [
+                    (
+                        TextLog::descriptor_text(),
+                        &[Text::from("gamma"), Text::from("delta")] as _,
+                    ),
+                    (
+                        TextLog::descriptor_color(),
+                        &[Color::from(0xFF0000FF), Color::from(0x00FF00FF)] as _,
+                    ),
+                ],
+            )
+            .build()
+            .expect("chunk should build");
+
+        chunk.sort_if_unsorted();
+        Arc::new(chunk)
+    }
+
+    /// Returns the indexed metadata for the sparse test chunk.
+    fn sparse_row_metas() -> Vec<TextLogRowMeta> {
+        TextLogCache::index_chunk(sparse_text_log_chunk())
+            .expect("chunk should be indexed")
+            .row_metas
+            .clone()
+    }
+
+    /// Verifies that indexing preserves sparse carry-forward semantics and newline counting.
+    #[test]
+    fn index_chunk_matches_old_clamping_behavior() {
+        let row_metas = sparse_row_metas();
+
+        assert_eq!(row_metas.len(), 4);
+        assert_eq!(row_metas[0].level, None);
+        assert_eq!(row_metas[1].level, None);
+        assert_eq!(
+            row_metas[2].level.as_ref().map(TextLogLevel::as_str),
+            Some(TextLogLevel::WARN)
+        );
+        assert_eq!(
+            row_metas[3].level.as_ref().map(TextLogLevel::as_str),
+            Some(TextLogLevel::WARN)
+        );
+        assert_eq!(row_metas[0].color, None);
+        assert_eq!(row_metas[1].color, None);
+        assert_eq!(row_metas[2].color, Some(Color::from(0xFF0000FF)));
+        assert_eq!(row_metas[3].color, Some(Color::from(0x00FF00FF)));
+        assert_eq!(row_metas[0].line_count, 1);
+        assert_eq!(row_metas[1].line_count, 2);
+    }
+
+    /// Verifies that visible body resolution still reads the original chunk data lazily.
+    #[test]
+    fn indexed_chunk_resolves_body_by_row_and_instance() {
+        let chunk = TextLogCache::index_chunk(sparse_text_log_chunk()).expect("chunk should exist");
+
+        assert_eq!(
+            chunk.resolve_body(1).as_ref().map(Text::as_str),
+            Some("beta\nbeta")
+        );
+        assert_eq!(chunk.resolve_body(2).as_ref().map(Text::as_str), Some("gamma"));
+        assert_eq!(chunk.resolve_body(3).as_ref().map(Text::as_str), Some("delta"));
+    }
+
+    /// Verifies that the cache tracks additive updates separately from rebuild-required changes.
+    #[test]
+    fn cache_revisions_distinguish_additive_and_non_additive_updates() {
+        let mut cache = TextLogCache::default();
+        cache.rebuild_from_chunks([sparse_text_log_chunk()]);
+
+        let initial_revision = cache.revision();
+        assert_eq!(initial_revision, 1);
+        assert!(!cache.is_additive_since(0));
+        assert!(cache.is_additive_since(initial_revision));
+
+        cache.append_delta_chunk(
+            Chunk::builder("logs/extra")
+                .with_component_batches(
+                    RowId::new(),
+                    [(Timeline::log_time(), 4)],
+                    [(
+                        TextLog::descriptor_text(),
+                        &[Text::from("epsilon")] as _,
+                    )],
+                )
+                .build()
+                .expect("chunk should build")
+                .into(),
+        );
+
+        let additive_revision = cache.revision();
+        assert!(cache.is_additive_since(initial_revision));
+        assert_eq!(cache.collect_added_chunks_since(&["logs/extra".into()].into_iter().collect(), initial_revision).len(), 1);
+
+        cache.mark_non_additive();
+
+        assert!(!cache.is_additive_since(additive_revision));
+    }
+
+    /// Verifies the explicit newline counter used by cached row heights.
+    #[test]
+    fn explicit_line_count_counts_visual_lines() {
+        assert_eq!(explicit_line_count(""), 1);
+        assert_eq!(explicit_line_count("single"), 1);
+        assert_eq!(explicit_line_count("two\nlines"), 2);
+        assert_eq!(explicit_line_count("three\nvisible\nlines"), 3);
+    }
+}

--- a/crates/viewer/re_view_text_log/src/lib.rs
+++ b/crates/viewer/re_view_text_log/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! A View that shows `TextLog` entries in a table and scrolls with the active time.
 
+mod cache;
 mod view_class;
 mod visualizer_system;
 

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -1,14 +1,17 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
+use egui::Color32;
+use re_chunk::ChunkId;
 use re_data_ui::item_ui::{self, timeline_button};
-use re_log_types::{EntityPath, TimelineName};
+use re_log_types::{EntityPath, TimeInt, TimelineName};
 use re_sdk_types::blueprint::archetypes::{TextLogColumns, TextLogFormat, TextLogRows};
 use re_sdk_types::blueprint::components::{Enabled, TextLogColumn, TimelineColumn};
 use re_sdk_types::blueprint::datatypes as bp_datatypes;
 use re_sdk_types::components::TextLogLevel;
 use re_sdk_types::{View as _, ViewClassIdentifier, datatypes};
 use re_ui::list_item::LabelContent;
-use re_ui::{DesignTokens, Help, UiExt as _};
+use re_ui::{Help, UiExt as _};
 use re_viewer_context::{
     IdentifiedViewSystem as _, ViewClass, ViewClassExt as _, ViewClassRegistryError, ViewContext,
     ViewId, ViewQuery, ViewSpawnHeuristics, ViewState, ViewStateExt as _, ViewSystemExecutionError,
@@ -16,10 +19,11 @@ use re_viewer_context::{
 };
 use re_viewport_blueprint::ViewProperty;
 
-use super::visualizer_system::{Entry, TextLogSystem};
+use super::cache::{IndexedTextLogChunk, TextLogCache, TextLogRowHandle};
+use super::visualizer_system::TextLogSystem;
 
-// TODO(andreas): This should be a blueprint component.
-#[derive(Clone, PartialEq, Eq, Default)]
+/// Transient state for the text-log view.
+#[derive(Default)]
 pub struct TextViewState {
     /// Keeps track of the latest time selection made by the user.
     ///
@@ -27,9 +31,11 @@ pub struct TextViewState {
     /// text entry window however they please when the time cursor isn't moving.
     latest_time: i64,
 
+    /// Cached set of levels exposed to the blueprint fallback provider.
     seen_levels: BTreeSet<String>,
 
-    last_columns_min_sizes: Vec<u32>,
+    /// Cached per-view projection over the store-wide text-log cache.
+    projection: TextLogProjectionState,
 }
 
 impl ViewState for TextViewState {
@@ -39,6 +45,369 @@ impl ViewState for TextViewState {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
+    }
+}
+
+/// Cached row projection tailored to the current view, timeline, and level filter.
+#[derive(Default)]
+struct TextLogProjectionState {
+    timeline: Option<TimelineName>,
+    included_entities: BTreeSet<EntityPath>,
+    cache_revision: u64,
+    chunks: BTreeMap<ChunkId, Arc<IndexedTextLogChunk>>,
+    all_rows: Vec<TextLogRowHandle>,
+    filtered_rows: Vec<TextLogRowHandle>,
+    prefix_line_counts: Vec<u64>,
+    seen_levels: BTreeSet<String>,
+    active_levels: Vec<String>,
+    needs_filter_refresh: bool,
+}
+
+impl TextLogProjectionState {
+    /// Synchronizes the projection with the store cache while preserving append-only fast paths.
+    fn refresh_from_cache(
+        &mut self,
+        cache: &TextLogCache,
+        included_entities: &BTreeSet<EntityPath>,
+        timeline: TimelineName,
+    ) {
+        let timeline_changed = self.timeline != Some(timeline);
+        let entities_changed = self.included_entities != *included_entities;
+        let additive_update = cache.is_additive_since(self.cache_revision);
+
+        if timeline_changed || entities_changed || !additive_update {
+            self.rebuild_from_cache(cache, included_entities, timeline);
+            return;
+        }
+
+        if cache.revision() == self.cache_revision {
+            return;
+        }
+
+        let added_chunks = cache.collect_added_chunks_since(included_entities, self.cache_revision);
+        self.cache_revision = cache.revision();
+        self.append_additive_chunks(added_chunks, timeline);
+    }
+
+    /// Rebuilds the projection from scratch for a new entity set, timeline, or non-additive edit.
+    fn rebuild_from_cache(
+        &mut self,
+        cache: &TextLogCache,
+        included_entities: &BTreeSet<EntityPath>,
+        timeline: TimelineName,
+    ) {
+        self.timeline = Some(timeline);
+        self.included_entities = included_entities.clone();
+        self.cache_revision = cache.revision();
+        self.chunks.clear();
+        self.all_rows.clear();
+        self.filtered_rows.clear();
+        self.prefix_line_counts.clear();
+        self.seen_levels.clear();
+
+        let chunks = cache.collect_chunks_for_entities(included_entities);
+        self.register_chunks(&chunks);
+
+        for chunk in &chunks {
+            chunk.append_row_handles_for_timeline(timeline, &mut self.all_rows);
+        }
+
+        self.all_rows.sort();
+        self.needs_filter_refresh = true;
+    }
+
+    /// Extends the projection with newly indexed chunks while keeping stable table ordering.
+    fn append_additive_chunks(
+        &mut self,
+        chunks: Vec<Arc<IndexedTextLogChunk>>,
+        timeline: TimelineName,
+    ) {
+        if chunks.is_empty() {
+            return;
+        }
+
+        self.register_chunks(&chunks);
+
+        let mut added_rows = Vec::new();
+        for chunk in &chunks {
+            chunk.append_row_handles_for_timeline(timeline, &mut added_rows);
+        }
+
+        if added_rows.is_empty() {
+            return;
+        }
+
+        added_rows.sort();
+
+        let can_append = self
+            .all_rows
+            .last()
+            .zip(added_rows.first())
+            .is_none_or(|(existing_last, added_first)| existing_last <= added_first);
+
+        if can_append {
+            self.all_rows.extend(added_rows);
+        } else {
+            self.all_rows = merge_sorted_rows(std::mem::take(&mut self.all_rows), added_rows);
+        }
+
+        self.needs_filter_refresh = true;
+    }
+
+    /// Registers chunk references and level metadata needed by the current projection.
+    fn register_chunks(&mut self, chunks: &[Arc<IndexedTextLogChunk>]) {
+        for chunk in chunks {
+            self.chunks.insert(chunk.chunk.id(), Arc::clone(chunk));
+
+            for row_meta in &chunk.row_metas {
+                if let Some(level) = &row_meta.level {
+                    self.seen_levels.insert(level.to_string());
+                }
+            }
+        }
+    }
+
+    /// Recomputes the filtered row list when the level filter or source rows change.
+    fn apply_level_filter(&mut self, levels: &[TextLogLevel]) {
+        let active_levels = levels
+            .iter()
+            .map(|level| level.as_str().to_owned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        if !self.needs_filter_refresh && self.active_levels == active_levels {
+            return;
+        }
+
+        self.active_levels = active_levels.clone();
+        let active_level_set = active_levels.into_iter().collect::<BTreeSet<_>>();
+
+        self.filtered_rows = self
+            .all_rows
+            .iter()
+            .copied()
+            .filter(|row| self.level_matches(row, &active_level_set))
+            .collect();
+
+        self.prefix_line_counts.clear();
+        self.prefix_line_counts
+            .reserve(self.filtered_rows.len().saturating_add(1));
+        self.prefix_line_counts.push(0);
+
+        for row in &self.filtered_rows {
+            let next = self
+                .prefix_line_counts
+                .last()
+                .copied()
+                .unwrap_or_default()
+                + self.row_line_count(row);
+            self.prefix_line_counts.push(next);
+        }
+
+        self.needs_filter_refresh = false;
+    }
+
+    /// Looks up the cached chunk and row metadata for one filtered row.
+    fn resolve_row(
+        &self,
+        row_nr: u64,
+    ) -> Option<(&Arc<IndexedTextLogChunk>, &TextLogRowHandle, &super::cache::TextLogRowMeta)> {
+        let handle = self.filtered_rows.get(row_nr as usize)?;
+        let chunk = self.chunks.get(&handle.chunk_id)?;
+        let row_meta = chunk.row_meta(handle.row_meta_idx)?;
+        Some((chunk, handle, row_meta))
+    }
+
+    /// Computes the top offset for a logical row using cached explicit line counts.
+    fn row_top_offset(&self, row_nr: u64, base_row_height: f32) -> f32 {
+        let prefix = self
+            .prefix_line_counts
+            .get(row_nr as usize)
+            .copied()
+            .or_else(|| self.prefix_line_counts.last().copied())
+            .unwrap_or_default();
+
+        prefix as f32 * base_row_height
+    }
+
+    /// Returns the cached explicit line count for one row.
+    fn row_line_count(&self, row: &TextLogRowHandle) -> u64 {
+        self.chunks
+            .get(&row.chunk_id)
+            .and_then(|chunk| chunk.row_meta(row.row_meta_idx))
+            .map(|row_meta| row_meta.line_count as u64)
+            .unwrap_or(1)
+    }
+
+    /// Applies the level filter rule that rows without a level are always visible.
+    fn level_matches(&self, row: &TextLogRowHandle, active_levels: &BTreeSet<String>) -> bool {
+        self.chunks
+            .get(&row.chunk_id)
+            .and_then(|chunk| chunk.row_meta(row.row_meta_idx))
+            .and_then(|row_meta| row_meta.level.as_ref())
+            .is_none_or(|level| active_levels.contains(level.as_str()))
+    }
+}
+
+/// Table column description used by the virtualized table delegate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TableColumn {
+    Timeline(TimelineName),
+    Text(bp_datatypes::TextLogColumnKind),
+}
+
+/// Cached visible-row data resolved just for the current frame.
+#[derive(Default)]
+struct PreparedTextLogRow {
+    body: Option<String>,
+}
+
+/// Horizontal marker placement for the current time indicator.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CurrentTimeMarker {
+    AboveRow(u64),
+    BelowRow(u64),
+}
+
+/// Virtualized table delegate for the text-log view.
+struct TextLogTableDelegate<'a> {
+    ctx: &'a ViewerContext<'a>,
+    projection: &'a TextLogProjectionState,
+    visible_columns: &'a [TableColumn],
+    monospace_body: bool,
+    row_height: f32,
+    cursor_color: Color32,
+    current_time_marker: Option<CurrentTimeMarker>,
+    prepared_rows: BTreeMap<u64, PreparedTextLogRow>,
+}
+
+impl TextLogTableDelegate<'_> {
+    /// Resolves and caches visible body strings for the current frame.
+    fn prepare_rows(&mut self, visible_rows: std::ops::Range<u64>) {
+        self.prepared_rows.clear();
+
+        if !self.visible_columns.iter().any(|column| {
+            matches!(column, TableColumn::Text(bp_datatypes::TextLogColumnKind::Body))
+        }) {
+            return;
+        }
+
+        for row_nr in visible_rows {
+            let body = self
+                .projection
+                .resolve_row(row_nr)
+                .and_then(|(chunk, handle, _)| chunk.resolve_body(handle.row_meta_idx))
+                .map(Into::into);
+
+            self.prepared_rows.insert(row_nr, PreparedTextLogRow { body });
+        }
+    }
+
+    /// Returns the body text prepared for the requested row.
+    fn prepared_body(&self, row_nr: u64) -> Option<&str> {
+        self.prepared_rows
+            .get(&row_nr)
+            .and_then(|row| row.body.as_deref())
+    }
+}
+
+impl egui_table::TableDelegate for TextLogTableDelegate<'_> {
+    /// Prepares only the visible body rows before cell rendering begins.
+    fn prepare(&mut self, info: &egui_table::PrefetchInfo) {
+        self.prepare_rows(info.visible_rows.clone());
+    }
+
+    /// Renders the single header row for the text-log table.
+    fn header_cell_ui(&mut self, ui: &mut egui::Ui, cell: &egui_table::HeaderCellInfo) {
+        let Some(column) = self.visible_columns.get(cell.col_range.start) else {
+            return;
+        };
+
+        match column {
+            TableColumn::Timeline(timeline) => {
+                timeline_button(&self.ctx.app_ctx, ui, timeline);
+            }
+            TableColumn::Text(kind) => {
+                column_name_ui(ui, kind);
+            }
+        };
+    }
+
+    /// Draws the current-time indicator on the matching visible row boundary.
+    fn row_ui(&mut self, ui: &mut egui::Ui, row_nr: u64) {
+        let Some(marker) = self.current_time_marker else {
+            return;
+        };
+
+        let y = match marker {
+            CurrentTimeMarker::AboveRow(marker_row) if marker_row == row_nr => Some(ui.max_rect().top()),
+            CurrentTimeMarker::BelowRow(marker_row) if marker_row == row_nr => Some(ui.max_rect().bottom()),
+            _ => None,
+        };
+
+        if let Some(y) = y {
+            ui.painter()
+                .hline(ui.max_rect().x_range(), y, (1.0, self.cursor_color));
+        }
+    }
+
+    /// Renders one visible text-log cell from cached metadata and lazily resolved bodies.
+    fn cell_ui(&mut self, ui: &mut egui::Ui, cell: &egui_table::CellInfo) {
+        let Some((chunk, _handle, row_meta)) = self.projection.resolve_row(cell.row_nr) else {
+            return;
+        };
+        let Some(column) = self.visible_columns.get(cell.col_nr) else {
+            return;
+        };
+
+        match column {
+            TableColumn::Timeline(timeline) => {
+                let row_time = row_meta
+                    .timepoint
+                    .get(timeline)
+                    .map(TimeInt::from)
+                    .unwrap_or(TimeInt::STATIC);
+                item_ui::time_button(self.ctx, ui, timeline, row_time);
+            }
+            TableColumn::Text(bp_datatypes::TextLogColumnKind::EntityPath) => {
+                item_ui::entity_path_button(
+                    &self.ctx.active_recording_store_view_context(),
+                    ui,
+                    None,
+                    chunk.entity_path(),
+                );
+            }
+            TableColumn::Text(bp_datatypes::TextLogColumnKind::LogLevel) => {
+                if let Some(level) = &row_meta.level {
+                    ui.label(level_to_rich_text(ui, level));
+                } else {
+                    ui.label("-");
+                }
+            }
+            TableColumn::Text(bp_datatypes::TextLogColumnKind::Body) => {
+                let mut text = egui::RichText::new(self.prepared_body(cell.row_nr).unwrap_or(""));
+
+                if self.monospace_body {
+                    text = text.monospace();
+                }
+                if let Some(color) = row_meta.color {
+                    text = text.color(color);
+                }
+
+                ui.label(text);
+            }
+        }
+    }
+
+    /// Uses cached prefix sums so row layout scales with visible rows instead of total history.
+    fn row_top_offset(&self, _ctx: &egui::Context, _table_id: egui::Id, row_nr: u64) -> f32 {
+        self.projection.row_top_offset(row_nr, self.row_height)
+    }
+
+    /// Returns the base single-line row height used by the prefix-sum offsets.
+    fn default_row_height(&self) -> f32 {
+        self.row_height
     }
 }
 
@@ -77,11 +446,17 @@ Filter message types and toggle column visibility in a selection panel.",
         system_registry.register_array_fallback_provider(
             TextLogColumns::descriptor_timeline_columns().component,
             |ctx| {
-                let active_timeline = ctx.viewer_ctx().time_ctrl.timeline_name();
-                vec![TimelineColumn(bp_datatypes::TimelineColumn {
-                    visible: true.into(),
-                    timeline: active_timeline.as_str().into(),
-                })]
+                ctx.viewer_ctx()
+                    .recording()
+                    .timelines()
+                    .keys()
+                    .map(|timeline| {
+                        TimelineColumn(bp_datatypes::TimelineColumn {
+                            visible: true.into(),
+                            timeline: timeline.as_str().into(),
+                        })
+                    })
+                    .collect::<Vec<_>>()
             },
         );
 
@@ -99,6 +474,7 @@ Filter message types and toggle column visibility in a selection panel.",
                         visible: true.into(),
                     })
                 })
+                .to_vec()
             },
         );
 
@@ -109,16 +485,17 @@ Filter message types and toggle column visibility in a selection panel.",
                     re_log::error_once!(
                         "Failed to get `TextViewState` in text log view fallback, this is a bug."
                     );
-
                     return Vec::new();
                 };
+
                 state
                     .seen_levels
                     .iter()
-                    .map(|lvl| TextLogLevel(datatypes::Utf8::from(lvl.as_str())))
+                    .map(|level| TextLogLevel(datatypes::Utf8::from(level.as_str())))
                     .collect::<Vec<_>>()
             },
         );
+
         system_registry.register_visualizer::<TextLogSystem>()
     }
 
@@ -127,7 +504,7 @@ Filter message types and toggle column visibility in a selection panel.",
     }
 
     fn preferred_tile_aspect_ratio(&self, _state: &dyn ViewState) -> Option<f32> {
-        Some(2.0) // Make text logs wide
+        Some(2.0)
     }
 
     fn layout_priority(&self) -> re_viewer_context::ViewClassLayoutPriority {
@@ -138,11 +515,9 @@ Filter message types and toggle column visibility in a selection panel.",
         &self,
         ctx: &ViewerContext<'_>,
         include_entity: &dyn Fn(&EntityPath) -> bool,
-    ) -> re_viewer_context::ViewSpawnHeuristics {
+    ) -> ViewSpawnHeuristics {
         re_tracing::profile_function!();
 
-        // Spawn a single log view at the root if there's any text logs around anywhere.
-        // Checking indicators is enough, since we know that this is enough to infer visualizability here.
         if ctx
             .indicated_entities_per_visualizer
             .get(&TextLogSystem::identifier())
@@ -181,14 +556,15 @@ Filter message types and toggle column visibility in a selection panel.",
         ui: &mut egui::Ui,
         state: &mut dyn ViewState,
         query: &ViewQuery<'_>,
-        system_output: re_viewer_context::SystemExecutionOutput,
+        _system_output: re_viewer_context::SystemExecutionOutput,
     ) -> Result<(), ViewSystemExecutionError> {
         re_tracing::profile_function!();
 
         let tokens = ui.tokens();
-        let state = state.downcast_mut::<TextViewState>()?;
-        let text = system_output.view_systems.get::<TextLogSystem>()?;
+        let table_style = re_ui::TableStyle::Dense;
+        let row_height = tokens.table_row_height(table_style);
 
+        let state = state.downcast_mut::<TextViewState>()?;
         let columns_property = ViewProperty::from_archetype::<TextLogColumns>(
             ctx.blueprint_db(),
             ctx.blueprint_query,
@@ -206,7 +582,6 @@ Filter message types and toggle column visibility in a selection panel.",
         );
 
         let view_ctx = self.view_context(ctx, query.view_id, state, query.space_origin);
-
         let monospace_body = format_property.component_or_fallback::<Enabled>(
             &view_ctx,
             TextLogFormat::descriptor_monospace_body().component,
@@ -215,262 +590,206 @@ Filter message types and toggle column visibility in a selection panel.",
             &view_ctx,
             TextLogColumns::descriptor_text_log_columns().component,
         )?;
-
         let timeline_columns = columns_property.component_array_or_fallback::<TimelineColumn>(
             &view_ctx,
             TextLogColumns::descriptor_timeline_columns().component,
         )?;
 
+        let included_entities = collect_included_entities(query);
+        let recording_ctx = ctx.active_recording_store_view_context();
+        recording_ctx.caches.entry::<TextLogCache, _>(|cache| {
+            cache.ensure_initialized(recording_ctx.db);
+            state
+                .projection
+                .refresh_from_cache(cache, &included_entities, query.timeline);
+        });
+
+        state.seen_levels = state.projection.seen_levels.clone();
+
+        let view_ctx = self.view_context(ctx, query.view_id, state, query.space_origin);
         let levels = rows_property.component_array_or_fallback::<TextLogLevel>(
             &view_ctx,
             TextLogRows::descriptor_filter_by_log_level().component,
         )?;
-
-        for te in &text.entries {
-            if let Some(lvl) = &te.level {
-                state.seen_levels.insert(lvl.to_string());
-            }
-        }
-
-        // TODO(andreas): Should filter text entries in the part-system instead.
-        // this likely requires a way to pass state into a context.
-        let entries = text
-            .entries
-            .iter()
-            .filter(|te| {
-                te.level
-                    .as_ref()
-                    .is_none_or(|lvl| levels.iter().any(|l| l.as_str() == lvl.as_str()))
-            })
-            .collect::<Vec<_>>();
+        state.projection.apply_level_filter(&levels);
 
         let time = ctx.time_ctrl.time_i64().unwrap_or(state.latest_time);
+        let time_cursor_moved = state.latest_time != time;
+        let scroll_to_row = time_cursor_moved
+            .then(|| scroll_target_row(&state.projection.filtered_rows, time))
+            .flatten();
+        let current_time_marker =
+            current_time_marker(&state.projection.filtered_rows, ctx.time_ctrl.time_int());
+
         egui::Frame {
             inner_margin: tokens.view_padding().into(),
             ..egui::Frame::default()
         }
         .show(ui, |ui| {
-            // Did the time cursor move since last time?
-            // - If it did, autoscroll to the text log to reveal the current time.
-            // - Otherwise, let the user scroll around freely!
-            let time_cursor_moved = state.latest_time != time;
-            let scroll_to_row = time_cursor_moved.then(|| {
-                re_tracing::profile_scope!("search scroll time");
-                entries.partition_point(|te| te.time.as_i64() < time)
-            });
-
-            ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
-                egui::ScrollArea::horizontal().show(ui, |ui| {
-                    re_tracing::profile_scope!("render table");
-                    table_ui(
-                        ctx,
-                        ui,
-                        state,
-                        &timeline_columns,
-                        &columns,
-                        **monospace_body,
-                        &entries,
-                        scroll_to_row,
-                    );
-                })
-            })
+            table_ui(
+                ctx,
+                ui,
+                query.view_id,
+                &state.projection,
+                &timeline_columns,
+                &columns,
+                **monospace_body,
+                row_height,
+                current_time_marker,
+                scroll_to_row,
+            );
         });
+
         state.latest_time = time;
 
         Ok(())
     }
 }
 
-// ---
-
-/// `scroll_to_row` indicates how far down we want to scroll in terms of logical rows,
-/// as opposed to `scroll_to_offset` (computed below) which is how far down we want to
-/// scroll in terms of actual points.
+/// Builds and renders the virtualized text-log table.
 #[expect(clippy::too_many_arguments)]
 fn table_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    state: &mut TextViewState,
+    view_id: ViewId,
+    projection: &TextLogProjectionState,
     timeline_columns: &[TimelineColumn],
     columns: &[TextLogColumn],
     monospace_body: bool,
-    entries: &[&Entry],
-    scroll_to_row: Option<usize>,
+    row_height: f32,
+    current_time_marker: Option<CurrentTimeMarker>,
+    scroll_to_row: Option<u64>,
 ) {
-    let tokens = ui.tokens();
-    let table_style = re_ui::TableStyle::Dense;
-
-    use egui_extras::Column;
-
-    let (global_timeline, global_time) = (*ctx.time_ctrl.timeline_name(), ctx.time_ctrl.time_int());
-
-    let mut table_builder = egui_extras::TableBuilder::new(ui)
-        .resizable(true)
-        .vscroll(true)
-        .auto_shrink([false; 2]) // expand to take up the whole View
-        .min_scrolled_height(0.0) // we can go as small as we need to be in order to fit within the view!
-        .max_scroll_height(f32::INFINITY) // Fill up whole height
-        .cell_layout(egui::Layout::left_to_right(egui::Align::Center));
+    let visible_columns = build_visible_columns(timeline_columns, columns);
+    let mut table = egui_table::Table::new()
+        .id_salt(egui::Id::new("__text_log__").with(view_id))
+        .headers(vec![egui_table::HeaderRow::new(
+            ui.tokens().table_header_height(),
+        )])
+        .num_rows(projection.filtered_rows.len() as u64)
+        .columns(
+            visible_columns
+                .iter()
+                .map(|column| match column {
+                    TableColumn::Timeline(timeline) => {
+                        egui_table::Column::new(120.0)
+                            .resizable(true)
+                            .id(egui::Id::new(("timeline", timeline.as_str())))
+                    }
+                    TableColumn::Text(bp_datatypes::TextLogColumnKind::EntityPath) => {
+                        egui_table::Column::new(180.0)
+                            .resizable(true)
+                            .id(egui::Id::new("entity_path"))
+                    }
+                    TableColumn::Text(bp_datatypes::TextLogColumnKind::LogLevel) => {
+                        egui_table::Column::new(90.0)
+                            .resizable(true)
+                            .id(egui::Id::new("log_level"))
+                    }
+                    TableColumn::Text(bp_datatypes::TextLogColumnKind::Body) => {
+                        egui_table::Column::new(420.0)
+                            .resizable(true)
+                            .id(egui::Id::new("body"))
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
 
     if let Some(scroll_to_row) = scroll_to_row {
-        table_builder = table_builder.scroll_to_row(scroll_to_row, Some(egui::Align::Center));
+        table = table.scroll_to_row(scroll_to_row, Some(egui::Align::Center));
     }
 
-    let mut body_clip_rect = None;
-    let mut current_time_y = None; // where to draw the current time indicator cursor
-
-    let mut new_column_sizes = Vec::new();
-    let mut last_columns = state.last_columns_min_sizes.iter();
-
-    let mut size_column = |column: Column, min_size: u32| {
-        // If this isn't the same min size as before the order changed.
-        let auto_resize = last_columns.next().is_some_and(|c| *c != min_size);
-
-        new_column_sizes.push(min_size);
-
-        column
-            .at_least(min_size as f32)
-            .auto_size_this_frame(auto_resize)
+    let mut table_delegate = TextLogTableDelegate {
+        ctx,
+        projection,
+        visible_columns: &visible_columns,
+        monospace_body,
+        row_height,
+        cursor_color: ui.tokens().strong_fg_color,
+        current_time_marker,
+        prepared_rows: BTreeMap::default(),
     };
 
-    for col in timeline_columns {
-        if *col.visible {
-            table_builder = table_builder.column(size_column(Column::auto().clip(true), 32));
-        }
-    }
+    table.show(ui, &mut table_delegate);
+}
 
-    for col in columns {
-        if !*col.visible {
-            continue;
-        }
+/// Collects the entity set currently included by the text-log visualizer instructions.
+fn collect_included_entities(query: &ViewQuery<'_>) -> BTreeSet<EntityPath> {
+    query
+        .iter_visualizer_instruction_for(TextLogSystem::identifier())
+        .map(|(data_result, _)| data_result.entity_path.clone())
+        .collect()
+}
 
-        let col = match col.kind {
-            bp_datatypes::TextLogColumnKind::EntityPath => {
-                size_column(Column::auto().clip(true), 32)
-            }
-            bp_datatypes::TextLogColumnKind::LogLevel => size_column(Column::auto(), 30),
-            bp_datatypes::TextLogColumnKind::Body => size_column(Column::remainder(), 100),
-        };
-
-        table_builder = table_builder.column(col);
-    }
-
-    state.last_columns_min_sizes = new_column_sizes;
-
-    table_builder
-        .header(tokens.deprecated_table_header_height(), |mut header| {
-            re_ui::DesignTokens::setup_table_header(&mut header);
-            for col in timeline_columns {
-                if !*col.visible {
-                    continue;
-                }
-
-                header.col(|ui| {
-                    timeline_button(&ctx.app_ctx, ui, &TimelineName::new(&col.timeline));
-                });
-            }
-            for col in columns {
-                if !*col.visible {
-                    continue;
-                }
-                header.col(|ui| {
-                    column_name_ui(ui, &col.kind);
-                });
-            }
-        })
-        .body(|mut body| {
-            tokens.setup_table_body(&mut body, table_style);
-
-            body_clip_rect = Some(body.max_rect());
-
-            let row_heights = entries
+/// Expands the currently visible timeline and text columns into a single table layout.
+fn build_visible_columns(
+    timeline_columns: &[TimelineColumn],
+    columns: &[TextLogColumn],
+) -> Vec<TableColumn> {
+    timeline_columns
+        .iter()
+        .filter(|column| *column.visible)
+        .map(|column| TableColumn::Timeline(TimelineName::new(&column.timeline)))
+        .chain(
+            columns
                 .iter()
-                .map(|te| calc_row_height(tokens, table_style, te));
-            body.heterogeneous_rows(row_heights, |mut row| {
-                let entry = &entries[row.index()];
+                .filter(|column| *column.visible)
+                .map(|column| TableColumn::Text(column.kind)),
+        )
+        .collect()
+}
 
-                for col in timeline_columns {
-                    if !*col.visible {
-                        continue;
-                    }
+/// Returns the row that should be scrolled into view when the time cursor moves.
+fn scroll_target_row(rows: &[TextLogRowHandle], time: i64) -> Option<u64> {
+    if rows.is_empty() {
+        return None;
+    }
 
-                    let timeline = TimelineName::new(&col.timeline);
+    Some(rows.partition_point(|row| row.sort_time.as_i64() < time) as u64)
+}
 
-                    row.col(|ui| {
-                        let row_time = entry
-                            .timepoint
-                            .get(&timeline)
-                            .map(re_log_types::TimeInt::from)
-                            .unwrap_or(re_log_types::TimeInt::STATIC);
-                        item_ui::time_button(ctx, ui, &timeline, row_time);
+/// Computes where the current-time indicator should be drawn for the filtered rows.
+fn current_time_marker(
+    rows: &[TextLogRowHandle],
+    global_time: Option<TimeInt>,
+) -> Option<CurrentTimeMarker> {
+    let global_time = global_time?;
+    let boundary = rows.partition_point(|row| row.sort_time <= global_time);
 
-                        if let Some(global_time) = global_time
-                            && timeline == global_timeline
-                        {
-                            if global_time < row_time {
-                                // We've past the global time - it is thus above this row.
-                                if current_time_y.is_none() {
-                                    current_time_y = Some(ui.max_rect().top());
-                                }
-                            } else if global_time == row_time {
-                                // This row is exactly at the current time.
-                                // We could draw the current time exactly onto this row, but that would look bad,
-                                // so let's draw it under instead. It looks better in the "following" mode.
-                                current_time_y = Some(ui.max_rect().bottom());
-                            }
-                        }
-                    });
-                }
-
-                for col in columns {
-                    if !*col.visible {
-                        continue;
-                    }
-
-                    row.col(|ui| match col.kind {
-                        bp_datatypes::TextLogColumnKind::EntityPath => {
-                            item_ui::entity_path_button(
-                                &ctx.active_recording_store_view_context(),
-                                ui,
-                                None,
-                                &entry.entity_path,
-                            );
-                        }
-                        bp_datatypes::TextLogColumnKind::LogLevel => {
-                            if let Some(lvl) = &entry.level {
-                                ui.label(level_to_rich_text(ui, lvl));
-                            } else {
-                                ui.label("-");
-                            }
-                        }
-                        bp_datatypes::TextLogColumnKind::Body => {
-                            let mut text = egui::RichText::new(entry.body.as_str());
-
-                            if monospace_body {
-                                text = text.monospace();
-                            }
-                            if let Some(color) = entry.color {
-                                text = text.color(color);
-                            }
-
-                            ui.label(text);
-                        }
-                    });
-                }
-            });
-        });
-
-    // TODO(cmc): this draws on top of the headers :(
-    if let (Some(body_clip_rect), Some(current_time_y)) = (body_clip_rect, current_time_y) {
-        // Show that the current time is here:
-        ui.painter().with_clip_rect(body_clip_rect).hline(
-            ui.max_rect().x_range(),
-            current_time_y,
-            (1.0, ui.tokens().strong_fg_color),
-        );
+    if rows.is_empty() {
+        None
+    } else if boundary < rows.len() {
+        Some(CurrentTimeMarker::AboveRow(boundary as u64))
+    } else {
+        Some(CurrentTimeMarker::BelowRow((rows.len() - 1) as u64))
     }
 }
 
+/// Merges two sorted row lists while keeping deterministic ordering for ties.
+fn merge_sorted_rows(
+    existing_rows: Vec<TextLogRowHandle>,
+    added_rows: Vec<TextLogRowHandle>,
+) -> Vec<TextLogRowHandle> {
+    let mut merged_rows = Vec::with_capacity(existing_rows.len() + added_rows.len());
+    let mut existing_index = 0;
+    let mut added_index = 0;
+
+    while existing_index < existing_rows.len() && added_index < added_rows.len() {
+        if existing_rows[existing_index] <= added_rows[added_index] {
+            merged_rows.push(existing_rows[existing_index]);
+            existing_index += 1;
+        } else {
+            merged_rows.push(added_rows[added_index]);
+            added_index += 1;
+        }
+    }
+
+    merged_rows.extend(existing_rows[existing_index..].iter().copied());
+    merged_rows.extend(added_rows[added_index..].iter().copied());
+    merged_rows
+}
+
+/// Renders a bold column label in the text-log header row.
 fn column_name_ui(ui: &mut egui::Ui, column: &bp_datatypes::TextLogColumnKind) -> egui::Response {
     ui.strong(column.name())
 }
@@ -527,31 +846,31 @@ fn view_property_ui_rows(ctx: &ViewContext<'_>, ui: &mut egui::Ui) {
                         let mut new_levels = state
                             .seen_levels
                             .iter()
-                            .map(|s| {
-                                let level_active = levels.iter().any(|l| l.as_str() == s);
-                                (s.clone(), level_active)
+                            .map(|level| {
+                                let level_active = levels.iter().any(|enabled| enabled.as_str() == level);
+                                (level.clone(), level_active)
                             })
                             .chain(
                                 levels
                                     .iter()
-                                    .filter(|lvl| !state.seen_levels.contains(lvl.as_str()))
-                                    .map(|lvl| (lvl.as_str().to_owned(), true)),
+                                    .filter(|level| !state.seen_levels.contains(level.as_str()))
+                                    .map(|level| (level.as_str().to_owned(), true)),
                             )
                             .collect::<Vec<_>>();
 
                         let mut any_change = false;
-                        for (lvl, active) in &mut new_levels {
+                        for (level, active) in &mut new_levels {
                             any_change |= ui
-                                .re_checkbox(active, level_to_rich_text(ui, lvl))
+                                .re_checkbox(active, level_to_rich_text(ui, level))
                                 .changed();
                         }
 
                         if any_change {
-                            let log_levels: Vec<_> = new_levels
+                            let log_levels = new_levels
                                 .into_iter()
                                 .filter(|(_, active)| *active)
-                                .map(|(lvl, _)| TextLogLevel(lvl.into()))
-                                .collect();
+                                .map(|(level, _)| TextLogLevel(level.into()))
+                                .collect::<Vec<_>>();
 
                             property.save_blueprint_component(
                                 ctx.viewer_ctx,
@@ -588,11 +907,218 @@ fn view_property_ui_rows(ctx: &ViewContext<'_>, ui: &mut egui::Ui) {
     }
 }
 
-fn calc_row_height(tokens: &DesignTokens, table_style: re_ui::TableStyle, entry: &Entry) -> f32 {
-    // Simple, fast, ugly, and functional
-    let num_newlines = entry.body.bytes().filter(|&c| c == b'\n').count();
-    let num_rows = 1 + num_newlines;
-    num_rows as f32 * tokens.table_row_height(table_style)
+#[cfg(test)]
+mod tests {
+    use super::{
+        CurrentTimeMarker, TextLogProjectionState, current_time_marker, merge_sorted_rows,
+        scroll_target_row,
+    };
+    use std::sync::Arc;
+
+    use re_chunk::{Chunk, RowId, Timeline};
+    use re_log_types::{TimeInt, TimePoint, TimelineName};
+    use re_sdk_types::archetypes::TextLog;
+    use re_sdk_types::components::{Text, TextLogLevel};
+
+    use crate::cache::{IndexedTextLogChunk, TextLogRowHandle, TextLogRowMeta};
+
+    /// Builds a minimal indexed chunk for projection tests.
+    fn indexed_chunk(
+        entity_path: &str,
+        row_metas: Vec<TextLogRowMeta>,
+    ) -> Arc<IndexedTextLogChunk> {
+        let chunk = Chunk::builder(entity_path)
+            .with_component_batches(
+                RowId::new(),
+                [(Timeline::log_time(), 0)],
+                [(
+                    TextLog::descriptor_text(),
+                    &[Text::from("placeholder")] as _,
+                )],
+            )
+            .build()
+            .expect("chunk should build");
+
+        Arc::new(IndexedTextLogChunk {
+            chunk: Arc::new(chunk),
+            row_metas,
+        })
+    }
+
+    /// Creates one cached row metadata entry for projection tests.
+    fn row_meta(time: i64, line_count: u32, level: Option<&str>) -> TextLogRowMeta {
+        TextLogRowMeta {
+            row_idx: 0,
+            instance_idx: 0,
+            row_id: RowId::new(),
+            timepoint: TimePoint::default().with(Timeline::log_time(), time),
+            level: level.map(TextLogLevel::from),
+            color: None,
+            line_count,
+        }
+    }
+
+    /// Verifies that level filtering keeps rows without levels and caches prefix sums.
+    #[test]
+    fn projection_filter_rebuilds_prefix_sums() {
+        let chunk_a = indexed_chunk("logs/a", vec![row_meta(1, 1, Some(TextLogLevel::INFO))]);
+        let chunk_b = indexed_chunk("logs/b", vec![row_meta(2, 3, None)]);
+        let mut projection = TextLogProjectionState::default();
+
+        projection
+            .chunks
+            .insert(chunk_a.chunk.id(), Arc::clone(&chunk_a));
+        projection
+            .chunks
+            .insert(chunk_b.chunk.id(), Arc::clone(&chunk_b));
+        chunk_a.append_row_handles_for_timeline(TimelineName::log_time(), &mut projection.all_rows);
+        chunk_b.append_row_handles_for_timeline(TimelineName::log_time(), &mut projection.all_rows);
+        projection.all_rows.sort();
+        projection.needs_filter_refresh = true;
+
+        projection.apply_level_filter(&[TextLogLevel::from(TextLogLevel::INFO)]);
+
+        assert_eq!(projection.filtered_rows.len(), 2);
+        assert_eq!(projection.prefix_line_counts, vec![0, 1, 4]);
+    }
+
+    /// Verifies that the sorted-row merge keeps deterministic ordering.
+    #[test]
+    fn merge_sorted_rows_preserves_order() {
+        let existing_rows = vec![
+            TextLogRowHandle {
+                chunk_id: Chunk::builder("logs/a")
+                    .with_component_batches(
+                        RowId::new(),
+                        [(Timeline::log_time(), 0)],
+                        [(
+                            TextLog::descriptor_text(),
+                            &[Text::from("a")] as _,
+                        )],
+                    )
+                    .build()
+                    .expect("chunk should build")
+                    .id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(1),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+            TextLogRowHandle {
+                chunk_id: Chunk::builder("logs/b")
+                    .with_component_batches(
+                        RowId::new(),
+                        [(Timeline::log_time(), 0)],
+                        [(
+                            TextLog::descriptor_text(),
+                            &[Text::from("b")] as _,
+                        )],
+                    )
+                    .build()
+                    .expect("chunk should build")
+                    .id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(3),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+        ];
+        let added_rows = vec![TextLogRowHandle {
+            chunk_id: Chunk::builder("logs/c")
+                .with_component_batches(
+                    RowId::new(),
+                    [(Timeline::log_time(), 0)],
+                    [(
+                        TextLog::descriptor_text(),
+                        &[Text::from("c")] as _,
+                    )],
+                )
+                .build()
+                .expect("chunk should build")
+                .id(),
+            row_meta_idx: 0,
+            sort_time: TimeInt::new_temporal(2),
+            row_id: RowId::new(),
+            instance_idx: 0,
+        }];
+
+        let merged_rows = merge_sorted_rows(existing_rows, added_rows);
+
+        assert_eq!(
+            merged_rows
+                .iter()
+                .map(|row| row.sort_time.as_i64())
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    /// Verifies the scroll target keeps the first row at or after the current time.
+    #[test]
+    fn scroll_target_uses_first_row_at_current_time() {
+        let rows = vec![
+            TextLogRowHandle {
+                chunk_id: indexed_chunk("logs/a", vec![row_meta(1, 1, None)]).chunk.id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(10),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+            TextLogRowHandle {
+                chunk_id: indexed_chunk("logs/b", vec![row_meta(2, 1, None)]).chunk.id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(20),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+            TextLogRowHandle {
+                chunk_id: indexed_chunk("logs/c", vec![row_meta(3, 1, None)]).chunk.id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(20),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+        ];
+
+        assert_eq!(scroll_target_row(&rows, 20), Some(1));
+    }
+
+    /// Verifies the time marker lands after the last row at or before the current time.
+    #[test]
+    fn current_time_marker_tracks_boundary_after_last_matching_row() {
+        let rows = vec![
+            TextLogRowHandle {
+                chunk_id: indexed_chunk("logs/a", vec![row_meta(1, 1, None)]).chunk.id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(10),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+            TextLogRowHandle {
+                chunk_id: indexed_chunk("logs/b", vec![row_meta(2, 1, None)]).chunk.id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(20),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+            TextLogRowHandle {
+                chunk_id: indexed_chunk("logs/c", vec![row_meta(3, 1, None)]).chunk.id(),
+                row_meta_idx: 0,
+                sort_time: TimeInt::new_temporal(20),
+                row_id: RowId::new(),
+                instance_idx: 0,
+            },
+        ];
+
+        assert_eq!(
+            current_time_marker(&rows, Some(TimeInt::new_temporal(20))),
+            Some(CurrentTimeMarker::BelowRow(2))
+        );
+        assert_eq!(
+            current_time_marker(&rows, Some(TimeInt::new_temporal(15))),
+            Some(CurrentTimeMarker::AboveRow(1))
+        );
+    }
 }
 
 #[test]

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -1,32 +1,12 @@
-use itertools::izip;
-use re_chunk_store::AbsoluteTimeRange;
-use re_entity_db::EntityPath;
-use re_log_types::{TimeInt, TimePoint};
-use re_query::{clamped_zip_1x2, range_zip_1x2};
-use re_sdk_types::Archetype as _;
 use re_sdk_types::archetypes::TextLog;
-use re_sdk_types::components::{Color, Text, TextLogLevel};
-use re_view::range_with_blueprint_resolved_data;
 use re_viewer_context::{
     IdentifiedViewSystem, ViewContext, ViewContextCollection, ViewQuery, ViewSystemExecutionError,
     VisualizerExecutionOutput, VisualizerQueryInfo, VisualizerSystem,
 };
 
-#[derive(Debug, Clone)]
-pub struct Entry {
-    pub entity_path: EntityPath,
-    pub time: TimeInt,
-    pub timepoint: TimePoint,
-    pub color: Option<Color>,
-    pub body: Text,
-    pub level: Option<TextLogLevel>,
-}
-
-/// A text scene, with everything needed to render it.
+/// Marker visualizer that keeps text-log entities discoverable for the view system.
 #[derive(Default)]
-pub struct TextLogSystem {
-    pub entries: Vec<Entry>,
-}
+pub struct TextLogSystem;
 
 impl IdentifiedViewSystem for TextLogSystem {
     fn identifier() -> re_viewer_context::ViewSystemIdentifier {
@@ -35,119 +15,21 @@ impl IdentifiedViewSystem for TextLogSystem {
 }
 
 impl VisualizerSystem for TextLogSystem {
+    /// Declares that this visualizer is driven by the `TextLog` archetype.
     fn visualizer_query_info(
         &self,
         _app_options: &re_viewer_context::AppOptions,
     ) -> VisualizerQueryInfo {
-        VisualizerQueryInfo::single_required_component::<Text>(
-            &TextLog::descriptor_text(),
-            &TextLog::all_components(),
-        )
+        VisualizerQueryInfo::from_archetype::<TextLog>()
     }
 
+    /// Leaves table data loading to the cached view path while keeping instruction wiring intact.
     fn execute(
         &mut self,
-        ctx: &ViewContext<'_>,
-        view_query: &ViewQuery<'_>,
+        _ctx: &ViewContext<'_>,
+        _view_query: &ViewQuery<'_>,
         _context_systems: &ViewContextCollection,
     ) -> Result<VisualizerExecutionOutput, ViewSystemExecutionError> {
-        re_tracing::profile_function!();
-
-        let output = VisualizerExecutionOutput::default();
-        let query =
-            re_chunk_store::RangeQuery::new(view_query.timeline, AbsoluteTimeRange::EVERYTHING)
-                .keep_extra_timelines(true);
-
-        for (data_result, instruction) in
-            view_query.iter_visualizer_instruction_for(Self::identifier())
-        {
-            self.process_visualizer_instruction(ctx, &query, data_result, instruction, &output);
-        }
-
-        {
-            // Sort by currently selected timeline
-            re_tracing::profile_scope!("sort");
-            self.entries.sort_by_key(|e| e.time);
-        }
-
-        Ok(output)
-    }
-}
-
-impl TextLogSystem {
-    fn process_visualizer_instruction(
-        &mut self,
-        ctx: &ViewContext<'_>,
-        query: &re_chunk_store::RangeQuery,
-        data_result: &re_viewer_context::DataResult,
-        instruction: &re_viewer_context::VisualizerInstruction,
-        output: &VisualizerExecutionOutput,
-    ) {
-        re_tracing::profile_function!();
-
-        let range_results = range_with_blueprint_resolved_data(
-            ctx,
-            None,
-            query,
-            data_result,
-            TextLog::all_component_identifiers(),
-            instruction,
-        );
-
-        // Convert to HybridResults for unified access
-        let results = re_view::BlueprintResolvedResults::from((query.clone(), range_results));
-        let results =
-            re_view::VisualizerInstructionQueryResults::new(instruction, &results, output);
-
-        let all_texts = results.iter_required(TextLog::descriptor_text().component);
-        if all_texts.is_empty() {
-            return;
-        }
-
-        // TODO(cmc): It would be more efficient (both space and compute) to do this lazily as
-        // we're rendering the table by indexing back into the original chunk etc.
-        // Let's keep it simple for now, until we have data suggested we need the extra perf.
-        let all_timepoints = all_texts
-            .chunks()
-            .iter()
-            .flat_map(|chunk| chunk.iter_component_timepoints());
-
-        let all_levels = results.iter_optional(TextLog::descriptor_level().component);
-        let all_colors = results.iter_optional(TextLog::descriptor_color().component);
-
-        let all_frames = range_zip_1x2(
-            all_texts.slice::<String>(),
-            all_levels.slice::<String>(),
-            all_colors.slice::<u32>(),
-        );
-
-        let all_frames = izip!(all_timepoints, all_frames);
-
-        for (timepoint, ((data_time, _row_id), bodies, levels, colors)) in all_frames {
-            let levels = levels.as_deref().unwrap_or(&[]).iter().cloned().map(Some);
-            let colors = colors
-                .unwrap_or(&[])
-                .iter()
-                .copied()
-                .map(Into::into)
-                .map(Some);
-
-            let level_default_fn = || None;
-            let color_default_fn = || None;
-
-            let results =
-                clamped_zip_1x2(bodies, levels, level_default_fn, colors, color_default_fn);
-
-            for (text, level, color) in results {
-                self.entries.push(Entry {
-                    entity_path: data_result.entity_path.clone(),
-                    time: data_time,
-                    timepoint: timepoint.clone(),
-                    color,
-                    body: text.clone().into(),
-                    level: level.clone().map(Into::into),
-                });
-            }
-        }
+        Ok(VisualizerExecutionOutput::default())
     }
 }


### PR DESCRIPTION
### Related

- No linked issue yet.

### What

Improve text log view performance for large numbers of log entries by replacing the eager per-frame expansion path with a cached, virtualized one.

Previously, the text log view eagerly expanded all matching `TextLog` data into a flat in-memory list, sorted the entire list, recalculated row heights from full text bodies, and rendered through the old heterogeneous row path. That approach works for small recordings, but it becomes expensive when a recording contains many log rows or large multi-line messages.

This PR introduces a store-level `TextLogCache` plus a per-view `TextLogProjectionState` so the view can work from lightweight row metadata instead of eagerly materializing every visible row body on every frame.

Main changes:
- Add `TextLogCache`, which indexes text-log chunks once and stores lightweight per-row metadata:
  - row id / instance id
  - timepoint
  - log level
  - color
  - explicit line count
  
- Support incremental append-only updates in the cache, while falling back to a rebuild for non-additive store edits.

- Add a per-view projection that:
  - tracks the currently included entities and active timeline
  - preserves the legacy stable row ordering
  - applies log-level filtering over cached row handles
  - caches prefix sums for multi-line row heights
  - reuses cached discovered levels for blueprint fallback UI
  
- Switch rendering to `egui_table` with a table delegate that:
  - resolves text bodies lazily for visible rows only
  - uses cached prefix sums for row positioning
  - preserves current-time autoscroll behavior
  - preserves current-time marker rendering
  
- Simplify `TextLogSystem` so it remains responsible for discoverability of `TextLog` entities, while the view owns cached loading/projection logic.

- Add unit tests covering:
  - sparse carry-forward behavior for level/color metadata
  - lazy body resolution from indexed chunks
  - additive vs non-additive cache revisions
  - explicit newline counting
  - filtered projection prefix sums
  - sorted merge behavior
  - scroll target behavior
  - current-time marker placement

This is intended to preserve existing user-visible behavior while making large text-log views much more responsive.

Local validation:
- `cargo check -p re_view_text_log`
- `cargo test -p re_view_text_log`

Both passed locally.

Breaking changes:
- None.

Migration guide:
- Not needed.
