### PR TITLE
Fix debug panic on single-point line series in SeriesLinesSystem

### DIFF
--- a/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_view_time_series/src/line_visualizer_system.rs
@@ -154,12 +154,11 @@ impl SeriesLinesSystem {
                     };
                     num_vertices += series_vertices;
                 }
-                PlotSeriesKind::Clear => {}
-                PlotSeriesKind::Scatter(_) => {
-                    re_log::debug_panic!(
-                        "Self::load_series produced an unexpected PlotSeriesKind: Scatter"
-                    );
-                }
+                // A series with a single point can't be drawn as a line, so
+                // `util::points_to_series` falls back to `Scatter` for it. This system only
+                // builds line strips, so such series are skipped here too, matching the
+                // `PlotSeriesKind::Scatter(_) | PlotSeriesKind::Clear => continue` arm below.
+                PlotSeriesKind::Clear | PlotSeriesKind::Scatter(_) => {}
             }
         }
 


### PR DESCRIPTION
## Summary

`SeriesLinesSystem::build_draw_data` hits `debug_panic!("Self::load_series produced an unexpected PlotSeriesKind: Scatter")` (`crates/viewer/re_view_time_series/src/line_visualizer_system.rs`) whenever a line series has exactly one point in the currently visible time range.

This isn't actually an invariant violation: `util::points_to_series` deliberately falls back to `PlotSeriesKind::Scatter` for single-point series, since a line can't be drawn through one point. The strip-building loop further down in the same function already treats `Scatter` correctly as a no-op (`PlotSeriesKind::Scatter(_) | PlotSeriesKind::Clear => continue`) — the vertex/strip-counting loop above it just never got the same treatment and instead asserts it can't happen.

Because `debug_panic!` compiles to a no-op in release builds, this only crashes debug builds — but reliably, any time a line series' visible window narrows to a single point (e.g. scrubbing the time cursor in a relative-range time series view close to the edge of a sparse series).

## Fix

Bring the counting loop in line with the strip-building loop: treat `Scatter` as a no-op, same as `Clear`, instead of asserting.

## Test plan
- [x] `cargo check -p re_view_time_series`
- [x] `cargo fmt -p re_view_time_series -- --check`

## Note
This is a minimal, behavior-preserving fix (matches existing release behavior, where the point was already silently dropped). A more complete fix would actually render such single-point series as a marker/dot instead of dropping them — I've filed that separately as a follow-up issue.

> Created by Claude Sonnet 5, for some reason it now skips these warnings