### PR TITLE
Print the full anyhow context chain in error messages

### DIFF
--- a/crates/store/re_mcap/src/error.rs
+++ b/crates/store/re_mcap/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     #[error("Channel {0} does not define a schema")]
     NoSchema(String),
 
-    #[error("Invalid schema {schema}: {source}")]
+    #[error("Invalid schema {schema}: {source:#}")]
     InvalidSchema {
         schema: String,
         source: anyhow::Error,
@@ -30,7 +30,7 @@ pub enum Error {
     #[error(transparent)]
     Chunk(#[from] re_chunk::ChunkError),
 
-    #[error(transparent)]
+    #[error("{0:#}")]
     Other(#[from] anyhow::Error),
 }
 

--- a/crates/store/re_mcap/src/parsers/cdr.rs
+++ b/crates/store/re_mcap/src/parsers/cdr.rs
@@ -74,6 +74,6 @@ pub enum CdrError {
     #[error("Message is not encoded using a CDR representation: `{0:?}`")]
     UnsupportedRepresentation(RepresentationIdentifier),
 
-    #[error("{0}")]
+    #[error("{0:#}")]
     Other(#[from] anyhow::Error),
 }

--- a/crates/store/re_parquet/src/streaming.rs
+++ b/crates/store/re_parquet/src/streaming.rs
@@ -31,7 +31,7 @@ pub enum ParquetError {
     #[error(transparent)]
     Arrow(#[from] arrow::error::ArrowError),
 
-    #[error(transparent)]
+    #[error("{0:#}")]
     Other(#[from] anyhow::Error),
 }
 

--- a/crates/store/re_server/src/store/error.rs
+++ b/crates/store/re_server/src/store/error.rs
@@ -56,7 +56,7 @@ pub enum Error {
     #[error(transparent)]
     LanceError(#[from] lance::Error),
 
-    #[error("Error loading RRD: {0}")]
+    #[error("Error loading RRD: {0:#}")]
     RrdLoadingError(anyhow::Error),
 
     #[error("Failed to encode chunk key: {0}")]

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -842,7 +842,7 @@ where
                 .downcast_ref::<std::io::Error>()
                 .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::AddrInUse) =>
         {
-            re_log::warn!("{err}");
+            re_log::warn!("{err:#}");
             Ok(1)
         }
 


### PR DESCRIPTION
### What

`anyhow::Error`'s `Display` impl only prints the outermost context, so the root cause is silently dropped (#8681). The alternate format, `{:#}`, walks the whole chain instead.

This fixes the places where an `anyhow::Error` was being flattened:

- `re_mcap::Error::InvalidSchema` — `{source}` → `{source:#}`
- `re_mcap::Error::Other` — `#[error(transparent)]` → `#[error("{0:#}")]`
- `re_mcap::parsers::cdr::CdrError::Other` — `{0}` → `{0:#}`
- `re_parquet::ParquetError::Other` — `#[error(transparent)]` → `#[error("{0:#}")]`
- `re_server`'s `Error::RrdLoadingError` — `{0}` → `{0:#}`
- the top-level `AddrInUse` warning in `entrypoint.rs`

This matches the pattern already used elsewhere in the codebase (`ChunkStoreError::VideoRebatch` uses `{0:#}`, and `re_query`/`re_importer`/`re_lerobot` use `re_error::format`).

The `#[from]` attribute still designates the field as the error `source()`, so replacing `transparent` with an explicit format string does not break source chaining.

Part of #8681.