### PR TITLE
Cache RGB8 image histograms

### DIFF
--- a/crates/viewer/re_data_ui/src/image_ui.rs
+++ b/crates/viewer/re_data_ui/src/image_ui.rs
@@ -10,9 +10,10 @@ use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{UiExt as _, icons, list_item};
 use re_viewer_context::gpu_bridge::{self, image_data_range_heuristic, image_to_gpu};
 use re_viewer_context::{
-    AppContext, ColormapWithRange, DownloadAction, ImageInfo, ImageStatsCache, StoreViewContext,
-    UiLayout,
+    AppContext, ColormapWithRange, DownloadAction, ImageHistogramCache, ImageInfo, ImageStatsCache,
+    Rgb8Histogram, StoreViewContext, UiLayout,
 };
+use std::sync::Arc;
 
 use crate::find_and_deserialize_archetype_mono_component;
 
@@ -279,30 +280,27 @@ fn largest_size_that_fits_in(aspect_ratio: f32, max_size: Vec2) -> Vec2 {
     }
 }
 
-fn rgb8_histogram_ui(ui: &mut egui::Ui, rgb: &[u8]) -> egui::Response {
+fn rgb8_histogram_ui(
+    ctx: &StoreViewContext<'_>,
+    ui: &mut egui::Ui,
+    image: &ImageInfo,
+) -> egui::Response {
     use egui::Color32;
     use itertools::Itertools as _;
 
     re_tracing::profile_function!();
 
-    let mut histograms = [[0_u64; 256]; 3];
-    {
-        // TODO(emilk): this is slow, so cache the results!
-        re_tracing::profile_scope!("build");
-        for pixel in rgb.chunks_exact(3) {
-            for c in 0..3 {
-                histograms[c][pixel[c] as usize] += 1;
-            }
-        }
-    }
+    // Two stores looking at the same image blob will share a single cached histogram.
+    let histogram: Arc<Rgb8Histogram> = ctx.memoizer(|c: &mut ImageHistogramCache| c.entry(image));
 
     use egui_plot::{Bar, BarChart, Legend, Plot};
 
     let names = ["R", "G", "B"];
     let colors = [Color32::RED, Color32::GREEN, Color32::BLUE];
 
-    let charts = histograms
-        .into_iter()
+    let charts = histogram
+        .bins
+        .iter()
         .enumerate()
         .map(|(component, histogram)| {
             let fill = colors[component].linear_multiply(0.5);
@@ -310,9 +308,9 @@ fn rgb8_histogram_ui(ui: &mut egui::Ui, rgb: &[u8]) -> egui::Response {
             BarChart::new(
                 "bar_chart",
                 histogram
-                    .into_iter()
+                    .iter()
                     .enumerate()
-                    .map(|(i, count)| {
+                    .map(|(i, &count)| {
                         Bar::new(i as _, count as _)
                             .width(1.0) // no gaps between bars
                             .fill(fill)
@@ -527,7 +525,7 @@ impl ImageUi {
             ui.section_collapsing_header("Histogram")
                 .default_open(false)
                 .show(ui, |ui| {
-                    rgb8_histogram_ui(ui, &image.buffer);
+                    rgb8_histogram_ui(ctx, ui, image);
                 });
         }
     }

--- a/crates/viewer/re_viewer_context/src/cache/image_histogram_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_histogram_cache.rs
@@ -1,0 +1,159 @@
+use crate::cache::filter_blob_removed_events;
+use crate::image_info::StoredBlobCacheKey;
+use crate::{Cache, CacheEntryAccess, ImageInfo};
+use ahash::HashMap;
+use re_byte_size::SizeBytes as _;
+use re_byte_size::{MemUsageTree, MemUsageTreeCapture};
+use re_chunk_store::ChunkStoreEvent;
+use re_entity_db::EntityDb;
+use std::sync::Arc;
+
+/// Per-channel histogram of an 8-bit `RGB` image.
+///
+/// Each channel has 256 bins.
+#[derive(Clone, Debug)]
+pub struct Rgb8Histogram {
+    /// One 256-bin histogram per channel (R, G, B).
+    pub bins: [[u64; 256]; 3],
+}
+
+impl re_byte_size::SizeBytes for Rgb8Histogram {
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    fn is_pod() -> bool {
+        true
+    }
+}
+
+impl Rgb8Histogram {
+    /// Compute the per-channel histogram of an interleaved 8-bit `RGB` buffer.
+    pub fn from_rgb8(rgb: &[u8]) -> Self {
+        re_tracing::profile_function!();
+
+        let mut bins_r = [0_u64; 256];
+        let mut bins_g = [0_u64; 256];
+        let mut bins_b = [0_u64; 256];
+
+        let (chunks, _remainder) = rgb.as_chunks::<3>();
+        for &[r, g, b] in chunks {
+            bins_r[r as usize] += 1;
+            bins_g[g as usize] += 1;
+            bins_b[b as usize] += 1;
+        }
+
+        Self {
+            bins: [bins_r, bins_g, bins_b],
+        }
+    }
+}
+
+/// Caches per-channel histograms for 8-bit RGB images, keyed by image content.
+#[derive(Default)]
+pub struct ImageHistogramCache(HashMap<StoredBlobCacheKey, Arc<Rgb8Histogram>>);
+
+impl ImageHistogramCache {
+    /// Get the histogram for the given 8-bit `RGB` image, computing and caching it on first access.
+    ///
+    /// The caller is responsible for only passing in images whose buffer is interleaved 8-bit RGB.
+    pub fn entry(&mut self, image: &ImageInfo) -> Arc<Rgb8Histogram> {
+        self.0
+            .entry(image.buffer_content_hash)
+            .or_insert_with(|| Arc::new(Rgb8Histogram::from_rgb8(&image.buffer)))
+            .clone()
+    }
+}
+
+impl CacheEntryAccess<ImageInfo, Arc<Rgb8Histogram>> for ImageHistogramCache {
+    fn read(&self, image: &ImageInfo) -> Option<Arc<Rgb8Histogram>> {
+        self.0.get(&image.buffer_content_hash).cloned()
+    }
+
+    fn compute(&mut self, image: &ImageInfo) -> Arc<Rgb8Histogram> {
+        self.entry(image)
+    }
+}
+
+impl Cache for ImageHistogramCache {
+    fn name(&self) -> &'static str {
+        "ImageHistogramCache"
+    }
+
+    fn purge_memory(&mut self) {
+        // [[u64; 256]; 3] ≈ 6 KiB per cached image — small enough that we
+        // leave it to store-event invalidation rather than periodic purging.
+    }
+
+    fn on_store_events(&mut self, events: &[&ChunkStoreEvent], _entity_db: &EntityDb) {
+        let removed = filter_blob_removed_events(events);
+        if removed.is_empty() {
+            return;
+        }
+        self.0.retain(|key, _| !removed.contains(key));
+    }
+}
+
+impl MemUsageTreeCapture for ImageHistogramCache {
+    fn capture_mem_usage_tree(&self) -> MemUsageTree {
+        MemUsageTree::Bytes(self.0.total_size_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_buffer_yields_zero_bins() {
+        let hist = Rgb8Histogram::from_rgb8(&[]);
+        for channel in &hist.bins {
+            assert!(channel.iter().all(|&c| c == 0));
+        }
+    }
+
+    #[test]
+    fn single_pixel_increments_one_bin_per_channel() {
+        let hist = Rgb8Histogram::from_rgb8(&[10, 20, 30]);
+        assert_eq!(hist.bins[0][10], 1);
+        assert_eq!(hist.bins[1][20], 1);
+        assert_eq!(hist.bins[2][30], 1);
+        let total: u64 = hist.bins.iter().flatten().sum();
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn trailing_bytes_are_ignored() {
+        // 4 trailing bytes; only the first complete pixel should contribute.
+        let hist = Rgb8Histogram::from_rgb8(&[1, 2, 3, 99]);
+        assert_eq!(hist.bins[0][1], 1);
+        assert_eq!(hist.bins[1][2], 1);
+        assert_eq!(hist.bins[2][3], 1);
+        assert_eq!(hist.bins[0][99], 0);
+        assert_eq!(hist.bins[1][99], 0);
+        assert_eq!(hist.bins[2][99], 0);
+    }
+
+    #[test]
+    fn many_pixels_count_correctly() {
+        // 100 pixels, all (5, 6, 7).
+        let buffer: Vec<u8> = (0..100).flat_map(|_| [5, 6, 7]).collect();
+        let hist = Rgb8Histogram::from_rgb8(&buffer);
+        assert_eq!(hist.bins[0][5], 100);
+        assert_eq!(hist.bins[1][6], 100);
+        assert_eq!(hist.bins[2][7], 100);
+        // No other bins should be set.
+        for channel in 0..3 {
+            for bin in 0..256 {
+                let expected = match (channel, bin) {
+                    (0, 5) | (1, 6) | (2, 7) => 100,
+                    _ => 0,
+                };
+                assert_eq!(
+                    hist.bins[channel][bin], expected,
+                    "channel {channel} bin {bin}"
+                );
+            }
+        }
+    }
+}

--- a/crates/viewer/re_viewer_context/src/cache/image_histogram_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_histogram_cache.rs
@@ -28,7 +28,7 @@ impl re_byte_size::SizeBytes for Rgb8Histogram {
 }
 
 impl Rgb8Histogram {
-    /// Compute the per-channel histogram of an interleaved 8-bit `RGB` buffer.
+    /// Compute the per-channel histogram of an 8-bit `RGB` buffer.
     pub fn from_rgb8(rgb: &[u8]) -> Self {
         re_tracing::profile_function!();
 
@@ -56,7 +56,7 @@ pub struct ImageHistogramCache(HashMap<StoredBlobCacheKey, Arc<Rgb8Histogram>>);
 impl ImageHistogramCache {
     /// Get the histogram for the given 8-bit `RGB` image, computing and caching it on first access.
     ///
-    /// The caller is responsible for only passing in images whose buffer is interleaved 8-bit RGB.
+    /// The caller is responsible for only passing in 8-bit RGB images.
     pub fn entry(&mut self, image: &ImageInfo) -> Arc<Rgb8Histogram> {
         self.0
             .entry(image.buffer_content_hash)

--- a/crates/viewer/re_viewer_context/src/cache/mod.rs
+++ b/crates/viewer/re_viewer_context/src/cache/mod.rs
@@ -5,6 +5,7 @@
 
 mod cache_trait;
 mod image_decode_cache;
+mod image_histogram_cache;
 mod image_stats_cache;
 mod memoizers;
 mod store_cache;
@@ -21,6 +22,7 @@ pub use store_cache::StoreCache;
 // The reason this happens it that various viewer crates wants to access these, mostly for ui purposes.
 // Ideally, they would only depend on the ones needed.
 pub use image_decode_cache::ImageDecodeCache;
+pub use image_histogram_cache::{ImageHistogramCache, Rgb8Histogram};
 pub use image_stats_cache::ImageStatsCache;
 pub use tensor_stats_cache::{TensorStatsAccessor, TensorStatsCache};
 pub use transform_database_store::TransformDatabaseStoreCache;

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -72,8 +72,8 @@ pub use self::blueprint_id::{
     BlueprintId, BlueprintIdRegistry, ContainerId, GLOBAL_VIEW_ID, ViewId,
 };
 pub use self::cache::{
-    Cache, CacheEntryAccess, ImageDecodeCache, ImageStatsCache, Memoizers,
-    SharablePlayableVideoStream, StoreCache, TensorStatsAccessor, TensorStatsCache,
+    Cache, CacheEntryAccess, ImageDecodeCache, ImageHistogramCache, ImageStatsCache, Memoizers,
+    Rgb8Histogram, SharablePlayableVideoStream, StoreCache, TensorStatsAccessor, TensorStatsCache,
     TransformDatabaseStoreCache, VideoAssetCache, VideoStreamCache, VideoStreamProcessingError,
 };
 pub use self::collapsed_id::{CollapseItem, CollapseScope, CollapsedId};


### PR DESCRIPTION
### Related

Addresses the existing TODO by @lucasmerlin in `image_ui.rs` about histogram computation being slow.

### What

- Adds `ImageHistogramCache` and `Rgb8Histogram` to cache per-channel histograms for 8-bit RGB images, keyed by `StoredBlobCacheKey` (same pattern as `ImageStatsCache`).
- Following `ImageStatsCache` and `ImageHistogramCache`, `purge_memory` does not clear the cache.
- Does **not** extend histogram support to other image formats (the separate TODO about supporting all image types remains).