### PR TITLE
Add ROS1 MCAP message deserialization

### DIFF
--- a/crates/store/re_mcap/src/decoders/mod.rs
+++ b/crates/store/re_mcap/src/decoders/mod.rs
@@ -3,6 +3,7 @@ mod metadata;
 mod protobuf;
 mod raw;
 mod recording_info;
+mod ros1;
 mod ros2;
 mod ros2_reflection;
 mod schema;
@@ -21,6 +22,7 @@ pub use self::metadata::McapMetadataDecoder;
 pub use self::protobuf::McapProtobufDecoder;
 pub use self::raw::McapRawDecoder;
 pub use self::recording_info::McapRecordingInfoDecoder;
+pub use self::ros1::McapRos1Decoder;
 pub use self::ros2::McapRos2Decoder;
 pub use self::ros2_reflection::McapRos2ReflectionDecoder;
 pub use self::schema::McapSchemaDecoder;
@@ -603,6 +605,7 @@ impl DecoderRegistry {
             .register_file_decoder::<McapSchemaDecoder>()
             .register_file_decoder::<McapStatisticDecoder>()
             // message decoders (priority order):
+            .register_message_decoder::<McapRos1Decoder>()
             .register_message_decoder::<McapRos2Decoder>()
             .register_message_decoder::<McapRos2ReflectionDecoder>()
             .register_message_decoder::<McapProtobufDecoder>();
@@ -923,6 +926,38 @@ mod tests {
         (summary, buffer)
     }
 
+    fn ros1_summary_with_message_encoding(
+        schema_name: &str,
+        topic: &str,
+        message_encoding: &str,
+        payload: &[u8],
+    ) -> (mcap::Summary, Vec<u8>) {
+        let cursor = io::Cursor::new(Vec::new());
+        let mut writer = mcap::Writer::new(cursor).expect("failed to create writer");
+        let schema_id = writer
+            .add_schema(schema_name, "ros1msg", b"string data")
+            .expect("failed to add schema");
+        let channel_id = writer
+            .add_channel(schema_id, topic, message_encoding, &Default::default())
+            .expect("failed to add channel");
+
+        writer
+            .write_to_known_channel(
+                &mcap::records::MessageHeader {
+                    channel_id,
+                    sequence: 0,
+                    log_time: 1,
+                    publish_time: 1,
+                },
+                payload,
+            )
+            .expect("failed to write message");
+
+        let summary = writer.finish().expect("failed to finish writer");
+        let buffer = writer.into_inner().into_inner();
+        (summary, buffer)
+    }
+
     /// We expect CDR as encoding for ros2msg-schema messages.
     /// Test that a non-CDR channel that claims to have ros2msg
     /// falls back to raw forwarding instead of message reflection.
@@ -978,6 +1013,73 @@ mod tests {
             .assignments
             .iter()
             .find(|assignment| assignment.topic == "non_cdr_string_topic")
+            .expect("missing assignment");
+        assert_eq!(assignment.decoder.to_string(), "raw");
+    }
+
+    #[test]
+    fn semantic_ros1_decoder_claims_ros1_channels() {
+        let mut payload = Vec::new();
+        payload.extend(5_u32.to_le_bytes());
+        payload.extend(b"hello");
+
+        let (summary, buffer) = ros1_summary_with_message_encoding(
+            "std_msgs/String",
+            "ros1_string_topic",
+            "ros1",
+            &payload,
+        );
+
+        let plan = DecoderRegistry::all_with_raw_fallback()
+            .plan(&buffer, &summary, &TopicFilter::default())
+            .expect("failed to plan");
+
+        let assignment = plan
+            .assignments
+            .iter()
+            .find(|assignment| assignment.topic == "ros1_string_topic")
+            .expect("missing assignment");
+        assert_eq!(assignment.decoder.to_string(), "ros1msg");
+    }
+
+    #[test]
+    fn unsupported_ros1_schema_falls_back_to_raw() {
+        let (summary, buffer) = ros1_summary_with_message_encoding(
+            "custom_msgs/Foo",
+            "custom_ros1_topic",
+            "ros1",
+            &[1, 2, 3],
+        );
+
+        let plan = DecoderRegistry::all_with_raw_fallback()
+            .plan(&buffer, &summary, &TopicFilter::default())
+            .expect("failed to plan");
+
+        let assignment = plan
+            .assignments
+            .iter()
+            .find(|assignment| assignment.topic == "custom_ros1_topic")
+            .expect("missing assignment");
+        assert_eq!(assignment.decoder.to_string(), "raw");
+    }
+
+    #[test]
+    fn non_ros1_ros1msg_channel_falls_back_to_raw() {
+        let (summary, buffer) = ros1_summary_with_message_encoding(
+            "std_msgs/String",
+            "json_ros1_topic",
+            "json",
+            br#"{"data":"hello"}"#,
+        );
+
+        let plan = DecoderRegistry::all_with_raw_fallback()
+            .plan(&buffer, &summary, &TopicFilter::default())
+            .expect("failed to plan");
+
+        let assignment = plan
+            .assignments
+            .iter()
+            .find(|assignment| assignment.topic == "json_ros1_topic")
             .expect("missing assignment");
         assert_eq!(assignment.decoder.to_string(), "raw");
     }

--- a/crates/store/re_mcap/src/decoders/ros1.rs
+++ b/crates/store/re_mcap/src/decoders/ros1.rs
@@ -1,0 +1,107 @@
+use std::collections::BTreeMap;
+
+use super::MessageDecoder;
+use crate::parsers::MessageParser;
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::nav_msgs::OccupancyGridMessageParser;
+use crate::parsers::ros1msg::sensor_msgs::{
+    CameraInfoMessageParser, CompressedImageMessageParser, ImageMessageParser,
+};
+use crate::parsers::ros1msg::std_msgs::StringMessageParser;
+use crate::parsers::ros1msg::tf2_msgs::tf_message::TfMessageParser;
+
+type ParserFactory = fn(usize) -> Box<dyn MessageParser>;
+
+#[derive(Debug)]
+pub struct McapRos1Decoder {
+    registry: BTreeMap<String, ParserFactory>,
+}
+
+impl McapRos1Decoder {
+    const SCHEMA_ENCODING: &str = "ros1msg";
+
+    fn empty() -> Self {
+        Self {
+            registry: BTreeMap::new(),
+        }
+    }
+
+    pub fn new() -> Self {
+        Self::empty()
+            .register_parser::<ImageMessageParser>("sensor_msgs/Image")
+            .register_parser::<CompressedImageMessageParser>("sensor_msgs/CompressedImage")
+            .register_parser::<CameraInfoMessageParser>("sensor_msgs/CameraInfo")
+            .register_parser::<TfMessageParser>("tf2_msgs/TFMessage")
+            .register_parser::<OccupancyGridMessageParser>("nav_msgs/OccupancyGrid")
+            .register_parser::<StringMessageParser>("std_msgs/String")
+    }
+
+    pub fn register_parser<T: Ros1MessageParser + 'static>(mut self, schema_name: &str) -> Self {
+        self.registry
+            .insert(schema_name.to_owned(), |n| Box::new(T::new(n)));
+        self
+    }
+}
+
+impl Default for McapRos1Decoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MessageDecoder for McapRos1Decoder {
+    fn identifier() -> super::DecoderIdentifier {
+        "ros1msg".into()
+    }
+
+    fn supports_channel(&self, channel: &mcap::Channel<'_>) -> bool {
+        let Some(schema) = channel.schema.as_ref() else {
+            return false;
+        };
+
+        self.registry.contains_key(&schema.name) && supports_ros1_channel(channel)
+    }
+
+    fn message_parser(
+        &self,
+        channel: &mcap::Channel<'_>,
+        num_rows: usize,
+    ) -> Option<Box<dyn MessageParser>> {
+        let schema = channel.schema.as_ref()?;
+        if schema.encoding.as_str() != Self::SCHEMA_ENCODING {
+            return None;
+        }
+
+        self.registry.get(&schema.name).map(|make| make(num_rows))
+    }
+}
+
+fn is_ros1_message_encoding(message_encoding: &str) -> bool {
+    message_encoding.eq_ignore_ascii_case("ros1")
+}
+
+fn supports_ros1_channel(channel: &mcap::Channel<'_>) -> bool {
+    let Some(schema) = channel.schema.as_ref() else {
+        return false;
+    };
+
+    if schema.encoding.as_str() != McapRos1Decoder::SCHEMA_ENCODING {
+        return false;
+    }
+
+    if !is_ros1_message_encoding(&channel.message_encoding) {
+        if !channel.message_encoding.trim().is_empty() {
+            re_log::warn_once!(
+                concat!(
+                    "MCAP channel '{}' has a ROS1 message schema, but unknown encoding '{}'. ",
+                    "ROS 1 deserialization is only supported for ros1-encoded messages."
+                ),
+                channel.topic,
+                channel.message_encoding,
+            );
+        }
+        return false;
+    }
+
+    true
+}

--- a/crates/store/re_mcap/src/decoders/ros1.rs
+++ b/crates/store/re_mcap/src/decoders/ros1.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use super::MessageDecoder;
 use crate::parsers::MessageParser;
 use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::geometry_msgs::PoseWithCovarianceStampedMessageParser;
 use crate::parsers::ros1msg::nav_msgs::OccupancyGridMessageParser;
 use crate::parsers::ros1msg::sensor_msgs::{
     CameraInfoMessageParser, CompressedImageMessageParser, ImageMessageParser,
@@ -28,6 +29,9 @@ impl McapRos1Decoder {
 
     pub fn new() -> Self {
         Self::empty()
+            .register_parser::<PoseWithCovarianceStampedMessageParser>(
+                "geometry_msgs/PoseWithCovarianceStamped",
+            )
             .register_parser::<ImageMessageParser>("sensor_msgs/Image")
             .register_parser::<CompressedImageMessageParser>("sensor_msgs/CompressedImage")
             .register_parser::<CameraInfoMessageParser>("sensor_msgs/CameraInfo")

--- a/crates/store/re_mcap/src/parsers/mod.rs
+++ b/crates/store/re_mcap/src/parsers/mod.rs
@@ -1,6 +1,7 @@
 pub mod cdr;
 pub(crate) mod dds;
 mod decode;
+pub(crate) mod ros1msg;
 pub(crate) mod ros2msg;
 
 pub use decode::{ChannelId, MessageParser, ParserContext};

--- a/crates/store/re_mcap/src/parsers/ros1msg/definitions/geometry_msgs.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/definitions/geometry_msgs.rs
@@ -1,0 +1,102 @@
+use super::super::wire::Ros1Reader;
+use super::std_msgs::Header;
+
+#[derive(Debug, Clone)]
+pub struct Vector3 {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Vector3 {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            x: reader.read_f64()?,
+            y: reader.read_f64()?,
+            z: reader.read_f64()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Quaternion {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub w: f64,
+}
+
+impl Quaternion {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            x: reader.read_f64()?,
+            y: reader.read_f64()?,
+            z: reader.read_f64()?,
+            w: reader.read_f64()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Point {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            x: reader.read_f64()?,
+            y: reader.read_f64()?,
+            z: reader.read_f64()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Pose {
+    pub position: Point,
+    pub orientation: Quaternion,
+}
+
+impl Pose {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            position: Point::read(reader)?,
+            orientation: Quaternion::read(reader)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Transform {
+    pub translation: Vector3,
+    pub rotation: Quaternion,
+}
+
+impl Transform {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            translation: Vector3::read(reader)?,
+            rotation: Quaternion::read(reader)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TransformStamped {
+    pub header: Header,
+    pub child_frame_id: String,
+    pub transform: Transform,
+}
+
+impl TransformStamped {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            header: Header::read(reader)?,
+            child_frame_id: reader.read_string()?,
+            transform: Transform::read(reader)?,
+        })
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/definitions/geometry_msgs.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/definitions/geometry_msgs.rs
@@ -70,6 +70,51 @@ impl Pose {
 }
 
 #[derive(Debug, Clone)]
+pub struct PoseStamped {
+    pub header: Header,
+    pub pose: Pose,
+}
+
+impl PoseStamped {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            header: Header::read(reader)?,
+            pose: Pose::read(reader)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PoseWithCovariance {
+    pub pose: Pose,
+    pub covariance: [f64; 36],
+}
+
+impl PoseWithCovariance {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            pose: Pose::read(reader)?,
+            covariance: reader.read_f64_array()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PoseWithCovarianceStamped {
+    pub header: Header,
+    pub pose: PoseWithCovariance,
+}
+
+impl PoseWithCovarianceStamped {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            header: Header::read(reader)?,
+            pose: PoseWithCovariance::read(reader)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Transform {
     pub translation: Vector3,
     pub rotation: Quaternion,

--- a/crates/store/re_mcap/src/parsers/ros1msg/definitions/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/definitions/mod.rs
@@ -1,0 +1,7 @@
+#![allow(dead_code)] // ROS1 schema structs intentionally include fields not yet mapped to Rerun.
+
+pub mod geometry_msgs;
+pub mod nav_msgs;
+pub mod sensor_msgs;
+pub mod std_msgs;
+pub mod tf2_msgs;

--- a/crates/store/re_mcap/src/parsers/ros1msg/definitions/nav_msgs.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/definitions/nav_msgs.rs
@@ -1,0 +1,41 @@
+use super::super::wire::Ros1Reader;
+use super::geometry_msgs::Pose;
+use super::std_msgs::{Header, Time};
+
+#[derive(Debug, Clone)]
+pub struct MapMetaData {
+    pub map_load_time: Time,
+    pub resolution: f32,
+    pub width: u32,
+    pub height: u32,
+    pub origin: Pose,
+}
+
+impl MapMetaData {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            map_load_time: Time::read(reader)?,
+            resolution: reader.read_f32()?,
+            width: reader.read_u32()?,
+            height: reader.read_u32()?,
+            origin: Pose::read(reader)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OccupancyGrid {
+    pub header: Header,
+    pub info: MapMetaData,
+    pub data: Vec<u8>,
+}
+
+impl OccupancyGrid {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            header: Header::read(reader)?,
+            info: MapMetaData::read(reader)?,
+            data: reader.read_i8_vec_as_u8()?,
+        })
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/definitions/sensor_msgs.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/definitions/sensor_msgs.rs
@@ -1,0 +1,98 @@
+use super::super::wire::Ros1Reader;
+use super::std_msgs::Header;
+
+#[derive(Debug, Clone)]
+pub struct Image {
+    pub header: Header,
+    pub height: u32,
+    pub width: u32,
+    pub encoding: String,
+    pub is_bigendian: u8,
+    pub step: u32,
+    pub data: Vec<u8>,
+}
+
+impl Image {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            header: Header::read(reader)?,
+            height: reader.read_u32()?,
+            width: reader.read_u32()?,
+            encoding: reader.read_string()?,
+            is_bigendian: reader.read_u8()?,
+            step: reader.read_u32()?,
+            data: reader.read_u8_vec()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompressedImage {
+    pub header: Header,
+    pub format: String,
+    pub data: Vec<u8>,
+}
+
+impl CompressedImage {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            header: Header::read(reader)?,
+            format: reader.read_string()?,
+            data: reader.read_u8_vec()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RegionOfInterest {
+    pub x_offset: u32,
+    pub y_offset: u32,
+    pub height: u32,
+    pub width: u32,
+    pub do_rectify: bool,
+}
+
+impl RegionOfInterest {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            x_offset: reader.read_u32()?,
+            y_offset: reader.read_u32()?,
+            height: reader.read_u32()?,
+            width: reader.read_u32()?,
+            do_rectify: reader.read_bool()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CameraInfo {
+    pub header: Header,
+    pub height: u32,
+    pub width: u32,
+    pub distortion_model: String,
+    pub d: Vec<f64>,
+    pub k: [f64; 9],
+    pub r: [f64; 9],
+    pub p: [f64; 12],
+    pub binning_x: u32,
+    pub binning_y: u32,
+    pub roi: RegionOfInterest,
+}
+
+impl CameraInfo {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            header: Header::read(reader)?,
+            height: reader.read_u32()?,
+            width: reader.read_u32()?,
+            distortion_model: reader.read_string()?,
+            d: reader.read_f64_vec()?,
+            k: reader.read_f64_array()?,
+            r: reader.read_f64_array()?,
+            p: reader.read_f64_array()?,
+            binning_x: reader.read_u32()?,
+            binning_y: reader.read_u32()?,
+            roi: RegionOfInterest::read(reader)?,
+        })
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/definitions/std_msgs.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/definitions/std_msgs.rs
@@ -1,0 +1,50 @@
+use super::super::wire::Ros1Reader;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Time {
+    pub sec: u32,
+    pub nsec: u32,
+}
+
+impl Time {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            sec: reader.read_u32()?,
+            nsec: reader.read_u32()?,
+        })
+    }
+
+    pub fn as_nanos(&self) -> u64 {
+        u64::from(self.sec) * 1_000_000_000 + u64::from(self.nsec)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Header {
+    pub seq: u32,
+    pub stamp: Time,
+    pub frame_id: String,
+}
+
+impl Header {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            seq: reader.read_u32()?,
+            stamp: Time::read(reader)?,
+            frame_id: reader.read_string()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringMessage {
+    pub data: String,
+}
+
+impl StringMessage {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        Ok(Self {
+            data: reader.read_string()?,
+        })
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/definitions/tf2_msgs.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/definitions/tf2_msgs.rs
@@ -1,0 +1,18 @@
+use super::super::wire::Ros1Reader;
+use super::geometry_msgs::TransformStamped;
+
+#[derive(Debug, Clone)]
+pub struct TFMessage {
+    pub transforms: Vec<TransformStamped>,
+}
+
+impl TFMessage {
+    pub fn read(reader: &mut Ros1Reader<'_>) -> anyhow::Result<Self> {
+        let len = reader.read_u32()? as usize;
+        Ok(Self {
+            transforms: (0..len)
+                .map(|_| TransformStamped::read(reader))
+                .collect::<anyhow::Result<_>>()?,
+        })
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/geometry_msgs/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/geometry_msgs/mod.rs
@@ -1,0 +1,3 @@
+mod pose_with_covariance_stamped;
+
+pub use pose_with_covariance_stamped::PoseWithCovarianceStampedMessageParser;

--- a/crates/store/re_mcap/src/parsers/ros1msg/geometry_msgs/pose_with_covariance_stamped.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/geometry_msgs/pose_with_covariance_stamped.rs
@@ -1,0 +1,147 @@
+use re_chunk::{Chunk, ChunkId};
+use re_sdk_types::archetypes::{CoordinateFrame, InstancePoses3D};
+use re_sdk_types::components::{RotationQuat, Translation3D};
+use re_sdk_types::datatypes::Quaternion;
+
+use crate::parsers::decode::{MessageParser, ParserContext};
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::definitions::geometry_msgs::PoseWithCovarianceStamped;
+use crate::parsers::ros1msg::wire::Ros1Reader;
+use crate::util::TimestampCell;
+
+pub struct PoseWithCovarianceStampedMessageParser {
+    translations: Vec<Translation3D>,
+    quaternions: Vec<RotationQuat>,
+    frame_ids: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
+
+    use mcap::{Channel, Message};
+    use re_log_types::TimeType;
+    use re_sdk_types::archetypes::{CoordinateFrame, InstancePoses3D};
+
+    use super::*;
+
+    fn push_string(bytes: &mut Vec<u8>, value: &str) {
+        bytes.extend((value.len() as u32).to_le_bytes());
+        bytes.extend(value.as_bytes());
+    }
+
+    fn message(data: Vec<u8>) -> Message<'static> {
+        Message {
+            channel: Arc::new(Channel {
+                id: 1,
+                topic: "/pose".to_owned(),
+                schema: None,
+                message_encoding: "ros1".to_owned(),
+                metadata: BTreeMap::default(),
+            }),
+            sequence: 0,
+            log_time: 0,
+            publish_time: 0,
+            data: Cow::Owned(data),
+        }
+    }
+
+    #[test]
+    fn decodes_pose_with_covariance_stamped_as_instance_pose() {
+        let mut data = Vec::new();
+        data.extend(7_u32.to_le_bytes()); // header.seq
+        data.extend(12_u32.to_le_bytes()); // stamp.sec
+        data.extend(34_u32.to_le_bytes()); // stamp.nsec
+        push_string(&mut data, "map");
+        for value in [1.0_f64, 2.0, 3.0] {
+            data.extend(value.to_le_bytes());
+        }
+        for value in [0.0_f64, 0.0, 0.0, 1.0] {
+            data.extend(value.to_le_bytes());
+        }
+        for value in [0.0_f64; 36] {
+            data.extend(value.to_le_bytes());
+        }
+
+        let mut parser = PoseWithCovarianceStampedMessageParser::new(1);
+        let mut ctx = ParserContext::new("/pose".into(), "/pose", TimeType::TimestampNs);
+        parser.append(&mut ctx, &message(data)).unwrap();
+
+        let chunk = Box::new(parser).finalize(ctx).unwrap().remove(0);
+        assert!(chunk.component_descriptors().any(|descriptor| {
+            descriptor.component == InstancePoses3D::descriptor_translations().component
+        }));
+        assert!(chunk.component_descriptors().any(|descriptor| {
+            descriptor.component == InstancePoses3D::descriptor_quaternions().component
+        }));
+        assert!(chunk.component_descriptors().any(|descriptor| {
+            descriptor.component == CoordinateFrame::descriptor_frame().component
+        }));
+    }
+}
+
+impl Ros1MessageParser for PoseWithCovarianceStampedMessageParser {
+    fn new(num_rows: usize) -> Self {
+        Self {
+            translations: Vec::with_capacity(num_rows),
+            quaternions: Vec::with_capacity(num_rows),
+            frame_ids: Vec::with_capacity(num_rows),
+        }
+    }
+}
+
+impl MessageParser for PoseWithCovarianceStampedMessageParser {
+    fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        let mut reader = Ros1Reader::new(&msg.data);
+        let message = PoseWithCovarianceStamped::read(&mut reader)?;
+        reader.finish()?;
+
+        ctx.add_timestamp_cell(TimestampCell::from_nanos_ros1(
+            message.header.stamp.as_nanos(),
+            ctx.time_type(),
+        ));
+
+        let position = message.pose.pose.position;
+        let orientation = message.pose.pose.orientation;
+
+        self.frame_ids.push(message.header.frame_id);
+        self.translations.push(Translation3D::new(
+            position.x as f32,
+            position.y as f32,
+            position.z as f32,
+        ));
+        self.quaternions.push(
+            Quaternion::from_xyzw([
+                orientation.x as f32,
+                orientation.y as f32,
+                orientation.z as f32,
+                orientation.w as f32,
+            ])
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<Chunk>> {
+        let pose_components: Vec<_> = InstancePoses3D::update_fields()
+            .with_translations(self.translations)
+            .with_quaternions(self.quaternions)
+            .columns_of_unit_batches()?
+            .collect();
+        let frame_components: Vec<_> = CoordinateFrame::update_fields()
+            .with_many_frame(self.frame_ids)
+            .columns_of_unit_batches()?
+            .collect();
+
+        Ok(vec![Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            ctx.entity_path().clone(),
+            ctx.build_timelines(),
+            pose_components
+                .into_iter()
+                .chain(frame_components)
+                .collect(),
+        )?])
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/mod.rs
@@ -1,6 +1,7 @@
 use crate::parsers::MessageParser;
 
 pub mod definitions;
+pub mod geometry_msgs;
 pub mod nav_msgs;
 pub mod sensor_msgs;
 pub mod std_msgs;

--- a/crates/store/re_mcap/src/parsers/ros1msg/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/mod.rs
@@ -1,0 +1,12 @@
+use crate::parsers::MessageParser;
+
+pub mod definitions;
+pub mod nav_msgs;
+pub mod sensor_msgs;
+pub mod std_msgs;
+pub mod tf2_msgs;
+pub mod wire;
+
+pub trait Ros1MessageParser: MessageParser {
+    fn new(num_rows: usize) -> Self;
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/nav_msgs/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/nav_msgs/mod.rs
@@ -1,0 +1,3 @@
+mod occupancy_grid;
+
+pub use occupancy_grid::OccupancyGridMessageParser;

--- a/crates/store/re_mcap/src/parsers/ros1msg/nav_msgs/occupancy_grid.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/nav_msgs/occupancy_grid.rs
@@ -1,0 +1,147 @@
+use anyhow::ensure;
+use re_chunk::{Chunk, ChunkId};
+use re_sdk_types::archetypes::{CoordinateFrame, GridMap};
+use re_sdk_types::components::{Colormap, RotationQuat, Translation3D};
+use re_sdk_types::datatypes::{ChannelDatatype, ColorModel, ImageFormat, Quaternion};
+
+use crate::parsers::decode::{MessageParser, ParserContext};
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::definitions::nav_msgs;
+use crate::parsers::ros1msg::wire::Ros1Reader;
+use crate::util::TimestampCell;
+
+pub struct OccupancyGridMessageParser {
+    data: Vec<Vec<u8>>,
+    formats: Vec<ImageFormat>,
+    cell_sizes: Vec<f32>,
+    translations: Vec<Translation3D>,
+    quaternions: Vec<RotationQuat>,
+    frame_ids: Vec<String>,
+    colormaps: Vec<Colormap>,
+}
+
+impl Ros1MessageParser for OccupancyGridMessageParser {
+    fn new(num_rows: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(num_rows),
+            formats: Vec::with_capacity(num_rows),
+            cell_sizes: Vec::with_capacity(num_rows),
+            translations: Vec::with_capacity(num_rows),
+            quaternions: Vec::with_capacity(num_rows),
+            frame_ids: Vec::with_capacity(num_rows),
+            colormaps: Vec::with_capacity(num_rows),
+        }
+    }
+}
+
+impl MessageParser for OccupancyGridMessageParser {
+    fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        let mut reader = Ros1Reader::new(&msg.data);
+        let grid = nav_msgs::OccupancyGrid::read(&mut reader)?;
+        reader.finish()?;
+
+        ctx.add_timestamp_cell(TimestampCell::from_nanos_ros1(
+            grid.header.stamp.as_nanos(),
+            ctx.time_type(),
+        ));
+
+        let width = grid.info.width as usize;
+        let height = grid.info.height as usize;
+        let expected_len = width
+            .checked_mul(height)
+            .ok_or_else(|| anyhow::anyhow!("OccupancyGrid dimensions overflow"))?;
+        ensure!(
+            grid.data.len() == expected_len,
+            "OccupancyGrid expected {expected_len} cells from {}x{}, got {}",
+            grid.info.width,
+            grid.info.height,
+            grid.data.len()
+        );
+
+        self.data.push(ros_map_to_image_buffer(
+            &grid.data,
+            grid.info.width as usize,
+            grid.info.height as usize,
+        ));
+        self.formats.push(ImageFormat::from_color_model(
+            [grid.info.width, grid.info.height],
+            ColorModel::L,
+            ChannelDatatype::U8,
+        ));
+        self.cell_sizes.push(grid.info.resolution);
+        self.translations.push(Translation3D::new(
+            grid.info.origin.position.x as f32,
+            grid.info.origin.position.y as f32,
+            grid.info.origin.position.z as f32,
+        ));
+        self.quaternions.push(
+            Quaternion::from_xyzw([
+                grid.info.origin.orientation.x as f32,
+                grid.info.origin.orientation.y as f32,
+                grid.info.origin.orientation.z as f32,
+                grid.info.origin.orientation.w as f32,
+            ])
+            .into(),
+        );
+        self.frame_ids.push(grid.header.frame_id);
+        self.colormaps.push(Colormap::RvizMap);
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<Chunk>> {
+        let Self {
+            data,
+            formats,
+            cell_sizes,
+            translations,
+            quaternions,
+            frame_ids,
+            colormaps,
+        } = *self;
+
+        let mut components: Vec<_> = GridMap::update_fields()
+            .with_many_data(data)
+            .with_many_format(formats)
+            .with_many_cell_size(cell_sizes)
+            .with_many_translation(translations)
+            .with_many_quaternion(quaternions)
+            .with_many_colormap(colormaps)
+            .columns_of_unit_batches()?
+            .collect();
+
+        components.extend(
+            CoordinateFrame::update_fields()
+                .with_many_frame(frame_ids)
+                .columns_of_unit_batches()?,
+        );
+
+        Ok(vec![Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            ctx.entity_path().clone(),
+            ctx.build_timelines(),
+            components.into_iter().collect(),
+        )?])
+    }
+}
+
+fn ros_map_to_image_buffer(data: &[u8], width: usize, height: usize) -> Vec<u8> {
+    let mut image = Vec::with_capacity(data.len());
+    for row in (0..height).rev() {
+        let start = row * width;
+        image.extend_from_slice(&data[start..start + width]);
+    }
+    image
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flips_ros_bottom_row_first_to_image_top_row_first() {
+        assert_eq!(
+            ros_map_to_image_buffer(&[1, 2, 3, 4, 5, 6], 3, 2),
+            vec![4, 5, 6, 1, 2, 3]
+        );
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/camera_info.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/camera_info.rs
@@ -1,0 +1,76 @@
+use re_chunk::{Chunk, ChunkId};
+use re_sdk_types::archetypes::{CoordinateFrame, Pinhole};
+
+use crate::parsers::decode::{MessageParser, ParserContext};
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::definitions::sensor_msgs;
+use crate::parsers::ros1msg::wire::Ros1Reader;
+use crate::parsers::ros2msg::util::suffix_image_plane_frame_ids;
+use crate::util::TimestampCell;
+
+pub struct CameraInfoMessageParser {
+    image_from_cameras: Vec<[f32; 9]>,
+    resolutions: Vec<(f32, f32)>,
+    frame_ids: Vec<String>,
+}
+
+impl Ros1MessageParser for CameraInfoMessageParser {
+    fn new(num_rows: usize) -> Self {
+        Self {
+            image_from_cameras: Vec::with_capacity(num_rows),
+            resolutions: Vec::with_capacity(num_rows),
+            frame_ids: Vec::with_capacity(num_rows),
+        }
+    }
+}
+
+impl MessageParser for CameraInfoMessageParser {
+    fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        let mut reader = Ros1Reader::new(&msg.data);
+        let camera_info = sensor_msgs::CameraInfo::read(&mut reader)?;
+        reader.finish()?;
+
+        ctx.add_timestamp_cell(TimestampCell::from_nanos_ros1(
+            camera_info.header.stamp.as_nanos(),
+            ctx.time_type(),
+        ));
+
+        let k = camera_info.k;
+        self.image_from_cameras
+            .push([k[0], k[3], k[6], k[1], k[4], k[7], k[2], k[5], k[8]].map(|x| x as f32));
+        self.resolutions
+            .push((camera_info.width as f32, camera_info.height as f32));
+        self.frame_ids.push(camera_info.header.frame_id);
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<Chunk>> {
+        let Self {
+            image_from_cameras,
+            resolutions,
+            frame_ids,
+        } = *self;
+
+        let image_plane_frame_ids = suffix_image_plane_frame_ids(frame_ids.clone());
+        let mut components: Vec<_> = Pinhole::update_fields()
+            .with_many_image_from_camera(image_from_cameras)
+            .with_many_resolution(resolutions)
+            .with_many_parent_frame(frame_ids.clone())
+            .with_many_child_frame(image_plane_frame_ids)
+            .columns_of_unit_batches()?
+            .collect();
+
+        components.extend(
+            CoordinateFrame::update_fields()
+                .with_many_frame(frame_ids)
+                .columns_of_unit_batches()?,
+        );
+
+        Ok(vec![Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            ctx.entity_path().clone(),
+            ctx.build_timelines(),
+            components.into_iter().collect(),
+        )?])
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/compressed_image.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/compressed_image.rs
@@ -1,0 +1,142 @@
+use anyhow::bail;
+use re_chunk::{Chunk, ChunkId, RowId, TimePoint};
+use re_sdk_types::archetypes::{CoordinateFrame, EncodedDepthImage, EncodedImage, VideoStream};
+use re_sdk_types::components::{MediaType, VideoCodec};
+
+use crate::parsers::decode::{MessageParser, ParserContext};
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::definitions::sensor_msgs;
+use crate::parsers::ros1msg::wire::Ros1Reader;
+use crate::parsers::ros2msg::util::suffix_image_plane_frame_ids;
+use crate::util::TimestampCell;
+
+pub struct CompressedImageMessageParser {
+    blobs: Vec<Vec<u8>>,
+    mode: ParsedPayloadKind,
+    frame_ids: Vec<String>,
+}
+
+impl Ros1MessageParser for CompressedImageMessageParser {
+    fn new(num_rows: usize) -> Self {
+        Self {
+            blobs: Vec::with_capacity(num_rows),
+            mode: ParsedPayloadKind::Unknown,
+            frame_ids: Vec::with_capacity(num_rows),
+        }
+    }
+}
+
+impl MessageParser for CompressedImageMessageParser {
+    fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        let mut reader = Ros1Reader::new(&msg.data);
+        let image = sensor_msgs::CompressedImage::read(&mut reader)?;
+        reader.finish()?;
+
+        ctx.add_timestamp_cell(TimestampCell::from_nanos_ros1(
+            image.header.stamp.as_nanos(),
+            ctx.time_type(),
+        ));
+        self.frame_ids.push(image.header.frame_id);
+
+        if is_rvl(&image.format) {
+            self.ensure_mode(ParsedPayloadKind::DepthRvl)?;
+        } else if image.format.eq_ignore_ascii_case("h264") {
+            self.ensure_mode(ParsedPayloadKind::H264)?;
+        } else {
+            self.ensure_mode(ParsedPayloadKind::Encoded)?;
+        }
+
+        self.blobs.push(image.data);
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<Chunk>> {
+        let Self {
+            blobs,
+            mode,
+            frame_ids,
+        } = *self;
+
+        let entity_path = ctx.entity_path().clone();
+        let timelines = ctx.build_timelines();
+
+        let mut components: Vec<_> = match mode {
+            ParsedPayloadKind::DepthRvl => EncodedDepthImage::update_fields()
+                .with_many_blob(blobs)
+                .with_many_media_type(std::iter::repeat_n(MediaType::rvl(), frame_ids.len()))
+                .columns_of_unit_batches()?
+                .collect(),
+            ParsedPayloadKind::H264 => VideoStream::update_fields()
+                .with_many_sample(blobs)
+                .columns_of_unit_batches()?
+                .collect(),
+            ParsedPayloadKind::Unknown | ParsedPayloadKind::Encoded => {
+                EncodedImage::update_fields()
+                    .with_many_blob(blobs)
+                    .columns_of_unit_batches()?
+                    .collect()
+            }
+        };
+
+        components.extend(
+            CoordinateFrame::update_fields()
+                .with_many_frame(suffix_image_plane_frame_ids(frame_ids))
+                .columns_of_unit_batches()?,
+        );
+
+        let chunk = Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            entity_path.clone(),
+            timelines,
+            components.into_iter().collect(),
+        )?;
+
+        if mode == ParsedPayloadKind::H264 {
+            let codec_chunk = Chunk::builder(entity_path)
+                .with_archetype(
+                    RowId::new(),
+                    TimePoint::default(),
+                    &VideoStream::update_fields().with_codec(VideoCodec::H264),
+                )
+                .build()?;
+            Ok(vec![chunk, codec_chunk])
+        } else {
+            Ok(vec![chunk])
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParsedPayloadKind {
+    Unknown,
+    Encoded,
+    H264,
+    DepthRvl,
+}
+
+impl CompressedImageMessageParser {
+    fn ensure_mode(&mut self, new_mode: ParsedPayloadKind) -> anyhow::Result<()> {
+        match (self.mode, new_mode) {
+            (ParsedPayloadKind::Unknown, mode) => {
+                self.mode = mode;
+                Ok(())
+            }
+            (mode, new_mode) if mode == new_mode => Ok(()),
+            _ => bail!(
+                "Encountered mixed compressed image payloads on the same topic; this is not supported"
+            ),
+        }
+    }
+}
+
+fn is_rvl(format: &str) -> bool {
+    let Some((encoding, remainder)) = format.split_once(';') else {
+        return false;
+    };
+    !encoding.trim().is_empty()
+        && remainder
+            .trim()
+            .to_ascii_lowercase()
+            .contains("compresseddepth")
+        && remainder.trim().to_ascii_lowercase().contains("rvl")
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/image.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/image.rs
@@ -1,0 +1,92 @@
+use anyhow::Context as _;
+use re_chunk::{Chunk, ChunkId};
+use re_sdk_types::archetypes::{CoordinateFrame, DepthImage, Image};
+
+use crate::parsers::decode::{MessageParser, ParserContext};
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::definitions::sensor_msgs;
+use crate::parsers::ros1msg::wire::Ros1Reader;
+use crate::parsers::ros2msg::sensor_msgs::decode_image_encoding;
+use crate::parsers::ros2msg::util::suffix_image_plane_frame_ids;
+
+pub struct ImageMessageParser {
+    blobs: Vec<Vec<u8>>,
+    formats: Vec<re_sdk_types::datatypes::ImageFormat>,
+    is_depth_image: bool,
+    frame_ids: Vec<String>,
+}
+
+impl Ros1MessageParser for ImageMessageParser {
+    fn new(num_rows: usize) -> Self {
+        Self {
+            blobs: Vec::with_capacity(num_rows),
+            formats: Vec::with_capacity(num_rows),
+            is_depth_image: false,
+            frame_ids: Vec::with_capacity(num_rows),
+        }
+    }
+}
+
+impl MessageParser for ImageMessageParser {
+    fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        let mut reader = Ros1Reader::new(&msg.data);
+        let image = sensor_msgs::Image::read(&mut reader)
+            .context("Failed to decode sensor_msgs/Image message from ROS1 data")?;
+        reader.finish()?;
+
+        ctx.add_timestamp_cell(crate::util::TimestampCell::from_nanos_ros1(
+            image.header.stamp.as_nanos(),
+            ctx.time_type(),
+        ));
+
+        let dimensions = [image.width, image.height];
+        let encoding = decode_image_encoding(&image.encoding).with_context(|| {
+            format!(
+                "Failed to decode image format for encoding '{}' with dimensions {}x{}",
+                image.encoding, image.width, image.height
+            )
+        })?;
+
+        self.is_depth_image = encoding.is_single_channel();
+        self.frame_ids.push(image.header.frame_id);
+        self.blobs.push(image.data);
+        self.formats.push(encoding.to_image_format(dimensions));
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<Chunk>> {
+        let Self {
+            blobs,
+            formats,
+            is_depth_image,
+            frame_ids,
+        } = *self;
+
+        let mut components: Vec<_> = if is_depth_image {
+            DepthImage::update_fields()
+                .with_many_buffer(blobs)
+                .with_many_format(formats)
+                .columns_of_unit_batches()?
+                .collect()
+        } else {
+            Image::update_fields()
+                .with_many_buffer(blobs)
+                .with_many_format(formats)
+                .columns_of_unit_batches()?
+                .collect()
+        };
+
+        components.extend(
+            CoordinateFrame::update_fields()
+                .with_many_frame(suffix_image_plane_frame_ids(frame_ids))
+                .columns_of_unit_batches()?,
+        );
+
+        Ok(vec![Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            ctx.entity_path().clone(),
+            ctx.build_timelines(),
+            components.into_iter().collect(),
+        )?])
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/sensor_msgs/mod.rs
@@ -1,0 +1,7 @@
+mod camera_info;
+mod compressed_image;
+mod image;
+
+pub use camera_info::CameraInfoMessageParser;
+pub use compressed_image::CompressedImageMessageParser;
+pub use image::ImageMessageParser;

--- a/crates/store/re_mcap/src/parsers/ros1msg/std_msgs/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/std_msgs/mod.rs
@@ -1,0 +1,3 @@
+mod string;
+
+pub use string::StringMessageParser;

--- a/crates/store/re_mcap/src/parsers/ros1msg/std_msgs/string.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/std_msgs/string.rs
@@ -1,0 +1,43 @@
+use re_chunk::{Chunk, ChunkId};
+use re_sdk_types::archetypes::TextDocument;
+
+use crate::parsers::decode::{MessageParser, ParserContext};
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::definitions::std_msgs;
+use crate::parsers::ros1msg::wire::Ros1Reader;
+
+pub struct StringMessageParser {
+    texts: Vec<String>,
+}
+
+impl Ros1MessageParser for StringMessageParser {
+    fn new(num_rows: usize) -> Self {
+        Self {
+            texts: Vec::with_capacity(num_rows),
+        }
+    }
+}
+
+impl MessageParser for StringMessageParser {
+    fn append(&mut self, _ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        let mut reader = Ros1Reader::new(&msg.data);
+        let message = std_msgs::StringMessage::read(&mut reader)?;
+        reader.finish()?;
+        self.texts.push(message.data);
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<Chunk>> {
+        let chunk = Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            ctx.entity_path().clone(),
+            ctx.build_timelines(),
+            TextDocument::update_fields()
+                .with_many_text(self.texts)
+                .columns_of_unit_batches()?
+                .collect(),
+        )?;
+
+        Ok(vec![chunk])
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/tf2_msgs/mod.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/tf2_msgs/mod.rs
@@ -1,0 +1,1 @@
+pub mod tf_message;

--- a/crates/store/re_mcap/src/parsers/ros1msg/tf2_msgs/tf_message.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/tf2_msgs/tf_message.rs
@@ -1,0 +1,116 @@
+use re_chunk::{Chunk, ChunkId};
+use re_sdk_types::archetypes::Transform3D;
+use re_sdk_types::components::{RotationQuat, Translation3D};
+use re_sdk_types::datatypes::Quaternion;
+
+use crate::parsers::decode::{MessageParser, ParserContext};
+use crate::parsers::ros1msg::Ros1MessageParser;
+use crate::parsers::ros1msg::definitions::geometry_msgs::{Transform, TransformStamped};
+use crate::parsers::ros1msg::definitions::std_msgs::Header;
+use crate::parsers::ros1msg::definitions::tf2_msgs::TFMessage;
+use crate::parsers::ros1msg::wire::Ros1Reader;
+use crate::util::{TimestampCell, log_and_publish_timepoint_from_msg};
+
+const STATIC_TF_TOPIC: &str = "/tf_static";
+
+fn static_chunk_timelines()
+-> re_chunk::external::nohash_hasher::IntMap<re_log_types::TimelineName, re_chunk::TimeColumn> {
+    re_chunk::external::nohash_hasher::IntMap::default()
+}
+
+fn decode_tf_message(data: &[u8]) -> anyhow::Result<TFMessage> {
+    let mut reader = Ros1Reader::new(data);
+    let message = TFMessage::read(&mut reader)?;
+    reader.finish()?;
+    Ok(message)
+}
+
+pub struct TfMessageParser {
+    translations: Vec<Translation3D>,
+    quaternions: Vec<RotationQuat>,
+    parent_frame_ids: Vec<String>,
+    child_frame_ids: Vec<String>,
+}
+
+impl Ros1MessageParser for TfMessageParser {
+    fn new(_num_rows: usize) -> Self {
+        Self {
+            translations: Vec::new(),
+            quaternions: Vec::new(),
+            parent_frame_ids: Vec::new(),
+            child_frame_ids: Vec::new(),
+        }
+    }
+}
+
+impl MessageParser for TfMessageParser {
+    fn get_log_and_publish_timepoints(
+        &self,
+        msg: &mcap::Message<'_>,
+        time_type: re_log_types::TimeType,
+    ) -> anyhow::Result<Vec<re_chunk::TimePoint>> {
+        Ok(vec![
+            log_and_publish_timepoint_from_msg(msg, time_type);
+            decode_tf_message(&msg.data)?.transforms.len()
+        ])
+    }
+
+    fn append(&mut self, ctx: &mut ParserContext, msg: &mcap::Message<'_>) -> anyhow::Result<()> {
+        for TransformStamped {
+            header: Header {
+                stamp, frame_id, ..
+            },
+            child_frame_id,
+            transform:
+                Transform {
+                    translation,
+                    rotation,
+                },
+        } in decode_tf_message(&msg.data)?.transforms
+        {
+            ctx.add_timestamp_cell(TimestampCell::from_nanos_ros1(
+                stamp.as_nanos(),
+                ctx.time_type(),
+            ));
+            self.parent_frame_ids.push(frame_id);
+            self.child_frame_ids.push(child_frame_id);
+            self.translations.push(Translation3D::new(
+                translation.x as f32,
+                translation.y as f32,
+                translation.z as f32,
+            ));
+            self.quaternions.push(
+                Quaternion::from_xyzw([
+                    rotation.x as f32,
+                    rotation.y as f32,
+                    rotation.z as f32,
+                    rotation.w as f32,
+                ])
+                .into(),
+            );
+        }
+        Ok(())
+    }
+
+    fn finalize(self: Box<Self>, ctx: ParserContext) -> anyhow::Result<Vec<Chunk>> {
+        let entity_path = ctx.entity_path().clone();
+        let timelines = if ctx.channel_topic() == STATIC_TF_TOPIC {
+            static_chunk_timelines()
+        } else {
+            ctx.build_timelines()
+        };
+
+        Ok(vec![Chunk::from_auto_row_ids(
+            ChunkId::new(),
+            entity_path,
+            timelines,
+            Transform3D::update_fields()
+                .with_many_translation(self.translations)
+                .with_many_quaternion(self.quaternions)
+                .with_many_child_frame(self.child_frame_ids)
+                .with_many_parent_frame(self.parent_frame_ids)
+                .columns_of_unit_batches()?
+                .collect(),
+        )?])
+    }
+}

--- a/crates/store/re_mcap/src/parsers/ros1msg/wire.rs
+++ b/crates/store/re_mcap/src/parsers/ros1msg/wire.rs
@@ -1,0 +1,132 @@
+use anyhow::{Context as _, ensure};
+
+pub struct Ros1Reader<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Ros1Reader<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data, offset: 0 }
+    }
+
+    pub fn finish(&self) -> anyhow::Result<()> {
+        ensure!(
+            self.offset == self.data.len(),
+            "ROS1 payload has {} trailing bytes",
+            self.data.len() - self.offset
+        );
+        Ok(())
+    }
+
+    fn take<const N: usize>(&mut self) -> anyhow::Result<[u8; N]> {
+        let end = self
+            .offset
+            .checked_add(N)
+            .context("ROS1 read offset overflow")?;
+        ensure!(
+            end <= self.data.len(),
+            "ROS1 payload ended while reading {N} bytes at offset {}",
+            self.offset
+        );
+        let bytes = self.data[self.offset..end].try_into()?;
+        self.offset = end;
+        Ok(bytes)
+    }
+
+    fn take_slice(&mut self, len: usize) -> anyhow::Result<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(len)
+            .context("ROS1 read offset overflow")?;
+        ensure!(
+            end <= self.data.len(),
+            "ROS1 payload ended while reading {len} bytes at offset {}",
+            self.offset
+        );
+        let slice = &self.data[self.offset..end];
+        self.offset = end;
+        Ok(slice)
+    }
+
+    pub fn read_bool(&mut self) -> anyhow::Result<bool> {
+        Ok(self.read_u8()? != 0)
+    }
+
+    pub fn read_u8(&mut self) -> anyhow::Result<u8> {
+        Ok(self.take::<1>()?[0])
+    }
+
+    pub fn read_u32(&mut self) -> anyhow::Result<u32> {
+        Ok(u32::from_le_bytes(self.take()?))
+    }
+
+    pub fn read_f32(&mut self) -> anyhow::Result<f32> {
+        Ok(f32::from_le_bytes(self.take()?))
+    }
+
+    pub fn read_f64(&mut self) -> anyhow::Result<f64> {
+        Ok(f64::from_le_bytes(self.take()?))
+    }
+
+    pub fn read_string(&mut self) -> anyhow::Result<String> {
+        let len = self.read_u32()? as usize;
+        let bytes = self.take_slice(len)?;
+        String::from_utf8(bytes.to_vec()).context("ROS1 string is not valid UTF-8")
+    }
+
+    pub fn read_u8_vec(&mut self) -> anyhow::Result<Vec<u8>> {
+        let len = self.read_u32()? as usize;
+        Ok(self.take_slice(len)?.to_vec())
+    }
+
+    pub fn read_i8_vec_as_u8(&mut self) -> anyhow::Result<Vec<u8>> {
+        let len = self.read_u32()? as usize;
+        Ok(self.take_slice(len)?.to_vec())
+    }
+
+    pub fn read_f64_vec(&mut self) -> anyhow::Result<Vec<f64>> {
+        let len = self.read_u32()? as usize;
+        (0..len).map(|_| self.read_f64()).collect()
+    }
+
+    pub fn read_f64_array<const N: usize>(&mut self) -> anyhow::Result<[f64; N]> {
+        let values = (0..N)
+            .map(|_| self.read_f64())
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(values.try_into().expect("fixed-size array length matches"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_string_and_primitives() {
+        let mut bytes = Vec::new();
+        bytes.extend(7_u32.to_le_bytes());
+        bytes.extend(1.5_f32.to_le_bytes());
+        bytes.extend(3_u32.to_le_bytes());
+        bytes.extend(b"map");
+
+        let mut reader = Ros1Reader::new(&bytes);
+        assert_eq!(reader.read_u32().unwrap(), 7);
+        assert_eq!(reader.read_f32().unwrap(), 1.5);
+        assert_eq!(reader.read_string().unwrap(), "map");
+        reader.finish().unwrap();
+    }
+
+    #[test]
+    fn rejects_short_buffers() {
+        let mut reader = Ros1Reader::new(&[1, 2, 3]);
+        assert!(reader.read_u32().is_err());
+    }
+
+    #[test]
+    fn rejects_length_overrun() {
+        let bytes = 4_u32.to_le_bytes();
+        let mut reader = Ros1Reader::new(&bytes);
+        assert!(reader.read_string().is_err());
+    }
+}

--- a/crates/store/re_mcap/src/util.rs
+++ b/crates/store/re_mcap/src/util.rs
@@ -132,6 +132,11 @@ impl TimestampCell {
         Self::from_nanos_with_type(timestamp_ns, "ros2_timestamp", time_type)
     }
 
+    /// Create a time cell on the `"ros1_timestamp"` timeline with the given [`TimeType`].
+    pub fn from_nanos_ros1(timestamp_ns: u64, time_type: TimeType) -> Self {
+        Self::from_nanos_with_type(timestamp_ns, "ros1_timestamp", time_type)
+    }
+
     /// The timeline name for this time cell.
     pub fn timeline_name(&self) -> &str {
         &self.timeline
@@ -173,6 +178,14 @@ mod tests {
         let ts: u64 = 1_672_531_200_000_000_000;
         let cell = TimestampCell::from_nanos_ros2(ts, TimeType::TimestampNs);
         assert_eq!(cell.timeline_name(), "ros2_timestamp");
+        assert!(matches!(cell.time.typ, TimeType::TimestampNs));
+    }
+
+    #[test]
+    fn test_from_nanos_ros1() {
+        let ts: u64 = 1_672_531_200_000_000_000;
+        let cell = TimestampCell::from_nanos_ros1(ts, TimeType::TimestampNs);
+        assert_eq!(cell.timeline_name(), "ros1_timestamp");
         assert!(matches!(cell.time.typ, TimeType::TimestampNs));
     }
 

--- a/docs/content/concepts/logging-and-ingestion/mcap/cli-reference.md
+++ b/docs/content/concepts/logging-and-ingestion/mcap/cli-reference.md
@@ -71,6 +71,7 @@ Decoding:
 
 Semantic:
 - **`foxglove`**: Semantic interpretation of Foxglove Protobuf messages
+- **`ros1msg`**: Semantic interpretation of ROS1 messages
 - **`ros2msg`**: Semantic interpretation of ROS2 messages
 
 ### Default behavior

--- a/docs/content/concepts/logging-and-ingestion/mcap/decoders-explained.md
+++ b/docs/content/concepts/logging-and-ingestion/mcap/decoders-explained.md
@@ -27,7 +27,7 @@ The `stats` decoder computes file-level metrics and statistics, creating entitie
 
 ### Semantic interpretation
 
-The `ros2msg` and `foxglove` decoders provide semantic interpretation and visualization of standard ROS 2 and Foxglove message types, creating meaningful Rerun visualization archetypes from data. Unlike the `protobuf` decoder, this decoder understands the semantics of the messages and creates appropriate visualizations: images become [Image](../../../reference/types/archetypes/image.md), point clouds become [Points3D](../../../reference/types/archetypes/points3d.md), IMU messages become [SeriesLines](../../../reference/types/archetypes/series_lines.md) with the data plotted over time, and so on.
+The `ros1msg`, `ros2msg`, and `foxglove` decoders provide semantic interpretation and visualization of standard ROS 1, ROS 2, and Foxglove message types, creating meaningful Rerun visualization archetypes from data. Unlike the `protobuf` decoder, these decoders understand the semantics of the messages and create appropriate visualizations: images become [Image](../../../reference/types/archetypes/image.md), point clouds become [Points3D](../../../reference/types/archetypes/points3d.md), IMU messages become [SeriesLines](../../../reference/types/archetypes/series_lines.md) with the data plotted over time, and so on.
 
 See [Message Formats](message-formats.md) for the complete list of supported message types.
 

--- a/docs/content/concepts/logging-and-ingestion/mcap/message-formats.md
+++ b/docs/content/concepts/logging-and-ingestion/mcap/message-formats.md
@@ -23,7 +23,7 @@ We are continually adding support for more standard message types.
 | Point cloud | `sensor_msgs/PointCloud2` | `PointCloud` | [Points3D](../../../reference/types/archetypes/points3d.md) |
 | Geo points | `sensor_msgs/NavSatFix` | `LocationFix`, `LocationFixes` | [GeoPoints](../../../reference/types/archetypes/geo_points.md) |
 | Transforms | `tf2_msgs/TFMessage` | `FrameTransform`, `FrameTransforms` | [Transform3D](../../../reference/types/archetypes/transform3d.md) |
-| Poses | `geometry_msgs/PoseStamped` | `PoseInFrame`, `PosesInFrame` | [InstancePoses3D](../../../reference/types/archetypes/instance_poses3d.md) |
+| Poses | `geometry_msgs/PoseStamped`, `geometry_msgs/PoseWithCovarianceStamped` | `PoseInFrame`, `PosesInFrame` | [InstancePoses3D](../../../reference/types/archetypes/instance_poses3d.md) |
 | Coordinate frame | `.frame_id` field in `std_msgs/Header` | `.frame_id` field | [CoordinateFrame](../../../reference/types/archetypes/coordinate_frame.md)
 | Magnetic field | `sensor_msgs/MagneticField` | - | [Arrows3D](../../../reference/types/archetypes/arrows3d.md) |
 | Misc. scalar sensor data | `sensor_msgs/Imu`, `sensor_msgs/JointState`, `sensor_msgs/Temperature`, `sensor_msgs/FluidPressure`, `sensor_msgs/RelativeHumidity`, `sensor_msgs/Illuminance`, `sensor_msgs/Range`, `sensor_msgs/BatteryState`, `sensor_msgs/Joy` | - *(usually covered via custom schemas, see [Schema reflection](#schema-reflection) below on this page)* | [Scalars](../../../reference/types/archetypes/scalars.md) |

--- a/docs/content/concepts/logging-and-ingestion/mcap/message-formats.md
+++ b/docs/content/concepts/logging-and-ingestion/mcap/message-formats.md
@@ -5,16 +5,16 @@ order: 200
 
 Rerun provides automatic visualization for common message types in MCAP files:
 
-* ROS 2 messages
+* ROS 1 and ROS 2 messages
 * Foxglove schemas (Protobuf)
 
 ## Overview
 
-This table shows an overview of the ROS 2 and Foxglove message schemas that are automatically converted to Rerun archetypes.
+This table shows an overview of the ROS and Foxglove message schemas that are automatically converted to Rerun archetypes.
 
 We are continually adding support for more standard message types.
 
-| Modality | ROS 2 | Foxglove Protobuf | Rerun Archetypes |
+| Modality | ROS | Foxglove Protobuf | Rerun Archetypes |
 | --- | --- | --- | --- |
 | Raw image | `sensor_msgs/Image` | `RawImage` | [Image](../../../reference/types/archetypes/image.md), [DepthImage](../../../reference/types/archetypes/depth_image.md) |
 | Encoded image | `sensor_msgs/CompressedImage` | `CompressedImage` | [EncodedImage](../../../reference/types/archetypes/encoded_image.md), [EncodedDepthImage](../../../reference/types/archetypes/encoded_depth_image.md) |
@@ -39,9 +39,9 @@ In addition to the `message_log_time` and `message_publish_time` timestamps that
 
 #### ROS
 
-Most ROS message payloads have an additional [`Header`]( https://docs.ros.org/en/noetic/api/std_msgs/html/msg/Header.html) that may also contain timestamp information. These timestamps are put onto specific `ros2_*` timelines.
+Most ROS message payloads have an additional [`Header`]( https://docs.ros.org/en/noetic/api/std_msgs/html/msg/Header.html) that may also contain timestamp information. These timestamps are put onto specific ROS timelines.
 
-Timestamps within Unix time range (1990-2100) create a `ros2_timestamp` timeline. Values outside this range create a `ros2_duration` timeline representing relative time from custom epochs.
+ROS 1 messages create a `ros1_timestamp` timeline. ROS 2 messages create a `ros2_timestamp` timeline.
 
 #### Foxglove
 

--- a/docs/content/howto/logging-and-ingestion/mcap.md
+++ b/docs/content/howto/logging-and-ingestion/mcap.md
@@ -64,6 +64,7 @@ Each layer extracts different types of information from the MCAP source and each
 - **`metadata`** Extracts metadata records (if present) into `__mcap_metadata` in the RRD
 - **`attachments`**: Extracts MCAP attachment records (if present) as static data under `__mcap_attachments`
 - **`protobuf`**: Automatically decodes protobuf-encoded messages using reflection
+- **`ros1msg`**: Provides semantic conversion of common ROS1 message types into Rerun's visualization components
 - **`ros2msg`**: Provides semantic conversion of common ROS2 message types into Rerun's visualization components
 - **`ros2_reflection`**: Automatically decodes ROS2 messages using reflection
 - **`recording_info`**: Extracts recording metadata such as message counts, start time, and session information into `__mcap_properties` in the RRD
@@ -79,7 +80,7 @@ The following shows how to select specific decoders:
 rerun mcap convert input.mcap -d protobuf -d stats -o output.rrd
 
 # Use multiple decoders for different perspectives
-rerun mcap convert input.mcap -d ros2msg -d raw -d recording_info -o output.rrd
+rerun mcap convert input.mcap -d ros1msg -d ros2msg -d raw -d recording_info -o output.rrd
 
 # Add robot geometry from robot_description topics
 rerun mcap convert input.mcap -d ros2msg -d urdf -o output.rrd


### PR DESCRIPTION
### Related

Closes #12780

### What

Adds support for deserializing and visualizing a limited set of ROS1 messages when loaded from an mcap file.

This is a draft right now because I had codex write this and haven't actually looked at the code, and I've only tested the tf and occupancy grid message support. Tf support doesn't work but occupancy grids do. I figured I'd put this up anyways to start discussion and provide a starting point if anyone else is going to work on this.

The diff is huge in part because codex decided it could do this without adding dependencies, but I'm also curious about seeing if using rosrust makes this easier, as per this comment: https://github.com/rerun-io/rerun/issues/1537#issuecomment-3412076152
