### PR TITLE
Fix --detach-process for standalone CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11425,6 +11425,7 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "jiff",
+ "libc",
  "log",
  "mcap",
  "parking_lot",

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -90,7 +90,7 @@ nasm = ["re_video/nasm"]
 ## This adds a lot of extra dependencies, so only enable this feature if you need it!
 ##
 ## Also enables the `rerun viewer-mcp` command.
-native_viewer = ["dep:re_viewer", "dep:re_crash_handler", "dep:re_viewer_mcp"]
+native_viewer = ["dep:libc", "dep:re_viewer", "dep:re_crash_handler", "dep:re_viewer_mcp"]
 
 ## Enable the in-memory Rerun data server.
 oss_server = ["dep:re_server"]
@@ -209,6 +209,9 @@ jiff = { workspace = true, optional = true }
 re_perf_telemetry = { workspace = true, optional = true }
 unindent = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
+
+[target.'cfg(target_family = "unix")'.dependencies]
+libc = { workspace = true, optional = true }
 
 [build-dependencies]
 re_build_tools.workspace = true

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -302,7 +302,9 @@ If no arguments are given, a server will be hosted which a Rerun SDK can connect
     #[clap(long)]
     hide_welcome_screen: bool,
 
-    /// Detach Rerun Viewer process from the application process.
+    /// Detach the native Rerun Viewer process from the invoking process.
+    ///
+    /// Ignored for any command that doesn't spawn a viewer.
     #[clap(long)]
     detach_process: bool,
 
@@ -851,16 +853,49 @@ where
 
 #[cfg(feature = "native_viewer")]
 fn should_relaunch_detached(args: &Args) -> bool {
-    args.detach_process
-        && !args.detached_process_child
-        && args.command.is_none()
-        && !args.headless
-        && !args.serve_grpc
-        && !args.serve_web
-        && !args.web_viewer
-        && args.save.is_none()
-        && !args.test_receive
-        && !args.version
+    // Destructure to ensure we consider all fields when adding new ones.
+    let Args {
+        detach_process,
+        detached_process_child,
+        command,
+        serve_grpc,
+        serve_web,
+        web_viewer,
+        save,
+        test_receive,
+        version,
+
+        headless: _,
+        bind: _,
+        memory_limit: _,
+        server_memory_limit: _,
+        newest_first: _,
+        cors_allow_origin: _,
+        persist_state: _,
+        port: _,
+        new: _,
+        profile: _,
+        screenshot_to: _,
+        connect: _,
+        expect_data_soon: _,
+        threads: _,
+        url_or_paths: _,
+        web_viewer_port: _,
+        hide_welcome_screen: _,
+        window_size: _,
+        renderer: _,
+        video_decoder: _,
+    } = args;
+
+    *detach_process
+        && !detached_process_child
+        && command.is_none()
+        && !serve_grpc
+        && !serve_web
+        && !web_viewer
+        && save.is_none()
+        && !test_receive
+        && !version
 }
 
 #[cfg(feature = "native_viewer")]

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -2022,9 +2022,10 @@ mod tests {
             );
 
             let child_args = detached_child_args(&raw_args);
-            let child = Args::try_parse_from(
-                std::iter::once(std::ffi::OsStr::new("rerun")).chain(child_args),
-            )
+            let child = Args::try_parse_from(std::iter::chain(
+                std::iter::once(std::ffi::OsStr::new("rerun")),
+                child_args,
+            ))
             .unwrap();
             assert!(child.detached_process_child);
             assert!(
@@ -2053,9 +2054,11 @@ mod tests {
             ]
         );
 
-        let child =
-            Args::try_parse_from(std::iter::once(std::ffi::OsStr::new("rerun")).chain(child_args))
-                .unwrap();
+        let child = Args::try_parse_from(std::iter::chain(
+            std::iter::once(std::ffi::OsStr::new("rerun")),
+            child_args,
+        ))
+        .unwrap();
         assert!(child.detached_process_child);
         assert!(!should_relaunch_detached(&child));
         assert_eq!(child.url_or_paths, ["recording.rrd"]);

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -864,13 +864,30 @@ fn should_relaunch_detached(args: &Args) -> bool {
 }
 
 #[cfg(feature = "native_viewer")]
+fn detached_child_args(raw_args: &[std::ffi::OsString]) -> Vec<&std::ffi::OsStr> {
+    let mut child_args = raw_args
+        .iter()
+        .skip(1)
+        .map(std::ffi::OsString::as_os_str)
+        .collect::<Vec<_>>();
+    let insertion_index = child_args
+        .iter()
+        .position(|arg| *arg == std::ffi::OsStr::new("--"))
+        .unwrap_or(child_args.len());
+    child_args.insert(
+        insertion_index,
+        std::ffi::OsStr::new("--detached-process-child"),
+    );
+    child_args
+}
+
+#[cfg(feature = "native_viewer")]
 fn relaunch_detached(raw_args: &[std::ffi::OsString]) -> anyhow::Result<()> {
     let executable = std::env::current_exe()
         .map_err(|err| anyhow::anyhow!("failed to locate the Rerun executable: {err}"))?;
     let mut command = std::process::Command::new(executable);
     command
-        .args(raw_args.iter().skip(1))
-        .arg("--detached-process-child")
+        .args(detached_child_args(raw_args))
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
@@ -1993,16 +2010,55 @@ mod tests {
                 "screenshot.png",
             ],
         ] {
-            let parent = Args::try_parse_from(cli_args).unwrap();
+            let raw_args = cli_args
+                .iter()
+                .copied()
+                .map(std::ffi::OsString::from)
+                .collect::<Vec<_>>();
+            let parent = Args::try_parse_from(raw_args.iter()).unwrap();
             assert!(
                 should_relaunch_detached(&parent),
                 "expected relaunch for {cli_args:?}"
             );
-        }
 
-        let child = Args::try_parse_from(["rerun", "--detach-process", "--detached-process-child"])
+            let child_args = detached_child_args(&raw_args);
+            let child = Args::try_parse_from(
+                std::iter::once(std::ffi::OsStr::new("rerun")).chain(child_args),
+            )
             .unwrap();
+            assert!(child.detached_process_child);
+            assert!(
+                !should_relaunch_detached(&child),
+                "unexpected second relaunch for {cli_args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn detach_child_marker_precedes_end_of_options_separator() {
+        let raw_args =
+            ["rerun", "--detach-process", "--", "recording.rrd"].map(std::ffi::OsString::from);
+        let parent = Args::try_parse_from(raw_args.iter()).unwrap();
+        assert!(should_relaunch_detached(&parent));
+
+        let child_args = detached_child_args(&raw_args);
+
+        assert_eq!(
+            child_args,
+            [
+                std::ffi::OsStr::new("--detach-process"),
+                std::ffi::OsStr::new("--detached-process-child"),
+                std::ffi::OsStr::new("--"),
+                std::ffi::OsStr::new("recording.rrd"),
+            ]
+        );
+
+        let child =
+            Args::try_parse_from(std::iter::once(std::ffi::OsStr::new("rerun")).chain(child_args))
+                .unwrap();
+        assert!(child.detached_process_child);
         assert!(!should_relaunch_detached(&child));
+        assert_eq!(child.url_or_paths, ["recording.rrd"]);
     }
 
     #[test]

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -306,6 +306,10 @@ If no arguments are given, a server will be hosted which a Rerun SDK can connect
     #[clap(long)]
     detach_process: bool,
 
+    /// Marks the relaunched child of a detached Rerun Viewer.
+    #[clap(long, hide = true)]
+    detached_process_child: bool,
+
     /// Run the viewer in headless mode (no OS window).
     ///
     /// The viewer is driven by an offscreen `egui_kittest` harness, while the
@@ -704,8 +708,17 @@ where
         std::env::set_var("OTEL_SERVICE_NAME", "rerun");
     }
 
+    let raw_args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+
     use clap::Parser as _;
-    let mut args = Args::parse_from(args);
+    let mut args = Args::parse_from(raw_args.iter());
+
+    #[cfg(feature = "native_viewer")]
+    if should_relaunch_detached(&args) {
+        relaunch_detached(&raw_args)?;
+        return Ok(0);
+    }
+
     #[cfg(feature = "analytics")]
     record_cli_command_analytics(&args);
 
@@ -834,6 +847,64 @@ where
         // Unclean failure -- re-raise exception
         Err(err) => Err(err),
     }
+}
+
+#[cfg(feature = "native_viewer")]
+fn should_relaunch_detached(args: &Args) -> bool {
+    args.detach_process
+        && !args.detached_process_child
+        && args.command.is_none()
+        && !args.headless
+        && !args.serve_grpc
+        && !args.serve_web
+        && !args.web_viewer
+        && args.save.is_none()
+        && !args.test_receive
+        && !args.version
+}
+
+#[cfg(feature = "native_viewer")]
+fn relaunch_detached(raw_args: &[std::ffi::OsString]) -> anyhow::Result<()> {
+    let executable = std::env::current_exe()
+        .map_err(|err| anyhow::anyhow!("failed to locate the Rerun executable: {err}"))?;
+    let mut command = std::process::Command::new(executable);
+    command
+        .args(raw_args.iter().skip(1))
+        .arg("--detached-process-child")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::process::CommandExt as _;
+
+        // SAFETY: This runs in the forked child before exec and only calls the
+        // async-signal-safe `setsid`.
+        #[expect(unsafe_code)]
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    Err(std::io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            });
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt as _;
+
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        command.creation_flags(DETACHED_PROCESS);
+    }
+
+    command
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("failed to launch the detached Rerun Viewer: {err}"))?;
+    Ok(())
 }
 
 fn run_impl(
@@ -1815,6 +1886,7 @@ fn record_cli_command_analytics(args: &Args) {
         detach_process,
 
         // Not logged
+        detached_process_child: _,
         threads: _,
         url_or_paths: _,
         version: _,
@@ -1901,4 +1973,40 @@ fn record_cli_command_analytics(args: &Args) {
         detach_process: *detach_process,
         test_receive: *test_receive,
     });
+}
+
+#[cfg(all(test, feature = "native_viewer"))]
+mod tests {
+    use super::*;
+
+    use clap::Parser as _;
+
+    #[test]
+    fn detach_relaunches_a_native_viewer_exactly_once() {
+        let parent = Args::try_parse_from(["rerun", "--detach-process"]).unwrap();
+        assert!(should_relaunch_detached(&parent));
+
+        let child = Args::try_parse_from(["rerun", "--detach-process", "--detached-process-child"])
+            .unwrap();
+        assert!(!should_relaunch_detached(&child));
+    }
+
+    #[test]
+    fn detach_does_not_relaunch_non_viewer_modes() {
+        for cli_args in [
+            &["rerun", "--detach-process", "--headless"][..],
+            &["rerun", "--detach-process", "--serve-grpc"],
+            &["rerun", "--detach-process", "--serve-web"],
+            &["rerun", "--detach-process", "--web-viewer"],
+            &["rerun", "--detach-process", "--save", "output.rrd"],
+            &["rerun", "--detach-process", "--test-receive"],
+            &["rerun", "--detach-process", "--version"],
+        ] {
+            let args = Args::try_parse_from(cli_args).unwrap();
+            assert!(
+                !should_relaunch_detached(&args),
+                "unexpected relaunch for {cli_args:?}"
+            );
+        }
+    }
 }

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -2038,6 +2038,7 @@ mod tests {
         for cli_args in [
             &["rerun", "--detach-process"][..],
             &["rerun", "--detach-process", "recording.rrd"],
+            &["rerun", "--detach-process", "--headless"],
             &[
                 "rerun",
                 "--detach-process",
@@ -2102,8 +2103,7 @@ mod tests {
     #[test]
     fn detach_does_not_relaunch_non_viewer_modes() {
         for cli_args in [
-            &["rerun", "--detach-process", "--headless"][..],
-            &["rerun", "--detach-process", "--serve-grpc"],
+            &["rerun", "--detach-process", "--serve-grpc"][..],
             &["rerun", "--detach-process", "--serve-web"],
             &["rerun", "--detach-process", "--web-viewer"],
             &["rerun", "--detach-process", "--save", "output.rrd"],

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -1983,8 +1983,22 @@ mod tests {
 
     #[test]
     fn detach_relaunches_a_native_viewer_exactly_once() {
-        let parent = Args::try_parse_from(["rerun", "--detach-process"]).unwrap();
-        assert!(should_relaunch_detached(&parent));
+        for cli_args in [
+            &["rerun", "--detach-process"][..],
+            &["rerun", "--detach-process", "recording.rrd"],
+            &[
+                "rerun",
+                "--detach-process",
+                "--screenshot-to",
+                "screenshot.png",
+            ],
+        ] {
+            let parent = Args::try_parse_from(cli_args).unwrap();
+            assert!(
+                should_relaunch_detached(&parent),
+                "expected relaunch for {cli_args:?}"
+            );
+        }
 
         let child = Args::try_parse_from(["rerun", "--detach-process", "--detached-process-child"])
             .unwrap();
@@ -2001,6 +2015,7 @@ mod tests {
             &["rerun", "--detach-process", "--save", "output.rrd"],
             &["rerun", "--detach-process", "--test-receive"],
             &["rerun", "--detach-process", "--version"],
+            &["rerun", "--detach-process", "reset"],
         ] {
             let args = Args::try_parse_from(cli_args).unwrap();
             assert!(

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -177,7 +177,7 @@ The Rerun command-line interface:
 * `--detach-process <DETACH_PROCESS>`
 > Detach the native Rerun Viewer process from the invoking process.
 >
-> Ignored for subcommands, headless mode, server and web modes, saving, testing, and version queries.
+> Ignored for any command that doesn't spawn a viewer.
 >
 > [Default: `false`]
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -175,7 +175,9 @@ The Rerun command-line interface:
 > [Default: `false`]
 
 * `--detach-process <DETACH_PROCESS>`
-> Detach Rerun Viewer process from the application process.
+> Detach the native Rerun Viewer process from the invoking process.
+>
+> Ignored for subcommands, headless mode, server and web modes, saving, testing, and version queries.
 >
 > [Default: `false`]
 


### PR DESCRIPTION
### Related

* Closes #11847

### What

`--detach-process` was copied into `StartupOptions`, but that field is never read by the standalone CLI, so the viewer kept running in the invoking process.

This change relaunches native-viewer CLI invocations once as a detached child:

* preserves the original CLI arguments and inserts a hidden child marker before any `--` end-of-options separator to prevent recursion;
* starts a new session with `setsid` on Unix and uses `DETACHED_PROCESS` on Windows;
* disconnects standard streams so captured pipes do not keep the launcher attached;
* leaves subcommands, headless/server/web/save/test/version modes in the original process.

Focused tests cover the one-time relaunch guard, representative native-viewer invocations, `rerun --detach-process -- recording.rrd`, and the modes that must remain attached.

### Testing

* `cargo test -p rerun --lib --no-default-features --features rerun/native_viewer,rerun/run detach_` (Windows and Linux; 3 passed on each)
* `cargo clippy -p rerun --lib --no-default-features --features rerun/native_viewer,rerun/run -- --deny warnings` (Windows and Linux)
* `cargo fmt -p rerun -- --check` (Windows and Linux)
* `cargo check -p rerun --lib --tests --no-default-features --features rerun/native_viewer,rerun/run` (Linux)
* `cargo build -p rerun-cli --no-default-features --features rerun-cli/native_viewer` (Linux)
* `pixi run lint-codegen`
* Changed-file fast lint checks for Rustfmt, TOML formatting, repository lint, typos, and notebook stripping
* Windows lifecycle test: the launcher exited successfully in 546 ms, the detached child was observed alive, produced a screenshot, and exited without a leftover process
* Linux lifecycle test: the launcher returned in 0 seconds, the child was observed with `PID == SID == PGID`, wrote a 124,236-byte PNG, and terminated

### Confidence

High. The dead data flow was reproduced on current `main`; both platform-specific paths compile, Windows and Linux process lifecycles were validated end to end, and viewer/non-viewer mode selection plus end-of-options handling have regression coverage.

### Agent

🤖 This PR was opened by a coding agent. The implementation and test results were reviewed in an LLM-assisted workflow.