### PR TITLE
Add missing standard library includes to C++ error handling (previously an issue for VS2017)

### DIFF
--- a/rerun_cpp/src/rerun/error.cpp
+++ b/rerun_cpp/src/rerun/error.cpp
@@ -4,6 +4,8 @@
 #include <arrow/status.h>
 
 #include <algorithm> // For std::transform
+#include <cctype>    // For std::tolower
+#include <cstdio>    // For fprintf & stderr
 #include <cstdlib>   // For getenv & std::exit
 #include <string>
 


### PR DESCRIPTION
### Related

* Addresses the compilation error reported in #7384.

### What

`rerun_cpp/src/rerun/error.cpp` directly uses `std::tolower`, `fprintf`, and
`stderr`, but previously relied on transitive includes to declare them. Include
their owning standard headers, `<cctype>` and `<cstdio>`, so the translation unit
is self-contained across standard library implementations and compiler versions.

This fixes the standards-conformance issue behind the reported VS 2017 error
without claiming broader VS 2017 CI coverage or official support. Runtime
behavior and public APIs are unchanged, and no documentation changes are needed.

Validation:

* `pixi run cpp-fmt-check`
* `pixi run cpp-test` — all 44 test cases passed (1055 assertions) with strict
  compilation warnings enabled on Ubuntu 22.04 / GNU 12.4.
* Clang-Tidy 18 `misc-include-cleaner` — reproduced both missing direct includes
  before the change and passed after the change.
* `g++ -std=c++17 -Wall -Wextra -Wpedantic -Werror -fsyntax-only` on
  `rerun_cpp/src/rerun/error.cpp`.

### Agent

This PR was prepared with LLM assistance and manually reviewed.

Confidence: high. The change only adds the standard headers that own the symbols
already used by this translation unit, and both focused include analysis and the
full C++ SDK test target pass.
