### PR TITLE
Sort TimePanel by nearness of data to cursor

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -1699,6 +1699,36 @@ impl TimeColumn {
         }
     }
 
+    /// Find the earliest time at or after `cursor` in this time column.
+    pub fn find_time_at_or_after(&self, cursor: TimeInt) -> Option<TimeInt> {
+        if self.is_sorted() {
+            let times = self.times_raw();
+            let idx = times.partition_point(|&t| t < cursor.as_i64());
+            (idx < times.len()).then(|| TimeInt::new_temporal(times[idx]))
+        } else {
+            self.times_raw()
+                .iter()
+                .filter(|&&t| t >= cursor.as_i64())
+                .min()
+                .map(|&t| TimeInt::new_temporal(t))
+        }
+    }
+
+    /// Find the latest time at or before `cursor` in this time column.
+    pub fn find_time_at_or_before(&self, cursor: TimeInt) -> Option<TimeInt> {
+        if self.is_sorted() {
+            let times = self.times_raw();
+            let idx = times.partition_point(|&t| t <= cursor.as_i64());
+            (idx > 0).then(|| TimeInt::new_temporal(times[idx - 1]))
+        } else {
+            self.times_raw()
+                .iter()
+                .filter(|&&t| t <= cursor.as_i64())
+                .max()
+                .map(|&t| TimeInt::new_temporal(t))
+        }
+    }
+
     /// Returns a new [`TimeColumn`] with all time values offset by `offset_ns` nanoseconds.
     ///
     /// Uses saturating arithmetic.

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -535,6 +535,108 @@ impl ChunkStore {
         Some(AbsoluteTimeRange::new(*start, *end))
     }
 
+    /// Returns the time of the earliest update for this entity, at or after `cursor`, on the
+    /// given timeline (ignoring static data).
+    ///
+    /// Looks inside chunks for individual row times (same prune + binary-search technique as
+    /// [`Self::next_time_on_timeline`], scoped to one entity). Intended for "what's coming up
+    /// next for this entity" sort/UI heuristics.
+    pub fn entity_time_at_or_after(
+        &self,
+        timeline: &TimelineName,
+        entity_path: &EntityPath,
+        cursor: TimeInt,
+    ) -> Option<TimeInt> {
+        re_tracing::profile_function!();
+
+        let temporal_chunk_ids_per_timeline =
+            self.temporal_chunk_ids_per_entity.get(entity_path)?;
+        let per_time = temporal_chunk_ids_per_timeline.get(timeline)?;
+
+        let mut result: Option<TimeInt> = None;
+
+        // Chunks whose start time is at or after the cursor.
+        for (&start_time, chunk_ids) in per_time.per_start_time.range(cursor..) {
+            if result.is_some_and(|r| r <= start_time) {
+                break;
+            }
+            for chunk_id in chunk_ids {
+                result = opt_min(
+                    result,
+                    self.search_chunk_by_time(timeline, chunk_id, |tc| {
+                        tc.find_time_at_or_after(cursor)
+                    }),
+                );
+            }
+        }
+
+        // Chunks that start before the cursor but may still contain times at or after it.
+        for (_start_time, chunk_ids) in per_time.per_start_time.range(..cursor).rev() {
+            for chunk_id in chunk_ids {
+                result = opt_min(
+                    result,
+                    self.search_chunk_by_time(timeline, chunk_id, |tc| {
+                        tc.find_time_at_or_after(cursor)
+                    }),
+                );
+            }
+        }
+
+        result
+    }
+
+    /// Returns the time of the most recent update for this entity, at or before `cursor`, on the
+    /// given timeline (ignoring static data).
+    ///
+    /// Looks inside chunks for individual row times (same prune + binary-search technique as
+    /// [`Self::prev_time_on_timeline`], scoped to one entity). Intended for "what just happened
+    /// for this entity" sort/UI heuristics.
+    pub fn entity_time_at_or_before(
+        &self,
+        timeline: &TimelineName,
+        entity_path: &EntityPath,
+        cursor: TimeInt,
+    ) -> Option<TimeInt> {
+        re_tracing::profile_function!();
+
+        let temporal_chunk_ids_per_timeline =
+            self.temporal_chunk_ids_per_entity.get(entity_path)?;
+        let per_time = temporal_chunk_ids_per_timeline.get(timeline)?;
+
+        let mut result: Option<TimeInt> = None;
+
+        // Chunks whose end time is at or before the cursor.
+        for (&end_time, chunk_ids) in per_time.per_end_time.range(..=cursor).rev() {
+            if result.is_some_and(|r| r >= end_time) {
+                break;
+            }
+            for chunk_id in chunk_ids {
+                result = opt_max(
+                    result,
+                    self.search_chunk_by_time(timeline, chunk_id, |tc| {
+                        tc.find_time_at_or_before(cursor)
+                    }),
+                );
+            }
+        }
+
+        // Chunks that end after the cursor but may still contain times at or before it.
+        for (_end_time, chunk_ids) in per_time.per_end_time.range(
+            (std::ops::Bound::Excluded(cursor), std::ops::Bound::Unbounded),
+        ) {
+            for chunk_id in chunk_ids {
+                result = opt_max(
+                    result,
+                    self.search_chunk_by_time(timeline, chunk_id, |tc| {
+                        tc.find_time_at_or_before(cursor)
+                    }),
+                );
+            }
+        }
+
+        result
+    }
+
     fn search_chunk_by_time(
         &self,
         timeline: &TimelineName,
@@ -1878,6 +1980,177 @@ mod tests {
         assert_eq!(
             store.prev_time_on_timeline(tl, TimeInt::new_temporal(10)),
             None
+        );
+    }
+
+    #[test]
+    fn entity_time_at_or_after_and_before_multi_row_chunk() {
+        let mut store = ChunkStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
+            crate::ChunkStoreConfig::ALL_DISABLED,
+        );
+
+        let entity_path: EntityPath = "entity".into();
+        let timeline = Timeline::new_sequence("frame");
+        let tl = timeline.name();
+        let point = MyPoint::new(1.0, 1.0);
+        let mut next_chunk_id = next_chunk_id_generator(0xDD);
+
+        // One chunk with three rows at times 10, 20, 30 — the in-chunk search must see past the
+        // chunk-start key (10) to find 20/30.
+        let chunk = Arc::new(
+            Chunk::builder_with_id(next_chunk_id(), entity_path.clone())
+                .with_component_batch(
+                    RowId::new(),
+                    TimePoint::from_iter([(timeline, 10)]),
+                    (
+                        MyPoints::descriptor_points(),
+                        &[point] as &dyn re_types_core::ComponentBatch,
+                    ),
+                )
+                .with_component_batch(
+                    RowId::new(),
+                    TimePoint::from_iter([(timeline, 20)]),
+                    (
+                        MyPoints::descriptor_points(),
+                        &[point] as &dyn re_types_core::ComponentBatch,
+                    ),
+                )
+                .with_component_batch(
+                    RowId::new(),
+                    TimePoint::from_iter([(timeline, 30)]),
+                    (
+                        MyPoints::descriptor_points(),
+                        &[point] as &dyn re_types_core::ComponentBatch,
+                    ),
+                )
+                .build()
+                .unwrap(),
+        );
+        store.insert_chunk(&chunk).unwrap();
+
+        // at_or_after: inclusive, looks inside the chunk.
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_path, TimeInt::new_temporal(0)),
+            Some(TimeInt::new_temporal(10))
+        );
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_path, TimeInt::new_temporal(10)),
+            Some(TimeInt::new_temporal(10))
+        );
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_path, TimeInt::new_temporal(15)),
+            Some(TimeInt::new_temporal(20))
+        );
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_path, TimeInt::new_temporal(20)),
+            Some(TimeInt::new_temporal(20))
+        );
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_path, TimeInt::new_temporal(25)),
+            Some(TimeInt::new_temporal(30))
+        );
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_path, TimeInt::new_temporal(30)),
+            Some(TimeInt::new_temporal(30))
+        );
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_path, TimeInt::new_temporal(31)),
+            None
+        );
+
+        // at_or_before: inclusive, looks inside the chunk.
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_path, TimeInt::new_temporal(99)),
+            Some(TimeInt::new_temporal(30))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_path, TimeInt::new_temporal(30)),
+            Some(TimeInt::new_temporal(30))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_path, TimeInt::new_temporal(25)),
+            Some(TimeInt::new_temporal(20))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_path, TimeInt::new_temporal(20)),
+            Some(TimeInt::new_temporal(20))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_path, TimeInt::new_temporal(15)),
+            Some(TimeInt::new_temporal(10))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_path, TimeInt::new_temporal(10)),
+            Some(TimeInt::new_temporal(10))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_path, TimeInt::new_temporal(9)),
+            None
+        );
+
+        // Missing entity / timeline.
+        let missing: EntityPath = "missing".into();
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &missing, TimeInt::new_temporal(0)),
+            None
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(
+                &TimelineName::from("other"),
+                &entity_path,
+                TimeInt::new_temporal(99)
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn entity_time_at_or_after_and_before_scoped_to_entity() {
+        let mut store = ChunkStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording, "test_app"),
+            crate::ChunkStoreConfig::ALL_DISABLED,
+        );
+
+        let timeline = Timeline::new_sequence("frame");
+        let tl = timeline.name();
+        let point = MyPoint::new(1.0, 1.0);
+        let mut next_chunk_id = next_chunk_id_generator(0xEE);
+
+        // Entity A has data at 10, 30.
+        // Entity B has data at 20, 40.
+        for (entity, times) in [("a", vec![10, 30]), ("b", vec![20, 40])] {
+            let entity_path: EntityPath = entity.into();
+            for t in times {
+                let chunk = create_chunk_with_point(
+                    next_chunk_id(),
+                    entity_path.clone(),
+                    TimePoint::from_iter([(timeline, t)]),
+                    point,
+                );
+                store.insert_chunk(&chunk).unwrap();
+            }
+        }
+
+        let entity_a: EntityPath = "a".into();
+        let entity_b: EntityPath = "b".into();
+
+        // Must not leak times from the other entity.
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_a, TimeInt::new_temporal(15)),
+            Some(TimeInt::new_temporal(30))
+        );
+        assert_eq!(
+            store.entity_time_at_or_after(tl, &entity_b, TimeInt::new_temporal(15)),
+            Some(TimeInt::new_temporal(20))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_a, TimeInt::new_temporal(35)),
+            Some(TimeInt::new_temporal(30))
+        );
+        assert_eq!(
+            store.entity_time_at_or_before(tl, &entity_b, TimeInt::new_temporal(35)),
+            Some(TimeInt::new_temporal(20))
         );
     }
 

--- a/crates/viewer/re_time_panel/src/streams_tree_data.rs
+++ b/crates/viewer/re_time_panel/src/streams_tree_data.rs
@@ -1,10 +1,11 @@
 use std::ops::{ControlFlow, Range};
 
 use itertools::Itertools as _;
+use re_chunk::TimelineName;
 use re_chunk_store::ChunkStore;
 use re_data_ui::{ArchetypeComponentMap, sorted_component_list_by_archetype_for_ui};
 use re_entity_db::{EntityTree, InstancePath};
-use re_log_types::{ComponentPath, EntityPath};
+use re_log_types::{ComponentPath, EntityPath, TimeInt};
 use re_sdk_types::ComponentDescriptor;
 use re_ui::filter_widget::{FilterMatcher, PathRanges};
 use re_viewer_context::{AppContext, CollapseScope, Item, ViewerContext, VisitorControlFlow};
@@ -23,6 +24,10 @@ impl StreamsTreeData {
         ctx: &ViewerContext<'_>,
         source: TimePanelSource,
         filter_matcher: &FilterMatcher,
+        // `Some((timeline, cursor, bin_width))` to sort by "temporal relevance" (closeness to
+        // `cursor`, in either direction, after rounding event times to the nearest multiple of
+        // `bin_width`) instead of the default hierarchical order.
+        temporal_relevance: Option<(TimelineName, TimeInt, i64)>,
     ) -> Self {
         re_tracing::profile_function!();
 
@@ -46,7 +51,7 @@ impl StreamsTreeData {
         // selection/hover state of the `/` entity is wrongly synchronized between both
         // stores, due to `Item::*` not tracking stores for entity paths.
 
-        Self {
+        let mut this = Self {
             children: match source {
                 TimePanelSource::Recording => root_data
                     .map(|entity_part_data| vec![entity_part_data])
@@ -55,7 +60,19 @@ impl StreamsTreeData {
                     .map(|entity_part_data| entity_part_data.children)
                     .unwrap_or_default(),
             },
+        };
+
+        if let Some((timeline, cursor, bin_width)) = temporal_relevance {
+            sort_children_by_temporal_relevance(
+                &mut this.children,
+                db_engine.store(),
+                &timeline,
+                cursor,
+                bin_width,
+            );
         }
+
+        this
     }
 
     /// Visit the entire tree.
@@ -247,6 +264,82 @@ impl EntityData {
             .item(self.item())
             .is_some_and(|collapse_id| collapse_id.is_open(egui_ctx).unwrap_or(self.default_open))
     }
+}
+
+/// Sorts `children` in place by "temporal relevance" -- closeness to `cursor`, in either
+/// direction -- recursively, depth-first, and returns the best (smallest) aggregate distance
+/// among them, considering both each child's own data and, recursively, all of its descendants'.
+///
+/// We deliberately sort by *distance* rather than only "next upcoming" or only "most recent
+/// past": a purely directional key saw an entity's rank sawtooth across its *entire* update
+/// interval every time the cursor passed one of its events (e.g. an entity that updates every
+/// 5s would drift up to 5s "away" right after each event, only to snap close again just before
+/// the next one). Distance-to-cursor halves that swing, since the moment you pass an event's
+/// midpoint to the next one, the nearer neighbor flips to the one just passed -- same idea,
+/// meaningfully less shuffling as the cursor moves. It also means we don't need to track which
+/// way the user last scrubbed at all.
+///
+/// Entities (and subtrees) with no temporal data on this timeline always sort last, after every
+/// entity that has some.
+///
+/// `bin_width` (a value of 0 disables it) rounds both `cursor` and every candidate event time to
+/// the nearest multiple of `bin_width` before computing distances, so that near-simultaneous
+/// events end up tied instead of causing constant reordering over trivial differences (repeated
+/// updates a few ms apart on a live-streaming entity, several components on the same entity
+/// logged in separate calls, etc).
+fn sort_children_by_temporal_relevance(
+    children: &mut Vec<EntityData>,
+    store: &ChunkStore,
+    timeline: &TimelineName,
+    cursor: TimeInt,
+    bin_width: i64,
+) -> Option<u64> {
+    let binned_cursor = round_to_bin(cursor.as_i64(), bin_width);
+
+    let mut keyed: Vec<(Option<u64>, EntityData)> = std::mem::take(children)
+        .into_iter()
+        .map(|mut child| {
+            let best_descendant = sort_children_by_temporal_relevance(
+                &mut child.children,
+                store,
+                timeline,
+                cursor,
+                bin_width,
+            );
+            let after = store.entity_time_at_or_after(timeline, &child.entity_path, cursor);
+            let before = store.entity_time_at_or_before(timeline, &child.entity_path, cursor);
+            let own_distance = [after, before]
+                .into_iter()
+                .flatten()
+                .map(|time| round_to_bin(time.as_i64(), bin_width).abs_diff(binned_cursor))
+                .min();
+            let key = [own_distance, best_descendant].into_iter().flatten().min();
+
+            (key, child)
+        })
+        .collect();
+
+    keyed.sort_by_key(|(key, _)| key.unwrap_or(u64::MAX));
+
+    let best = keyed.first().and_then(|(key, _)| *key);
+    *children = keyed.into_iter().map(|(_, child)| child).collect();
+    best
+}
+
+/// Rounds `value` to the nearest multiple of `bin_width` (a `bin_width` of 0 or less is a no-op).
+///
+/// Uses integer arithmetic throughout (never converts through `f64`) since these are nanosecond
+/// timestamps that can exceed `f64`'s 53-bit exact-integer range.
+fn round_to_bin(value: i64, bin_width: i64) -> i64 {
+    if bin_width <= 0 {
+        return value;
+    }
+    // Saturating throughout: `value` can be the `TimeInt::MIN` sentinel (used before any time
+    // cursor is set), and rounding that can otherwise overshoot `i64::MIN` on the final multiply.
+    value
+        .saturating_add(bin_width / 2)
+        .div_euclid(bin_width)
+        .saturating_mul(bin_width)
 }
 
 /// Lists the components to be displayed for the given entity

--- a/crates/viewer/re_time_panel/src/time_panel.rs
+++ b/crates/viewer/re_time_panel/src/time_panel.rs
@@ -4,18 +4,20 @@ use egui::{
     Align, CursorIcon, Modifiers, NumExt as _, Painter, PointerButton, Rect, Response, RichText,
     TextEdit, Ui, Vec2, WidgetInfo, WidgetType,
 };
+use re_chunk::TimelineName;
 use re_context_menu::{SelectionUpdateBehavior, context_menu_ui_for_item_with_context};
 use re_data_ui::DataUi as _;
 use re_entity_db::InstancePath;
 use re_entity_db::entity_db::RedapConnectionState;
 use re_log_types::{
     AbsoluteTimeRange, AbsoluteTimeRangeF, ApplicationId, ComponentPath, EntityPath, TimeInt,
-    TimeReal,
+    TimeReal, TimeType,
 };
 use re_sdk_types::ComponentIdentifier;
 use re_sdk_types::blueprint::components::PanelState;
 use re_sdk_types::reflection::ComponentDescriptorExt as _;
 use re_ui::filter_widget::format_matching_text;
+use re_ui::list_item::ListItemContentButtonsExt as _;
 use re_ui::{
     ContextExt as _, DesignTokens, Help, IconText, ReButton, Size, UiExt as _, Variant,
     filter_widget, icons, list_item,
@@ -148,6 +150,26 @@ pub struct TimePanel {
     /// If we're hovering a specific event - what time is it?
     #[serde(skip)]
     hovered_event_time: Option<TimeInt>,
+
+    /// Whether the streams tree is sorted by "temporal relevance" (closeness to the current time
+    /// cursor, in either direction) instead of the default alphabetical/hierarchical order.
+    temporal_relevance_sort: bool,
+
+    /// The cursor value the temporal-relevance sort is currently using, held fixed for the
+    /// duration of a pointer press. See `tree_ui` for why.
+    #[serde(skip)]
+    temporal_relevance_reference: Option<(TimelineName, TimeInt)>,
+
+    /// A time-cursor jump requested by clicking a row's data density graph, held back one frame
+    /// before being turned into a `TimeControlCommand`.
+    ///
+    /// Clicking a row both selects it and jumps the cursor to the clicked point. If the cursor
+    /// moves in the very same frame the selection is made, the temporal-relevance sort (which is
+    /// keyed off the cursor) reshuffles the list before the selection has had a chance to land,
+    /// so the click can appear to hit the wrong row. Applying the jump a frame late gives the
+    /// selection a full frame to settle on the list as it stood when clicked.
+    #[serde(skip)]
+    pending_time_jump: Option<TimeReal>,
 }
 
 impl Default for TimePanel {
@@ -167,6 +189,9 @@ impl Default for TimePanel {
             scroll_to_me_item: None,
             time_edit_string: None,
             hovered_event_time: None,
+            temporal_relevance_sort: false,
+            temporal_relevance_reference: None,
+            pending_time_jump: None,
         }
     }
 }
@@ -227,6 +252,13 @@ impl TimePanel {
         self.hovered_event_time = None;
 
         let mut time_commands = Vec::new();
+
+        // A jump requested by a row click last frame: apply it now, one frame after the click,
+        // so the selection made by that same click gets a frame to settle before the
+        // temporal-relevance sort reacts to the new cursor. See `pending_time_jump`.
+        if let Some(time) = self.pending_time_jump.take() {
+            time_commands.push(TimeControlCommand::SetTimeClamped(time));
+        }
 
         // this is the size of everything above the central panel (window title bar, top bar on web,
         // etc.)
@@ -593,15 +625,7 @@ impl TimePanel {
                 ui.spacing_mut().item_spacing.y = 0.0;
 
                 ui.full_span_scope(0.0..=time_x_left, |ui| {
-                    self.filter_state.section_title_ui(
-                        ui,
-                        egui::RichText::new(if self.source == TimePanelSource::Blueprint {
-                            "Blueprint Streams"
-                        } else {
-                            "Streams"
-                        })
-                        .strong(),
-                    );
+                    self.streams_section_title_ui(ui);
                 });
             })
             .response
@@ -766,11 +790,57 @@ impl TimePanel {
 
                 let filter_matcher = self.filter_state.filter();
 
+                let temporal_relevance = self.temporal_relevance_sort.then(|| {
+                    let timeline = *store_ctx.time_ctrl.timeline_name();
+                    let live_cursor = store_ctx.time_ctrl.time_int().unwrap_or(TimeInt::MIN);
+
+                    // Freeze the sort's reference cursor for the duration of a press.
+                    //
+                    // `data_density_graph_ui`'s click handling checks the frame-global
+                    // `pointer.primary_clicked()`, not a per-row `egui::Response` -- so it doesn't
+                    // have egui's usual guarantee that a click is attributed to whichever widget
+                    // was actually under the pointer at *press* time. It's decided fresh, by
+                    // whichever row's rect the pointer happens to be over on the *release* frame.
+                    // If the list reorders in between -- whether from this very press moving the
+                    // cursor, or just from a live/playing recording advancing it on its own -- the
+                    // release can land on a different entity than the one that was pressed.
+                    // Holding the sort still for the whole press means the list can't reorder out
+                    // from under the pointer mid-click, regardless of why the cursor is moving.
+                    let cursor = if ui.input(|i| i.pointer.primary_down()) {
+                        match self.temporal_relevance_reference {
+                            Some((ref_timeline, ref_cursor)) if ref_timeline == timeline => {
+                                ref_cursor
+                            }
+                            _ => {
+                                self.temporal_relevance_reference = Some((timeline, live_cursor));
+                                live_cursor
+                            }
+                        }
+                    } else {
+                        self.temporal_relevance_reference = None;
+                        live_cursor
+                    };
+
+                    // Bin event times to a coarse, fixed-size grid before comparing distances,
+                    // so that near-simultaneous events (repeated updates on a live-streaming
+                    // entity, several components logged a few ms apart, etc.) tie instead of
+                    // causing constant reordering over trivial differences. This is a
+                    // data-precision concern, not a zoom concern, so the bin size is a fixed
+                    // real-world duration rather than scaled to the visible time span.
+                    let bin_width_ns: i64 = match store_ctx.time_ctrl.time_type() {
+                        Some(TimeType::DurationNs | TimeType::TimestampNs) => 100_000_000, // 0.1s
+                        _ => 0, // sequence timelines have no natural sub-unit to bin away
+                    };
+
+                    (timeline, cursor, bin_width_ns)
+                });
+
                 let streams_tree_data =
                     crate::streams_tree_data::StreamsTreeData::from_source_and_filter(
                         viewer_ctx,
                         self.source,
                         &filter_matcher,
+                        temporal_relevance,
                     );
 
                 // If an item is focused, expand every node leading to it so it becomes visible
@@ -808,6 +878,67 @@ impl TimePanel {
                     );
                 }
             });
+    }
+
+    fn streams_section_title_ui(&mut self, ui: &mut egui::Ui) {
+        let title = egui::RichText::new(if self.source == TimePanelSource::Blueprint {
+            "Blueprint Streams"
+        } else {
+            "Streams"
+        })
+        .strong();
+
+        // While searching, fall back to the filter widget's built-in title/search UI.
+        // Sort stays active if already enabled; the toggle is shown when not searching.
+        if self.filter_state.is_active() {
+            self.filter_state.section_title_ui(ui, title);
+            return;
+        }
+
+        let mut activate_search = false;
+        let mut temporal_relevance_sort = self.temporal_relevance_sort;
+
+        list_item::list_item_scope(ui, "streams_section_title", |ui| {
+            ui.list_item()
+                .interactive(false)
+                .force_background(ui.tokens().section_header_color)
+                .show_flat(
+                    ui,
+                    list_item::LabelContent::new(title)
+                        .with_always_show_buttons(true)
+                        // `LabelContent::desired_width` only measures the title text -- it has
+                        // no idea buttons are attached -- so without this, the row gets sized to
+                        // fit "Streams" alone (during egui's sizing pass, which then sticks for
+                        // every following frame) and the buttons render with nowhere to go.
+                        .min_desired_width(150.0)
+                        // Right-to-left: right-most button first.
+                        .with_action_button(&icons::SEARCH, "Search", || {
+                            activate_search = true;
+                        })
+                        .with_buttons(|ui| {
+                            let mut response = ui.add(
+                                ui.small_icon_button_widget(
+                                    &icons::VIEW_STATE_TIMELINE,
+                                    "Sort streams by temporal relevance",
+                                )
+                                .selected(temporal_relevance_sort),
+                            );
+                            if response.clicked() {
+                                temporal_relevance_sort = !temporal_relevance_sort;
+                                response.mark_changed();
+                            }
+                            response.on_hover_text(
+                                "Sort streams by closeness to the current time cursor \
+                                 (nearest update, before or after, first).",
+                            );
+                        }),
+                );
+        });
+
+        self.temporal_relevance_sort = temporal_relevance_sort;
+        if activate_search {
+            self.filter_state.activate("");
+        }
     }
 
     /// Display the list item for an entity.
@@ -947,14 +1078,7 @@ impl TimePanel {
 
                 // show the density graph only if that item is closed
                 if is_closed {
-                    self.data_density_graph_ui(
-                        store_ctx,
-                        time_area_painter,
-                        ui,
-                        row_rect,
-                        &item,
-                        time_commands,
-                    );
+                    self.data_density_graph_ui(store_ctx, time_area_painter, ui, row_rect, &item);
                 }
             }
         }
@@ -1145,7 +1269,6 @@ impl TimePanel {
                             ui,
                             row_rect,
                             &item,
-                            time_commands,
                         );
                     }
                 }
@@ -1200,7 +1323,6 @@ impl TimePanel {
         ui: &egui::Ui,
         row_rect: Rect,
         item: &TimePanelItem,
-        time_commands: &mut Vec<TimeControlCommand>,
     ) {
         let hovered_time = data_density_graph::data_density_graph_ui(
             &mut self.data_density_graph_painter,
@@ -1221,7 +1343,14 @@ impl TimePanel {
                 ctx.command_sender
                     .send_system(SystemCommand::SetSelection(item.to_item().into()));
 
-                time_commands.push(TimeControlCommand::SetTimeClamped(hovered_time.into()));
+                // Deferred by a frame -- see `pending_time_jump`.
+                self.pending_time_jump = Some(hovered_time.into());
+
+                // The temporal-relevance sort can relocate this row once the cursor jump lands
+                // (e.g. clicking a row far down a long scrolled list can send its own row to the
+                // very top). Without this, the newly-selected row can scroll out of view, making
+                // the click look like it did nothing.
+                self.scroll_to_me_item = Some(item.to_item());
             } else {
                 ctx.selection_state().set_hovered(item.to_item());
             }


### PR DESCRIPTION
### Related

None that I found

### What

When searching around a recording with a lot of entities, like a Revy recording, it can be hard to find where the action is. With this PR, the TimePanel's list of entities is sorted (stably) so that entities with data near the time-cursor are at the top. This makes it easy to skip around the recording and see what is acting, when.

This PR is not ready for merge, it is missing:

1. Performance review -- I suspect that as implemented this is too slow for rerun's intended data sizes; nothing is cached between frames
2. Changelog entry


Demo

<img width="2304" height="338" alt="rerun-2" src="https://github.com/user-attachments/assets/4739af55-5131-470e-a009-da519f70e38a" />
