### PR TITLE
Give a clear error when a glTF/GLB requires an unsupported extension

### DIFF
--- a/crates/viewer/re_renderer/src/importer/gltf.rs
+++ b/crates/viewer/re_renderer/src/importer/gltf.rs
@@ -31,6 +31,12 @@ pub enum GltfImportError {
 
     #[error("Mesh {mesh_name:?} has no triangle primitives.")]
     NoTrianglePrimitives { mesh_name: String },
+
+    #[error(
+        "This file requires glTF extension(s) that Rerun does not support: {0}. \
+         If this is Draco or meshopt compression, re-export the model uncompressed."
+    )]
+    UnsupportedRequiredExtensions(String),
 }
 
 /// Loads both gltf and glb into the mesh & texture manager.
@@ -43,7 +49,7 @@ pub fn load_gltf_from_buffer(
 
     let (doc, buffers, images) = {
         re_tracing::profile_scope!("gltf::import_slice");
-        gltf::import_slice(buffer)?
+        gltf::import_slice(buffer).map_err(|err| explain_import_error(err, buffer))?
     };
 
     let mut images_as_textures = Vec::with_capacity(images.len());
@@ -120,6 +126,25 @@ pub fn load_gltf_from_buffer(
     }
 
     Ok(re_model)
+}
+
+/// Turn an opaque `gltf` loading error into an actionable one when the cause is an
+/// unsupported required extension.
+///
+/// `gltf` rejects unsupported `extensionsRequired` during validation, before we ever get
+/// to the geometry, so we re-parse without validation just to name the offending extensions.
+fn explain_import_error(err: gltf::Error, buffer: &[u8]) -> GltfImportError {
+    if let Ok(gltf) = gltf::Gltf::from_slice_without_validation(buffer) {
+        let unsupported = gltf
+            .document
+            .extensions_required()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        if !unsupported.is_empty() {
+            return GltfImportError::UnsupportedRequiredExtensions(unsupported.join(", "));
+        }
+    }
+    GltfImportError::GltfLoading(err)
 }
 
 fn map_format(format: gltf::image::Format) -> Option<wgpu::TextureFormat> {
@@ -327,5 +352,25 @@ fn gather_instances_recursive(
         && let Some(&mesh_key) = meshes.get(&mesh.index())
     {
         model.add_instance(mesh_key, transform);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GltfImportError, explain_import_error};
+
+    #[test]
+    fn unsupported_required_extension_is_named() {
+        // A file that requires Draco compression fails validation in `gltf::import_slice`
+        // before any geometry is read. We should turn that into an actionable error.
+        let json = br#"{"asset":{"version":"2.0"},"extensionsUsed":["KHR_draco_mesh_compression"],"extensionsRequired":["KHR_draco_mesh_compression"]}"#;
+        let err = gltf::import_slice(json).unwrap_err();
+
+        match explain_import_error(err, json) {
+            GltfImportError::UnsupportedRequiredExtensions(exts) => {
+                assert_eq!(exts, "KHR_draco_mesh_compression");
+            }
+            other => panic!("expected UnsupportedRequiredExtensions, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
### What

Loading a Draco- or meshopt-compressed glTF/GLB currently surfaces the raw `gltf` crate validation error:

```
invalid glTF: extensionsRequired[0] = "KHR_draco_mesh_compression": Unsupported extension
```

which names the extension but doesn't tell the user what to do. This maps that case to an actionable error instead:

```
This file requires glTF extension(s) that Rerun does not support: KHR_draco_mesh_compression.
If this is Draco or meshopt compression, re-export the model uncompressed.
```

### How

`gltf::import_slice` rejects unsupported `extensionsRequired` during validation, *before* any geometry is read (verified against gltf 1.4.1), so the previously-hypothesized "mesh has no triangles" path never triggers. On the `import_slice` error we re-parse with `Gltf::from_slice_without_validation` purely to recover and name the required extensions.

This is the "give a decent error message" slice of #6365 — it does **not** add Draco/meshopt decoding.

### Confidence / disclosure

Written with the help of a coding agent (Claude), reviewed by me. Confidence is high: the change is small and localized to the import error path, the underlying `gltf` behavior was verified empirically, and there's a unit test covering the extension-naming. I'm less familiar with how this error ultimately renders in the viewer UI, so pointers there are welcome.

Part of #6365.