### PR TITLE
Expose remaining blueprint view types in the Rust SDK

### DIFF
--- a/crates/top/re_sdk/src/blueprint/container.rs
+++ b/crates/top/re_sdk/src/blueprint/container.rs
@@ -365,6 +365,36 @@ impl From<crate::blueprint::TextDocumentView> for ContainerLike {
     }
 }
 
+impl From<crate::blueprint::TextLogView> for ContainerLike {
+    fn from(view: crate::blueprint::TextLogView) -> Self {
+        Self::View(view.0)
+    }
+}
+
+impl From<crate::blueprint::BarChartView> for ContainerLike {
+    fn from(view: crate::blueprint::BarChartView) -> Self {
+        Self::View(view.0)
+    }
+}
+
+impl From<crate::blueprint::DataframeView> for ContainerLike {
+    fn from(view: crate::blueprint::DataframeView) -> Self {
+        Self::View(view.0)
+    }
+}
+
+impl From<crate::blueprint::StateTimelineView> for ContainerLike {
+    fn from(view: crate::blueprint::StateTimelineView) -> Self {
+        Self::View(view.0)
+    }
+}
+
+impl From<crate::blueprint::TensorView> for ContainerLike {
+    fn from(view: crate::blueprint::TensorView) -> Self {
+        Self::View(view.0)
+    }
+}
+
 impl From<crate::blueprint::Spatial2DView> for ContainerLike {
     fn from(view: crate::blueprint::Spatial2DView) -> Self {
         Self::View(view.0)

--- a/crates/top/re_sdk/src/blueprint/mod.rs
+++ b/crates/top/re_sdk/src/blueprint/mod.rs
@@ -9,7 +9,8 @@ pub use api::{Blueprint, BlueprintActivation, BlueprintOpts};
 pub use container::{ContainerLike, Grid, Horizontal, Tabs, Vertical};
 pub use panel::{BlueprintPanel, SelectionPanel, TimePanel};
 pub use view::{
-    GraphView, MapView, Spatial2DView, Spatial3DView, TextDocumentView, TimeSeriesView, View,
+    BarChartView, DataframeView, GraphView, MapView, Spatial2DView, Spatial3DView,
+    StateTimelineView, TensorView, TextDocumentView, TextLogView, TimeSeriesView, View,
 };
 
 // Re-export types for working with visualizers and component mappings

--- a/crates/top/re_sdk/src/blueprint/view.rs
+++ b/crates/top/re_sdk/src/blueprint/view.rs
@@ -510,6 +510,63 @@ impl GraphView {
     }
 }
 
+/// Text log view, for use with [`re_sdk_types::archetypes::TextLog`].
+pub struct TextLogView(pub(crate) View);
+
+impl TextLogView {
+    /// Create a new text log view.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(View {
+            class_identifier: "TextLog".into(),
+            name: Some(name.into()),
+            ..Default::default()
+        })
+    }
+
+    /// Set the origin entity path.
+    pub fn with_origin(mut self, origin: impl Into<EntityPath>) -> Self {
+        self.0.origin = origin.into();
+        self
+    }
+
+    /// Set the contents query expressions.
+    pub fn with_contents(mut self, queries: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.0.contents = queries.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set visibility.
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        self.0.visible = Some(visible);
+        self
+    }
+
+    /// Add a default archetype that applies to all entities in the view.
+    pub fn with_defaults(mut self, archetype: &dyn AsComponents) -> Self {
+        self.0.add_defaults(archetype);
+        self
+    }
+
+    /// Add a visualizer override for a specific entity.
+    pub fn with_override(
+        self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl Into<Visualizer>,
+    ) -> Self {
+        self.with_overrides(entity_path, [visualizers])
+    }
+
+    /// Add visualizer overrides for a specific entity.
+    pub fn with_overrides(
+        mut self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl IntoIterator<Item = impl Into<Visualizer>>,
+    ) -> Self {
+        self.0.add_overrides(entity_path, visualizers);
+        self
+    }
+}
+
 /// Text document view for markdown rendering.
 pub struct TextDocumentView(pub(crate) View);
 
@@ -518,6 +575,234 @@ impl TextDocumentView {
     pub fn new(name: impl Into<String>) -> Self {
         Self(View {
             class_identifier: "TextDocument".into(),
+            name: Some(name.into()),
+            ..Default::default()
+        })
+    }
+
+    /// Set the origin entity path.
+    pub fn with_origin(mut self, origin: impl Into<EntityPath>) -> Self {
+        self.0.origin = origin.into();
+        self
+    }
+
+    /// Set the contents query expressions.
+    pub fn with_contents(mut self, queries: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.0.contents = queries.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set visibility.
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        self.0.visible = Some(visible);
+        self
+    }
+
+    /// Add a default archetype that applies to all entities in the view.
+    pub fn with_defaults(mut self, archetype: &dyn AsComponents) -> Self {
+        self.0.add_defaults(archetype);
+        self
+    }
+
+    /// Add a visualizer override for a specific entity.
+    pub fn with_override(
+        self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl Into<Visualizer>,
+    ) -> Self {
+        self.with_overrides(entity_path, [visualizers])
+    }
+
+    /// Add visualizer overrides for a specific entity.
+    pub fn with_overrides(
+        mut self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl IntoIterator<Item = impl Into<Visualizer>>,
+    ) -> Self {
+        self.0.add_overrides(entity_path, visualizers);
+        self
+    }
+}
+
+/// Bar chart view, for use with [`re_sdk_types::archetypes::BarChart`].
+pub struct BarChartView(pub(crate) View);
+
+impl BarChartView {
+    /// Create a new bar chart view.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(View {
+            class_identifier: "BarChart".into(),
+            name: Some(name.into()),
+            ..Default::default()
+        })
+    }
+
+    /// Set the origin entity path.
+    pub fn with_origin(mut self, origin: impl Into<EntityPath>) -> Self {
+        self.0.origin = origin.into();
+        self
+    }
+
+    /// Set the contents query expressions.
+    pub fn with_contents(mut self, queries: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.0.contents = queries.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set visibility.
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        self.0.visible = Some(visible);
+        self
+    }
+
+    /// Add a default archetype that applies to all entities in the view.
+    pub fn with_defaults(mut self, archetype: &dyn AsComponents) -> Self {
+        self.0.add_defaults(archetype);
+        self
+    }
+
+    /// Add a visualizer override for a specific entity.
+    pub fn with_override(
+        self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl Into<Visualizer>,
+    ) -> Self {
+        self.with_overrides(entity_path, [visualizers])
+    }
+
+    /// Add visualizer overrides for a specific entity.
+    pub fn with_overrides(
+        mut self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl IntoIterator<Item = impl Into<Visualizer>>,
+    ) -> Self {
+        self.0.add_overrides(entity_path, visualizers);
+        self
+    }
+}
+
+/// Dataframe view, for displaying entities in a tabular form.
+pub struct DataframeView(pub(crate) View);
+
+impl DataframeView {
+    /// Create a new dataframe view.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(View {
+            class_identifier: "Dataframe".into(),
+            name: Some(name.into()),
+            ..Default::default()
+        })
+    }
+
+    /// Set the origin entity path.
+    pub fn with_origin(mut self, origin: impl Into<EntityPath>) -> Self {
+        self.0.origin = origin.into();
+        self
+    }
+
+    /// Set the contents query expressions.
+    pub fn with_contents(mut self, queries: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.0.contents = queries.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set visibility.
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        self.0.visible = Some(visible);
+        self
+    }
+
+    /// Add a default archetype that applies to all entities in the view.
+    pub fn with_defaults(mut self, archetype: &dyn AsComponents) -> Self {
+        self.0.add_defaults(archetype);
+        self
+    }
+
+    /// Add a visualizer override for a specific entity.
+    pub fn with_override(
+        self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl Into<Visualizer>,
+    ) -> Self {
+        self.with_overrides(entity_path, [visualizers])
+    }
+
+    /// Add visualizer overrides for a specific entity.
+    pub fn with_overrides(
+        mut self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl IntoIterator<Item = impl Into<Visualizer>>,
+    ) -> Self {
+        self.0.add_overrides(entity_path, visualizers);
+        self
+    }
+}
+
+/// State timeline view, for visualizing discrete state changes over time.
+pub struct StateTimelineView(pub(crate) View);
+
+impl StateTimelineView {
+    /// Create a new state timeline view.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(View {
+            class_identifier: "StateTimeline".into(),
+            name: Some(name.into()),
+            ..Default::default()
+        })
+    }
+
+    /// Set the origin entity path.
+    pub fn with_origin(mut self, origin: impl Into<EntityPath>) -> Self {
+        self.0.origin = origin.into();
+        self
+    }
+
+    /// Set the contents query expressions.
+    pub fn with_contents(mut self, queries: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.0.contents = queries.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set visibility.
+    pub fn with_visible(mut self, visible: bool) -> Self {
+        self.0.visible = Some(visible);
+        self
+    }
+
+    /// Add a default archetype that applies to all entities in the view.
+    pub fn with_defaults(mut self, archetype: &dyn AsComponents) -> Self {
+        self.0.add_defaults(archetype);
+        self
+    }
+
+    /// Add a visualizer override for a specific entity.
+    pub fn with_override(
+        self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl Into<Visualizer>,
+    ) -> Self {
+        self.with_overrides(entity_path, [visualizers])
+    }
+
+    /// Add visualizer overrides for a specific entity.
+    pub fn with_overrides(
+        mut self,
+        entity_path: impl Into<EntityPath>,
+        visualizers: impl IntoIterator<Item = impl Into<Visualizer>>,
+    ) -> Self {
+        self.0.add_overrides(entity_path, visualizers);
+        self
+    }
+}
+
+/// Tensor view, for use with [`re_sdk_types::archetypes::Tensor`].
+pub struct TensorView(pub(crate) View);
+
+impl TensorView {
+    /// Create a new tensor view.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(View {
+            class_identifier: "Tensor".into(),
             name: Some(name.into()),
             ..Default::default()
         })


### PR DESCRIPTION
## Summary

The Python SDK exposes 11 blueprint view types, but the Rust SDK in `re_sdk::blueprint` only exposes 6 of them. This adds the missing ones:

- `BarChartView`
- `DataframeView`
- `StateTimelineView`
- `TensorView`
- `TextLogView`

Each follows the existing minimal builder pattern used by `Spatial2DView`, `TimeSeriesView`, etc. — `with_origin` / `with_contents` / `with_visible` / `with_defaults` / `with_override(s)` — and gets a `From<…> for ContainerLike` impl so they can be placed inside `Vertical` / `Horizontal` / `Grid` / `Tabs`.

The original motivation was that `TextLogView` was unreachable from a downstream Rust crate building a blueprint — the others have the same gap.

View-specific property setters (e.g. `TextLog` columns/rows/format_options, `Dataframe` query options, `TimeSeries` axes, etc.) are *not* exposed in the Rust SDK for any view yet — that's a separate, larger gap.

## Test plan

- [x] `cargo clippy -p re_sdk` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)