### PR TITLE
Make `tracing-subscriber` an optional dependency of `re_log`

### DIFF
--- a/crates/store/re_chunk_store/Cargo.toml
+++ b/crates/store/re_chunk_store/Cargo.toml
@@ -32,7 +32,7 @@ re_byte_size.workspace = true
 re_chunk.workspace = true
 re_format.workspace = true
 re_int.workspace = true
-re_log = { workspace = true, features = ["setup"] }
+re_log.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder"] }
 re_log_types.workspace = true
 re_sdk_types.workspace = true
@@ -57,6 +57,7 @@ web-time.workspace = true
 
 [dev-dependencies]
 re_format.workspace = true
+re_log = { workspace = true, features = ["setup"] }
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
 re_sdk_types = { workspace = true, features = ["testing"] }
 

--- a/crates/store/re_dataframe/Cargo.toml
+++ b/crates/store/re_dataframe/Cargo.toml
@@ -45,6 +45,7 @@ rayon.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 re_sdk_types.workspace = true
 # External dependencies:
 criterion.workspace = true

--- a/crates/store/re_entity_db/Cargo.toml
+++ b/crates/store/re_entity_db/Cargo.toml
@@ -60,6 +60,7 @@ vec1.workspace = true
 web-time.workspace = true
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 re_build_info.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
 

--- a/crates/store/re_grpc_server/Cargo.toml
+++ b/crates/store/re_grpc_server/Cargo.toml
@@ -18,13 +18,22 @@ workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+default = []
+
+## Build the standalone `re_grpc_server` binary (needs logging setup).
+bin = ["re_log/setup"]
+
+[[bin]]
+name = "re_grpc_server"
+required-features = ["bin"]
 
 [dependencies]
 re_byte_size.workspace = true
 re_chunk.workspace = true
 re_error.workspace = true
 re_format.workspace = true
-re_log = { workspace = true, features = ["setup"] }
+re_log.workspace = true
 re_log_channel.workspace = true
 re_log_encoding = { workspace = true, features = ["encoder", "decoder"] }
 re_log_types.workspace = true

--- a/crates/store/re_query/Cargo.toml
+++ b/crates/store/re_query/Cargo.toml
@@ -52,6 +52,7 @@ thiserror.workspace = true
 
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 re_arrow_util.workspace = true
 re_log_encoding.workspace = true
 re_sdk_types.workspace = true

--- a/crates/store/re_redap_client/Cargo.toml
+++ b/crates/store/re_redap_client/Cargo.toml
@@ -86,6 +86,7 @@ tonic-web-wasm-client.workspace = true
 tonic = { workspace = true, default-features = false }
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 re_uri.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/crates/store/re_tf/Cargo.toml
+++ b/crates/store/re_tf/Cargo.toml
@@ -41,6 +41,7 @@ parking_lot.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 criterion.workspace = true
 insta.workspace = true
 mimalloc.workspace = true

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -76,6 +76,13 @@ image = ["re_sdk_types?/image"]
 ## Integration with the [`log`](https://crates.io/crates/log/) crate.
 log = ["dep:env_filter", "dep:log"]
 
+## Enable the logging-setup helpers on the re-exported `re_log`,
+## i.e. `rerun::external::re_log::setup_logging`.
+##
+## Only useful in binaries: it pulls in `tracing-subscriber`, which a library
+## should leave to whoever owns `main`.
+log_setup = ["re_log/setup"]
+
 ## Support the map view.
 ## This adds a lot of extra dependencies.
 map_view = ["re_viewer?/map_view"]

--- a/crates/utils/re_analytics/Cargo.toml
+++ b/crates/utils/re_analytics/Cargo.toml
@@ -48,4 +48,5 @@ directories.workspace = true
 web-sys = { workspace = true, features = ["Storage"] }
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 regex-lite.workspace = true

--- a/crates/utils/re_log/Cargo.toml
+++ b/crates/utils/re_log/Cargo.toml
@@ -27,7 +27,7 @@ default = []
 
 ## Feature to set up logging in binaries,
 ## i.e. from `main` or in a web-app.
-setup = ["dep:tracing-log", "dep:tracing-web"]
+setup = ["dep:tracing-log", "dep:tracing-subscriber", "dep:tracing-web"]
 
 
 [dependencies]
@@ -36,7 +36,7 @@ crossbeam.workspace = true
 parking_lot.workspace = true
 
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, optional = true }
 tracing-log = { workspace = true, optional = true }
 
 # web dependencies:

--- a/crates/viewer/re_selection_panel/Cargo.toml
+++ b/crates/viewer/re_selection_panel/Cargo.toml
@@ -44,6 +44,7 @@ smallvec.workspace = true
 static_assertions.workspace = true
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 re_component_ui.workspace = true
 re_test_context.workspace = true
 re_test_viewport.workspace = true

--- a/crates/viewer/re_test_context/Cargo.toml
+++ b/crates/viewer/re_test_context/Cargo.toml
@@ -43,3 +43,6 @@ jiff.workspace = true
 parking_lot.workspace = true
 pollster.workspace = true
 wgpu.workspace = true
+
+[dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }

--- a/crates/viewer/re_ui/Cargo.toml
+++ b/crates/viewer/re_ui/Cargo.toml
@@ -41,7 +41,7 @@ re_async.workspace = true # to run the fetch behind a `RequestedObject`
 re_entity_db.workspace = true # syntax-highlighting for InstancePath. TODO(emilk): move InstancePath
 re_error.workspace = true
 re_format.workspace = true
-re_log.workspace = true
+re_log = { workspace = true, features = ["setup"] }
 re_log_types.workspace = true # syntax-highlighting for EntityPath
 re_mutex.workspace = true
 re_quota_channel.workspace = true

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -96,6 +96,7 @@ re_async.workspace = true
 re_web.workspace = true
 
 [dev-dependencies]
+re_log = { workspace = true, features = ["setup"] }
 re_ui = { workspace = true, features = ["testing"] }
 
 egui_kittest.workspace = true

--- a/docs/content/changelog/upcoming/tracing-subscriber-optional.md
+++ b/docs/content/changelog/upcoming/tracing-subscriber-optional.md
@@ -1,0 +1,31 @@
+---
+title: "Log setup functions and `tracing-subscriber` are opt-in with feature `log_setup`"
+hidden: true
+type: breaking
+---
+
+### "Log setup for binaries is opt-in with feature `log_setup`"
+
+`re_log` depended on `tracing-subscriber` unconditionally, and every Rerun crate depends on `re_log`.
+Because the workspace pins `tracing-subscriber` at `^0.3.23`, a project pinning an earlier `0.3.x` could not depend on Rerun at all — even when using it purely as a SDK, with no viewer and no subscriber of its own.
+
+`tracing-subscriber` now sits behind `re_log`'s existing `setup` feature.
+All source-code usage of `tracing-subscriber` was already gated on this feature.
+
+The `rerun` crate exposes `re_log/setup` as a new `log_setup` feature, off by default.
+`log_setup` covers the whole of `re_log`'s application-level logging setup: `setup_logging`, `setup_logging_with_filter`, `add_log_msg_receiver`, `LogMsg`, `Receiver`, `Sender`, `FieldValue`, `PanicOnWarnScope`, and `LevelFilter`.
+Libraries should probably leave it off and let whoever owns `main` configure logging.
+
+Binaries that set up logging through the re-exported `re_log` must now opt in.
+Without the feature, the call no longer resolves:
+
+```
+error[E0425]: cannot find function `setup_logging` in crate `re_log`
+note: found an item that was configured out
+      the item is gated behind the `setup` feature
+```
+
+| Before           | After                                                    |
+|------------------|----------------------------------------------------------|
+| `rerun = "0.37"` | `rerun = { version = "0.37", features = ["log_setup"] }` |
+

--- a/examples/rust/animated_urdf/Cargo.toml
+++ b/examples/rust/animated_urdf/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["clap", "importers"] }
+rerun = { path = "../../../crates/top/rerun", features = ["clap", "importers", "log_setup"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/clock/Cargo.toml
+++ b/examples/rust/clock/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap"] }
+rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap", "log_setup"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/custom_callback/Cargo.toml
+++ b/examples/rust/custom_callback/Cargo.toml
@@ -26,6 +26,7 @@ rerun = { path = "../../../crates/top/rerun", default-features = false, features
   "run",
   "server",
   "video",
+  "log_setup",
 ] }
 
 bincode.workspace = true

--- a/examples/rust/custom_importer/Cargo.toml
+++ b/examples/rust/custom_importer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 crossbeam.workspace = true
 re_quota_channel = { path = "../../../crates/utils/re_quota_channel" }
-rerun = { path = "../../../crates/top/rerun", features = ["native_viewer", "run"] }
+rerun = { path = "../../../crates/top/rerun", features = ["native_viewer", "run", "log_setup"] }
 
 [build-dependencies]
 re_build_tools = { path = "../../../crates/build/re_build_tools" }

--- a/examples/rust/custom_store_subscriber/Cargo.toml
+++ b/examples/rust/custom_store_subscriber/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["native_viewer", "run"] }
+rerun = { path = "../../../crates/top/rerun", features = ["native_viewer", "run", "log_setup"] }
 
 [build-dependencies]
 re_build_tools = { path = "../../../crates/build/re_build_tools" }

--- a/examples/rust/custom_view/Cargo.toml
+++ b/examples/rust/custom_view/Cargo.toml
@@ -17,6 +17,7 @@ rerun = { path = "../../../crates/top/rerun", default-features = false, features
   "native_viewer",
   "sdk",
   "server",
+  "log_setup",
 ] }
 
 # mimalloc is a much faster allocator:

--- a/examples/rust/custom_visualizer/Cargo.toml
+++ b/examples/rust/custom_visualizer/Cargo.toml
@@ -18,6 +18,7 @@ rerun = { path = "../../../crates/top/rerun", default-features = false, features
   "run",
   "server",
   "video",
+  "log_setup",
 ] }
 
 # Need a direct dependency for `#[derive(bytemuck::Pod, bytemuck::Zeroable)]`.

--- a/examples/rust/dna/Cargo.toml
+++ b/examples/rust/dna/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun" }
+rerun = { path = "../../../crates/top/rerun", features = ["log_setup"] }
 
 itertools.workspace = true
 rand = { workspace = true, features = ["std", "thread_rng"] }

--- a/examples/rust/extend_viewer_ui/Cargo.toml
+++ b/examples/rust/extend_viewer_ui/Cargo.toml
@@ -17,6 +17,7 @@ rerun = { path = "../../../crates/top/rerun", default-features = false, features
   "native_viewer",
   "sdk",
   "server",
+  "log_setup",
 ] }
 
 # mimalloc is a much faster allocator:

--- a/examples/rust/incremental_logging/Cargo.toml
+++ b/examples/rust/incremental_logging/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap"] }
+rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap", "log_setup"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/lenses/Cargo.toml
+++ b/examples/rust/lenses/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap"] }
+rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap", "log_setup"] }
 
 anyhow.workspace = true
 arrow.workspace = true

--- a/examples/rust/log_file/Cargo.toml
+++ b/examples/rust/log_file/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap"] }
+rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap", "log_setup"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap"] }
+rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap", "log_setup"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap"] }
+rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap", "log_setup"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/examples/rust/raw_mesh/Cargo.toml
+++ b/examples/rust/raw_mesh/Cargo.toml
@@ -7,7 +7,12 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-rerun = { path = "../../../crates/top/rerun", features = ["web_viewer", "clap", "ecolor"] }
+rerun = { path = "../../../crates/top/rerun", features = [
+  "web_viewer",
+  "clap",
+  "ecolor",
+  "log_setup",
+] }
 
 anyhow.workspace = true
 bytes.workspace = true

--- a/examples/rust/viewer_callbacks/Cargo.toml
+++ b/examples/rust/viewer_callbacks/Cargo.toml
@@ -16,6 +16,7 @@ analytics = ["rerun/analytics"]
 rerun = { path = "../../../crates/top/rerun", default-features = false, features = [
   "native_viewer",
   "server",
+  "log_setup",
 ] }
 
 # mimalloc is a much faster allocator:

--- a/tests/rust/log_benchmark/Cargo.toml
+++ b/tests/rust/log_benchmark/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 re_tracing = { path = "../../../crates/utils/re_tracing", features = ["server"] }
-rerun = { path = "../../../crates/top/rerun" }
+rerun = { path = "../../../crates/top/rerun", features = ["log_setup"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
# Template

### Related

`tracing-subscriber` was pinned here: https://github.com/rerun-io/rerun/pull/11072

### What

This makes `tracing-subscriber` an optional dependency of `re_log`, with the ultimate goal of making `tracing-subscriber` optional for library-only users (i.e. those using the SDK, not building the viewer). `tracing-subscriber` is for configuring the tracing behavior of an application, and yet prior to this branch it was essentially mandatory for the SDK. 

Rust/Cargo dependency resolution rules disallow the presence of two versions of the same dependency at the patch level. I'm stuck on 3.2.19 until something like [this](https://github.com/tokio-rs/tracing/issues/3595) lands. Because rerun-sdk currently requires tracing subscribe at `^3.2.23`, I'm forced to either stay on an old version of rerun-sdk or upgrade TS to 3.2.23 which causes broken output in my application.

`tracing-subscribe` usage was already gated behind the `setup` feature or in test code, so placing it behind the `setup` feature essentially does the trick.

