### PR TITLE
Cache point cloud GPU uploads across frames

### DIFF
--- a/crates/viewer/re_renderer/src/point_cloud_builder.rs
+++ b/crates/viewer/re_renderer/src/point_cloud_builder.rs
@@ -258,8 +258,12 @@ impl PointCloudBatchBuilder<'_, '_> {
             && batch.sort_order_cache.is_some();
         if wants_sorting {
             re_tracing::profile_scope!("sort_positions");
-            let sort_positions = self.batch_mut().sort_positions.get_or_insert_with(Vec::new);
-            sort_positions.extend(positions_and_radii.iter().map(|pr| pr.pos));
+            let sort_positions = self
+                .batch_mut()
+                .sort_positions
+                .get_or_insert_with(|| std::sync::Arc::new(Vec::new()));
+            std::sync::Arc::make_mut(sort_positions)
+                .extend(positions_and_radii.iter().map(|pr| pr.pos));
         }
 
         {

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -21,7 +21,8 @@ pub use generic_skybox::{GenericSkyboxDrawData, GenericSkyboxType};
 pub use lines::{LineBatchInfo, LineDrawData, LineDrawDataError, LineStripFlags};
 pub use mesh_renderer::{GpuMeshInstance, MeshDrawData};
 pub use point_cloud::{
-    PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData, PointCloudDrawDataError,
+    GpuPointCloud, PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData,
+    PointCloudDrawDataError,
 };
 pub use rectangles::{
     ColorMapper, ColormappedTexture, RectangleDrawData, RectangleOptions, ShaderDecoding,

--- a/crates/viewer/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/point_cloud.rs
@@ -21,10 +21,11 @@ use bitflags::bitflags;
 use enumset::{EnumSet, enum_set};
 use itertools::Itertools as _;
 use parking_lot::Mutex;
+use re_log::ResultExt as _;
 use smallvec::smallvec;
 
 use super::{DrawData, DrawError, RenderContext, Renderer};
-use crate::allocator::create_and_fill_uniform_buffer_batch;
+use crate::allocator::{DataTextureSource, create_and_fill_uniform_buffer_batch};
 use crate::draw_phases::{
     DrawPhase, OutlineMaskProcessor, PickingLayerObjectId, PickingLayerProcessor,
 };
@@ -36,11 +37,12 @@ use crate::transparent_sort::{
 use crate::view_builder::ViewBuilder;
 use crate::wgpu_resources::{
     BindGroupDesc, BindGroupEntry, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
-    GpuRenderPipelineHandle, GpuRenderPipelinePoolAccessor, PipelineLayoutDesc, RenderPipelineDesc,
+    GpuRenderPipelineHandle, GpuRenderPipelinePoolAccessor, GpuTexture, PipelineLayoutDesc,
+    RenderPipelineDesc,
 };
 use crate::{
-    DepthOffset, DrawableCollector, Label, OutlineMaskPreference, PointCloudBuilder,
-    include_shader_module,
+    Color32, DepthOffset, DrawableCollector, Label, OutlineMaskPreference, PickingLayerInstanceId,
+    PointCloudBuilder, PositionRadius, include_shader_module,
 };
 
 bitflags! {
@@ -258,9 +260,14 @@ pub struct PointCloudBatchInfo {
     pub flags: PointCloudBatchFlags,
 
     /// Number of points covered by this batch.
-    ///
-    /// The batch will start with the next point after the one the previous batch ended with.
     pub point_count: u32,
+
+    /// Index of this batch's first point in the shared point-data textures.
+    ///
+    /// `None` continues right after the point the previous batch ended with, which is what
+    /// [`crate::PointCloudBuilder`] produces. Setting it explicitly lets several batches draw
+    /// overlapping ranges of a single upload, e.g. one batch per instance transform.
+    pub first_point_index: Option<u32>,
 
     /// Object-space bounds used to place the batch in the draw-phase distance ordering.
     pub object_space_bounding_box: macaw::BoundingBox,
@@ -288,7 +295,9 @@ pub struct PointCloudBatchInfo {
     ///
     /// Only populated for batches with [`PointCloudBatchFlags::FLAG_PREMULTIPLIED_ALPHA`];
     /// filled in automatically by [`crate::PointCloudBuilder`].
-    pub sort_positions: Option<Vec<glam::Vec3>>,
+    ///
+    /// Shared so that batches over a cached upload can reuse one copy of the positions.
+    pub sort_positions: Option<Arc<Vec<glam::Vec3>>>,
 
     /// Caller-owned cache for the back-to-front ordering, persisted across frames to seed the next
     /// sort for each view.
@@ -306,6 +315,7 @@ impl Default for PointCloudBatchInfo {
             world_from_obj: glam::Affine3A::IDENTITY,
             flags: PointCloudBatchFlags::FLAG_ENABLE_SHADING,
             point_count: 0,
+            first_point_index: None,
             object_space_bounding_box: macaw::BoundingBox::nothing(),
             overall_outline_mask_ids: OutlineMaskPreference::NONE,
             additional_outline_mask_ids_vertex_ranges: Vec::new(),
@@ -321,6 +331,133 @@ impl Default for PointCloudBatchInfo {
 pub enum PointCloudDrawDataError {
     #[error("Failed to transfer data to the GPU: {0}")]
     FailedTransferringDataToGpu(#[from] crate::allocator::CpuWriteGpuReadError),
+}
+
+/// Point data residing on the GPU, shareable across frames and draw data instances.
+///
+/// Uploading is the expensive part of drawing a point cloud, so callers whose point data is
+/// unchanged from frame to frame should hold on to this and only rebuild the per-frame
+/// [`PointCloudDrawData`] around it via [`PointCloudDrawData::from_gpu_cloud`].
+/// Keeping it alive keeps the data textures from being reclaimed by the resource pool.
+pub struct GpuPointCloud {
+    position_data_texture: GpuTexture,
+    color_texture: GpuTexture,
+    picking_instance_id_texture: GpuTexture,
+
+    /// Number of points that were actually uploaded.
+    ///
+    /// May be lower than the number of points passed in if the data texture limit was reached.
+    num_points: u32,
+}
+
+impl GpuPointCloud {
+    /// Uploads point data to the GPU.
+    ///
+    /// `colors` and `picking_ids` are clamped to edge if they are shorter than
+    /// `positions_and_radii`. Returns `None` if there are no points to upload.
+    pub fn new(
+        ctx: &RenderContext,
+        positions_and_radii: &[PositionRadius],
+        colors: &[Color32],
+        picking_ids: &[PickingLayerInstanceId],
+    ) -> Result<Option<Self>, PointCloudDrawDataError> {
+        re_tracing::profile_function!();
+
+        let mut position_radius_buffer = DataTextureSource::new(ctx);
+
+        // The data texture limit is the same for all three textures, so checking one is enough.
+        let num_points = position_radius_buffer
+            .reserve(positions_and_radii.len())?
+            .min(positions_and_radii.len());
+        if num_points == 0 {
+            return Ok(None);
+        }
+        if num_points < positions_and_radii.len() {
+            re_log::error_once!(
+                "Reached maximum number of points for point cloud of {num_points}. Ignoring all excess points."
+            );
+        }
+
+        position_radius_buffer
+            .extend_from_slice(&positions_and_radii[..num_points])
+            .ok_or_log_error();
+
+        let mut color_buffer = DataTextureSource::new(ctx);
+        color_buffer.reserve(num_points)?;
+        color_buffer
+            .extend_from_slice_clamped(
+                &colors[..num_points.min(colors.len())],
+                Color32::WHITE,
+                num_points,
+            )
+            .ok_or_log_error();
+
+        let mut picking_instance_ids_buffer = DataTextureSource::new(ctx);
+        picking_instance_ids_buffer.reserve(num_points)?;
+        picking_instance_ids_buffer
+            .extend_from_slice_clamped(
+                &picking_ids[..num_points.min(picking_ids.len())],
+                PickingLayerInstanceId::default(),
+                num_points,
+            )
+            .ok_or_log_error();
+
+        Self::from_data_texture_sources(
+            position_radius_buffer,
+            color_buffer,
+            picking_instance_ids_buffer,
+        )
+        .map(Some)
+    }
+
+    /// Encodes the copies from already-staged point data into freshly allocated data textures.
+    fn from_data_texture_sources(
+        position_radius_buffer: DataTextureSource<'_, PositionRadius>,
+        color_buffer: DataTextureSource<'_, Color32>,
+        picking_instance_ids_buffer: DataTextureSource<'_, PickingLayerInstanceId>,
+    ) -> Result<Self, PointCloudDrawDataError> {
+        let num_points = position_radius_buffer.len() as u32;
+
+        Ok(Self {
+            position_data_texture: position_radius_buffer.finish(
+                wgpu::TextureFormat::Rgba32Float,
+                "GpuPointCloud::position_data_texture",
+            )?,
+            color_texture: color_buffer.finish(
+                wgpu::TextureFormat::Rgba8UnormSrgb,
+                "GpuPointCloud::color_texture",
+            )?,
+            picking_instance_id_texture: picking_instance_ids_buffer.finish(
+                wgpu::TextureFormat::Rg32Uint,
+                "GpuPointCloud::picking_instance_id_texture",
+            )?,
+            num_points,
+        })
+    }
+
+    /// Number of points that were actually uploaded.
+    #[inline]
+    pub fn num_points(&self) -> u32 {
+        self.num_points
+    }
+
+    /// Approximate number of GPU bytes occupied by the data textures.
+    ///
+    /// Ignores padding introduced by the driver as well as any GPU-side compression.
+    pub fn gpu_byte_size(&self) -> u64 {
+        [
+            &self.position_data_texture,
+            &self.color_texture,
+            &self.picking_instance_id_texture,
+        ]
+        .into_iter()
+        .map(|texture| {
+            let desc = &texture.creation_desc;
+            let num_texels = desc.size.width as u64 * desc.size.height as u64;
+            num_texels * desc.format.block_copy_size(None).unwrap_or(0) as u64
+        })
+        .sum()
+    }
 }
 
 impl PointCloudDrawData {
@@ -342,25 +479,60 @@ impl PointCloudDrawData {
             radius_boost_in_ui_points_for_outlines,
         } = builder;
 
-        let point_renderer = ctx.renderer::<PointCloudRenderer>();
-        let batches = batches.as_slice();
-
         if vertices_buffer.is_empty() {
-            return Ok(Self {
-                bind_group_all_points: None,
-                bind_group_all_points_outline_mask: None,
-                batches: Vec::new(),
-                drawables: Arc::new(Mutex::new(SortedDrawables::default())),
-            });
+            return Ok(Self::empty());
         }
 
-        let num_vertices = vertices_buffer.len();
+        let gpu_cloud = GpuPointCloud::from_data_texture_sources(
+            vertices_buffer,
+            color_buffer,
+            picking_instance_ids_buffer,
+        )?;
+
+        Ok(Self::from_gpu_cloud(
+            ctx,
+            &gpu_cloud,
+            &batches,
+            radius_boost_in_ui_points_for_outlines,
+        ))
+    }
+
+    fn empty() -> Self {
+        Self {
+            bind_group_all_points: None,
+            bind_group_all_points_outline_mask: None,
+            batches: Vec::new(),
+            drawables: Arc::new(Mutex::new(SortedDrawables::default())),
+        }
+    }
+
+    /// Builds the per-frame draw data for an already uploaded point cloud.
+    ///
+    /// Only the per-batch state (transforms, flags, outline masks, picking ids, depth offsets and
+    /// transparent sorting) is rebuilt here; the point data itself is reused as-is.
+    ///
+    /// If no batches are passed, all points are assumed to be in a single batch with identity transform.
+    pub fn from_gpu_cloud(
+        ctx: &RenderContext,
+        gpu_cloud: &GpuPointCloud,
+        batches: &[PointCloudBatchInfo],
+        radius_boost_in_ui_points_for_outlines: f32,
+    ) -> Self {
+        re_tracing::profile_function!();
+
+        let point_renderer = ctx.renderer::<PointCloudRenderer>();
+
+        let num_vertices = gpu_cloud.num_points;
+        if num_vertices == 0 {
+            return Self::empty();
+        }
 
         let fallback_batches = [PointCloudBatchInfo {
             label: "fallback_batches".into(),
             world_from_obj: glam::Affine3A::IDENTITY,
             flags: PointCloudBatchFlags::empty(),
-            point_count: num_vertices as _,
+            point_count: num_vertices,
+            first_point_index: None,
             object_space_bounding_box: macaw::BoundingBox::nothing(),
             overall_outline_mask_ids: OutlineMaskPreference::NONE,
             additional_outline_mask_ids_vertex_ranges: Vec::new(),
@@ -375,18 +547,26 @@ impl PointCloudDrawData {
             batches
         };
 
-        let position_data_texture = vertices_buffer.finish(
-            wgpu::TextureFormat::Rgba32Float,
-            "PointCloudDrawData::position_data_texture",
-        )?;
-        let color_texture = color_buffer.finish(
-            wgpu::TextureFormat::Rgba8UnormSrgb,
-            "PointCloudDrawData::color_texture",
-        )?;
-        let picking_instance_id_texture = picking_instance_ids_buffer.finish(
-            wgpu::TextureFormat::Rg32Uint,
-            "PointCloudDrawData::picking_instance_id_texture",
-        )?;
+        // Resolve which slice of the shared point-data textures each batch draws.
+        // Batches without an explicit start continue right after the previous one; explicit starts
+        // let several batches share a single upload.
+        let point_ranges = {
+            let mut next_point_index = 0;
+            batches
+                .iter()
+                .map(|batch_info| {
+                    let start = batch_info
+                        .first_point_index
+                        .unwrap_or(next_point_index)
+                        .min(num_vertices);
+                    let end = start
+                        .saturating_add(batch_info.point_count)
+                        .min(num_vertices);
+                    next_point_index = end;
+                    start..end
+                })
+                .collect_vec()
+        };
 
         let draw_data_uniform_buffer_bindings = create_and_fill_uniform_buffer_batch(
             ctx,
@@ -416,9 +596,11 @@ impl PointCloudDrawData {
                 &BindGroupDesc {
                     label,
                     entries: smallvec![
-                        BindGroupEntry::DefaultTextureView(position_data_texture.handle),
-                        BindGroupEntry::DefaultTextureView(color_texture.handle),
-                        BindGroupEntry::DefaultTextureView(picking_instance_id_texture.handle),
+                        BindGroupEntry::DefaultTextureView(gpu_cloud.position_data_texture.handle),
+                        BindGroupEntry::DefaultTextureView(gpu_cloud.color_texture.handle),
+                        BindGroupEntry::DefaultTextureView(
+                            gpu_cloud.picking_instance_id_texture.handle
+                        ),
                         draw_data_uniform_buffer_binding,
                     ],
                     layout: point_renderer.bind_group_layout_all_points,
@@ -438,14 +620,10 @@ impl PointCloudDrawData {
         // Process batches
         let mut batches_internal = Vec::with_capacity(batches.len());
         {
-            let mut first_point_index = 0;
             let uniform_buffer_bindings = create_and_fill_uniform_buffer_batch(
                 ctx,
                 "point batch uniform buffers".into(),
-                batches.iter().map(|batch_info| {
-                    let current_first_point_index = first_point_index;
-                    first_point_index += batch_info.point_count;
-
+                std::iter::zip(batches, &point_ranges).map(|(batch_info, point_range)| {
                     let enable_index_lookup = batch_info
                         .sort_positions
                         .as_ref()
@@ -467,7 +645,7 @@ impl PointCloudDrawData {
                             .into(),
                         picking_object_id: batch_info.picking_object_id,
                         depth_offset: batch_info.depth_offset as f32,
-                        first_point_index: current_first_point_index,
+                        first_point_index: point_range.start,
                         _row_padding: 0,
                         end_padding: Default::default(),
                     }
@@ -480,45 +658,37 @@ impl PointCloudDrawData {
                 create_and_fill_uniform_buffer_batch(
                     ctx,
                     "lines batch uniform buffers - mask only".into(),
-                    batches
-                        .iter()
-                        .scan(0, |first_point_index, batch_info| {
-                            let current_first_point_index = *first_point_index;
-                            *first_point_index += batch_info.point_count;
-
+                    std::iter::zip(batches, &point_ranges)
+                        .flat_map(|(batch_info, point_range)| {
                             // Masks never use sorting, so we don't need index lookup here.
                             let flags = batch_info
                                 .flags
                                 .difference(PointCloudBatchFlags::FLAG_ENABLE_INDEX_LOOKUP)
                                 .bits();
 
-                            Some(
-                                batch_info
-                                    .additional_outline_mask_ids_vertex_ranges
-                                    .iter()
-                                    .map(move |(_, mask)| gpu_data::BatchUniformBuffer {
-                                        world_from_obj: batch_info.world_from_obj.into(),
-                                        flags,
-                                        outline_mask_ids: mask.0.unwrap_or_default().into(),
-                                        picking_object_id: batch_info.picking_object_id,
-                                        depth_offset: batch_info.depth_offset as f32,
-                                        first_point_index: current_first_point_index,
-                                        _row_padding: 0,
-                                        end_padding: Default::default(),
-                                    }),
-                            )
+                            batch_info
+                                .additional_outline_mask_ids_vertex_ranges
+                                .iter()
+                                .map(move |(_, mask)| gpu_data::BatchUniformBuffer {
+                                    world_from_obj: batch_info.world_from_obj.into(),
+                                    flags,
+                                    outline_mask_ids: mask.0.unwrap_or_default().into(),
+                                    picking_object_id: batch_info.picking_object_id,
+                                    depth_offset: batch_info.depth_offset as f32,
+                                    first_point_index: point_range.start,
+                                    _row_padding: 0,
+                                    end_padding: Default::default(),
+                                })
                         })
-                        .flatten()
                         .collect::<Vec<_>>()
                         .into_iter(),
                 )
                 .into_iter();
 
-            let mut start_point_for_next_batch = 0;
-            for (batch_info, uniform_buffer_binding) in
-                std::iter::zip(batches, uniform_buffer_bindings)
-            {
-                let point_vertex_range_end = start_point_for_next_batch + batch_info.point_count;
+            for ((batch_info, point_range), uniform_buffer_binding) in std::iter::zip(
+                std::iter::zip(batches, &point_ranges),
+                uniform_buffer_bindings,
+            ) {
                 // Transparent batches are alpha-blended in the transparent phase, everything else
                 // is drawn opaque (relying on alpha-to-coverage for edge anti-aliasing).
                 let color_phase = if batch_info
@@ -542,7 +712,7 @@ impl PointCloudDrawData {
                     .as_ref()
                     .filter(|positions| !positions.is_empty())
                     .map(|obj_positions| TransparentSort {
-                        object_positions: Arc::new(obj_positions.clone()),
+                        object_positions: obj_positions.clone(),
                         object_from_world: batch_info.world_from_obj.inverse(),
                         sort_order_cache: batch_info.sort_order_cache.clone(),
                     });
@@ -561,15 +731,16 @@ impl PointCloudDrawData {
                     ctx,
                     batch_info.label.clone(),
                     uniform_buffer_binding,
-                    start_point_for_next_batch..point_vertex_range_end,
+                    point_range.clone(),
                     center_world_position,
                     active_phases,
                     sort,
                 ));
 
                 for (range, _) in &batch_info.additional_outline_mask_ids_vertex_ranges {
-                    let range = (range.start + start_point_for_next_batch)
-                        ..(range.end + start_point_for_next_batch);
+                    // Ranges are relative to the batch, and must stay within what was uploaded.
+                    let range = (range.start + point_range.start).min(point_range.end)
+                        ..(range.end + point_range.start).min(point_range.end);
                     batches_internal.push(point_renderer.create_point_cloud_batch(
                         ctx,
                         format!("{:?} strip-only {:?}", batch_info.label, range).into(),
@@ -580,22 +751,15 @@ impl PointCloudDrawData {
                         None,
                     ));
                 }
-
-                start_point_for_next_batch = point_vertex_range_end;
-
-                // Should happen only if the number of vertices was clamped.
-                if start_point_for_next_batch >= num_vertices as u32 {
-                    break;
-                }
             }
         }
 
-        Ok(Self {
+        Self {
             bind_group_all_points: Some(bind_group_all_points),
             bind_group_all_points_outline_mask: Some(bind_group_all_points_outline_mask),
             batches: batches_internal,
             drawables: Arc::new(Mutex::new(SortedDrawables::default())),
-        })
+        }
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
@@ -588,12 +588,10 @@ impl VisualizerSystem for Points3DVisualizer {
         )?;
 
         Ok(output
-            .with_draw_data(
-                point_draw_data
-                    .into_iter()
-                    .map(Into::into)
-                    .chain([line_builder.into_draw_data()?.into()]),
-            )
+            .with_draw_data(itertools::chain!(
+                point_draw_data.into_iter().map(Into::into),
+                [line_builder.into_draw_data()?.into()],
+            ))
             .with_visualizer_data(view_data))
     }
 }

--- a/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/points3d.rs
@@ -1,14 +1,16 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use itertools::Itertools as _;
 use nohash_hasher::IntMap;
 use parking_lot::Mutex;
 use re_byte_size::SizeBytes as _;
 use re_entity_db::EntityDb;
+use re_log::ResultExt as _;
 use re_log_types::hash::Hash64;
-use re_renderer::{
-    LineDrawableBuilder, PickingLayerInstanceId, PointCloudBuilder, PositionRadius, SortOrderCache,
+use re_renderer::renderer::{
+    GpuPointCloud, PointCloudBatchFlags, PointCloudBatchInfo, PointCloudDrawData,
 };
+use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId, PositionRadius, SortOrderCache};
 use re_sdk_types::Archetype as _;
 use re_sdk_types::ArrowString;
 use re_sdk_types::archetypes::Points3D;
@@ -77,6 +79,18 @@ struct Points3DCpu {
     ///
     /// Each instance transform has its own cache, which tracks ordering per rendered view.
     sort_order_caches: Mutex<Vec<SortOrderCache>>,
+
+    /// The same point data residing on the GPU, uploaded once when this entry is created.
+    ///
+    /// `None` if there was nothing to upload or the upload failed.
+    #[size_bytes(ignore)] // VRAM, reported through `Points3DCache::vram_usage` instead.
+    gpu: Option<Arc<GpuPointCloud>>,
+
+    /// Object-space positions handed to the renderer for back-to-front sorting.
+    ///
+    /// Only materialized for clouds that are actually drawn transparently.
+    #[size_bytes(ignore)] // Only populated for transparent clouds.
+    sort_positions: OnceLock<Arc<Vec<glam::Vec3>>>,
 }
 
 impl Points3DCpu {
@@ -131,6 +145,18 @@ impl Points3DCpu {
 
         let has_transparency = colors.iter().any(|c| !c.is_opaque());
 
+        // Uploading here (rather than per frame) is the whole point of this cache: the same
+        // textures are reused for as long as this entry lives.
+        let gpu = GpuPointCloud::new(
+            ctx.viewer_ctx().render_ctx(),
+            &position_radii,
+            &colors,
+            &picking_ids,
+        )
+        .ok_or_log_error()
+        .flatten()
+        .map(Arc::new);
+
         Self {
             position_radii,
             robust_bounds,
@@ -140,6 +166,8 @@ impl Points3DCpu {
             colors,
             has_transparency,
             sort_order_caches: Mutex::new(Vec::new()),
+            gpu,
+            sort_positions: OnceLock::new(),
         }
     }
 
@@ -147,6 +175,15 @@ impl Points3DCpu {
         let mut caches = self.sort_order_caches.lock();
         caches.resize_with(transform_index + 1, SortOrderCache::default);
         caches[transform_index].clone()
+    }
+
+    fn sort_positions(&self) -> Arc<Vec<glam::Vec3>> {
+        self.sort_positions
+            .get_or_init(|| {
+                re_tracing::profile_scope!("sort_positions");
+                Arc::new(self.position_radii.iter().map(|pr| pr.pos).collect())
+            })
+            .clone()
     }
 }
 
@@ -219,6 +256,16 @@ impl Cache for Points3DCache {
         self.cache.clear();
     }
 
+    fn vram_usage(&self) -> re_byte_size::MemUsageTree {
+        re_byte_size::MemUsageTree::Bytes(
+            self.cache
+                .values()
+                .filter_map(|entry| entry.cpu.gpu.as_ref())
+                .map(|gpu| gpu.gpu_byte_size())
+                .sum(),
+        )
+    }
+
     fn on_store_events(
         &mut self,
         _events: &[&re_chunk_store::ChunkStoreEvent],
@@ -256,7 +303,7 @@ impl Points3DVisualizer {
     fn process_data<'a>(
         view_data: &mut SpatialViewVisualizerData,
         ctx: &QueryContext<'_>,
-        point_builder: &mut PointCloudBuilder<'_>,
+        point_draw_data: &mut Vec<PointCloudDrawData>,
         line_builder: &mut LineDrawableBuilder<'_>,
         query: &ViewQuery<'_>,
         ent_context: &SpatialSceneVisualizerInstructionContext<'_>,
@@ -292,10 +339,15 @@ impl Points3DVisualizer {
                 typed_fallback_for(ctx, Points3D::descriptor_point_shading().component)
             });
 
-            // TODO(grtlr): The following is a quick fix to get multiple instance poses to work
-            // with point clouds: We sent the same point cloud multiple times to the GPU (bad
-            // for memory) and render them with multiple draw calls across different batches (bad
-            // for performance).
+            // All instance transforms draw the same, singly-uploaded point data; only the
+            // per-batch state differs.
+            let Some(gpu_cloud) = cpu.gpu.clone() else {
+                continue;
+            };
+            let point_count = gpu_cloud.num_points();
+            let mut batches =
+                Vec::with_capacity(ent_context.transform_info.target_from_instances().len());
+
             for (transform_index, world_from_obj) in ent_context
                 .transform_info
                 .target_from_instances()
@@ -307,23 +359,15 @@ impl Points3DVisualizer {
 
                 let alpha_blend = transparency_enabled && cpu.has_transparency;
 
-                let mut point_batch = point_builder
-                    .batch(entity_path.to_string())
-                    .enable_shading(matches!(point_shading, PointShading::Gradient))
-                    .enable_alpha_blending(alpha_blend)
-                    .world_from_obj(world_from_obj)
-                    .object_space_bounding_box(cpu.robust_bounds.exact)
-                    .outline_mask_ids(ent_context.highlight.overall)
-                    .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
-
-                if alpha_blend {
-                    point_batch = point_batch.sort_order(cpu.sort_order_cache(transform_index));
-                }
-
-                let mut point_range_builder =
-                    point_batch.add_points(&cpu.position_radii, &cpu.colors, &cpu.picking_ids);
+                let mut flags = PointCloudBatchFlags::empty();
+                flags.set(
+                    PointCloudBatchFlags::FLAG_ENABLE_SHADING,
+                    matches!(point_shading, PointShading::Gradient),
+                );
+                flags.set(PointCloudBatchFlags::FLAG_PREMULTIPLIED_ALPHA, alpha_blend);
 
                 // Determine if there's any sub-ranges that need extra highlighting.
+                let mut additional_outline_mask_ids_vertex_ranges = Vec::new();
                 {
                     #[expect(clippy::iter_over_hash_type)]
                     // Non-overlapping per-instance mask ranges.
@@ -332,15 +376,29 @@ impl Points3DVisualizer {
                             < num_instances as u64)
                             .then_some(highlighted_key.get());
                         if let Some(highlighted_point_index) = highlighted_point_index {
-                            point_range_builder = point_range_builder
-                                .push_additional_outline_mask_ids_for_range(
-                                    highlighted_point_index as u32
-                                        ..highlighted_point_index as u32 + 1,
-                                    *instance_mask_ids,
-                                );
+                            additional_outline_mask_ids_vertex_ranges.push((
+                                highlighted_point_index as u32..highlighted_point_index as u32 + 1,
+                                *instance_mask_ids,
+                            ));
                         }
                     }
                 }
+
+                batches.push(PointCloudBatchInfo {
+                    label: entity_path.to_string().into(),
+                    world_from_obj,
+                    flags,
+                    point_count,
+                    // Every transform draws the entire, shared upload.
+                    first_point_index: Some(0),
+                    object_space_bounding_box: cpu.robust_bounds.exact,
+                    overall_outline_mask_ids: ent_context.highlight.overall,
+                    additional_outline_mask_ids_vertex_ranges,
+                    picking_object_id: re_renderer::PickingLayerObjectId(entity_path.hash64()),
+                    depth_offset: 0,
+                    sort_positions: alpha_blend.then(|| cpu.sort_positions()),
+                    sort_order_cache: alpha_blend.then(|| cpu.sort_order_cache(transform_index)),
+                });
 
                 view_data.add_bounds(
                     entity_path.hash(),
@@ -374,6 +432,13 @@ impl Points3DVisualizer {
                     world_from_obj,
                 ));
             }
+
+            point_draw_data.push(PointCloudDrawData::from_gpu_cloud(
+                ctx.viewer_ctx().render_ctx(),
+                &gpu_cloud,
+                &batches,
+                re_view::SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES,
+            ));
         }
 
         Ok(())
@@ -414,10 +479,8 @@ impl VisualizerSystem for Points3DVisualizer {
         let mut view_data = SpatialViewVisualizerData::default();
         let output = VisualizerExecutionOutput::default();
 
-        let mut point_builder = PointCloudBuilder::new(ctx.viewer_ctx.render_ctx());
-        point_builder.radius_boost_in_ui_points_for_outlines(
-            re_view::SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES,
-        );
+        // One draw data per cached point cloud: each has its own, independently cached upload.
+        let mut point_draw_data = Vec::new();
 
         // We need lines from keypoints. The number of lines we'll have is harder to predict, so we'll go
         // with the dynamic allocation approach.
@@ -442,7 +505,7 @@ impl VisualizerSystem for Points3DVisualizer {
                     return Ok(());
                 }
 
-                let num_positions = {
+                let num_positions: usize = {
                     re_tracing::profile_scope!("num_positions");
                     all_positions
                         .chunks()
@@ -456,7 +519,6 @@ impl VisualizerSystem for Points3DVisualizer {
                     return Ok(());
                 }
 
-                point_builder.reserve(num_positions)?;
                 let all_colors = results.iter_optional(Points3D::descriptor_colors().component);
                 let all_radii = results.iter_optional(Points3D::descriptor_radii().component);
                 let all_labels = results.iter_optional(Points3D::descriptor_labels().component);
@@ -516,7 +578,7 @@ impl VisualizerSystem for Points3DVisualizer {
                 Self::process_data(
                     &mut view_data,
                     ctx,
-                    &mut point_builder,
+                    &mut point_draw_data,
                     &mut line_builder,
                     view_query,
                     spatial_ctx,
@@ -526,10 +588,12 @@ impl VisualizerSystem for Points3DVisualizer {
         )?;
 
         Ok(output
-            .with_draw_data([
-                point_builder.into_draw_data()?.into(),
-                line_builder.into_draw_data()?.into(),
-            ])
+            .with_draw_data(
+                point_draw_data
+                    .into_iter()
+                    .map(Into::into)
+                    .chain([line_builder.into_draw_data()?.into()]),
+            )
             .with_visualizer_data(view_data))
     }
 }


### PR DESCRIPTION
### Related

* Part of #1136

### What

The viewer currently re-uploads every point cloud's data (positions/radii, colors, picking ids) to the GPU on every frame, even when nothing changed — the main remaining action item from #1136. This PR caches the uploaded data textures and reuses them across frames.

**`re_renderer`:** the upload is split out of `PointCloudDrawData::new` into a new persistent `GpuPointCloud` (the three finished data textures + point count). `PointCloudDrawData::from_gpu_cloud(..)` then builds only the genuinely per-frame state: the "all points" bind groups (they embed the per-draw-data radius-boost uniform), per-batch uniform buffers/bind groups, and transparent-sort data. The existing immediate-mode `PointCloudBuilder::into_draw_data()` path is reimplemented on top of the same split, so there is a single upload code path and other callers are untouched. `PointCloudBatchInfo` gains an optional `first_point_index` so multiple batches can address overlapping ranges of one upload, and `sort_positions` becomes `Option<Arc<Vec<Vec3>>>` (also removing a per-frame `Vec` clone in the transparent-sort path).

**`re_view_spatial`:** `Points3DCpu` — already memoized on `query_result_hash` — now also holds an `Arc<GpuPointCloud>`, uploaded once on cache miss. Per frame the visualizer only builds `PointCloudBatchInfo`s (transform, flags, highlights, picking id) referencing the cached upload. Invalidation and eviction ride on the existing generation-based `Points3DCache`; the cache implements `vram_usage()` so the memory panel accounts for the textures. As a side effect this also fixes the `TODO(grtlr)` where N instance transforms re-uploaded the same cloud N times — they are now N batches over one upload.

Behavior is intended to be unchanged (shading, alpha blending + back-to-front sorting, outlines incl. per-instance highlight ranges, picking, labels, bounds). The relevant snapshot tests (`point_shading`, `transparent_geometry`, `keypoint_rendering`, `select_box_instances`, `transform_clamping`, `transform_hierarchy`, `draw_order`, `gaussian_splats3d`) pass; `cargo clippy -D warnings`, `cargo fmt --check`, and `cargo test` on `re_renderer`/`re_view_spatial` are clean.

Natural follow-ups (left on the immediate-mode path for now): `points2d` and `gaussian_splats3d`, which have the same per-frame re-upload structure.


### Benchmarks

Headless harness reusing the repo's own snapshot-test infra (`TestContext` + `egui_kittest`): one static opaque `Points3D` entity with N seeded random points; per frame, `step()` = visualizer execution + draw-data creation + upload staging, `render()` = submit + offscreen readback ending in `device.poll(Wait)` so GPU time is included. 10 warmup + 100 measured frames, baseline/branch interleaved A/B/A/B, 2 repetitions. Ryzen 9 9950X3D, RTX 5070 (driver 580.173.02, Vulkan), rustc 1.96.0, `--release`. Baseline `b5dbd31` (v0.36.2) vs this branch.

Median ms/frame on the RTX 5070 (rep1 / rep2):

| N points | phase | baseline | this PR | speedup |
|---:|---|---|---|---|
| 1 M | full frame | 4.14 / 4.15 | 2.11 / 2.19 | **1.9×** |
| 1 M | step (CPU + upload) | 2.43 / 2.48 | 0.72 / 0.73 | 3.4× |
| 5 M | full frame | 15.12 / 15.17 | 5.11 / 5.11 | **3.0×** |
| 5 M | step | 9.65 / 9.72 | 0.81 / 0.84 | 11.8× |
| 10 M | full frame | 28.43 / 28.35 | 8.91 / 9.00 | **3.2×** |
| 10 M | step | 18.47 / 18.45 | 0.89 / 0.90 | 20.6× |

<img width="1920" height="840" alt="image" src="https://github.com/user-attachments/assets/cf172d62-ba5d-4e91-a6b3-ebd3698ccf72" />

p90 tracks the medians (10 M: 29.4 → 9.6 ms); rep-to-rep spread is ≤1.1%. The signature is exactly what the change predicts: per-frame CPU/upload cost becomes independent of N (0.72 → 0.89 ms from 1 M to 10 M) instead of linear (2.4 → 18.5 ms). On llvmpipe the CPU-phase win is the same (10 M: 18.5 → 1.1 ms) but total frame time is rasterization-dominated and too noisy to claim.

Caveats, honestly: this is the best case for the cache (static scene, one opaque entity, one transform); a scene whose data changes every frame pays the same upload as before (during warmup, deliberately not charged to either side). Headless readback serializes CPU/GPU, so the full-frame ratio is an upper bound — the step-phase result is the robust one. Happy to share the harness (single self-contained test file) if useful.

### Agent

🤖 This PR was opened by a coding agent (Claude Code, model Claude Fable 5), directed by @kaashmonee. Confidence: the mechanism follows the maintainers' own roadmap item from #1136 ("cache uploads, so we only upload when the points change"), reuses the existing `query_result_hash`-keyed memoization for invalidation, and is validated by the existing snapshot tests plus the benchmarks above. Kept in draft pending human review of the code; design feedback welcome in the meantime.
