### PR TITLE
Mimalloc v3 has a threading issue so pin to v2 until resolved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,9 @@ macaw = "0.30.0"
 mcap = "0.25.0"
 memmap2 = "0.9.11"
 memory-stats = "1.2"
-mimalloc = "0.1.52"
+mimalloc = { version = "0.1.52", features = [
+  "v2",
+] } # Waiting for fix from microsoft/mimalloc/issues/1287 to land in mimalloc crate
 mime_guess2 = "2.3" # infer MIME type by file extension, and map mime to file extension
 mint = "0.5.9"
 natord = "1.0"


### PR DESCRIPTION
### Related
uv run --no-project --with "rerun-sdk==0.34.0-rc.2" python -X faulthandler -c "import rerun"  is giving me Fatal Python error: Segmentation fault

### What
There is a bug in mimalloc that the crate exposes for v3, so use v2 until that gets resolved https://github.com/microsoft/mimalloc/issues/1287. This seems to be exacerbated when multiple python-rust packages are imported together.