### PR TITLE
Harden server-backed chunk streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10083,6 +10083,7 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+ "ureq 3.3.0",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/crates/store/re_datafusion/src/chunk_fetcher.rs
+++ b/crates/store/re_datafusion/src/chunk_fetcher.rs
@@ -851,7 +851,8 @@ async fn fetch_merged_range(
 
     let mut http_request = http_client
         .get(url)
-        .header("Range", format!("bytes={range_start}-{range_end}"));
+        .header("Range", format!("bytes={range_start}-{range_end}"))
+        .header(reqwest::header::ACCEPT_ENCODING, "identity");
 
     // If-Match header to detect manifest drift at the source.
     if let Some(etag) = expected_etag.and_then(ETag::as_if_match) {
@@ -888,20 +889,8 @@ async fn fetch_merged_range(
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
 
-    let merged_bytes = response
-        .bytes()
-        .await
-        .map_err(|err| DirectFetchError::new(format!("failed to read body: {err}"), true))?;
-    if merged_bytes.len() != expected_len {
-        return Err(DirectFetchError::new(
-            format!(
-                "HTTP range response body length mismatch: expected {expected_len} bytes for \
-                 bytes={range_start}-{range_end}, got {}",
-                merged_bytes.len()
-            ),
-            false,
-        ));
-    }
+    let merged_bytes =
+        read_range_response_body(response, expected_len, *range_start, range_end).await?;
 
     tracing::Span::current().record("bytes", merged_bytes.len());
 
@@ -953,6 +942,68 @@ async fn fetch_merged_range(
                 .map(|chunk_with_segment| (info.original_row_index, chunk_with_segment))
         })
         .try_collect()
+}
+
+async fn read_range_response_body(
+    mut response: reqwest::Response,
+    expected_len: usize,
+    range_start: usize,
+    range_end: usize,
+) -> Result<Vec<u8>, DirectFetchError> {
+    let mut body = Vec::with_capacity(expected_len);
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|err| DirectFetchError::new(format!("failed to read body: {err}"), true))?
+    {
+        append_range_response_body_chunk(
+            &mut body,
+            chunk.as_ref(),
+            expected_len,
+            range_start,
+            range_end,
+        )?;
+    }
+
+    if body.len() != expected_len {
+        return Err(DirectFetchError::new(
+            format!(
+                "HTTP range response body length mismatch: expected {expected_len} bytes for \
+                 bytes={range_start}-{range_end}, got {}",
+                body.len()
+            ),
+            false,
+        ));
+    }
+
+    Ok(body)
+}
+
+fn append_range_response_body_chunk(
+    body: &mut Vec<u8>,
+    chunk: &[u8],
+    expected_len: usize,
+    range_start: usize,
+    range_end: usize,
+) -> Result<(), DirectFetchError> {
+    let Some(next_len) = body
+        .len()
+        .checked_add(chunk.len())
+        .filter(|next_len| *next_len <= expected_len)
+    else {
+        return Err(DirectFetchError::new(
+            format!(
+                "HTTP range response body exceeded Content-Length: expected {expected_len} bytes \
+                 for bytes={range_start}-{range_end}, got at least {}",
+                body.len().saturating_add(chunk.len())
+            ),
+            false,
+        ));
+    };
+
+    body.extend_from_slice(chunk);
+    debug_assert_eq!(body.len(), next_len);
+    Ok(())
 }
 
 fn validate_range_response_headers(
@@ -1132,5 +1183,27 @@ mod tests {
 
         assert!(!err.retryable);
         assert!(err.to_string().contains("missing Content-Length"));
+    }
+
+    #[test]
+    fn bounded_body_reader_accepts_chunks_up_to_exact_length() {
+        let mut body = Vec::new();
+
+        append_range_response_body_chunk(&mut body, b"abc", 5, 10, 14).expect("first chunk fits");
+        append_range_response_body_chunk(&mut body, b"de", 5, 10, 14).expect("second chunk fits");
+
+        assert_eq!(body, b"abcde");
+    }
+
+    #[test]
+    fn bounded_body_reader_rejects_chunks_past_exact_length() {
+        let mut body = b"abcd".to_vec();
+
+        let err = append_range_response_body_chunk(&mut body, b"ef", 5, 10, 14)
+            .expect_err("response body must not grow beyond the requested range");
+
+        assert!(!err.retryable);
+        assert!(err.to_string().contains("exceeded Content-Length"));
+        assert_eq!(body, b"abcd");
     }
 }

--- a/crates/store/re_datafusion/src/chunk_fetcher.rs
+++ b/crates/store/re_datafusion/src/chunk_fetcher.rs
@@ -387,6 +387,7 @@ fn status_retryable(status: reqwest::StatusCode) -> bool {
             | reqwest::StatusCode::UNAUTHORIZED
             | reqwest::StatusCode::FORBIDDEN
             | reqwest::StatusCode::METHOD_NOT_ALLOWED
+            | reqwest::StatusCode::RANGE_NOT_SATISFIABLE
     )
 }
 
@@ -866,6 +867,13 @@ async fn fetch_merged_range(
         return Err(classify_http_status(response.status()));
     }
 
+    let expected_len = validate_range_response_headers(
+        response.status(),
+        response.headers(),
+        *range_start,
+        range_end,
+    )?;
+
     // Captured for decode-failure attribution (RR-4549): compared against
     // `expected_etag` if the chunk fails to decode. `last_modified` is
     // logged alongside for diagnostics.
@@ -884,6 +892,16 @@ async fn fetch_merged_range(
         .bytes()
         .await
         .map_err(|err| DirectFetchError::new(format!("failed to read body: {err}"), true))?;
+    if merged_bytes.len() != expected_len {
+        return Err(DirectFetchError::new(
+            format!(
+                "HTTP range response body length mismatch: expected {expected_len} bytes for \
+                 bytes={range_start}-{range_end}, got {}",
+                merged_bytes.len()
+            ),
+            false,
+        ));
+    }
 
     tracing::Span::current().record("bytes", merged_bytes.len());
 
@@ -935,4 +953,184 @@ async fn fetch_merged_range(
                 .map(|chunk_with_segment| (info.original_row_index, chunk_with_segment))
         })
         .try_collect()
+}
+
+fn validate_range_response_headers(
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+    range_start: usize,
+    range_end: usize,
+) -> Result<usize, DirectFetchError> {
+    if range_end < range_start {
+        return Err(DirectFetchError::new(
+            format!("invalid HTTP range bytes={range_start}-{range_end}"),
+            false,
+        ));
+    }
+    let expected_len = range_end - range_start + 1;
+
+    if status != reqwest::StatusCode::PARTIAL_CONTENT {
+        return Err(DirectFetchError::new(
+            format!(
+                "HTTP range request returned status {status}; expected 206 Partial Content for \
+                 bytes={range_start}-{range_end}"
+            ),
+            false,
+        ));
+    }
+
+    let content_range = headers
+        .get(reqwest::header::CONTENT_RANGE)
+        .ok_or_else(|| {
+            DirectFetchError::new(
+                format!(
+                    "HTTP 206 response missing Content-Range for bytes={range_start}-{range_end}"
+                ),
+                false,
+            )
+        })?
+        .to_str()
+        .map_err(|err| {
+            DirectFetchError::new(
+                format!("invalid Content-Range header for bytes={range_start}-{range_end}: {err}"),
+                false,
+            )
+        })?;
+    let (actual_start, actual_end) = parse_content_range(content_range).ok_or_else(|| {
+        DirectFetchError::new(
+            format!("invalid Content-Range header {content_range:?}"),
+            false,
+        )
+    })?;
+    if actual_start != range_start || actual_end != range_end {
+        return Err(DirectFetchError::new(
+            format!(
+                "HTTP Content-Range mismatch: expected bytes {range_start}-{range_end}, got \
+                 {actual_start}-{actual_end}"
+            ),
+            false,
+        ));
+    }
+
+    let content_length = headers
+        .get(reqwest::header::CONTENT_LENGTH)
+        .ok_or_else(|| {
+            DirectFetchError::new(
+                format!(
+                    "HTTP 206 response missing Content-Length for bytes={range_start}-{range_end}"
+                ),
+                false,
+            )
+        })?
+        .to_str()
+        .map_err(|err| {
+            DirectFetchError::new(
+                format!("invalid Content-Length header for bytes={range_start}-{range_end}: {err}"),
+                false,
+            )
+        })?
+        .parse::<usize>()
+        .map_err(|err| {
+            DirectFetchError::new(
+                format!("invalid Content-Length header for bytes={range_start}-{range_end}: {err}"),
+                false,
+            )
+        })?;
+    if content_length != expected_len {
+        return Err(DirectFetchError::new(
+            format!(
+                "HTTP Content-Length mismatch: expected {expected_len} bytes for \
+                 bytes={range_start}-{range_end}, got {content_length}"
+            ),
+            false,
+        ));
+    }
+
+    Ok(expected_len)
+}
+
+fn parse_content_range(content_range: &str) -> Option<(usize, usize)> {
+    let range = content_range.trim().strip_prefix("bytes ")?;
+    let (range, _complete_len) = range.split_once('/')?;
+    let (start, end) = range.split_once('-')?;
+    Some((start.parse().ok()?, end.parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::header::{CONTENT_LENGTH, CONTENT_RANGE, HeaderMap, HeaderValue};
+
+    use super::*;
+
+    fn range_headers(content_range: &str, content_length: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_RANGE,
+            HeaderValue::from_str(content_range).expect("valid content range"),
+        );
+        headers.insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(content_length).expect("valid content length"),
+        );
+        headers
+    }
+
+    #[test]
+    fn validates_exact_partial_content_response() {
+        let headers = range_headers("bytes 10-19/100", "10");
+
+        let len =
+            validate_range_response_headers(reqwest::StatusCode::PARTIAL_CONTENT, &headers, 10, 19)
+                .expect("valid range response");
+
+        assert_eq!(len, 10);
+    }
+
+    #[test]
+    fn rejects_range_response_when_server_ignored_range_header() {
+        let headers = range_headers("bytes 10-19/100", "10");
+
+        let err = validate_range_response_headers(reqwest::StatusCode::OK, &headers, 10, 19)
+            .expect_err("200 means the range header was ignored");
+
+        assert!(!err.retryable);
+        assert!(err.to_string().contains("expected 206 Partial Content"));
+    }
+
+    #[test]
+    fn rejects_partial_content_with_mismatched_content_range() {
+        let headers = range_headers("bytes 0-99/100", "100");
+
+        let err =
+            validate_range_response_headers(reqwest::StatusCode::PARTIAL_CONTENT, &headers, 10, 19)
+                .expect_err("Content-Range must describe the requested byte window");
+
+        assert!(!err.retryable);
+        assert!(err.to_string().contains("Content-Range mismatch"));
+    }
+
+    #[test]
+    fn rejects_partial_content_with_mismatched_content_length() {
+        let headers = range_headers("bytes 10-19/100", "11");
+
+        let err =
+            validate_range_response_headers(reqwest::StatusCode::PARTIAL_CONTENT, &headers, 10, 19)
+                .expect_err("Content-Length must match the requested byte window");
+
+        assert!(!err.retryable);
+        assert!(err.to_string().contains("Content-Length mismatch"));
+    }
+
+    #[test]
+    fn rejects_partial_content_without_content_length() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_RANGE, HeaderValue::from_static("bytes 10-19/100"));
+
+        let err =
+            validate_range_response_headers(reqwest::StatusCode::PARTIAL_CONTENT, &headers, 10, 19)
+                .expect_err("Content-Length gates body reads for direct fetches");
+
+        assert!(!err.retryable);
+        assert!(err.to_string().contains("missing Content-Length"));
+    }
 }

--- a/crates/store/re_datafusion/src/chunk_fetcher.rs
+++ b/crates/store/re_datafusion/src/chunk_fetcher.rs
@@ -25,7 +25,7 @@ use re_protos::{
 };
 use re_redap_client::ApiResult;
 
-use crate::analytics::{DirectFetchFailureReason, PendingQueryAnalytics, TaskFetchStats};
+use crate::analytics::{DirectFetchFailureReason, TaskFetchStats};
 use crate::dataframe_query_common::DataframeClientAPI;
 
 // --- Telemetry ---
@@ -274,8 +274,7 @@ pub async fn fetch_batch_direct(
     batch: &RecordBatch,
     http_client: &reqwest::Client,
     stats: &mut TaskFetchStats,
-    pending: &PendingQueryAnalytics,
-) -> ApiResult<Vec<ChunksWithSegment>> {
+) -> Result<Vec<ChunksWithSegment>, DirectFetchError> {
     #[cfg(not(target_arch = "wasm32"))]
     let byte_size = batch_byte_size(batch);
 
@@ -292,14 +291,9 @@ pub async fn fetch_batch_direct(
         }
         Err(err) => {
             let reason = DirectFetchFailureReason::classify(&err);
-            pending.record_direct_terminal_failure(reason);
             #[cfg(not(target_arch = "wasm32"))]
             metrics::record_direct_failure(reason.as_str());
-            Err(re_redap_client::ApiError::connection_with_source(
-                None,
-                err,
-                "fetching chunks via direct URLs",
-            ))
+            Err(err)
         }
     }
 }
@@ -310,7 +304,7 @@ impl DirectFetchFailureReason {
     /// Source-changed errors are matched on the typed [`DirectFetchErrorKind`]
     /// discriminant; everything else still falls through to message
     /// pattern-matching for now.
-    fn classify(err: &DirectFetchError) -> Self {
+    pub(crate) fn classify(err: &DirectFetchError) -> Self {
         if err.kind == DirectFetchErrorKind::SourceChanged {
             return Self::SourceChanged;
         }

--- a/crates/store/re_datafusion/src/dataframe_query_provider/io_loop.rs
+++ b/crates/store/re_datafusion/src/dataframe_query_provider/io_loop.rs
@@ -19,9 +19,9 @@ use tracing::Instrument as _;
 
 use crate::analytics::{QueryErrorKind, TaskFetchStats};
 use crate::chunk_fetcher::{
-    ChunksWithSegment, SortedChunksWithSegment, batch_byte_size, batch_byte_size_uncompressed,
-    batch_has_any_direct_urls, fetch_batch_direct, fetch_batch_group_via_grpc,
-    split_batch_by_direct_url,
+    ChunksWithSegment, DirectFetchErrorKind, SortedChunksWithSegment, batch_byte_size,
+    batch_byte_size_uncompressed, batch_has_any_direct_urls, fetch_batch_direct,
+    fetch_batch_group_via_grpc, split_batch_by_direct_url,
 };
 use crate::dataframe_query_common::{DataframeClientAPI, force_grpc};
 use crate::metrics_capture::QueryMetrics;
@@ -979,21 +979,58 @@ pub(super) async fn chunk_stream_io_loop<T: DataframeClientAPI>(
                                 &batch,
                                 &http_client,
                                 &mut stats,
-                                &pending_analytics,
                             )
                             .await
                             {
-                                Ok(chunks) => chunks,
+                                Ok(chunks) => {
+                                    stats.record_direct_fetch(bytes);
+                                    chunks
+                                }
                                 Err(err) => {
-                                    stats.try_flush_into(
-                                        &pending_analytics,
-                                        &metrics,
-                                        Err(QueryErrorKind::DirectFetch),
+                                    let reason =
+                                        crate::analytics::DirectFetchFailureReason::classify(&err);
+                                    if err.kind == DirectFetchErrorKind::SourceChanged {
+                                        pending_analytics.record_direct_terminal_failure(reason);
+                                        stats.try_flush_into(
+                                            &pending_analytics,
+                                            &metrics,
+                                            Err(QueryErrorKind::DirectFetch),
+                                        );
+                                        return Err(re_redap_client::ApiError::connection_with_source(
+                                            None,
+                                            err,
+                                            "fetching chunks via direct URLs",
+                                        ));
+                                    }
+
+                                    re_log::warn!(
+                                        %err,
+                                        reason = reason.as_str(),
+                                        "Direct chunk fetch failed; retrying batch via FetchChunks gRPC"
                                     );
-                                    return Err(err);
+                                    match fetch_batch_group_via_grpc(
+                                        std::slice::from_ref(&batch),
+                                        &client,
+                                    )
+                                    .await
+                                    {
+                                        Ok(chunks) => {
+                                            stats.record_grpc_fetch(bytes);
+                                            chunks
+                                        }
+                                        Err(grpc_err) => {
+                                            pending_analytics
+                                                .record_direct_terminal_failure(reason);
+                                            stats.try_flush_into(
+                                                &pending_analytics,
+                                                &metrics,
+                                                Err(QueryErrorKind::GrpcFetch),
+                                            );
+                                            return Err(grpc_err);
+                                        }
+                                    }
                                 }
                             };
-                            stats.record_direct_fetch(bytes);
                             chunks
                         }
                         FetchTask::Grpc(batch) => {

--- a/crates/store/re_datafusion/src/pipeline_budget.rs
+++ b/crates/store/re_datafusion/src/pipeline_budget.rs
@@ -28,29 +28,16 @@
 //! budget       = per_partition * num_partitions
 //! ```
 //!
-//! ## Compile-time defaults: budget is currently effectively disengaged
+//! ## Compile-time defaults
 //!
-//! The shipping defaults (`FRACTION=1.0`, `MIN=4 GiB`, `MAX=1 TiB`) are
-//! picked so the budget never bites in practice. The current CPU worker
-//! buffers an entire segment before releasing, so a per-partition cap
-//! below the largest decoded segment's working set deadlocks: chunks
-//! pin the budget at full before the segment-finalization `release`
-//! fires, with no path to forward progress. Reproduced on PR #1736
-//! against `rerun-synthetic-structs-10k` at 50 segments — adaptive
-//! sizing produced a 283 MB total budget that pinned at 282/283 with
-//! 72 IO tasks parked at wait #1 and zero `release` calls.
-//!
-//! Once the follow-up CPU-worker streaming-release refactor lands —
-//! which releases chunks as the safe time horizon advances rather than
-//! at segment boundaries — dial these back to realistic host RSS
-//! budgets (originally targeted: `FRACTION=0.25`, `MIN=64 MiB`, `MAX=1 GiB`).
-//! With those values, for a 4 GB query at most ~1 GB of decoded chunks
-//! live in RAM while the remaining ~3 GB are still on the wire, on disk,
-//! or already flushed downstream — small queries still stream (no reason
-//! to buffer everything when the working set is tiny) and large queries
-//! stay well clear of the host RSS limit. Tighter fractions trade memory
-//! headroom for more frequent IO stalls; looser fractions risk OOM under
-//! co-tenancy.
+//! The shipping defaults (`FRACTION=0.25`, `MIN=64 MiB`, `MAX=1 GiB`) keep the
+//! IO side ahead of the CPU side without letting it run away. For a 4 GB query,
+//! at most ~1 GB of decoded chunks live in RAM while the remaining ~3 GB are
+//! still on the wire, on disk, or already flushed downstream. Small queries
+//! still stream, because the per-partition floor avoids spending more time
+//! parking tasks than fetching data; large queries stay well clear of unbounded
+//! host RSS growth. Tighter fractions trade memory headroom for more frequent
+//! IO stalls; looser fractions risk OOM under co-tenancy.
 //!
 //! When the server does not provide uncompressed sizes (older server), the
 //! compressed wire size is used as a fallback — this under-estimates, producing
@@ -63,9 +50,9 @@
 //!
 //! | Variable                          | Type   | Accepted range | Default |
 //! |-----------------------------------|--------|----------------|---------|
-//! | `RERUN_PIPELINE_BUDGET_MIN`       | size   | `> 0`          | `4GiB`  |
-//! | `RERUN_PIPELINE_BUDGET_MAX`       | size   | `> 0`          | `1TiB`  |
-//! | `RERUN_PIPELINE_BUDGET_FRACTION`  | float  | `(0.0, 1.0]`   | 1.0     |
+//! | `RERUN_PIPELINE_BUDGET_MIN`       | size   | `> 0`          | `64MiB` |
+//! | `RERUN_PIPELINE_BUDGET_MAX`       | size   | `> 0`          | `1GiB`  |
+//! | `RERUN_PIPELINE_BUDGET_FRACTION`  | float  | `(0.0, 1.0]`   | 0.25    |
 //!
 //! Sizes accept either a SI/IEC suffix (`64MB`, `1GiB`, `512KiB`) or a
 //! bare positive integer interpreted as bytes. Values are trimmed of
@@ -223,45 +210,17 @@ use re_log_types::TimeInt;
 use parking_lot::Mutex;
 use tokio::sync::Notify;
 
-// ---------------------------------------------------------------------------
-// Defaults are intentionally tuned to leave the budget effectively disengaged.
-//
-// The current CPU worker buffers an entire segment before releasing, so any
-// per-partition cap below the largest decoded segment's working set risks
-// deadlock: a segment's chunks pin the budget at full before that segment's
-// release fires at finalization, with no way to make forward progress.
-// Empirically reproduced on PR #1736 against `rerun-synthetic-structs-10k`
-// at 50 segments — adaptive sizing produced a 283 MB total budget that
-// pinned at 282/283 with 72 IO tasks parked at wait #1, no `release` ever
-// fired (zero `remote materialize` lines after 22 min stall).
-//
-// Until the follow-up CPU-worker refactor lands — which releases chunks as
-// the safe time horizon advances rather than at segment boundaries — both
-// FRACTION and the MIN/MAX clamps are set so the budget never bites in
-// practice:
-//
-//   per_partition = (total * 1.0) / num_partitions
-//   per_partition = clamp(per_partition, 4 GiB, 1 TiB)   // both bounds huge
-//   budget        = per_partition * num_partitions       // ≥ 4 GiB * N
-//
-// Once streaming release is in place, dial these back to realistic host
-// RSS budgets (originally targeted: FRACTION=0.25, MIN=64 MiB, MAX=1 GiB).
-// ---------------------------------------------------------------------------
-
 /// Default fraction of total query data to allow in-flight at once.
-/// Override with [`ENV_BUDGET_FRACTION`]. Set to `1.0` so adaptive sizing
-/// uses the full uncompressed estimate; see top-of-section note for why.
-const BUDGET_FRACTION: f64 = 1.0;
+/// Override with [`ENV_BUDGET_FRACTION`].
+const BUDGET_FRACTION: f64 = 0.25;
 
 /// Default minimum adaptive budget per partition.
-/// Override with [`ENV_BUDGET_MIN`]. Set high so the per-partition clamp's
-/// lower bound dominates and adaptive sizing can't pull the budget below
-/// a single segment's working set; see top-of-section note for why.
-pub(crate) const MIN_BUDGET_PER_PARTITION: usize = 4 * 1024 * 1024 * 1024; // 4 GiB
+/// Override with [`ENV_BUDGET_MIN`].
+pub(crate) const MIN_BUDGET_PER_PARTITION: usize = 64 * 1024 * 1024; // 64 MiB
 
 /// Default maximum adaptive budget per partition.
-/// Override with [`ENV_BUDGET_MAX`]. See top-of-section note.
-pub(crate) const MAX_BUDGET_PER_PARTITION: usize = 1024 * 1024 * 1024 * 1024; // 1 TiB
+/// Override with [`ENV_BUDGET_MAX`].
+pub(crate) const MAX_BUDGET_PER_PARTITION: usize = 1024 * 1024 * 1024; // 1 GiB
 
 /// Environment variable to override the minimum per-partition budget.
 /// Value accepts a SI/IEC suffix (`64MB`, `1GiB`, `512KiB`) or a bare

--- a/crates/store/re_datafusion/src/pipeline_budget/tests.rs
+++ b/crates/store/re_datafusion/src/pipeline_budget/tests.rs
@@ -2,48 +2,40 @@ use std::sync::Arc;
 
 use super::*;
 
-// Default constants are tuned to leave the budget effectively
-// disengaged (FRACTION=1.0, MIN=4 GiB, MAX=1 TiB). The tests below
-// assert the clamp logic still selects the right bound at the
-// extremes — not that the budget meaningfully restricts in-flight
-// bytes at typical data sizes. Once the CPU-worker streaming-release
-// refactor lands and the constants come back down (FRACTION=0.25,
-// MIN=64 MiB, MAX=1 GiB), tighten these to also assert proportional
-// sizing in the small/medium ranges.
-
 #[test]
 fn test_budget_clamps_to_min() {
-    // 10 MB total, 1 partition → 100% = 10 MB, clamped to MIN_BUDGET_PER_PARTITION (4 GiB)
+    // 10 MiB total, 1 partition → 25% = 2.5 MiB,
+    // clamped to MIN_BUDGET_PER_PARTITION (64 MiB).
     let budget = PipelineBudget::new(10 * 1024 * 1024, 1);
     assert_eq!(budget.budget, MIN_BUDGET_PER_PARTITION);
 }
 
 #[test]
 fn test_budget_clamps_to_max() {
-    // 8 PiB total, 1 partition → 100% = 8 PiB, clamped to MAX_BUDGET_PER_PARTITION (1 TiB)
-    let budget = PipelineBudget::new(8 * 1024 * 1024 * 1024 * 1024 * 1024, 1);
+    // 8 GiB total, 1 partition → 25% = 2 GiB,
+    // clamped to MAX_BUDGET_PER_PARTITION (1 GiB).
+    let budget = PipelineBudget::new(8 * 1024 * 1024 * 1024, 1);
     assert_eq!(budget.budget, MAX_BUDGET_PER_PARTITION);
 }
 
 #[test]
 fn test_budget_scales_with_partitions() {
-    // 64 PiB total, 14 partitions → 100% / 14 ≈ 4.6 PiB per partition,
-    // clamped to MAX_BUDGET_PER_PARTITION (1 TiB) each.
-    let budget = PipelineBudget::new(64 * 1024 * 1024 * 1024 * 1024 * 1024, 14);
-    assert_eq!(budget.budget, MAX_BUDGET_PER_PARTITION * 14);
+    // 4 GiB total, 4 partitions → (25% / 4) = 256 MiB per partition.
+    let budget = PipelineBudget::new(4 * 1024 * 1024 * 1024, 4);
+    assert_eq!(budget.budget, 1024 * 1024 * 1024);
 }
 
 #[test]
 fn test_budget_small_data_many_partitions() {
-    // 100 MB total, 4 partitions → 100% / 4 = 25 MB per partition,
-    // clamped to MIN_BUDGET_PER_PARTITION (4 GiB) each.
+    // 100 MiB total, 4 partitions → (25% / 4) = 6.25 MiB per partition,
+    // clamped to MIN_BUDGET_PER_PARTITION (64 MiB) each.
     let budget = PipelineBudget::new(100 * 1024 * 1024, 4);
     assert_eq!(budget.budget, MIN_BUDGET_PER_PARTITION * 4);
 }
 
 #[tokio::test]
 async fn test_reserve_blocks_when_budget_exhausted() {
-    let budget = Arc::new(PipelineBudget::new(0, 1)); // clamps up to MIN_BUDGET_PER_PARTITION (4 GiB)
+    let budget = Arc::new(PipelineBudget::new(0, 1)); // clamps up to MIN_BUDGET_PER_PARTITION
     budget.set_multiplier(1.0);
     let half = budget.budget / 2;
 
@@ -86,7 +78,7 @@ async fn test_reserve_blocks_when_budget_exhausted() {
 
 #[tokio::test]
 async fn test_adjust_reservation_corrects_estimate() {
-    let budget = Arc::new(PipelineBudget::new(0, 1)); // clamps up to MIN_BUDGET_PER_PARTITION (4 GiB)
+    let budget = Arc::new(PipelineBudget::new(0, 1)); // clamps up to MIN_BUDGET_PER_PARTITION
     budget.set_multiplier(1.0);
 
     let estimated = 1000;

--- a/crates/store/re_server/Cargo.toml
+++ b/crates/store/re_server/Cargo.toml
@@ -95,6 +95,7 @@ tonic-web.workspace = true
 tower.workspace = true
 tower-service.workspace = true
 tracing.workspace = true
+ureq.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 chrono = { workspace = true, features = ["wasmbind"] }

--- a/crates/store/re_server/src/rerun_cloud/mod.rs
+++ b/crates/store/re_server/src/rerun_cloud/mod.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use arrow::array::BinaryArray;
+use arrow::array::{Array as _, BinaryArray};
 use arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use futures::StreamExt as _;
@@ -40,11 +40,11 @@ use re_protos::missing_field;
 use re_protos::{
     EntryName,
     cloud::v1alpha1::ext::{
-        self, CreateDatasetEntryRequest, CreateDatasetEntryResponse, CreateTableEntryRequest,
-        DataSource, EntryDetailsUpdate, QueryDatasetRequest, ReadDatasetEntryResponse,
-        ReadTableEntryResponse, TableInsertMode, UpdateDatasetEntryRequest,
-        UpdateDatasetEntryResponse, UpdateEntryRequest, UpdateEntryResponse,
-        UpdateTableEntryRequest, UpdateTableEntryResponse,
+        self, ChunkKey as DirectChunkKey, CreateDatasetEntryRequest, CreateDatasetEntryResponse,
+        CreateTableEntryRequest, DataSource, DataSourceKind, EntryDetailsUpdate,
+        QueryDatasetRequest, ReadDatasetEntryResponse, ReadTableEntryResponse, RrdChunkLocation,
+        TableInsertMode, UpdateDatasetEntryRequest, UpdateDatasetEntryResponse, UpdateEntryRequest,
+        UpdateEntryResponse, UpdateTableEntryRequest, UpdateTableEntryResponse,
     },
 };
 #[cfg(not(target_arch = "wasm32"))]
@@ -1452,7 +1452,7 @@ impl RerunCloudService for RerunCloudHandler {
             exclude_temporal_data,
             scan_parameters,
             query,
-            generate_direct_urls: _,
+            generate_direct_urls,
         } = request.into_inner().try_into()?;
 
         if scan_parameters.is_some() {
@@ -1630,6 +1630,18 @@ impl RerunCloudService for RerunCloudHandler {
                 };
 
                 let num_chunks = metadata_vec.len();
+                let direct_rrd_source_url = if generate_direct_urls {
+                    match &resolved {
+                        ResolvedStore::Lazy(lazy) => lazy
+                            .source()
+                            .parse::<url::Url>()
+                            .ok()
+                            .filter(|url| matches!(url.scheme(), "http" | "https")),
+                        ResolvedStore::Eager(_) => None,
+                    }
+                } else {
+                    None
+                };
 
                 let mut chunk_ids = Vec::with_capacity(num_chunks);
                 let mut chunk_segment_ids = Vec::with_capacity(num_chunks);
@@ -1704,15 +1716,22 @@ impl RerunCloudService for RerunCloudHandler {
                     // OSS server stores decoded data, so compressed == uncompressed.
                     chunk_byte_sizes_uncompressed.push(Some(meta.byte_size));
 
-                    chunk_keys.push(
-                        ChunkKey {
-                            chunk_id: meta.chunk_id,
-                            store_slot_id,
-                        }
-                        .encode()?,
-                    );
-
-                    chunk_direct_urls.push(None);
+                    if let Some(direct_url) = &direct_rrd_source_url
+                        && let Some((direct_chunk_key, direct_url)) =
+                            direct_rrd_chunk_key(&resolved, direct_url, meta.chunk_id)
+                    {
+                        chunk_keys.push(direct_chunk_key);
+                        chunk_direct_urls.push(Some(direct_url));
+                    } else {
+                        chunk_keys.push(
+                            ChunkKey {
+                                chunk_id: meta.chunk_id,
+                                store_slot_id,
+                            }
+                            .encode()?,
+                        );
+                        chunk_direct_urls.push(None);
+                    }
                     chunk_direct_url_expiry.push(None);
                 }
 
@@ -1758,7 +1777,8 @@ impl RerunCloudService for RerunCloudHandler {
         // worth noting that FetchChunks is not per-dataset request, it simply contains chunk infos
         let request = request.into_inner();
 
-        let mut chunk_keys = vec![];
+        let mut local_chunk_keys = vec![];
+        let mut direct_rrd_chunk_keys = vec![];
         for chunk_info_data in request.chunk_infos {
             let chunk_info_batch: RecordBatch = chunk_info_data.try_into().map_err(|err| {
                 tonic::Status::internal(format!("Failed to decode chunk_info: {err:#}"))
@@ -1787,7 +1807,10 @@ impl RerunCloudService for RerunCloudHandler {
                     ))
                 })?;
 
-            for chunk_key in chunk_keys_arr {
+            let direct_url_col = chunk_info_batch
+                .column_by_name(QueryDatasetDataframe::COLUMN_RERUN_LAYER_DIRECT_URL_NAME);
+
+            for (row_idx, chunk_key) in chunk_keys_arr.iter().enumerate() {
                 let chunk_key = chunk_key.ok_or_else(|| {
                     tonic::Status::invalid_argument(format!(
                         "{} must not be null",
@@ -1795,16 +1818,45 @@ impl RerunCloudService for RerunCloudHandler {
                     ))
                 })?;
 
-                let chunk_key = ChunkKey::decode(chunk_key)?;
-                chunk_keys.push(chunk_key);
+                let has_direct_url = direct_url_col.is_some_and(|col| !col.is_null(row_idx));
+                if has_direct_url {
+                    match DirectChunkKey::try_from(chunk_key) {
+                        Ok(chunk_key) => direct_rrd_chunk_keys.push(chunk_key),
+                        Err(direct_err) => {
+                            let chunk_key = ChunkKey::decode(chunk_key).map_err(|local_err| {
+                                tonic::Status::invalid_argument(format!(
+                                    "Failed to decode chunk_key as direct RRD key ({direct_err:#}) or local key ({local_err:#})"
+                                ))
+                            })?;
+                            local_chunk_keys.push(chunk_key);
+                        }
+                    }
+                } else {
+                    match ChunkKey::decode(chunk_key) {
+                        Ok(chunk_key) => local_chunk_keys.push(chunk_key),
+                        Err(local_err) => {
+                            let chunk_key =
+                                DirectChunkKey::try_from(chunk_key).map_err(|direct_err| {
+                                    tonic::Status::invalid_argument(format!(
+                                        "Failed to decode chunk_key as local key ({local_err:#}) or direct RRD key ({direct_err:#})"
+                                    ))
+                                })?;
+                            direct_rrd_chunk_keys.push(chunk_key);
+                        }
+                    }
+                }
             }
         }
 
-        let chunks = self
+        let mut chunks = self
             .store
             .read()
             .await
-            .chunks_from_chunk_keys(&chunk_keys)?;
+            .chunks_from_chunk_keys(&local_chunk_keys)?;
+
+        for chunk_key in direct_rrd_chunk_keys {
+            chunks.push(load_direct_rrd_chunk(chunk_key)?);
+        }
 
         let stream = futures::stream::iter(chunks).map(|(store_id, chunk)| {
             let arrow_msg = re_log_types::ArrowMsg {
@@ -2214,6 +2266,108 @@ impl ChunkMetadata {
             timelines: chunk_timelines.cloned().unwrap_or_default(),
         }
     }
+}
+
+fn direct_rrd_chunk_key(
+    resolved: &ResolvedStore,
+    source_url: &url::Url,
+    chunk_id: ChunkId,
+) -> Option<(Vec<u8>, String)> {
+    let ResolvedStore::Lazy(lazy) = resolved else {
+        return None;
+    };
+
+    let row_idx = lazy.chunk_row_index(&chunk_id)?;
+    let manifest = lazy.manifest();
+    let payload_offset = *manifest.col_chunk_byte_offset().get(row_idx)?;
+    let payload_length = *manifest.col_chunk_byte_size().get(row_idx)?;
+    let header_length = re_log_encoding::MessageHeader::ENCODED_SIZE_BYTES as u64;
+    let offset = payload_offset.checked_sub(header_length)?;
+    let length = payload_length.checked_add(header_length)?;
+
+    let location = RrdChunkLocation {
+        url: source_url.clone(),
+        offset,
+        length,
+    };
+    let chunk_key = DirectChunkKey {
+        chunk_id,
+        data_source_kind: DataSourceKind::Rrd,
+        location: location.as_bytes(),
+        etag: None,
+        registration_time: None,
+    };
+
+    Some((chunk_key.as_bytes(), source_url.to_string()))
+}
+
+fn load_direct_rrd_chunk(chunk_key: DirectChunkKey) -> tonic::Result<(StoreId, Arc<Chunk>)> {
+    if chunk_key.data_source_kind != DataSourceKind::Rrd {
+        return Err(tonic::Status::invalid_argument(format!(
+            "unsupported direct chunk data source kind: {:?}",
+            chunk_key.data_source_kind
+        )));
+    }
+
+    let location = RrdChunkLocation::try_from(chunk_key.location.as_slice()).map_err(|err| {
+        tonic::Status::invalid_argument(format!("failed to decode RRD chunk location: {err:#}"))
+    })?;
+
+    let mut reader = crate::store::HttpRangeReader::new(location.url.clone()).map_err(|err| {
+        tonic::Status::internal(format!(
+            "failed to open remote RRD source {}: {err:#}",
+            location.url
+        ))
+    })?;
+
+    use std::io::{Read as _, Seek as _};
+    reader
+        .seek(std::io::SeekFrom::Start(location.offset))
+        .map_err(|err| {
+            tonic::Status::internal(format!(
+                "failed to seek remote RRD source {} to {}: {err:#}",
+                location.url, location.offset
+            ))
+        })?;
+
+    let mut bytes = vec![
+        0;
+        usize::try_from(location.length).map_err(|err| {
+            tonic::Status::invalid_argument(format!("RRD chunk length does not fit usize: {err:#}"))
+        })?
+    ];
+    reader.read_exact(&mut bytes).map_err(|err| {
+        tonic::Status::internal(format!(
+            "failed to read RRD chunk range {} bytes at {} from {}: {err:#}",
+            location.length, location.offset, location.url
+        ))
+    })?;
+
+    use re_log_encoding::{Decodable, ToApplication as _};
+    let raw_msg =
+        <Option<re_protos::log_msg::v1alpha1::log_msg::Msg> as Decodable>::from_rrd_bytes(&bytes)
+            .map_err(|err| tonic::Status::internal(format!("failed to decode RRD chunk: {err:#}")))?
+            .ok_or_else(|| tonic::Status::internal("empty RRD chunk message"))?;
+    let re_protos::log_msg::v1alpha1::log_msg::Msg::ArrowMsg(transport_arrow_msg) = raw_msg else {
+        return Err(tonic::Status::internal(
+            "RRD chunk did not contain ArrowMsg",
+        ));
+    };
+
+    let store_id: StoreId = transport_arrow_msg
+        .store_id
+        .clone()
+        .ok_or_else(|| tonic::Status::internal("RRD chunk ArrowMsg missing store_id"))?
+        .try_into()
+        .map_err(|err| tonic::Status::internal(format!("failed to decode store_id: {err:#?}")))?;
+    let app_arrow_msg = transport_arrow_msg
+        .to_application(())
+        .map_err(|err| tonic::Status::internal(format!("failed to convert ArrowMsg: {err:#}")))?;
+    let chunk = Chunk::from_record_batch(&app_arrow_msg.batch).map_err(|err| {
+        tonic::Status::internal(format!("error decoding chunk from record batch: {err:#}"))
+    })?;
+
+    Ok((store_id, Arc::new(chunk)))
 }
 
 /// Returns physical chunks and missing virtual chunk IDs for a query.

--- a/crates/store/re_server/src/rerun_cloud/register_with_dataset.rs
+++ b/crates/store/re_server/src/rerun_cloud/register_with_dataset.rs
@@ -51,6 +51,10 @@ enum ValidatedSource {
         layer_info: Arc<LayerInfo>,
         storage_url: url::Url,
     },
+    Http {
+        storage_url: url::Url,
+        layer_info: Arc<LayerInfo>,
+    },
     Memory {
         store_slot_id: StoreSlotId,
         resolved: ResolvedStore,
@@ -139,6 +143,15 @@ async fn validate_sources(
             continue;
         }
 
+        if matches!(storage_url.scheme(), "http" | "https") {
+            if let Some(http_source) =
+                validate_http_source(store_kind, &storage_url, layer_info, &mut seen).await?
+            {
+                validated.push(http_source);
+            }
+            continue;
+        }
+
         if let Some(file_source) =
             validate_file_source(store_kind, &storage_url, layer_info, &mut seen).await?
         {
@@ -179,6 +192,52 @@ fn validate_memory_source(
         segment_id,
         layer_info,
     })
+}
+
+/// Returns `None` if the file's store kind doesn't match (silently skipped).
+#[cfg(not(target_arch = "wasm32"))]
+async fn validate_http_source(
+    store_kind: StoreKind,
+    storage_url: &url::Url,
+    layer_info: Arc<LayerInfo>,
+    seen: &mut BTreeMap<(LayerName, SegmentId), Vec<url::Url>>,
+) -> tonic::Result<Option<ValidatedSource>> {
+    let store_ids = load_store_ids_http_url(storage_url).await?;
+
+    let mut matched = false;
+    for store_id in store_ids {
+        if store_id.kind() != store_kind {
+            continue;
+        }
+        matched = true;
+        seen.entry((
+            layer_info.name.clone(),
+            SegmentId::from(store_id.recording_id()),
+        ))
+        .or_default()
+        .push(storage_url.clone());
+    }
+
+    if !matched {
+        return Ok(None);
+    }
+
+    Ok(Some(ValidatedSource::Http {
+        storage_url: storage_url.clone(),
+        layer_info,
+    }))
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn validate_http_source(
+    _store_kind: StoreKind,
+    storage_url: &url::Url,
+    _layer_info: Arc<LayerInfo>,
+    _seen: &mut BTreeMap<(LayerName, SegmentId), Vec<url::Url>>,
+) -> tonic::Result<Option<ValidatedSource>> {
+    Err(tonic::Status::unimplemented(format!(
+        "register_with_dataset only supports HTTP(S) RRD sources on native targets: {storage_url}"
+    )))
 }
 
 /// Returns `None` if the file's store kind doesn't match (silently skipped).
@@ -336,6 +395,23 @@ async fn load_sources(
                     });
                 }
             }
+
+            ValidatedSource::Http {
+                storage_url,
+                layer_info,
+            } => {
+                let stores = ResolvedStore::load_rrd_http_url(&storage_url, store_kind).await?;
+
+                for (store_id, resolved) in stores {
+                    ready.push(ReadySource {
+                        store_slot_id: StoreSlotId::new(),
+                        resolved,
+                        segment_id: SegmentId::new(store_id.recording_id().to_string()),
+                        layer_info: layer_info.clone(),
+                        storage_url: storage_url.clone(),
+                    });
+                }
+            }
         }
     }
 
@@ -452,6 +528,29 @@ async fn load_store_ids(rrd_path: &RrdPath) -> tonic::Result<BTreeSet<StoreId>> 
     })?;
 
     Ok(store_ids.into_iter().collect())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn load_store_ids_http_url(storage_url: &url::Url) -> tonic::Result<BTreeSet<StoreId>> {
+    let storage_url = storage_url.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut reader =
+            crate::store::HttpRangeReader::new(storage_url.clone()).map_err(|err| {
+                tonic::Status::internal(format!(
+                    "Failed to open remote RRD source {storage_url}: {err:#}"
+                ))
+            })?;
+
+        let store_ids = re_log_encoding::enumerate_rrd_stores(&mut reader).map_err(|err| {
+            tonic::Status::internal(format!(
+                "Failed to enumerate remote RRD stores {storage_url}: {err:#}"
+            ))
+        })?;
+
+        Ok(store_ids.into_iter().collect())
+    })
+    .await
+    .map_err(|err| tonic::Status::internal(format!("remote RRD task failed: {err:#}")))?
 }
 
 /// Parses a `memory:///store/{store_slot_id}` URL and returns the [`StoreSlotId`].

--- a/crates/store/re_server/src/store/http_range_reader.rs
+++ b/crates/store/re_server/src/store/http_range_reader.rs
@@ -1,0 +1,140 @@
+use std::io::{Read, Seek, SeekFrom};
+
+use url::Url;
+
+/// Blocking HTTP range reader for lazy RRD registration/loading.
+///
+/// The RRD footer and chunk provider APIs are synchronous `Read + Seek`, so this
+/// adapter performs one HTTP range request per `read` at the current cursor.
+pub struct HttpRangeReader {
+    url: Url,
+    agent: ureq::Agent,
+    len: u64,
+    pos: u64,
+}
+
+impl HttpRangeReader {
+    pub fn new(url: Url) -> std::io::Result<Self> {
+        let agent = ureq::Agent::new_with_defaults();
+        let len = content_len(&agent, &url)?;
+        Ok(Self {
+            url,
+            agent,
+            len,
+            pos: 0,
+        })
+    }
+}
+
+impl Read for HttpRangeReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if buf.is_empty() || self.pos >= self.len {
+            return Ok(0);
+        }
+
+        let requested_len = u64::try_from(buf.len()).map_err(std::io::Error::other)?;
+        let end = self.pos.saturating_add(requested_len).min(self.len) - 1;
+        let expected_len = usize::try_from(end - self.pos + 1).map_err(std::io::Error::other)?;
+
+        let response = self
+            .agent
+            .get(self.url.as_str())
+            .header("Range", &format!("bytes={}-{}", self.pos, end))
+            .header("Accept-Encoding", "identity")
+            .call()
+            .map_err(to_io_error)?;
+
+        if response.status() != 206 {
+            return Err(std::io::Error::other(format!(
+                "HTTP range request for {} returned {}; expected 206 Partial Content",
+                self.url,
+                response.status()
+            )));
+        }
+
+        if let Some(content_range) = response.headers().get("Content-Range") {
+            let expected = format!("bytes {}-{}/{}", self.pos, end, self.len);
+            if content_range.to_str().ok() != Some(expected.as_str()) {
+                return Err(std::io::Error::other(format!(
+                    "HTTP Content-Range mismatch for {}: expected {expected}, got {:?}",
+                    self.url, content_range
+                )));
+            }
+        }
+
+        let mut body = response.into_body();
+        let bytes = body.read_to_vec().map_err(std::io::Error::other)?;
+        if bytes.len() != expected_len {
+            return Err(std::io::Error::other(format!(
+                "HTTP range response for {} returned {} bytes; expected {expected_len}",
+                self.url,
+                bytes.len()
+            )));
+        }
+
+        buf[..expected_len].copy_from_slice(&bytes);
+        self.pos += u64::try_from(expected_len).map_err(std::io::Error::other)?;
+        Ok(expected_len)
+    }
+}
+
+impl Seek for HttpRangeReader {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(offset) => i128::from(offset),
+            SeekFrom::End(offset) => i128::from(self.len) + i128::from(offset),
+            SeekFrom::Current(offset) => i128::from(self.pos) + i128::from(offset),
+        };
+
+        if new_pos < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "cannot seek before start of HTTP object",
+            ));
+        }
+
+        self.pos = u64::try_from(new_pos).map_err(std::io::Error::other)?;
+        Ok(self.pos)
+    }
+}
+
+fn content_len(agent: &ureq::Agent, url: &Url) -> std::io::Result<u64> {
+    let response = agent.head(url.as_str()).call().map_err(to_io_error)?;
+    let len = response
+        .headers()
+        .get("Content-Length")
+        .ok_or_else(|| {
+            std::io::Error::other(format!("HTTP response missing Content-Length: {url}"))
+        })?
+        .to_str()
+        .map_err(std::io::Error::other)?
+        .parse::<u64>()
+        .map_err(std::io::Error::other)?;
+
+    if let Some(accept_ranges) = response.headers().get("Accept-Ranges")
+        && accept_ranges
+            .to_str()
+            .is_ok_and(|value| value.eq_ignore_ascii_case("bytes"))
+    {
+        return Ok(len);
+    }
+
+    // Some CDNs omit Accept-Ranges on HEAD but still support Range on GET.
+    let probe = agent
+        .get(url.as_str())
+        .header("Range", "bytes=0-0")
+        .header("Accept-Encoding", "identity")
+        .call()
+        .map_err(to_io_error)?;
+    if probe.status() != 206 {
+        return Err(std::io::Error::other(format!(
+            "HTTP source does not support byte ranges: {url}"
+        )));
+    }
+
+    Ok(len)
+}
+
+fn to_io_error(err: ureq::Error) -> std::io::Error {
+    std::io::Error::other(err)
+}

--- a/crates/store/re_server/src/store/mod.rs
+++ b/crates/store/re_server/src/store/mod.rs
@@ -1,6 +1,8 @@
 mod chunk_key;
 mod dataset;
 mod error;
+#[cfg(not(target_arch = "wasm32"))]
+mod http_range_reader;
 mod in_memory_store;
 mod layer_info;
 mod resolved_store;
@@ -14,6 +16,8 @@ mod tracked;
 pub use self::chunk_key::ChunkKey;
 pub use self::dataset::Dataset;
 pub use self::error::Error;
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::http_range_reader::HttpRangeReader;
 pub use self::in_memory_store::InMemoryStore;
 pub use self::layer_info::LayerInfo;
 pub use self::resolved_store::ResolvedStore;

--- a/crates/store/re_server/src/store/resolved_store.rs
+++ b/crates/store/re_server/src/store/resolved_store.rs
@@ -11,6 +11,8 @@ use re_chunk_store::{
 use re_log_encoding::RrdChunkProvider;
 use re_log_encoding::RrdManifest;
 use re_log_types::{EntityPath, StoreId, StoreKind};
+#[cfg(not(target_arch = "wasm32"))]
+use url::Url;
 
 /// A store backend: either an in-memory eager store or a provider-backed lazy store.
 ///
@@ -187,6 +189,43 @@ impl ResolvedStore {
                 &super::InMemoryStore::default_eager_chunk_store_config(),
             )
         }
+    }
+
+    /// Load an HTTP(S) RRD as lazy [`ResolvedStore`]s by reading only footer/manifest ranges.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn load_rrd_http_url(
+        url: &Url,
+        store_kind: StoreKind,
+    ) -> Result<Vec<(StoreId, Self)>, super::Error> {
+        let url = url.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut footer_reader = super::HttpRangeReader::new(url.clone())?;
+            let footer = re_log_encoding::read_rrd_footer(&mut footer_reader)
+                .map_err(|err| super::Error::RrdLoadingError(err.into()))?
+                .ok_or_else(|| {
+                    super::Error::RrdLoadingError(anyhow::anyhow!(
+                        "HTTP RRD sources must have a footer for lazy registration: {url}"
+                    ))
+                })?;
+
+            let mut out = Vec::with_capacity(footer.manifests.len());
+            for (store_id, raw_manifest) in footer.manifests {
+                if store_id.kind() != store_kind {
+                    continue;
+                }
+                let reader = super::HttpRangeReader::new(url.clone())?;
+                let provider = Arc::new(
+                    RrdChunkProvider::from_reader(reader, url.to_string(), Arc::new(raw_manifest))
+                        .map_err(|err| super::Error::RrdLoadingError(err.into()))?,
+                );
+                let lazy = Arc::new(LazyStore::new(provider));
+                out.push((store_id, Self::Lazy(lazy)));
+            }
+
+            Ok(out)
+        })
+        .await
+        .map_err(|err| super::Error::RrdLoadingError(anyhow::anyhow!(err)))?
     }
 }
 

--- a/rerun_py/rerun_sdk/rerun/catalog/_entry.py
+++ b/rerun_py/rerun_sdk/rerun/catalog/_entry.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
 from abc import ABC
 from collections.abc import Sequence
 from enum import Enum
@@ -24,6 +28,9 @@ from . import ContentFilter, EntryId
 _BatchesType: TypeAlias = (
     RecordBatchReader | pa.RecordBatch | Sequence[pa.RecordBatch] | Sequence[Sequence[pa.RecordBatch]]
 )
+
+_HF_DATASET_TREE_API = "https://huggingface.co/api/datasets/{repo_id}/tree/{revision}/{path}"
+_HF_DATASET_RESOLVE_URL = "https://huggingface.co/datasets/{repo_id}/resolve/{revision}/{path}"
 
 if TYPE_CHECKING:
     from datetime import datetime, timedelta
@@ -57,6 +64,116 @@ class OnDuplicateSegmentLayer(str, Enum):
     ERROR = "error"
     SKIP = "skip"
     REPLACE = "replace"
+
+
+def _resolve_huggingface_rrd_urls_from_tree(
+    repo_id: str,
+    revision: str,
+    tree: Sequence[dict[str, Any]],
+    *,
+    limit: int | None,
+) -> list[str]:
+    """Resolve `.rrd` file entries from a Hugging Face dataset tree response."""
+    urls = []
+    quoted_repo = urllib.parse.quote(repo_id, safe="/")
+    quoted_revision = urllib.parse.quote(revision, safe="")
+
+    for entry in tree:
+        if entry.get("type") != "file":
+            continue
+
+        path = entry.get("path")
+        if not isinstance(path, str) or not path.endswith(".rrd"):
+            continue
+
+        quoted_path = urllib.parse.quote(path, safe="/")
+        urls.append(
+            _HF_DATASET_RESOLVE_URL.format(
+                repo_id=quoted_repo,
+                revision=quoted_revision,
+                path=quoted_path,
+            )
+        )
+
+        if limit is not None and len(urls) >= limit:
+            break
+
+    return urls
+
+
+def _huggingface_next_link(link_header: str | None) -> str | None:
+    if not link_header:
+        return None
+
+    for part in link_header.split(","):
+        pieces = [piece.strip() for piece in part.split(";")]
+        if len(pieces) < 2:
+            continue
+        if 'rel="next"' not in pieces[1:]:
+            continue
+
+        target = pieces[0]
+        if target.startswith("<") and target.endswith(">"):
+            return target[1:-1]
+
+    return None
+
+
+def _resolve_huggingface_rrd_urls(
+    repo_id: str,
+    *,
+    revision: str = "main",
+    path: str = "",
+    token: str | None = None,
+    limit: int | None = None,
+) -> list[str]:
+    """List `.rrd` files in a Hugging Face dataset repo as raw `resolve/` URLs."""
+    if limit is not None and limit <= 0:
+        raise ValueError("`limit` must be greater than zero")
+
+    quoted_repo = urllib.parse.quote(repo_id, safe="/")
+    quoted_revision = urllib.parse.quote(revision, safe="")
+    quoted_path = urllib.parse.quote(path.strip("/"), safe="/")
+    api_url = _HF_DATASET_TREE_API.format(
+        repo_id=quoted_repo,
+        revision=quoted_revision,
+        path=quoted_path,
+    )
+    api_url = f"{api_url}?recursive=1"
+
+    headers = {"Accept": "application/json"}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+
+    urls: list[str] = []
+    next_url: str | None = api_url
+    while next_url is not None:
+        request = urllib.request.Request(next_url, headers=headers)
+
+        try:
+            with urllib.request.urlopen(request) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                next_url = _huggingface_next_link(response.headers.get("Link"))
+        except urllib.error.HTTPError as err:
+            raise ValueError(f"failed to list Hugging Face dataset {repo_id!r}: HTTP {err.code}") from err
+        except urllib.error.URLError as err:
+            raise ValueError(f"failed to list Hugging Face dataset {repo_id!r}: {err.reason}") from err
+
+        if not isinstance(payload, list):
+            raise ValueError(f"unexpected Hugging Face tree response for dataset {repo_id!r}")
+
+        remaining = None if limit is None else limit - len(urls)
+        urls.extend(_resolve_huggingface_rrd_urls_from_tree(repo_id, revision, payload, limit=remaining))
+        if limit is not None and len(urls) >= limit:
+            break
+
+    if not urls:
+        target = f"{repo_id}@{revision}"
+        if path:
+            target = f"{target}/{path.strip('/')}"
+        raise ValueError(f"no .rrd files found in Hugging Face dataset {target!r}")
+
+    return urls
 
 
 InternalEntryT = TypeVar("InternalEntryT", DatasetEntryInternal, TableEntryInternal)
@@ -635,6 +752,63 @@ class DatasetEntry(Entry[DatasetEntryInternal]):
             layer_name = "base"
 
         return RegistrationHandle(self._internal.register_prefix(recordings_prefix, layer_name, on_duplicate))
+
+    def register_huggingface(
+        self,
+        repo_id: str,
+        *,
+        revision: str = "main",
+        path: str = "",
+        layer_name: str = "base",
+        token: str | None = None,
+        limit: int | None = None,
+        on_duplicate: OnDuplicateSegmentLayer = OnDuplicateSegmentLayer.ERROR,
+    ) -> RegistrationHandle:
+        """
+        Register `.rrd` files from a Hugging Face dataset repo.
+
+        The Hugging Face dataset tree is expanded client-side into canonical
+        `https://huggingface.co/datasets/{repo}/resolve/{revision}/...` URLs,
+        then registered as ordinary remote RRD URLs. This keeps the registration
+        request explicit and makes downstream REDAP chunk fetches use normal
+        HTTP range requests against the Hugging Face CDN/object backend.
+
+        Parameters
+        ----------
+        repo_id:
+            Hugging Face dataset repo id, e.g. `"rerun/droid_sample"`.
+        revision:
+            Branch, tag, or commit to resolve. Defaults to `"main"`.
+        path:
+            Optional subdirectory within the dataset repo.
+        layer_name:
+            Dataset layer for all registered files. Defaults to `"base"`.
+        token:
+            Optional Hugging Face token for private/gated datasets or higher
+            rate limits.
+        limit:
+            Optional maximum number of `.rrd` files to register.
+        on_duplicate:
+            How to handle duplicate segment layers.
+
+        !!! note
+            The target REDAP service must be able to register and later read
+            HTTPS storage URLs. The local in-process OSS server only supports
+            local file/memory registration today.
+
+        Returns
+        -------
+        A handle to track and wait on the registration tasks.
+
+        """
+        urls = _resolve_huggingface_rrd_urls(
+            repo_id,
+            revision=revision,
+            path=path,
+            token=token,
+            limit=limit,
+        )
+        return self.register(urls, layer_name=layer_name, on_duplicate=on_duplicate)
 
     def segment_store(self, segment_id: str) -> LazyStore:
         """

--- a/rerun_py/tests/e2e_redap_tests/test_query_metrics_behaviors.py
+++ b/rerun_py/tests/e2e_redap_tests/test_query_metrics_behaviors.py
@@ -21,11 +21,32 @@ from datafusion import col, lit
 from rerun.experimental import query_metrics
 
 if TYPE_CHECKING:
+    import pyarrow as pa
     from rerun.catalog import DatasetEntry
 
 
 # `time_1` hits the datafusion-python bug noted in other tests in this suite.
 _INDEX = "time_2"
+
+
+def _valid_index_values(dataset: DatasetEntry, time_idx: str) -> list[pa.Scalar]:
+    times = dataset.reader(index=time_idx).select(time_idx).sort(col(time_idx)).collect()
+    return [v for rb in times for v in rb[0] if v.is_valid]
+
+
+def _index_range_seek_points(dataset: DatasetEntry, time_idx: str) -> list[tuple[str, pa.Scalar]]:
+    start_col = f"{time_idx}:start"
+    ranges = dataset.get_index_ranges().select("rerun_segment_id", start_col).sort("rerun_segment_id").collect()
+
+    points = []
+    for rb in ranges:
+        segment_ids = rb.column(0)
+        starts = rb.column(1)
+        for row_idx in range(rb.num_rows):
+            start = starts[row_idx]
+            if start.is_valid:
+                points.append((segment_ids[row_idx].as_py(), start))
+    return points
 
 
 @pytest.mark.skip(reason="failing in CI")
@@ -79,8 +100,7 @@ def test_empty_result_filter_still_pushes_down(readonly_test_dataset: DatasetEnt
     fetch path that bails out early.
     """
     # Find the dataset's max time so we can build a filter just past it.
-    times = readonly_test_dataset.reader(index=_INDEX).select(_INDEX).sort(col(_INDEX)).collect()
-    values = [v for rb in times for v in rb[0] if v.is_valid]
+    values = _valid_index_values(readonly_test_dataset, _INDEX)
     assert values, f"expected readonly_test_dataset to contain at least one valid {_INDEX} value"
     max_time = values[-1]
 
@@ -139,6 +159,69 @@ def test_no_filter_no_pushdown(readonly_test_dataset: DatasetEntry) -> None:
     assert qm is not None
     assert qm.filters_pushed_down == 0
     assert qm.filters_applied_client_side == 0
+
+
+def test_scrub_seeks_fetch_bounded_slices(readonly_test_dataset: DatasetEntry) -> None:
+    """
+    Repeated timeline seeks must not degenerate into repeated full-dataset scans.
+
+    This is the CI-sized proxy for the issue #11315 user story: an interactive
+    viewer scrubbing through a large remote dataset should ask REDAP for narrow
+    index slices, then fetch only the chunks in those slices. The committed
+    fixture is intentionally small, but it still has enough chunks/segments to
+    catch the class of regression where every seek plans and fetches the full
+    dataset.
+    """
+    points = _index_range_seek_points(readonly_test_dataset, _INDEX)
+    assert len(points) >= 5, f"expected enough {_INDEX} ranges to simulate multiple seeks"
+
+    # Pick points away from the exact edges so the test exercises real middle
+    # slices rather than "before all data" / "after all data" early-outs.
+    seek_points = [points[len(points) // 4], points[len(points) // 2], points[(3 * len(points)) // 4]]
+
+    with query_metrics() as m:
+        full_rows = sum(rb.num_rows for rb in readonly_test_dataset.reader(index=_INDEX).collect())
+
+    full = m.last_query()
+    assert full is not None
+    assert full_rows > 0
+    assert full.query_chunks > 1
+    assert full.fetch_requests >= 1
+    assert full.fetch_bytes > 0
+    assert full.error_kind is None
+
+    for segment_id, seek_value in seek_points:
+        with query_metrics() as m:
+            rows = sum(
+                rb.num_rows
+                for rb in (
+                    readonly_test_dataset
+                    .filter_segments(segment_id)
+                    .reader(index=_INDEX)
+                    .filter(col(_INDEX) == lit(seek_value))
+                    .collect()
+                )
+            )
+
+        qm = m.last_query()
+        assert qm is not None, f"no QueryMetrics captured for seek at {segment_id} / {seek_value}"
+        assert rows > 0, f"seek at {segment_id} / {seek_value} should hit at least one row in the fixture"
+        assert qm.error_kind is None
+        assert qm.filters_pushed_down >= 1
+        assert qm.filters_applied_client_side == 0
+        assert qm.query_segments == 1
+        assert qm.query_chunks < full.query_chunks, (
+            f"seek at {segment_id} / {seek_value} planned too much data: "
+            f"seek={qm.query_chunks} full={full.query_chunks}"
+        )
+        assert qm.query_bytes < full.query_bytes, (
+            f"seek at {segment_id} / {seek_value} planned too many bytes: seek={qm.query_bytes} full={full.query_bytes}"
+        )
+        assert qm.fetch_requests >= 1
+        assert qm.fetch_bytes > 0
+        assert qm.fetch_bytes < full.fetch_bytes, (
+            f"seek at {segment_id} / {seek_value} fetched too many bytes: seek={qm.fetch_bytes} full={full.fetch_bytes}"
+        )
 
 
 def test_queries_outside_scope_do_not_appear(readonly_test_dataset: DatasetEntry) -> None:

--- a/rerun_py/tests/unit/test_catalog_huggingface.py
+++ b/rerun_py/tests/unit/test_catalog_huggingface.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from rerun.catalog._entry import _huggingface_next_link, _resolve_huggingface_rrd_urls_from_tree
+
+
+def test_resolve_huggingface_rrd_urls_from_tree_filters_and_quotes_paths() -> None:
+    tree = [
+        {"type": "file", "path": "README.md"},
+        {"type": "directory", "path": "episodes"},
+        {"type": "file", "path": "episodes/one.rrd"},
+        {"type": "file", "path": "episodes/two with space.rrd"},
+        {"type": "file", "path": "episodes/two.mp4"},
+    ]
+
+    assert _resolve_huggingface_rrd_urls_from_tree("rerun/droid_sample", "main", tree, limit=None) == [
+        "https://huggingface.co/datasets/rerun/droid_sample/resolve/main/episodes/one.rrd",
+        "https://huggingface.co/datasets/rerun/droid_sample/resolve/main/episodes/two%20with%20space.rrd",
+    ]
+
+
+def test_resolve_huggingface_rrd_urls_from_tree_respects_limit() -> None:
+    tree = [
+        {"type": "file", "path": "one.rrd"},
+        {"type": "file", "path": "two.rrd"},
+    ]
+
+    assert _resolve_huggingface_rrd_urls_from_tree("owner/data", "branch/name", tree, limit=1) == [
+        "https://huggingface.co/datasets/owner/data/resolve/branch%2Fname/one.rrd"
+    ]
+
+
+def test_huggingface_next_link_parses_next_relation() -> None:
+    header = (
+        '<https://huggingface.co/api/datasets/rerun/droid_sample/tree/main?cursor=abc>; rel="next", '
+        '<https://huggingface.co/api/datasets/rerun/droid_sample/tree/main?cursor=last>; rel="last"'
+    )
+
+    assert (
+        _huggingface_next_link(header)
+        == "https://huggingface.co/api/datasets/rerun/droid_sample/tree/main?cursor=abc"
+    )
+    assert _huggingface_next_link(None) is None

--- a/scripts/redap_scrub_metrics.py
+++ b/scripts/redap_scrub_metrics.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Measure REDAP scrub/seek queries against a dataset.
+
+This is an opt-in harness for issue #11315 style validation. It connects to a
+REDAP server, optionally registers a remote RRD prefix, samples seek points from
+the dataset's index-range metadata, then runs repeated narrow index queries
+under `rerun.experimental.query_metrics()`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import time
+from typing import Any
+
+from datafusion import col, lit
+
+from rerun.catalog import CatalogClient
+from rerun.experimental import QueryMetrics, query_metrics
+
+
+@dataclasses.dataclass
+class SeekPoint:
+    segment_id: str
+    value: Any
+
+
+def _json_value(value: Any) -> Any:
+    if hasattr(value, "as_py"):
+        value = value.as_py()
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    if hasattr(value, "total_seconds"):
+        return value.total_seconds()
+    return value
+
+
+def _query_metrics_dict(metrics: QueryMetrics) -> dict[str, Any]:
+    return {
+        "query_chunks": metrics.query_chunks,
+        "query_segments": metrics.query_segments,
+        "query_bytes": metrics.query_bytes,
+        "filters_pushed_down": metrics.filters_pushed_down,
+        "filters_applied_client_side": metrics.filters_applied_client_side,
+        "fetch_grpc_requests": metrics.fetch_grpc_requests,
+        "fetch_grpc_bytes": metrics.fetch_grpc_bytes,
+        "fetch_direct_requests": metrics.fetch_direct_requests,
+        "fetch_direct_bytes": metrics.fetch_direct_bytes,
+        "fetch_direct_retries": metrics.fetch_direct_retries,
+        "fetch_direct_original_ranges": metrics.fetch_direct_original_ranges,
+        "fetch_direct_merged_ranges": metrics.fetch_direct_merged_ranges,
+        "fetch_requests": metrics.fetch_requests,
+        "fetch_bytes": metrics.fetch_bytes,
+        "time_to_first_chunk_ms": (
+            metrics.time_to_first_chunk.total_seconds() * 1000 if metrics.time_to_first_chunk is not None else None
+        ),
+        "total_duration_ms": metrics.total_duration.total_seconds() * 1000,
+        "error_kind": metrics.error_kind,
+        "direct_terminal_reason": metrics.direct_terminal_reason,
+    }
+
+
+def _dataset(args: argparse.Namespace):
+    client = CatalogClient(url=args.redap_url, token=args.redap_token)
+
+    if args.register_prefix is not None:
+        dataset = client.create_dataset(args.dataset, exist_ok=True)
+        handle = dataset.register_prefix(args.register_prefix)
+        handle.wait(timeout_secs=args.registration_timeout_secs)
+        return dataset
+
+    return client.get_dataset(args.dataset)
+
+
+def _sample_seek_points(dataset: Any, index: str, count: int) -> list[SeekPoint]:
+    start_col = f"{index}:start"
+    batches = (
+        dataset
+        .get_index_ranges()
+        .select("rerun_segment_id", start_col)
+        .sort("rerun_segment_id")
+        .limit(max(count * 4, count))
+        .collect()
+    )
+
+    points: list[SeekPoint] = []
+    seen: set[tuple[str, str]] = set()
+    for batch in batches:
+        segment_ids = batch.column(0)
+        starts = batch.column(1)
+        for row_idx in range(batch.num_rows):
+            start = starts[row_idx]
+            if not start.is_valid:
+                continue
+            segment_id = segment_ids[row_idx].as_py()
+            key = (segment_id, repr(start))
+            if key in seen:
+                continue
+            seen.add(key)
+            points.append(SeekPoint(segment_id=segment_id, value=start))
+            if len(points) >= count:
+                return points
+
+    return points
+
+
+def _run_seek(dataset: Any, index: str, point: SeekPoint) -> dict[str, Any]:
+    start = time.perf_counter()
+    with query_metrics() as collector:
+        rows = sum(
+            batch.num_rows
+            for batch in (
+                dataset
+                .filter_segments(point.segment_id)
+                .reader(index=index)
+                .filter(col(index) == lit(point.value))
+                .collect()
+            )
+        )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    metrics = collector.last_query()
+    if metrics is None:
+        raise RuntimeError(f"seek for segment {point.segment_id!r} at {point.value!r} produced no query metrics")
+
+    return {
+        "segment_id": point.segment_id,
+        "seek_value": _json_value(point.value),
+        "rows": rows,
+        "wall_time_ms": elapsed_ms,
+        **_query_metrics_dict(metrics),
+    }
+
+
+def _run_full_scan(dataset: Any, index: str) -> dict[str, Any]:
+    start = time.perf_counter()
+    with query_metrics() as collector:
+        rows = sum(batch.num_rows for batch in dataset.reader(index=index).collect())
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    metrics = collector.last_query()
+    if metrics is None:
+        raise RuntimeError("full scan produced no query metrics")
+
+    return {"rows": rows, "wall_time_ms": elapsed_ms, **_query_metrics_dict(metrics)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Measure REDAP narrow seek/scrub query metrics.")
+    parser.add_argument("--redap-url", required=True, help="REDAP URL, e.g. rerun+http://localhost:51234")
+    parser.add_argument("--redap-token", default=None, help="Optional REDAP auth token")
+    parser.add_argument("--dataset", required=True, help="Dataset name")
+    parser.add_argument("--index", required=True, help="Timeline/index name to scrub on")
+    parser.add_argument(
+        "--register-prefix",
+        default=None,
+        help="Optional remote RRD prefix to register into --dataset before measuring",
+    )
+    parser.add_argument("--registration-timeout-secs", type=int, default=600)
+    parser.add_argument("--seek-count", type=int, default=8)
+    parser.add_argument(
+        "--include-full-scan",
+        action="store_true",
+        help="Also collect the whole dataset once for comparison. Avoid this on very large datasets.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a compact text table")
+    args = parser.parse_args()
+
+    dataset = _dataset(args)
+    seek_points = _sample_seek_points(dataset, args.index, args.seek_count)
+    if not seek_points:
+        raise RuntimeError(f"could not sample any seek points from index {args.index!r}")
+
+    result = {
+        "redap_url": args.redap_url,
+        "dataset": args.dataset,
+        "index": args.index,
+        "full_scan": _run_full_scan(dataset, args.index) if args.include_full_scan else None,
+        "seeks": [_run_seek(dataset, args.index, point) for point in seek_points],
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return
+
+    full = result["full_scan"]
+    if full is not None:
+        print(
+            "full_scan "
+            f"rows={full['rows']} chunks={full['query_chunks']} "
+            f"query_bytes={full['query_bytes']} fetch_bytes={full['fetch_bytes']} "
+            f"wall_ms={full['wall_time_ms']:.1f}"
+        )
+
+    print("seek segment_id seek_value rows chunks query_bytes fetch_bytes direct_bytes grpc_bytes wall_ms")
+    for seek in result["seeks"]:
+        print(
+            f"seek {seek['segment_id']} {seek['seek_value']} {seek['rows']} "
+            f"{seek['query_chunks']} {seek['query_bytes']} {seek['fetch_bytes']} "
+            f"{seek['fetch_direct_bytes']} {seek['fetch_grpc_bytes']} {seek['wall_time_ms']:.1f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/redap_scrub_metrics.py
+++ b/scripts/redap_scrub_metrics.py
@@ -65,9 +65,22 @@ def _query_metrics_dict(metrics: QueryMetrics) -> dict[str, Any]:
 def _dataset(args: argparse.Namespace):
     client = CatalogClient(url=args.redap_url, token=args.redap_token)
 
+    if args.hf_repo is not None:
+        dataset = client.create_dataset(args.dataset, exist_ok=True)
+        handle = dataset.register_huggingface(
+            args.hf_repo,
+            revision=args.hf_revision,
+            path=args.hf_path,
+            layer_name=args.layer_name,
+            token=args.hf_token,
+            limit=args.hf_limit,
+        )
+        handle.wait(timeout_secs=args.registration_timeout_secs)
+        return dataset
+
     if args.register_prefix is not None:
         dataset = client.create_dataset(args.dataset, exist_ok=True)
-        handle = dataset.register_prefix(args.register_prefix)
+        handle = dataset.register_prefix(args.register_prefix, layer_name=args.layer_name)
         handle.wait(timeout_secs=args.registration_timeout_secs)
         return dataset
 
@@ -153,11 +166,21 @@ def main() -> None:
     parser.add_argument("--redap-token", default=None, help="Optional REDAP auth token")
     parser.add_argument("--dataset", required=True, help="Dataset name")
     parser.add_argument("--index", required=True, help="Timeline/index name to scrub on")
+    parser.add_argument("--layer-name", default="base", help="Layer name used when registering a remote source")
     parser.add_argument(
         "--register-prefix",
         default=None,
         help="Optional remote RRD prefix to register into --dataset before measuring",
     )
+    parser.add_argument(
+        "--hf-repo",
+        default=None,
+        help="Optional Hugging Face dataset repo id containing .rrd files, e.g. rerun/droid_sample",
+    )
+    parser.add_argument("--hf-revision", default="main", help="Hugging Face revision to resolve")
+    parser.add_argument("--hf-path", default="", help="Optional subdirectory inside the Hugging Face dataset repo")
+    parser.add_argument("--hf-token", default=None, help="Optional Hugging Face token")
+    parser.add_argument("--hf-limit", type=int, default=None, help="Optional maximum number of HF .rrd files to register")
     parser.add_argument("--registration-timeout-secs", type=int, default=600)
     parser.add_argument("--seek-count", type=int, default=8)
     parser.add_argument(
@@ -167,6 +190,9 @@ def main() -> None:
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of a compact text table")
     args = parser.parse_args()
+
+    if args.register_prefix is not None and args.hf_repo is not None:
+        raise ValueError("--register-prefix and --hf-repo are mutually exclusive")
 
     dataset = _dataset(args)
     seek_points = _sample_seek_points(dataset, args.index, args.seek_count)


### PR DESCRIPTION
### What

This tightens the native server-backed chunk query path and adds the first user-facing Hugging Face registration path for #11315:

1. Direct HTTP Range fetches now fail closed when the remote store does not behave like a range-safe object store.
2. Non-drift direct-fetch failures now fall back to the `FetchChunks` gRPC proxy instead of failing the query outright.
3. The adaptive `PipelineBudget` defaults are lowered from effectively-disabled values to real larger-than-RAM backpressure defaults.
4. The REDAP Python e2e suite now has a scrub/seek regression check, plus `scripts/redap_scrub_metrics.py` for measuring narrow seek queries against an external REDAP server, remote registered prefix, or Hugging Face dataset repo.
5. `DatasetEntry.register_huggingface(...)` resolves `.rrd` files from a Hugging Face dataset repo into canonical `resolve/` URLs and registers them as remote RRD sources. The metrics harness can use this via `--hf-repo`.
6. The local OSS REDAP server can now register `http://` / `https://` RRD URLs as lazy range-backed stores. It reads footer/manifest ranges up front, then emits direct URL chunk metadata so native clients can fetch selected chunks from the original HTTP(S) object store without downloading the full RRD locally or proxying all bytes through REDAP.
7. `FetchChunks` fallback now also understands direct RRD chunk keys, so a failed direct fetch can still be served by the REDAP server from the same HTTP range-backed source.

For direct fetches, the client now:

- sends `Accept-Encoding: identity` alongside the byte `Range` request
- requires `206 Partial Content` instead of accepting any successful 2xx response
- requires `Content-Range` matching the requested byte window
- requires `Content-Length` matching the requested byte count
- stops reading as soon as the response body exceeds the validated range length
- rejects short bodies before decoding
- falls back through `FetchChunks` gRPC for non-source-drift direct failures

`416 Range Not Satisfiable` is also treated as non-retryable. Source-changed direct failures remain terminal so stale manifests do not get hidden by a fallback path.

For query memory backpressure, the default budget moves from the old effectively-unbounded settings:

- fraction: `1.0` -> `0.25`
- min per partition: `4 GiB` -> `64 MiB`
- max per partition: `1 TiB` -> `1 GiB`

### Why

For larger-than-RAM / on-demand dataset access (#11315), accepting a `200 OK` after sending `Range` is dangerous: it means the server may have ignored the range header and returned the entire object. Even if headers look right, a broken server should not be able to make the client allocate more than the byte window it asked for.

At the same time, users should still be able to query through the storage node when direct object-store access is unavailable or misconfigured. The gRPC fallback preserves that path without allowing accidental full-object direct downloads.

Separately, the existing `PipelineBudget` machinery already tracks decoded bytes, gates segment concurrency, releases bytes during safe-horizon GC, and has a stall breaker. But the old default clamps (`4 GiB` min, `1 TiB` max) meant the budget basically never applied in normal use. Lowering these defaults makes the existing remote query pipeline apply real backpressure by default while still allowing env overrides via `RERUN_PIPELINE_BUDGET_*`.

The new scrub e2e test covers the interaction that matters for viewer-style scrubbing: sample `(segment, index)` seek points from index-range metadata, seek those narrow slices, and assert they push down filters, stay on one segment, and fetch/plan less than a full scan. The script version is intentionally opt-in so it can be pointed at a real external REDAP deployment or public Hugging Face repo without making CI depend on a huge remote dataset.

The Hugging Face helper handles the missing entry point for `.rrd` datasets hosted on HF: it uses the HF dataset tree API, follows pagination, filters `.rrd` files, preserves subpaths, supports private/gated repos via token, and registers explicit raw URLs instead of requiring a local download.

The local REDAP HTTP loader intentionally requires range-capable RRDs with a footer. That keeps registration lazy: validation/enumeration reads the remote footer/manifest over HTTP ranges, and later queries either fetch selected chunks directly from the HTTP source or fall back to `FetchChunks`, which now understands the same direct RRD chunk keys.

Example measurement flow:

```bash
pixi run uvpy scripts/redap_scrub_metrics.py \
  --redap-url rerun+http://127.0.0.1:<port> \
  --dataset droid_sample \
  --index log_time \
  --hf-repo rerun/droid_sample \
  --hf-limit 20 \
  --seek-count 8 \
  --json
```

Live local-server smoke against `rerun/droid_sample` (`--hf-limit 3`, `--index log_time`, direct URLs enabled):

| query | segments | chunks | direct requests | direct bytes | gRPC bytes | rows | wall ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| full scan | 3 | 756 | 16 | 109,099,488 | 0 | 3,082 | 58,549 |
| seek 1 | 1 | 211 | 3 | 16,208,664 | 0 | 1 | 2,327 |
| seek 2 | 1 | 211 | 3 | 16,207,640 | 0 | 1 | 999 |
| seek 3 | 1 | 211 | 3 | 16,200,088 | 0 | 1 | 997 |

All three seeks had `filters_pushed_down=1`, `filters_applied_client_side=0`, `error_kind=null`, `fetch_direct_bytes == fetch_bytes`, and `fetch_grpc_bytes=0`.

Larger no-full-scan smoke against the same public HF repo (`--hf-limit 10`, `--seek-count 5`) also stayed bounded: each seek touched one segment, fetched ~16.2 MB via direct HTTP ranges, had `fetch_grpc_bytes=0`, and completed in ~0.9-2.6s wall time on this machine/network.

### Tests

- `cargo fmt --package re_datafusion`
- `cargo test -p re_datafusion --lib`
- `python -m py_compile scripts/redap_scrub_metrics.py rerun_py/tests/e2e_redap_tests/test_query_metrics_behaviors.py rerun_py/rerun_sdk/rerun/catalog/_entry.py rerun_py/tests/unit/test_catalog_huggingface.py`
- `pixi run ruff check scripts/redap_scrub_metrics.py rerun_py/tests/e2e_redap_tests/test_query_metrics_behaviors.py rerun_py/rerun_sdk/rerun/catalog/_entry.py rerun_py/tests/unit/test_catalog_huggingface.py`
- `pixi run uvpy -m pytest -c rerun_py/pyproject.toml rerun_py/tests/e2e_redap_tests/test_query_metrics_behaviors.py -q`
- `pixi run uvpy -m pytest -c rerun_py/pyproject.toml rerun_py/tests/unit/test_catalog_huggingface.py rerun_py/tests/e2e_redap_tests/test_query_metrics_behaviors.py::test_scrub_seeks_fetch_bounded_slices -q`
- `cargo fmt --package re_server`
- `cargo check -p re_server`
- `pixi run py-build`
- `pixi run rrpy -m pytest -q rerun_py/tests/unit/test_catalog_huggingface.py rerun_py/tests/e2e_redap_tests/test_query_metrics_behaviors.py::test_scrub_seeks_fetch_bounded_slices`
- Live resolver smoke: `_resolve_huggingface_rrd_urls("rerun/droid_sample", limit=3)` returned canonical HF `.rrd` URLs without downloading them.
- Live local REDAP smoke: `rr.server.Server()` registered `DatasetEntry.register_huggingface("rerun/droid_sample", limit=1)`, and `get_index_ranges()` returned `log_tick`, `log_time`, and `real_time` ranges.
- Live local REDAP direct metrics smoke: `scripts/redap_scrub_metrics.py --hf-repo rerun/droid_sample --hf-limit 3 --seek-count 3 --include-full-scan --json` produced the direct-fetch table above.
- Live local REDAP larger scrub smoke: `scripts/redap_scrub_metrics.py --hf-repo rerun/droid_sample --hf-limit 10 --seek-count 5 --json` kept all sampled seeks to one segment and direct HTTP ranges only.

Fixes part of #11315.
