### PR TITLE
Improve TextLog view performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11103,7 +11103,6 @@ dependencies = [
  "re_entity_db",
  "re_log",
  "re_log_types",
- "re_query",
  "re_sdk_types",
  "re_test_context",
  "re_test_viewport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11093,12 +11093,13 @@ name = "re_view_text_log"
 version = "0.37.0-alpha.1+dev"
 dependencies = [
  "egui",
- "egui_extras",
+ "egui_table",
  "itertools 0.15.0",
  "re_byte_size",
  "re_chunk",
  "re_chunk_store",
  "re_data_ui",
+ "re_dataframe_ui",
  "re_entity_db",
  "re_log",
  "re_log_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11094,7 +11094,6 @@ version = "0.37.0-alpha.1+dev"
 dependencies = [
  "egui",
  "egui_table",
- "itertools 0.15.0",
  "re_byte_size",
  "re_chunk",
  "re_chunk_store",

--- a/crates/viewer/re_view_text_log/Cargo.toml
+++ b/crates/viewer/re_view_text_log/Cargo.toml
@@ -35,7 +35,6 @@ re_viewport_blueprint.workspace = true
 
 egui_table.workspace = true
 egui.workspace = true
-itertools.workspace = true
 
 [dev-dependencies]
 re_chunk.workspace = true

--- a/crates/viewer/re_view_text_log/Cargo.toml
+++ b/crates/viewer/re_view_text_log/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 re_byte_size.workspace = true
 re_chunk_store.workspace = true
 re_data_ui.workspace = true
+re_dataframe_ui.workspace = true
 re_entity_db.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
@@ -33,7 +34,7 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 
-egui_extras.workspace = true
+egui_table.workspace = true
 egui.workspace = true
 itertools.workspace = true
 

--- a/crates/viewer/re_view_text_log/Cargo.toml
+++ b/crates/viewer/re_view_text_log/Cargo.toml
@@ -26,7 +26,6 @@ re_dataframe_ui.workspace = true
 re_entity_db.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
-re_query.workspace = true
 re_view.workspace = true
 re_tracing.workspace = true
 re_sdk_types.workspace = true

--- a/crates/viewer/re_view_text_log/src/lib.rs
+++ b/crates/viewer/re_view_text_log/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! A View that shows `TextLog` entries in a table and scrolls with the active time.
 
-mod scroll_geometry;
+mod row_layout;
 mod view_class;
 mod visualizer_system;
 

--- a/crates/viewer/re_view_text_log/src/lib.rs
+++ b/crates/viewer/re_view_text_log/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! A View that shows `TextLog` entries in a table and scrolls with the active time.
 
+mod scroll_geometry;
 mod view_class;
 mod visualizer_system;
 

--- a/crates/viewer/re_view_text_log/src/row_layout.rs
+++ b/crates/viewer/re_view_text_log/src/row_layout.rs
@@ -1,22 +1,44 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::Range;
-use std::sync::Arc;
 
 use re_chunk_store::external::arrow::array::{
     Array as _, ListArray as ArrowListArray, StringArray as ArrowStringArray,
+    UInt32Array as ArrowUInt32Array,
 };
-use re_chunk_store::{
-    AbsoluteTimeRange, Chunk, ChunkId, ChunkStore, ChunkStoreEvent, ChunkTrackingMode, RangeQuery,
-    TimeInt,
-};
+use re_chunk_store::{AbsoluteTimeRange, Chunk, ChunkId, ChunkStoreEvent, TimeInt};
 use re_entity_db::EntityPath;
 use re_log_types::TimelineName;
 use re_sdk_types::ComponentIdentifier;
+use re_sdk_types::components::Color;
 use re_viewer_context::Cache;
 
-/// An explicit log level filter: only rows whose level is in the set are shown.
+/// Blueprint overrides and view defaults for an entity's text log rows.
 ///
-/// Rows without a level always pass.
+/// Both are per-entity constants (a blueprint override/default is a single latest-at value),
+/// which is what keeps them compatible with the metadata-derived row layout: they never
+/// require per-row joins. A row's effective level/color is resolved as
+/// override > the row's own value > view default.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct RowOverrides {
+    pub level_override: Option<String>,
+    pub level_default: Option<String>,
+    pub color_override: Option<Color>,
+    pub color_default: Option<Color>,
+}
+
+impl RowOverrides {
+    /// The level a row effectively has: override > the row's own level > default.
+    fn effective_level<'a>(&'a self, row_level: Option<&'a str>) -> Option<&'a str> {
+        self.level_override
+            .as_deref()
+            .or(row_level)
+            .or(self.level_default.as_deref())
+    }
+}
+
+/// An explicit log level filter: only rows whose (effective) level is in the set are shown.
+///
+/// Rows without any level always pass.
 #[derive(Clone, PartialEq, Eq)]
 pub struct LevelFilter(pub BTreeSet<String>);
 
@@ -37,8 +59,27 @@ pub struct LevelCounts {
 }
 
 impl LevelCounts {
-    fn matching(&self, filter: &LevelFilter) -> u64 {
-        self.unleveled
+    fn total(&self) -> u64 {
+        self.unleveled + self.per_level.values().sum::<u64>()
+    }
+
+    fn matching(&self, filter: &LevelFilter, overrides: &RowOverrides) -> u64 {
+        // An override applies to every row alike: all or nothing.
+        if let Some(lvl) = &overrides.level_override {
+            return if filter.0.contains(lvl) {
+                self.total()
+            } else {
+                0
+            };
+        }
+
+        // A default only applies to rows without their own level.
+        let unleveled = match &overrides.level_default {
+            Some(default) if !filter.0.contains(default) => 0,
+            _ => self.unleveled,
+        };
+
+        unleveled
             + filter
                 .0
                 .iter()
@@ -55,12 +96,11 @@ impl re_byte_size::SizeBytes for LevelCounts {
 
 /// Per-chunk [`LevelCounts`], computed once per chunk and shared by all text log views.
 ///
-/// Chunks are immutable, so an entry stays valid until the chunk is evicted from the store,
-/// which is what makes level-filtered row counts as cheap as unfiltered ones after the first frame.
+/// Chunks are immutable, so an entry stays valid until the chunk is evicted from the store
+/// (deleted or compacted away), which is what makes level-filtered row counts (and the set
+/// of levels offered by the filter UI) as cheap as unfiltered ones after a chunk's first frame.
 #[derive(Default)]
-pub struct LevelCountCache(
-    BTreeMap<(ChunkId, ComponentIdentifier, ComponentIdentifier), LevelCounts>,
-);
+pub struct LevelCountCache(BTreeMap<ChunkId, LevelCounts>);
 
 impl LevelCountCache {
     fn counts_for(
@@ -70,7 +110,7 @@ impl LevelCountCache {
         level_component: ComponentIdentifier,
     ) -> &LevelCounts {
         self.0
-            .entry((chunk.id(), component, level_component))
+            .entry(chunk.id())
             .or_insert_with(|| level_counts_for_chunk(chunk, component, level_component))
     }
 }
@@ -100,8 +140,7 @@ impl Cache for LevelCountCache {
             return;
         }
 
-        self.0
-            .retain(|(chunk_id, _, _), _| !deleted.contains(chunk_id));
+        self.0.retain(|chunk_id, _| !deleted.contains(chunk_id));
     }
 }
 
@@ -124,24 +163,32 @@ struct ChunkSpan {
 
     is_static: bool,
 
-    chunk: Arc<Chunk>,
+    chunk: Chunk,
+
+    /// Blueprint overrides/defaults of the chunk's entity.
+    overrides: RowOverrides,
 }
 
 /// Row layout of the text log table, derived from chunk-level metadata only.
 ///
-/// This is what allows the view to know how many rows there are, without touching any row data:
-/// row counts come from the per-chunk validity bitmaps (or, with a level filter active, from cached
-/// per-chunk level counts) and are exact, and only locating a time window boundary *inside* a chunk requires
-/// looking at that chunk's time column.
+/// This is what allows the view to know how many rows there are without touching any row data:
+/// row counts come from the per-chunk validity bitmaps (or, with a level filter active, from
+/// cached per-chunk level counts) and are exact, and only locating a time boundary *inside* a
+/// chunk requires looking at that chunk's time column.
 ///
 /// Rows are ordered with static rows first, then by time.
 /// Where chunks of different entities overlap in time, the layout is approximate at chunk
-/// granularity, but stable since the visible window itself is always rendered in exact time order.
+/// granularity, but stable since the visible window itself is always rendered in exact time
+/// order (see [`Self::visible_rows`]).
+///
+/// Owns the (cheaply cloned, arrow-backed) chunks it was built from, so resolving visible
+/// rows and reading their data needs no further store access.
 #[derive(Clone)]
 pub struct RowLayout {
     timeline: TimelineName,
     component: ComponentIdentifier,
     level_component: ComponentIdentifier,
+    color_component: ComponentIdentifier,
 
     /// The active level filter; when set, all row counts only cover matching rows.
     filter: Option<LevelFilter>,
@@ -156,97 +203,99 @@ pub struct RowLayout {
 
     /// All log levels that occur anywhere in the considered chunks.
     levels: BTreeSet<String>,
-
-    /// Chunks that the store knows of but that aren't loaded; row counts are incomplete.
-    //
-    // TODO(gijsd): once this is fed from the `RrdManifestIndex`, unloaded chunks can
-    // contribute their row counts too, making the layout complete in streaming scenarios.
-    pub any_missing: bool,
 }
 
 impl RowLayout {
-    /// Build a row layout for the given entities and timeline, optionally applying a level filter.
+    /// Build a row layout for the given text log chunks, optionally applying a level filter.
     ///
-    /// Note: the level counting is done on the raw store data: blueprint overrides of the
-    /// `level` component are not taken into account by `filter`.
-    pub fn build<'a>(
-        store: &ChunkStore,
+    /// The chunks are expected to come from a range query for `component`
+    /// (see `TextLogSystem::execute`), i.e. every row holds a text value.
+    ///
+    /// `overrides` carries the per-entity blueprint overrides and view defaults for
+    /// level/color; the filter counts rows by their *effective* level, so counts and
+    /// displayed rows always agree.
+    pub fn build(
+        chunks: Vec<Chunk>,
         timeline: &TimelineName,
         component: ComponentIdentifier,
         level_component: ComponentIdentifier,
-        entities: impl Iterator<Item = &'a EntityPath>,
+        color_component: ComponentIdentifier,
         filter: Option<&LevelFilter>,
+        overrides: &HashMap<EntityPath, RowOverrides>,
         level_counts: &mut LevelCountCache,
     ) -> Self {
         re_tracing::profile_function!();
 
-        let query = RangeQuery::new(*timeline, AbsoluteTimeRange::EVERYTHING);
-
-        let mut chunks = Vec::new();
+        let mut spans = Vec::new();
         let mut levels = BTreeSet::new();
-        let mut any_missing = false;
 
-        for entity_path in entities {
-            // don't trigger chunk downloads just to compute the row layout.
-            let results = store.range_relevant_chunks(
-                ChunkTrackingMode::Ignore,
-                &query,
-                entity_path,
-                component,
-            );
-            any_missing |= !results.missing_virtual.is_empty();
-
-            for chunk in results.chunks {
-                let Some(total_rows) = chunk.num_events_for_component(component) else {
-                    continue;
-                };
-                if total_rows == 0 {
-                    continue;
-                }
-
-                // One-time scan per chunk (chunks are immutable, so the cache never goes stale)
-                // this is what makes level-filtered row counts viable
-                let counts = level_counts.counts_for(&chunk, component, level_component);
-                levels.extend(counts.per_level.keys().cloned());
-
-                let num_rows = match filter {
-                    Some(filter) => counts.matching(filter),
-                    None => total_rows,
-                };
-                if num_rows == 0 {
-                    continue;
-                }
-
-                let is_static = chunk.is_static();
-                let time_range = if is_static {
-                    AbsoluteTimeRange::EMPTY
-                } else if let Some(time_column) = chunk.timelines().get(timeline) {
-                    time_column.time_range()
-                } else {
-                    continue;
-                };
-
-                chunks.push(ChunkSpan {
-                    time_range,
-                    num_rows,
-                    is_static,
-                    chunk,
-                });
+        for chunk in chunks {
+            let Some(total_rows) = chunk.num_events_for_component(component) else {
+                continue;
+            };
+            if total_rows == 0 {
+                continue;
             }
+
+            let chunk_overrides = overrides
+                .get(chunk.entity_path())
+                .cloned()
+                .unwrap_or_default();
+
+            // One-time scan per chunk (chunks are immutable, so the counts never go stale);
+            // this is what makes level-filtered row counts viable.
+            let counts = level_counts.counts_for(&chunk, component, level_component);
+
+            // Offer exactly the levels that can show up in the table.
+            if let Some(lvl) = &chunk_overrides.level_override {
+                levels.insert(lvl.clone());
+            } else {
+                levels.extend(counts.per_level.keys().cloned());
+                if counts.unleveled > 0
+                    && let Some(default) = &chunk_overrides.level_default
+                {
+                    levels.insert(default.clone());
+                }
+            }
+
+            let num_rows = match filter {
+                Some(filter) => counts.matching(filter, &chunk_overrides),
+                None => total_rows,
+            };
+            if num_rows == 0 {
+                continue;
+            }
+
+            let is_static = chunk.is_static();
+            let time_range = if is_static {
+                AbsoluteTimeRange::EMPTY
+            } else if let Some(time_column) = chunk.timelines().get(timeline) {
+                time_column.time_range()
+            } else {
+                continue;
+            };
+
+            spans.push(ChunkSpan {
+                time_range,
+                num_rows,
+                is_static,
+                chunk,
+                overrides: chunk_overrides,
+            });
         }
 
         // Static chunks first, then by time.
-        chunks.sort_by_key(|span| (!span.is_static, span.time_range.min(), span.chunk.id()));
+        spans.sort_by_key(|span| (!span.is_static, span.time_range.min(), span.chunk.id()));
 
-        let mut prefix_rows = Vec::with_capacity(chunks.len() + 1);
+        let mut prefix_rows = Vec::with_capacity(spans.len() + 1);
         let mut total = 0;
         prefix_rows.push(0);
-        for span in &chunks {
+        for span in &spans {
             total += span.num_rows;
             prefix_rows.push(total);
         }
 
-        let num_static_rows = chunks
+        let num_static_rows = spans
             .iter()
             .take_while(|span| span.is_static)
             .map(|span| span.num_rows)
@@ -256,12 +305,12 @@ impl RowLayout {
             timeline: *timeline,
             component,
             level_component,
+            color_component,
             filter: filter.cloned(),
-            chunks,
+            chunks: spans,
             prefix_rows,
             num_static_rows,
             levels,
-            any_missing,
         }
     }
 
@@ -273,10 +322,6 @@ impl RowLayout {
     /// Total number of text log rows (static and temporal).
     pub fn num_rows(&self) -> u64 {
         self.prefix_rows.last().copied().unwrap_or(0)
-    }
-
-    pub fn num_static_rows(&self) -> u64 {
-        self.num_static_rows
     }
 
     /// Number of rows strictly before time `t`: all static rows plus temporal rows with time < `t`.
@@ -299,24 +344,156 @@ impl RowLayout {
             if span.time_range.max() < t {
                 count += span.num_rows;
             } else {
-                count += count_rows_before_in_chunk(
-                    &span.chunk,
-                    &self.timeline,
-                    self.component,
-                    self.level_component,
-                    self.filter.as_ref(),
-                    t,
-                );
+                count += self.count_rows_before_in_chunk(span, t);
             }
         }
         count
     }
 
+    /// Resolves the rows of the table that are currently on screen.
+    ///
+    /// This is the only place where actual row data (time and level columns) is touched, and
+    /// it only looks inside the chunks overlapping the visible time window.
+    pub fn visible_rows(&self, rows: Range<u64>) -> VisibleRows {
+        re_tracing::profile_function!();
+
+        // Static rows sit at the top of the table; there are usually only a handful,
+        // so resolve all of them whenever any is visible.
+        let mut static_rows = Vec::new();
+        if rows.start < self.num_static_rows {
+            for (span_idx, span) in self.chunks.iter().enumerate() {
+                if !span.is_static {
+                    break;
+                }
+                self.collect_span_rows(span_idx, span, None, &mut static_rows);
+            }
+        }
+
+        // For the temporal part, resolve *all* rows within the time window covered by the
+        // visible rows' chunks: that guarantees exact global row indices (offset by the exact
+        // number of rows before the window), even where chunks of different entities overlap.
+        let temporal = rows.start.max(self.num_static_rows)..rows.end.max(self.num_static_rows);
+        let mut temporal_offset = 0;
+        let mut temporal_rows = Vec::new();
+        if temporal.start < temporal.end
+            && let Some((min, max)) = self.time_window_for_rows(temporal)
+        {
+            temporal_offset = self.rows_before(min);
+
+            for (span_idx, span) in self.chunks.iter().enumerate() {
+                if span.is_static {
+                    continue;
+                }
+                if span.time_range.min() > max {
+                    break;
+                }
+                if span.time_range.max() < min {
+                    continue;
+                }
+                self.collect_span_rows(span_idx, span, Some((min, max)), &mut temporal_rows);
+            }
+
+            // Sort is stable, so rows with equal times stay in chunk order,
+            // consistent with how `rows_before` counts them.
+            temporal_rows.sort_by_key(|row| row.time);
+        }
+
+        VisibleRows {
+            num_static_rows: self.num_static_rows,
+            static_rows,
+            temporal_offset,
+            temporal_rows,
+        }
+    }
+
+    /// The data of a single row: the underlying chunk row, with the entity's blueprint
+    /// overrides/defaults applied.
+    pub fn row_data(&self, row: &RowRef) -> RowData<'_> {
+        let span = &self.chunks[row.span_idx];
+        let chunk = &span.chunk;
+        let overrides = &span.overrides;
+
+        let row_level = RowStrings::new(chunk, self.level_component).first(row.row);
+        let row_color = row_color(chunk, self.color_component, row.row).map(Color::from);
+
+        RowData {
+            entity_path: chunk.entity_path(),
+            body: RowStrings::new(chunk, self.component).first(row.row),
+            level: overrides.effective_level(row_level),
+            color: overrides
+                .color_override
+                .or(row_color)
+                .or(overrides.color_default),
+        }
+    }
+
+    /// The time of a single row on the given timeline, or [`TimeInt::STATIC`] if the row's
+    /// chunk has no data on it.
+    pub fn row_time(&self, row: &RowRef, timeline: &TimelineName) -> TimeInt {
+        let chunk = &self.chunks[row.span_idx].chunk;
+        chunk
+            .timelines()
+            .get(timeline)
+            .map_or(TimeInt::STATIC, |time_column| {
+                TimeInt::new_temporal(time_column.times_raw()[row.row])
+            })
+    }
+
+    /// Pushes a [`RowRef`] for every filter-matching row of the span, in row order,
+    /// optionally restricted to an (inclusive) time range.
+    fn collect_span_rows(
+        &self,
+        span_idx: usize,
+        span: &ChunkSpan,
+        time_bounds: Option<(TimeInt, TimeInt)>,
+        out: &mut Vec<RowRef>,
+    ) {
+        let Some(list_array) = span.chunk.components().get_array(self.component) else {
+            return;
+        };
+
+        let times = span
+            .chunk
+            .timelines()
+            .get(&self.timeline)
+            .map(|time_column| time_column.times_raw());
+
+        let validity = list_array.nulls();
+        let levels = self
+            .filter
+            .as_ref()
+            .map(|filter| (filter, RowStrings::new(&span.chunk, self.level_component)));
+
+        for row in 0..list_array.len() {
+            if validity.is_some_and(|validity| !validity.is_valid(row)) {
+                continue;
+            }
+
+            let time = times.map_or(TimeInt::STATIC, |times| TimeInt::new_temporal(times[row]));
+            if let Some((min, max)) = time_bounds
+                && !(min <= time && time <= max)
+            {
+                continue;
+            }
+
+            if levels.as_ref().is_some_and(|(filter, levels)| {
+                !filter.matches(span.overrides.effective_level(levels.first(row)))
+            }) {
+                continue;
+            }
+
+            out.push(RowRef {
+                span_idx,
+                row,
+                time,
+            });
+        }
+    }
+
     /// The time window covering all chunks that contribute rows in `rows`.
     ///
     /// Returns `None` when no temporal chunk overlaps the given row range.
-    /// (Static chunks are excluded: any range query returns them regardless.)
-    pub fn time_window_for_rows(&self, rows: Range<u64>) -> Option<(TimeInt, TimeInt)> {
+    fn time_window_for_rows(&self, rows: Range<u64>) -> Option<(TimeInt, TimeInt)> {
         let mut window: Option<(TimeInt, TimeInt)> = None;
 
         for (i, span) in self.chunks.iter().enumerate() {
@@ -336,66 +513,106 @@ impl RowLayout {
 
         window
     }
+
+    /// Counts the rows of the span that hold a (non-null) text value at a time strictly
+    /// before `t` (and that pass the level filter, if any).
+    ///
+    /// Handles unsorted chunks (out-of-order logging) correctly by scanning the time column.
+    fn count_rows_before_in_chunk(&self, span: &ChunkSpan, t: TimeInt) -> u64 {
+        re_tracing::profile_function!();
+
+        let Some(time_column) = span.chunk.timelines().get(&self.timeline) else {
+            return 0;
+        };
+        let Some(list_array) = span.chunk.components().get_array(self.component) else {
+            return 0;
+        };
+
+        let t = t.as_i64();
+        let times = time_column.times_raw();
+        let validity = list_array.nulls();
+        let levels = self
+            .filter
+            .as_ref()
+            .map(|filter| (filter, RowStrings::new(&span.chunk, self.level_component)));
+
+        (0..times.len())
+            .filter(|&row| {
+                validity.is_none_or(|validity| validity.is_valid(row))
+                    && times[row] < t
+                    && levels.as_ref().is_none_or(|(filter, levels)| {
+                        filter.matches(span.overrides.effective_level(levels.first(row)))
+                    })
+            })
+            .count() as u64
+    }
 }
 
-/// Counts the rows in `chunk` that hold a (non-null) `component` value at a time strictly
-/// before `t` (and that pass the level filter, if any).
-///
-/// Handles unsorted chunks (out-of-order logging) correctly by scanning the time column.
-fn count_rows_before_in_chunk(
-    chunk: &Chunk,
-    timeline: &TimelineName,
-    component: ComponentIdentifier,
-    level_component: ComponentIdentifier,
-    filter: Option<&LevelFilter>,
-    t: TimeInt,
-) -> u64 {
-    re_tracing::profile_function!();
+/// Reference to a single table row inside a [`RowLayout`]'s chunks.
+pub struct RowRef {
+    span_idx: usize,
+    row: usize,
 
-    let Some(time_column) = chunk.timelines().get(timeline) else {
-        return 0;
-    };
-    let Some(list_array) = chunk.components().get_array(component) else {
-        return 0;
-    };
-
-    let t = t.as_i64();
-    let times = time_column.times_raw();
-    let validity = list_array.nulls();
-    let levels = filter.map(|filter| (filter, RowLevels::new(chunk, level_component)));
-
-    (0..times.len())
-        .filter(|&row| {
-            validity.is_none_or(|validity| validity.is_valid(row))
-                && times[row] < t
-                && levels
-                    .as_ref()
-                    .is_none_or(|(filter, levels)| filter.matches(levels.first(row)))
-        })
-        .count() as u64
+    /// Time on the layout's timeline; [`TimeInt::STATIC`] for static rows.
+    pub time: TimeInt,
 }
 
-/// Per-row access to the first log level instance of a chunk.
+/// The currently visible table rows, resolved to exact positions inside the chunks.
 ///
-/// This deliberately only looks at the chunk row itself, just like how the visualizer builds its entries
-/// so that row counts derived here always line up with the materialize entries.
-struct RowLevels<'a> {
+/// Global row indices map to [`RowRef`]s: static rows sit at the very top, temporal rows
+/// follow in exact time order starting at `temporal_offset`.
+#[derive(Default)]
+pub struct VisibleRows {
+    num_static_rows: u64,
+
+    /// All static rows (only resolved when any of them is visible); global rows `0..len`.
+    static_rows: Vec<RowRef>,
+
+    /// Global row index of `temporal_rows[0]`.
+    temporal_offset: u64,
+
+    /// All rows within the visible chunks' time window, sorted by time.
+    temporal_rows: Vec<RowRef>,
+}
+
+impl VisibleRows {
+    pub fn get(&self, row_nr: u64) -> Option<&RowRef> {
+        if row_nr < self.num_static_rows {
+            self.static_rows.get(usize::try_from(row_nr).ok()?)
+        } else {
+            let idx = row_nr.checked_sub(self.temporal_offset)?;
+            self.temporal_rows.get(usize::try_from(idx).ok()?)
+        }
+    }
+}
+
+/// The data of a single text log row, borrowed from its chunk (with the entity's blueprint
+/// overrides/defaults applied to level and color).
+pub struct RowData<'a> {
+    pub entity_path: &'a EntityPath,
+    pub body: Option<&'a str>,
+    pub level: Option<&'a str>,
+    pub color: Option<Color>,
+}
+
+/// Per-row access to the first instance of a string component of a chunk.
+///
+/// This deliberately only looks at the chunk row itself: a text log row's data comes from
+/// that row alone, so that displayed values always line up with the metadata-derived layout.
+struct RowStrings<'a> {
     list_and_values: Option<(&'a ArrowListArray, &'a ArrowStringArray)>,
 }
 
-impl<'a> RowLevels<'a> {
-    fn new(chunk: &'a Chunk, level_component: ComponentIdentifier) -> Self {
-        let list_and_values = chunk
-            .components()
-            .get_array(level_component)
-            .and_then(|list| {
-                let values = list.values().as_any().downcast_ref::<ArrowStringArray>()?;
-                Some((list, values))
-            });
+impl<'a> RowStrings<'a> {
+    fn new(chunk: &'a Chunk, component: ComponentIdentifier) -> Self {
+        let list_and_values = chunk.components().get_array(component).and_then(|list| {
+            let values = list.values().as_any().downcast_ref::<ArrowStringArray>()?;
+            Some((list, values))
+        });
         Self { list_and_values }
     }
 
-    /// The first level value of the given chunk row, if any.
+    /// The first value of the given chunk row, if any.
     fn first(&self, row: usize) -> Option<&'a str> {
         let (list, values) = self.list_and_values?;
         if list.nulls().is_some_and(|validity| !validity.is_valid(row)) {
@@ -405,6 +622,18 @@ impl<'a> RowLevels<'a> {
         let end = usize::try_from(list.value_offsets()[row + 1]).ok()?;
         (start < end && values.is_valid(start)).then(|| values.value(start))
     }
+}
+
+/// The first color instance of the given chunk row, if any.
+fn row_color(chunk: &Chunk, color_component: ComponentIdentifier, row: usize) -> Option<u32> {
+    let list = chunk.components().get_array(color_component)?;
+    if list.nulls().is_some_and(|validity| !validity.is_valid(row)) {
+        return None;
+    }
+    let values = list.values().as_any().downcast_ref::<ArrowUInt32Array>()?;
+    let start = usize::try_from(list.value_offsets()[row]).ok()?;
+    let end = usize::try_from(list.value_offsets()[row + 1]).ok()?;
+    (start < end && values.is_valid(start)).then(|| values.value(start))
 }
 
 /// Counts, per log level, the rows of `chunk` that hold a (non-null) `component` value.
@@ -422,7 +651,7 @@ fn level_counts_for_chunk(
     };
 
     let validity = list_array.nulls();
-    let levels = RowLevels::new(chunk, level_component);
+    let levels = RowStrings::new(chunk, level_component);
 
     for row in 0..list_array.len() {
         if validity.is_some_and(|validity| !validity.is_valid(row)) {
@@ -445,22 +674,10 @@ fn level_counts_for_chunk(
 
 #[cfg(test)]
 mod tests {
-    use re_chunk_store::{ChunkStore, ChunkStoreConfig};
-    use re_log_types::{StoreId, StoreKind, Timeline};
+    use re_log_types::Timeline;
     use re_sdk_types::archetypes::TextLog;
 
     use super::*;
-
-    fn store_with_chunks(chunks: impl IntoIterator<Item = Chunk>) -> ChunkStore {
-        let mut store = ChunkStore::new(
-            StoreId::random(StoreKind::Recording, "test_app"),
-            ChunkStoreConfig::COMPACTION_DISABLED,
-        );
-        for chunk in chunks {
-            store.insert_chunk(&Arc::new(chunk)).unwrap();
-        }
-        store
-    }
 
     fn text_chunk(entity: &str, timeline: Timeline, ticks: impl IntoIterator<Item = i64>) -> Chunk {
         let mut builder = Chunk::builder(entity);
@@ -473,23 +690,32 @@ mod tests {
         builder.build().unwrap()
     }
 
-    fn layout_for(store: &ChunkStore, timeline: &Timeline, entities: &[EntityPath]) -> RowLayout {
-        layout_with_filter(store, timeline, entities, None)
+    fn layout_for(chunks: &[Chunk], timeline: &Timeline) -> RowLayout {
+        layout_with_filter(chunks, timeline, None)
     }
 
     fn layout_with_filter(
-        store: &ChunkStore,
+        chunks: &[Chunk],
         timeline: &Timeline,
-        entities: &[EntityPath],
         filter: Option<&LevelFilter>,
     ) -> RowLayout {
+        layout_with_overrides(chunks, timeline, filter, &HashMap::default())
+    }
+
+    fn layout_with_overrides(
+        chunks: &[Chunk],
+        timeline: &Timeline,
+        filter: Option<&LevelFilter>,
+        overrides: &HashMap<EntityPath, RowOverrides>,
+    ) -> RowLayout {
         RowLayout::build(
-            store,
+            chunks.to_vec(),
             timeline.name(),
             TextLog::descriptor_text().component,
             TextLog::descriptor_level().component,
-            entities.iter(),
+            TextLog::descriptor_color().component,
             filter,
+            overrides,
             &mut LevelCountCache::default(),
         )
     }
@@ -497,18 +723,14 @@ mod tests {
     #[test]
     fn overlapping_chunks_have_exact_counts() {
         let timeline = Timeline::log_tick();
-        let store = store_with_chunks([
+        let chunks = [
             text_chunk("a", timeline, [0, 2, 4, 6, 8]),
             text_chunk("b", timeline, [1, 3, 5, 7, 9]),
-        ]);
-        let layout = layout_for(
-            &store,
-            &timeline,
-            &[EntityPath::from("a"), EntityPath::from("b")],
-        );
+        ];
+        let layout = layout_for(&chunks, &timeline);
 
         assert_eq!(layout.num_rows(), 10);
-        assert_eq!(layout.num_static_rows(), 0);
+        assert_eq!(layout.rows_before(TimeInt::MIN), 0); // no static rows
 
         // Both chunks overlap the whole range, so every boundary requires exact,
         // per-chunk row counting.
@@ -522,6 +744,31 @@ mod tests {
     }
 
     #[test]
+    fn visible_rows_interleave_overlapping_chunks_in_time_order() {
+        let timeline = Timeline::log_tick();
+        let chunks = [
+            text_chunk("a", timeline, [0, 2, 4, 6, 8]),
+            text_chunk("b", timeline, [1, 3, 5, 7, 9]),
+        ];
+        let layout = layout_for(&chunks, &timeline);
+
+        // Any visible sub-range resolves to globally time-ordered rows.
+        let visible = layout.visible_rows(3..7);
+        for row_nr in 3_u64..7 {
+            let row = visible.get(row_nr).unwrap();
+            assert_eq!(
+                row.time,
+                TimeInt::new_temporal(i64::try_from(row_nr).unwrap())
+            );
+            let data = layout.row_data(row);
+            assert_eq!(
+                data.body.unwrap(),
+                format!("{} {row_nr}", if row_nr % 2 == 0 { "a" } else { "b" })
+            );
+        }
+    }
+
+    #[test]
     fn static_rows_sort_first() {
         let timeline = Timeline::log_tick();
 
@@ -530,45 +777,47 @@ mod tests {
             .build()
             .unwrap();
 
-        let store = store_with_chunks([static_chunk, text_chunk("a", timeline, [10, 20])]);
-        let layout = layout_for(
-            &store,
-            &timeline,
-            &[EntityPath::from("static"), EntityPath::from("a")],
-        );
+        let chunks = [static_chunk, text_chunk("a", timeline, [10, 20])];
+        let layout = layout_for(&chunks, &timeline);
 
         assert_eq!(layout.num_rows(), 3);
-        assert_eq!(layout.num_static_rows(), 1);
+        assert_eq!(layout.rows_before(TimeInt::MIN), 1); // just the static row
 
         // The static row counts as "before" any temporal time.
         assert_eq!(layout.rows_before(TimeInt::new_temporal(0)), 1);
         assert_eq!(layout.rows_before(TimeInt::new_temporal(15)), 2);
         assert_eq!(layout.rows_before(TimeInt::new_temporal(21)), 3);
+
+        // The static row resolves with a static time; temporal rows follow.
+        let visible = layout.visible_rows(0..3);
+        assert_eq!(visible.get(0).unwrap().time, TimeInt::STATIC);
+        assert_eq!(visible.get(1).unwrap().time, TimeInt::new_temporal(10));
+        assert_eq!(visible.get(2).unwrap().time, TimeInt::new_temporal(20));
     }
 
     #[test]
-    fn time_window_covers_requested_rows() {
+    fn visible_rows_cover_requested_range() {
         let timeline = Timeline::log_tick();
-        let store = store_with_chunks([
+        let chunks = [
             text_chunk("a", timeline, [0, 1, 2]),
             text_chunk("a", timeline, [10, 11, 12]),
             text_chunk("a", timeline, [20, 21, 22]),
-        ]);
-        let layout = layout_for(&store, &timeline, &[EntityPath::from("a")]);
+        ];
+        let layout = layout_for(&chunks, &timeline);
 
         assert_eq!(layout.num_rows(), 9);
 
         // Rows 3..6 live in the middle chunk.
-        let (min, max) = layout.time_window_for_rows(3..6).unwrap();
-        assert_eq!(min, TimeInt::new_temporal(10));
-        assert_eq!(max, TimeInt::new_temporal(12));
+        let visible = layout.visible_rows(3..6);
+        assert_eq!(visible.get(3).unwrap().time, TimeInt::new_temporal(10));
+        assert_eq!(visible.get(5).unwrap().time, TimeInt::new_temporal(12));
 
         // A range spanning chunk boundaries covers both chunks.
-        let (min, max) = layout.time_window_for_rows(2..4).unwrap();
-        assert_eq!(min, TimeInt::new_temporal(0));
-        assert_eq!(max, TimeInt::new_temporal(12));
+        let visible = layout.visible_rows(2..4);
+        assert_eq!(visible.get(2).unwrap().time, TimeInt::new_temporal(2));
+        assert_eq!(visible.get(3).unwrap().time, TimeInt::new_temporal(10));
 
-        assert!(layout.time_window_for_rows(9..9).is_none());
+        assert!(layout.visible_rows(9..9).get(9).is_none());
     }
 
     #[test]
@@ -585,13 +834,12 @@ mod tests {
             );
         }
         // A second chunk whose rows have no level at all: those always pass the filter.
-        let store = store_with_chunks([
+        let chunks = [
             builder.build().unwrap(),
             text_chunk("a", timeline, [100, 101]),
-        ]);
-        let entities = [EntityPath::from("a")];
+        ];
 
-        let unfiltered = layout_for(&store, &timeline, &entities);
+        let unfiltered = layout_for(&chunks, &timeline);
         assert_eq!(unfiltered.num_rows(), 12);
         assert_eq!(
             unfiltered.levels().iter().cloned().collect::<Vec<_>>(),
@@ -599,7 +847,7 @@ mod tests {
         );
 
         let filter = LevelFilter(std::iter::once("WARN".to_owned()).collect());
-        let filtered = layout_with_filter(&store, &timeline, &entities, Some(&filter));
+        let filtered = layout_with_filter(&chunks, &timeline, Some(&filter));
 
         // 5 WARN rows + 2 unleveled rows.
         assert_eq!(filtered.num_rows(), 7);
@@ -611,9 +859,143 @@ mod tests {
         assert_eq!(filtered.rows_before(TimeInt::new_temporal(50)), 5);
         assert_eq!(filtered.rows_before(TimeInt::new_temporal(101)), 6);
 
+        // The resolved rows skip filtered-out ones and line up with the counts.
+        let visible = filtered.visible_rows(0..7);
+        let times: Vec<_> = (0..7)
+            .map(|row_nr| visible.get(row_nr).unwrap().time.as_i64())
+            .collect();
+        assert_eq!(times, vec![1, 3, 5, 7, 9, 100, 101]);
+
         // A filter matching nothing still shows unleveled rows.
         let none = LevelFilter(BTreeSet::default());
-        let none = layout_with_filter(&store, &timeline, &entities, Some(&none));
+        let none = layout_with_filter(&chunks, &timeline, Some(&none));
         assert_eq!(none.num_rows(), 2);
+    }
+
+    #[test]
+    fn level_counts_survive_chunks_excluded_by_the_filter() {
+        let timeline = Timeline::log_tick();
+
+        let mut builder = Chunk::builder("a");
+        for tick in 0..10 {
+            builder = builder.with_archetype_auto_row(
+                [(timeline, tick)],
+                &TextLog::new(format!("{tick}")).with_level("INFO"),
+            );
+        }
+        let chunks = [builder.build().unwrap()];
+
+        // The filter excludes the whole chunk, so it contributes no span…
+        let mut cache = LevelCountCache::default();
+        let filter = LevelFilter(std::iter::once("WARN".to_owned()).collect());
+        let layout = RowLayout::build(
+            chunks.to_vec(),
+            timeline.name(),
+            TextLog::descriptor_text().component,
+            TextLog::descriptor_level().component,
+            TextLog::descriptor_color().component,
+            Some(&filter),
+            &HashMap::default(),
+            &mut cache,
+        );
+        assert_eq!(layout.num_rows(), 0);
+
+        // …but its cached counts must survive (eviction only happens on chunk deletion),
+        // or it would be rescanned every frame.
+        assert_eq!(cache.0.len(), 1);
+    }
+
+    #[test]
+    fn level_override_applies_to_all_rows() {
+        let timeline = Timeline::log_tick();
+
+        // Rows logged as INFO, but the blueprint overrides the entity's level to WARN.
+        let mut builder = Chunk::builder("a");
+        for tick in 0..4 {
+            builder = builder.with_archetype_auto_row(
+                [(timeline, tick)],
+                &TextLog::new(format!("{tick}")).with_level("INFO"),
+            );
+        }
+        let chunks = [builder.build().unwrap()];
+        let overrides = HashMap::from([(
+            EntityPath::from("a"),
+            RowOverrides {
+                level_override: Some("WARN".to_owned()),
+                color_override: Some(Color::from_rgb(255, 0, 0)),
+                ..Default::default()
+            },
+        )]);
+
+        // The override wins over the rows' own levels, in counts and in row data alike.
+        let filter = LevelFilter(std::iter::once("INFO".to_owned()).collect());
+        let layout = layout_with_overrides(&chunks, &timeline, Some(&filter), &overrides);
+        assert_eq!(layout.num_rows(), 0);
+
+        let filter = LevelFilter(std::iter::once("WARN".to_owned()).collect());
+        let layout = layout_with_overrides(&chunks, &timeline, Some(&filter), &overrides);
+        assert_eq!(layout.num_rows(), 4);
+        assert_eq!(layout.rows_before(TimeInt::new_temporal(2)), 2);
+
+        // The filter UI only offers the level that actually shows.
+        assert_eq!(
+            layout.levels().iter().cloned().collect::<Vec<_>>(),
+            vec!["WARN".to_owned()]
+        );
+
+        let visible = layout.visible_rows(0..4);
+        let data = layout.row_data(visible.get(0).unwrap());
+        assert_eq!(data.level, Some("WARN"));
+        assert_eq!(data.color, Some(Color::from_rgb(255, 0, 0)));
+    }
+
+    #[test]
+    fn level_default_applies_to_unleveled_rows_only() {
+        let timeline = Timeline::log_tick();
+
+        // Rows 0/2 are INFO; rows 1/3 have no level and fall back to the view default.
+        let mut builder = Chunk::builder("a");
+        for tick in 0..4 {
+            let mut row = TextLog::new(format!("{tick}"));
+            if tick % 2 == 0 {
+                row = row.with_level("INFO");
+            }
+            builder = builder.with_archetype_auto_row([(timeline, tick)], &row);
+        }
+        let chunks = [builder.build().unwrap()];
+        let overrides = HashMap::from([(
+            EntityPath::from("a"),
+            RowOverrides {
+                level_default: Some("DEBUG".to_owned()),
+                ..Default::default()
+            },
+        )]);
+
+        // Unleveled rows now count as DEBUG: they no longer pass every filter.
+        let filter = LevelFilter(std::iter::once("INFO".to_owned()).collect());
+        let layout = layout_with_overrides(&chunks, &timeline, Some(&filter), &overrides);
+        assert_eq!(layout.num_rows(), 2);
+
+        let filter = LevelFilter(std::iter::once("DEBUG".to_owned()).collect());
+        let layout = layout_with_overrides(&chunks, &timeline, Some(&filter), &overrides);
+        assert_eq!(layout.num_rows(), 2);
+        assert_eq!(layout.rows_before(TimeInt::new_temporal(3)), 1); // DEBUG@1
+
+        // Both the logged and the default level are offered by the filter UI.
+        let unfiltered = layout_with_overrides(&chunks, &timeline, None, &overrides);
+        assert_eq!(
+            unfiltered.levels().iter().cloned().collect::<Vec<_>>(),
+            vec!["DEBUG".to_owned(), "INFO".to_owned()]
+        );
+
+        let visible = unfiltered.visible_rows(0..4);
+        assert_eq!(
+            unfiltered.row_data(visible.get(0).unwrap()).level,
+            Some("INFO")
+        );
+        assert_eq!(
+            unfiltered.row_data(visible.get(1).unwrap()).level,
+            Some("DEBUG")
+        );
     }
 }

--- a/crates/viewer/re_view_text_log/src/row_layout.rs
+++ b/crates/viewer/re_view_text_log/src/row_layout.rs
@@ -6,11 +6,13 @@ use re_chunk_store::external::arrow::array::{
     Array as _, ListArray as ArrowListArray, StringArray as ArrowStringArray,
 };
 use re_chunk_store::{
-    AbsoluteTimeRange, Chunk, ChunkId, ChunkStore, ChunkTrackingMode, RangeQuery, TimeInt,
+    AbsoluteTimeRange, Chunk, ChunkId, ChunkStore, ChunkStoreEvent, ChunkTrackingMode, RangeQuery,
+    TimeInt,
 };
 use re_entity_db::EntityPath;
 use re_log_types::TimelineName;
 use re_sdk_types::ComponentIdentifier;
+use re_viewer_context::Cache;
 
 /// An explicit log level filter: only rows whose level is in the set are shown.
 ///
@@ -25,9 +27,6 @@ impl LevelFilter {
 }
 
 /// Per-level row counts for a single chunk.
-///
-/// Chunks are immutable, so these can be cached indefinitely (keyed by [`ChunkId`]),
-/// which makes level-filtered row counts as cheap as unfiltered ones after the first frame.
 #[derive(Clone, Default, PartialEq, Eq)]
 pub struct LevelCounts {
     /// Number of text log rows whose (first) level value is the given string.
@@ -54,10 +53,66 @@ impl re_byte_size::SizeBytes for LevelCounts {
     }
 }
 
-/// Cached per-chunk level counts, keyed by chunk id.
-pub type LevelCountCache = BTreeMap<ChunkId, LevelCounts>;
+/// Per-chunk [`LevelCounts`], computed once per chunk and shared by all text log views.
+///
+/// Chunks are immutable, so an entry stays valid until the chunk is evicted from the store,
+/// which is what makes level-filtered row counts as cheap as unfiltered ones after the first frame.
+#[derive(Default)]
+pub struct LevelCountCache(
+    BTreeMap<(ChunkId, ComponentIdentifier, ComponentIdentifier), LevelCounts>,
+);
+
+impl LevelCountCache {
+    fn counts_for(
+        &mut self,
+        chunk: &Chunk,
+        component: ComponentIdentifier,
+        level_component: ComponentIdentifier,
+    ) -> &LevelCounts {
+        self.0
+            .entry((chunk.id(), component, level_component))
+            .or_insert_with(|| level_counts_for_chunk(chunk, component, level_component))
+    }
+}
+
+impl Cache for LevelCountCache {
+    fn name(&self) -> &'static str {
+        "TextLogLevelCountCache"
+    }
+
+    fn purge_memory(&mut self) {
+        self.0.clear();
+    }
+
+    fn on_store_events(
+        &mut self,
+        events: &[&ChunkStoreEvent],
+        _entity_db: &re_entity_db::EntityDb,
+    ) {
+        re_tracing::profile_function!();
+
+        let deleted: BTreeSet<ChunkId> = events
+            .iter()
+            .filter_map(|event| event.to_deletion())
+            .map(|deletion| deletion.chunk.id())
+            .collect();
+        if deleted.is_empty() {
+            return;
+        }
+
+        self.0
+            .retain(|(chunk_id, _, _), _| !deleted.contains(chunk_id));
+    }
+}
+
+impl re_byte_size::MemUsageTreeCapture for LevelCountCache {
+    fn capture_mem_usage_tree(&self) -> re_byte_size::MemUsageTree {
+        re_byte_size::MemUsageTree::Bytes(re_byte_size::SizeBytes::total_size_bytes(&self.0))
+    }
+}
 
 /// The contiguous span of table rows contributed by one chunk.
+#[derive(Clone)]
 struct ChunkSpan {
     /// Time range covered by the chunk on the layout's timeline.
     ///
@@ -82,6 +137,7 @@ struct ChunkSpan {
 /// Rows are ordered with static rows first, then by time.
 /// Where chunks of different entities overlap in time, the layout is approximate at chunk
 /// granularity, but stable since the visible window itself is always rendered in exact time order.
+#[derive(Clone)]
 pub struct RowLayout {
     timeline: TimelineName,
     component: ComponentIdentifier,
@@ -129,7 +185,6 @@ impl RowLayout {
         let mut chunks = Vec::new();
         let mut levels = BTreeSet::new();
         let mut any_missing = false;
-        let mut live_chunks = BTreeSet::new();
 
         for entity_path in entities {
             // don't trigger chunk downloads just to compute the row layout.
@@ -149,13 +204,9 @@ impl RowLayout {
                     continue;
                 }
 
-                live_chunks.insert(chunk.id());
-
                 // One-time scan per chunk (chunks are immutable, so the cache never goes stale)
                 // this is what makes level-filtered row counts viable
-                let counts = level_counts
-                    .entry(chunk.id())
-                    .or_insert_with(|| level_counts_for_chunk(&chunk, component, level_component));
+                let counts = level_counts.counts_for(&chunk, component, level_component);
                 levels.extend(counts.per_level.keys().cloned());
 
                 let num_rows = match filter {
@@ -183,9 +234,6 @@ impl RowLayout {
                 });
             }
         }
-
-        // Drop cache entries for chunks that no longer exist
-        level_counts.retain(|chunk_id, _| live_chunks.contains(chunk_id));
 
         // Static chunks first, then by time.
         chunks.sort_by_key(|span| (!span.is_static, span.time_range.min(), span.chunk.id()));

--- a/crates/viewer/re_view_text_log/src/row_layout.rs
+++ b/crates/viewer/re_view_text_log/src/row_layout.rs
@@ -103,7 +103,7 @@ pub struct RowLayout {
 
     /// Chunks that the store knows of but that aren't loaded; row counts are incomplete.
     //
-    // TODO(#7562): once this is fed from the `RrdManifestIndex`, unloaded chunks can
+    // TODO(gijsd): once this is fed from the `RrdManifestIndex`, unloaded chunks can
     // contribute their row counts too, making the layout complete in streaming scenarios.
     pub any_missing: bool,
 }

--- a/crates/viewer/re_view_text_log/src/row_layout.rs
+++ b/crates/viewer/re_view_text_log/src/row_layout.rs
@@ -74,16 +74,14 @@ struct ChunkSpan {
 
 /// Row layout of the text log table, derived from chunk-level metadata only.
 ///
-/// This is what allows the view to know how many rows there are — and roughly where in time
-/// each row lives — without touching any row data:
-/// row counts come from the per-chunk validity bitmaps (or, with a level filter active,
-/// from cached per-chunk level counts) and are exact,
-/// and only locating a time window boundary *inside* a chunk requires peeking at that
-/// (already loaded) chunk's time column.
+/// This is what allows the view to know how many rows there are, without touching any row data:
+/// row counts come from the per-chunk validity bitmaps (or, with a level filter active, from cached
+/// per-chunk level counts) and are exact, and only locating a time window boundary *inside* a chunk requires
+/// looking at that chunk's time column.
 ///
 /// Rows are ordered with static rows first, then by time.
 /// Where chunks of different entities overlap in time, the layout is approximate at chunk
-/// granularity, but stable; the visible window itself is always rendered in exact time order.
+/// granularity, but stable since the visible window itself is always rendered in exact time order.
 pub struct RowLayout {
     timeline: TimelineName,
     component: ComponentIdentifier,
@@ -111,7 +109,9 @@ pub struct RowLayout {
 }
 
 impl RowLayout {
-    /// Note that the level counting is done on the raw store data: blueprint overrides of the
+    /// Build a row layout for the given entities and timeline, optionally applying a level filter.
+    ///
+    /// Note: the level counting is done on the raw store data: blueprint overrides of the
     /// `level` component are not taken into account by `filter`.
     pub fn build<'a>(
         store: &ChunkStore,
@@ -132,7 +132,7 @@ impl RowLayout {
         let mut live_chunks = BTreeSet::new();
 
         for entity_path in entities {
-            // `Ignore`: don't trigger chunk downloads just to compute the row layout.
+            // don't trigger chunk downloads just to compute the row layout.
             let results = store.range_relevant_chunks(
                 ChunkTrackingMode::Ignore,
                 &query,
@@ -151,9 +151,8 @@ impl RowLayout {
 
                 live_chunks.insert(chunk.id());
 
-                // One-time scan per chunk (chunks are immutable, so the cache never goes
-                // stale); this is what makes level-filtered row counts affordable, and it
-                // gives us the complete set of occurring levels for the filter UI.
+                // One-time scan per chunk (chunks are immutable, so the cache never goes stale)
+                // this is what makes level-filtered row counts viable
                 let counts = level_counts
                     .entry(chunk.id())
                     .or_insert_with(|| level_counts_for_chunk(&chunk, component, level_component));
@@ -185,7 +184,7 @@ impl RowLayout {
             }
         }
 
-        // Drop cache entries for chunks that no longer exist (compacted or garbage collected).
+        // Drop cache entries for chunks that no longer exist
         level_counts.retain(|chunk_id, _| live_chunks.contains(chunk_id));
 
         // Static chunks first, then by time.
@@ -330,10 +329,8 @@ fn count_rows_before_in_chunk(
 
 /// Per-row access to the first log level instance of a chunk.
 ///
-/// This deliberately only looks at the chunk row itself — no blueprint overrides, no
-/// latest-at clamping from earlier rows — mirroring how the visualizer builds its entries
-/// (exact index join), so that row counts derived here always line up with the materialized
-/// entries.
+/// This deliberately only looks at the chunk row itself, just like how the visualizer builds its entries
+/// so that row counts derived here always line up with the materialize entries.
 struct RowLevels<'a> {
     list_and_values: Option<(&'a ArrowListArray, &'a ArrowStringArray)>,
 }

--- a/crates/viewer/re_view_text_log/src/row_layout.rs
+++ b/crates/viewer/re_view_text_log/src/row_layout.rs
@@ -57,14 +57,14 @@ impl re_byte_size::SizeBytes for LevelCounts {
 /// Cached per-chunk level counts, keyed by chunk id.
 pub type LevelCountCache = BTreeMap<ChunkId, LevelCounts>;
 
-/// Chunk-level metadata for one chunk holding text log rows.
-struct ChunkGeom {
-    /// Time range covered by the chunk on the geometry's timeline.
+/// The contiguous span of table rows contributed by one chunk.
+struct ChunkSpan {
+    /// Time range covered by the chunk on the layout's timeline.
     ///
     /// Meaningless for static chunks ([`AbsoluteTimeRange`] cannot represent static times).
     time_range: AbsoluteTimeRange,
 
-    /// Number of text log rows in this chunk.
+    /// Number of table rows this chunk contributes (only filter-matching rows count).
     num_rows: u64,
 
     is_static: bool,
@@ -84,7 +84,7 @@ struct ChunkGeom {
 /// Rows are ordered with static rows first, then by time.
 /// Where chunks of different entities overlap in time, the layout is approximate at chunk
 /// granularity, but stable; the visible window itself is always rendered in exact time order.
-pub struct ScrollGeometry {
+pub struct RowLayout {
     timeline: TimelineName,
     component: ComponentIdentifier,
     level_component: ComponentIdentifier,
@@ -93,7 +93,7 @@ pub struct ScrollGeometry {
     filter: Option<LevelFilter>,
 
     /// Sorted by `time_range.min` (which puts static chunks first).
-    chunks: Vec<ChunkGeom>,
+    chunks: Vec<ChunkSpan>,
 
     /// Prefix sums of `chunks[..i].num_rows`; length is `chunks.len() + 1`.
     prefix_rows: Vec<u64>,
@@ -110,7 +110,7 @@ pub struct ScrollGeometry {
     pub any_missing: bool,
 }
 
-impl ScrollGeometry {
+impl RowLayout {
     /// Note that the level counting is done on the raw store data: blueprint overrides of the
     /// `level` component are not taken into account by `filter`.
     pub fn build<'a>(
@@ -176,7 +176,7 @@ impl ScrollGeometry {
                     continue;
                 };
 
-                chunks.push(ChunkGeom {
+                chunks.push(ChunkSpan {
                     time_range,
                     num_rows,
                     is_static,
@@ -189,20 +189,20 @@ impl ScrollGeometry {
         level_counts.retain(|chunk_id, _| live_chunks.contains(chunk_id));
 
         // Static chunks first, then by time.
-        chunks.sort_by_key(|geom| (!geom.is_static, geom.time_range.min(), geom.chunk.id()));
+        chunks.sort_by_key(|span| (!span.is_static, span.time_range.min(), span.chunk.id()));
 
         let mut prefix_rows = Vec::with_capacity(chunks.len() + 1);
         let mut total = 0;
         prefix_rows.push(0);
-        for geom in &chunks {
-            total += geom.num_rows;
+        for span in &chunks {
+            total += span.num_rows;
             prefix_rows.push(total);
         }
 
         let num_static_rows = chunks
             .iter()
-            .take_while(|geom| geom.is_static)
-            .map(|geom| geom.num_rows)
+            .take_while(|span| span.is_static)
+            .map(|span| span.num_rows)
             .sum();
 
         Self {
@@ -239,21 +239,21 @@ impl ScrollGeometry {
         re_tracing::profile_function!();
 
         let mut count = 0;
-        for geom in &self.chunks {
-            if geom.is_static {
+        for span in &self.chunks {
+            if span.is_static {
                 // Static rows sort before any temporal time.
-                count += geom.num_rows;
+                count += span.num_rows;
                 continue;
             }
-            if geom.time_range.min() >= t {
+            if span.time_range.min() >= t {
                 // Chunks are sorted by min time: no further chunk can contribute.
                 break;
             }
-            if geom.time_range.max() < t {
-                count += geom.num_rows;
+            if span.time_range.max() < t {
+                count += span.num_rows;
             } else {
                 count += count_rows_before_in_chunk(
-                    &geom.chunk,
+                    &span.chunk,
                     &self.timeline,
                     self.component,
                     self.level_component,
@@ -272,18 +272,18 @@ impl ScrollGeometry {
     pub fn time_window_for_rows(&self, rows: Range<u64>) -> Option<(TimeInt, TimeInt)> {
         let mut window: Option<(TimeInt, TimeInt)> = None;
 
-        for (i, geom) in self.chunks.iter().enumerate() {
+        for (i, span) in self.chunks.iter().enumerate() {
             if self.prefix_rows[i] >= rows.end {
                 break;
             }
-            if self.prefix_rows[i + 1] <= rows.start || geom.is_static {
+            if self.prefix_rows[i + 1] <= rows.start || span.is_static {
                 continue;
             }
 
             let (min, max) = window.unwrap_or((TimeInt::MAX, TimeInt::MIN));
             window = Some((
-                min.min(geom.time_range.min()),
-                max.max(geom.time_range.max()),
+                min.min(span.time_range.min()),
+                max.max(span.time_range.max()),
             ));
         }
 
@@ -428,21 +428,17 @@ mod tests {
         builder.build().unwrap()
     }
 
-    fn geometry_for(
-        store: &ChunkStore,
-        timeline: &Timeline,
-        entities: &[EntityPath],
-    ) -> ScrollGeometry {
-        geometry_with_filter(store, timeline, entities, None)
+    fn layout_for(store: &ChunkStore, timeline: &Timeline, entities: &[EntityPath]) -> RowLayout {
+        layout_with_filter(store, timeline, entities, None)
     }
 
-    fn geometry_with_filter(
+    fn layout_with_filter(
         store: &ChunkStore,
         timeline: &Timeline,
         entities: &[EntityPath],
         filter: Option<&LevelFilter>,
-    ) -> ScrollGeometry {
-        ScrollGeometry::build(
+    ) -> RowLayout {
+        RowLayout::build(
             store,
             timeline.name(),
             TextLog::descriptor_text().component,
@@ -460,20 +456,20 @@ mod tests {
             text_chunk("a", timeline, [0, 2, 4, 6, 8]),
             text_chunk("b", timeline, [1, 3, 5, 7, 9]),
         ]);
-        let geometry = geometry_for(
+        let layout = layout_for(
             &store,
             &timeline,
             &[EntityPath::from("a"), EntityPath::from("b")],
         );
 
-        assert_eq!(geometry.num_rows(), 10);
-        assert_eq!(geometry.num_static_rows(), 0);
+        assert_eq!(layout.num_rows(), 10);
+        assert_eq!(layout.num_static_rows(), 0);
 
         // Both chunks overlap the whole range, so every boundary requires exact,
         // per-chunk row counting.
         for t in 0..=10 {
             assert_eq!(
-                geometry.rows_before(TimeInt::new_temporal(t)),
+                layout.rows_before(TimeInt::new_temporal(t)),
                 t as u64,
                 "rows_before({t})"
             );
@@ -490,19 +486,19 @@ mod tests {
             .unwrap();
 
         let store = store_with_chunks([static_chunk, text_chunk("a", timeline, [10, 20])]);
-        let geometry = geometry_for(
+        let layout = layout_for(
             &store,
             &timeline,
             &[EntityPath::from("static"), EntityPath::from("a")],
         );
 
-        assert_eq!(geometry.num_rows(), 3);
-        assert_eq!(geometry.num_static_rows(), 1);
+        assert_eq!(layout.num_rows(), 3);
+        assert_eq!(layout.num_static_rows(), 1);
 
         // The static row counts as "before" any temporal time.
-        assert_eq!(geometry.rows_before(TimeInt::new_temporal(0)), 1);
-        assert_eq!(geometry.rows_before(TimeInt::new_temporal(15)), 2);
-        assert_eq!(geometry.rows_before(TimeInt::new_temporal(21)), 3);
+        assert_eq!(layout.rows_before(TimeInt::new_temporal(0)), 1);
+        assert_eq!(layout.rows_before(TimeInt::new_temporal(15)), 2);
+        assert_eq!(layout.rows_before(TimeInt::new_temporal(21)), 3);
     }
 
     #[test]
@@ -513,21 +509,21 @@ mod tests {
             text_chunk("a", timeline, [10, 11, 12]),
             text_chunk("a", timeline, [20, 21, 22]),
         ]);
-        let geometry = geometry_for(&store, &timeline, &[EntityPath::from("a")]);
+        let layout = layout_for(&store, &timeline, &[EntityPath::from("a")]);
 
-        assert_eq!(geometry.num_rows(), 9);
+        assert_eq!(layout.num_rows(), 9);
 
         // Rows 3..6 live in the middle chunk.
-        let (min, max) = geometry.time_window_for_rows(3..6).unwrap();
+        let (min, max) = layout.time_window_for_rows(3..6).unwrap();
         assert_eq!(min, TimeInt::new_temporal(10));
         assert_eq!(max, TimeInt::new_temporal(12));
 
         // A range spanning chunk boundaries covers both chunks.
-        let (min, max) = geometry.time_window_for_rows(2..4).unwrap();
+        let (min, max) = layout.time_window_for_rows(2..4).unwrap();
         assert_eq!(min, TimeInt::new_temporal(0));
         assert_eq!(max, TimeInt::new_temporal(12));
 
-        assert!(geometry.time_window_for_rows(9..9).is_none());
+        assert!(layout.time_window_for_rows(9..9).is_none());
     }
 
     #[test]
@@ -550,7 +546,7 @@ mod tests {
         ]);
         let entities = [EntityPath::from("a")];
 
-        let unfiltered = geometry_for(&store, &timeline, &entities);
+        let unfiltered = layout_for(&store, &timeline, &entities);
         assert_eq!(unfiltered.num_rows(), 12);
         assert_eq!(
             unfiltered.levels().iter().cloned().collect::<Vec<_>>(),
@@ -558,7 +554,7 @@ mod tests {
         );
 
         let filter = LevelFilter(std::iter::once("WARN".to_owned()).collect());
-        let filtered = geometry_with_filter(&store, &timeline, &entities, Some(&filter));
+        let filtered = layout_with_filter(&store, &timeline, &entities, Some(&filter));
 
         // 5 WARN rows + 2 unleveled rows.
         assert_eq!(filtered.num_rows(), 7);
@@ -572,7 +568,7 @@ mod tests {
 
         // A filter matching nothing still shows unleveled rows.
         let none = LevelFilter(BTreeSet::default());
-        let none = geometry_with_filter(&store, &timeline, &entities, Some(&none));
+        let none = layout_with_filter(&store, &timeline, &entities, Some(&none));
         assert_eq!(none.num_rows(), 2);
     }
 }

--- a/crates/viewer/re_view_text_log/src/scroll_geometry.rs
+++ b/crates/viewer/re_view_text_log/src/scroll_geometry.rs
@@ -1,0 +1,347 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use re_chunk_store::external::arrow::array::Array as _;
+use re_chunk_store::{
+    AbsoluteTimeRange, Chunk, ChunkStore, ChunkTrackingMode, RangeQuery, TimeInt,
+};
+use re_entity_db::EntityPath;
+use re_log_types::TimelineName;
+use re_sdk_types::ComponentIdentifier;
+
+/// Chunk-level metadata for one chunk holding text log rows.
+struct ChunkGeom {
+    /// Time range covered by the chunk on the geometry's timeline.
+    ///
+    /// Meaningless for static chunks ([`AbsoluteTimeRange`] cannot represent static times).
+    time_range: AbsoluteTimeRange,
+
+    /// Number of text log rows in this chunk.
+    num_rows: u64,
+
+    is_static: bool,
+
+    chunk: Arc<Chunk>,
+}
+
+/// Row layout of the text log table, derived from chunk-level metadata only.
+///
+/// This is what allows the view to know how many rows there are — and roughly where in time
+/// each row lives — without touching any row data:
+/// row counts come from the per-chunk validity bitmaps and are exact,
+/// and only locating a time window boundary *inside* a chunk requires peeking at that
+/// (already loaded) chunk's time column.
+///
+/// Rows are ordered with static rows first, then by time.
+/// Where chunks of different entities overlap in time, the layout is approximate at chunk
+/// granularity, but stable; the visible window itself is always rendered in exact time order.
+pub struct ScrollGeometry {
+    timeline: TimelineName,
+    component: ComponentIdentifier,
+
+    /// Sorted by `time_range.min` (which puts static chunks first).
+    chunks: Vec<ChunkGeom>,
+
+    /// Prefix sums of `chunks[..i].num_rows`; length is `chunks.len() + 1`.
+    prefix_rows: Vec<u64>,
+
+    num_static_rows: u64,
+
+    /// Chunks that the store knows of but that aren't loaded; row counts are incomplete.
+    //
+    // TODO(#7562): once this is fed from the `RrdManifestIndex`, unloaded chunks can
+    // contribute their row counts too, making the layout complete in streaming scenarios.
+    pub any_missing: bool,
+}
+
+impl ScrollGeometry {
+    pub fn build<'a>(
+        store: &ChunkStore,
+        timeline: &TimelineName,
+        component: ComponentIdentifier,
+        entities: impl Iterator<Item = &'a EntityPath>,
+    ) -> Self {
+        re_tracing::profile_function!();
+
+        let query = RangeQuery::new(*timeline, AbsoluteTimeRange::EVERYTHING);
+
+        let mut chunks = Vec::new();
+        let mut any_missing = false;
+
+        for entity_path in entities {
+            // `Ignore`: don't trigger chunk downloads just to compute the row layout.
+            let results = store.range_relevant_chunks(
+                ChunkTrackingMode::Ignore,
+                &query,
+                entity_path,
+                component,
+            );
+            any_missing |= !results.missing_virtual.is_empty();
+
+            for chunk in results.chunks {
+                let Some(num_rows) = chunk.num_events_for_component(component) else {
+                    continue;
+                };
+                if num_rows == 0 {
+                    continue;
+                }
+
+                let is_static = chunk.is_static();
+                let time_range = if is_static {
+                    AbsoluteTimeRange::EMPTY
+                } else if let Some(time_column) = chunk.timelines().get(timeline) {
+                    time_column.time_range()
+                } else {
+                    continue;
+                };
+
+                chunks.push(ChunkGeom {
+                    time_range,
+                    num_rows,
+                    is_static,
+                    chunk,
+                });
+            }
+        }
+
+        // Static chunks first, then by time.
+        chunks.sort_by_key(|geom| (!geom.is_static, geom.time_range.min(), geom.chunk.id()));
+
+        let mut prefix_rows = Vec::with_capacity(chunks.len() + 1);
+        let mut total = 0;
+        prefix_rows.push(0);
+        for geom in &chunks {
+            total += geom.num_rows;
+            prefix_rows.push(total);
+        }
+
+        let num_static_rows = chunks
+            .iter()
+            .take_while(|geom| geom.is_static)
+            .map(|geom| geom.num_rows)
+            .sum();
+
+        Self {
+            timeline: *timeline,
+            component,
+            chunks,
+            prefix_rows,
+            num_static_rows,
+            any_missing,
+        }
+    }
+
+    /// Total number of text log rows (static and temporal).
+    pub fn num_rows(&self) -> u64 {
+        self.prefix_rows.last().copied().unwrap_or(0)
+    }
+
+    pub fn num_static_rows(&self) -> u64 {
+        self.num_static_rows
+    }
+
+    /// Number of rows strictly before time `t`: all static rows plus temporal rows with time < `t`.
+    ///
+    /// Equivalently: the global row index of the first temporal row with time >= `t`.
+    pub fn rows_before(&self, t: TimeInt) -> u64 {
+        re_tracing::profile_function!();
+
+        let mut count = 0;
+        for geom in &self.chunks {
+            if geom.is_static {
+                // Static rows sort before any temporal time.
+                count += geom.num_rows;
+                continue;
+            }
+            if geom.time_range.min() >= t {
+                // Chunks are sorted by min time: no further chunk can contribute.
+                break;
+            }
+            if geom.time_range.max() < t {
+                count += geom.num_rows;
+            } else {
+                count += count_rows_before_in_chunk(&geom.chunk, &self.timeline, self.component, t);
+            }
+        }
+        count
+    }
+
+    /// The time window covering all chunks that contribute rows in `rows`.
+    ///
+    /// Returns `None` when no temporal chunk overlaps the given row range.
+    /// (Static chunks are excluded: any range query returns them regardless.)
+    pub fn time_window_for_rows(&self, rows: Range<u64>) -> Option<(TimeInt, TimeInt)> {
+        let mut window: Option<(TimeInt, TimeInt)> = None;
+
+        for (i, geom) in self.chunks.iter().enumerate() {
+            if self.prefix_rows[i] >= rows.end {
+                break;
+            }
+            if self.prefix_rows[i + 1] <= rows.start || geom.is_static {
+                continue;
+            }
+
+            let (min, max) = window.unwrap_or((TimeInt::MAX, TimeInt::MIN));
+            window = Some((
+                min.min(geom.time_range.min()),
+                max.max(geom.time_range.max()),
+            ));
+        }
+
+        window
+    }
+}
+
+/// Counts the rows in `chunk` that hold a (non-null) `component` value at a time strictly
+/// before `t`.
+///
+/// Handles unsorted chunks (out-of-order logging) correctly by scanning the time column.
+fn count_rows_before_in_chunk(
+    chunk: &Chunk,
+    timeline: &TimelineName,
+    component: ComponentIdentifier,
+    t: TimeInt,
+) -> u64 {
+    re_tracing::profile_function!();
+
+    let Some(time_column) = chunk.timelines().get(timeline) else {
+        return 0;
+    };
+    let Some(list_array) = chunk.components().get_array(component) else {
+        return 0;
+    };
+
+    let t = t.as_i64();
+    let times = time_column.times_raw();
+
+    if let Some(validity) = list_array.nulls() {
+        times
+            .iter()
+            .zip(validity.iter())
+            .filter(|&(&time, valid)| valid && time < t)
+            .count() as u64
+    } else {
+        times.iter().filter(|&&time| time < t).count() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use re_chunk_store::{ChunkStore, ChunkStoreConfig};
+    use re_log_types::{StoreId, StoreKind, Timeline};
+    use re_sdk_types::archetypes::TextLog;
+
+    use super::*;
+
+    fn store_with_chunks(chunks: impl IntoIterator<Item = Chunk>) -> ChunkStore {
+        let mut store = ChunkStore::new(
+            StoreId::random(StoreKind::Recording, "test_app"),
+            ChunkStoreConfig::COMPACTION_DISABLED,
+        );
+        for chunk in chunks {
+            store.insert_chunk(&Arc::new(chunk)).unwrap();
+        }
+        store
+    }
+
+    fn text_chunk(entity: &str, timeline: Timeline, ticks: impl IntoIterator<Item = i64>) -> Chunk {
+        let mut builder = Chunk::builder(entity);
+        for tick in ticks {
+            builder = builder.with_archetype_auto_row(
+                [(timeline, tick)],
+                &TextLog::new(format!("{entity} {tick}")),
+            );
+        }
+        builder.build().unwrap()
+    }
+
+    fn geometry_for(
+        store: &ChunkStore,
+        timeline: &Timeline,
+        entities: &[EntityPath],
+    ) -> ScrollGeometry {
+        ScrollGeometry::build(
+            store,
+            timeline.name(),
+            TextLog::descriptor_text().component,
+            entities.iter(),
+        )
+    }
+
+    #[test]
+    fn overlapping_chunks_have_exact_counts() {
+        let timeline = Timeline::log_tick();
+        let store = store_with_chunks([
+            text_chunk("a", timeline, [0, 2, 4, 6, 8]),
+            text_chunk("b", timeline, [1, 3, 5, 7, 9]),
+        ]);
+        let geometry = geometry_for(
+            &store,
+            &timeline,
+            &[EntityPath::from("a"), EntityPath::from("b")],
+        );
+
+        assert_eq!(geometry.num_rows(), 10);
+        assert_eq!(geometry.num_static_rows(), 0);
+
+        // Both chunks overlap the whole range, so every boundary requires exact,
+        // per-chunk row counting.
+        for t in 0..=10 {
+            assert_eq!(
+                geometry.rows_before(TimeInt::new_temporal(t)),
+                t as u64,
+                "rows_before({t})"
+            );
+        }
+    }
+
+    #[test]
+    fn static_rows_sort_first() {
+        let timeline = Timeline::log_tick();
+
+        let static_chunk = Chunk::builder("static")
+            .with_archetype_auto_row(re_log_types::TimePoint::default(), &TextLog::new("static"))
+            .build()
+            .unwrap();
+
+        let store = store_with_chunks([static_chunk, text_chunk("a", timeline, [10, 20])]);
+        let geometry = geometry_for(
+            &store,
+            &timeline,
+            &[EntityPath::from("static"), EntityPath::from("a")],
+        );
+
+        assert_eq!(geometry.num_rows(), 3);
+        assert_eq!(geometry.num_static_rows(), 1);
+
+        // The static row counts as "before" any temporal time.
+        assert_eq!(geometry.rows_before(TimeInt::new_temporal(0)), 1);
+        assert_eq!(geometry.rows_before(TimeInt::new_temporal(15)), 2);
+        assert_eq!(geometry.rows_before(TimeInt::new_temporal(21)), 3);
+    }
+
+    #[test]
+    fn time_window_covers_requested_rows() {
+        let timeline = Timeline::log_tick();
+        let store = store_with_chunks([
+            text_chunk("a", timeline, [0, 1, 2]),
+            text_chunk("a", timeline, [10, 11, 12]),
+            text_chunk("a", timeline, [20, 21, 22]),
+        ]);
+        let geometry = geometry_for(&store, &timeline, &[EntityPath::from("a")]);
+
+        assert_eq!(geometry.num_rows(), 9);
+
+        // Rows 3..6 live in the middle chunk.
+        let (min, max) = geometry.time_window_for_rows(3..6).unwrap();
+        assert_eq!(min, TimeInt::new_temporal(10));
+        assert_eq!(max, TimeInt::new_temporal(12));
+
+        // A range spanning chunk boundaries covers both chunks.
+        let (min, max) = geometry.time_window_for_rows(2..4).unwrap();
+        assert_eq!(min, TimeInt::new_temporal(0));
+        assert_eq!(max, TimeInt::new_temporal(12));
+
+        assert!(geometry.time_window_for_rows(9..9).is_none());
+    }
+}

--- a/crates/viewer/re_view_text_log/src/scroll_geometry.rs
+++ b/crates/viewer/re_view_text_log/src/scroll_geometry.rs
@@ -1,13 +1,61 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Range;
 use std::sync::Arc;
 
-use re_chunk_store::external::arrow::array::Array as _;
+use re_chunk_store::external::arrow::array::{
+    Array as _, ListArray as ArrowListArray, StringArray as ArrowStringArray,
+};
 use re_chunk_store::{
-    AbsoluteTimeRange, Chunk, ChunkStore, ChunkTrackingMode, RangeQuery, TimeInt,
+    AbsoluteTimeRange, Chunk, ChunkId, ChunkStore, ChunkTrackingMode, RangeQuery, TimeInt,
 };
 use re_entity_db::EntityPath;
 use re_log_types::TimelineName;
 use re_sdk_types::ComponentIdentifier;
+
+/// An explicit log level filter: only rows whose level is in the set are shown.
+///
+/// Rows without a level always pass.
+#[derive(Clone, PartialEq, Eq)]
+pub struct LevelFilter(pub BTreeSet<String>);
+
+impl LevelFilter {
+    pub fn matches(&self, level: Option<&str>) -> bool {
+        level.is_none_or(|lvl| self.0.contains(lvl))
+    }
+}
+
+/// Per-level row counts for a single chunk.
+///
+/// Chunks are immutable, so these can be cached indefinitely (keyed by [`ChunkId`]),
+/// which makes level-filtered row counts as cheap as unfiltered ones after the first frame.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct LevelCounts {
+    /// Number of text log rows whose (first) level value is the given string.
+    per_level: BTreeMap<String, u64>,
+
+    /// Number of text log rows without a level value.
+    unleveled: u64,
+}
+
+impl LevelCounts {
+    fn matching(&self, filter: &LevelFilter) -> u64 {
+        self.unleveled
+            + filter
+                .0
+                .iter()
+                .filter_map(|lvl| self.per_level.get(lvl))
+                .sum::<u64>()
+    }
+}
+
+impl re_byte_size::SizeBytes for LevelCounts {
+    fn heap_size_bytes(&self) -> u64 {
+        re_byte_size::SizeBytes::heap_size_bytes(&self.per_level)
+    }
+}
+
+/// Cached per-chunk level counts, keyed by chunk id.
+pub type LevelCountCache = BTreeMap<ChunkId, LevelCounts>;
 
 /// Chunk-level metadata for one chunk holding text log rows.
 struct ChunkGeom {
@@ -28,7 +76,8 @@ struct ChunkGeom {
 ///
 /// This is what allows the view to know how many rows there are — and roughly where in time
 /// each row lives — without touching any row data:
-/// row counts come from the per-chunk validity bitmaps and are exact,
+/// row counts come from the per-chunk validity bitmaps (or, with a level filter active,
+/// from cached per-chunk level counts) and are exact,
 /// and only locating a time window boundary *inside* a chunk requires peeking at that
 /// (already loaded) chunk's time column.
 ///
@@ -38,6 +87,10 @@ struct ChunkGeom {
 pub struct ScrollGeometry {
     timeline: TimelineName,
     component: ComponentIdentifier,
+    level_component: ComponentIdentifier,
+
+    /// The active level filter; when set, all row counts only cover matching rows.
+    filter: Option<LevelFilter>,
 
     /// Sorted by `time_range.min` (which puts static chunks first).
     chunks: Vec<ChunkGeom>,
@@ -47,6 +100,9 @@ pub struct ScrollGeometry {
 
     num_static_rows: u64,
 
+    /// All log levels that occur anywhere in the considered chunks.
+    levels: BTreeSet<String>,
+
     /// Chunks that the store knows of but that aren't loaded; row counts are incomplete.
     //
     // TODO(#7562): once this is fed from the `RrdManifestIndex`, unloaded chunks can
@@ -55,18 +111,25 @@ pub struct ScrollGeometry {
 }
 
 impl ScrollGeometry {
+    /// Note that the level counting is done on the raw store data: blueprint overrides of the
+    /// `level` component are not taken into account by `filter`.
     pub fn build<'a>(
         store: &ChunkStore,
         timeline: &TimelineName,
         component: ComponentIdentifier,
+        level_component: ComponentIdentifier,
         entities: impl Iterator<Item = &'a EntityPath>,
+        filter: Option<&LevelFilter>,
+        level_counts: &mut LevelCountCache,
     ) -> Self {
         re_tracing::profile_function!();
 
         let query = RangeQuery::new(*timeline, AbsoluteTimeRange::EVERYTHING);
 
         let mut chunks = Vec::new();
+        let mut levels = BTreeSet::new();
         let mut any_missing = false;
+        let mut live_chunks = BTreeSet::new();
 
         for entity_path in entities {
             // `Ignore`: don't trigger chunk downloads just to compute the row layout.
@@ -79,8 +142,26 @@ impl ScrollGeometry {
             any_missing |= !results.missing_virtual.is_empty();
 
             for chunk in results.chunks {
-                let Some(num_rows) = chunk.num_events_for_component(component) else {
+                let Some(total_rows) = chunk.num_events_for_component(component) else {
                     continue;
+                };
+                if total_rows == 0 {
+                    continue;
+                }
+
+                live_chunks.insert(chunk.id());
+
+                // One-time scan per chunk (chunks are immutable, so the cache never goes
+                // stale); this is what makes level-filtered row counts affordable, and it
+                // gives us the complete set of occurring levels for the filter UI.
+                let counts = level_counts
+                    .entry(chunk.id())
+                    .or_insert_with(|| level_counts_for_chunk(&chunk, component, level_component));
+                levels.extend(counts.per_level.keys().cloned());
+
+                let num_rows = match filter {
+                    Some(filter) => counts.matching(filter),
+                    None => total_rows,
                 };
                 if num_rows == 0 {
                     continue;
@@ -104,6 +185,9 @@ impl ScrollGeometry {
             }
         }
 
+        // Drop cache entries for chunks that no longer exist (compacted or garbage collected).
+        level_counts.retain(|chunk_id, _| live_chunks.contains(chunk_id));
+
         // Static chunks first, then by time.
         chunks.sort_by_key(|geom| (!geom.is_static, geom.time_range.min(), geom.chunk.id()));
 
@@ -124,11 +208,19 @@ impl ScrollGeometry {
         Self {
             timeline: *timeline,
             component,
+            level_component,
+            filter: filter.cloned(),
             chunks,
             prefix_rows,
             num_static_rows,
+            levels,
             any_missing,
         }
+    }
+
+    /// All log levels that occur anywhere in the considered chunks.
+    pub fn levels(&self) -> &BTreeSet<String> {
+        &self.levels
     }
 
     /// Total number of text log rows (static and temporal).
@@ -160,7 +252,14 @@ impl ScrollGeometry {
             if geom.time_range.max() < t {
                 count += geom.num_rows;
             } else {
-                count += count_rows_before_in_chunk(&geom.chunk, &self.timeline, self.component, t);
+                count += count_rows_before_in_chunk(
+                    &geom.chunk,
+                    &self.timeline,
+                    self.component,
+                    self.level_component,
+                    self.filter.as_ref(),
+                    t,
+                );
             }
         }
         count
@@ -193,13 +292,15 @@ impl ScrollGeometry {
 }
 
 /// Counts the rows in `chunk` that hold a (non-null) `component` value at a time strictly
-/// before `t`.
+/// before `t` (and that pass the level filter, if any).
 ///
 /// Handles unsorted chunks (out-of-order logging) correctly by scanning the time column.
 fn count_rows_before_in_chunk(
     chunk: &Chunk,
     timeline: &TimelineName,
     component: ComponentIdentifier,
+    level_component: ComponentIdentifier,
+    filter: Option<&LevelFilter>,
     t: TimeInt,
 ) -> u64 {
     re_tracing::profile_function!();
@@ -213,16 +314,88 @@ fn count_rows_before_in_chunk(
 
     let t = t.as_i64();
     let times = time_column.times_raw();
+    let validity = list_array.nulls();
+    let levels = filter.map(|filter| (filter, RowLevels::new(chunk, level_component)));
 
-    if let Some(validity) = list_array.nulls() {
-        times
-            .iter()
-            .zip(validity.iter())
-            .filter(|&(&time, valid)| valid && time < t)
-            .count() as u64
-    } else {
-        times.iter().filter(|&&time| time < t).count() as u64
+    (0..times.len())
+        .filter(|&row| {
+            validity.is_none_or(|validity| validity.is_valid(row))
+                && times[row] < t
+                && levels
+                    .as_ref()
+                    .is_none_or(|(filter, levels)| filter.matches(levels.first(row)))
+        })
+        .count() as u64
+}
+
+/// Per-row access to the first log level instance of a chunk.
+///
+/// This deliberately only looks at the chunk row itself — no blueprint overrides, no
+/// latest-at clamping from earlier rows — mirroring how the visualizer builds its entries
+/// (exact index join), so that row counts derived here always line up with the materialized
+/// entries.
+struct RowLevels<'a> {
+    list_and_values: Option<(&'a ArrowListArray, &'a ArrowStringArray)>,
+}
+
+impl<'a> RowLevels<'a> {
+    fn new(chunk: &'a Chunk, level_component: ComponentIdentifier) -> Self {
+        let list_and_values = chunk
+            .components()
+            .get_array(level_component)
+            .and_then(|list| {
+                let values = list.values().as_any().downcast_ref::<ArrowStringArray>()?;
+                Some((list, values))
+            });
+        Self { list_and_values }
     }
+
+    /// The first level value of the given chunk row, if any.
+    fn first(&self, row: usize) -> Option<&'a str> {
+        let (list, values) = self.list_and_values?;
+        if list.nulls().is_some_and(|validity| !validity.is_valid(row)) {
+            return None;
+        }
+        let start = usize::try_from(list.value_offsets()[row]).ok()?;
+        let end = usize::try_from(list.value_offsets()[row + 1]).ok()?;
+        (start < end && values.is_valid(start)).then(|| values.value(start))
+    }
+}
+
+/// Counts, per log level, the rows of `chunk` that hold a (non-null) `component` value.
+fn level_counts_for_chunk(
+    chunk: &Chunk,
+    component: ComponentIdentifier,
+    level_component: ComponentIdentifier,
+) -> LevelCounts {
+    re_tracing::profile_function!();
+
+    let mut counts = LevelCounts::default();
+
+    let Some(list_array) = chunk.components().get_array(component) else {
+        return counts;
+    };
+
+    let validity = list_array.nulls();
+    let levels = RowLevels::new(chunk, level_component);
+
+    for row in 0..list_array.len() {
+        if validity.is_some_and(|validity| !validity.is_valid(row)) {
+            continue;
+        }
+        match levels.first(row) {
+            Some(level) => {
+                if let Some(count) = counts.per_level.get_mut(level) {
+                    *count += 1;
+                } else {
+                    counts.per_level.insert(level.to_owned(), 1);
+                }
+            }
+            None => counts.unleveled += 1,
+        }
+    }
+
+    counts
 }
 
 #[cfg(test)]
@@ -260,11 +433,23 @@ mod tests {
         timeline: &Timeline,
         entities: &[EntityPath],
     ) -> ScrollGeometry {
+        geometry_with_filter(store, timeline, entities, None)
+    }
+
+    fn geometry_with_filter(
+        store: &ChunkStore,
+        timeline: &Timeline,
+        entities: &[EntityPath],
+        filter: Option<&LevelFilter>,
+    ) -> ScrollGeometry {
         ScrollGeometry::build(
             store,
             timeline.name(),
             TextLog::descriptor_text().component,
+            TextLog::descriptor_level().component,
             entities.iter(),
+            filter,
+            &mut LevelCountCache::default(),
         )
     }
 
@@ -343,5 +528,51 @@ mod tests {
         assert_eq!(max, TimeInt::new_temporal(12));
 
         assert!(geometry.time_window_for_rows(9..9).is_none());
+    }
+
+    #[test]
+    fn level_filter_gives_exact_counts() {
+        let timeline = Timeline::log_tick();
+
+        // Ticks 0..10; even ticks are INFO, odd ticks are WARN.
+        let mut builder = Chunk::builder("a");
+        for tick in 0..10 {
+            let level = if tick % 2 == 0 { "INFO" } else { "WARN" };
+            builder = builder.with_archetype_auto_row(
+                [(timeline, tick)],
+                &TextLog::new(format!("{tick}")).with_level(level),
+            );
+        }
+        // A second chunk whose rows have no level at all: those always pass the filter.
+        let store = store_with_chunks([
+            builder.build().unwrap(),
+            text_chunk("a", timeline, [100, 101]),
+        ]);
+        let entities = [EntityPath::from("a")];
+
+        let unfiltered = geometry_for(&store, &timeline, &entities);
+        assert_eq!(unfiltered.num_rows(), 12);
+        assert_eq!(
+            unfiltered.levels().iter().cloned().collect::<Vec<_>>(),
+            vec!["INFO".to_owned(), "WARN".to_owned()]
+        );
+
+        let filter = LevelFilter(std::iter::once("WARN".to_owned()).collect());
+        let filtered = geometry_with_filter(&store, &timeline, &entities, Some(&filter));
+
+        // 5 WARN rows + 2 unleveled rows.
+        assert_eq!(filtered.num_rows(), 7);
+
+        // Boundaries inside the mixed chunk require filtered per-row counting.
+        assert_eq!(filtered.rows_before(TimeInt::new_temporal(0)), 0);
+        assert_eq!(filtered.rows_before(TimeInt::new_temporal(2)), 1); // WARN@1
+        assert_eq!(filtered.rows_before(TimeInt::new_temporal(6)), 3); // WARN@1,3,5
+        assert_eq!(filtered.rows_before(TimeInt::new_temporal(50)), 5);
+        assert_eq!(filtered.rows_before(TimeInt::new_temporal(101)), 6);
+
+        // A filter matching nothing still shows unleveled rows.
+        let none = LevelFilter(BTreeSet::default());
+        let none = geometry_with_filter(&store, &timeline, &entities, Some(&none));
+        assert_eq!(none.num_rows(), 2);
     }
 }

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -324,20 +324,20 @@ Filter message types and toggle column visibility in a selection panel.",
                 TimelineName::try_new(col.timeline.as_str()).ok_or_log_error_once()
             {
                 column_kinds.push(ColumnKind::Timeline(timeline));
-                table_columns.push(egui_table::Column::new(110.0).resizable(true));
+                table_columns.push(text_log_column(110.0, 60.0));
             }
         }
         for col in &columns {
             if !*col.visible {
                 continue;
             }
-            let width = match col.kind {
-                bp_encodings::TextLogColumnKind::EntityPath => 120.0,
-                bp_encodings::TextLogColumnKind::LogLevel => 50.0,
-                bp_encodings::TextLogColumnKind::Body => 400.0,
+            let (width, min_width) = match col.kind {
+                bp_encodings::TextLogColumnKind::EntityPath => (120.0, 60.0),
+                bp_encodings::TextLogColumnKind::LogLevel => (50.0, 44.0),
+                bp_encodings::TextLogColumnKind::Body => (400.0, 100.0),
             };
             column_kinds.push(ColumnKind::Kind(col.kind));
-            table_columns.push(egui_table::Column::new(width).resizable(true));
+            table_columns.push(text_log_column(width, min_width));
         }
 
         let mut delegate = TextLogTableDelegate {
@@ -362,6 +362,7 @@ Filter message types and toggle column visibility in a selection panel.",
             let mut table = egui_table::Table::new()
                 .id_salt(egui::Id::new("text_log").with(query.view_id))
                 .columns(table_columns)
+                .auto_size_mode(egui_table::AutoSizeMode::Always)
                 .headers(vec![egui_table::HeaderRow::new(
                     tokens.table_header_height(),
                 )])
@@ -403,6 +404,14 @@ Filter message types and toggle column visibility in a selection panel.",
 enum ColumnKind {
     Timeline(TimelineName),
     Kind(bp_encodings::TextLogColumnKind),
+}
+
+/// A resizable column that starts out `width` wide but may be squeezed down to `min_width`
+/// when the view is too narrow to fit every column at its preferred width.
+fn text_log_column(width: f32, min_width: f32) -> egui_table::Column {
+    egui_table::Column::new(width)
+        .range(egui::Rangef::new(min_width, f32::INFINITY))
+        .resizable(true)
 }
 
 /// Maps a global row index to a (possibly not-yet-fetched) [`Entry`].

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -7,7 +7,6 @@ use re_data_ui::item_ui::{self, timeline_button};
 use re_dataframe_ui::apply_table_style_fixes;
 use re_log::ResultExt as _;
 use re_log_types::{EntityPath, TimelineName};
-use re_sdk_types::archetypes::TextLog;
 use re_sdk_types::blueprint::archetypes::{TextLogColumns, TextLogFormat, TextLogRows};
 use re_sdk_types::blueprint::components::{Enabled, TextLogColumn, TimelineColumn};
 use re_sdk_types::blueprint::encodings as bp_encodings;
@@ -23,7 +22,7 @@ use re_viewer_context::{
 use re_viewport_blueprint::ViewProperty;
 
 use super::visualizer_system::{Entry, FetchWindow, TextLogOutput, TextLogSystem};
-use crate::row_layout::{LevelCountCache, LevelFilter, RowLayout};
+use crate::row_layout::RowLayout;
 
 // TODO(andreas): This should be a blueprint component.
 #[derive(Clone, PartialEq, Eq, Default, re_byte_size::SizeBytes)]
@@ -50,10 +49,6 @@ pub struct TextViewState {
     /// Written at the end of `ui()` based on the visible rows, read by
     /// [`TextLogSystem`]'s `execute()` one frame later.
     pub(crate) fetch_window: Option<FetchWindow>,
-
-    /// Cached per-chunk log level counts, used to lay out the table when a level filter is
-    /// active (see [`RowLayout`]).
-    level_counts: LevelCountCache,
 }
 
 impl ViewState for TextViewState {
@@ -205,7 +200,7 @@ Filter message types and toggle column visibility in a selection panel.",
     fn ui(
         &self,
         ctx: &ViewerContext<'_>,
-        missing_chunk_reporter: &re_viewer_context::MissingChunkReporter,
+        _missing_chunk_reporter: &re_viewer_context::MissingChunkReporter,
         ui: &mut egui::Ui,
         state: &mut dyn ViewState,
         query: &ViewQuery<'_>,
@@ -222,7 +217,6 @@ Filter message types and toggle column visibility in a selection panel.",
 
         let view_ctx = self.view_context(ctx, query.view_id, state, query.space_origin);
         let columns_property = ViewProperty::from_archetype::<TextLogColumns>(&view_ctx);
-        let rows_property = ViewProperty::from_archetype::<TextLogRows>(&view_ctx);
         let format_property = ViewProperty::from_archetype::<TextLogFormat>(&view_ctx);
 
         let monospace_body = format_property.component_or_fallback::<Enabled>(
@@ -239,64 +233,33 @@ Filter message types and toggle column visibility in a selection panel.",
             TextLogColumns::descriptor_timeline_columns().component,
         )?;
 
-        // An *explicit* level filter (i.e. one set in the blueprint, not the show-everything
-        // fallback) changes which rows are shown; the row layout then comes from cached
-        // per-chunk level counts instead of plain chunk row counts.
-        let filter = rows_property
-            .component_array::<TextLogLevel>(
-                TextLogRows::descriptor_filter_by_log_level().component,
-            )?
-            .map(|levels| LevelFilter(levels.iter().map(|lvl| lvl.as_str().to_owned()).collect()));
-
         let time = ctx.time_ctrl.time_i64().unwrap_or(state.latest_time);
 
-        // Only the fetched window's entries are materialized; the rest of the row layout comes
-        // from chunk-level metadata (time ranges + row counts), so we never have to touch the
-        // full data. See <https://github.com/rerun-io/rerun/issues/7562>.
-        let layout = {
-            let engine = ctx.recording_engine();
-            RowLayout::build(
-                engine.store(),
-                &query.timeline,
-                TextLog::descriptor_text().component,
-                TextLog::descriptor_level().component,
-                query
-                    .iter_visualizer_instruction_for(TextLogSystem::identifier())
-                    .map(|(data_result, _)| &data_result.entity_path),
-                filter.as_ref(),
-                &mut state.level_counts,
-            )
-        };
+        // Everything about *where* rows live comes from the visualizer, which derives it from
+        // chunk-level metadata rather than the row data itself.
+        // `None` means the visualizer didn't run, i.e. the view has no active instructions.
+        let layout = output.layout.as_ref();
 
-        state.seen_levels.extend(layout.levels().iter().cloned());
-
-        if layout.any_missing {
-            missing_chunk_reporter.report_missing_chunk();
+        if let Some(layout) = layout {
+            state.seen_levels.extend(layout.levels().iter().cloned());
         }
 
-        // The fetched window contains *all* rows in its time range; apply the level filter
-        // here so the entries line up with the (filtered) row layout.
-        let visible_entries: Vec<&Entry> = match &filter {
-            Some(filter) => output
-                .entries
-                .iter()
-                .filter(|te| filter.matches(te.level.as_ref().map(|lvl| lvl.as_str())))
-                .collect(),
-            None => output.entries.iter().collect(),
-        };
+        let num_rows = layout.map_or(0, RowLayout::num_rows);
+        let num_static_rows = layout.map_or(0, RowLayout::num_static_rows);
+        let rows_before = |t: TimeInt| layout.map_or(0, |layout| layout.rows_before(t));
 
-        let num_rows = layout.num_rows();
-        let scroll_row = layout.rows_before(TimeInt::new_temporal(time));
-        let anchor_row = layout.rows_before(TimeInt::new_temporal(time).inc());
+        let scroll_row = rows_before(TimeInt::new_temporal(time));
+        let anchor_row = rows_before(TimeInt::new_temporal(time).inc());
 
         let rows = RowLookup {
-            num_static: layout.num_static_rows(),
-            fetched_static: visible_entries.partition_point(|entry| entry.time.is_static()) as u64,
-            temporal_offset: output.window.map_or_else(
-                || layout.num_static_rows(),
-                |window| layout.rows_before(window.min),
-            ),
-            entries: visible_entries,
+            num_static: num_static_rows,
+            fetched_static: output
+                .entries
+                .partition_point(|entry| entry.time.is_static()) as u64,
+            temporal_offset: output
+                .window
+                .map_or(num_static_rows, |window| rows_before(window.min)),
+            entries: &output.entries,
         };
 
         // Auto-scroll when the time cursor moves, or whenever the row below the cursor shifts
@@ -383,7 +346,7 @@ Filter message types and toggle column visibility in a selection panel.",
         let prefetch_rows =
             visible_rows.start.saturating_sub(page)..(visible_rows.end + page).min(num_rows);
         let new_window = layout
-            .time_window_for_rows(prefetch_rows)
+            .and_then(|layout| layout.time_window_for_rows(prefetch_rows))
             .map(|(min, max)| FetchWindow {
                 timeline: query.timeline,
                 min,
@@ -419,7 +382,7 @@ fn text_log_column(width: f32, min_width: f32) -> egui_table::Column {
 /// Only the fetched time window is materialized.
 struct RowLookup<'a> {
     /// Fetched entries that pass the level filter, sorted by time, static entries first.
-    entries: Vec<&'a Entry>,
+    entries: &'a [Entry],
 
     /// Total number of static rows according to chunk metadata.
     num_static: u64,
@@ -434,10 +397,10 @@ struct RowLookup<'a> {
 impl RowLookup<'_> {
     fn entry(&self, row_nr: u64) -> Option<&Entry> {
         if row_nr < self.num_static {
-            (row_nr < self.fetched_static).then(|| self.entries[row_nr as usize])
+            (row_nr < self.fetched_static).then(|| &self.entries[row_nr as usize])
         } else {
             let idx = self.fetched_static + row_nr.checked_sub(self.temporal_offset)?;
-            self.entries.get(idx as usize).copied()
+            self.entries.get(idx as usize)
         }
     }
 }

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -23,7 +23,7 @@ use re_viewer_context::{
 use re_viewport_blueprint::ViewProperty;
 
 use super::visualizer_system::{Entry, FetchWindow, TextLogOutput, TextLogSystem};
-use crate::scroll_geometry::{LevelCountCache, LevelFilter, ScrollGeometry};
+use crate::row_layout::{LevelCountCache, LevelFilter, RowLayout};
 
 // TODO(andreas): This should be a blueprint component.
 #[derive(Clone, PartialEq, Eq, Default, re_byte_size::SizeBytes)]
@@ -52,7 +52,7 @@ pub struct TextViewState {
     pub(crate) fetch_window: Option<FetchWindow>,
 
     /// Cached per-chunk log level counts, used to lay out the table when a level filter is
-    /// active (see [`ScrollGeometry`]).
+    /// active (see [`RowLayout`]).
     level_counts: LevelCountCache,
 }
 
@@ -253,9 +253,9 @@ Filter message types and toggle column visibility in a selection panel.",
         // Only the fetched window's entries are materialized; the rest of the row layout comes
         // from chunk-level metadata (time ranges + row counts), so we never have to touch the
         // full data. See <https://github.com/rerun-io/rerun/issues/7562>.
-        let geometry = {
+        let layout = {
             let engine = ctx.recording_engine();
-            ScrollGeometry::build(
+            RowLayout::build(
                 engine.store(),
                 &query.timeline,
                 TextLog::descriptor_text().component,
@@ -268,9 +268,9 @@ Filter message types and toggle column visibility in a selection panel.",
             )
         };
 
-        state.seen_levels.extend(geometry.levels().iter().cloned());
+        state.seen_levels.extend(layout.levels().iter().cloned());
 
-        if geometry.any_missing {
+        if layout.any_missing {
             missing_chunk_reporter.report_missing_chunk();
         }
 
@@ -285,16 +285,16 @@ Filter message types and toggle column visibility in a selection panel.",
             None => output.entries.iter().collect(),
         };
 
-        let num_rows = geometry.num_rows();
-        let scroll_row = geometry.rows_before(TimeInt::new_temporal(time));
-        let anchor_row = geometry.rows_before(TimeInt::new_temporal(time).inc());
+        let num_rows = layout.num_rows();
+        let scroll_row = layout.rows_before(TimeInt::new_temporal(time));
+        let anchor_row = layout.rows_before(TimeInt::new_temporal(time).inc());
 
         let rows = RowLookup {
-            num_static: geometry.num_static_rows(),
+            num_static: layout.num_static_rows(),
             fetched_static: visible_entries.partition_point(|entry| entry.time.is_static()) as u64,
             temporal_offset: output.window.map_or_else(
-                || geometry.num_static_rows(),
-                |window| geometry.rows_before(window.min),
+                || layout.num_static_rows(),
+                |window| layout.rows_before(window.min),
             ),
             entries: visible_entries,
         };
@@ -381,7 +381,7 @@ Filter message types and toggle column visibility in a selection panel.",
         let page = (visible_rows.end - visible_rows.start).max(1);
         let prefetch_rows =
             visible_rows.start.saturating_sub(page)..(visible_rows.end + page).min(num_rows);
-        let new_window = geometry
+        let new_window = layout
             .time_window_for_rows(prefetch_rows)
             .map(|(min, max)| FetchWindow {
                 timeline: query.timeline,

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -23,7 +23,7 @@ use re_viewer_context::{
 use re_viewport_blueprint::ViewProperty;
 
 use super::visualizer_system::{Entry, FetchWindow, TextLogOutput, TextLogSystem};
-use crate::scroll_geometry::ScrollGeometry;
+use crate::scroll_geometry::{LevelCountCache, LevelFilter, ScrollGeometry};
 
 // TODO(andreas): This should be a blueprint component.
 #[derive(Clone, PartialEq, Eq, Default, re_byte_size::SizeBytes)]
@@ -51,11 +51,9 @@ pub struct TextViewState {
     /// [`TextLogSystem::execute`] one frame later.
     pub(crate) fetch_window: Option<FetchWindow>,
 
-    /// Whether an explicit log level filter is set.
-    ///
-    /// If so, the visualizer queries the full time range, since the row layout can then no
-    /// longer be derived from chunk-level metadata.
-    pub(crate) filter_active: bool,
+    /// Cached per-chunk log level counts, used to lay out the table when a level filter is
+    /// active (see [`ScrollGeometry`]).
+    level_counts: LevelCountCache,
 }
 
 impl ViewState for TextViewState {
@@ -242,82 +240,63 @@ Filter message types and toggle column visibility in a selection panel.",
         )?;
 
         // An *explicit* level filter (i.e. one set in the blueprint, not the show-everything
-        // fallback) means the row count can no longer be derived from chunk-level metadata,
-        // so the visualizer falls back to fetching the full range and we filter here.
-        let explicit_levels = rows_property.component_array::<TextLogLevel>(
-            TextLogRows::descriptor_filter_by_log_level().component,
-        )?;
-        let filter_active = explicit_levels.is_some();
-
-        for te in &output.entries {
-            if let Some(lvl) = &te.level {
-                state.seen_levels.insert(lvl.to_string());
-            }
-        }
+        // fallback) changes which rows are shown; the row layout then comes from cached
+        // per-chunk level counts instead of plain chunk row counts.
+        let filter = rows_property
+            .component_array::<TextLogLevel>(
+                TextLogRows::descriptor_filter_by_log_level().component,
+            )?
+            .map(|levels| LevelFilter(levels.iter().map(|lvl| lvl.as_str().to_owned()).collect()));
 
         let time = ctx.time_ctrl.time_i64().unwrap_or(state.latest_time);
 
         // Only the fetched window's entries are materialized; the rest of the row layout comes
         // from chunk-level metadata (time ranges + row counts), so we never have to touch the
         // full data. See <https://github.com/rerun-io/rerun/issues/7562>.
-        let geometry = if filter_active {
-            None
-        } else {
+        let geometry = {
             let engine = ctx.recording_engine();
-            Some(ScrollGeometry::build(
+            ScrollGeometry::build(
                 engine.store(),
                 &query.timeline,
                 TextLog::descriptor_text().component,
+                TextLog::descriptor_level().component,
                 query
                     .iter_visualizer_instruction_for(TextLogSystem::identifier())
                     .map(|(data_result, _)| &data_result.entity_path),
-            ))
+                filter.as_ref(),
+                &mut state.level_counts,
+            )
         };
 
-        if geometry.as_ref().is_some_and(|g| g.any_missing) {
+        state.seen_levels.extend(geometry.levels().iter().cloned());
+
+        if geometry.any_missing {
             missing_chunk_reporter.report_missing_chunk();
         }
 
-        let filtered_entries: Vec<&Entry>; // Only used when the level filter is active.
-        let (num_rows, rows, scroll_row, anchor_row) = if let Some(geometry) = &geometry {
-            let scroll_row = geometry.rows_before(TimeInt::new_temporal(time));
-            let anchor_row = geometry.rows_before(TimeInt::new_temporal(time).inc());
-
-            let rows = RowLookup::Virtual {
-                entries: &output.entries,
-                num_static: geometry.num_static_rows(),
-                fetched_static: output
-                    .entries
-                    .partition_point(|entry| entry.time.is_static())
-                    as u64,
-                temporal_offset: output.window.map_or_else(
-                    || geometry.num_static_rows(),
-                    |window| geometry.rows_before(window.min),
-                ),
-            };
-
-            (geometry.num_rows(), rows, scroll_row, anchor_row)
-        } else {
-            let levels = explicit_levels.as_deref().unwrap_or(&[]);
-            filtered_entries = output
+        // The fetched window contains *all* rows in its time range; apply the level filter
+        // here so the entries line up with the (filtered) row layout.
+        let visible_entries: Vec<&Entry> = match &filter {
+            Some(filter) => output
                 .entries
                 .iter()
-                .filter(|te| {
-                    te.level
-                        .as_ref()
-                        .is_none_or(|lvl| levels.iter().any(|l| l.as_str() == lvl.as_str()))
-                })
-                .collect();
+                .filter(|te| filter.matches(te.level.as_ref().map(|lvl| lvl.as_str())))
+                .collect(),
+            None => output.entries.iter().collect(),
+        };
 
-            let scroll_row = filtered_entries.partition_point(|te| te.time.as_i64() < time) as u64;
-            let anchor_row = filtered_entries.partition_point(|te| te.time.as_i64() <= time) as u64;
+        let num_rows = geometry.num_rows();
+        let scroll_row = geometry.rows_before(TimeInt::new_temporal(time));
+        let anchor_row = geometry.rows_before(TimeInt::new_temporal(time).inc());
 
-            (
-                filtered_entries.len() as u64,
-                RowLookup::Materialized(&filtered_entries),
-                scroll_row,
-                anchor_row,
-            )
+        let rows = RowLookup {
+            num_static: geometry.num_static_rows(),
+            fetched_static: visible_entries.partition_point(|entry| entry.time.is_static()) as u64,
+            temporal_offset: output.window.map_or_else(
+                || geometry.num_static_rows(),
+                |window| geometry.rows_before(window.min),
+            ),
+            entries: visible_entries,
         };
 
         // Auto-scroll when the time cursor moves, or whenever the row below the cursor shifts
@@ -399,31 +378,19 @@ Filter message types and toggle column visibility in a selection panel.",
         // Tell the visualizer which time window to fetch next frame: the visible rows,
         // padded by one page on each side for scroll responsiveness.
         let visible_rows = delegate.visible_rows.clone();
-        let new_window = if let Some(geometry) = &geometry {
-            let page = (visible_rows.end - visible_rows.start).max(1);
-            let prefetch_rows =
-                visible_rows.start.saturating_sub(page)..(visible_rows.end + page).min(num_rows);
-            geometry
-                .time_window_for_rows(prefetch_rows)
-                .map(|(min, max)| FetchWindow {
-                    timeline: query.timeline,
-                    min,
-                    max,
-                })
-        } else {
-            // Level filter active: the window is unused, keep it around for when the filter
-            // is removed again.
-            state.fetch_window
-        };
+        let page = (visible_rows.end - visible_rows.start).max(1);
+        let prefetch_rows =
+            visible_rows.start.saturating_sub(page)..(visible_rows.end + page).min(num_rows);
+        let new_window = geometry
+            .time_window_for_rows(prefetch_rows)
+            .map(|(min, max)| FetchWindow {
+                timeline: query.timeline,
+                min,
+                max,
+            });
 
-        // The `is_full_range` check covers the frame on which a level filter was just
-        // activated: the visualizer only picks the new mode up on the next frame.
-        if state.fetch_window != new_window
-            || state.filter_active != filter_active
-            || (filter_active && !output.is_full_range)
-        {
+        if state.fetch_window != new_window {
             state.fetch_window = new_window;
-            state.filter_active = filter_active;
             ui.ctx().request_repaint();
         }
 
@@ -439,40 +406,29 @@ enum ColumnKind {
 }
 
 /// Maps a global row index to a (possibly not-yet-fetched) [`Entry`].
-enum RowLookup<'a> {
-    /// Only the fetched time window is materialized.
-    Virtual {
-        /// Sorted by time, static entries first.
-        entries: &'a [Entry],
-        /// Total number of static rows according to chunk metadata.
-        num_static: u64,
-        /// Number of static entries at the front of `entries`.
-        fetched_static: u64,
-        /// Global row index of the first fetched temporal entry.
-        temporal_offset: u64,
-    },
+///
+/// Only the fetched time window is materialized.
+struct RowLookup<'a> {
+    /// Fetched entries that pass the level filter, sorted by time, static entries first.
+    entries: Vec<&'a Entry>,
 
-    /// Everything is materialized (level filter active).
-    Materialized(&'a [&'a Entry]),
+    /// Total number of static rows according to chunk metadata.
+    num_static: u64,
+
+    /// Number of static entries at the front of `entries`.
+    fetched_static: u64,
+
+    /// Global row index of the first fetched temporal entry.
+    temporal_offset: u64,
 }
 
 impl RowLookup<'_> {
     fn entry(&self, row_nr: u64) -> Option<&Entry> {
-        match self {
-            Self::Virtual {
-                entries,
-                num_static,
-                fetched_static,
-                temporal_offset,
-            } => {
-                if row_nr < *num_static {
-                    (row_nr < *fetched_static).then(|| &entries[row_nr as usize])
-                } else {
-                    let idx = fetched_static + row_nr.checked_sub(*temporal_offset)?;
-                    entries.get(idx as usize)
-                }
-            }
-            Self::Materialized(entries) => entries.get(row_nr as usize).copied(),
+        if row_nr < self.num_static {
+            (row_nr < self.fetched_static).then(|| self.entries[row_nr as usize])
+        } else {
+            let idx = self.fetched_static + row_nr.checked_sub(self.temporal_offset)?;
+            self.entries.get(idx as usize).copied()
         }
     }
 }
@@ -694,17 +650,27 @@ fn view_property_ui_rows(ctx: &ViewContext<'_>, ui: &mut egui::Ui) {
                         }
 
                         if any_change {
-                            let log_levels: Vec<_> = new_levels
-                                .into_iter()
-                                .filter(|(_, active)| *active)
-                                .map(|(lvl, _)| TextLogLevel(lvl.into()))
-                                .collect();
+                            if new_levels.iter().all(|(_, active)| *active) {
+                                // Nothing is filtered out: remove the filter entirely, so that
+                                // levels showing up later stay visible and the view stays on
+                                // the cheaper unfiltered path.
+                                property.reset_blueprint_component(
+                                    ctx.viewer_ctx,
+                                    TextLogRows::descriptor_filter_by_log_level(),
+                                );
+                            } else {
+                                let log_levels: Vec<_> = new_levels
+                                    .into_iter()
+                                    .filter(|(_, active)| *active)
+                                    .map(|(lvl, _)| TextLogLevel(lvl.into()))
+                                    .collect();
 
-                            property.save_blueprint_component(
-                                ctx.viewer_ctx,
-                                &TextLogRows::descriptor_filter_by_log_level(),
-                                &log_levels,
-                            );
+                                property.save_blueprint_component(
+                                    ctx.viewer_ctx,
+                                    &TextLogRows::descriptor_filter_by_log_level(),
+                                    &log_levels,
+                                );
+                            }
                         }
                     }),
                 );

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -48,7 +48,7 @@ pub struct TextViewState {
     /// Time window that the visualizer should query on the next frame.
     ///
     /// Written at the end of `ui()` based on the visible rows, read by
-    /// [`TextLogSystem::execute`] one frame later.
+    /// [`TextLogSystem`]'s `execute()` one frame later.
     pub(crate) fetch_window: Option<FetchWindow>,
 
     /// Cached per-chunk log level counts, used to lay out the table when a level filter is

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -1,15 +1,20 @@
 use std::collections::BTreeSet;
+use std::ops::Range;
 
+use egui::emath::GuiRounding as _;
+use re_chunk_store::TimeInt;
 use re_data_ui::item_ui::{self, timeline_button};
+use re_dataframe_ui::apply_table_style_fixes;
 use re_log::ResultExt as _;
 use re_log_types::{EntityPath, TimelineName};
+use re_sdk_types::archetypes::TextLog;
 use re_sdk_types::blueprint::archetypes::{TextLogColumns, TextLogFormat, TextLogRows};
 use re_sdk_types::blueprint::components::{Enabled, TextLogColumn, TimelineColumn};
 use re_sdk_types::blueprint::encodings as bp_encodings;
 use re_sdk_types::components::TextLogLevel;
 use re_sdk_types::{View as _, ViewClassIdentifier, encodings};
 use re_ui::list_item::LabelContent;
-use re_ui::{DesignTokens, Help, UiExt as _};
+use re_ui::{Help, TableStyle, UiExt as _};
 use re_viewer_context::{
     IdentifiedViewSystem as _, ViewClass, ViewClassExt as _, ViewClassRegistryError, ViewContext,
     ViewId, ViewQuery, ViewSpawnHeuristics, ViewState, ViewStateExt as _, ViewSystemExecutionError,
@@ -17,7 +22,8 @@ use re_viewer_context::{
 };
 use re_viewport_blueprint::ViewProperty;
 
-use super::visualizer_system::{Entry, TextLogSystem};
+use super::visualizer_system::{Entry, FetchWindow, TextLogOutput, TextLogSystem};
+use crate::scroll_geometry::ScrollGeometry;
 
 // TODO(andreas): This should be a blueprint component.
 #[derive(Clone, PartialEq, Eq, Default, re_byte_size::SizeBytes)]
@@ -28,18 +34,28 @@ pub struct TextViewState {
     /// text entry window however they please when the time cursor isn't moving.
     latest_time: i64,
 
-    /// Time of the latest entry at or before the cursor on the previous render.
+    /// Row just below the time cursor on the previous render.
     ///
     /// We auto-scroll whenever this changes so the view tracks the latest-at
     /// row as new (possibly out-of-order) data streams in. This handles both
     /// the initial catch-up to a programmatic `SetTime` (e.g. a `#when` URL
     /// anchor pointing past the data loaded so far) and any later arrival
-    /// that lands closer to the cursor.
-    last_anchor_time: Option<i64>,
+    /// that lands at or before the cursor.
+    last_anchor_row: Option<u64>,
 
     seen_levels: BTreeSet<String>,
 
-    last_columns_min_sizes: Vec<u32>,
+    /// Time window that the visualizer should query on the next frame.
+    ///
+    /// Written at the end of `ui()` based on the visible rows, read by
+    /// [`TextLogSystem::execute`] one frame later.
+    pub(crate) fetch_window: Option<FetchWindow>,
+
+    /// Whether an explicit log level filter is set.
+    ///
+    /// If so, the visualizer queries the full time range, since the row layout can then no
+    /// longer be derived from chunk-level metadata.
+    pub(crate) filter_active: bool,
 }
 
 impl ViewState for TextViewState {
@@ -191,7 +207,7 @@ Filter message types and toggle column visibility in a selection panel.",
     fn ui(
         &self,
         ctx: &ViewerContext<'_>,
-        _missing_chunk_reporter: &re_viewer_context::MissingChunkReporter,
+        missing_chunk_reporter: &re_viewer_context::MissingChunkReporter,
         ui: &mut egui::Ui,
         state: &mut dyn ViewState,
         query: &ViewQuery<'_>,
@@ -200,9 +216,11 @@ Filter message types and toggle column visibility in a selection panel.",
         re_tracing::profile_function!();
 
         let tokens = ui.tokens();
+        let table_style = TableStyle::Dense;
         let state = state.downcast_mut::<TextViewState>()?;
-        let text =
-            system_output.visualizer_data_or_default::<Vec<Entry>>(TextLogSystem::identifier())?;
+        let output = system_output
+            .visualizer_data_or_default::<TextLogOutput>(TextLogSystem::identifier())?;
+        let output: &TextLogOutput = &output;
 
         let view_ctx = self.view_context(ctx, query.view_id, state, query.space_origin);
         let columns_property = ViewProperty::from_archetype::<TextLogColumns>(&view_ctx);
@@ -223,66 +241,191 @@ Filter message types and toggle column visibility in a selection panel.",
             TextLogColumns::descriptor_timeline_columns().component,
         )?;
 
-        let levels = rows_property.component_array_or_fallback::<TextLogLevel>(
-            &view_ctx,
+        // An *explicit* level filter (i.e. one set in the blueprint, not the show-everything
+        // fallback) means the row count can no longer be derived from chunk-level metadata,
+        // so the visualizer falls back to fetching the full range and we filter here.
+        let explicit_levels = rows_property.component_array::<TextLogLevel>(
             TextLogRows::descriptor_filter_by_log_level().component,
         )?;
+        let filter_active = explicit_levels.is_some();
 
-        for te in text.iter() {
+        for te in &output.entries {
             if let Some(lvl) = &te.level {
                 state.seen_levels.insert(lvl.to_string());
             }
         }
 
-        // TODO(andreas): Should filter text entries in the part-system instead.
-        // this likely requires a way to pass state into a context.
-        let entries = text
-            .iter()
-            .filter(|te| {
-                te.level
-                    .as_ref()
-                    .is_none_or(|lvl| levels.iter().any(|l| l.as_str() == lvl.as_str()))
-            })
-            .collect::<Vec<_>>();
-
         let time = ctx.time_ctrl.time_i64().unwrap_or(state.latest_time);
+
+        // Only the fetched window's entries are materialized; the rest of the row layout comes
+        // from chunk-level metadata (time ranges + row counts), so we never have to touch the
+        // full data. See <https://github.com/rerun-io/rerun/issues/7562>.
+        let geometry = if filter_active {
+            None
+        } else {
+            let engine = ctx.recording_engine();
+            Some(ScrollGeometry::build(
+                engine.store(),
+                &query.timeline,
+                TextLog::descriptor_text().component,
+                query
+                    .iter_visualizer_instruction_for(TextLogSystem::identifier())
+                    .map(|(data_result, _)| &data_result.entity_path),
+            ))
+        };
+
+        if geometry.as_ref().is_some_and(|g| g.any_missing) {
+            missing_chunk_reporter.report_missing_chunk();
+        }
+
+        let filtered_entries: Vec<&Entry>; // Only used when the level filter is active.
+        let (num_rows, rows, scroll_row, anchor_row) = if let Some(geometry) = &geometry {
+            let scroll_row = geometry.rows_before(TimeInt::new_temporal(time));
+            let anchor_row = geometry.rows_before(TimeInt::new_temporal(time).inc());
+
+            let rows = RowLookup::Virtual {
+                entries: &output.entries,
+                num_static: geometry.num_static_rows(),
+                fetched_static: output
+                    .entries
+                    .partition_point(|entry| entry.time.is_static())
+                    as u64,
+                temporal_offset: output.window.map_or_else(
+                    || geometry.num_static_rows(),
+                    |window| geometry.rows_before(window.min),
+                ),
+            };
+
+            (geometry.num_rows(), rows, scroll_row, anchor_row)
+        } else {
+            let levels = explicit_levels.as_deref().unwrap_or(&[]);
+            filtered_entries = output
+                .entries
+                .iter()
+                .filter(|te| {
+                    te.level
+                        .as_ref()
+                        .is_none_or(|lvl| levels.iter().any(|l| l.as_str() == lvl.as_str()))
+                })
+                .collect();
+
+            let scroll_row = filtered_entries.partition_point(|te| te.time.as_i64() < time) as u64;
+            let anchor_row = filtered_entries.partition_point(|te| te.time.as_i64() <= time) as u64;
+
+            (
+                filtered_entries.len() as u64,
+                RowLookup::Materialized(&filtered_entries),
+                scroll_row,
+                anchor_row,
+            )
+        };
+
+        // Auto-scroll when the time cursor moves, or whenever the row below the cursor shifts
+        // because new (possibly out-of-order) data landed at or before the cursor.
+        let time_cursor_moved = state.latest_time != time;
+        let anchor_moved = state.last_anchor_row != Some(anchor_row);
+        let scroll_to = (time_cursor_moved || anchor_moved).then_some(scroll_row);
+        state.last_anchor_row = Some(anchor_row);
+        state.latest_time = time;
+
+        // Draw the current time indicator when the active timeline is shown as a column.
+        let marker_row = (ctx.time_ctrl.time_int().is_some()
+            && timeline_columns
+                .iter()
+                .any(|col| *col.visible && col.timeline.as_str() == query.timeline.as_str()))
+        .then_some(anchor_row);
+
+        let mut column_kinds = Vec::new();
+        let mut table_columns = Vec::new();
+        for col in &timeline_columns {
+            if !*col.visible {
+                continue;
+            }
+            if let Some(timeline) =
+                TimelineName::try_new(col.timeline.as_str()).ok_or_log_error_once()
+            {
+                column_kinds.push(ColumnKind::Timeline(timeline));
+                table_columns.push(egui_table::Column::new(110.0).resizable(true));
+            }
+        }
+        for col in &columns {
+            if !*col.visible {
+                continue;
+            }
+            let width = match col.kind {
+                bp_encodings::TextLogColumnKind::EntityPath => 120.0,
+                bp_encodings::TextLogColumnKind::LogLevel => 50.0,
+                bp_encodings::TextLogColumnKind::Body => 400.0,
+            };
+            column_kinds.push(ColumnKind::Kind(col.kind));
+            table_columns.push(egui_table::Column::new(width).resizable(true));
+        }
+
+        let mut delegate = TextLogTableDelegate {
+            ctx,
+            table_style,
+            row_height: tokens.table_row_height(table_style),
+            column_kinds: &column_kinds,
+            monospace_body: **monospace_body,
+            rows,
+            num_rows,
+            marker_row,
+            visible_rows: 0..0,
+        };
+
         egui::Frame {
             inner_margin: tokens.view_padding().into(),
             ..egui::Frame::default()
         }
         .show(ui, |ui| {
-            // Auto-scroll when the time cursor moves, or whenever the
-            // latest-at row shifts because new (possibly out-of-order) data
-            // landed closer to the cursor.
-            let anchor_time = entries
-                .partition_point(|te| te.time.as_i64() <= time)
-                .checked_sub(1)
-                .map(|i| entries[i].time.as_i64());
-            let anchor_moved = anchor_time != state.last_anchor_time;
-            let time_cursor_moved = state.latest_time != time;
-            let scroll_to_row = (time_cursor_moved || anchor_moved).then(|| {
-                re_tracing::profile_scope!("search scroll time");
-                entries.partition_point(|te| te.time.as_i64() < time)
-            });
-            state.last_anchor_time = anchor_time;
+            apply_table_style_fixes(ui.style_mut());
 
-            ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
-                egui::ScrollArea::horizontal().show(ui, |ui| {
-                    re_tracing::profile_scope!("render table");
-                    table_ui(
-                        ctx,
-                        ui,
-                        state,
-                        &timeline_columns,
-                        &columns,
-                        **monospace_body,
-                        &entries,
-                        scroll_to_row,
-                    );
-                })
-            })
+            let mut table = egui_table::Table::new()
+                .id_salt(egui::Id::new("text_log").with(query.view_id))
+                .columns(table_columns)
+                .headers(vec![egui_table::HeaderRow::new(
+                    tokens.table_header_height(),
+                )])
+                .num_rows(num_rows);
+
+            if let Some(scroll_to) = scroll_to {
+                table = table.scroll_to_row(scroll_to, Some(egui::Align::Center));
+            }
+
+            re_tracing::profile_scope!("render table");
+            table.show(ui, &mut delegate);
         });
-        state.latest_time = time;
+
+        // Tell the visualizer which time window to fetch next frame: the visible rows,
+        // padded by one page on each side for scroll responsiveness.
+        let visible_rows = delegate.visible_rows.clone();
+        let new_window = if let Some(geometry) = &geometry {
+            let page = (visible_rows.end - visible_rows.start).max(1);
+            let prefetch_rows =
+                visible_rows.start.saturating_sub(page)..(visible_rows.end + page).min(num_rows);
+            geometry
+                .time_window_for_rows(prefetch_rows)
+                .map(|(min, max)| FetchWindow {
+                    timeline: query.timeline,
+                    min,
+                    max,
+                })
+        } else {
+            // Level filter active: the window is unused, keep it around for when the filter
+            // is removed again.
+            state.fetch_window
+        };
+
+        // The `is_full_range` check covers the frame on which a level filter was just
+        // activated: the visualizer only picks the new mode up on the next frame.
+        if state.fetch_window != new_window
+            || state.filter_active != filter_active
+            || (filter_active && !output.is_full_range)
+        {
+            state.fetch_window = new_window;
+            state.filter_active = filter_active;
+            ui.ctx().request_repaint();
+        }
 
         Ok(Default::default())
     }
@@ -290,203 +433,200 @@ Filter message types and toggle column visibility in a selection panel.",
 
 // ---
 
-/// `scroll_to_row` indicates how far down we want to scroll in terms of logical rows,
-/// as opposed to `scroll_to_offset` (computed below) which is how far down we want to
-/// scroll in terms of actual points.
-fn table_ui(
-    ctx: &ViewerContext<'_>,
-    ui: &mut egui::Ui,
-    state: &mut TextViewState,
-    timeline_columns: &[TimelineColumn],
-    columns: &[TextLogColumn],
-    monospace_body: bool,
-    entries: &[&Entry],
-    scroll_to_row: Option<usize>,
-) {
-    let tokens = ui.tokens();
-    let table_style = re_ui::TableStyle::Dense;
+enum ColumnKind {
+    Timeline(TimelineName),
+    Kind(bp_encodings::TextLogColumnKind),
+}
 
-    use egui_extras::Column;
+/// Maps a global row index to a (possibly not-yet-fetched) [`Entry`].
+enum RowLookup<'a> {
+    /// Only the fetched time window is materialized.
+    Virtual {
+        /// Sorted by time, static entries first.
+        entries: &'a [Entry],
+        /// Total number of static rows according to chunk metadata.
+        num_static: u64,
+        /// Number of static entries at the front of `entries`.
+        fetched_static: u64,
+        /// Global row index of the first fetched temporal entry.
+        temporal_offset: u64,
+    },
 
-    let (global_timeline, global_time) = (*ctx.time_ctrl.timeline_name(), ctx.time_ctrl.time_int());
+    /// Everything is materialized (level filter active).
+    Materialized(&'a [&'a Entry]),
+}
 
-    let mut table_builder = egui_extras::TableBuilder::new(ui)
-        .resizable(true)
-        .vscroll(true)
-        .auto_shrink([false; 2]) // expand to take up the whole View
-        .min_scrolled_height(0.0) // we can go as small as we need to be in order to fit within the view!
-        .max_scroll_height(f32::INFINITY) // Fill up whole height
-        .cell_layout(egui::Layout::left_to_right(egui::Align::Center));
-
-    if let Some(scroll_to_row) = scroll_to_row {
-        table_builder = table_builder.scroll_to_row(scroll_to_row, Some(egui::Align::Center));
-    }
-
-    let mut body_clip_rect = None;
-    let mut current_time_y = None; // where to draw the current time indicator cursor
-
-    let mut new_column_sizes = Vec::new();
-    let mut last_columns = state.last_columns_min_sizes.iter();
-
-    let mut size_column = |column: Column, min_size: u32| {
-        // If this isn't the same min size as before the order changed.
-        let auto_resize = last_columns.next().is_some_and(|c| *c != min_size);
-
-        new_column_sizes.push(min_size);
-
-        column
-            .at_least(min_size as f32)
-            .auto_size_this_frame(auto_resize)
-    };
-
-    for col in timeline_columns {
-        if *col.visible {
-            table_builder = table_builder.column(size_column(Column::auto().clip(true), 32));
+impl RowLookup<'_> {
+    fn entry(&self, row_nr: u64) -> Option<&Entry> {
+        match self {
+            Self::Virtual {
+                entries,
+                num_static,
+                fetched_static,
+                temporal_offset,
+            } => {
+                if row_nr < *num_static {
+                    (row_nr < *fetched_static).then(|| &entries[row_nr as usize])
+                } else {
+                    let idx = fetched_static + row_nr.checked_sub(*temporal_offset)?;
+                    entries.get(idx as usize)
+                }
+            }
+            Self::Materialized(entries) => entries.get(row_nr as usize).copied(),
         }
-    }
-
-    for col in columns {
-        if !*col.visible {
-            continue;
-        }
-
-        let col = match col.kind {
-            bp_encodings::TextLogColumnKind::EntityPath => {
-                size_column(Column::auto().clip(true), 32)
-            }
-            bp_encodings::TextLogColumnKind::LogLevel => size_column(Column::auto(), 30),
-            bp_encodings::TextLogColumnKind::Body => size_column(Column::remainder(), 100),
-        };
-
-        table_builder = table_builder.column(col);
-    }
-
-    state.last_columns_min_sizes = new_column_sizes;
-
-    table_builder
-        .header(tokens.deprecated_table_header_height(), |mut header| {
-            re_ui::DesignTokens::setup_table_header(&mut header);
-            for col in timeline_columns {
-                if !*col.visible {
-                    continue;
-                }
-
-                header.col(|ui| {
-                    if let Some(timeline) =
-                        TimelineName::try_new(col.timeline.as_str()).ok_or_log_error_once()
-                    {
-                        timeline_button(&ctx.app_ctx, ui, &timeline);
-                    }
-                });
-            }
-            for col in columns {
-                if !*col.visible {
-                    continue;
-                }
-                header.col(|ui| {
-                    column_name_ui(ui, &col.kind);
-                });
-            }
-        })
-        .body(|mut body| {
-            tokens.setup_table_body(&mut body, table_style);
-
-            body_clip_rect = Some(body.max_rect());
-
-            let row_heights = entries
-                .iter()
-                .map(|te| calc_row_height(tokens, table_style, te));
-            body.heterogeneous_rows(row_heights, |mut row| {
-                let entry = &entries[row.index()];
-
-                for col in timeline_columns {
-                    if !*col.visible {
-                        continue;
-                    }
-
-                    let Some(timeline) =
-                        TimelineName::try_new(col.timeline.as_str()).ok_or_log_error_once()
-                    else {
-                        continue;
-                    };
-
-                    row.col(|ui| {
-                        let row_time = entry
-                            .timepoint
-                            .get(&timeline)
-                            .map(re_log_types::TimeInt::from)
-                            .unwrap_or(re_log_types::TimeInt::STATIC);
-                        item_ui::time_button(ctx, ui, &timeline, row_time);
-
-                        if let Some(global_time) = global_time
-                            && timeline == global_timeline
-                        {
-                            if global_time < row_time {
-                                // We've past the global time - it is thus above this row.
-                                if current_time_y.is_none() {
-                                    current_time_y = Some(ui.max_rect().top());
-                                }
-                            } else if global_time == row_time {
-                                // This row is exactly at the current time.
-                                // We could draw the current time exactly onto this row, but that would look bad,
-                                // so let's draw it under instead. It looks better in the "following" mode.
-                                current_time_y = Some(ui.max_rect().bottom());
-                            }
-                        }
-                    });
-                }
-
-                for col in columns {
-                    if !*col.visible {
-                        continue;
-                    }
-
-                    row.col(|ui| match col.kind {
-                        bp_encodings::TextLogColumnKind::EntityPath => {
-                            item_ui::entity_path_button(
-                                &ctx.active_recording_store_view_context(),
-                                ui,
-                                None,
-                                &entry.entity_path,
-                            );
-                        }
-                        bp_encodings::TextLogColumnKind::LogLevel => {
-                            if let Some(lvl) = &entry.level {
-                                ui.label(level_to_rich_text(ui, lvl));
-                            } else {
-                                ui.label("-");
-                            }
-                        }
-                        bp_encodings::TextLogColumnKind::Body => {
-                            let mut text = egui::RichText::new(entry.body.as_str());
-
-                            if monospace_body {
-                                text = text.monospace();
-                            }
-                            if let Some(color) = entry.color {
-                                text = text.color(color);
-                            }
-
-                            ui.label(text);
-                        }
-                    });
-                }
-            });
-        });
-
-    // TODO(cmc): this draws on top of the headers :(
-    if let (Some(body_clip_rect), Some(current_time_y)) = (body_clip_rect, current_time_y) {
-        // Show that the current time is here:
-        ui.painter().with_clip_rect(body_clip_rect).hline(
-            ui.max_rect().x_range(),
-            current_time_y,
-            (1.0, ui.tokens().strong_fg_color),
-        );
     }
 }
 
-fn column_name_ui(ui: &mut egui::Ui, column: &bp_encodings::TextLogColumnKind) -> egui::Response {
-    ui.strong(column.name())
+struct TextLogTableDelegate<'a> {
+    ctx: &'a ViewerContext<'a>,
+    table_style: TableStyle,
+    row_height: f32,
+    column_kinds: &'a [ColumnKind],
+    monospace_body: bool,
+    rows: RowLookup<'a>,
+    num_rows: u64,
+
+    /// Paint the current time indicator at the top of this row
+    /// (or at the bottom of the last row if this is one past the end).
+    marker_row: Option<u64>,
+
+    /// Rows that were visible this frame, captured from the prefetch info.
+    visible_rows: Range<u64>,
+}
+
+impl egui_table::TableDelegate for TextLogTableDelegate<'_> {
+    fn prepare(&mut self, info: &egui_table::PrefetchInfo) {
+        self.visible_rows = info.visible_rows.clone();
+    }
+
+    fn default_row_height(&self) -> f32 {
+        self.row_height
+    }
+
+    fn header_cell_ui(&mut self, ui: &mut egui::Ui, cell: &egui_table::HeaderCellInfo) {
+        let col_nr = cell.col_range.start;
+
+        egui::Frame::new()
+            .inner_margin(ui.tokens().header_cell_margin(self.table_style))
+            .show(ui, |ui| match &self.column_kinds[col_nr] {
+                ColumnKind::Timeline(timeline) => {
+                    timeline_button(&self.ctx.app_ctx, ui, timeline);
+                }
+                ColumnKind::Kind(kind) => {
+                    ui.strong(kind.name());
+                }
+            });
+
+        let rect = ui.max_rect().round_to_pixels(ui.pixels_per_point());
+        self.paint_column_separator(ui, col_nr, rect);
+
+        // A single subtle line under the header, tiled across the columns.
+        // Note: `apply_table_style_fixes` blanks `noninteractive.bg_stroke`, so use the token.
+        ui.painter().hline(
+            rect.x_range(),
+            rect.max.y - re_dataframe_ui::CELL_SEPARATOR_STROKE_OFFSET,
+            egui::Stroke::new(1.0, ui.tokens().table_interaction_noninteractive_bg_stroke),
+        );
+    }
+
+    fn row_ui(&mut self, ui: &mut egui::Ui, row_nr: u64) {
+        let paint_marker_at = if self.marker_row == Some(row_nr) {
+            Some(ui.max_rect().top())
+        } else if row_nr + 1 == self.num_rows && self.marker_row == Some(self.num_rows) {
+            // The time cursor is past all rows: draw the marker below the last one.
+            Some(ui.max_rect().bottom())
+        } else {
+            None
+        };
+
+        if let Some(y) = paint_marker_at {
+            ui.painter().hline(
+                ui.max_rect().x_range(),
+                y,
+                (1.0, ui.tokens().strong_fg_color),
+            );
+        }
+    }
+
+    fn cell_ui(&mut self, ui: &mut egui::Ui, cell: &egui_table::CellInfo) {
+        let col_nr = cell.col_nr;
+
+        egui::Frame::new()
+            .inner_margin(ui.tokens().table_cell_margin(self.table_style))
+            .show(ui, |ui| {
+                let Some(entry) = self.rows.entry(cell.row_nr) else {
+                    // This row's time window hasn't been fetched yet; it arrives next frame.
+                    ui.weak("…");
+                    return;
+                };
+
+                match &self.column_kinds[col_nr] {
+                    ColumnKind::Timeline(timeline) => {
+                        let row_time = entry
+                            .timepoint
+                            .get(timeline)
+                            .map(re_log_types::TimeInt::from)
+                            .unwrap_or(re_log_types::TimeInt::STATIC);
+                        item_ui::time_button(self.ctx, ui, timeline, row_time);
+                    }
+                    ColumnKind::Kind(bp_encodings::TextLogColumnKind::EntityPath) => {
+                        item_ui::entity_path_button(
+                            &self.ctx.active_recording_store_view_context(),
+                            ui,
+                            None,
+                            &entry.entity_path,
+                        );
+                    }
+                    ColumnKind::Kind(bp_encodings::TextLogColumnKind::LogLevel) => {
+                        if let Some(lvl) = &entry.level {
+                            ui.label(level_to_rich_text(ui, lvl));
+                        } else {
+                            ui.label("-");
+                        }
+                    }
+                    ColumnKind::Kind(bp_encodings::TextLogColumnKind::Body) => {
+                        // Rows have a fixed height; show only the first line of multi-line bodies.
+                        let body = entry.body.as_str();
+                        let (first_line, truncated) = match body.split_once('\n') {
+                            Some((first_line, _)) => (first_line, true),
+                            None => (body, false),
+                        };
+
+                        let mut text = if truncated {
+                            egui::RichText::new(format!("{first_line} …"))
+                        } else {
+                            egui::RichText::new(first_line)
+                        };
+
+                        if self.monospace_body {
+                            text = text.monospace();
+                        }
+                        if let Some(color) = entry.color {
+                            text = text.color(color);
+                        }
+
+                        ui.label(text).on_hover_text(body);
+                    }
+                }
+            });
+
+        let rect = ui.max_rect().round_to_pixels(ui.pixels_per_point());
+        self.paint_column_separator(ui, col_nr, rect);
+    }
+}
+
+impl TextLogTableDelegate<'_> {
+    /// A vertical line between columns (but not after the last one), like the old
+    /// `egui_extras`-based renderer had.
+    fn paint_column_separator(&self, ui: &egui::Ui, col_nr: usize, rect: egui::Rect) {
+        if col_nr + 1 < self.column_kinds.len() {
+            ui.painter().vline(
+                rect.max.x - re_dataframe_ui::CELL_SEPARATOR_STROKE_OFFSET,
+                rect.y_range(),
+                egui::Stroke::new(1.0, ui.tokens().table_interaction_noninteractive_bg_stroke),
+            );
+        }
+    }
 }
 
 /// We need this to be a custom ui to be able to use the view state to get seen text log levels.
@@ -593,13 +733,6 @@ fn view_property_ui_rows(ctx: &ViewContext<'_>, ui: &mut egui::Ui) {
                 sub_prop_ui,
             );
     }
-}
-
-fn calc_row_height(tokens: &DesignTokens, table_style: re_ui::TableStyle, entry: &Entry) -> f32 {
-    // Simple, fast, ugly, and functional
-    let num_newlines = entry.body.bytes().filter(|&c| c == b'\n').count();
-    let num_rows = 1 + num_newlines;
-    num_rows as f32 * tokens.table_row_height(table_style)
 }
 
 #[test]

--- a/crates/viewer/re_view_text_log/src/view_class.rs
+++ b/crates/viewer/re_view_text_log/src/view_class.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeSet;
-use std::ops::Range;
 
 use egui::emath::GuiRounding as _;
 use re_chunk_store::TimeInt;
@@ -21,8 +20,8 @@ use re_viewer_context::{
 };
 use re_viewport_blueprint::ViewProperty;
 
-use super::visualizer_system::{Entry, FetchWindow, TextLogOutput, TextLogSystem};
-use crate::row_layout::RowLayout;
+use super::visualizer_system::{TextLogOutput, TextLogSystem};
+use crate::row_layout::{RowLayout, VisibleRows};
 
 // TODO(andreas): This should be a blueprint component.
 #[derive(Clone, PartialEq, Eq, Default, re_byte_size::SizeBytes)]
@@ -43,12 +42,6 @@ pub struct TextViewState {
     last_anchor_row: Option<u64>,
 
     seen_levels: BTreeSet<String>,
-
-    /// Time window that the visualizer should query on the next frame.
-    ///
-    /// Written at the end of `ui()` based on the visible rows, read by
-    /// [`TextLogSystem`]'s `execute()` one frame later.
-    pub(crate) fetch_window: Option<FetchWindow>,
 }
 
 impl ViewState for TextViewState {
@@ -235,8 +228,9 @@ Filter message types and toggle column visibility in a selection panel.",
 
         let time = ctx.time_ctrl.time_i64().unwrap_or(state.latest_time);
 
-        // Everything about *where* rows live comes from the visualizer, which derives it from
-        // chunk-level metadata rather than the row data itself.
+        // Everything about *where* rows live comes from the visualizer's row layout, derived
+        // from chunk-level metadata; only the rows that end up on screen are resolved from the
+        // actual row data (in `prepare()`).
         // `None` means the visualizer didn't run, i.e. the view has no active instructions.
         let layout = output.layout.as_ref();
 
@@ -245,22 +239,10 @@ Filter message types and toggle column visibility in a selection panel.",
         }
 
         let num_rows = layout.map_or(0, RowLayout::num_rows);
-        let num_static_rows = layout.map_or(0, RowLayout::num_static_rows);
         let rows_before = |t: TimeInt| layout.map_or(0, |layout| layout.rows_before(t));
 
         let scroll_row = rows_before(TimeInt::new_temporal(time));
         let anchor_row = rows_before(TimeInt::new_temporal(time).inc());
-
-        let rows = RowLookup {
-            num_static: num_static_rows,
-            fetched_static: output
-                .entries
-                .partition_point(|entry| entry.time.is_static()) as u64,
-            temporal_offset: output
-                .window
-                .map_or(num_static_rows, |window| rows_before(window.min)),
-            entries: &output.entries,
-        };
 
         // Auto-scroll when the time cursor moves, or whenever the row below the cursor shifts
         // because new (possibly out-of-order) data landed at or before the cursor.
@@ -309,10 +291,10 @@ Filter message types and toggle column visibility in a selection panel.",
             row_height: tokens.table_row_height(table_style),
             column_kinds: &column_kinds,
             monospace_body: **monospace_body,
-            rows,
+            layout,
+            visible: VisibleRows::default(),
             num_rows,
             marker_row,
-            visible_rows: 0..0,
         };
 
         egui::Frame {
@@ -339,25 +321,6 @@ Filter message types and toggle column visibility in a selection panel.",
             table.show(ui, &mut delegate);
         });
 
-        // Tell the visualizer which time window to fetch next frame: the visible rows,
-        // padded by one page on each side for scroll responsiveness.
-        let visible_rows = delegate.visible_rows.clone();
-        let page = (visible_rows.end - visible_rows.start).max(1);
-        let prefetch_rows =
-            visible_rows.start.saturating_sub(page)..(visible_rows.end + page).min(num_rows);
-        let new_window = layout
-            .and_then(|layout| layout.time_window_for_rows(prefetch_rows))
-            .map(|(min, max)| FetchWindow {
-                timeline: query.timeline,
-                min,
-                max,
-            });
-
-        if state.fetch_window != new_window {
-            state.fetch_window = new_window;
-            ui.ctx().request_repaint();
-        }
-
         Ok(Default::default())
     }
 }
@@ -377,54 +340,28 @@ fn text_log_column(width: f32, min_width: f32) -> egui_table::Column {
         .resizable(true)
 }
 
-/// Maps a global row index to a (possibly not-yet-fetched) [`Entry`].
-///
-/// Only the fetched time window is materialized.
-struct RowLookup<'a> {
-    /// Fetched entries that pass the level filter, sorted by time, static entries first.
-    entries: &'a [Entry],
-
-    /// Total number of static rows according to chunk metadata.
-    num_static: u64,
-
-    /// Number of static entries at the front of `entries`.
-    fetched_static: u64,
-
-    /// Global row index of the first fetched temporal entry.
-    temporal_offset: u64,
-}
-
-impl RowLookup<'_> {
-    fn entry(&self, row_nr: u64) -> Option<&Entry> {
-        if row_nr < self.num_static {
-            (row_nr < self.fetched_static).then(|| &self.entries[row_nr as usize])
-        } else {
-            let idx = self.fetched_static + row_nr.checked_sub(self.temporal_offset)?;
-            self.entries.get(idx as usize)
-        }
-    }
-}
-
 struct TextLogTableDelegate<'a> {
     ctx: &'a ViewerContext<'a>,
     table_style: TableStyle,
     row_height: f32,
     column_kinds: &'a [ColumnKind],
     monospace_body: bool,
-    rows: RowLookup<'a>,
+    layout: Option<&'a RowLayout>,
     num_rows: u64,
 
     /// Paint the current time indicator at the top of this row
     /// (or at the bottom of the last row if this is one past the end).
     marker_row: Option<u64>,
 
-    /// Rows that were visible this frame, captured from the prefetch info.
-    visible_rows: Range<u64>,
+    /// The rows on screen this frame, resolved from the layout in [`Self::prepare`].
+    visible: VisibleRows,
 }
 
 impl egui_table::TableDelegate for TextLogTableDelegate<'_> {
     fn prepare(&mut self, info: &egui_table::PrefetchInfo) {
-        self.visible_rows = info.visible_rows.clone();
+        self.visible = self.layout.map_or_else(VisibleRows::default, |layout| {
+            layout.visible_rows(info.visible_rows.clone())
+        });
     }
 
     fn default_row_height(&self) -> f32 {
@@ -482,19 +419,16 @@ impl egui_table::TableDelegate for TextLogTableDelegate<'_> {
         egui::Frame::new()
             .inner_margin(ui.tokens().table_cell_margin(self.table_style))
             .show(ui, |ui| {
-                let Some(entry) = self.rows.entry(cell.row_nr) else {
-                    // This row's time window hasn't been fetched yet; it arrives next frame.
+                let Some((layout, row)) = Option::zip(self.layout, self.visible.get(cell.row_nr))
+                else {
+                    // Can only happen if the table requests a row outside the prepared range.
                     ui.weak("…");
                     return;
                 };
 
                 match &self.column_kinds[col_nr] {
                     ColumnKind::Timeline(timeline) => {
-                        let row_time = entry
-                            .timepoint
-                            .get(timeline)
-                            .map(re_log_types::TimeInt::from)
-                            .unwrap_or(re_log_types::TimeInt::STATIC);
+                        let row_time = layout.row_time(row, timeline);
                         item_ui::time_button(self.ctx, ui, timeline, row_time);
                     }
                     ColumnKind::Kind(bp_encodings::TextLogColumnKind::EntityPath) => {
@@ -502,19 +436,21 @@ impl egui_table::TableDelegate for TextLogTableDelegate<'_> {
                             &self.ctx.active_recording_store_view_context(),
                             ui,
                             None,
-                            &entry.entity_path,
+                            layout.row_data(row).entity_path,
                         );
                     }
                     ColumnKind::Kind(bp_encodings::TextLogColumnKind::LogLevel) => {
-                        if let Some(lvl) = &entry.level {
+                        if let Some(lvl) = layout.row_data(row).level {
                             ui.label(level_to_rich_text(ui, lvl));
                         } else {
                             ui.label("-");
                         }
                     }
                     ColumnKind::Kind(bp_encodings::TextLogColumnKind::Body) => {
+                        let data = layout.row_data(row);
+
                         // Rows have a fixed height; show only the first line of multi-line bodies.
-                        let body = entry.body.as_str();
+                        let body = data.body.unwrap_or_default();
                         let (first_line, truncated) = match body.split_once('\n') {
                             Some((first_line, _)) => (first_line, true),
                             None => (body, false),
@@ -529,7 +465,7 @@ impl egui_table::TableDelegate for TextLogTableDelegate<'_> {
                         if self.monospace_body {
                             text = text.monospace();
                         }
-                        if let Some(color) = entry.color {
+                        if let Some(color) = data.color {
                             text = text.color(color);
                         }
 

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -27,8 +27,7 @@ pub struct Entry {
 
 /// Time window on a timeline that the visualizer should query.
 ///
-/// Written by the view's `ui()` (which owns the scrolling) each frame, and read here on the
-/// *next* frame — the same one-frame feedback loop the time series view uses.
+/// Written by the view's `ui()` each frame, and read here on the next frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FetchWindow {
     pub timeline: TimelineName,
@@ -47,8 +46,7 @@ impl re_byte_size::SizeBytes for FetchWindow {
 pub struct TextLogOutput {
     /// Entries sorted by time on the active timeline, static entries first.
     ///
-    /// This only covers [`Self::window`]
-    /// (plus all static entries, which any range query returns).
+    /// This only covers [`Self::window`] plus all static entries.
     pub entries: Vec<Entry>,
 
     /// The time window that was queried, if any.
@@ -89,9 +87,7 @@ impl VisualizerSystem for TextLogSystem {
 
         let output = VisualizerExecutionOutput::default();
 
-        // The view's `ui()` tells us which time window is actually visible, so that we don't
-        // have to query (and materialize entries for) the entire recording.
-        // See <https://github.com/rerun-io/rerun/issues/7562>.
+        // The view knows which time window is actually visible, so we only need query that window.
         let state = ctx.view_state.downcast_ref::<TextViewState>().ok();
         let window = state
             .and_then(|state| state.fetch_window)
@@ -100,9 +96,7 @@ impl VisualizerSystem for TextLogSystem {
         let time_range = if let Some(window) = window {
             AbsoluteTimeRange::new(window.min, window.max)
         } else {
-            // We don't know the visible window yet (first frame, or the timeline changed).
-            // Query a degenerate range: static chunks are returned regardless, and the view
-            // will request a repaint once it has computed the window.
+            // We don't know the visible window yet, query everything.
             AbsoluteTimeRange::new(TimeInt::MAX, TimeInt::MAX)
         };
 
@@ -126,7 +120,6 @@ impl VisualizerSystem for TextLogSystem {
 
         {
             // Sort by currently selected timeline.
-            // The sort is stable, so entries at the same time keep a deterministic order.
             re_tracing::profile_scope!("sort");
             entries.sort_by_key(|e| e.time);
         }
@@ -170,12 +163,10 @@ impl TextLogSystem {
             .iter()
             .flat_map(|chunk| chunk.iter_component_timepoints());
 
-        // A text log entry is one row, and its level/color are read from that same row only
-        // (i.e. the same log call), by joining on the exact `(time, row id)` index — as opposed
-        // to the usual latest-at clamping from earlier rows. This keeps the levels in sync with
-        // the chunk-level metadata that the view uses to lay out the table (see
-        // `RowLayout`); it also means that blueprint overrides and defaults of these
-        // components are not applied here.
+        // A text log entry is one row, and its level/color are read from that same row only.
+        // This is different from the usual latest-at semantics, but keeps the levels and row counts in sync
+        // with the chunk-level metadata which we use to layout the table.
+        // However, this does mean that if a level/color is overridden in a blueprint, it won't be applied here.
         let all_levels: HashMap<(TimeInt, RowId), _> = results
             .iter_optional(TextLog::descriptor_level().component)
             .slice::<String>()
@@ -197,8 +188,6 @@ impl TextLogSystem {
                 time: data_time,
                 timepoint,
                 color: all_colors.get(&index).copied().map(Into::into),
-                // We only ever look at the first instance of each component: a text log entry
-                // is one row, which keeps the row count in sync with the chunk-level metadata.
                 body: bodies.first().cloned().map(Into::into).unwrap_or_default(),
                 level: all_levels.get(&index).cloned().map(Into::into),
             });

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
+
 use itertools::izip;
-use re_chunk_store::AbsoluteTimeRange;
+use re_chunk_store::{AbsoluteTimeRange, RowId};
 use re_entity_db::EntityPath;
 use re_log_types::{TimeInt, TimePoint, TimelineName};
-use re_query::range_zip_1x2;
 use re_sdk_types::Archetype as _;
 use re_sdk_types::archetypes::TextLog;
 use re_sdk_types::components::{Color, Text, TextLogLevel};
@@ -46,15 +47,12 @@ impl re_byte_size::SizeBytes for FetchWindow {
 pub struct TextLogOutput {
     /// Entries sorted by time on the active timeline, static entries first.
     ///
-    /// Unless [`Self::is_full_range`] is set, this only covers [`Self::window`]
+    /// This only covers [`Self::window`]
     /// (plus all static entries, which any range query returns).
     pub entries: Vec<Entry>,
 
     /// The time window that was queried, if any.
     pub window: Option<FetchWindow>,
-
-    /// Whether the query covered the entire timeline (used when a log level filter is active).
-    pub is_full_range: bool,
 }
 
 /// A text scene, with everything needed to render it.
@@ -95,22 +93,17 @@ impl VisualizerSystem for TextLogSystem {
         // have to query (and materialize entries for) the entire recording.
         // See <https://github.com/rerun-io/rerun/issues/7562>.
         let state = ctx.view_state.downcast_ref::<TextViewState>().ok();
-        let filter_active = state.is_some_and(|state| state.filter_active);
         let window = state
             .and_then(|state| state.fetch_window)
             .filter(|window| window.timeline == view_query.timeline);
 
-        let (time_range, is_full_range) = if filter_active {
-            // With a log level filter active we can't derive the row layout from chunk-level
-            // metadata (the filter changes the row count), so fall back to fetching everything.
-            (AbsoluteTimeRange::EVERYTHING, true)
-        } else if let Some(window) = window {
-            (AbsoluteTimeRange::new(window.min, window.max), false)
+        let time_range = if let Some(window) = window {
+            AbsoluteTimeRange::new(window.min, window.max)
         } else {
             // We don't know the visible window yet (first frame, or the timeline changed).
             // Query a degenerate range: static chunks are returned regardless, and the view
             // will request a repaint once it has computed the window.
-            (AbsoluteTimeRange::new(TimeInt::MAX, TimeInt::MAX), false)
+            AbsoluteTimeRange::new(TimeInt::MAX, TimeInt::MAX)
         };
 
         let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range)
@@ -138,11 +131,7 @@ impl VisualizerSystem for TextLogSystem {
             entries.sort_by_key(|e| e.time);
         }
 
-        Ok(output.with_visualizer_data(TextLogOutput {
-            entries,
-            window,
-            is_full_range,
-        }))
+        Ok(output.with_visualizer_data(TextLogOutput { entries, window }))
     }
 }
 
@@ -181,36 +170,37 @@ impl TextLogSystem {
             .iter()
             .flat_map(|chunk| chunk.iter_component_timepoints());
 
-        let all_levels = results.iter_optional(TextLog::descriptor_level().component);
-        let all_colors = results.iter_optional(TextLog::descriptor_color().component);
+        // A text log entry is one row, and its level/color are read from that same row only
+        // (i.e. the same log call), by joining on the exact `(time, row id)` index — as opposed
+        // to the usual latest-at clamping from earlier rows. This keeps the levels in sync with
+        // the chunk-level metadata that the view uses to lay out the table (see
+        // `ScrollGeometry`); it also means that blueprint overrides and defaults of these
+        // components are not applied here.
+        let all_levels: HashMap<(TimeInt, RowId), _> = results
+            .iter_optional(TextLog::descriptor_level().component)
+            .slice::<String>()
+            .filter_map(|(index, levels)| levels.first().map(|level| (index, level.clone())))
+            .collect();
+        let all_colors: HashMap<(TimeInt, RowId), u32> = results
+            .iter_optional(TextLog::descriptor_color().component)
+            .slice::<u32>()
+            .filter_map(|(index, colors)| colors.first().map(|color| (index, *color)))
+            .collect();
 
-        let all_frames = range_zip_1x2(
-            all_texts.slice::<String>(),
-            all_levels.slice::<String>(),
-            all_colors.slice::<u32>(),
-        );
+        let all_frames = izip!(all_timepoints, all_texts.slice::<String>());
 
-        let all_frames = izip!(all_timepoints, all_frames);
-
-        for (timepoint, ((data_time, _row_id), bodies, levels, colors)) in all_frames {
-            // A text log entry is one row; we only ever look at the first instance of each
-            // component. This keeps the row count in sync with the chunk-level metadata that
-            // the view uses to lay out the table.
-            let Some(body) = bodies.first() else {
-                continue;
-            };
+        for (timepoint, (index, bodies)) in all_frames {
+            let (data_time, _row_id) = index;
 
             entries.push(Entry {
                 entity_path: data_result.entity_path.clone(),
                 time: data_time,
                 timepoint,
-                color: colors
-                    .and_then(|colors| colors.first().copied())
-                    .map(Into::into),
-                body: body.clone().into(),
-                level: levels
-                    .and_then(|levels| levels.first().cloned())
-                    .map(Into::into),
+                color: all_colors.get(&index).copied().map(Into::into),
+                // We only ever look at the first instance of each component: a text log entry
+                // is one row, which keeps the row count in sync with the chunk-level metadata.
+                body: bodies.first().cloned().map(Into::into).unwrap_or_default(),
+                level: all_levels.get(&index).cloned().map(Into::into),
             });
         }
     }

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -6,13 +6,16 @@ use re_entity_db::EntityPath;
 use re_log_types::{TimeInt, TimePoint, TimelineName};
 use re_sdk_types::Archetype as _;
 use re_sdk_types::archetypes::TextLog;
+use re_sdk_types::blueprint::archetypes::TextLogRows;
 use re_sdk_types::components::{Color, Text, TextLogLevel};
 use re_view::range_with_blueprint_resolved_data;
 use re_viewer_context::{
     IdentifiedViewSystem, ViewContext, ViewContextCollection, ViewQuery, ViewStateExt as _,
     ViewSystemExecutionError, VisualizerExecutionOutput, VisualizerQueryInfo, VisualizerSystem,
 };
+use re_viewport_blueprint::ViewProperty;
 
+use crate::row_layout::{LevelCountCache, LevelFilter, RowLayout};
 use crate::view_class::TextViewState;
 
 #[derive(Debug, Clone)]
@@ -46,11 +49,17 @@ impl re_byte_size::SizeBytes for FetchWindow {
 pub struct TextLogOutput {
     /// Entries sorted by time on the active timeline, static entries first.
     ///
-    /// This only covers [`Self::window`] plus all static entries.
+    /// This only covers [`Self::window`] plus all static entries, and only rows that pass the
+    /// level filter.
     pub entries: Vec<Entry>,
 
     /// The time window that was queried, if any.
     pub window: Option<FetchWindow>,
+
+    /// Where every row of the table lives, including the ones outside [`Self::window`].
+    ///
+    /// `None` if the visualizer didn't run at all, i.e. the view has no active instructions.
+    pub layout: Option<RowLayout>,
 }
 
 /// A text scene, with everything needed to render it.
@@ -103,6 +112,41 @@ impl VisualizerSystem for TextLogSystem {
         let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range)
             .keep_extra_timelines(true);
 
+        // An *explicit* level filter (i.e. one set in the blueprint, not the show-everything
+        // fallback) changes which rows are shown; the row layout then comes from cached
+        // per-chunk level counts instead of plain chunk row counts.
+        let filter = ViewProperty::from_archetype::<TextLogRows>(ctx)
+            .component_array::<TextLogLevel>(
+                TextLogRows::descriptor_filter_by_log_level().component,
+            )?
+            .map(|levels| LevelFilter(levels.iter().map(|lvl| lvl.as_str().to_owned()).collect()));
+
+        // Only the fetched window's entries are materialized; the rest of the row layout comes
+        // from chunk-level metadata (time ranges + row counts), so we never have to touch the
+        // full data. See <https://github.com/rerun-io/rerun/issues/7562>.
+        let layout = {
+            let engine = ctx.recording_engine();
+            ctx.viewer_ctx
+                .store_context
+                .memoizer(|level_counts: &mut LevelCountCache| {
+                    RowLayout::build(
+                        engine.store(),
+                        &view_query.timeline,
+                        TextLog::descriptor_text().component,
+                        TextLog::descriptor_level().component,
+                        view_query
+                            .iter_visualizer_instruction_for(Self::identifier())
+                            .map(|(data_result, _)| &data_result.entity_path),
+                        filter.as_ref(),
+                        level_counts,
+                    )
+                })
+        };
+
+        if layout.any_missing {
+            output.set_missing_chunks();
+        }
+
         let mut entries = Vec::new();
 
         for (data_result, instruction) in
@@ -118,13 +162,24 @@ impl VisualizerSystem for TextLogSystem {
             );
         }
 
+        // The fetched window contains *all* rows in its time range; apply the level filter
+        // here so the entries line up with the (filtered) row layout.
+        if let Some(filter) = &filter {
+            re_tracing::profile_scope!("filter");
+            entries.retain(|entry| filter.matches(entry.level.as_ref().map(|lvl| lvl.as_str())));
+        }
+
         {
             // Sort by currently selected timeline.
             re_tracing::profile_scope!("sort");
             entries.sort_by_key(|e| e.time);
         }
 
-        Ok(output.with_visualizer_data(TextLogOutput { entries, window }))
+        Ok(output.with_visualizer_data(TextLogOutput {
+            entries,
+            window,
+            layout: Some(layout),
+        }))
     }
 }
 

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -1,63 +1,26 @@
 use std::collections::HashMap;
 
-use itertools::izip;
-use re_chunk_store::{AbsoluteTimeRange, RowId};
-use re_entity_db::EntityPath;
-use re_log_types::{TimeInt, TimePoint, TimelineName};
+use re_chunk_store::{AbsoluteTimeRange, ChunkTrackingMode, RangeQuery};
 use re_sdk_types::Archetype as _;
 use re_sdk_types::archetypes::TextLog;
 use re_sdk_types::blueprint::archetypes::TextLogRows;
+use re_sdk_types::blueprint::encodings::ComponentSourceKind;
 use re_sdk_types::components::{Color, Text, TextLogLevel};
-use re_view::range_with_blueprint_resolved_data;
 use re_viewer_context::{
-    IdentifiedViewSystem, ViewContext, ViewContextCollection, ViewQuery, ViewStateExt as _,
-    ViewSystemExecutionError, VisualizerExecutionOutput, VisualizerQueryInfo, VisualizerSystem,
+    IdentifiedViewSystem, ViewContext, ViewContextCollection, ViewQuery, ViewSystemExecutionError,
+    VisualizerExecutionOutput, VisualizerQueryInfo, VisualizerSystem,
 };
 use re_viewport_blueprint::ViewProperty;
 
-use crate::row_layout::{LevelCountCache, LevelFilter, RowLayout};
-use crate::view_class::TextViewState;
+use crate::row_layout::{LevelCountCache, LevelFilter, RowLayout, RowOverrides};
 
-#[derive(Debug, Clone)]
-pub struct Entry {
-    pub entity_path: EntityPath,
-    pub time: TimeInt,
-    pub timepoint: TimePoint,
-    pub color: Option<Color>,
-    pub body: Text,
-    pub level: Option<TextLogLevel>,
-}
-
-/// Time window on a timeline that the visualizer should query.
+/// Result of executing [`TextLogSystem`] for one frame: the row layout of the text log table.
 ///
-/// Written by the view's `ui()` each frame, and read here on the next frame.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FetchWindow {
-    pub timeline: TimelineName,
-    pub min: TimeInt,
-    pub max: TimeInt,
-}
-
-impl re_byte_size::SizeBytes for FetchWindow {
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-}
-
-/// Result of executing [`TextLogSystem`] for one frame.
+/// No row data is materialized here: the layout is derived from chunk-level metadata of the
+/// range query results (which are densified around the text component and pre-sorted on the
+/// query timeline), and the view resolves only the rows that are actually on screen.
 #[derive(Clone, Default)]
 pub struct TextLogOutput {
-    /// Entries sorted by time on the active timeline, static entries first.
-    ///
-    /// This only covers [`Self::window`] plus all static entries, and only rows that pass the
-    /// level filter.
-    pub entries: Vec<Entry>,
-
-    /// The time window that was queried, if any.
-    pub window: Option<FetchWindow>,
-
-    /// Where every row of the table lives, including the ones outside [`Self::window`].
-    ///
     /// `None` if the visualizer didn't run at all, i.e. the view has no active instructions.
     pub layout: Option<RowLayout>,
 }
@@ -96,21 +59,83 @@ impl VisualizerSystem for TextLogSystem {
 
         let output = VisualizerExecutionOutput::default();
 
-        // The view knows which time window is actually visible, so we only need query that window.
-        let state = ctx.view_state.downcast_ref::<TextViewState>().ok();
-        let window = state
-            .and_then(|state| state.fetch_window)
-            .filter(|window| window.timeline == view_query.timeline);
+        // A text log row's level/color are read from that same row only (plus per-entity
+        // blueprint overrides/defaults, see below), and other timelines' timestamps may be
+        // shown as columns, so keep all of the chunks' columns around.
+        //
+        // Note that this means latest-at semantics do not apply to the level/color of a row
+        // (which is desirable for this archetype: a log line should not inherit the previous
+        // line's level).
+        let query = RangeQuery::new(view_query.timeline, AbsoluteTimeRange::EVERYTHING)
+            .keep_extra_timelines(true)
+            .keep_extra_components(true);
 
-        let time_range = if let Some(window) = window {
-            AbsoluteTimeRange::new(window.min, window.max)
-        } else {
-            // We don't know the visible window yet, query everything.
-            AbsoluteTimeRange::new(TimeInt::MAX, TimeInt::MAX)
-        };
+        let component = TextLog::descriptor_text().component;
+        let level_component = TextLog::descriptor_level().component;
+        let color_component = TextLog::descriptor_color().component;
 
-        let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range)
-            .keep_extra_timelines(true);
+        let latest_at_query = ctx.current_query();
+        let engine = ctx.recording_engine();
+
+        let mut chunks = Vec::new();
+        let mut overrides = HashMap::new();
+        for (data_result, instruction) in
+            view_query.iter_visualizer_instruction_for(Self::identifier())
+        {
+            let mut results = engine.cache().range(
+                ChunkTrackingMode::Report,
+                &query,
+                &data_result.entity_path,
+                [component],
+            );
+
+            if !results.missing_virtual.is_empty() {
+                output.set_missing_chunks();
+            }
+
+            if let Some(entity_chunks) = results.components.remove(&component) {
+                chunks.extend(entity_chunks);
+            }
+
+            // Blueprint overrides and view defaults for level/color are per-entity constants,
+            // which is what keeps them compatible with the metadata-derived row layout.
+            // The standard `Override > Store > Default` resolution decides where a component
+            // comes from; only when it's the store do the rows' own values apply (per row,
+            // straight from the chunks — see `RowLayout`).
+            let resolved = re_view::latest_at_with_blueprint_resolved_data(
+                ctx,
+                None,
+                &latest_at_query,
+                data_result,
+                [level_component, color_component],
+                Some(instruction),
+            );
+
+            let mut entity_overrides = RowOverrides::default();
+            match resolved.component_source_kind_for(level_component) {
+                Some(Ok(ComponentSourceKind::Override)) => {
+                    entity_overrides.level_override = resolved
+                        .get_mono::<TextLogLevel>(level_component)
+                        .map(|lvl| lvl.as_str().to_owned());
+                }
+                Some(Ok(ComponentSourceKind::Default)) => {
+                    entity_overrides.level_default = resolved
+                        .get_mono::<TextLogLevel>(level_component)
+                        .map(|lvl| lvl.as_str().to_owned());
+                }
+                _ => {}
+            }
+            match resolved.component_source_kind_for(color_component) {
+                Some(Ok(ComponentSourceKind::Override)) => {
+                    entity_overrides.color_override = resolved.get_mono::<Color>(color_component);
+                }
+                Some(Ok(ComponentSourceKind::Default)) => {
+                    entity_overrides.color_default = resolved.get_mono::<Color>(color_component);
+                }
+                _ => {}
+            }
+            overrides.insert(data_result.entity_path.clone(), entity_overrides);
+        }
 
         // An *explicit* level filter (i.e. one set in the blueprint, not the show-everything
         // fallback) changes which rows are shown; the row layout then comes from cached
@@ -121,131 +146,24 @@ impl VisualizerSystem for TextLogSystem {
             )?
             .map(|levels| LevelFilter(levels.iter().map(|lvl| lvl.as_str().to_owned()).collect()));
 
-        // Only the fetched window's entries are materialized; the rest of the row layout comes
-        // from chunk-level metadata (time ranges + row counts), so we never have to touch the
-        // full data. See <https://github.com/rerun-io/rerun/issues/7562>.
-        let layout = {
-            let engine = ctx.recording_engine();
-            ctx.viewer_ctx
-                .store_context
-                .memoizer(|level_counts: &mut LevelCountCache| {
-                    RowLayout::build(
-                        engine.store(),
-                        &view_query.timeline,
-                        TextLog::descriptor_text().component,
-                        TextLog::descriptor_level().component,
-                        view_query
-                            .iter_visualizer_instruction_for(Self::identifier())
-                            .map(|(data_result, _)| &data_result.entity_path),
-                        filter.as_ref(),
-                        level_counts,
-                    )
-                })
-        };
-
-        if layout.any_missing {
-            output.set_missing_chunks();
-        }
-
-        let mut entries = Vec::new();
-
-        for (data_result, instruction) in
-            view_query.iter_visualizer_instruction_for(Self::identifier())
-        {
-            Self::process_visualizer_instruction(
-                &mut entries,
-                ctx,
-                &query,
-                data_result,
-                instruction,
-                &output,
-            );
-        }
-
-        // The fetched window contains *all* rows in its time range; apply the level filter
-        // here so the entries line up with the (filtered) row layout.
-        if let Some(filter) = &filter {
-            re_tracing::profile_scope!("filter");
-            entries.retain(|entry| filter.matches(entry.level.as_ref().map(|lvl| lvl.as_str())));
-        }
-
-        {
-            // Sort by currently selected timeline.
-            re_tracing::profile_scope!("sort");
-            entries.sort_by_key(|e| e.time);
-        }
+        let layout = ctx
+            .viewer_ctx
+            .store_context
+            .memoizer(|level_counts: &mut LevelCountCache| {
+                RowLayout::build(
+                    chunks,
+                    &view_query.timeline,
+                    component,
+                    level_component,
+                    color_component,
+                    filter.as_ref(),
+                    &overrides,
+                    level_counts,
+                )
+            });
 
         Ok(output.with_visualizer_data(TextLogOutput {
-            entries,
-            window,
             layout: Some(layout),
         }))
-    }
-}
-
-impl TextLogSystem {
-    fn process_visualizer_instruction(
-        entries: &mut Vec<Entry>,
-        ctx: &ViewContext<'_>,
-        query: &re_chunk_store::RangeQuery,
-        data_result: &re_viewer_context::DataResult,
-        instruction: &re_viewer_context::VisualizerInstruction,
-        output: &VisualizerExecutionOutput,
-    ) {
-        re_tracing::profile_function!();
-
-        let range_results = range_with_blueprint_resolved_data(
-            ctx,
-            None,
-            query,
-            data_result,
-            TextLog::all_component_identifiers(),
-            instruction,
-        );
-
-        // Convert to HybridResults for unified access
-        let results = re_view::BlueprintResolvedResults::from((query.clone(), range_results));
-        let results =
-            re_view::VisualizerInstructionQueryResults::new(instruction, &results, output);
-
-        let all_texts = results.iter_required(TextLog::descriptor_text().component);
-        if all_texts.is_empty() {
-            return;
-        }
-
-        let all_timepoints = all_texts
-            .chunks()
-            .iter()
-            .flat_map(|chunk| chunk.iter_component_timepoints());
-
-        // A text log entry is one row, and its level/color are read from that same row only.
-        // This is different from the usual latest-at semantics, but keeps the levels and row counts in sync
-        // with the chunk-level metadata which we use to layout the table.
-        // However, this does mean that if a level/color is overridden in a blueprint, it won't be applied here.
-        let all_levels: HashMap<(TimeInt, RowId), _> = results
-            .iter_optional(TextLog::descriptor_level().component)
-            .slice::<String>()
-            .filter_map(|(index, levels)| levels.first().map(|level| (index, level.clone())))
-            .collect();
-        let all_colors: HashMap<(TimeInt, RowId), u32> = results
-            .iter_optional(TextLog::descriptor_color().component)
-            .slice::<u32>()
-            .filter_map(|(index, colors)| colors.first().map(|color| (index, *color)))
-            .collect();
-
-        let all_frames = izip!(all_timepoints, all_texts.slice::<String>());
-
-        for (timepoint, (index, bodies)) in all_frames {
-            let (data_time, _row_id) = index;
-
-            entries.push(Entry {
-                entity_path: data_result.entity_path.clone(),
-                time: data_time,
-                timepoint,
-                color: all_colors.get(&index).copied().map(Into::into),
-                body: bodies.first().cloned().map(Into::into).unwrap_or_default(),
-                level: all_levels.get(&index).cloned().map(Into::into),
-            });
-        }
     }
 }

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -174,7 +174,7 @@ impl TextLogSystem {
         // (i.e. the same log call), by joining on the exact `(time, row id)` index — as opposed
         // to the usual latest-at clamping from earlier rows. This keeps the levels in sync with
         // the chunk-level metadata that the view uses to lay out the table (see
-        // `ScrollGeometry`); it also means that blueprint overrides and defaults of these
+        // `RowLayout`); it also means that blueprint overrides and defaults of these
         // components are not applied here.
         let all_levels: HashMap<(TimeInt, RowId), _> = results
             .iter_optional(TextLog::descriptor_level().component)

--- a/crates/viewer/re_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_view_text_log/src/visualizer_system.rs
@@ -1,16 +1,18 @@
 use itertools::izip;
 use re_chunk_store::AbsoluteTimeRange;
 use re_entity_db::EntityPath;
-use re_log_types::{TimeInt, TimePoint};
-use re_query::{clamped_zip_1x2, range_zip_1x2};
+use re_log_types::{TimeInt, TimePoint, TimelineName};
+use re_query::range_zip_1x2;
 use re_sdk_types::Archetype as _;
 use re_sdk_types::archetypes::TextLog;
 use re_sdk_types::components::{Color, Text, TextLogLevel};
 use re_view::range_with_blueprint_resolved_data;
 use re_viewer_context::{
-    IdentifiedViewSystem, ViewContext, ViewContextCollection, ViewQuery, ViewSystemExecutionError,
-    VisualizerExecutionOutput, VisualizerQueryInfo, VisualizerSystem,
+    IdentifiedViewSystem, ViewContext, ViewContextCollection, ViewQuery, ViewStateExt as _,
+    ViewSystemExecutionError, VisualizerExecutionOutput, VisualizerQueryInfo, VisualizerSystem,
 };
+
+use crate::view_class::TextViewState;
 
 #[derive(Debug, Clone)]
 pub struct Entry {
@@ -20,6 +22,39 @@ pub struct Entry {
     pub color: Option<Color>,
     pub body: Text,
     pub level: Option<TextLogLevel>,
+}
+
+/// Time window on a timeline that the visualizer should query.
+///
+/// Written by the view's `ui()` (which owns the scrolling) each frame, and read here on the
+/// *next* frame — the same one-frame feedback loop the time series view uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FetchWindow {
+    pub timeline: TimelineName,
+    pub min: TimeInt,
+    pub max: TimeInt,
+}
+
+impl re_byte_size::SizeBytes for FetchWindow {
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+}
+
+/// Result of executing [`TextLogSystem`] for one frame.
+#[derive(Clone, Default)]
+pub struct TextLogOutput {
+    /// Entries sorted by time on the active timeline, static entries first.
+    ///
+    /// Unless [`Self::is_full_range`] is set, this only covers [`Self::window`]
+    /// (plus all static entries, which any range query returns).
+    pub entries: Vec<Entry>,
+
+    /// The time window that was queried, if any.
+    pub window: Option<FetchWindow>,
+
+    /// Whether the query covered the entire timeline (used when a log level filter is active).
+    pub is_full_range: bool,
 }
 
 /// A text scene, with everything needed to render it.
@@ -55,9 +90,31 @@ impl VisualizerSystem for TextLogSystem {
         re_tracing::profile_function!();
 
         let output = VisualizerExecutionOutput::default();
-        let query =
-            re_chunk_store::RangeQuery::new(view_query.timeline, AbsoluteTimeRange::EVERYTHING)
-                .keep_extra_timelines(true);
+
+        // The view's `ui()` tells us which time window is actually visible, so that we don't
+        // have to query (and materialize entries for) the entire recording.
+        // See <https://github.com/rerun-io/rerun/issues/7562>.
+        let state = ctx.view_state.downcast_ref::<TextViewState>().ok();
+        let filter_active = state.is_some_and(|state| state.filter_active);
+        let window = state
+            .and_then(|state| state.fetch_window)
+            .filter(|window| window.timeline == view_query.timeline);
+
+        let (time_range, is_full_range) = if filter_active {
+            // With a log level filter active we can't derive the row layout from chunk-level
+            // metadata (the filter changes the row count), so fall back to fetching everything.
+            (AbsoluteTimeRange::EVERYTHING, true)
+        } else if let Some(window) = window {
+            (AbsoluteTimeRange::new(window.min, window.max), false)
+        } else {
+            // We don't know the visible window yet (first frame, or the timeline changed).
+            // Query a degenerate range: static chunks are returned regardless, and the view
+            // will request a repaint once it has computed the window.
+            (AbsoluteTimeRange::new(TimeInt::MAX, TimeInt::MAX), false)
+        };
+
+        let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range)
+            .keep_extra_timelines(true);
 
         let mut entries = Vec::new();
 
@@ -75,12 +132,17 @@ impl VisualizerSystem for TextLogSystem {
         }
 
         {
-            // Sort by currently selected timeline
+            // Sort by currently selected timeline.
+            // The sort is stable, so entries at the same time keep a deterministic order.
             re_tracing::profile_scope!("sort");
             entries.sort_by_key(|e| e.time);
         }
 
-        Ok(output.with_visualizer_data(entries))
+        Ok(output.with_visualizer_data(TextLogOutput {
+            entries,
+            window,
+            is_full_range,
+        }))
     }
 }
 
@@ -114,9 +176,6 @@ impl TextLogSystem {
             return;
         }
 
-        // TODO(cmc): It would be more efficient (both space and compute) to do this lazily as
-        // we're rendering the table by indexing back into the original chunk etc.
-        // Let's keep it simple for now, until we have data suggested we need the extra perf.
         let all_timepoints = all_texts
             .chunks()
             .iter()
@@ -134,30 +193,25 @@ impl TextLogSystem {
         let all_frames = izip!(all_timepoints, all_frames);
 
         for (timepoint, ((data_time, _row_id), bodies, levels, colors)) in all_frames {
-            let levels = levels.as_deref().unwrap_or(&[]).iter().cloned().map(Some);
-            let colors = colors
-                .unwrap_or(&[])
-                .iter()
-                .copied()
-                .map(Into::into)
-                .map(Some);
+            // A text log entry is one row; we only ever look at the first instance of each
+            // component. This keeps the row count in sync with the chunk-level metadata that
+            // the view uses to lay out the table.
+            let Some(body) = bodies.first() else {
+                continue;
+            };
 
-            let level_default_fn = || None;
-            let color_default_fn = || None;
-
-            let results =
-                clamped_zip_1x2(bodies, levels, level_default_fn, colors, color_default_fn);
-
-            for (text, level, color) in results {
-                entries.push(Entry {
-                    entity_path: data_result.entity_path.clone(),
-                    time: data_time,
-                    timepoint: timepoint.clone(),
-                    color,
-                    body: text.clone().into(),
-                    level: level.clone().map(Into::into),
-                });
-            }
+            entries.push(Entry {
+                entity_path: data_result.entity_path.clone(),
+                time: data_time,
+                timepoint,
+                color: colors
+                    .and_then(|colors| colors.first().copied())
+                    .map(Into::into),
+                body: body.clone().into(),
+                level: levels
+                    .and_then(|levels| levels.first().cloned())
+                    .map(Into::into),
+            });
         }
     }
 }

--- a/crates/viewer/re_view_text_log/tests/basic.rs
+++ b/crates/viewer/re_view_text_log/tests/basic.rs
@@ -113,6 +113,64 @@ fn level_filter() {
     ));
 }
 
+/// A view default for the level follows the standard `Override > Store > Default` resolution:
+/// it applies to entities that never logged a level, while entities with their own levels
+/// are unaffected.
+#[test]
+fn view_default_level() {
+    let mut snapshot_results = SnapshotResults::new();
+    let mut test_context = TestContext::new_with_view_class::<TextView>();
+
+    let timeline = Timeline::log_tick();
+
+    // `logs/leveled` logs its own levels (on every other row): the view default must not apply.
+    let mut leveled = Chunk::builder("logs/leveled");
+    // `logs/plain` never logs a level: every row falls back to the view default.
+    let mut plain = Chunk::builder("logs/plain");
+    for tick in 0_i64..6 {
+        let mut row = TextLog::new(format!("Leveled at tick {tick}"));
+        if tick % 2 == 0 {
+            row = row.with_level("INFO");
+        }
+        leveled = leveled.with_archetype_auto_row([(timeline, tick)], &row);
+        plain = plain.with_archetype_auto_row(
+            [(timeline, tick)],
+            &TextLog::new(format!("Plain at tick {tick}")),
+        );
+    }
+    test_context.add_chunks(
+        [leveled, plain]
+            .map(|builder| builder.build().expect("failed to build chunk"))
+            .into_iter(),
+    );
+
+    test_context.set_active_timeline(*timeline.name());
+    test_context.send_time_commands(
+        test_context.active_store_id(),
+        [TimeControlCommand::SetTime(TimeInt::new_temporal(6).into())],
+    );
+    test_context.handle_system_commands(&egui::Context::default());
+
+    let view_id = test_context.setup_viewport_blueprint(|ctx, blueprint| {
+        let view_id = blueprint
+            .add_view_at_root(ViewBlueprint::new_with_root_wildcard(TextView::identifier()));
+
+        ctx.save_blueprint_archetype(
+            re_viewport_blueprint::ViewBlueprint::defaults_path(view_id),
+            &TextLog::update_fields().with_level("ERROR"),
+        );
+
+        view_id
+    });
+
+    snapshot_results.add(test_context.run_view_ui_and_save_snapshot(
+        view_id,
+        "text_log_view_default_level",
+        egui::vec2(500.0, 420.0),
+        None,
+    ));
+}
+
 fn text_log_chunks(timeline: Timeline) -> impl Iterator<Item = Chunk> {
     (0_i64..=200).step_by(10).map(move |tick| {
         Chunk::builder("logs")

--- a/crates/viewer/re_view_text_log/tests/basic.rs
+++ b/crates/viewer/re_view_text_log/tests/basic.rs
@@ -1,11 +1,17 @@
 use re_chunk::Chunk;
 use re_log_types::{TimeInt, Timeline};
+use re_sdk_types::Archetype as _;
 use re_sdk_types::archetypes::TextLog;
+use re_sdk_types::blueprint::archetypes::TextLogRows;
 use re_test_context::TestContext;
 use re_test_context::external::egui_kittest::SnapshotResults;
 use re_test_viewport::TestContextExt as _;
 use re_view_text_log::TextView;
+<<<<<<< HEAD
 use re_viewer_context::{ViewClass as _, ViewId};
+=======
+use re_viewer_context::{BlueprintContext as _, TimeControlCommand, ViewClass as _, ViewId};
+>>>>>>> a319e308d2 (level filter caching)
 use re_viewport_blueprint::ViewBlueprint;
 
 fn setup_blueprint(test_context: &mut TestContext) -> ViewId {
@@ -44,6 +50,65 @@ fn temporal_anchor_between_sequence_steps() {
         view_id,
         "text_log_temporal_anchor_between_steps_rest",
         egui::vec2(500.0, 180.0),
+        None,
+    ));
+}
+
+/// With a level filter active, only matching rows (and rows without a level) are shown,
+/// laid out from cached per-chunk level counts.
+#[test]
+fn level_filter() {
+    let mut snapshot_results = SnapshotResults::new();
+    let mut test_context = TestContext::new_with_view_class::<TextView>();
+
+    let timeline = Timeline::log_tick();
+
+    let mut builder = Chunk::builder("logs");
+    for tick in 0_i64..30 {
+        let mut row = TextLog::new(format!("Log at tick {tick}"));
+        // Every third row has no level: those always pass the filter.
+        if tick % 3 != 2 {
+            row = row.with_level(if tick % 2 == 0 { "INFO" } else { "WARN" });
+        }
+        builder = builder.with_archetype_auto_row([(timeline, tick)], &row);
+    }
+    test_context.add_chunks(std::iter::once(
+        builder.build().expect("failed to build chunk"),
+    ));
+
+    test_context.set_active_timeline(*timeline.name());
+    test_context.send_time_commands(
+        test_context.active_store_id(),
+        [TimeControlCommand::SetTime(
+            TimeInt::new_temporal(15).into(),
+        )],
+    );
+    test_context.handle_system_commands(&egui::Context::default());
+
+    let view_id = test_context.setup_viewport_blueprint(|ctx, blueprint| {
+        let view_id = blueprint
+            .add_view_at_root(ViewBlueprint::new_with_root_wildcard(TextView::identifier()));
+
+        let property_path = {
+            let engine = ctx.store_context.blueprint.storage_engine();
+            re_viewport_blueprint::entity_path_for_view_property(
+                view_id,
+                engine.store().entity_tree(),
+                TextLogRows::name(),
+            )
+        };
+        ctx.save_blueprint_archetype(
+            property_path,
+            &TextLogRows::new().with_filter_by_log_level(["WARN"]),
+        );
+
+        view_id
+    });
+
+    snapshot_results.add(test_context.run_view_ui_and_save_snapshot(
+        view_id,
+        "text_log_level_filter",
+        egui::vec2(500.0, 420.0),
         None,
     ));
 }

--- a/crates/viewer/re_view_text_log/tests/perf.rs
+++ b/crates/viewer/re_view_text_log/tests/perf.rs
@@ -1,0 +1,86 @@
+//! Frame-time measurement for the text log view with large recordings.
+//!
+//! See <https://github.com/rerun-io/rerun/issues/7562>.
+//!
+//! This is not run on CI (timings are machine-dependent); run it manually with:
+//! ```sh
+//! cargo test -p re_view_text_log --test perf --release -- --ignored --nocapture
+//! ```
+
+use std::time::Instant;
+
+use re_chunk::Chunk;
+use re_log_types::{TimeInt, Timeline};
+use re_sdk_types::archetypes::TextLog;
+use re_test_context::TestContext;
+use re_test_viewport::TestContextExt as _;
+use re_view_text_log::TextView;
+use re_viewer_context::{TimeControlCommand, ViewClass as _};
+use re_viewport_blueprint::ViewBlueprint;
+
+const ROWS_PER_CHUNK: usize = 25_000;
+
+#[test]
+#[ignore = "manual benchmark, run with --ignored --nocapture"]
+fn frame_time_large_log() {
+    // Number of chunks of 25k rows each; override with e.g. `PERF_NUM_CHUNKS=80` for 2M rows.
+    let num_chunks: usize = std::env::var("PERF_NUM_CHUNKS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20);
+    let num_rows = num_chunks * ROWS_PER_CHUNK;
+
+    let mut test_context = TestContext::new_with_view_class::<TextView>();
+    let timeline = Timeline::log_tick();
+
+    {
+        let start = Instant::now();
+        let chunks = (0..num_chunks).map(|chunk_idx| {
+            let mut builder = Chunk::builder("logs");
+            for row in 0..ROWS_PER_CHUNK {
+                let tick =
+                    i64::try_from(chunk_idx * ROWS_PER_CHUNK + row).expect("row count fits in i64");
+                builder = builder.with_archetype_auto_row(
+                    [(timeline, tick)],
+                    &TextLog::new(format!("log entry {tick}")),
+                );
+            }
+            builder.build().expect("failed to build chunk")
+        });
+        test_context.add_chunks(chunks);
+        eprintln!("built {num_rows} rows in {:.1?}", start.elapsed());
+    }
+
+    test_context.set_active_timeline(*timeline.name());
+    test_context.send_time_commands(
+        test_context.active_store_id(),
+        [TimeControlCommand::SetTime(
+            TimeInt::new_temporal(i64::try_from(num_rows / 2).expect("row count fits in i64"))
+                .into(),
+        )],
+    );
+    test_context.handle_system_commands(&egui::Context::default());
+
+    let view_id = test_context.setup_viewport_blueprint(|_ctx, blueprint| {
+        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(TextView::identifier()))
+    });
+
+    let mut harness = test_context
+        .setup_kittest_for_rendering_ui(egui::vec2(1024.0, 768.0))
+        .build_ui(|ui| test_context.run_with_single_view(ui, view_id));
+
+    // Warm-up: let the view settle (auto-scroll, initial queries, …).
+    harness.run_steps(5);
+
+    const NUM_FRAMES: usize = 20;
+    let start = Instant::now();
+    for _ in 0..NUM_FRAMES {
+        harness.step();
+    }
+    let elapsed = start.elapsed();
+
+    eprintln!(
+        "text log view with {num_rows} rows: {:.2} ms/frame (avg over {NUM_FRAMES} frames)",
+        elapsed.as_secs_f64() * 1000.0 / NUM_FRAMES as f64
+    );
+}

--- a/crates/viewer/re_view_text_log/tests/perf.rs
+++ b/crates/viewer/re_view_text_log/tests/perf.rs
@@ -2,7 +2,7 @@
 //!
 //! See <https://github.com/rerun-io/rerun/issues/7562>.
 //!
-//! This is not run on CI (timings are machine-dependent); run it manually with:
+//! This is not run on CI, run it manually with:
 //! ```sh
 //! cargo test -p re_view_text_log --test perf --release -- --ignored --nocapture
 //! ```

--- a/crates/viewer/re_view_text_log/tests/perf.rs
+++ b/crates/viewer/re_view_text_log/tests/perf.rs
@@ -11,14 +11,18 @@ use std::time::Instant;
 
 use re_chunk::Chunk;
 use re_log_types::{TimeInt, Timeline};
+use re_sdk_types::Archetype as _;
 use re_sdk_types::archetypes::TextLog;
+use re_sdk_types::blueprint::archetypes::TextLogRows;
 use re_test_context::TestContext;
 use re_test_viewport::TestContextExt as _;
 use re_view_text_log::TextView;
-use re_viewer_context::{TimeControlCommand, ViewClass as _};
+use re_viewer_context::{BlueprintContext as _, TimeControlCommand, ViewClass as _};
 use re_viewport_blueprint::ViewBlueprint;
 
 const ROWS_PER_CHUNK: usize = 25_000;
+
+const LEVELS: [&str; 5] = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR"];
 
 #[test]
 #[ignore = "manual benchmark, run with --ignored --nocapture"]
@@ -29,6 +33,12 @@ fn frame_time_large_log() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(20);
     let num_rows = num_chunks * ROWS_PER_CHUNK;
+
+    // Optionally set an explicit log level filter, e.g. `PERF_LEVEL_FILTER=WARN,ERROR`,
+    // to measure the level-filtered path.
+    let level_filter: Option<Vec<String>> = std::env::var("PERF_LEVEL_FILTER")
+        .ok()
+        .map(|levels| levels.split(',').map(|lvl| lvl.trim().to_owned()).collect());
 
     let mut test_context = TestContext::new_with_view_class::<TextView>();
     let timeline = Timeline::log_tick();
@@ -42,7 +52,8 @@ fn frame_time_large_log() {
                     i64::try_from(chunk_idx * ROWS_PER_CHUNK + row).expect("row count fits in i64");
                 builder = builder.with_archetype_auto_row(
                     [(timeline, tick)],
-                    &TextLog::new(format!("log entry {tick}")),
+                    &TextLog::new(format!("log entry {tick}"))
+                        .with_level(LEVELS[tick as usize % LEVELS.len()]),
                 );
             }
             builder.build().expect("failed to build chunk")
@@ -61,8 +72,26 @@ fn frame_time_large_log() {
     );
     test_context.handle_system_commands(&egui::Context::default());
 
-    let view_id = test_context.setup_viewport_blueprint(|_ctx, blueprint| {
-        blueprint.add_view_at_root(ViewBlueprint::new_with_root_wildcard(TextView::identifier()))
+    let view_id = test_context.setup_viewport_blueprint(|ctx, blueprint| {
+        let view_id = blueprint
+            .add_view_at_root(ViewBlueprint::new_with_root_wildcard(TextView::identifier()));
+
+        if let Some(levels) = &level_filter {
+            let property_path = {
+                let engine = ctx.store_context.blueprint.storage_engine();
+                re_viewport_blueprint::entity_path_for_view_property(
+                    view_id,
+                    engine.store().entity_tree(),
+                    TextLogRows::name(),
+                )
+            };
+            ctx.save_blueprint_archetype(
+                property_path,
+                &TextLogRows::new().with_filter_by_log_level(levels.iter().map(|lvl| lvl.as_str())),
+            );
+        }
+
+        view_id
     });
 
     let mut harness = test_context

--- a/crates/viewer/re_view_text_log/tests/snapshots/text_log_level_filter.png
+++ b/crates/viewer/re_view_text_log/tests/snapshots/text_log_level_filter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec3f3465185ab0129692ab50ac3b9b68e055d0908866df7e16e78c1f63e6a8fd
+size 73658

--- a/crates/viewer/re_view_text_log/tests/snapshots/text_log_level_filter.png
+++ b/crates/viewer/re_view_text_log/tests/snapshots/text_log_level_filter.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec3f3465185ab0129692ab50ac3b9b68e055d0908866df7e16e78c1f63e6a8fd
-size 73658
+oid sha256:cf13ffbf5ccc6304b4ba82342fea17323551ddadc272c228be65db9242c4640b
+size 73620

--- a/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_first_chunk.png
+++ b/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_first_chunk.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:078e6d2ed16db1ba3203c5a8723208c404d674dc504ca7ce3d9063d311d2f03a
-size 9725
+oid sha256:dcb1b13762ed4f731672650adb5089f62405a2b78e4b44dd7e1c44e89351369d
+size 9737

--- a/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_first_chunk.png
+++ b/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_first_chunk.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcb1b13762ed4f731672650adb5089f62405a2b78e4b44dd7e1c44e89351369d
-size 9737
+oid sha256:4fbad36107e5638aae92b98c48dc0d1f05d4057cf48ee9a58d5f34af4930ea99
+size 9703

--- a/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_rest.png
+++ b/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_rest.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4d0f155338c94880fc4e57e6f5bc2b9846d44ea50af6a637714856075d50df7
-size 27848
+oid sha256:767fd25fc09a72055a128fe9aa0a10eebcee10381c97c0812d08b8084545ce06
+size 25914

--- a/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_rest.png
+++ b/crates/viewer/re_view_text_log/tests/snapshots/text_log_temporal_anchor_between_steps_rest.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:767fd25fc09a72055a128fe9aa0a10eebcee10381c97c0812d08b8084545ce06
-size 25914
+oid sha256:7fb63cc2942d371947378dc2ecf5f4c7f677c9a3ae64165539ead04ba215ffc5
+size 25892

--- a/crates/viewer/re_view_text_log/tests/snapshots/text_log_view_default_level.png
+++ b/crates/viewer/re_view_text_log/tests/snapshots/text_log_view_default_level.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9ac0521556d325e44f8ba6492b9a3a44e5e0df4cc3e94f73ba3f64fe05396e3
+size 67403


### PR DESCRIPTION
### Related

* Closes https://github.com/rerun-io/rerun/issues/7562

### What

Speed up the TextLog view by only querying the view range of text logs instead of EVERYTHING!

<img width="800" height="550" alt="image" src="https://github.com/user-attachments/assets/3760b5fe-bed0-4f4c-b444-ab2e6f9502e9" />

#### How

Previously the visualizer did a range query for **EVERYTHING** and materialized every textlog entry on each frame, just to figure out how many rows it had and where to scroll to.

This scales linearly with the amount of `TextLog`s logged! 😱 This is fine for a few text logs, but the viewer grinds down to 5fps for recordings with 500k lines (https://github.com/rerun-io/rerun/issues/7562).

The fix is to stop querying the actual data to create the view layout and instead create the layout using chunk metadata. Chunks already know their time range and `TextLog` counts, so that's enough to derive the total row count and which rows fall where in time. This lets us only query the data for the currently visible time range.

Additionally this replaces the view's current `egui_extras::TableBuilder` rendering with `egui_table` which supports virtual scrolling over a known number of rows (we already do this for the dataframe view!).

Filtering by log levels through the blueprint is a bit complicated, since it requires log level component information from inside each chunk. But since chunks are immutable (right?), we can get around this by scanning a chunk once and caching the per-level row counts by `ChunkId`.

This new approach also doesn't support rendering multi line logs, the data is shown when hovering. Implementing this makes the accounting a lot more tedious and should be done as a followup.

<img width="350" height="96" alt="image" src="https://github.com/user-attachments/assets/058dbfe8-8309-4436-87f4-451576567cbe" />


---

However, this does mean a `TextLog` row's level/color must come from that row alone, which means blueprint overrides/defaults for them are no longer applied. Also, level/color no longer carry follow the latest-at semantics (which I think is fine for this archetype, and actually desired?)