### PR TITLE
Limit Cargo build parallelism on Windows

### DIFF
--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -150,6 +150,10 @@ jobs:
 
     if: ${{ inputs.CHANNEL == 'main' }}
     runs-on: ${{ matrix.runs_on }}
+    env:
+      # Windows runners have 64 GB of RAM, which is enough to OOM the build process
+      # if there are too many in parallel.
+      CARGO_BUILD_JOBS: ${{ matrix.name == 'windows' && '16' || 'default' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -229,6 +233,10 @@ jobs:
 
     if: ${{ inputs.CHANNEL == 'nightly' }}
     runs-on: ${{ matrix.platform.runs_on }}
+    env:
+      # Windows runners have 64 GB of RAM, which is enough to OOM the build process
+      # if there are too many in parallel.
+      CARGO_BUILD_JOBS: ${{ matrix.platform.name == 'windows' && '16' || 'default' }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### What

`Tests only (main)` on Windows fails with what looks like a corrupt build cache:

```
error[E0786]: found invalid metadata files for crate `time` which `rerun` depends on
  = note: failed to mmap rmeta metadata: '…\target\debug\deps\libtime-bb5218f4ca4a981b.rmeta'
  = note: failed to mmap file '…libtime-bb5218f4ca4a981b.rlib':
          The paging file is too small for this operation to complete. (os error 1455)
```

`os error 1455` is `ERROR_COMMITMENT_LIMIT`.
The artifacts are fine — rustc cannot map them because the runner is out of commit charge.
Everything downstream (`can't find crate for std`, `cannot find type Vec`, `cannot find trait Send`) is fallout from the failed mmap.

The remaining pressure is `rs-check --only tests`, which runs `cargo nextest run --all-targets`.
`--all-targets` links each of the 31 crates in `examples/rust/` as its own binary — the same many-binaries problem #2809 fixed for integration tests, in a directory it did not touch.

```ts
// Windows runners have 64 GB of RAM, which is enough to OOM the build process
// if there are too many in parallel.
...(info.platform === "windows" ? { "CARGO_BUILD_JOBS": "16" } : {}),
```

Applied to both Windows-running Rust jobs (`mac-windows-tests-main` and `mac-windows-checks-nightly`).
Mac and Linux are unchanged.

### Testing

That the cause is exhaustion rather than corruption is confirmed by the affected crates being disjoint across runs — corrupt artifacts would poison the same files every time:

* #12864 — `bitpacking`, `icu_segmenter`, `re_view_time_series`, `time`, `unicode_normalization`
* #12865 — `bitvec`, `lance_file`, `lance_namespace_reqwest_client`, `re_view_spatial`

On the `default` fallback: an empty `CARGO_BUILD_JOBS` is a hard error (`could not parse ``. Number of parallel jobs should be `default` or a number.`), so the non-Windows branch cannot be `''`.
`default` is accepted by Cargo and preserves current Mac behavior — verified locally against `cargo build`.

### Compatibility

CI configuration only.
No change to the SDK, the data platform, or any stored data.
Windows builds may take slightly longer at 16 jobs, which is the trade #2809 already accepted on the reality side.

### Agent

🤖 This PR was opened by a coding agent (Claude Opus 5).
