### PR TITLE
Default Safari to WebGL — Safari 26.4 broke 3D under WebGPU

### DIFF
--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -584,9 +584,13 @@ pub fn validate_graphics_backend_applicability(backend: wgpu::Backend) -> Result
 pub fn is_safari_browser() -> bool {
     #[cfg(target_arch = "wasm32")]
     fn is_safari_browser_inner() -> Option<bool> {
+        use web_sys::wasm_bindgen::JsCast as _;
         use web_sys::wasm_bindgen::JsValue;
         let window = web_sys::window()?;
-        Some(window.has_own_property(&JsValue::from("safari")))
+        Some(web_sys::js_sys::Object::has_own(
+            window.unchecked_ref::<web_sys::js_sys::Object>(),
+            &JsValue::from("safari"),
+        ))
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/viewer/re_renderer/src/device_caps.rs
+++ b/crates/viewer/re_renderer/src/device_caps.rs
@@ -502,7 +502,8 @@ pub fn default_backends() -> wgpu::Backends {
         // For changing the backend we use standard wgpu env var, i.e. WGPU_BACKEND.
         wgpu::Backends::from_env()
             .unwrap_or(wgpu::Backends::VULKAN | wgpu::Backends::METAL | wgpu::Backends::GL)
-    } else if is_firefox_browser() {
+    } else if is_safari_browser() || is_firefox_browser() {
+        // TODO(#12788): Safari WebGPU broken on 26.4 (3D content fails to render)
         // TODO(#11009): Fix videos on WebGPU firefox
         wgpu::Backends::GL
     } else {
@@ -577,6 +578,23 @@ pub fn validate_graphics_backend_applicability(backend: wgpu::Backend) -> Result
         }
     }
     Ok(())
+}
+
+/// Are we running inside the Safari browser?
+pub fn is_safari_browser() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    fn is_safari_browser_inner() -> Option<bool> {
+        use web_sys::wasm_bindgen::JsValue;
+        let window = web_sys::window()?;
+        Some(window.has_own_property(&JsValue::from("safari")))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn is_safari_browser_inner() -> Option<bool> {
+        None
+    }
+
+    is_safari_browser_inner().unwrap_or(false)
 }
 
 /// Are we running inside the Firefox browser?


### PR DESCRIPTION
The viewer previously defaulted Safari to WebGPU on macOS 26 Tahoe+, where WebGPU was newly enabled. Safari 26.4 (released 2026-03-23) has since regressed 3D rendering under WebGPU: the Spatial 3D viewport renders black on macOS 26.4 and iPadOS 26.4, while every other view type renders correctly. iOS 26.3 still works — confirming the regression entered with Safari 26.4 across all WebKit clients.

This restores the Safari → WebGL fallback by re-grouping Safari with Firefox in `default_backends()` and re-adding the `is_safari_browser()` helper to `device_caps.rs`. It is a near-pure revert of rerun-io/rerun@76bd562982 (with updated TODO issue ref).

**Note:** this is a mitigation, not a root-cause fix. The underlying Safari WebGPU bug is tracked in rerun-io/rerun#12788; that issue should remain open until Safari ships a fix and we can re-enable WebGPU as the default on Safari.

### Related

* rerun-io/rerun#12788 — underlying Safari WebGPU 3D rendering bug (kept open intentionally)

### What

Affects only the default graphics backend selection on Safari. No view-type, visualizer, or data-handling code paths change. Safari users will now use WebGL by default; the "Restart with WebGPU" menu option (and the `?renderer=webgpu` URL parameter) remain available for users who want to opt in.

### Testing

Verified via locally built web viewer (`pixi run rerun-web`) on:

| OS / Device | Safari | Result |
|---|---|---|
| macOS 26.4.1 Tahoe (M5) | 26.4 (21624.1.16.11.4) | ✅ defaults to WebGL, 3D renders |
| iPadOS 26.4.2 | 26.4 | ✅ defaults to WebGL, 3D renders |
| iOS 26.3.1 (iPhone 17) | 26.3 | ✅ defaults to WebGL, 3D renders |
| macOS 15.7.4 Sequoia | 18.6 | ✅ defaults to WebGL (already did pre-change) |

Confirmed in each case via the viewer menu showing "Restart with WebGPU" (i.e. WebGL is the active backend). Chrome and Firefox on Tahoe unaffected by this change.

### Compatibility

No compatibility impact. This is a runtime default for graphics backend selection — no changes to data formats, SDK APIs, or persisted state. Users who have explicitly forced WebGPU via the `?renderer=webgpu` URL parameter retain that override.
