### PR TITLE
Fix C++ and Python Snippet Docs

### DIFF
--- a/docs/snippets/README.md
+++ b/docs/snippets/README.md
@@ -7,7 +7,7 @@ Small, self-contained examples in `all/`, organized by category (`archetypes/`, 
 Rust and C++ snippets compile into a single dispatcher binary that takes the snippet name (without path/extension) as first argument.
 
 - **C++**: `pixi run -e cpp cpp-build-snippets`, then `./build/debug/docs/snippets/snippets <name>`
-- **Python**: `pixi run py-build && pixi run uvpy <name>.py`
+- **Python**: `pixi run py-build && pixi run uvpy <path>`
 - **Rust**: `cargo run -p snippets -- <name> [args]`
 
 ## Build system

--- a/docs/snippets/README.md
+++ b/docs/snippets/README.md
@@ -6,7 +6,7 @@ Small, self-contained examples in `all/`, organized by category (`archetypes/`, 
 
 Rust and C++ snippets compile into a single dispatcher binary that takes the snippet name (without path/extension) as first argument.
 
-- **C++**: `pixi run -e cpp cpp-build-snippets`, then `./build/debug/docs/snippets/all/<name>`
+- **C++**: `pixi run -e cpp cpp-build-snippets`, then `./build/debug/docs/snippets/snippets <name>`
 - **Python**: `pixi run py-build && pixi run uvpy <name>.py`
 - **Rust**: `cargo run -p snippets -- <name> [args]`
 


### PR DESCRIPTION
### Related

* [b0a3876bc26ae1caff59ad1bf230279182522bb9](https://github.com/rerun-io/rerun/commit/b0a3876bc26ae1caff59ad1bf230279182522bb9) introduced building C++ snippets into a single executable to avoid link time overhead
* [618e23527d213ca6d19b769e0307e1c7fb795cd7](https://github.com/rerun-io/rerun/commit/618e23527d213ca6d19b769e0307e1c7fb795cd7) updated the description text of the readme accordingly

### What

Fixes the documentation for how to run C++ and Python snippets. The C++ command still referred to the old per-snippet binary path, it now uses the single `snippets` executable introduced in the related commits. The Python command takes a file path, not just the snippet name. I also verified that the Rust command is correct.
