### PR TITLE
Handle empty ROS2 camera `frame_id` without panicking

### DIFF
--- a/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/camera_info.rs
+++ b/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/camera_info.rs
@@ -3,7 +3,7 @@ use re_sdk_types::archetypes::{CoordinateFrame, Pinhole};
 
 use super::super::Ros2MessageParser;
 use super::super::definitions::sensor_msgs;
-use super::super::util::suffix_image_plane_frame_ids;
+use super::super::util::spatial_camera_frame_ids_or_log_missing;
 use crate::Error;
 use crate::parsers::cdr;
 use crate::parsers::decode::{MessageParser, ParserContext};
@@ -73,24 +73,29 @@ impl MessageParser for CameraInfoMessageParser {
         } = *self;
 
         let entity_path = ctx.entity_path().clone();
+        let Some(frame_ids) = spatial_camera_frame_ids_or_log_missing(
+            ctx.channel_topic(),
+            &entity_path,
+            "sensor_msgs/msg/CameraInfo",
+            "Skipping camera calibration import for this topic.",
+            frame_ids,
+        ) else {
+            return Ok(Vec::new());
+        };
         let timelines = ctx.build_timelines();
-
-        // We need a frame ID for the image plane. This doesn't exist in ROS,
-        // so we use the camera frame ID with a suffix here (and in the image parsers).
-        let image_plane_frame_ids = suffix_image_plane_frame_ids(frame_ids.clone());
 
         let mut components: Vec<_> = Pinhole::update_fields()
             .with_many_image_from_camera(image_from_cameras)
             .with_many_resolution(resolutions)
-            .with_many_parent_frame(frame_ids.clone())
-            .with_many_child_frame(image_plane_frame_ids)
+            .with_many_parent_frame(frame_ids.camera_frame_ids.clone())
+            .with_many_child_frame(frame_ids.image_plane_frame_ids)
             .columns_of_unit_batches()
             .map_err(|err| Error::Other(anyhow::anyhow!(err)))?
             .collect();
 
         components.extend(
             CoordinateFrame::update_fields()
-                .with_many_frame(frame_ids)
+                .with_many_frame(frame_ids.camera_frame_ids)
                 .columns_of_unit_batches()
                 .map_err(|err| Error::Other(anyhow::anyhow!(err)))?,
         );
@@ -103,5 +108,88 @@ impl MessageParser for CameraInfoMessageParser {
         )?;
 
         Ok(vec![pinhole_chunk])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use re_chunk::EntityPath;
+    use re_log_types::TimeType;
+
+    use super::*;
+
+    fn test_ctx() -> ParserContext {
+        ParserContext::new(
+            EntityPath::from("/tests/camera_info"),
+            "/tests/camera_info",
+            TimeType::TimestampNs,
+        )
+    }
+
+    fn install_warn_logger() -> re_log::Receiver<re_log::LogMsg> {
+        re_log::setup_logging();
+        let (logger, log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Warn);
+        re_log::add_boxed_logger(Box::new(logger)).expect("Failed to add logger");
+        log_rx
+    }
+
+    #[track_caller]
+    fn expect_single_matching_warning(
+        log_rx: &re_log::Receiver<re_log::LogMsg>,
+        expected_substring: &str,
+    ) {
+        let matching_logs = std::iter::from_fn(|| log_rx.try_recv().ok())
+            .filter(|log| log.level == re_log::Level::Warn && log.msg.contains(expected_substring))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching_logs.len(),
+            1,
+            "Expected exactly one matching warning containing {expected_substring:?}, got {matching_logs:?}"
+        );
+    }
+
+    #[test]
+    fn drops_camera_info_topic_when_any_frame_id_is_missing() {
+        let log_rx = install_warn_logger();
+
+        let parser = CameraInfoMessageParser {
+            image_from_cameras: vec![[1.0; 9], [2.0; 9]],
+            resolutions: vec![(640.0, 480.0), (640.0, 480.0)],
+            frame_ids: vec!["camera".to_owned(), "   ".to_owned()],
+        };
+
+        let chunks = Box::new(parser).finalize(test_ctx()).unwrap();
+
+        assert!(chunks.is_empty());
+        expect_single_matching_warning(&log_rx, "Skipping camera calibration import");
+    }
+
+    #[test]
+    fn keeps_spatial_components_for_camera_info_with_valid_frame_ids() {
+        let parser = CameraInfoMessageParser {
+            image_from_cameras: vec![[1.0; 9]],
+            resolutions: vec![(640.0, 480.0)],
+            frame_ids: vec!["camera".to_owned()],
+        };
+
+        let chunks = Box::new(parser).finalize(test_ctx()).unwrap();
+        let chunk = chunks.first().unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            chunk
+                .components()
+                .contains_component(Pinhole::descriptor_parent_frame().component)
+        );
+        assert!(
+            chunk
+                .components()
+                .contains_component(Pinhole::descriptor_child_frame().component)
+        );
+        assert!(
+            chunk
+                .components()
+                .contains_component(CoordinateFrame::descriptor_frame().component)
+        );
     }
 }

--- a/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/compressed_image.rs
+++ b/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/compressed_image.rs
@@ -5,7 +5,7 @@ use re_sdk_types::components::{MediaType, VideoCodec};
 
 use super::super::Ros2MessageParser;
 use super::super::definitions::sensor_msgs;
-use super::super::util::suffix_image_plane_frame_ids;
+use super::super::util::spatial_camera_frame_ids_or_log_missing;
 use crate::parsers::cdr;
 use crate::parsers::decode::{MessageParser, ParserContext};
 use crate::util::TimestampCell;
@@ -70,6 +70,13 @@ impl MessageParser for CompressedImageMessageParser {
         } = *self;
 
         let entity_path = ctx.entity_path().clone();
+        let spatial_frame_ids = spatial_camera_frame_ids_or_log_missing(
+            ctx.channel_topic(),
+            &entity_path,
+            "sensor_msgs/msg/CompressedImage",
+            "Importing the topic as plain 2D image/video data.",
+            frame_ids,
+        );
         let timelines = ctx.build_timelines();
 
         let mut components: Vec<_> = match mode {
@@ -94,14 +101,13 @@ impl MessageParser for CompressedImageMessageParser {
             }
         };
 
-        // We need a frame ID for the image plane. This doesn't exist in ROS,
-        // so we use the camera frame ID with a suffix here (see also camera info parser).
-        let image_plane_frame_ids = suffix_image_plane_frame_ids(frame_ids);
-        components.extend(
-            CoordinateFrame::update_fields()
-                .with_many_frame(image_plane_frame_ids)
-                .columns_of_unit_batches()?,
-        );
+        if let Some(frame_ids) = spatial_frame_ids {
+            components.extend(
+                CoordinateFrame::update_fields()
+                    .with_many_frame(frame_ids.image_plane_frame_ids)
+                    .columns_of_unit_batches()?,
+            );
+        }
 
         let chunk = Chunk::from_auto_row_ids(
             ChunkId::new(),
@@ -172,5 +178,76 @@ mod tests {
         assert!(is_rvl("32FC1; compressedDepth RVL"));
         assert!(!is_rvl("16UC1; compressedDepth png"));
         assert!(!is_rvl("jpeg"));
+    }
+
+    fn test_ctx() -> ParserContext {
+        ParserContext::new(
+            re_chunk::EntityPath::from("/tests/compressed_image"),
+            "/tests/compressed_image",
+            re_log_types::TimeType::TimestampNs,
+        )
+    }
+
+    fn install_warn_logger() -> re_log::Receiver<re_log::LogMsg> {
+        re_log::setup_logging();
+        let (logger, log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Warn);
+        re_log::add_boxed_logger(Box::new(logger)).expect("Failed to add logger");
+        log_rx
+    }
+
+    #[track_caller]
+    fn expect_single_matching_warning(
+        log_rx: &re_log::Receiver<re_log::LogMsg>,
+        expected_substring: &str,
+    ) {
+        let matching_logs = std::iter::from_fn(|| log_rx.try_recv().ok())
+            .filter(|log| log.level == re_log::Level::Warn && log.msg.contains(expected_substring))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching_logs.len(),
+            1,
+            "Expected exactly one matching warning containing {expected_substring:?}, got {matching_logs:?}"
+        );
+    }
+
+    #[test]
+    fn omits_coordinate_frame_when_any_compressed_image_frame_id_is_missing() {
+        let log_rx = install_warn_logger();
+
+        let parser = CompressedImageMessageParser {
+            blobs: vec![vec![1, 2, 3], vec![4, 5, 6]],
+            mode: ParsedPayloadKind::Encoded,
+            frame_ids: vec!["camera".to_owned(), " \t".to_owned()],
+        };
+
+        let chunks = Box::new(parser).finalize(test_ctx()).unwrap();
+        let chunk = chunks.first().unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            !chunk
+                .components()
+                .contains_component(CoordinateFrame::descriptor_frame().component)
+        );
+        expect_single_matching_warning(&log_rx, "plain 2D image/video data");
+    }
+
+    #[test]
+    fn keeps_coordinate_frame_for_valid_compressed_image_frame_ids() {
+        let parser = CompressedImageMessageParser {
+            blobs: vec![vec![1, 2, 3]],
+            mode: ParsedPayloadKind::Encoded,
+            frame_ids: vec!["camera".to_owned()],
+        };
+
+        let chunks = Box::new(parser).finalize(test_ctx()).unwrap();
+        let chunk = chunks.first().unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            chunk
+                .components()
+                .contains_component(CoordinateFrame::descriptor_frame().component)
+        );
     }
 }

--- a/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/image.rs
+++ b/crates/store/re_mcap/src/parsers/ros2msg/sensor_msgs/image.rs
@@ -4,7 +4,7 @@ use re_sdk_types::archetypes::{CoordinateFrame, DepthImage, Image};
 use re_sdk_types::datatypes::{ChannelDatatype, ColorModel, ImageFormat, PixelFormat};
 
 use super::super::Ros2MessageParser;
-use super::super::util::suffix_image_plane_frame_ids;
+use super::super::util::spatial_camera_frame_ids_or_log_missing;
 use crate::parsers::cdr;
 use crate::parsers::decode::{MessageParser, ParserContext};
 use crate::parsers::ros2msg::definitions::sensor_msgs;
@@ -75,6 +75,13 @@ impl MessageParser for ImageMessageParser {
         } = *self;
 
         let entity_path = ctx.entity_path().clone();
+        let spatial_frame_ids = spatial_camera_frame_ids_or_log_missing(
+            ctx.channel_topic(),
+            &entity_path,
+            "sensor_msgs/msg/Image",
+            "Importing the topic as plain 2D image data.",
+            frame_ids,
+        );
         let timelines = ctx.build_timelines();
 
         // TODO(#10726): big assumption here: image format can technically be different for each image on the topic, e.g. depth and color archetypes could be mixed here!
@@ -92,14 +99,13 @@ impl MessageParser for ImageMessageParser {
                 .collect()
         };
 
-        // We need a frame ID for the image plane. This doesn't exist in ROS,
-        // so we use the camera frame ID with a suffix here (see also camera info parser).
-        let image_plane_frame_ids = suffix_image_plane_frame_ids(frame_ids);
-        chunk_components.extend(
-            CoordinateFrame::update_fields()
-                .with_many_frame(image_plane_frame_ids)
-                .columns_of_unit_batches()?,
-        );
+        if let Some(frame_ids) = spatial_frame_ids {
+            chunk_components.extend(
+                CoordinateFrame::update_fields()
+                    .with_many_frame(frame_ids.image_plane_frame_ids)
+                    .columns_of_unit_batches()?,
+            );
+        }
 
         Ok(vec![Chunk::from_auto_row_ids(
             ChunkId::new(),
@@ -107,6 +113,87 @@ impl MessageParser for ImageMessageParser {
             timelines.clone(),
             chunk_components.into_iter().collect(),
         )?])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use re_chunk::EntityPath;
+    use re_log_types::TimeType;
+
+    use super::*;
+
+    fn test_ctx() -> ParserContext {
+        ParserContext::new(
+            EntityPath::from("/tests/image"),
+            "/tests/image",
+            TimeType::TimestampNs,
+        )
+    }
+
+    fn install_warn_logger() -> re_log::Receiver<re_log::LogMsg> {
+        re_log::setup_logging();
+        let (logger, log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Warn);
+        re_log::add_boxed_logger(Box::new(logger)).expect("Failed to add logger");
+        log_rx
+    }
+
+    #[track_caller]
+    fn expect_single_matching_warning(
+        log_rx: &re_log::Receiver<re_log::LogMsg>,
+        expected_substring: &str,
+    ) {
+        let matching_logs = std::iter::from_fn(|| log_rx.try_recv().ok())
+            .filter(|log| log.level == re_log::Level::Warn && log.msg.contains(expected_substring))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            matching_logs.len(),
+            1,
+            "Expected exactly one matching warning containing {expected_substring:?}, got {matching_logs:?}"
+        );
+    }
+
+    #[test]
+    fn omits_coordinate_frame_when_any_image_frame_id_is_missing() {
+        let log_rx = install_warn_logger();
+
+        let parser = ImageMessageParser {
+            blobs: vec![vec![255, 0, 0], vec![0, 255, 0]],
+            image_formats: vec![ImageFormat::rgb8([1, 1]), ImageFormat::rgb8([1, 1])],
+            is_depth_image: false,
+            frame_ids: vec!["camera".to_owned(), "".to_owned()],
+        };
+
+        let chunks = Box::new(parser).finalize(test_ctx()).unwrap();
+        let chunk = chunks.first().unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            !chunk
+                .components()
+                .contains_component(CoordinateFrame::descriptor_frame().component)
+        );
+        expect_single_matching_warning(&log_rx, "plain 2D image data");
+    }
+
+    #[test]
+    fn keeps_coordinate_frame_for_valid_image_frame_ids() {
+        let parser = ImageMessageParser {
+            blobs: vec![vec![255, 0, 0]],
+            image_formats: vec![ImageFormat::rgb8([1, 1])],
+            is_depth_image: false,
+            frame_ids: vec!["camera".to_owned()],
+        };
+
+        let chunks = Box::new(parser).finalize(test_ctx()).unwrap();
+        let chunk = chunks.first().unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            chunk
+                .components()
+                .contains_component(CoordinateFrame::descriptor_frame().component)
+        );
     }
 }
 

--- a/crates/store/re_mcap/src/parsers/ros2msg/util.rs
+++ b/crates/store/re_mcap/src/parsers/ros2msg/util.rs
@@ -1,18 +1,37 @@
-/// Helper for suffixing image frame IDs with `image_plane`.
-///
-/// This is required to match the Rerun model for named pinhole frames, where the image plane has its own frame ID
-/// different from the pinhole frame. In ROS, both image and camera info share the same frame ID.
-///
-/// Note: empty frame ID strings are left unchanged, since they are not valid frame IDs and should not be modified.
-pub fn suffix_image_plane_frame_ids(frame_ids: impl IntoIterator<Item = String>) -> Vec<String> {
-    frame_ids
-        .into_iter()
-        .map(|id| {
-            if id.is_empty() {
-                id
-            } else {
-                format!("{id}_image_plane")
-            }
+use re_log_types::EntityPath;
+
+/// The frame ids needed to import a ROS camera topic with spatial metadata.
+pub struct SpatialCameraFrameIds {
+    pub camera_frame_ids: Vec<String>,
+    pub image_plane_frame_ids: Vec<String>,
+}
+
+/// Returns the spatial frame ids for a ROS camera topic, or `None` if any row is missing a
+/// `header.frame_id` and the topic should be downgraded to plain 2D import.
+pub fn spatial_camera_frame_ids_or_log_missing(
+    topic: &str,
+    entity_path: &EntityPath,
+    data_kind: &str,
+    fallback: &str,
+    camera_frame_ids: Vec<String>,
+) -> Option<SpatialCameraFrameIds> {
+    if camera_frame_ids
+        .iter()
+        .any(|frame_id| frame_id.trim().is_empty())
+    {
+        re_log::warn_once!(
+            "Ignoring spatial camera metadata for {data_kind} on topic {topic:?} at entity {entity_path:?}: at least one message had a missing ROS `header.frame_id`. {fallback}"
+        );
+        None
+    } else {
+        let image_plane_frame_ids = camera_frame_ids
+            .iter()
+            .map(|frame_id| format!("{frame_id}_image_plane"))
+            .collect();
+
+        Some(SpatialCameraFrameIds {
+            camera_frame_ids,
+            image_plane_frame_ids,
         })
-        .collect::<Vec<_>>()
+    }
 }

--- a/crates/store/re_tf/src/transform_forest.rs
+++ b/crates/store/re_tf/src/transform_forest.rs
@@ -780,7 +780,7 @@ fn transforms_at(
     #![expect(clippy::useless_let_if_seq)]
 
     let mut parent_from_child;
-    let pinhole_projection;
+    let mut pinhole_projection;
 
     if let Some(source_transforms) = transforms_for_timeline.frame_transforms(child_frame) {
         parent_from_child =
@@ -789,6 +789,18 @@ fn transforms_at(
             source_transforms.latest_at_pinhole(entity_db, missing_chunk_reporter, query);
     } else {
         parent_from_child = None;
+        pinhole_projection = None;
+    }
+
+    if let Some(projection) = pinhole_projection.as_ref()
+        && projection.parent == child_frame
+    {
+        re_log::warn_once!(
+            "Ignoring self-referential pinhole projection on frame {:?}: pinhole parent and child frame ids must differ.",
+            id_registry
+                .lookup_frame_id(child_frame)
+                .map_or_else(|| format!("{child_frame:?}"), ToString::to_string)
+        );
         pinhole_projection = None;
     }
 
@@ -953,6 +965,15 @@ mod tests {
             result = result.replace(&format!("{hash:#?}"), &format!("{frame}"));
         }
         result
+    }
+
+    fn drain_matching_warnings(
+        log_rx: &re_log::Receiver<re_log::LogMsg>,
+        needle: &str,
+    ) -> Vec<re_log::LogMsg> {
+        std::iter::from_fn(|| log_rx.try_recv().ok())
+            .filter(|log| log.level == re_log::Level::Warn && log.msg.contains(needle))
+            .collect()
     }
 
     #[test]
@@ -1523,15 +1544,49 @@ mod tests {
             )]
         );
 
-        let received_log = log_rx.try_recv()?;
-        assert_eq!(received_log.level, re_log::Level::Warn);
-        assert!(
-            received_log
-                .msg
-                .contains("Ignoring transform at root entity"),
-            "Expected warning about ignoring implicit root parent frame, got: {}",
-            received_log.msg
+        let matching_logs = drain_matching_warnings(&log_rx, "Ignoring transform at root entity");
+        assert_eq!(
+            matching_logs.len(),
+            1,
+            "Expected exactly one warning about ignoring the implicit root parent frame, got: {matching_logs:?}",
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_self_referential_pinhole_is_ignored_with_warning()
+    -> Result<(), Box<dyn std::error::Error>> {
+        re_log::setup_logging();
+        let (logger, log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Warn);
+        re_log::add_boxed_logger(Box::new(logger)).expect("Failed to add logger");
+
+        let mut entity_db = EntityDb::new(StoreInfo::testing().store_id);
+        entity_db.add_chunk(&Arc::new(
+            Chunk::builder(EntityPath::from("camera"))
+                .with_archetype(
+                    RowId::new(),
+                    TimePoint::STATIC,
+                    &test_pinhole().with_child_frame("").with_parent_frame(""),
+                )
+                .build()?,
+        ))?;
+
+        let query = LatestAtQuery::latest(TimelineName::log_tick());
+        let mut transform_cache = TransformResolutionCache::new(&entity_db);
+        transform_cache
+            .ensure_timeline_is_initialized(entity_db.storage_engine().store(), query.timeline());
+        let transform_forest = TransformForest::new(&entity_db, &transform_cache, &query);
+        assert!(!transform_forest.any_missing_chunks());
+
+        assert_eq!(
+            transform_forest.root_info(TransformFrameIdHash::from_str("")),
+            Some(&TransformTreeRootInfo::TransformFrameRoot)
+        );
+
+        let matching_logs =
+            drain_matching_warnings(&log_rx, "Ignoring self-referential pinhole projection");
+        assert_eq!(matching_logs.len(), 1);
 
         Ok(())
     }

--- a/crates/store/re_tf/src/transform_resolution_cache/tests.rs
+++ b/crates/store/re_tf/src/transform_resolution_cache/tests.rs
@@ -1618,11 +1618,14 @@ fn test_different_associated_paths_for_static_and_temporal()
     Ok(())
 }
 
-#[track_caller]
-fn ensure_no_logged_error(rx: &re_log::Receiver<re_log::LogMsg>) {
-    if let Ok(msg) = rx.try_recv() {
-        panic!("Unexpected log output: {msg:?}");
-    }
+fn drain_matching_logs(
+    rx: &re_log::Receiver<re_log::LogMsg>,
+    level: re_log::Level,
+    needle: &str,
+) -> Vec<re_log::LogMsg> {
+    std::iter::from_fn(|| rx.try_recv().ok())
+        .filter(|msg| msg.level == level && msg.msg.contains(needle))
+        .collect()
 }
 
 fn test_error_on_changing_associated_path(time: TimeInt) -> Result<(), Box<dyn std::error::Error>> {
@@ -1642,42 +1645,60 @@ fn test_error_on_changing_associated_path(time: TimeInt) -> Result<(), Box<dyn s
         [(timeline, time)].into()
     };
 
+    let (entity_a, entity_b, frame_name) = if time.is_static() {
+        ("entity_a_static", "entity_b_static", "my_frame_static")
+    } else {
+        (
+            "entity_a_temporal",
+            "entity_b_temporal",
+            "my_frame_temporal",
+        )
+    };
+
     // First, create temporal transform
-    let temporal_chunk1 = Chunk::builder(EntityPath::from("entity_a"))
+    let temporal_chunk1 = Chunk::builder(EntityPath::from(entity_a))
         .with_archetype_auto_row(
             time_point.clone(),
-            &Transform3D::from_translation([1.0, 0.0, 0.0]).with_child_frame("my_frame"),
+            &Transform3D::from_translation([1.0, 0.0, 0.0]).with_child_frame(frame_name),
         )
         .build()?;
     cache.process_store_events(entity_db.add_chunk(&Arc::new(temporal_chunk1))?.iter());
 
-    ensure_no_logged_error(&log_rx);
+    assert!(
+        drain_matching_logs(&log_rx, re_log::Level::Error, frame_name).is_empty(),
+        "Unexpected matching log output for {frame_name:?}",
+    );
 
     // Try to associate the same frame with a different temporal entity - should log error
-    let temporal_chunk2 = Chunk::builder(EntityPath::from("entity_b"))
+    let temporal_chunk2 = Chunk::builder(EntityPath::from(entity_b))
         .with_archetype_auto_row(
             time_point,
-            &Transform3D::from_translation([2.0, 0.0, 0.0]).with_child_frame("my_frame"),
+            &Transform3D::from_translation([2.0, 0.0, 0.0]).with_child_frame(frame_name),
         )
         .build()?;
     cache.process_store_events(entity_db.add_chunk(&Arc::new(temporal_chunk2))?.iter());
 
-    let error = log_rx.try_recv().unwrap();
-    ensure_no_logged_error(&log_rx); // Exactly one error.
+    let matching_errors = drain_matching_logs(&log_rx, re_log::Level::Error, frame_name);
+    assert_eq!(
+        matching_errors.len(),
+        1,
+        "Expected exactly one matching error for {frame_name:?}, got {matching_errors:?}",
+    );
+    let error = &matching_errors[0];
 
     assert_eq!(error.level, re_log::Level::Error);
     assert!(
-        error.msg.contains("entity_a"),
+        error.msg.contains(entity_a),
         "Expected to mention previous entity, but msg was {}",
         error.msg
     );
     assert!(
-        error.msg.contains("entity_b"),
+        error.msg.contains(entity_b),
         "Expected to mention new entity, but msg was {}",
         error.msg
     );
     assert!(
-        error.msg.contains("my_frame"),
+        error.msg.contains(frame_name),
         "Expected to mention target, but msg was {}",
         error.msg
     );


### PR DESCRIPTION
<!--
Thank you for filing a pull request! We kindly ask you to:

1. Fill out this pull request template below, to make the review smoother.
2. Enable edits to your branch by our maintainers. This helps us to get your branch ready to merge. See here for more details:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
-->

### Related
Closes #12718
<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->

Empty `header.frame_id` in ROS2 camera messages caused a `TransformForest` panic due to self-referential pinhole topology. At the MCAP parser level, empty frame IDs now trigger a graceful downgrade: `CameraInfo` import is skipped entirely, while `Image` and `CompressedImage` fall back to plain 2D import without spatial metadata. As a defense-in-depth measure, `TransformForest` now also ignores self-referential pinhole projections instead of panicking.