### PR TITLE
Support hosting the message proxy behind a path prefix

### DIFF
--- a/crates/store/re_grpc_client/src/read.rs
+++ b/crates/store/re_grpc_client/src/read.rs
@@ -28,7 +28,9 @@ async fn stream_async(
     tx: &re_log_channel::LogSender,
 ) -> Result<(), StreamError> {
     let mut client = {
-        let url = uri.origin.as_url();
+        // `base_url()` (not `origin.as_url()`) so a proxy mounted behind a path
+        // prefix (`…/prefix/proxy`) keeps that prefix on its gRPC requests.
+        let url = uri.base_url();
 
         #[cfg(target_arch = "wasm32")]
         let tonic_client = {

--- a/crates/store/re_grpc_client/src/write.rs
+++ b/crates/store/re_grpc_client/src/write.rs
@@ -335,7 +335,7 @@ async fn message_proxy_client(
     compression: Compression,
     status: Arc<AtomicCell<ClientConnectionState>>,
 ) {
-    let endpoint = match Endpoint::from_shared(uri.origin.as_url()) {
+    let endpoint = match Endpoint::from_shared(uri.base_url()) {
         Ok(endpoint) => endpoint,
         Err(err) => {
             status.store(ClientConnectionState::Disconnected(Err(

--- a/crates/store/re_uri/src/endpoints/proxy.rs
+++ b/crates/store/re_uri/src/endpoints/proxy.rs
@@ -3,17 +3,45 @@ use crate::{Origin, RedapUri};
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProxyUri {
     pub origin: Origin,
+
+    /// Optional path prefix the proxy is mounted behind, e.g. `Some("foo/bar")`
+    /// for `rerun+http://host/foo/bar/proxy`. `None` for the common
+    /// `rerun+http://host/proxy`. Lets the message proxy be hosted behind a
+    /// reverse proxy at a sub-path; the prefix is preserved when building the
+    /// gRPC client base URL so requests go to `…/foo/bar/<service>/<method>`.
+    pub path: Option<String>,
 }
 
 impl std::fmt::Display for ProxyUri {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/proxy", self.origin)
+        match &self.path {
+            Some(path) => write!(f, "{}/{path}/proxy", self.origin),
+            None => write!(f, "{}/proxy", self.origin),
+        }
     }
 }
 
 impl ProxyUri {
     pub fn new(origin: Origin) -> Self {
-        Self { origin }
+        Self { origin, path: None }
+    }
+
+    /// Set the path prefix the proxy is mounted behind (see [`Self::path`]).
+    #[inline]
+    pub fn with_path(mut self, path: Option<String>) -> Self {
+        self.path = path;
+        self
+    }
+
+    /// The `http(s)://host:port[/prefix]` base URL the gRPC client should target.
+    ///
+    /// Unlike [`Origin::as_url`] this includes the optional mount [`Self::path`],
+    /// so gRPC-web requests are issued to `…/<prefix>/<service>/<method>`.
+    pub fn base_url(&self) -> String {
+        match &self.path {
+            Some(path) => format!("{}/{path}", self.origin.as_url()),
+            None => self.origin.as_url(),
+        }
     }
 }
 

--- a/crates/store/re_uri/src/redap_uri.rs
+++ b/crates/store/re_uri/src/redap_uri.rs
@@ -82,18 +82,34 @@ impl std::str::FromStr for RedapUri {
 
         let (origin, http_url) = Origin::replace_and_parse(input, Some(default_localhost_port))?;
 
-        // :warning: We limit the amount of segments, which might need to be
-        // adjusted when adding additional resources.
-        let segments = http_url
+        let all_segments = http_url
             .path_segments()
             .ok_or_else(|| Error::UnexpectedBaseUrl(input.to_owned()))?
-            .take(2)
             .filter(|s| !s.is_empty()) // handle trailing slashes
             .collect::<Vec<_>>();
 
-        match segments.as_slice() {
-            ["proxy"] => Ok(Self::Proxy(ProxyUri::new(origin))),
+        // Proxy endpoint, optionally mounted behind a path prefix:
+        //   rerun+http://host/proxy
+        //   rerun+http://host/some/prefix/proxy   -> path = Some("some/prefix")
+        // The prefix lets the proxy be served behind a reverse proxy at a
+        // sub-path. We distinguish it from the REDAP resource endpoints
+        // (catalog/entry/folder/dataset) by their leading segment, so e.g. a
+        // folder literally named "proxy" is still parsed as a folder.
+        let is_redap_resource = all_segments
+            .first()
+            .is_some_and(|s| matches!(*s, "catalog" | "entry" | "folder" | "dataset"));
+        if !is_redap_resource {
+            if let [prefix @ .., "proxy"] = all_segments.as_slice() {
+                let path = (!prefix.is_empty()).then(|| prefix.join("/"));
+                return Ok(Self::Proxy(ProxyUri::new(origin).with_path(path)));
+            }
+        }
 
+        // :warning: We limit the amount of segments, which might need to be
+        // adjusted when adding additional resources.
+        let segments = all_segments.into_iter().take(2).collect::<Vec<_>>();
+
+        match segments.as_slice() {
             ["catalog"] | [] => Ok(Self::Catalog(CatalogUri::new(origin))),
 
             ["entry", entry_id] => {
@@ -404,6 +420,7 @@ mod tests {
                 host: url::Host::Domain("localhost".to_owned()),
                 port: 51234,
             },
+            path: None,
         });
 
         assert_eq!(address.unwrap(), expected);
@@ -425,9 +442,40 @@ mod tests {
                 host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
                 port: 9876,
             },
+            path: None,
         });
 
         assert_eq!(address.unwrap(), expected);
+    }
+
+    #[test]
+    fn test_proxy_endpoint_with_path_prefix() {
+        // The proxy can be mounted behind a reverse proxy at a sub-path; the
+        // prefix segments before `/proxy` are preserved.
+        let url = "rerun+http://host:9876/foo/bar/proxy";
+        let parsed: RedapUri = url.parse().unwrap();
+
+        let expected = RedapUri::Proxy(ProxyUri {
+            origin: Origin {
+                scheme: Scheme::RerunHttp,
+                host: url::Host::Domain("host".to_owned()),
+                port: 9876,
+            },
+            path: Some("foo/bar".to_owned()),
+        });
+        assert_eq!(parsed, expected);
+
+        let RedapUri::Proxy(proxy) = parsed else {
+            panic!("expected proxy uri");
+        };
+        // The prefix is carried into the gRPC client base URL...
+        assert_eq!(proxy.base_url(), "http://host:9876/foo/bar");
+        // ...and round-trips through Display/FromStr.
+        assert_eq!(proxy.to_string(), "rerun+http://host:9876/foo/bar/proxy");
+
+        // A folder literally named "proxy" is still a folder, not a proxy.
+        let folder: RedapUri = "rerun+http://host/folder/proxy".parse().unwrap();
+        assert!(matches!(folder, RedapUri::Folder(_)));
     }
 
     #[test]
@@ -461,6 +509,7 @@ mod tests {
                         host: url::Host::Domain("localhost".to_owned()),
                         port: DEFAULT_PROXY_PORT,
                     },
+                    path: None,
                 }),
             ),
             (
@@ -471,6 +520,7 @@ mod tests {
                         host: url::Host::Ipv4(Ipv4Addr::LOCALHOST),
                         port: DEFAULT_PROXY_PORT,
                     },
+                    path: None,
                 }),
             ),
             (


### PR DESCRIPTION
### What

The viewer connects to a message proxy via `rerun+http://host/proxy`, but the gRPC client (both the `tonic-web-wasm` path and the native `tonic` path) discards the URL path and issues every request to the **origin root** — `http(s)://host:port/rerun.sdk_comms.v1alpha1.MessageProxyService/<method>`. That makes it impossible to serve the proxy behind a **reverse proxy mounted at a sub-path**.

This PR lets `ProxyUri` carry an optional path prefix and preserves it on the client's requests:

- `rerun+http://host/proxy` → unchanged (`path = None`)
- `rerun+http://host/foo/bar/proxy` → `path = Some("foo/bar")`, requests go to `…/foo/bar/rerun.sdk_comms…/<method>`

### Details

- `ProxyUri` gains a `path: Option<String>` field, a `with_path()` setter, and a `base_url()` helper (`origin.as_url()` + the optional prefix).
- The parser collects all path segments and recognizes `[<prefix…>, "proxy"]`. The prefixed form is distinguished from the REDAP resource endpoints (`catalog`/`entry`/`folder`/`dataset`) by their **leading** segment, so e.g. a folder literally named `proxy` still parses as a folder.
- `re_grpc_client`'s read (viewer) and write (SDK) proxy clients now build their base URL via `ProxyUri::base_url()`.
- Round-trips through `Display`/`FromStr`. Added a unit test covering parsing, `base_url()`, the `Display` round-trip, and the `folder/proxy` disambiguation.

### Compatibility

Fully backward compatible — the common `…/proxy` form is unchanged (`path = None`), and all existing `re_uri` tests pass.

Note: the wasm (`tonic-web-wasm-client`) client appends the method path to the full base URL, so the prefix is honored there. The native `tonic` client connects by authority and may not forward a base path prefix; the primary use case (the web viewer behind a reverse proxy) is the wasm path.