### PR TITLE
Fix parsing of unicode escapes above U+FFFF in entity paths

### DIFF
--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -677,6 +677,19 @@ mod tests {
     }
 
     #[test]
+    fn test_roundtrip_above_bmp() {
+        // Code points above `U+FFFF` (emoji, …) are escaped with more than four
+        // hex digits, and must survive a roundtrip through `Display`.
+        let path = EntityPath::new(vec!["camera".into(), "😀".into()]);
+        assert_eq!(path.to_string(), r"/camera/\u{1F600}");
+        assert_eq!(
+            EntityPath::parse_strict(&path.to_string()),
+            Ok(path.clone())
+        );
+        assert_eq!(EntityPath::from(path.to_string().as_str()), path);
+    }
+
+    #[test]
     fn test_incremental_walk() {
         assert_eq!(
             EntityPath::incremental_walk(None, &EntityPath::root()).collect::<Vec<_>>(),

--- a/crates/store/re_log_types/src/path/entity_path_part.rs
+++ b/crates/store/re_log_types/src/path/entity_path_part.rs
@@ -211,12 +211,20 @@ impl EntityPathPart {
 
 /// Parses e.g. `{262E}`.
 ///
+/// Rust-style unicode escapes: 1-6 hexadecimal digits between the braces,
+/// e.g. `{A}`, `{262E}`, `{1F600}`.
+/// Code points above `U+FFFF` need more than four digits,
+/// so a fixed width of four would reject e.g. emoji.
+///
 /// Returns the consumed input characters on fail.
 fn parse_unicode_escape(input: &mut impl Iterator<Item = char>) -> Result<char, String> {
+    /// `{` + at most six hex digits + `}`
+    const MAX_LEN: usize = 8;
+
     let mut all_chars = String::new();
     for c in input {
         all_chars.push(c);
-        if c == '}' || all_chars.len() == 6 {
+        if c == '}' || MAX_LEN <= all_chars.len() {
             break;
         }
     }
@@ -230,7 +238,7 @@ fn parse_unicode_escape(input: &mut impl Iterator<Item = char>) -> Result<char, 
         return Err(all_chars);
     };
 
-    if chars.len() != 4 {
+    if chars.is_empty() || 6 < chars.len() || !chars.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err(all_chars);
     }
 
@@ -340,6 +348,46 @@ fn test_parse_entity_path_part() {
         assert_eq!(
             EntityPathPart::parse_strict(str).unwrap().escaped_string(),
             str
+        );
+    }
+}
+
+/// Code points above `U+FFFF` are escaped with more than four hex digits,
+/// and must survive a roundtrip through [`EntityPathPart::escaped_string`].
+#[test]
+fn test_parse_entity_path_part_above_bmp() {
+    for unescaped in ["😀", "𝄞", "\u{10FFFF}", "a😀b"] {
+        let escaped = EntityPathPart::new(unescaped).escaped_string();
+
+        assert_eq!(
+            EntityPathPart::parse_strict(&escaped)
+                .expect("should parse")
+                .unescaped_str(),
+            unescaped,
+        );
+        assert_eq!(
+            EntityPathPart::parse_forgiving(&escaped).unescaped_str(),
+            unescaped,
+        );
+    }
+
+    assert_eq!(
+        EntityPathPart::parse_strict(r"\u{1F600}"),
+        Ok(EntityPathPart::from("😀"))
+    );
+    assert_eq!(EntityPathPart::from("😀").escaped_string(), r"\u{1F600}");
+
+    // Rust-style escapes accept 1-6 hex digits:
+    assert_eq!(
+        EntityPathPart::parse_strict(r"\u{A}\u{7F}\u{262E}\u{01F600}").unwrap(),
+        EntityPathPart::from("\u{A}\u{7F}☮😀")
+    );
+
+    // …but not zero digits, more than six, or non-hex:
+    for bad in [r"\u{}", r"\u{1234567}", r"\u{+123}", r"\u{DEAD}"] {
+        assert!(
+            EntityPathPart::parse_strict(bad).is_err(),
+            "{bad:?} should not parse"
         );
     }
 }


### PR DESCRIPTION
### Related
* None — found while reading the entity-path escaping code.

### What

`EntityPathPart::escaped_string` emits Rust-style `\u{…}` escapes with as many hex digits as the code point needs, but `parse_unicode_escape` only accepted exactly four. Every code point above `U+FFFF` (emoji, musical symbols, CJK extensions) therefore failed to round-trip:

```
EntityPath::new(vec!["camera".into(), "😀".into()]).to_string()
// "/camera/\u{1F600}"

EntityPath::parse_strict(r"/camera/\u{1F600}")
// Err(InvalidUnicodeEscape("{1F600"))

EntityPath::from(r"/camera/\u{1F600}").to_string()
// "/camera/\\u\{1F600\}"  <- silently a *different* entity path
```

The forgiving parser, the one used on ingest, doesn't error. It turns the escape back into its literal characters, so logging to such a path and reading it back gives a different path than the one that was logged. `escape_entity_path_part` is exposed to the Python and C++ SDKs too, so all three are affected.

The docs promise that any character is allowed in a path part, and that `\u{262E}` inserts an arbitrary code point, so this is a round-trip violation rather than an intentional restriction. The existing round-trip test only covered BMP code points.

This accepts 1-6 hex digits, as Rust's own `\u{…}` syntax does, and requires them to actually be hex digits. The read-ahead limit becomes 8 bytes (`{` plus six digits plus `}`) and a `<=` comparison, so a multi-byte character inside the braces can no longer skip past the limit and swallow the rest of the input.

Tested with `cargo test -p re_log_types --all-features` (the new tests fail on `main`), plus clippy, rustfmt and `scripts/lint.py`.

### Agent

🤖 This PR was opened by a coding agent (Claude Opus 4.5).

On confidence: the logic change is 8 lines. It is covered by two tests that fail on `main` and pass here, the full `re_log_types` suite (66 tests plus 3 doctests) passes, and clippy, rustfmt and `scripts/lint.py` are clean. The behaviour being restored is the one stated in the entity-path docs, so the intended semantics are not in question. The secondary change to the read-ahead guard is the part most worth a careful look, since it alters loop termination rather than validation.
