### PR TITLE
fix(python): report bound server port

### DIFF
--- a/rerun_py/src/server.rs
+++ b/rerun_py/src/server.rs
@@ -1,5 +1,3 @@
-use std::net::SocketAddr;
-
 use pyo3::exceptions::PyValueError;
 use pyo3::types::{
     PyAnyMethods as _, PyDict, PyDictMethods as _, PyModule, PyModuleMethods as _, PyString,
@@ -48,20 +46,11 @@ impl PyServerInternal {
             .parse()
             .map_err(|err| PyValueError::new_err(format!("Invalid IP: {host:?}: {err}")))?;
 
-        let connect_ip = if host.is_unspecified() {
-            // We usually cannot connect to 0.0.0.0 or ::, so tell clients to connect to 127.0.0.1 instead:
-            std::net::Ipv4Addr::LOCALHOST.into()
-        } else {
-            host
-        };
-        let connect_address = SocketAddr::new(connect_ip, args.port);
-
-        let url = format!("rerun+http://{connect_address}");
-
         crate::utils::wait_for_future(py, async {
             let handle = args.create_server_handle().await.map_err(|err| {
                 PyValueError::new_err(format!("Failed to start Rerun server: {err:#}"))
             })?;
+            let url = format!("rerun+http://{}", handle.connect_addr());
 
             Ok(Self {
                 handle: Some(handle),

--- a/rerun_py/tests/unit/test_server.py
+++ b/rerun_py/tests/unit/test_server.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import socket
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pyarrow as pa
 import pytest
@@ -48,6 +50,17 @@ def test_server_random_port() -> None:
         assert server1.is_running()
         assert server2.is_running()
         assert server1.url() != server2.url()
+
+
+def test_server_port_zero_reports_bound_port() -> None:
+    """Test that port zero reports the OS-assigned port rather than zero."""
+    with Server(host="127.0.0.1", port=0) as server:
+        url = urlparse(server.url().replace("rerun+http://", "http://", 1))
+        assert url.hostname is not None
+        assert url.port not in (None, 0)
+
+        with socket.create_connection((url.hostname, url.port), timeout=1):
+            pass
 
 
 def test_server_shutdown_twice_raises() -> None:


### PR DESCRIPTION
### Related

* Closes #12905

### What

While using `rerun-sdk==0.35.0`, I found that `rr.server.Server(host="127.0.0.1", port=0)` binds an OS-assigned ephemeral port but returns `rerun+http://127.0.0.1:0`, which clients cannot use.

This change builds the Python server URL after startup from `ServerHandle::connect_addr()`, so it reports the actual bound port while preserving the existing connectable-host behavior for unspecified bind addresses. It also adds a regression test that verifies the reported port is nonzero and accepts a TCP connection.

Confidence: high. The Python binding was constructing the URL from the requested address before the server started; the server handle already exposes the resolved connect address after binding.

Validation:

* `pixi run py-build`
* `pixi run py-fmt`
* `pixi run lint-rerun rerun_py/src/server.rs rerun_py/tests/unit/test_server.py`
* `rustup run stable rustfmt --edition 2024 --check rerun_py/src/server.rs`
* `pixi run uv run pytest -q rerun_py/tests/unit/test_server.py -k "port_zero_reports_bound_port or random_port"` — 2 passed
* `git diff --check`

The complete `test_server.py` run reached 12 passing tests and 3 dataset-fixture failures because this shallow checkout contains Git LFS pointer files instead of the RRD fixtures (the loader reads `vers` rather than an `RRF2` header).

### Disclosure

I used an LLM-assisted workflow for this contribution. I manually reproduced the released behavior, reviewed the binding and server-handle paths, implemented the fix, and ran the validation listed above.