### PR TITLE
re_server: refresh schema cache after add_layer

### DIFF
--- a/crates/store/re_server/src/store/dataset.rs
+++ b/crates/store/re_server/src/store/dataset.rs
@@ -17,7 +17,8 @@ use re_protos::cloud::v1alpha1::{
 use re_protos::common::v1alpha1::ext::{DatasetHandle, IfDuplicateBehavior, SegmentId};
 
 use crate::store::{
-    Error, Layer, ResolvedStore, Segment, StoreSlotId, Tracked, store_pool::StorePool,
+    Error, Layer, LayerInsertOutcome, ResolvedStore, Segment, StoreSlotId, Tracked,
+    store_pool::StorePool,
 };
 
 /// The mutable inner state of a [`Dataset`], wrapped in [`Tracked`] for automatic timestamp updates.
@@ -520,13 +521,15 @@ impl Dataset {
                 )?;
             }
         }
-        Schema::try_merge([current_schema, new_layer_schema]).map_err(|err| {
-            Error::SchemaConflict(format!(
-                "schema incompatibility on segment '{segment_id}', layer '{layer_name}': {err}"
-            ))
-        })?;
+        // Keep the merged schema so we can refresh the cache below.
+        let merged_schema = Schema::try_merge([current_schema.clone(), new_layer_schema])
+            .map_err(|err| {
+                Error::SchemaConflict(format!(
+                    "schema incompatibility on segment '{segment_id}', layer '{layer_name}': {err}"
+                ))
+            })?;
 
-        let overwritten = self
+        let outcome = self
             .inner
             .modify()
             .segments
@@ -538,13 +541,43 @@ impl Dataset {
                 on_duplicate,
             )?;
 
+        // Refresh the schema cache after each successful add_layer to avoid
+        // the O(N²) recompute pattern when register_with_dataset adds many
+        // layers in a single batch. `self.inner.modify()` always bumps
+        // `updated_at`, which would otherwise invalidate the cache on every
+        // iteration.
+        //
+        // - Inserted:     dataset schema is exactly `merged_schema`.
+        // - Skipped:      insert_layer was a no-op, so the schema is
+        //                 unchanged → reuse `current_schema`.
+        // - Overwritten:  the old layer's exclusive fields may no longer be
+        //                 present anywhere, so the schema may shrink in ways
+        //                 we can't reconstruct here. Drop the cache; the next
+        //                 `schema()` call will pay the full recompute.
+        //                 (Overwrite is rare relative to fresh insert in
+        //                 registration batches.)
+        {
+            let mut cache = self.cached_schema.lock();
+            let updated_at = self.updated_at();
+            *cache = match outcome {
+                LayerInsertOutcome::Inserted => Some((updated_at, Arc::new(merged_schema))),
+                LayerInsertOutcome::Skipped => Some((updated_at, Arc::new(current_schema))),
+                LayerInsertOutcome::Overwritten => None,
+            };
+        }
+
         #[cfg(feature = "lance")]
         self.indexes()
-            .on_layer_added(segment_id, &resolved, &layer_name, overwritten)
+            .on_layer_added(
+                segment_id,
+                &resolved,
+                &layer_name,
+                outcome == LayerInsertOutcome::Overwritten,
+            )
             .await?;
 
         #[cfg(not(feature = "lance"))]
-        let _ = overwritten;
+        let _ = outcome;
 
         Ok(())
     }

--- a/crates/store/re_server/src/store/mod.rs
+++ b/crates/store/re_server/src/store/mod.rs
@@ -16,7 +16,7 @@ pub use self::error::Error;
 pub use self::in_memory_store::InMemoryStore;
 pub use self::layer::Layer;
 pub use self::resolved_store::ResolvedStore;
-pub use self::segment::Segment;
+pub use self::segment::{LayerInsertOutcome, Segment};
 pub use self::store_pool::StoreSlotId;
 pub use self::table::Table;
 pub use self::task_registry::{TASK_ID_SUCCESS, TaskResult};

--- a/crates/store/re_server/src/store/segment.rs
+++ b/crates/store/re_server/src/store/segment.rs
@@ -27,6 +27,23 @@ impl Default for Segment {
     }
 }
 
+/// What happened to a segment's layer map as a result of an
+/// [`Segment::insert_layer`] call.
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LayerInsertOutcome {
+    /// The layer name was not previously present; the new layer was added.
+    Inserted,
+
+    /// The layer name was already present; the existing layer was replaced
+    /// (per [`IfDuplicateBehavior::Overwrite`]).
+    Overwritten,
+
+    /// The layer name was already present and the existing layer was kept
+    /// (per [`IfDuplicateBehavior::Skip`]). No mutation occurred.
+    Skipped,
+}
+
 impl Segment {
     pub fn layer_count(&self) -> usize {
         self.inner.layers.len()
@@ -58,32 +75,40 @@ impl Segment {
         self.inner.updated_at()
     }
 
-    /// Result: a successful result is `true` if the layer existed and was overwritten
+    /// Insert a layer into this segment, observing `on_duplicate` if the
+    /// layer name is already present.
+    ///
+    /// Returns:
+    /// - `Ok(Inserted)`    on fresh insert
+    /// - `Ok(Overwritten)` if the layer existed and `on_duplicate = Overwrite`
+    /// - `Ok(Skipped)`     if the layer existed and `on_duplicate = Skip`
+    ///   (no mutation occurs; the existing layer is unchanged)
+    /// - `Err(LayerAlreadyExists)` if the layer existed and
+    ///   `on_duplicate = Error`
     pub fn insert_layer(
         &mut self,
         layer_name: String,
         layer: Layer,
         on_duplicate: IfDuplicateBehavior,
-    ) -> Result<bool, Error> {
-        // Check if the layer already exists first
+    ) -> Result<LayerInsertOutcome, Error> {
         if self.inner.layers.contains_key(&layer_name) {
             match on_duplicate {
                 IfDuplicateBehavior::Overwrite => {
                     // Will overwrite, so modify
                     self.inner.modify().layers.insert(layer_name, layer);
                     // Timestamp updated when guard drops
-                    Ok(true)
+                    Ok(LayerInsertOutcome::Overwritten)
                 }
                 IfDuplicateBehavior::Skip => {
                     re_log::info!("Ignoring layer '{layer_name}': already exists in segment");
                     // No modification, no timestamp update
-                    Ok(true)
+                    Ok(LayerInsertOutcome::Skipped)
                 }
                 IfDuplicateBehavior::Error => Err(Error::LayerAlreadyExists(layer_name)),
             }
         } else {
             self.inner.modify().layers.insert(layer_name, layer);
-            Ok(false)
+            Ok(LayerInsertOutcome::Inserted)
         }
     }
 


### PR DESCRIPTION
Resolves:
- https://github.com/rerun-io/rerun/issues/12778

## Explanation

`Dataset::schema()` caches the merged dataset schema keyed on `Tracked<DatasetInner>::updated_at`. Every successful `add_layer` ends with `self.inner.modify()` whose guard's `Drop` unconditionally bumps that timestamp, so the cache is invalidated on every iteration of a `register_with_dataset` batch. Each subsequent `add_layer` then pays the full `schema()` recompute over every prior layer — O(N²) overall.

On happy-path of SKIP or INSERT, we update the cache from the in-hand `(current_schema, merged_schema)` pair at the bottom of `add_layer`, so the next iteration in the batch sees a hit instead of a miss.

While here, replace `Segment::insert_layer`'s `Result<bool, _>` with a `Result<LayerInsertOutcome, _>` (`Inserted`/`Overwritten`/`Skipped`). The bool was returning `Ok(true)` for both Overwrite and Skip, and the schema-cache logic needs to distinguish those two cases (Skip leaves the schema unchanged; Overwrite may shrink it). The enum carries that distinction in the type. `#[must_use]` also guards against future callers silently discarding the result.

NOTE:
- This is still painfully slow if re-registering a dataset with policy REPLACE.  This is more work that could be done to track the set of schemas based on schema-hash and limit the schema-computation to be O(unique) rather than O(recordings). 

## Benchmarks
Using the script from https://github.com/rerun-io/rerun/issues/12778

Before:
```
    N    wall (s)   ms/recording
----------------------------------
  100        0.13            1.3
  200        0.43            2.1
  400        1.56            3.9
  800        6.33            7.9
  ```
  
  After:
```
    N    wall (s)   ms/recording
----------------------------------
  100        0.05            0.5
  200        0.10            0.5
  400        0.20            0.5
  800        0.39            0.5
  ```