### PR TITLE
Better docs description of alpha behavior for Points3D and LineStrips3D

### DIFF
--- a/crates/store/re_sdk_types/definitions/rerun/archetypes/line_strips3d.fbs
+++ b/crates/store/re_sdk_types/definitions/rerun/archetypes/line_strips3d.fbs
@@ -27,6 +27,8 @@ table LineStrips3D (
   radii: [rerun.components.Radius] ("attr.rerun.component_recommended", nullable, order: 2000);
 
   /// Optional colors for the line strips.
+  ///
+  /// The alpha channel is ignored.
   colors: [rerun.components.Color] ("attr.rerun.component_recommended", nullable, order: 2100);
 
   // --- Optional ---

--- a/crates/store/re_sdk_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/store/re_sdk_types/definitions/rerun/archetypes/points3d.fbs
@@ -33,6 +33,9 @@ table Points3D (
   ///
   /// \py The colors are interpreted as RGB or RGBA in sRGB gamma-space,
   /// \py As either 0-1 floats or 0-255 integers, with separate alpha.
+  ///
+  /// The alpha channel affects the brightness (not transparency). 
+  /// TODO(#1611): The alpha channel does not yet affect transparency.
   colors: [rerun.components.Color] ("attr.rerun.component_recommended", nullable, order: 2100);
 
   // --- Optional ---

--- a/crates/store/re_sdk_types/definitions/rerun/archetypes/points3d.fbs
+++ b/crates/store/re_sdk_types/definitions/rerun/archetypes/points3d.fbs
@@ -34,8 +34,8 @@ table Points3D (
   /// \py The colors are interpreted as RGB or RGBA in sRGB gamma-space,
   /// \py As either 0-1 floats or 0-255 integers, with separate alpha.
   ///
-  /// The alpha channel affects the brightness (not transparency). 
-  /// TODO(#1611): The alpha channel does not yet affect transparency.
+  /// By default, the alpha channel affects brightness rather than transparency.
+  /// TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
   colors: [rerun.components.Color] ("attr.rerun.component_recommended", nullable, order: 2100);
 
   // --- Optional ---

--- a/crates/store/re_sdk_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/line_strips3d.rs
@@ -116,6 +116,8 @@ pub struct LineStrips3D {
     pub radii: Option<SerializedComponentBatch>,
 
     /// Optional colors for the line strips.
+    ///
+    /// The alpha channel is ignored.
     pub colors: Option<SerializedComponentBatch>,
 
     /// Optional text labels for the line strips.
@@ -501,6 +503,8 @@ impl LineStrips3D {
     }
 
     /// Optional colors for the line strips.
+    ///
+    /// The alpha channel is ignored.
     #[inline]
     pub fn with_colors(
         mut self,

--- a/crates/store/re_sdk_types/src/archetypes/points3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/points3d.rs
@@ -214,6 +214,9 @@ pub struct Points3D {
     pub radii: Option<SerializedComponentBatch>,
 
     /// Optional colors for the points.
+    ///
+    /// The alpha channel affects the brightness (not transparency).
+    /// TODO(#1611): The alpha channel does not yet affect transparency.
     pub colors: Option<SerializedComponentBatch>,
 
     /// Optional text labels for the points.
@@ -677,6 +680,9 @@ impl Points3D {
     }
 
     /// Optional colors for the points.
+    ///
+    /// The alpha channel affects the brightness (not transparency).
+    /// TODO(#1611): The alpha channel does not yet affect transparency.
     #[inline]
     pub fn with_colors(
         mut self,

--- a/crates/store/re_sdk_types/src/archetypes/points3d.rs
+++ b/crates/store/re_sdk_types/src/archetypes/points3d.rs
@@ -215,8 +215,8 @@ pub struct Points3D {
 
     /// Optional colors for the points.
     ///
-    /// The alpha channel affects the brightness (not transparency).
-    /// TODO(#1611): The alpha channel does not yet affect transparency.
+    /// By default, the alpha channel affects brightness rather than transparency.
+    /// TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
     pub colors: Option<SerializedComponentBatch>,
 
     /// Optional text labels for the points.
@@ -681,8 +681,8 @@ impl Points3D {
 
     /// Optional colors for the points.
     ///
-    /// The alpha channel affects the brightness (not transparency).
-    /// TODO(#1611): The alpha channel does not yet affect transparency.
+    /// By default, the alpha channel affects brightness rather than transparency.
+    /// TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
     #[inline]
     pub fn with_colors(
         mut self,

--- a/crates/store/re_sdk_types/src/reflection/mod.rs
+++ b/crates/store/re_sdk_types/src/reflection/mod.rs
@@ -3329,7 +3329,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                         name: "colors",
                         display_name: "Colors",
                         component_type: "rerun.components.Color".into(),
-                        docstring_md: "Optional colors for the points.",
+                        docstring_md: "Optional colors for the points.\n\nThe alpha channel affects the brightness (not transparency). \nTODO(#1611): The alpha channel does not yet affect transparency.",
                         flags: ArchetypeFieldFlags::UI_EDITABLE,
                     },
                     ArchetypeFieldReflection {

--- a/crates/store/re_sdk_types/src/reflection/mod.rs
+++ b/crates/store/re_sdk_types/src/reflection/mod.rs
@@ -2893,7 +2893,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                         name: "colors",
                         display_name: "Colors",
                         component_type: "rerun.components.Color".into(),
-                        docstring_md: "Optional colors for the line strips.",
+                        docstring_md: "Optional colors for the line strips.\n\nThe alpha channel is ignored.",
                         flags: ArchetypeFieldFlags::UI_EDITABLE,
                     },
                     ArchetypeFieldReflection {

--- a/crates/store/re_sdk_types/src/reflection/mod.rs
+++ b/crates/store/re_sdk_types/src/reflection/mod.rs
@@ -3329,7 +3329,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                         name: "colors",
                         display_name: "Colors",
                         component_type: "rerun.components.Color".into(),
-                        docstring_md: "Optional colors for the points.\n\nThe alpha channel affects the brightness (not transparency). \nTODO(#1611): The alpha channel does not yet affect transparency.",
+                        docstring_md: "Optional colors for the points.\n\nBy default, the alpha channel affects brightness rather than transparency.\nTODO(#1611): To use the alpha channel for transparency, enable the experimental \"Transparent point clouds\" feature flag.",
                         flags: ArchetypeFieldFlags::UI_EDITABLE,
                     },
                     ArchetypeFieldReflection {

--- a/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/line_strips3d.hpp
@@ -108,6 +108,8 @@ namespace rerun::archetypes {
         std::optional<ComponentBatch> radii;
 
         /// Optional colors for the line strips.
+        ///
+        /// The alpha channel is ignored.
         std::optional<ComponentBatch> colors;
 
         /// Optional text labels for the line strips.
@@ -191,6 +193,8 @@ namespace rerun::archetypes {
         }
 
         /// Optional colors for the line strips.
+        ///
+        /// The alpha channel is ignored.
         LineStrips3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -205,6 +205,9 @@ namespace rerun::archetypes {
         std::optional<ComponentBatch> radii;
 
         /// Optional colors for the points.
+        ///
+        /// The alpha channel affects the brightness (not transparency).
+        /// TODO(#1611): The alpha channel does not yet affect transparency.
         std::optional<ComponentBatch> colors;
 
         /// Optional text labels for the points.
@@ -313,6 +316,9 @@ namespace rerun::archetypes {
         }
 
         /// Optional colors for the points.
+        ///
+        /// The alpha channel affects the brightness (not transparency).
+        /// TODO(#1611): The alpha channel does not yet affect transparency.
         Points3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
             return std::move(*this);

--- a/rerun_cpp/src/rerun/archetypes/points3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/points3d.hpp
@@ -206,8 +206,8 @@ namespace rerun::archetypes {
 
         /// Optional colors for the points.
         ///
-        /// The alpha channel affects the brightness (not transparency).
-        /// TODO(#1611): The alpha channel does not yet affect transparency.
+        /// By default, the alpha channel affects brightness rather than transparency.
+        /// TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
         std::optional<ComponentBatch> colors;
 
         /// Optional text labels for the points.
@@ -317,8 +317,8 @@ namespace rerun::archetypes {
 
         /// Optional colors for the points.
         ///
-        /// The alpha channel affects the brightness (not transparency).
-        /// TODO(#1611): The alpha channel does not yet affect transparency.
+        /// By default, the alpha channel affects brightness rather than transparency.
+        /// TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
         Points3D with_colors(const Collection<rerun::components::Color>& _colors) && {
             colors = ComponentBatch::from_loggable(_colors, Descriptor_colors).value_or_throw();
             return std::move(*this);

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -202,6 +202,8 @@ class LineStrips3D(Archetype, VisualizableArchetype):
             Optional radii for the line strips.
         colors:
             Optional colors for the line strips.
+
+            The alpha channel is ignored.
         labels:
             Optional text labels for the line strips.
 
@@ -270,6 +272,8 @@ class LineStrips3D(Archetype, VisualizableArchetype):
             Optional radii for the line strips.
         colors:
             Optional colors for the line strips.
+
+            The alpha channel is ignored.
         labels:
             Optional text labels for the line strips.
 
@@ -387,6 +391,8 @@ class LineStrips3D(Archetype, VisualizableArchetype):
             Optional radii for the line strips.
         colors:
             Optional colors for the line strips.
+
+            The alpha channel is ignored.
         labels:
             Optional text labels for the line strips.
 
@@ -484,6 +490,8 @@ class LineStrips3D(Archetype, VisualizableArchetype):
         converter=components.ColorBatch._converter,  # type: ignore[misc]
     )
     # Optional colors for the line strips.
+    #
+    # The alpha channel is ignored.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -237,6 +237,9 @@ class Points3D(Points3DExt, Archetype, VisualizableArchetype):
 
             The colors are interpreted as RGB or RGBA in sRGB gamma-space,
             As either 0-1 floats or 0-255 integers, with separate alpha.
+
+            The alpha channel affects the brightness (not transparency).
+            TODO(#1611): The alpha channel does not yet affect transparency.
         labels:
             Optional text labels for the points.
 
@@ -390,6 +393,9 @@ class Points3D(Points3DExt, Archetype, VisualizableArchetype):
 
             The colors are interpreted as RGB or RGBA in sRGB gamma-space,
             As either 0-1 floats or 0-255 integers, with separate alpha.
+
+            The alpha channel affects the brightness (not transparency).
+            TODO(#1611): The alpha channel does not yet affect transparency.
         labels:
             Optional text labels for the points.
 
@@ -507,6 +513,9 @@ class Points3D(Points3DExt, Archetype, VisualizableArchetype):
     #
     # The colors are interpreted as RGB or RGBA in sRGB gamma-space,
     # As either 0-1 floats or 0-255 integers, with separate alpha.
+    #
+    # The alpha channel affects the brightness (not transparency).
+    # TODO(#1611): The alpha channel does not yet affect transparency.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -238,8 +238,8 @@ class Points3D(Points3DExt, Archetype, VisualizableArchetype):
             The colors are interpreted as RGB or RGBA in sRGB gamma-space,
             As either 0-1 floats or 0-255 integers, with separate alpha.
 
-            The alpha channel affects the brightness (not transparency).
-            TODO(#1611): The alpha channel does not yet affect transparency.
+            By default, the alpha channel affects brightness rather than transparency.
+            TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
         labels:
             Optional text labels for the points.
 
@@ -394,8 +394,8 @@ class Points3D(Points3DExt, Archetype, VisualizableArchetype):
             The colors are interpreted as RGB or RGBA in sRGB gamma-space,
             As either 0-1 floats or 0-255 integers, with separate alpha.
 
-            The alpha channel affects the brightness (not transparency).
-            TODO(#1611): The alpha channel does not yet affect transparency.
+            By default, the alpha channel affects brightness rather than transparency.
+            TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
         labels:
             Optional text labels for the points.
 
@@ -514,8 +514,8 @@ class Points3D(Points3DExt, Archetype, VisualizableArchetype):
     # The colors are interpreted as RGB or RGBA in sRGB gamma-space,
     # As either 0-1 floats or 0-255 integers, with separate alpha.
     #
-    # The alpha channel affects the brightness (not transparency).
-    # TODO(#1611): The alpha channel does not yet affect transparency.
+    # By default, the alpha channel affects brightness rather than transparency.
+    # TODO(#1611): To use the alpha channel for transparency, enable the experimental "Transparent point clouds" feature flag.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### Related
* Clarify docs as part of #1611 
### What
Transparency doesn't work for Points3D and LineStrips3D. It would be better to document this until it is supported (For example, Mesh3D correctly documents where alpha is ignored). 
<img width="689" height="419" alt="image" src="https://github.com/user-attachments/assets/c3fab4ac-2365-43fb-9adf-08e4f8c09c8b" />
