### PR TITLE
docs(cpp): document vcpkg package

### DIFF
--- a/rerun_cpp/README.md
+++ b/rerun_cpp/README.md
@@ -138,6 +138,22 @@ find_package(rerun_sdk REQUIRED)
 target_link_libraries(<yourtarget> PRIVATE rerun_sdk)
 ```
 
+### Install with vcpkg
+
+The Rerun C++ SDK is also available as the community-maintained [`rerun-sdk` vcpkg port](https://vcpkg.io/en/package/rerun-sdk).
+You can install it with:
+
+```bash
+vcpkg install rerun-sdk
+```
+
+Once installed, consume it from CMake like any other vcpkg-provided package:
+
+```cmake
+find_package(rerun_sdk CONFIG REQUIRED)
+
+target_link_libraries(<yourtarget> PRIVATE rerun_sdk)
+```
 
 ## Development in the Rerun repository
 


### PR DESCRIPTION
## What

- Adds a short `Install with vcpkg` section to `rerun_cpp/README.md`.
- Links to the community-maintained `rerun-sdk` vcpkg port.
- Shows the basic `vcpkg install rerun-sdk` and CMake consumption snippets.

Closes #11269.

## Verification

- `python3.11 scripts/ci/mdlint.py --glob 'rerun_cpp/README.md'`\n\n## Risk\n\nDocumentation-only change; no code or generated files changed.