### PR TITLE
Add support to manually specify own design tokens to use with re_ui

### DIFF
--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -342,10 +342,23 @@ pub struct DesignTokens {
 impl DesignTokens {
     /// Load design tokens from `data/design_tokens_*.ron`.
     pub fn load(theme: Theme, tokens_ron: &str) -> anyhow::Result<Self> {
+        Self::load_with_color_table(theme, tokens_ron, include_str!("../data/color_table.ron"))
+    }
+
+    /// Load design tokens, supplying a custom color-table RON instead of the embedded one.
+    ///
+    /// Useful for downstream crates that want to ship their own color palette without forking
+    /// `re_ui`. The provided `color_table_ron` must have the same shape as the bundled
+    /// `data/color_table.ron`.
+    pub fn load_with_color_table(
+        theme: Theme,
+        tokens_ron: &str,
+        color_table_ron: &str,
+    ) -> anyhow::Result<Self> {
         anyhow::ensure!(!tokens_ron.trim().is_empty(), "Empty theme file");
 
-        let color_table_ron: ron::Value = ron::from_str(include_str!("../data/color_table.ron"))
-            .expect("Failed to parse data/color_table.ron");
+        let color_table_ron: ron::Value =
+            ron::from_str(color_table_ron).context("Failed to parse color-table .ron")?;
         let colors = load_color_table(&color_table_ron);
 
         let theme_value: ron::Value = ron::from_str(tokens_ron)

--- a/crates/viewer/re_ui/src/hot_reload_design_tokens.rs
+++ b/crates/viewer/re_ui/src/hot_reload_design_tokens.rs
@@ -1,8 +1,8 @@
 use crate::DesignTokens;
 
-pub(crate) struct DesignTokensPerTheme {
-    pub(crate) dark: DesignTokens,
-    pub(crate) light: DesignTokens,
+struct DesignTokensPerTheme {
+    dark: DesignTokens,
+    light: DesignTokens,
 }
 
 impl DesignTokensPerTheme {
@@ -40,6 +40,8 @@ impl DesignTokensPerTheme {
 mod design_token_access {
     use std::sync::OnceLock;
 
+    use crate::DesignTokens;
+
     use super::DesignTokensPerTheme;
 
     static DESIGN_TOKENS: OnceLock<DesignTokensPerTheme> = OnceLock::new();
@@ -49,8 +51,10 @@ mod design_token_access {
             .get_or_init(|| DesignTokensPerTheme::load().expect("Failed to load design tokens"))
     }
 
-    pub fn try_set_design_tokens(tokens: DesignTokensPerTheme) -> Result<(), ()> {
-        DESIGN_TOKENS.set(tokens).map_err(|_| ())
+    pub fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
+        DESIGN_TOKENS
+            .set(DesignTokensPerTheme { dark, light })
+            .map_err(|_| ())
     }
 }
 
@@ -61,6 +65,8 @@ mod design_token_access {
 
     use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
     use parking_lot::{Mutex, RwLock};
+
+    use crate::DesignTokens;
 
     use super::DesignTokensPerTheme;
 
@@ -159,12 +165,13 @@ mod design_token_access {
         *current.read()
     }
 
-    pub fn try_set_design_tokens(tokens: DesignTokensPerTheme) -> Result<(), ()> {
+    pub fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
         // Mirrors the OnceLock-based variant: only succeed if the static is not yet initialized.
         // In hot-reload mode the file watcher may overwrite this later — that's intentional, as
         // this build flavor is only enabled inside the rerun workspace, where the file watcher
         // already leaks on every reload.
-        let leaked: &'static DesignTokensPerTheme = Box::leak(Box::new(tokens));
+        let leaked: &'static DesignTokensPerTheme =
+            Box::leak(Box::new(DesignTokensPerTheme { dark, light }));
         CURRENT_TOKENS.set(RwLock::new(leaked)).map_err(|_| ())
     }
 }
@@ -176,9 +183,7 @@ pub fn design_tokens_of(theme: egui::Theme) -> &'static DesignTokens {
     }
 }
 
-pub(crate) fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
-    design_token_access::try_set_design_tokens(DesignTokensPerTheme { dark, light })
-}
+pub(crate) use design_token_access::try_set_design_tokens;
 
 #[cfg(hot_reload_design_tokens)]
 pub use design_token_access::{hot_reload_design_tokens, install_hot_reload};

--- a/crates/viewer/re_ui/src/hot_reload_design_tokens.rs
+++ b/crates/viewer/re_ui/src/hot_reload_design_tokens.rs
@@ -1,8 +1,8 @@
 use crate::DesignTokens;
 
-struct DesignTokensPerTheme {
-    dark: DesignTokens,
-    light: DesignTokens,
+pub(crate) struct DesignTokensPerTheme {
+    pub(crate) dark: DesignTokens,
+    pub(crate) light: DesignTokens,
 }
 
 impl DesignTokensPerTheme {
@@ -42,10 +42,15 @@ mod design_token_access {
 
     use super::DesignTokensPerTheme;
 
+    static DESIGN_TOKENS: OnceLock<DesignTokensPerTheme> = OnceLock::new();
+
     pub fn design_tokens_per_theme() -> &'static DesignTokensPerTheme {
-        static DESIGN_TOKENS: OnceLock<DesignTokensPerTheme> = OnceLock::new();
         DESIGN_TOKENS
             .get_or_init(|| DesignTokensPerTheme::load().expect("Failed to load design tokens"))
+    }
+
+    pub fn try_set_design_tokens(tokens: DesignTokensPerTheme) -> Result<(), ()> {
+        DESIGN_TOKENS.set(tokens).map_err(|_| ())
     }
 }
 
@@ -153,6 +158,15 @@ mod design_token_access {
 
         *current.read()
     }
+
+    pub fn try_set_design_tokens(tokens: DesignTokensPerTheme) -> Result<(), ()> {
+        // Mirrors the OnceLock-based variant: only succeed if the static is not yet initialized.
+        // In hot-reload mode the file watcher may overwrite this later — that's intentional, as
+        // this build flavor is only enabled inside the rerun workspace, where the file watcher
+        // already leaks on every reload.
+        let leaked: &'static DesignTokensPerTheme = Box::leak(Box::new(tokens));
+        CURRENT_TOKENS.set(RwLock::new(leaked)).map_err(|_| ())
+    }
 }
 
 pub fn design_tokens_of(theme: egui::Theme) -> &'static DesignTokens {
@@ -160,6 +174,10 @@ pub fn design_tokens_of(theme: egui::Theme) -> &'static DesignTokens {
         egui::Theme::Dark => &design_token_access::design_tokens_per_theme().dark,
         egui::Theme::Light => &design_token_access::design_tokens_per_theme().light,
     }
+}
+
+pub(crate) fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
+    design_token_access::try_set_design_tokens(DesignTokensPerTheme { dark, light })
 }
 
 #[cfg(hot_reload_design_tokens)]

--- a/crates/viewer/re_ui/src/hot_reload_design_tokens.rs
+++ b/crates/viewer/re_ui/src/hot_reload_design_tokens.rs
@@ -1,5 +1,17 @@
 use crate::DesignTokens;
 
+/// Returned by [`crate::try_set_design_tokens`] when the design tokens have already been initialized.
+#[derive(Clone, Copy, Debug)]
+pub struct DesignTokensAlreadyInitializedError;
+
+impl std::fmt::Display for DesignTokensAlreadyInitializedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Design tokens have already been initialized")
+    }
+}
+
+impl std::error::Error for DesignTokensAlreadyInitializedError {}
+
 struct DesignTokensPerTheme {
     dark: DesignTokens,
     light: DesignTokens,
@@ -42,7 +54,7 @@ mod design_token_access {
 
     use crate::DesignTokens;
 
-    use super::DesignTokensPerTheme;
+    use super::{DesignTokensAlreadyInitializedError, DesignTokensPerTheme};
 
     static DESIGN_TOKENS: OnceLock<DesignTokensPerTheme> = OnceLock::new();
 
@@ -51,10 +63,17 @@ mod design_token_access {
             .get_or_init(|| DesignTokensPerTheme::load().expect("Failed to load design tokens"))
     }
 
-    pub fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
-        DESIGN_TOKENS
+    pub fn try_set_design_tokens(
+        dark: DesignTokens,
+        light: DesignTokens,
+    ) -> Result<(), DesignTokensAlreadyInitializedError> {
+        if DESIGN_TOKENS
             .set(DesignTokensPerTheme { dark, light })
-            .map_err(|_| ())
+            .is_err()
+        {
+            return Err(DesignTokensAlreadyInitializedError);
+        }
+        Ok(())
     }
 }
 
@@ -68,7 +87,7 @@ mod design_token_access {
 
     use crate::DesignTokens;
 
-    use super::DesignTokensPerTheme;
+    use super::{DesignTokensAlreadyInitializedError, DesignTokensPerTheme};
 
     static CURRENT_TOKENS: OnceLock<RwLock<&'static DesignTokensPerTheme>> = OnceLock::new();
 
@@ -165,14 +184,20 @@ mod design_token_access {
         *current.read()
     }
 
-    pub fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
+    pub fn try_set_design_tokens(
+        dark: DesignTokens,
+        light: DesignTokens,
+    ) -> Result<(), DesignTokensAlreadyInitializedError> {
         // Mirrors the OnceLock-based variant: only succeed if the static is not yet initialized.
         // In hot-reload mode the file watcher may overwrite this later — that's intentional, as
         // this build flavor is only enabled inside the rerun workspace, where the file watcher
         // already leaks on every reload.
         let leaked: &'static DesignTokensPerTheme =
             Box::leak(Box::new(DesignTokensPerTheme { dark, light }));
-        CURRENT_TOKENS.set(RwLock::new(leaked)).map_err(|_| ())
+        if CURRENT_TOKENS.set(RwLock::new(leaked)).is_err() {
+            return Err(DesignTokensAlreadyInitializedError);
+        }
+        Ok(())
     }
 }
 

--- a/crates/viewer/re_ui/src/lib.rs
+++ b/crates/viewer/re_ui/src/lib.rs
@@ -62,7 +62,7 @@ pub use self::design_tokens::{
 pub use self::egui_ext::widget_ext::*;
 pub use self::fuzzy::{FuzzyMatch, FuzzyQuery};
 pub use self::help::*;
-pub use self::hot_reload_design_tokens::design_tokens_of;
+pub use self::hot_reload_design_tokens::{DesignTokensAlreadyInitializedError, design_tokens_of};
 pub use self::icon_text::*;
 pub use self::icons::Icon;
 pub use self::link_button::LinkButton;
@@ -194,12 +194,15 @@ impl HasDesignTokens for egui::Visuals {
 /// [`apply_style_and_install_loaders`] (or any other code path that triggers design-token
 /// initialization).
 ///
-/// Returns `Err(())` if the design tokens have already been initialized; in that case `dark` and
-/// `light` are dropped.
+/// Returns [`DesignTokensAlreadyInitializedError`] if the design tokens have already been
+/// initialized; in that case `dark` and `light` are dropped.
 ///
 /// Note: when `re_ui` is built with hot-reloading enabled (only inside the rerun workspace),
 /// the file watcher may subsequently overwrite the supplied values.
-pub fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
+pub fn try_set_design_tokens(
+    dark: DesignTokens,
+    light: DesignTokens,
+) -> Result<(), DesignTokensAlreadyInitializedError> {
     self::hot_reload_design_tokens::try_set_design_tokens(dark, light)
 }
 

--- a/crates/viewer/re_ui/src/lib.rs
+++ b/crates/viewer/re_ui/src/lib.rs
@@ -186,6 +186,23 @@ impl HasDesignTokens for egui::Visuals {
     }
 }
 
+/// Override the embedded design tokens before they're first read.
+///
+/// Lets downstream crates ship their own theming (e.g. a tweaked color palette) without forking
+/// `re_ui`. Construct `dark` and `light` via [`DesignTokens::load`] or
+/// [`DesignTokens::load_with_color_table`] and call this **before**
+/// [`apply_style_and_install_loaders`] (or any other code path that triggers design-token
+/// initialization).
+///
+/// Returns `Err(())` if the design tokens have already been initialized; in that case `dark` and
+/// `light` are dropped.
+///
+/// Note: when `re_ui` is built with hot-reloading enabled (only inside the rerun workspace),
+/// the file watcher may subsequently overwrite the supplied values.
+pub fn try_set_design_tokens(dark: DesignTokens, light: DesignTokens) -> Result<(), ()> {
+    self::hot_reload_design_tokens::try_set_design_tokens(dark, light)
+}
+
 /// Apply the Rerun design tokens to the given egui context and install image loaders.
 pub fn apply_style_and_install_loaders(egui_ctx: &egui::Context) {
     re_tracing::profile_function!();


### PR DESCRIPTION
Hi rerun team!
First: Thanks for making `re_ui` able to use as a standalone library, it really helps to build fancy UI's in Rust!

The design tokens got changed in `re_ui` 0.32, so I want to add a feature to like add the old ones back or manually set the design tokens in your app that uses `re_ui`, but also to maintain own design tokens if you want to change the ones.

