### PR TITLE
Fix explicit web viewer theme on first load

### DIFF
--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -871,25 +871,6 @@ fn create_app(
     };
     crate::customize_eframe_and_setup_renderer(cc)?;
 
-    if let Some(theme) = theme {
-        match theme.to_ascii_lowercase().as_str() {
-            "dark" => cc
-                .egui_ctx
-                .options_mut(|o| o.theme_preference = egui::ThemePreference::Dark),
-            "light" => cc
-                .egui_ctx
-                .options_mut(|o| o.theme_preference = egui::ThemePreference::Light),
-            "system" => cc
-                .egui_ctx
-                .options_mut(|o| o.theme_preference = egui::ThemePreference::System),
-            _ => {
-                re_log::warn!(
-                    "Ignoring unknown `theme` value {theme:?}; expected `dark`, `light`, or `system`."
-                );
-            }
-        }
-    }
-
     let mut app = crate::App::new(
         main_thread_token,
         build_info,
@@ -899,6 +880,26 @@ fn create_app(
         Some(connection_registry),
         AsyncRuntimeHandle::from_current_tokio_runtime_or_wasmbindgen().expect("Infallible on web"),
     );
+
+    // An explicit web option takes precedence over the restored theme preference.
+    if let Some(theme) = theme {
+        match theme.to_ascii_lowercase().as_str() {
+            "dark" => app
+                .egui_ctx
+                .options_mut(|o| o.theme_preference = egui::ThemePreference::Dark),
+            "light" => app
+                .egui_ctx
+                .options_mut(|o| o.theme_preference = egui::ThemePreference::Light),
+            "system" => app
+                .egui_ctx
+                .options_mut(|o| o.theme_preference = egui::ThemePreference::System),
+            _ => {
+                re_log::warn!(
+                    "Ignoring unknown `theme` value {theme:?}; expected `dark`, `light`, or `system`."
+                );
+            }
+        }
+    }
 
     if enable_history {
         install_popstate_listener(&mut app).ok_or_log_error();


### PR DESCRIPTION
### Related

- Closes #12897

### What

An explicit web viewer theme was applied before application construction, but construction restores and migrates persisted UI state.

On a clean origin, that migration selected the system theme and overwrote the host's explicit `dark`, `light`, or `system` option. As a result, the first startup could ignore the requested theme.

This change constructs and restores the application first, then applies an explicit host-provided theme. Theme precedence is now:

1. Defaults
2. Restored or migrated state
3. Explicit WebViewer option

When no theme is supplied, persisted and system-theme behavior is unchanged. Invalid values retain the existing warning and fallback behavior.

Please review the initialization-order precedence and whether applying host options after state restoration is the preferred boundary.

Confidence: high. The change is limited to startup ordering and has been verified in real browsers using clean origins.

### Testing

#### Reproduction before the fix

The failure was verified through both public entry points:

1. Opened `https://app.rerun.io/version/0.36.0/?theme=dark` with clean browser storage and a light system preference. The first render was light; reloading the same origin rendered dark.
2. Built current main and opened `?theme=dark` on a random local port with a fresh Chrome profile. The first render was light while `rerun.version` was absent; a second startup rendered dark after the version and egui state had been persisted.

#### Browser regression after the fix

Each case used a fresh Chrome profile or origin.

| Startup option | System preference | Result |
| --- | --- | --- |
| `theme=dark` | Light | First completed render was dark |
| `theme=light` | Emulated dark | Render remained light |
| `theme=system` | Emulated dark | Render was dark |
| Theme omitted | Light | Existing system-default behavior remained light |
| Invalid theme | Light | Viewer loaded and emitted the unchanged validation warning |

#### Build and static checks

- Debug WebViewer WASM build passed.
- Rustfmt passed for the changed source.
- Rerun's custom lint passed for the changed source.
- Clippy passed for the wasm32 WebViewer target; only pre-existing warnings in other crates were reported.

No automated regression test is included because the existing browser integration harness forces the dark theme and disables persistence, so it cannot exercise clean-origin migration. A parser-only unit test would not cover the initialization-order regression.

The full `pixi run fast-lint` task did not start locally because the installed Pixi version is 0.68.1 while the repository requires at least 0.71.3.

