### PR TITLE
Report unsound advisories from transitive dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,11 +9,13 @@
 # For finding duplicate dependencies:  cargo deny check bans --hide-inclusion-graph
 
 
-# Note: running just `cargo deny check` without a `--target` can result in
-# false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
+# Note: `cargo deny check` is run without `--target` so that all of the triples below are
+# evaluated in one pass. Checking them one at a time makes a platform-conditional `ignore`
+# unused on every other triple, which `unused-ignored-advisory = "deny"` rejects.
 [graph]
 targets = [
   { triple = "aarch64-apple-darwin" },
+  { triple = "aarch64-unknown-linux-gnu" },
   { triple = "i686-pc-windows-gnu" },
   { triple = "i686-pc-windows-msvc" },
   { triple = "i686-unknown-linux-gnu" },
@@ -31,6 +33,9 @@ all-features = true
 [advisories]
 version = 2
 unused-ignored-advisory = "deny"
+# `unsound` defaults to `workspace` scope, which silently skips transitive deps;
+# `unmaintained` already defaults to `all`.
+unsound = "all"
 ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained — https://github.com/dtolnay/paste" },
   { id = "RUSTSEC-2024-0014", reason = "generational-arena is unmaintained" },
@@ -39,6 +44,11 @@ ignore = [
   { id = "RUSTSEC-2026-0177", reason = "RR-4865 can't update to pyo3 0.29 until numpy crate is updated" },
   { id = "RUSTSEC-2026-0194", reason = "quick-xml is pulled in by upstream crates that do not yet allow 0.41" },
   { id = "RUSTSEC-2026-0195", reason = "quick-xml is pulled in by upstream crates that do not yet allow 0.41" },
+  # memmap2 0.5.10 via cacache -> http-cache -> http-cache-reqwest -> walkers -> re_view_map.
+  # The advisory is scoped to `advise_range`/`unchecked_advise_range`/`flush_range`/`flush_async_range`;
+  # cacache only ever calls `MmapMut::map_mut` (content/write.rs), so none of the affected functions run.
+  # Remove when `cacache` bumps memmap2 to >= 0.9.11, or when `walkers` drops the http-cache stack.
+  { id = "RUSTSEC-2026-0186", reason = "memmap2 0.5.10 unsound in advise/flush range fns, which cacache never calls (see comment above)" },
 ]
 
 

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -241,6 +241,19 @@ def sdk_variations(results: list[Result]) -> None:
     results.append(run_cargo("check", "-p re_server"))
 
 
+# Targets to check for leaked UI dependencies in `denied_sdk_deps`.
+# `cargo deny` gets its targets from `[graph].targets` in `deny.toml` instead.
+sdk_dep_targets = [
+    "aarch64-apple-darwin",
+    "wasm32-unknown-unknown",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+]
+
+
 def cargo_deny(results: list[Result]) -> None:
     # Targets come from `[graph].targets` in `deny.toml`, checked together in a single run.
     # Passing `--target` instead would evaluate one triple at a time, which makes any
@@ -289,7 +302,7 @@ def denied_sdk_deps(results: list[Result]) -> None:
         return None
 
     for features in ["default", "default,auth,oss_server,perf_telemetry,web_viewer"]:
-        for target in deny_targets:
+        for target in sdk_dep_targets:
             result = run_cargo(
                 "tree",
                 # -f '{lib}' is used here because otherwise cargo tree would print links to repositories of patched crates

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -241,27 +241,15 @@ def sdk_variations(results: list[Result]) -> None:
     results.append(run_cargo("check", "-p re_server"))
 
 
-deny_targets = [
-    "aarch64-apple-darwin",
-    "wasm32-unknown-unknown",
-    "x86_64-apple-darwin",
-    "x86_64-pc-windows-gnu",
-    "x86_64-pc-windows-msvc",
-    "x86_64-unknown-linux-gnu",
-    "x86_64-unknown-linux-musl",
-]
-
-
 def cargo_deny(results: list[Result]) -> None:
-    # Note: running just `cargo deny check` without a `--target` can result in
-    # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
+    # Targets come from `[graph].targets` in `deny.toml`, checked together in a single run.
+    # Passing `--target` instead would evaluate one triple at a time, which makes any
+    # platform-conditional `ignore` unused on the other triples and therefore an error
+    # under `unused-ignored-advisory = "deny"`.
     # Installing is quite quick if it's already installed.
     results.append(run_cargo("install", "--locked cargo-deny@^0.19"))
 
-    for target in deny_targets:
-        results.append(
-            run_cargo("deny", f"--all-features --exclude-dev --log-level error --target {target} check"),
-        )
+    results.append(run_cargo("deny", "--all-features --exclude-dev --log-level error check"))
 
 
 def denied_sdk_deps(results: list[Result]) -> None:


### PR DESCRIPTION
### What

`unsound` defaults to `workspace` scope, so unsound advisories in transitive dependencies were never reported — `unmaintained` already defaults to `all`. Setting `unsound = "all"` surfaces one: `memmap2` 0.5.10, reached via `cacache` → `http-cache` → `walkers`. It is ignored rather than fixed, because the advisory covers only `advise_range` / `unchecked_advise_range` / `flush_range` / `flush_async_range` and `cacache` only ever calls `MmapMut::map_mut`, and because `cacache` requires `memmap2 ^0.5.8` so 0.5.10 is the ceiling.

Also adds `aarch64-unknown-linux-gnu` to `[graph].targets`, which we build but never checked.

`cargo deny` now runs once across all targets in `deny.toml` rather than once per target. Checking one target at a time leaves a platform-specific `ignore` unused on every other target, which `unused-ignored-advisory = "deny"` rejects — the new `memmap2` ignore fails on `wasm32-unknown-unknown` that way, since `memmap2` is absent from that graph.

### Testing

`cargo deny --all-features --exclude-dev check` reports `advisories ok, bans ok, licenses ok, sources ok`. Before switching to the single run, each target was also checked individually to confirm the new `aarch64-unknown-linux-gnu` target introduces no advisory, ban, license, or source violation.

### Compatibility

CI configuration only. A PR that introduces a transitive unsound advisory, or an issue specific to arm64 Linux, will now fail where it previously passed.

### Agent

🤖 This PR was opened by a coding agent (Claude Code).
