### PR TITLE
add missing `App::logic` callbacks to examples

### DIFF
--- a/examples/rust/custom_callback/src/panel.rs
+++ b/examples/rust/custom_callback/src/panel.rs
@@ -58,6 +58,10 @@ impl eframe::App for Control {
 
         self.app.ui(ui, frame);
     }
+
+    fn logic(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        self.app.logic(ctx, frame);
+    }
 }
 
 impl Control {

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -87,6 +87,10 @@ impl eframe::App for MyApp {
         // Now show the Rerun Viewer in the remaining space:
         self.rerun_app.ui(ui, frame);
     }
+
+    fn logic(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        self.rerun_app.logic(ctx, frame);
+    }
 }
 
 impl MyApp {


### PR DESCRIPTION
add missing `App::logic` callbacks to `custom_callback` and `extend_viewer` examples

## What
without it the examples were unable to open recordings.