### PR TITLE
refactor: split importers into their own a la carte features to improve compile times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9416,6 +9416,7 @@ dependencies = [
  "anyhow",
  "arrow",
  "crossbeam",
+ "document-features",
  "image",
  "indexmap 2.14.0",
  "insta",
@@ -9512,6 +9513,7 @@ name = "re_lenses"
 version = "0.37.0-alpha.1+dev"
 dependencies = [
  "arrow",
+ "document-features",
  "insta",
  "itertools 0.15.0",
  "re_arrow_util",

--- a/crates/store/re_importer/Cargo.toml
+++ b/crates/store/re_importer/Cargo.toml
@@ -20,18 +20,16 @@ all-features = true
 
 
 [features]
-default = ["archetype", "mcap", "lerobot", "parquet", "urdf"]
+default = ["image", "video", "mcap", "lerobot", "parquet", "urdf"]
 
-# Generic importers for image and video data.
-archetype = [
-    "dep:image",
-    "dep:re_mp4_reader",
-    "re_sdk_types/image",
-    "re_sdk_types/video",
-]
+## Every importer feature.
+all = ["image", "lerobot", "mcap", "parquet", "urdf", "video"]
 
-# MCAP file import. Also pulls in `urdf` since `robot_description` topics are
-# decoded via the URDF importer's XML parser.
+## Import of common image formats (PNG, JPEG, …) as `EncodedImage`/`EncodedDepthImage`.
+image = ["dep:image", "re_sdk_types/image"]
+
+## MCAP file import. Also pulls in `urdf` since `robot_description` topics are
+## decoded via the URDF importer's XML parser.
 mcap = [
     "dep:mcap",
     "dep:memmap2",
@@ -40,15 +38,18 @@ mcap = [
     "urdf",
 ]
 
-# LeRobot dataset import. Pulls in `parquet`/`arrow` transitively via `re_lerobot`
-# regardless of whether the `parquet` feature is also on.
+## LeRobot dataset import. Pulls in `parquet`/`arrow` transitively via `re_lerobot`
+## regardless of whether the `parquet` feature is also on.
 lerobot = ["dep:re_lerobot"]
 
-# Parquet file import.
+## Parquet file import.
 parquet = ["dep:parquet", "dep:re_parquet"]
 
-# URDF file import.
+## URDF file import.
 urdf = ["dep:urdf-rs", "dep:ureq"]
+
+## Import of MP4 video as `AssetVideo`.
+video = ["dep:re_mp4_reader", "re_sdk_types/video"]
 
 
 [[test]]
@@ -64,12 +65,11 @@ required-features = ["mcap"]
 [[test]]
 name = "test_mp4_importer"
 path = "tests/test_mp4_importer.rs"
-required-features = ["archetype"]
+required-features = ["video"]
 
 [[test]]
 name = "test_ply_importer"
 path = "tests/test_ply_importer.rs"
-required-features = ["archetype"]
 
 [[test]]
 name = "test_urdf_importer"
@@ -96,6 +96,7 @@ re_tracing.workspace = true
 ahash.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
+document-features.workspace = true
 memmap2 = { workspace = true, optional = true }
 crossbeam.workspace = true
 image = { workspace = true, optional = true }

--- a/crates/store/re_importer/Cargo.toml
+++ b/crates/store/re_importer/Cargo.toml
@@ -20,7 +20,61 @@ all-features = true
 
 
 [features]
-default = []
+default = ["archetype", "mcap", "lerobot", "parquet", "urdf"]
+
+# Generic importers for image and video data.
+archetype = [
+    "dep:image",
+    "dep:re_mp4_reader",
+    "re_sdk_types/image",
+    "re_sdk_types/video",
+]
+
+# MCAP file import. Also pulls in `urdf` since `robot_description` topics are
+# decoded via the URDF importer's XML parser.
+mcap = [
+    "dep:mcap",
+    "dep:memmap2",
+    "dep:re_mcap",
+    "dep:re_lenses",
+    "urdf",
+]
+
+# LeRobot dataset import. Pulls in `parquet`/`arrow` transitively via `re_lerobot`
+# regardless of whether the `parquet` feature is also on.
+lerobot = ["dep:re_lerobot"]
+
+# Parquet file import.
+parquet = ["dep:parquet", "dep:re_parquet"]
+
+# URDF file import.
+urdf = ["dep:urdf-rs", "dep:ureq"]
+
+
+[[test]]
+name = "test_lerobot_importer"
+path = "tests/test_lerobot_importer.rs"
+required-features = ["lerobot"]
+
+[[test]]
+name = "test_mcap_importer"
+path = "tests/test_mcap_importer.rs"
+required-features = ["mcap"]
+
+[[test]]
+name = "test_mp4_importer"
+path = "tests/test_mp4_importer.rs"
+required-features = ["archetype"]
+
+[[test]]
+name = "test_ply_importer"
+path = "tests/test_ply_importer.rs"
+required-features = ["archetype"]
+
+[[test]]
+name = "test_urdf_importer"
+path = "tests/test_urdf_importer.rs"
+required-features = ["urdf"]
 
 
 [dependencies]
@@ -28,38 +82,39 @@ re_arrow_util.workspace = true
 re_chunk.workspace = true
 re_error.workspace = true
 re_format.workspace = true
-re_lenses.workspace = true
+re_lenses = { workspace = true, features = ["semantic"], optional = true }
 re_log_channel.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder"] }
 re_log_types.workspace = true
 re_log.workspace = true
-re_mcap.workspace = true
-re_mp4_reader.workspace = true
+re_mcap = { workspace = true, optional = true }
+re_mp4_reader = { workspace = true, optional = true }
 re_quota_channel.workspace = true
-re_sdk_types = { workspace = true, features = ["ecolor", "glam", "image", "video"] }
+re_sdk_types = { workspace = true, features = ["ecolor", "glam"] }
 re_tracing.workspace = true
 
 ahash.workspace = true
 anyhow.workspace = true
 arrow.workspace = true
-memmap2.workspace = true
+memmap2 = { workspace = true, optional = true }
 crossbeam.workspace = true
-image.workspace = true
+image = { workspace = true, optional = true }
 indexmap.workspace = true
 itertools.workspace = true
-mcap.workspace = true
+mcap = { workspace = true, optional = true }
 parking_lot.workspace = true
 rayon.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-urdf-rs.workspace = true
+urdf-rs = { workspace = true, optional = true }
 walkdir.workspace = true
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
-parquet = { workspace = true, features = ["arrow", "snap", "zstd"] }
-re_lerobot.workspace = true
-re_parquet.workspace = true
-ureq.workspace = true
+parquet = { workspace = true, features = ["arrow", "snap", "zstd"], optional = true }
+re_lerobot = { workspace = true, optional = true }
+re_parquet = { workspace = true, optional = true }
+# Used by importer_urdf for http(s):// mesh resource references.
+ureq = { workspace = true, optional = true }
 
 [dev-dependencies]
 re_chunk_store.workspace = true

--- a/crates/store/re_importer/Cargo.toml
+++ b/crates/store/re_importer/Cargo.toml
@@ -34,13 +34,7 @@ lerobot = ["dep:re_lerobot"]
 
 ## MCAP file import. Also pulls in `urdf` since `robot_description` topics are
 ## decoded via the URDF importer's XML parser.
-mcap = [
-    "dep:mcap",
-    "dep:memmap2",
-    "dep:re_mcap",
-    "dep:re_lenses",
-    "urdf",
-]
+mcap = ["dep:mcap", "dep:memmap2", "dep:re_mcap", "dep:re_lenses", "urdf"]
 
 ## Parquet file import.
 parquet = ["dep:parquet", "dep:re_parquet"]

--- a/crates/store/re_importer/Cargo.toml
+++ b/crates/store/re_importer/Cargo.toml
@@ -28,6 +28,10 @@ all = ["image", "lerobot", "mcap", "parquet", "urdf", "video"]
 ## Import of common image formats (PNG, JPEG, …) as `EncodedImage`/`EncodedDepthImage`.
 image = ["dep:image", "re_sdk_types/image"]
 
+## LeRobot dataset import. Pulls in `parquet`/`arrow` transitively via `re_lerobot`
+## regardless of whether the `parquet` feature is also on.
+lerobot = ["dep:re_lerobot"]
+
 ## MCAP file import. Also pulls in `urdf` since `robot_description` topics are
 ## decoded via the URDF importer's XML parser.
 mcap = [
@@ -37,10 +41,6 @@ mcap = [
     "dep:re_lenses",
     "urdf",
 ]
-
-## LeRobot dataset import. Pulls in `parquet`/`arrow` transitively via `re_lerobot`
-## regardless of whether the `parquet` feature is also on.
-lerobot = ["dep:re_lerobot"]
 
 ## Parquet file import.
 parquet = ["dep:parquet", "dep:re_parquet"]

--- a/crates/store/re_importer/src/import_file.rs
+++ b/crates/store/re_importer/src/import_file.rs
@@ -41,10 +41,10 @@ pub fn import_from_path(
         .clone()
         .or_else(|| application_id_from_path(path));
     // When importing a LeRobot dataset, avoid sending a `SetStoreInfo` message since the LeRobot importer handles this automatically.
-    #[cfg(feature = "lerobot")]
-    let force_store_info = !crate::is_lerobot_dataset(path);
-    #[cfg(not(feature = "lerobot"))]
-    let force_store_info = true;
+    let force_store_info = cfg_select! {
+        feature = "lerobot" => !crate::is_lerobot_dataset(path),
+        _ => true,
+    };
 
     let settings = crate::ImporterSettings {
         application_id,

--- a/crates/store/re_importer/src/import_file.rs
+++ b/crates/store/re_importer/src/import_file.rs
@@ -40,10 +40,15 @@ pub fn import_from_path(
         .application_id
         .clone()
         .or_else(|| application_id_from_path(path));
+    // When importing a LeRobot dataset, avoid sending a `SetStoreInfo` message since the LeRobot importer handles this automatically.
+    #[cfg(feature = "lerobot")]
+    let force_store_info = !crate::is_lerobot_dataset(path);
+    #[cfg(not(feature = "lerobot"))]
+    let force_store_info = true;
+
     let settings = crate::ImporterSettings {
-        // When importing a LeRobot dataset, avoid sending a `SetStoreInfo` message since the LeRobot importer handles this automatically.
-        force_store_info: !re_lerobot::is_lerobot_dataset(path),
         application_id,
+        force_store_info,
         ..settings.clone()
     };
 

--- a/crates/store/re_importer/src/importer_archetype.rs
+++ b/crates/store/re_importer/src/importer_archetype.rs
@@ -118,16 +118,31 @@ impl Importer for ArchetypeImporter {
         // backpressure actually limits how much is held in memory at once.
         let chunks_sent = if crate::SUPPORTED_IMAGE_EXTENSIONS.contains(&extension.as_str()) {
             re_log::debug!(?filepath, importer = self.name(), "Loading image…",);
-            load_image(&filepath, timepoint, entity_path, contents.into_owned())
-                .map(|chunks| self.send_chunks(&tx, &store_id, chunks))
+            cfg_select! {
+                feature = "image" => {
+                    load_image(&filepath, timepoint, entity_path, contents.into_owned())
+                        .map(|chunks| self.send_chunks(&tx, &store_id, chunks))
+                }
+                _ => Err(crate::ImporterError::Incompatible(filepath.clone())),
+            }
         } else if crate::SUPPORTED_DEPTH_IMAGE_EXTENSIONS.contains(&extension.as_str()) {
             re_log::debug!(?filepath, importer = self.name(), "Loading depth image…",);
-            load_depth_image(&filepath, timepoint, entity_path, contents.into_owned())
-                .map(|chunks| self.send_chunks(&tx, &store_id, chunks))
+            cfg_select! {
+                feature = "image" => {
+                    load_depth_image(&filepath, timepoint, entity_path, contents.into_owned())
+                        .map(|chunks| self.send_chunks(&tx, &store_id, chunks))
+                }
+                _ => Err(crate::ImporterError::Incompatible(filepath.clone())),
+            }
         } else if crate::SUPPORTED_VIDEO_EXTENSIONS.contains(&extension.as_str()) {
             re_log::debug!(?filepath, importer = self.name(), "Loading video…",);
-            load_video(&filepath, timepoint, &entity_path, contents.into_owned())
-                .map(|chunks| self.send_chunks(&tx, &store_id, chunks))
+            cfg_select! {
+                feature = "video" => {
+                    load_video(&filepath, timepoint, &entity_path, contents.into_owned())
+                        .map(|chunks| self.send_chunks(&tx, &store_id, chunks))
+                }
+                _ => Err(crate::ImporterError::Incompatible(filepath.clone())),
+            }
         } else if crate::SUPPORTED_MESH_EXTENSIONS.contains(&extension.as_str()) {
             re_log::debug!(?filepath, importer = self.name(), "Loading 3D model…",);
             load_mesh(
@@ -188,6 +203,7 @@ impl ArchetypeImporter {
 
 // ---
 
+#[cfg(feature = "image")]
 fn load_image(
     filepath: &std::path::Path,
     timepoint: TimePoint,
@@ -214,6 +230,7 @@ fn load_image(
     Ok(rows.into_iter())
 }
 
+#[cfg(feature = "image")]
 fn load_depth_image(
     filepath: &std::path::Path,
     timepoint: TimePoint,
@@ -243,6 +260,7 @@ fn load_depth_image(
     Ok(rows.into_iter())
 }
 
+#[cfg(feature = "video")]
 fn load_video(
     filepath: &std::path::Path,
     mut timepoint: TimePoint,

--- a/crates/store/re_importer/src/importer_directory.rs
+++ b/crates/store/re_importer/src/importer_directory.rs
@@ -27,8 +27,9 @@ impl crate::Importer for DirectoryImporter {
             return Err(crate::ImporterError::Incompatible(dirpath.clone()));
         }
 
-        if re_lerobot::is_lerobot_dataset(&dirpath) {
-            // LeRobot dataset is loaded by LeRobotDatasetImporter
+        // LeRobot datasets are loaded by LeRobotDatasetImporter.
+        #[cfg(feature = "lerobot")]
+        if crate::is_lerobot_dataset(&dirpath) {
             return Err(crate::ImporterError::Incompatible(dirpath.clone()));
         }
 

--- a/crates/store/re_importer/src/importer_urdf/mod.rs
+++ b/crates/store/re_importer/src/importer_urdf/mod.rs
@@ -1,8 +1,11 @@
 //! Rerun importer and utilities for URDF files.
 
 pub mod joint_transform;
+#[cfg(feature = "mcap")]
 mod robot_description_parser;
 mod urdf_tree;
+// Only consumed by importer_mcap's `robot_description` topic decoding.
+#[cfg(feature = "mcap")]
 pub(crate) use robot_description_parser::build_urdf_chunks_from_xml;
 pub use urdf_tree::UrdfTree;
 

--- a/crates/store/re_importer/src/lib.rs
+++ b/crates/store/re_importer/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Handles importing of Rerun data from file using importer plugins.
 
+#[cfg(feature = "mcap")]
 use std::collections::BTreeSet;
 use std::sync::{Arc, LazyLock};
 
@@ -12,28 +13,34 @@ use re_log_types::{ArrowMsg, EntityPath, LogMsg, RecordingId, StoreId, TimePoint
 // ----------------------------------------------------------------------------
 
 mod import_file;
+#[cfg(feature = "archetype")]
 mod importer_archetype;
 mod importer_directory;
 mod importer_rrd;
+#[cfg(feature = "urdf")]
 mod importer_urdf;
 
 // This importer currently only works when loading the entire dataset directory, and we cannot do that on web yet.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "lerobot", not(target_arch = "wasm32")))]
 pub mod importer_lerobot;
 
 // This importer currently uses native-only features under the hood, and we cannot do that on web yet.
+#[cfg(feature = "mcap")]
 pub mod importer_mcap;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod importer_external;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "parquet", not(target_arch = "wasm32")))]
 pub mod importer_parquet;
 
 pub use self::import_file::{import_from_file_contents, prepare_store_info};
+#[cfg(feature = "archetype")]
 pub use self::importer_archetype::ArchetypeImporter;
 pub use self::importer_directory::DirectoryImporter;
+#[cfg(feature = "mcap")]
 pub use self::importer_mcap::McapImporter;
 pub use self::importer_rrd::RrdImporter;
+#[cfg(feature = "urdf")]
 pub use self::importer_urdf::{UrdfImporter, UrdfTree, joint_transform as urdf_joint_transform};
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::{
@@ -42,11 +49,14 @@ pub use self::{
         EXTERNAL_IMPORTER_INCOMPATIBLE_EXIT_CODE, EXTERNAL_IMPORTER_PREFIX, ExternalImporter,
         iter_external_importers,
     },
-    importer_lerobot::LeRobotDatasetImporter,
-    importer_parquet::ParquetImporter,
 };
+#[cfg(all(feature = "lerobot", not(target_arch = "wasm32")))]
+pub use self::importer_lerobot::LeRobotDatasetImporter;
+#[cfg(all(feature = "parquet", not(target_arch = "wasm32")))]
+pub use self::importer_parquet::ParquetImporter;
 
 pub mod external {
+    #[cfg(feature = "urdf")]
     pub use urdf_rs;
 }
 
@@ -61,6 +71,7 @@ pub const URDF_DECODER_IDENTIFIER: &str = "urdf";
 /// All decoder-like identifiers supported by [`McapImporter`].
 ///
 /// This merges the built-in MCAP decoders from [`re_mcap`] and the semantic interpretation (e.g. lenses) that are in this crate.
+#[cfg(feature = "mcap")]
 pub fn supported_mcap_decoder_identifiers(
     raw_fallback_enabled: bool,
 ) -> Vec<re_mcap::DecoderIdentifier> {
@@ -76,6 +87,12 @@ pub fn supported_mcap_decoder_identifiers(
     ]);
 
     identifiers.into_iter().collect()
+}
+
+/// Whether `path` looks like a `LeRobot` dataset.
+#[cfg(all(feature = "lerobot", not(target_arch = "wasm32")))]
+pub(crate) fn is_lerobot_dataset(path: &std::path::Path) -> bool {
+    re_lerobot::is_lerobot_dataset(path)
 }
 
 // ----------------------------------------------------------------------------
@@ -396,9 +413,11 @@ pub enum ImporterError {
     #[error("No importer support for {0:?}")]
     Incompatible(std::path::PathBuf),
 
+    #[cfg(feature = "mcap")]
     #[error(transparent)]
     Mcap(#[from] ::mcap::McapError),
 
+    #[cfg(feature = "archetype")]
     #[error("Failed to import mp4 video: {source}\nFile path: {path:?}")]
     Mp4 {
         path: std::path::PathBuf,
@@ -422,7 +441,9 @@ impl ImporterError {
     pub fn with_path(self, path: &std::path::Path) -> Self {
         match self {
             // These already name the file.
-            Self::Incompatible { .. } | Self::Mp4 { .. } | Self::File { .. } => self,
+            #[cfg(feature = "archetype")]
+            Self::Mp4 { .. } => self,
+            Self::Incompatible { .. } | Self::File { .. } => self,
             err => Self::File {
                 path: path.display().to_string(),
                 source: Box::new(err),
@@ -506,15 +527,18 @@ impl ImportedData {
 static BUILTIN_IMPORTERS: LazyLock<Vec<Arc<dyn Importer>>> = LazyLock::new(|| {
     vec![
         Arc::new(RrdImporter) as Arc<dyn Importer>,
+        #[cfg(feature = "archetype")]
         Arc::new(ArchetypeImporter),
         Arc::new(DirectoryImporter),
+        #[cfg(feature = "mcap")]
         Arc::new(McapImporter::default()),
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(feature = "parquet", not(target_arch = "wasm32")))]
         Arc::new(ParquetImporter::default()),
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(feature = "lerobot", not(target_arch = "wasm32")))]
         Arc::new(LeRobotDatasetImporter),
         #[cfg(not(target_arch = "wasm32"))]
         Arc::new(ExternalImporter),
+        #[cfg(feature = "urdf")]
         Arc::new(UrdfImporter),
     ]
 });
@@ -644,6 +668,7 @@ fn test_supported_extensions() {
 }
 
 #[test]
+#[cfg(feature = "mcap")]
 fn test_supported_mcap_decoder_identifiers() {
     let identifiers = supported_mcap_decoder_identifiers(true);
     let as_strings = identifiers

--- a/crates/store/re_importer/src/lib.rs
+++ b/crates/store/re_importer/src/lib.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::iter_over_hash_type)]
 
 //! Handles importing of Rerun data from file using importer plugins.
+//!
+//! ## Feature flags
+#![doc = document_features::document_features!()]
+//!
 
 #[cfg(feature = "mcap")]
 use std::collections::BTreeSet;
@@ -13,7 +17,6 @@ use re_log_types::{ArrowMsg, EntityPath, LogMsg, RecordingId, StoreId, TimePoint
 // ----------------------------------------------------------------------------
 
 mod import_file;
-#[cfg(feature = "archetype")]
 mod importer_archetype;
 mod importer_directory;
 mod importer_rrd;
@@ -34,11 +37,14 @@ mod importer_external;
 pub mod importer_parquet;
 
 pub use self::import_file::{import_from_file_contents, prepare_store_info};
-#[cfg(feature = "archetype")]
 pub use self::importer_archetype::ArchetypeImporter;
 pub use self::importer_directory::DirectoryImporter;
+#[cfg(all(feature = "lerobot", not(target_arch = "wasm32")))]
+pub use self::importer_lerobot::LeRobotDatasetImporter;
 #[cfg(feature = "mcap")]
 pub use self::importer_mcap::McapImporter;
+#[cfg(all(feature = "parquet", not(target_arch = "wasm32")))]
+pub use self::importer_parquet::ParquetImporter;
 pub use self::importer_rrd::RrdImporter;
 #[cfg(feature = "urdf")]
 pub use self::importer_urdf::{UrdfImporter, UrdfTree, joint_transform as urdf_joint_transform};
@@ -50,10 +56,6 @@ pub use self::{
         iter_external_importers,
     },
 };
-#[cfg(all(feature = "lerobot", not(target_arch = "wasm32")))]
-pub use self::importer_lerobot::LeRobotDatasetImporter;
-#[cfg(all(feature = "parquet", not(target_arch = "wasm32")))]
-pub use self::importer_parquet::ParquetImporter;
 
 pub mod external {
     #[cfg(feature = "urdf")]
@@ -417,7 +419,7 @@ pub enum ImporterError {
     #[error(transparent)]
     Mcap(#[from] ::mcap::McapError),
 
-    #[cfg(feature = "archetype")]
+    #[cfg(feature = "video")]
     #[error("Failed to import mp4 video: {source}\nFile path: {path:?}")]
     Mp4 {
         path: std::path::PathBuf,
@@ -441,7 +443,7 @@ impl ImporterError {
     pub fn with_path(self, path: &std::path::Path) -> Self {
         match self {
             // These already name the file.
-            #[cfg(feature = "archetype")]
+            #[cfg(feature = "video")]
             Self::Mp4 { .. } => self,
             Self::Incompatible { .. } | Self::File { .. } => self,
             err => Self::File {
@@ -527,7 +529,6 @@ impl ImportedData {
 static BUILTIN_IMPORTERS: LazyLock<Vec<Arc<dyn Importer>>> = LazyLock::new(|| {
     vec![
         Arc::new(RrdImporter) as Arc<dyn Importer>,
-        #[cfg(feature = "archetype")]
         Arc::new(ArchetypeImporter),
         Arc::new(DirectoryImporter),
         #[cfg(feature = "mcap")]

--- a/crates/store/re_lenses/Cargo.toml
+++ b/crates/store/re_lenses/Cargo.toml
@@ -17,6 +17,12 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = ["semantic"]
+
+# Builtin lens pipelines for known MCAP topic conventions.
+semantic = ["dep:re_mcap"]
+
 [dependencies]
 re_arrow_util.workspace = true
 re_int.workspace = true
@@ -24,7 +30,7 @@ re_lenses_core.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true
 # TODO(RR-5373): Remove this `re_mcap` dependency once all remaining MCAP semantic conversions use lenses.
-re_mcap.workspace = true
+re_mcap = { workspace = true, optional = true }
 re_sdk_types.workspace = true
 re_tracing.workspace = true
 

--- a/crates/store/re_lenses/Cargo.toml
+++ b/crates/store/re_lenses/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 [features]
 default = ["semantic"]
 
-# Builtin lens pipelines for known MCAP topic conventions.
+## Builtin lens pipelines for known MCAP topic conventions.
 semantic = ["dep:re_mcap"]
 
 [dependencies]
@@ -35,6 +35,7 @@ re_sdk_types.workspace = true
 re_tracing.workspace = true
 
 arrow.workspace = true
+document-features.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]

--- a/crates/store/re_lenses/src/lib.rs
+++ b/crates/store/re_lenses/src/lib.rs
@@ -2,6 +2,10 @@
 //! are applied to chunks that contain the target component.
 //!
 //! See [`Lens`] for more details and assumptions.
+//!
+//! ## Feature flags
+#![doc = document_features::document_features!()]
+//!
 
 pub mod op;
 mod runtime;

--- a/crates/store/re_lenses/src/lib.rs
+++ b/crates/store/re_lenses/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod op;
 mod runtime;
+#[cfg(feature = "semantic")]
 pub mod semantic;
 
 pub use self::runtime::default_runtime;

--- a/crates/top/re_sdk/Cargo.toml
+++ b/crates/top/re_sdk/Cargo.toml
@@ -28,11 +28,7 @@ default = []
 ##
 ## See our `log_file` example and <https://www.rerun.io/docs/concepts/logging-and-ingestion/importers/overview>
 ## for more information.
-importers = [
-  "dep:re_importer",
-  "dep:re_log_channel",
-  "re_importer?/all",
-]
+importers = ["dep:re_importer", "dep:re_log_channel", "re_importer?/all"]
 
 ## Support serving a web viewer over HTTP.
 ##

--- a/crates/top/re_sdk/Cargo.toml
+++ b/crates/top/re_sdk/Cargo.toml
@@ -31,11 +31,7 @@ default = []
 importers = [
   "dep:re_importer",
   "dep:re_log_channel",
-  "re_importer?/archetype",
-  "re_importer?/mcap",
-  "re_importer?/lerobot",
-  "re_importer?/parquet",
-  "re_importer?/urdf",
+  "re_importer?/all",
 ]
 
 ## Support serving a web viewer over HTTP.

--- a/crates/top/re_sdk/Cargo.toml
+++ b/crates/top/re_sdk/Cargo.toml
@@ -28,7 +28,15 @@ default = []
 ##
 ## See our `log_file` example and <https://www.rerun.io/docs/concepts/logging-and-ingestion/importers/overview>
 ## for more information.
-importers = ["dep:re_importer", "dep:re_log_channel"]
+importers = [
+  "dep:re_importer",
+  "dep:re_log_channel",
+  "re_importer?/archetype",
+  "re_importer?/mcap",
+  "re_importer?/lerobot",
+  "re_importer?/parquet",
+  "re_importer?/urdf",
+]
 
 ## Support serving a web viewer over HTTP.
 ##

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -122,6 +122,7 @@ rerun = { workspace = true, default-features = false, features = [
   "log",
   "run",
   "server",
+  "video",
 ] }
 
 re_server = { workspace = true, optional = true }

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -34,6 +34,7 @@ default = [
   "rrd",
   "sdk",
   "server",
+  "video",
 ]
 
 ## Support the `rerun auth` command
@@ -85,7 +86,7 @@ mint = ["re_sdk_types?/mint"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://github.com/netwide-assembler/nasm) to compile with this feature.
-nasm = ["re_video/nasm"]
+nasm = ["re_video?/nasm"]
 
 ## Support spawning a native viewer and allow to extend the viewer.
 ## This adds a lot of extra dependencies, so only enable this feature if you need it!
@@ -150,6 +151,10 @@ server = ["dep:re_grpc_server", "re_sdk/server", "tokio/signal"]
 ## to the compile time since it requires compiling and bundling the viewer as wasm.
 web_viewer = ["server", "dep:re_web_viewer_server", "re_sdk?/web_viewer"]
 
+## Native video decoding/keyframe-detection support, used by the `rrd split`/`rrd merge-optimize`
+## CLI commands and by `--version`'s feature listing. Not needed for the SDK logging API.
+video = ["dep:re_video", "re_sdk_types?/video"]
+
 
 [dependencies]
 re_async.workspace = true
@@ -173,7 +178,7 @@ re_sorbet.workspace = true
 re_span.workspace = true
 re_tracing.workspace = true
 re_uri.workspace = true
-re_video.workspace = true
+re_video = { workspace = true, optional = true }
 
 ahash.workspace = true
 anyhow.workspace = true

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -140,6 +140,10 @@ sdk = ["dep:re_sdk", "dep:re_sdk_types"]
 ## Support for running a gRPC server that listens to incoming log messages from a Rerun SDK.
 server = ["dep:re_grpc_server", "re_sdk/server", "tokio/signal"]
 
+## Native video decoding/keyframe-detection support, used by the `rrd split`/`rrd merge-optimize`
+## CLI commands and by `--version`'s feature listing. Not needed for the SDK logging API.
+video = ["dep:re_video", "re_sdk_types?/video"]
+
 ## Support serving a web viewer over HTTP.
 ##
 ## Enabling this inflates the binary size quite a bit, since it embeds the viewer wasm.
@@ -150,10 +154,6 @@ server = ["dep:re_grpc_server", "re_sdk/server", "tokio/signal"]
 ## However, when building from source in the repository, this feature adds quite a bit
 ## to the compile time since it requires compiling and bundling the viewer as wasm.
 web_viewer = ["server", "dep:re_web_viewer_server", "re_sdk?/web_viewer"]
-
-## Native video decoding/keyframe-detection support, used by the `rrd split`/`rrd merge-optimize`
-## CLI commands and by `--version`'s feature listing. Not needed for the SDK logging API.
-video = ["dep:re_video", "re_sdk_types?/video"]
 
 
 [dependencies]

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -748,10 +748,13 @@ where
 
     if args.version {
         println!("{build_info}");
+        #[cfg(feature = "video")]
         println!(
             "Video features: {}",
             re_video::enabled_features().iter().join(" ")
         );
+        #[cfg(not(feature = "video"))]
+        println!("Video features: (video support disabled in this build)");
         return Ok(0);
     }
 

--- a/crates/top/rerun/src/commands/rrd/merge_optimize.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_optimize.rs
@@ -198,6 +198,7 @@ pub struct OptimizeCommand {
 
 impl OptimizeCommand {
     pub fn run(&self) -> anyhow::Result<()> {
+        #[cfg_attr(not(feature = "video"), allow(unused_variables))]
         let Self {
             path_to_input_rrds,
             path_to_output_rrd,
@@ -240,6 +241,7 @@ impl OptimizeCommand {
 
         let num_extra_passes = num_extra_passes.unwrap_or(profile.num_extra_passes);
 
+        #[cfg(feature = "video")]
         let gop_batching = !*no_rebatch_videos && profile.gop_batching;
 
         if let Some(ratio) = *split_size_ratio {
@@ -251,10 +253,15 @@ impl OptimizeCommand {
 
         let split_size_ratio = split_size_ratio.or(profile.split_size_ratio);
 
+        let is_start_of_gop = cfg_select! {
+            feature = "video" => gop_batching.then(crate::rrd::gop_detector),
+            _ => None,
+        };
+
         let compaction_options = CompactionOptions {
             config: store_config.clone(),
             num_extra_passes: Some(num_extra_passes as usize),
-            is_start_of_gop: gop_batching.then(crate::rrd::gop_detector),
+            is_start_of_gop,
             split_size_ratio,
             fix_keyframe: *fix_keyframe,
         };

--- a/crates/top/rerun/src/commands/rrd/split.rs
+++ b/crates/top/rerun/src/commands/rrd/split.rs
@@ -200,7 +200,13 @@ impl SplitCommand {
         );
 
         re_log::info!("extracting keyframes…");
+        #[cfg(feature = "video")]
         let mut keyframes_per_entity: IntMap<_, Vec<_>> = IntMap::default();
+        #[cfg(not(feature = "video"))]
+        let keyframes_per_entity: IntMap<_, Vec<_>> = IntMap::default();
+        // Without the `video` feature there is no keyframe detection, so no entity ever
+        // gets keyframe-based rebatching.
+        #[cfg(feature = "video")]
         for store in stores.values() {
             for entity in store.all_entities() {
                 let keyframes = extract_keyframes(&entity, store, cutoff_timeline);
@@ -789,6 +795,7 @@ impl SplitCommand {
 }
 
 // TODO(RR-3810): For a virtual store implementation, we'd want this to load no more than 1 chunk at a time.
+#[cfg(feature = "video")]
 fn extract_keyframes(
     entity_path: &EntityPath,
     store: &ChunkStore,

--- a/crates/top/rerun/src/rrd.rs
+++ b/crates/top/rerun/src/rrd.rs
@@ -14,6 +14,7 @@ use re_log_types::{StoreId, StoreKind};
 pub use re_chunk_store::OptimizationProfile;
 
 /// The [`CompactionOptions::is_start_of_gop`] callback, backed by `re_video`.
+#[cfg(feature = "video")]
 pub(crate) fn gop_detector() -> re_chunk_store::IsStartOfGop {
     std::sync::Arc::new(|data, codec| {
         re_video::is_start_of_gop(data, codec.into()).map_err(|err| anyhow::anyhow!(err))
@@ -34,7 +35,10 @@ fn compaction_options(profile: &OptimizationProfile) -> CompactionOptions {
     CompactionOptions {
         config,
         num_extra_passes: Some(profile.num_extra_passes as usize),
-        is_start_of_gop: profile.gop_batching.then(gop_detector),
+        is_start_of_gop: cfg_select! {
+            feature = "video" => profile.gop_batching.then(gop_detector),
+            _ => None,
+        },
         split_size_ratio: profile.split_size_ratio,
         fix_keyframe: false,
     }

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -45,7 +45,7 @@ re_rvl.workspace = true
 re_string_interner.workspace = true
 re_tf.workspace = true
 re_tracing.workspace = true
-re_sdk_types = { workspace = true, features = ["ecolor", "glam", "image"] }
+re_sdk_types = { workspace = true, features = ["ecolor", "glam", "image", "video"] }
 re_types_core.workspace = true
 re_ui.workspace = true
 re_uri.workspace = true

--- a/docs/content/changelog/upcoming/a-la-carte-importer-features.md
+++ b/docs/content/changelog/upcoming/a-la-carte-importer-features.md
@@ -1,0 +1,22 @@
+---
+title: "A la carte features for file importers"
+hidden: true
+type: feature
+---
+
+### A la carte features for file importers
+
+`re_importer` now gates every import format behind its own Cargo feature — `image`, `lerobot`, `mcap`, `parquet`, `urdf`, and `video` — and the `rerun` crate gates native video handling behind a new `video` feature.
+All of them are on by default, so nothing changes unless you opt out.
+
+Rust users who only need a few formats can now skip the rest and cut compile times.
+For example, a project that only imports URDF:
+
+```toml
+re_importer = { version = "0.37", default-features = false, features = ["urdf"] }
+```
+
+Dropping the other importers cut roughly 20% off both debug and release build times in the author's project.
+
+`re_sdk`'s `importers` feature still enables the full set, so `RecordingStream::log_file_from_path` keeps working with every format.
+To benefit from the split, depend on `re_importer` directly and pick your formats there.

--- a/examples/rust/custom_callback/Cargo.toml
+++ b/examples/rust/custom_callback/Cargo.toml
@@ -25,6 +25,7 @@ rerun = { path = "../../../crates/top/rerun", default-features = false, features
   "native_viewer",
   "run",
   "server",
+  "video",
 ] }
 
 bincode.workspace = true

--- a/examples/rust/custom_visualizer/Cargo.toml
+++ b/examples/rust/custom_visualizer/Cargo.toml
@@ -17,6 +17,7 @@ rerun = { path = "../../../crates/top/rerun", default-features = false, features
   "native_viewer",
   "run",
   "server",
+  "video",
 ] }
 
 # Need a direct dependency for `#[derive(bytemuck::Pod, bytemuck::Zeroable)]`.

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -63,7 +63,7 @@ re_lenses_core.workspace = true
 re_lenses.workspace = true
 re_chunk_store.workspace = true
 re_format.workspace = true
-re_importer = { workspace = true, features = ["mcap"] }
+re_importer = { workspace = true, features = ["all"] }
 re_datafusion.workspace = true
 re_error.workspace = true
 re_redap_client.workspace = true

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -63,7 +63,7 @@ re_lenses_core.workspace = true
 re_lenses.workspace = true
 re_chunk_store.workspace = true
 re_format.workspace = true
-re_importer.workspace = true
+re_importer = { workspace = true, features = ["mcap"] }
 re_datafusion.workspace = true
 re_error.workspace = true
 re_redap_client.workspace = true


### PR DESCRIPTION
<!--
Thank you for filing a pull request! We kindly ask you to:

1. Fill out this pull request template below, to make the review smoother.
2. Enable edits to your branch by our maintainers. This helps us to get your branch ready to merge. See here for more details:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork
-->

### Related

Improves compile times (#1316) targeted to my own use case.

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

This PR factors out features for heavyweight crates in two places: 
- `re_importers` gets a-la-carte features for every import format.
- `rerun` gets a `video` feature that enables processing video.

The new features give advanced users a way to speed up compilation times by excluding more code that they don't actually use, especially MCAP, which is rather expensive. In my own use case, I import URDFs, but don't need any other file importers, so we waste a lot of compilation time on things that aren't really relevant.

Accessing these speedups as-implemented requires users to reach for direct imports from `re_importers` as opposed to the main `rerun` crate.
If you want, we could also expose those features at the top level.
The main limitation right now is that `log_file_from_path()` is not available with an incomplete subset of import features, which I chose to avoid silent breakage for people who forgot to include a format. Another approach would be to only run the importers for file formats that the client has been compiled with.

In my project, this gives a ~19% reduction in compile times on debug builds.

For `cargo build`:
| config | Wall time | CPU time |
|---|---|---|
| Baseline | 64.33s | 640.18s |
| With a la carte importing | 52.26s | 464.11s |
| delta | **-18.8%** | **-27.5%** |

For `cargo build --release`:
| config | Wall time | CPU time |
|---|---|---|
| Baseline | 159.64s | 2341.35s |
| A la carte | 126.14s | 1772.28s |
| Delta | **-21.0%** | **-24.3%** |

I am not sure if this is worth including in the changelog, since I'm not quite sure how much internal crate featuresets are part of the API.


<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`. Every PR needs exactly one of these changelog labels:

* `exclude from changelog`: not user-facing — kept out of the changelog.
* `🪳 bug`: a bug fix — auto-added to the changelog from this PR's title.
* `📉 performance`: a performance improvement — auto-added to the changelog from this PR's title.
* `include in changelog`: a user-facing change — add a hand-written entry by copying
  `docs/content/changelog/upcoming/_template.md` to `upcoming/<short-slug>.md` (one file per
  PR avoids conflicts), including a migration guide (breaking changes), screenshot/GIF (visual
  features), and docs/example links (new features). A `TODO(name): …` placeholder is fine, but
  it blocks the release.

It's fine to combine `🪳 bug` with `exclude from changelog` for a fix to a bug that was never
released (e.g. introduced earlier in the same release cycle) — users never saw it, so it doesn't
belong in the changelog.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.

For more details check the PR section on <https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md>.
-->

<!--
If you are a coding agent, include the section below.
Make sure to remove the comments and instructions around this section.
Optionally add information about the model that was used.

### Agent

🤖 This PR was opened by a coding agent.
-->
