### PR TITLE
Add iteration and length support to `RRDArchive`

### DIFF
--- a/rerun_py/rerun_sdk/rerun/recording/_recording.py
+++ b/rerun_py/rerun_sdk/rerun/recording/_recording.py
@@ -104,6 +104,12 @@ class RRDArchive:
     def __init__(self, inner: RRDArchiveInternal) -> None:
         self._internal = inner
 
+    def __len__(self) -> int:
+        return self.num_recordings()
+
+    def __iter__(self) -> Generator[Recording, None, None]:
+        yield from self.all_recordings()
+
     def num_recordings(self) -> int:
         """The number of recordings in the archive."""
         return self._internal.num_recordings()

--- a/rerun_py/tests/unit/test_recording.py
+++ b/rerun_py/tests/unit/test_recording.py
@@ -286,6 +286,22 @@ def test_load_recording_path_types(tmp_path: pathlib.Path) -> None:
     assert recording is not None
 
 
+def test_archive_len_and_iter(tmp_path: pathlib.Path) -> None:
+    rrd = tmp_path / "tmp.rrd"
+
+    expected_recording_id = uuid.uuid4()
+    with rr.RecordingStream(APP_ID, recording_id=expected_recording_id) as rec:
+        rec.save(rrd)
+        rec.log("foo", rr.TextLog("bar"))
+
+    archive = rr.recording.load_archive(rrd)
+
+    assert len(archive) == 1
+    recordings = list(archive)
+    assert len(recordings) == 1
+    assert recordings[0].recording_id() == str(expected_recording_id)
+
+
 def test_chunk_record_batch(tmp_path: pathlib.Path, snapshot: syrupy.SnapshotAssertion) -> None:
     """Test that Chunk.format() returns a human-readable table with expected data."""
 


### PR DESCRIPTION
Resolves #11206

This diff makes `rerun.recording.RRDArchive` more Pythonic by adding `__len__` and `__iter__`. Archives can now be used directly with `len(archive)` and for recording in archive, matching the existing `num_recordings` and `all_recordings` behavior without changing the underlying loading logic.
