### PR TITLE
Load OBJ material sidecars in importer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9208,6 +9208,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tobj",
  "urdf-rs",
  "walkdir",
 ]

--- a/crates/store/re_importer/Cargo.toml
+++ b/crates/store/re_importer/Cargo.toml
@@ -58,6 +58,7 @@ rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tobj.workspace = true
 urdf-rs.workspace = true
 walkdir.workspace = true
 

--- a/crates/store/re_importer/src/importer_archetype.rs
+++ b/crates/store/re_importer/src/importer_archetype.rs
@@ -1,5 +1,10 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
 use re_chunk::{Chunk, RowId};
 use re_log_types::{ApplicationId, EntityPath, TimePoint};
+use re_sdk_types::datatypes::Rgba32;
 
 use crate::{ImportedData, Importer, ImporterError};
 
@@ -142,12 +147,7 @@ impl Importer for ArchetypeImporter {
             self.send_chunks(
                 &tx,
                 &store_id,
-                load_mesh(
-                    filepath.clone(),
-                    timepoint,
-                    entity_path,
-                    contents.into_owned(),
-                )?,
+                load_mesh(&filepath, timepoint, entity_path, contents.into_owned())?,
             )
         } else if crate::SUPPORTED_POINT_CLOUD_EXTENSIONS.contains(&extension.as_str()) {
             re_log::debug!(?filepath, importer = self.name(), "Loading 3D point cloud…",);
@@ -305,27 +305,208 @@ fn load_video(
 }
 
 fn load_mesh(
-    filepath: std::path::PathBuf,
+    filepath: &std::path::Path,
     timepoint: TimePoint,
     entity_path: EntityPath,
     contents: Vec<u8>,
-) -> Result<impl ExactSizeIterator<Item = Chunk>, ImporterError> {
+) -> Result<std::vec::IntoIter<Chunk>, ImporterError> {
     re_tracing::profile_function!();
 
-    let rows = [
-        {
-            let arch = re_sdk_types::archetypes::Asset3D::from_file_contents(
-                contents,
-                re_sdk_types::components::MediaType::guess_from_path(filepath),
-            );
-            Chunk::builder(entity_path)
-                .with_archetype(RowId::new(), timepoint, &arch)
-                .build()?
-        },
-        //
-    ];
+    let rows = if crate::extension(filepath) == "obj" {
+        load_obj_meshes(filepath, &timepoint, &entity_path, contents)?
+    } else {
+        vec![
+            {
+                let arch = re_sdk_types::archetypes::Asset3D::from_file_contents(
+                    contents,
+                    re_sdk_types::components::MediaType::guess_from_path(filepath),
+                );
+                Chunk::builder(entity_path)
+                    .with_archetype(RowId::new(), timepoint, &arch)
+                    .build()?
+            },
+            //
+        ]
+    };
 
     Ok(rows.into_iter())
+}
+
+fn load_obj_meshes(
+    filepath: &Path,
+    timepoint: &TimePoint,
+    entity_path: &EntityPath,
+    contents: Vec<u8>,
+) -> Result<Vec<Chunk>, ImporterError> {
+    re_tracing::profile_function!();
+
+    let obj_dir = filepath.parent().unwrap_or_else(|| Path::new(""));
+    let material_base_dirs = RefCell::new(HashMap::<String, PathBuf>::new());
+
+    let (models, materials_result) = tobj::load_obj_buf(
+        &mut std::io::Cursor::new(contents),
+        &tobj::LoadOptions {
+            single_index: true,
+            triangulate: true,
+            ..Default::default()
+        },
+        |material_path| {
+            let material_path = resolve_obj_resource_path(obj_dir, material_path);
+            let material_base_dir = material_path
+                .parent()
+                .unwrap_or_else(|| Path::new(""))
+                .to_owned();
+
+            let loaded = tobj::load_mtl(&material_path);
+            if let Ok((materials, _)) = &loaded {
+                material_base_dirs.borrow_mut().extend(
+                    materials
+                        .iter()
+                        .map(|material| (material.name.clone(), material_base_dir.clone())),
+                );
+            }
+            loaded
+        },
+    )
+    .map_err(anyhow::Error::from)?;
+
+    let materials = match materials_result {
+        Ok(materials) => materials,
+        Err(err) => {
+            re_log::warn!(
+                "Failed to load material library referenced by {}: {err}",
+                filepath.display()
+            );
+            Vec::new()
+        }
+    };
+    let material_base_dirs = material_base_dirs.into_inner();
+
+    let mut rows = Vec::with_capacity(models.len());
+    for (model_index, obj_model) in models.into_iter().enumerate() {
+        let mesh = obj_model.mesh;
+
+        let vertex_positions = mesh
+            .positions
+            .chunks_exact(3)
+            .map(|p| [p[0], p[1], p[2]])
+            .collect::<Vec<_>>();
+
+        let triangle_indices = mesh
+            .indices
+            .chunks_exact(3)
+            .map(|p| [p[0], p[1], p[2]])
+            .collect::<Vec<_>>();
+
+        let vertex_normals = mesh
+            .normals
+            .chunks_exact(3)
+            .map(|n| [n[0], n[1], n[2]])
+            .collect::<Vec<_>>();
+
+        let vertex_texcoords = mesh
+            .texcoords
+            .chunks_exact(2)
+            // OBJ/MTL texture coordinates follow OpenGL's lower-left texture
+            // origin, while Rerun image buffers use an upper-left origin.
+            .map(|t| [t[0], 1.0 - t[1]])
+            .collect::<Vec<_>>();
+
+        let mut arch = re_sdk_types::archetypes::Mesh3D::new(vertex_positions)
+            .with_triangle_indices(triangle_indices);
+
+        if !vertex_normals.is_empty() {
+            arch = arch.with_vertex_normals(vertex_normals);
+        }
+        if !vertex_texcoords.is_empty() {
+            arch = arch.with_vertex_texcoords(vertex_texcoords);
+        }
+
+        if let Some(material) = mesh.material_id.and_then(|id| materials.get(id)) {
+            if let Some(albedo_factor) = material_albedo_factor(material) {
+                arch = arch.with_albedo_factor(albedo_factor);
+            }
+
+            if let Some(diffuse_texture) = material.diffuse_texture.as_deref()
+                && let Some(texture) = load_obj_texture(
+                    material_base_dirs
+                        .get(&material.name)
+                        .map(PathBuf::as_path)
+                        .unwrap_or(obj_dir),
+                    diffuse_texture,
+                )
+            {
+                arch = arch.with_albedo_texture_image(texture);
+            }
+        }
+
+        let entity_path = if model_index == 0 && rows.is_empty() {
+            entity_path.clone()
+        } else {
+            entity_path.join(&EntityPath::from_single_string(format!(
+                "mesh_{model_index}_{}",
+                obj_model.name
+            )))
+        };
+
+        rows.push(
+            Chunk::builder(entity_path)
+                .with_archetype(RowId::new(), timepoint.clone(), &arch)
+                .build()?,
+        );
+    }
+
+    Ok(rows)
+}
+
+fn resolve_obj_resource_path(base_dir: &Path, resource_path: &Path) -> PathBuf {
+    if resource_path.is_absolute() {
+        resource_path.to_owned()
+    } else {
+        base_dir.join(resource_path)
+    }
+}
+
+fn material_albedo_factor(material: &tobj::Material) -> Option<Rgba32> {
+    let diffuse = material.diffuse?;
+    let alpha = material.dissolve.unwrap_or(1.0);
+
+    Some(Rgba32::from_linear_unmultiplied_rgba_f32(
+        diffuse[0], diffuse[1], diffuse[2], alpha,
+    ))
+}
+
+fn load_obj_texture(
+    material_base_dir: &Path,
+    diffuse_texture: &str,
+) -> Option<re_sdk_types::archetypes::Image> {
+    let texture_path = resolve_obj_resource_path(
+        material_base_dir,
+        Path::new(
+            diffuse_texture
+                .split_whitespace()
+                .last()
+                .unwrap_or(diffuse_texture),
+        ),
+    );
+
+    let image = image::open(&texture_path)
+        .inspect_err(|err| {
+            re_log::warn!(
+                "Failed to load OBJ material texture {}: {err}",
+                texture_path.display()
+            );
+        })
+        .ok()?;
+
+    re_sdk_types::archetypes::Image::from_dynamic_image(image)
+        .inspect_err(|err| {
+            re_log::warn!(
+                "Failed to convert OBJ material texture {}: {err}",
+                texture_path.display()
+            );
+        })
+        .ok()
 }
 
 fn load_point_cloud(

--- a/crates/store/re_importer/tests/test_obj_importer.rs
+++ b/crates/store/re_importer/tests/test_obj_importer.rs
@@ -1,0 +1,126 @@
+//! Tests for Wavefront OBJ import through the generic archetype importer.
+
+#[cfg(test)]
+mod tests {
+    use re_chunk::Chunk;
+    use re_importer::{ArchetypeImporter, ImportedData, Importer as _, ImporterSettings};
+    use re_sdk_types::archetypes::{Asset3D, Mesh3D};
+    use re_sdk_types::components::Texcoord2D;
+    use re_sdk_types::external::re_types_core::ComponentDescriptor;
+
+    fn load_obj_chunks(path: impl AsRef<std::path::Path>) -> Vec<Chunk> {
+        let path = path.as_ref().to_path_buf();
+        let (tx, rx) = crossbeam::channel::bounded(1024);
+        let settings = ImporterSettings::recommended("test");
+
+        ArchetypeImporter
+            .import_from_path(&settings, path, tx.clone())
+            .unwrap();
+        drop(tx);
+
+        rx.iter().filter_map(ImportedData::into_chunk).collect()
+    }
+
+    fn has_descriptor(chunk: &Chunk, descriptor: &ComponentDescriptor) -> bool {
+        chunk.component_descriptors().any(|d| d == descriptor)
+    }
+
+    fn texcoords(chunk: &Chunk) -> Vec<Texcoord2D> {
+        let component = Mesh3D::descriptor_vertex_texcoords().component;
+        chunk
+            .iter_component::<Texcoord2D>(component)
+            .flat_map(|batch| batch.as_slice().to_vec())
+            .collect()
+    }
+
+    fn write_basic_obj(dir: &std::path::Path, mtl_body: &str) -> std::path::PathBuf {
+        let obj_path = dir.join("model.obj");
+        std::fs::write(
+            &obj_path,
+            "\
+mtllib model.mtl
+o triangle
+v 0.0 0.0 0.0
+v 1.0 0.0 0.0
+v 0.0 1.0 0.0
+vn 0.0 0.0 1.0
+vt 0.0 0.0
+vt 1.0 0.0
+vt 0.0 1.0
+usemtl material
+f 1/1/1 2/2/1 3/3/1
+",
+        )
+        .unwrap();
+        std::fs::write(dir.join("model.mtl"), mtl_body).unwrap();
+        obj_path
+    }
+
+    #[test]
+    fn obj_imports_mtl_diffuse_material_as_mesh3d() {
+        let dir = tempfile::tempdir().unwrap();
+        let obj_path = write_basic_obj(
+            dir.path(),
+            "\
+newmtl material
+Kd 0.25 0.50 0.75
+d 0.80
+",
+        );
+
+        let chunks = load_obj_chunks(obj_path);
+
+        assert_eq!(chunks.len(), 1);
+        let chunk = &chunks[0];
+        assert!(
+            has_descriptor(chunk, &Mesh3D::descriptor_vertex_positions()),
+            "OBJ imports should emit native Mesh3D data"
+        );
+        assert!(
+            has_descriptor(chunk, &Mesh3D::descriptor_albedo_factor()),
+            "Kd/d from the MTL should be logged as the mesh albedo factor"
+        );
+        assert!(
+            !has_descriptor(chunk, &Asset3D::descriptor_blob()),
+            "OBJ file imports need resolved sidecar data, not a standalone Asset3D blob"
+        );
+    }
+
+    #[test]
+    fn obj_imports_mtl_diffuse_texture() {
+        let dir = tempfile::tempdir().unwrap();
+        let texture_path = dir.path().join("texture.png");
+        image::RgbImage::from_fn(2, 2, |x, y| image::Rgb([x as u8 * 120, y as u8 * 120, 200]))
+            .save(&texture_path)
+            .unwrap();
+
+        let obj_path = write_basic_obj(
+            dir.path(),
+            "\
+newmtl material
+Kd 1.0 1.0 1.0
+map_Kd texture.png
+",
+        );
+
+        let chunks = load_obj_chunks(obj_path);
+
+        assert_eq!(chunks.len(), 1);
+        let chunk = &chunks[0];
+        assert!(
+            has_descriptor(chunk, &Mesh3D::descriptor_albedo_texture_buffer()),
+            "map_Kd from the MTL should be decoded and logged as a mesh texture"
+        );
+        assert!(
+            has_descriptor(chunk, &Mesh3D::descriptor_albedo_texture_format()),
+            "decoded mesh textures should include an ImageFormat"
+        );
+
+        let texcoords = texcoords(chunk);
+        assert_eq!(
+            texcoords.iter().map(Texcoord2D::v).collect::<Vec<_>>(),
+            vec![1.0, 1.0, 0.0],
+            "OBJ texture V coordinates should be converted from lower-left to upper-left origin"
+        );
+    }
+}


### PR DESCRIPTION
### Related

* Closes #3773
* Follows up #3772

### What

This PR makes native OBJ file imports resolve their Wavefront material sidecars instead of logging the OBJ bytes as a standalone `Asset3D` blob.

When an `.obj` file is opened through the importer, Rerun now:

* loads referenced `.mtl` files relative to the OBJ file,
* converts each OBJ model into native `Mesh3D` data,
* preserves positions, triangle indices, normals, and UV coordinates,
* maps MTL `Kd`/`d` values to `Mesh3D::albedo_factor`,
* decodes `map_Kd` diffuse textures and logs them as `Mesh3D` albedo textures.

This leaves non-OBJ mesh imports on the existing `Asset3D` path.

### Screenshot

Imported OBJ with its referenced MTL and PNG texture preserved:

![Imported textured OBJ in Rerun](https://raw.githubusercontent.com/Reza2kn/rerun-codex-fork/codex/pr-assets/pr-assets/3773/color_ripple_obj_front_perspective_c_9576d31.png)

### Notes

#3772 fixed `.obj` media-type guessing. The remaining issue in #3773 was that an OBJ file loaded by itself has no access to its MTL/texture sidecars at render time. Resolving those sidecars in the native file importer lets the viewer receive complete `Mesh3D` archetypes with material data already attached.

### Validation

* `cargo fmt -p re_importer`
* `git diff --check`
* `cargo check -p re_importer`
* `cargo test -p re_importer --test test_obj_importer`
* `cargo test -p re_importer`
* `cargo clippy -p re_importer --all-targets -- -D warnings`
* `cargo check -p re_view_spatial`
* `RUST_LOG=error cargo run --package rerun-cli --no-default-features --features release_no_web_viewer -- /Users/Ajab/Downloads/Meshy_AI_Color_Ripple_0710165213_texture_obj/Meshy_AI_Color_Ripple_0710165213_texture.obj --headless --screenshot-to .context/obj-mtl-screenshot/color_ripple_obj_import_wide.png --window-size 1900x1100 --renderer=metal`


