### PR TITLE
Patch auto-downloaded arrow for C++ for latest macos libtool

### DIFF
--- a/rerun_cpp/download_and_build_arrow.cmake
+++ b/rerun_cpp/download_and_build_arrow.cmake
@@ -81,7 +81,11 @@ function(download_and_build_arrow)
         set(VERSION_PATCH "-DCMAKE_POLICY_VERSION_MINIMUM=${CMAKE_POLICY_VERSION_MINIMUM}")
     endif()
 
-    set(MIMALLOC_PATCH ${CMAKE_CURRENT_LIST_DIR}/patches/mimalloc_cmake4.patch)
+    set(ARROW_PATCHES
+        # TODO(apache/arrow#45985): Arrow can't support CMake 4.0 yet
+        ${CMAKE_CURRENT_LIST_DIR}/patches/mimalloc_cmake4.patch
+        # TODO update to arrow 24 and remove this patch
+        ${CMAKE_CURRENT_LIST_DIR}/patches/arrow_libtool.patch)
 
     ExternalProject_Add(
         arrow_cpp
@@ -92,8 +96,8 @@ function(download_and_build_arrow)
         UPDATE_COMMAND "" # Prevent unnecessary rebuilds on every cmake --build
 
         # Apply patch after checkout but before configure
-        # TODO(apache/arrow#45985): Arrow can't support CMake 4.0 yet
-        PATCH_COMMAND git apply --check ${MIMALLOC_PATCH} && git apply ${MIMALLOC_PATCH} || true
+        # Since this is downloading a release tarball, we need to init a git repository in order to apply the patches.
+        PATCH_COMMAND git init && git apply --check ${ARROW_PATCHES} && git apply ${ARROW_PATCHES} || true
 
         # LOG_X ON means that the output of the command will
         # be logged to a file _instead_ of printed to the console.

--- a/rerun_cpp/patches/arrow_libtool.patch
+++ b/rerun_cpp/patches/arrow_libtool.patch
@@ -1,0 +1,13 @@
+diff --git a/cpp/cmake_modules/BuildUtils.cmake b/cpp/cmake_modules/BuildUtils.cmake
+index 692efa7..4f8f5e7 100644
+--- a/cpp/cmake_modules/BuildUtils.cmake
++++ b/cpp/cmake_modules/BuildUtils.cmake
+@@ -112,7 +112,7 @@ function(arrow_create_merged_static_lib output_target)
+     execute_process(COMMAND ${LIBTOOL_MACOS} -V
+                     OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
+                     OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
++    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools.+([0-9.]+).*")
+       message(FATAL_ERROR "libtool found appears to be the incompatible GNU libtool: ${LIBTOOL_MACOS}"
+       )
+     endif()


### PR DESCRIPTION
<!--
Thank you for filing a pull request! We kindly ask you to:

1. Fill out this pull request template below, to make the review smoother.
2. Enable edits to your branch by our maintainers. This helps us to get your branch ready to merge. See here for more details:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
-->

### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

Closes #12748 

### What

Latest macOS's libtool returns the version with a slightly different format so the regex used by arrow fails to recognize it, and aborts as if GNU's libtool is being used (which is not supported).

See https://github.com/apache/arrow/pull/49370 

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->
