### PR TITLE
Unpin wasm-bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,8 +428,8 @@ wildmatch = "2.6.1"
 #     Do not make this an `=` dependency, because that may break Rust users’ builds when a newer
 #     version is released, even if they are not building the web viewer.
 #     For details see https://github.com/rerun-io/rerun/issues/8766
-wasm-bindgen = "=0.2.117" # ⚠️ read above notice before touching this!
-wasm-bindgen-cli-support = "=0.2.117" # ⚠️ read above notice before touching this!
+wasm-bindgen = "0.2.117" # ⚠️ read above notice before touching this!
+wasm-bindgen-cli-support = "0.2.117" # ⚠️ read above notice before touching this!
 wasm-bindgen-futures = "0.4.67"
 web-sys = "0.3.94"
 wayland-sys = "0.31.9"


### PR DESCRIPTION
The comment specifically specifies to never pin this dependency, but we do anyways. This prevents us from upgrading.

[>  Do not make this an `=` dependency, because that may break Rust users’ builds when a newer
](https://github.com/rerun-io/rerun/blob/main/Cargo.toml#L428)

This was done correctly prior to https://github.com/rerun-io/rerun/commit/af1f737838afe980ae98dd561a3cf4fffec50bd8 which pinned it without clear justification.