### PR TITLE
Fix anamorphic pinhole projection in 2D views

### DIFF
--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -437,8 +437,6 @@ fn setup_target_config(
     // * a perspective camera *at the origin* for 3D rendering
     // Both share the same view-builder and the same viewport transformation but are independent otherwise.
 
-    // TODO(andreas): Support anamorphic pinhole cameras properly.
-
     let pinhole = if let Some(scene_pinhole) = scene_pinhole {
         // The user has a pinhole, and we may want to project 3D stuff into this 2D space,
         // and we want to use that pinhole projection to do so.
@@ -464,11 +462,10 @@ fn setup_target_config(
         egui::vec2(pinhole.resolution.x, pinhole.resolution.y),
     );
 
-    let focal_length = pinhole.focal_length_in_pixels();
-    let focal_length = 2.0 / (1.0 / focal_length.x + 1.0 / focal_length.y); // harmonic mean (lack of anamorphic support)
+    let focal_length = virtual_camera_focal_length(&pinhole);
 
     let projection_from_view = re_renderer::view_builder::Projection::Perspective {
-        vertical_fov: pinhole.fov_y(),
+        vertical_fov: 2.0 * (0.5 * pinhole.resolution.y / focal_length).atan(),
         near_plane_distance: near_clip_plane * focal_length / 500.0, // TODO(#8373): The need to scale this by 500 is quite hacky.
         aspect_ratio: pinhole.aspect_ratio(),
     };
@@ -514,6 +511,16 @@ fn setup_target_config(
             picking_config,
         }
     })
+}
+
+/// Focal length of the virtual camera used to view the pinhole's image plane.
+///
+/// This must be the arithmetic mean because `re_tf` uses the harmonic mean of the inverse
+/// focal lengths for the image plane's depth scale.
+/// Keeping the two reciprocal makes perspective division reproduce both `fx` and `fy`.
+fn virtual_camera_focal_length(pinhole: &Pinhole) -> f32 {
+    let focal_length = pinhole.focal_length_in_pixels();
+    0.5 * (focal_length.x + focal_length.y)
 }
 
 fn re_render_rect_from_egui_rect(rect: egui::Rect) -> re_renderer::RectF32 {
@@ -574,4 +581,53 @@ fn show_projections_from_3d_space(
 #[test]
 fn test_help_view() {
     re_test_context::TestContext::test_help_view(help);
+}
+
+#[test]
+fn anamorphic_virtual_camera_matches_pinhole_projection() {
+    let resolution = glam::vec2(800.0, 600.0);
+    let focal_length = glam::vec2(900.0, 450.0);
+    let principal_point = 0.5 * resolution;
+    let pinhole = Pinhole {
+        image_from_camera: glam::Mat3::from_cols(
+            glam::vec3(focal_length.x, 0.0, 0.0),
+            glam::vec3(0.0, focal_length.y, 0.0),
+            principal_point.extend(1.0),
+        ),
+        resolution,
+    };
+
+    let camera_point = glam::vec3(0.4, -0.3, 2.5);
+    let image_plane_distance = 500.0;
+    let virtual_focal_length = virtual_camera_focal_length(&pinhole);
+
+    // Reproduce the 3D-to-2D transform constructed by `re_tf::pinhole3d_from_image_plane`.
+    let target_point = glam::vec3(
+        focal_length.x * camera_point.x / image_plane_distance + principal_point.x,
+        focal_length.y * camera_point.y / image_plane_distance + principal_point.y,
+        virtual_focal_length * (camera_point.z - image_plane_distance) / image_plane_distance,
+    );
+    let view_from_world = macaw::IsoTransform::look_at_rh(
+        principal_point.extend(-virtual_focal_length),
+        principal_point.extend(0.0),
+        -glam::Vec3::Y,
+    )
+    .unwrap()
+    .to_mat4();
+    let vertical_fov = 2.0 * (0.5 * resolution.y / virtual_focal_length).atan();
+    let projection_from_view =
+        glam::Mat4::perspective_infinite_reverse_rh(vertical_fov, resolution.x / resolution.y, 0.1);
+
+    let clip = projection_from_view * view_from_world * target_point.extend(1.0);
+    let ndc = clip.truncate() / clip.w;
+    let projected = glam::vec2(
+        (ndc.x + 1.0) * 0.5 * resolution.x,
+        (1.0 - ndc.y) * 0.5 * resolution.y,
+    );
+    let expected = camera_point.truncate() * focal_length / camera_point.z + principal_point;
+
+    assert!(
+        (projected - expected).abs().max_element() < 1.0e-2,
+        "projected {projected:?}, expected {expected:?}"
+    );
 }

--- a/crates/viewer/re_view_spatial/tests/project_2d_and_3d.rs
+++ b/crates/viewer/re_view_spatial/tests/project_2d_and_3d.rs
@@ -10,6 +10,14 @@ use re_viewer_context::{RecommendedView, ViewClass as _};
 use re_viewport_blueprint::{ViewBlueprint, ViewProperty};
 
 fn setup_scene(test_context: &mut TestContext, use_explicit_frames: bool) {
+    setup_scene_with_focal_length(test_context, use_explicit_frames, [2.0, 2.0]);
+}
+
+fn setup_scene_with_focal_length(
+    test_context: &mut TestContext,
+    use_explicit_frames: bool,
+    focal_length: [f32; 2],
+) {
     use ndarray::{Array, ShapeBuilder as _};
 
     let eye_position = glam::vec3(0.0, -1.0, 0.2);
@@ -19,7 +27,7 @@ fn setup_scene(test_context: &mut TestContext, use_explicit_frames: bool) {
     )
     .with_translation(eye_position);
     let camera_intrinsics =
-        archetypes::Pinhole::from_focal_length_and_resolution([2., 2.], [3., 2.])
+        archetypes::Pinhole::from_focal_length_and_resolution(focal_length, [3., 2.])
             .with_image_plane_distance(1.0);
     let camera_image = {
         let height = 2;
@@ -263,4 +271,31 @@ fn test_3d_in_2d_with_explicit_frames() {
 #[test]
 fn test_3d_in_2d_without_explicit_frames() {
     test_3d_in_2d(false);
+}
+
+#[test]
+fn test_anamorphic_3d_in_2d() {
+    let mut test_context = TestContext::new_with_view_class::<re_view_spatial::SpatialView2D>();
+    setup_scene_with_focal_length(&mut test_context, false, [3.0, 1.0]);
+
+    let view_id = test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+        blueprint.add_view_at_root(ViewBlueprint::new(
+            re_view_spatial::SpatialView2D::identifier(),
+            RecommendedView {
+                origin: "origin/camera".into(),
+                query_filter: EntityPathFilter::all(),
+            },
+        ))
+    });
+
+    let mut harness = test_context
+        .setup_kittest_for_rendering_3d([400.0, 300.0])
+        .build_ui(|ui| {
+            test_context.run_ui(ui, |ctx, ui| {
+                test_context.ui_for_single_view(ui, ctx, view_id);
+            });
+        });
+
+    harness.run();
+    harness.snapshot("anamorphic_3d_in_2d");
 }

--- a/crates/viewer/re_view_spatial/tests/snapshots/anamorphic_3d_in_2d.png
+++ b/crates/viewer/re_view_spatial/tests/snapshots/anamorphic_3d_in_2d.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1629d7f882706dbb9db9523988e3f4848da75485351d4dd018af5cf280b143fe
+size 10335


### PR DESCRIPTION
### Related

* Closes #11076
* Uses a narrower approach than the closed #11854

### What

Fixes 3D-to-2D projection for pinhole cameras with unequal focal lengths (`fx != fy`).

The transform layer already scales the image-plane X and Y axes independently and uses the harmonic mean of those inverse-focal scales for depth.
The 2D view camera must therefore use the reciprocal value—the arithmetic mean of `fx` and `fy`—for both its distance and its vertical field of view.
This makes the auxiliary image-plane distance cancel out and reproduces the pinhole equations on both axes without adding a renderer projection variant or changing shaders.

The change adds:

* a unit test comparing the complete virtual-camera transform with `u = fx * X / Z + cx` and `v = fy * Y / Z + cy`;
* a GPU snapshot test with `fx = 3` and `fy = 1`;
* no behavior change for regular pinholes where `fx == fy`.

![Anamorphic 3D-to-2D projection snapshot](https://github.com/Daniiiil1/rerun/blob/fix/anamorphic-camera-projection/crates/viewer/re_view_spatial/tests/snapshots/anamorphic_3d_in_2d.png?raw=true)

Local validation:

* `pixi run rs-fmt`
* `cargo clippy --all-features -p re_view_spatial --tests -- -D warnings`
* `cargo test --all-features --doc -p re_view_spatial`
* targeted unit and GPU snapshot tests: 2 passed
* full `re_view_spatial` nextest run: 106 passed; 3 existing image snapshots differed on this Metal host (two are 3D-only, and the 2D case uses `fx == fy`, where the old and new calculations are identical)

### Agent

🤖 This PR was opened by a coding agent.
